### PR TITLE
Fix for FLINK-708 and FLINK-887 

### DIFF
--- a/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/ApplicationMaster.java
+++ b/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/ApplicationMaster.java
@@ -62,7 +62,6 @@ import eu.stratosphere.nephele.jobmanager.JobManager;
 public class ApplicationMaster {
 
 	private static final Log LOG = LogFactory.getLog(ApplicationMaster.class);
-	private static final int HEAP_LIMIT_CAP = 500;
 	
 	private void run() throws Exception  {
 		//Utils.logFilesInCurrentDirectory(LOG);
@@ -83,10 +82,7 @@ public class ApplicationMaster {
 		final int memoryPerTaskManager = Integer.valueOf(envs.get(Client.ENV_TM_MEMORY));
 		final int coresPerTaskManager = Integer.valueOf(envs.get(Client.ENV_TM_CORES));
 		
-		int heapLimit = (int)((float)memoryPerTaskManager*0.85);
-		if( (memoryPerTaskManager - heapLimit) > HEAP_LIMIT_CAP) {
-			heapLimit = memoryPerTaskManager-HEAP_LIMIT_CAP;
-		}
+		int heapLimit = Utils.calculateHeapSize(memoryPerTaskManager);
 		
 		if(currDir == null) {
 			throw new RuntimeException("Current directory unknown");

--- a/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/Client.java
+++ b/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/Client.java
@@ -347,7 +347,7 @@ public class Client {
 				.newRecord(ContainerLaunchContext.class);
 		
 		String amCommand = "$JAVA_HOME/bin/java"
-					+ " -Xmx"+jmMemory+"M " +javaOpts;
+					+ " -Xmx"+Utils.calculateHeapSize(jmMemory)+"M " +javaOpts;
 		if(hasLog4j) {
 			amCommand 	+= " -Dlog.file=\""+ApplicationConstants.LOG_DIR_EXPANSION_VAR +"/jobmanager-log4j.log\" -Dlog4j.configuration=file:log4j.properties";
 		}

--- a/stratosphere-dist/src/main/stratosphere-bin/yarn-bin/yarn-session.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/yarn-bin/yarn-session.sh
@@ -49,5 +49,5 @@ CC_CLASSPATH=`manglePathList $(constructCLIClientClassPath)`
 export STRATOSPHERE_CONF_DIR
 # $log_setting
 
-$JAVA_RUN $JVM_ARGS  -classpath $CC_CLASSPATH eu.stratosphere.yarn.Client -ship ship/ -confDir $STRATOSPHERE_CONF_DIR -j $STRATOSPHERE_LIB_DIR/*yarn-uberjar.jar $*
+$JAVA_RUN $JVM_ARGS  -classpath $CC_CLASSPATH eu.stratosphere.yarn.Client -ship $bin/../ship/ -confDir $STRATOSPHERE_CONF_DIR -j $STRATOSPHERE_LIB_DIR/*yarn-uberjar.jar $*
 


### PR DESCRIPTION
I tested Flink on Amazon EMR (Hadoop 2.4.0). It was necessary to change some code due to a API change in YARN. Flink should now support all Hadoop versions >= 2.2.0.

I also fixed the JobManager heap space calculation for YARN. The JM sometimes failed one large jobs.

I would like to include the commit into the 0.5.1 release.
