### PR TITLE
Serialized String comparison, Unicode support

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
@@ -39,7 +39,7 @@ public final class StringComparator extends BasicTypeComparator<String> {
 
 	@Override
 	public int compare(DataInputView firstSource, DataInputView secondSource) throws IOException {
-		int comp = StringValue.compareUnicode(firstSource, secondSource);
+		int comp = StringValue.compareUnicodeString(firstSource, secondSource);
 		return ascendingComparison ? comp : -comp;
 	}
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
@@ -39,9 +39,7 @@ public final class StringComparator extends BasicTypeComparator<String> {
 
 	@Override
 	public int compare(DataInputView firstSource, DataInputView secondSource) throws IOException {
-		String s1 = StringValue.readString(firstSource);
-		String s2 = StringValue.readString(secondSource);
-		int comp = s1.compareTo(s2); 
+		int comp = StringValue.compareUnicode(firstSource, secondSource);
 		return ascendingComparison ? comp : -comp;
 	}
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringSerializer.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringSerializer.java
@@ -57,16 +57,16 @@ public class StringSerializer extends TypeSerializer<String> {
 
 	@Override
 	public void serialize(String record, DataOutputView target) throws IOException {
-		StringValue.writeString(record, target);
+		StringValue.writeUnicode(record, target);
 	}
 
 	@Override
 	public String deserialize(String record, DataInputView source) throws IOException {
-		return StringValue.readString(source);
+		return StringValue.readUnicode(source);
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		StringValue.copyString(source, target);
+		StringValue.copyUnicode(source, target);
 	}
 }

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringSerializer.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringSerializer.java
@@ -57,16 +57,16 @@ public class StringSerializer extends TypeSerializer<String> {
 
 	@Override
 	public void serialize(String record, DataOutputView target) throws IOException {
-		StringValue.writeUnicode(record, target);
+		StringValue.writeUnicodeString(record, target);
 	}
 
 	@Override
 	public String deserialize(String record, DataInputView source) throws IOException {
-		return StringValue.readUnicode(source);
+		return StringValue.readUnicodeString(source);
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		StringValue.copyUnicode(source, target);
+		StringValue.copyUnicodeString(source, target);
 	}
 }

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/StringValue.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/StringValue.java
@@ -841,7 +841,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 @param out output channel
 	 @throws IOException 
 	 */
-	public static final void writeUnicode(CharSequence cs, DataOutput out) throws IOException {
+	public static final void writeUnicodeString(CharSequence cs, DataOutput out) throws IOException {
 		if (cs == null) {
 			writeLength(0, out);
 		} else {
@@ -900,7 +900,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 @return Unicode String
 	 @throws IOException 
 	 */
-	public static final String readUnicode(DataInput in) throws IOException {
+	public static final String readUnicodeString(DataInput in) throws IOException {
 		int len = readLength(in);
 		
 		if(len==0){
@@ -969,7 +969,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 @param out output channel
 	 @throws IOException 
 	 */
-	public static final void copyUnicode(DataInput in, DataOutput out) throws IOException {
+	public static final void copyUnicodeString(DataInput in, DataOutput out) throws IOException {
 		//copy length
 		int length = readLength(in);
 		// the length we write is offset by one, because a length of zero indicates a null value
@@ -992,7 +992,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 @return A negative value if the first String is less than the second, 0 if equal, a positive value if greater.
 	 @throws IOException 
 	 */
-	public static final int compareUnicode(DataInputView firstSource, DataInputView secondSource) throws IOException {
+	public static final int compareUnicodeString(DataInputView firstSource, DataInputView secondSource) throws IOException {
 		int lengthFirst = readLength(firstSource);
 		int lengthSecond = readLength(secondSource);
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/StringValue.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/StringValue.java
@@ -874,9 +874,14 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 		}
 
 	}
-
+	
+	/**
+	Writes the given int variable-length encoded to the given DataOutput. NOT adjusted for null offset.
+	@param lenToWrite int to write
+	@param out output
+	@throws IOException 
+	*/
 	private static void writeLength(int lenToWrite, DataOutput out) throws IOException {
-		// the length we write is offset by one, because a length of zero indicates a null value
 		if (lenToWrite < 0) {
 			throw new IllegalArgumentException("CharSequence is too long.");
 		}
@@ -908,8 +913,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 			int r = 0;
 			int c;
 			while ((c = in.readUnsignedByte()) >= HIGH_BIT) {
-				c &= 0x7F;
-				r |= c;
+				r |= (c & 0x7F) ;
 				r <<= 7;
 			}
 			r |= c;
@@ -918,7 +922,13 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 		}
 		return new String(data, 0, len);
 	}
-
+	
+	/**
+	Reads a variable-length encoded int from the given DataInput. Adjusted for null offset.
+	@param in input
+	@return read int
+	@throws IOException 
+	*/
 	private static int readLength(DataInput in) throws IOException {
 		// the length we read is offset by one, because a length of zero indicates a null value
 		int len = in.readUnsignedByte();

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringComparatorTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringComparatorTest.java
@@ -42,7 +42,8 @@ public class StringComparatorTest extends ComparatorTestBase<String> {
 			"accd",
 			"bbcd",
 			"bbcde",
-			((char)128)+""+((char)32896)
+			((char)128)+""+((char)32896),
+			((char)128)+""+((char)32897)
 		};
 	}
 }

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringComparatorTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringComparatorTest.java
@@ -17,8 +17,6 @@ package eu.stratosphere.api.common.typeutils.base;
 import eu.stratosphere.api.common.typeutils.ComparatorTestBase;
 import eu.stratosphere.api.common.typeutils.TypeComparator;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
-import eu.stratosphere.api.common.typeutils.base.StringComparator;
-import eu.stratosphere.api.common.typeutils.base.StringSerializer;
 
 public class StringComparatorTest extends ComparatorTestBase<String> {
 
@@ -42,7 +40,9 @@ public class StringComparatorTest extends ComparatorTestBase<String> {
 			"abce",
 			"abdd",
 			"accd",
-			"bbcd"
+			"bbcd",
+			"bbcde",
+			((char)128)+""+((char)32896)
 		};
 	}
 }

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
@@ -42,7 +42,9 @@ public class StringSerializerTest extends SerializerTestBase<String> {
 	@Override
 	protected String[] getTestData() {
 		Random rnd = new Random(289347567856686223L);
-		return new String[] {StringUtils.getRandomString(rnd, 300, 350), new String(Character.toChars(127315)), 
+		return new String[] {
+			StringUtils.getRandomString(rnd, 300, 350), new String(Character.toChars(127315)), 
+			(char)128+(char)32896+"", // flag collisions
 			"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
 	}
 }

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
@@ -16,6 +16,8 @@ package eu.stratosphere.api.common.typeutils.base;
 
 import eu.stratosphere.api.common.typeutils.SerializerTestBase;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.util.StringUtils;
+import java.util.Random;
 
 /**
  * A test for the {@link StringSerializer}.
@@ -39,6 +41,8 @@ public class StringSerializerTest extends SerializerTestBase<String> {
 	
 	@Override
 	protected String[] getTestData() {
-		return new String[] {"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
+		Random rnd = new Random(289347567856686223L);
+		return new String[] {StringUtils.getRandomString(rnd, 300, 350), new String(Character.toChars(127315)), 
+			"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
 	}
 }

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
@@ -44,7 +44,9 @@ public class StringSerializerTest extends SerializerTestBase<String> {
 		Random rnd = new Random(289347567856686223L);
 		return new String[] {
 			StringUtils.getRandomString(rnd, 300, 350), new String(Character.toChars(127315)), 
-			(char)128+(char)32896+"", // flag collisions
+			(char)128+(char)32896+"", ""+(char)24640+(char)24640+(char)24640+(char)24640+(char)24640,
+			""+(char)65535+(char)65535+(char)65535+(char)65535+(char)65535,
+			""+(char)0,
 			"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
 	}
 }


### PR DESCRIPTION
The StringComparator now works on serialized data.

To this end new string read/write/copy/compare methods were introduced, which use a variable-length encoding for the characters.

~~key-points:~~
  ~~- The most significant bits are written/read first.~~
  ~~- The first 2 bits of the character are used to encode the size of the character.~~
 ~~- A character is at most 3 Bytes big.~~

Additionally, the StringSerializer now has full unicode support. ~~i couldn't find a unicode character that ~~uses more than 22 bits, as such 3 Bytes should be sufficient.~~
