### PR TITLE
[FLINK-898] Clean up distribution default config

### DIFF
--- a/stratosphere-dist/src/main/stratosphere-bin/conf/stratosphere-conf.yaml
+++ b/stratosphere-dist/src/main/stratosphere-bin/conf/stratosphere-conf.yaml
@@ -1,6 +1,6 @@
 ########################################################################################################################
 # 
-#  Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+#  Copyright (C) 2010-2014 by the Stratosphere project (http://stratosphere.eu)
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 #  the License. You may obtain a copy of the License at
@@ -13,103 +13,59 @@
 # 
 ########################################################################################################################
 
-#
-# This configuration file contains a list of the most commonly adjusted config parameters.
-# Please see the configuration reference for a list of all configurable options.
-#
-
-#=======================================================================================================================
-#                                                   SYSTEM ENVIRONMENT
-#=======================================================================================================================
-
-# Home directory of Java JVM installation (JAVA_HOME)
-# env.java.home: /usr/lib/jvm/java-7-oracle
-# env.java.opts: 
-
-#=======================================================================================================================
-#                                                   JOB MANAGER (MASTER)
-#=======================================================================================================================
+#==============================================================================
+# Common
+#==============================================================================
 
 jobmanager.rpc.address: localhost
 
 jobmanager.rpc.port: 6123
 
-# JVM heap size in MB
 jobmanager.heap.mb: 256
 
-jobmanager.profiling.enable: false
+taskmanager.heap.mb: 512
 
-# Number of RPC handler threads
-#jobmanager.rpc.numhandler: 8
+parallelization.degree.default: 1
+
+#==============================================================================
+# Web Frontend
+#==============================================================================
 
 jobmanager.web.port: 8081
 
-# Number of jobs that are kept in the history
-jobmanager.web.history: 5
-
-#=======================================================================================================================
-#                                                   TASK MANAGER (WORKERs)
-#=======================================================================================================================
-
-# Stratosphere chooses a port automatically, if this value is not set.
-# If setting this variable when using YARN, beware that there might be conflicts when multiple
-# TaskManagers are running on the same machine.
-#taskmanager.rpc.port: 6122
-
-# JVM heap size in MB
-taskmanager.heap.mb: 512
-
-# Directories for temporary files. Add a delimited list for multiple directories, using the system directory delimiter
-# (colon ':' on unix) or a comma character ','. An example would be /data1/tmp:/data2/tmp:/data3/tmp or
-# /data1/tmp,/data2/tmp,/data3/tmp
-# Note: Each directory entry is read from and written to by a different I/O thread. You can include the same directory
-# multiple times in that list to create multiple I/O threads against that directory. This is for example relevant for
-# high-throughput RAIDs.
-# If not specified, the system-specific Java temporary directory is taken (java.io.tmpdir property)
-# taskmanager.tmp.dirs: /tmp
-
-# Number of network buffers (used by each TaskManager)
-taskmanager.network.numberOfBuffers: 2048
-
-# Size of network buffers
-taskmanager.network.bufferSizeInBytes: 32768
-
-#=======================================================================================================================
-#                                                      CLIENTS
-#=======================================================================================================================
-
-# Specify the path to the Hadoop configuration. 
-# The Configuration is used when writing into HDFS. Unless specified, HDFS file creation will use HDFS default settings with
-# respect to block-size, replication factor, etc. 
-# (If the hdfs-site.xml file is in another location, specify it using fs.hdfs.hdfsdefault: /path/to/hadoop/conf/hdfs-site.xml)
-# fs.hdfs.hadoopconf: /path/to/hadoop/conf/
-
-#=======================================================================================================================
-#                                                    PARALLELISM
-#=======================================================================================================================
-
-# The default degree of parallelism for jobs, if no other degree is explicitly specified.
-parallelization.degree.default: -1
-
-# The maximum number of parallel instances per taskmanager. If set to -1, no limit exists.
-parallelization.intra-node.default: -1
-
-#=======================================================================================================================
-#                                                   WEB FRONTEND
-#=======================================================================================================================
-
 webclient.port: 8080
 
-webclient.rootpath: ./resources/web-docs/
+#==============================================================================
+# Advanced
+#==============================================================================
 
-# The temp directory for the web server
-# If not specified, the system-specific Java temporary directory is taken (java.io.tmpdir property)
-# webclient.tempdir: /tmp
+# The number of buffers for the network stack.
+#
+# taskmanager.network.numberOfBuffers: 2048
 
-# Directory into which the web server will store uploaded PACT programs
-# If not specified, the system-specific Java temporary directory is taken (java.io.tmpdir property) as base.
-# webclient.uploaddir: /tmp/webclient-jobs
+# Directories for temporary files.
+#
+# Add a delimited list for multiple directories, using the system directory
+# delimiter (colon ':' on unix) or a comma, e.g.:
+#     /data1/tmp:/data2/tmp:/data3/tmp
+#
+# Note: Each directory entry is read from and written to by a different I/O
+# thread. You can include the same directory multiple times in order to create
+# multiple I/O threads against that directory. This is for example relevant for
+# high-throughput RAIDs.
+#
+# If not specified, the system-specific Java temporary directory (java.io.tmpdir
+# property) is taken.
+#
+# taskmanager.tmp.dirs: /tmp
 
-# The directory into which the web server will dump temporary JSON files describing pact plans
-# If not specified, the system-specific Java temporary directory is taken (java.io.tmpdir property) as base.
-# webclient.plandump: /tmp/webclient-plans
+# Path to the Hadoop configuration directory.
+#
+# This configuration is used when writing into HDFS. Unless specified otherwise,
+# HDFS file creation will use HDFS default settings with respect to block-size,
+# replication factor, etc.
+#
+# You can also directly specify the paths to hdfs-default.xml and hdfs-site.xml
+# via keys 'fs.hdfs.hdfsdefault' and 'fs.hdfs.hdfssite'.
+#
+# fs.hdfs.hadoopconf: /path/to/hadoop/conf/


### PR DESCRIPTION
This PR cleans up the distribution default config.

Removed entries:
- `env.java.home`,
- `env.java.opts`,
- `jobmanager.profiling.enable`,
- `jobmanager.rpc.handler`, 
- `jobmanager.web.history`,
- `taskmanager.rpc.port`,
- `taskmanager.network.bufferSizeInBytes`,
- `webclient.rootpath`,
- `webclient.tempdir`,
- `webclient.uploaddir`, and
- `webclient.plandump`.

Active entries:
- `jobmanager.rpc.address: localhost`
- `jobmanager.rpc.port: 6123`,
- `jobmanager.heap.mb: 256`,
- `taskmanager.heap.mb: 512`,
- `parallelization.degree.default: 1`,
- `jobmanager.web.port: 8081`, and
- `webclient.port: 8080`.

Suggested entries:
- `taskmanager.network.numberOfBuffers: 2048`,
- `taskmanager.tmp.dirs: /tmp`, and
- `fs.hdfs.hadoopconf: /path/to/hadoop/conf/`.

`webclient.port` and `taskmanager.network.numberOfBuffers` will be removed in the future, when the web interfaces have been merged and the memory management reworked.
