### PR TITLE
[FLINK-934] Remove default values for JVM heap sizes in startup scripts

### DIFF
--- a/stratosphere-dist/src/main/stratosphere-bin/bin/config.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/config.sh
@@ -62,8 +62,6 @@ readFromConfig() {
 # WARNING !!! , these values are only used if there is nothing else is specified in
 # conf/stratosphere-conf.yaml
 
-DEFAULT_JOBM_HEAP_MB=256                            # Java heap size for the JobManager (in MB)
-DEFAULT_TASKM_HEAP_MB=512                           # Java heap size for the TaskManager (in MB)
 DEFAULT_ENV_PID_DIR="/tmp"                          # Directory to store *.pid files to
 DEFAULT_ENV_LOG_MAX=5                               # Maximum number of old log files to keep
 DEFAULT_ENV_JAVA_OPTS=""                            # Optional JVM args
@@ -153,12 +151,12 @@ fi
 
 # Define STRATOSPHERE_JM_HEAP if it is not already set
 if [ -z "${STRATOSPHERE_JM_HEAP}" ]; then
-    STRATOSPHERE_JM_HEAP=$(readFromConfig ${KEY_JOBM_HEAP_MB} ${DEFAULT_JOBM_HEAP_MB} "${YAML_CONF}")
+    STRATOSPHERE_JM_HEAP=$(readFromConfig ${KEY_JOBM_HEAP_MB} 0 "${YAML_CONF}")
 fi
 
 # Define STRATOSPHERE_TM_HEAP if it is not already set
 if [ -z "${STRATOSPHERE_TM_HEAP}" ]; then
-    STRATOSPHERE_TM_HEAP=$(readFromConfig ${KEY_TASKM_HEAP_MB} ${DEFAULT_TASKM_HEAP_MB} "${YAML_CONF}")
+    STRATOSPHERE_TM_HEAP=$(readFromConfig ${KEY_TASKM_HEAP_MB} 0 "${YAML_CONF}")
 fi
 
 if [ -z "${MAX_LOG_FILE_NUMBER}" ]; then

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/jobmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/jobmanager.sh
@@ -26,7 +26,11 @@ if [ "$EXECUTIONMODE" = "local" ]; then
     STRATOSPHERE_JM_HEAP=`expr $STRATOSPHERE_JM_HEAP + $STRATOSPHERE_TM_HEAP`
 fi
 
-JVM_ARGS="$JVM_ARGS -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m -Xms"$STRATOSPHERE_JM_HEAP"m -Xmx"$STRATOSPHERE_JM_HEAP"m"
+JVM_ARGS="$JVM_ARGS -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m"
+
+if [ "$STRATOSPHERE_JM_HEAP" -gt 0 ]; then
+    JVM_ARGS="$JVM_ARGS -Xms"$STRATOSPHERE_JM_HEAP"m -Xmx"$STRATOSPHERE_JM_HEAP"m"
+fi
 
 if [ "$STRATOSPHERE_IDENT_STRING" = "" ]; then
     STRATOSPHERE_IDENT_STRING="$USER"

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/taskmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/taskmanager.sh
@@ -47,7 +47,11 @@ out=$STRATOSPHERE_LOG_DIR/stratosphere-$STRATOSPHERE_IDENT_STRING-taskmanager-$H
 pid=$STRATOSPHERE_PID_DIR/stratosphere-$STRATOSPHERE_IDENT_STRING-taskmanager.pid
 log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$STRATOSPHERE_CONF_DIR"/log4j.properties)
 
-JVM_ARGS="$JVM_ARGS -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m -XX:NewRatio=6 -Xms"$STRATOSPHERE_TM_HEAP"m -Xmx"$STRATOSPHERE_TM_HEAP"m"
+JVM_ARGS="$JVM_ARGS -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m -XX:NewRatio=6"
+
+if [ "$STRATOSPHERE_TM_HEAP" -gt 0 ]; then
+    JVM_ARGS="$JVM_ARGS -Xms"$STRATOSPHERE_TM_HEAP"m -Xmx"$STRATOSPHERE_TM_HEAP"m"
+fi
 
 case $STARTSTOP in
 


### PR DESCRIPTION
This is a fix for [FLINK-934](https://issues.apache.org/jira/browse/FLINK-934). As a follow up we should have the heap config keys only as suggested entries (commented out) in [FLINK-898](https://issues.apache.org/jira/browse/FLINK-898) aka #6.

With `jobmanager.heap.mb` and `taskmanager.heap.mb` not set, 16 GB of main memory and Java 7.

``` bash
$ ./bin/start-local.sh 
Starting job manager
$ jps
9601 JobManager
$ jinfo -flag MaxHeapSize 9601
-XX:MaxHeapSize=4294967296
```

JobManager with 4294967296/2^20 = 4096 MB heap size.

---

``` bash
$ bin/start-cluster.sh 
Starting job manager
Starting task manager on host batman
$ jps
10049 TaskManager
9966 JobManager
$ jinfo -flag MaxHeapSize 9966
-XX:MaxHeapSize=4294967296
$jinfo -flag MaxHeapSize 10049
-XX:MaxHeapSize=4294967296
```

Both JobManager and TaskManager with 4294967296/2^20 = 4096 MB heap size each.

---

Setting `jobmanager.heap.mb` and `taskmanager.heap.mb` to 256 and 512 MB respectively.

``` bash
$ bin/start-local.sh 
Starting job manager
$ jps
10542 JobManager
$ jinfo -flag MaxHeapSize 10542
-XX:MaxHeapSize=805306368
```

JobManager with 805306368/2^20 = 768 MB (256 for the JobManager and 512 MB for the TaskManager).

---

``` bash
$ bin/start-cluster.sh 
Starting job manager
Starting task manager on host batman
$ jps
10833 JobManager
10918 TaskManager
$ jinfo -flag MaxHeapSize 10833
-XX:MaxHeapSize=268435456
$jinfo -flag MaxHeapSize 10918
-XX:MaxHeapSize=536870912
```

JobManager with 268435456/2^20 = 256 MB and TaskManager with 536870912/2^20 = 512 MB.
