### PR TITLE
[FLINK-758] Add initial value to GenericReduce and adjust AllReduceDriver

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericReduce.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericReduce.java
@@ -13,8 +13,12 @@
 
 package eu.stratosphere.api.common.functions;
 
-
 public interface GenericReduce<T> extends Function {
-	
+
 	T reduce(T value1, T value2) throws Exception;
+
+	T getInitialValue();
+
+	void setInitialValue(T value);
+
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -243,6 +243,13 @@ public abstract class DataSet<T> {
 		}
 		return new ReduceOperator<T>(this, reducer);
 	}
+
+	public ReduceOperator<T> reduce(ReduceFunction<T> reducer, T initialValue) {
+		if (reducer == null) {
+			throw new NullPointerException("Reduce function must not be null.");
+		}
+		return new ReduceOperator<T>(this, reducer, initialValue);
+	}
 	
 	/**
 	 * Applies a GroupReduce transformation on a non-grouped {@link DataSet}.<br/>

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/ReduceFunction.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/ReduceFunction.java
@@ -41,8 +41,10 @@ import eu.stratosphere.api.common.functions.GenericReduce;
  * @param <IN> Type of the elements that this function processes.
  */
 public abstract class ReduceFunction<T> extends AbstractFunction implements GenericReduce<T> {
-	
+
 	private static final long serialVersionUID = 1L;
+
+	private T initialValue;
 
 	/**
 	 * The core method of the ReduceFunction, combining two values into one value of the same type.
@@ -56,4 +58,14 @@ public abstract class ReduceFunction<T> extends AbstractFunction implements Gene
 	 *                   to fail and may trigger recovery.
 	 */
 	public abstract T reduce(T value1, T value2) throws Exception;
+
+	@Override
+	public void setInitialValue(T value) {
+		initialValue = value;
+	}
+
+	@Override
+	public T getInitialValue() {
+		return initialValue;
+	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
@@ -58,6 +58,16 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		
 		extractSemanticAnnotationsFromUdf(function.getClass());
 	}
+
+	public ReduceOperator(DataSet<IN> input, ReduceFunction<IN> function, IN initialValue) {
+		super(input, input.getType());
+
+		this.function = function;
+		this.function.setInitialValue(initialValue);
+		this.grouper = null;
+
+		extractSemanticAnnotationsFromUdf(function.getClass());
+	}
 	
 	
 	public ReduceOperator(Grouping<IN> input, ReduceFunction<IN> function) {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanUnwrappingReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanUnwrappingReduceOperator.java
@@ -39,7 +39,8 @@ public class PlanUnwrappingReduceOperator<T, K> extends ReduceOperatorBase<Tuple
 		implements GenericReduce<Tuple2<K, T>>
 	{
 		private static final long serialVersionUID = 1L;
-		
+
+		private Tuple2<K, T> initialValue;
 
 		private ReduceWrapper(ReduceFunction<T> wrapped) {
 			super(wrapped);
@@ -49,6 +50,16 @@ public class PlanUnwrappingReduceOperator<T, K> extends ReduceOperatorBase<Tuple
 		public Tuple2<K, T> reduce(Tuple2<K, T> value1, Tuple2<K, T> value2) throws Exception {
 			value1.f1 = this.wrappedFunction.reduce(value1.f1, value2.f1);
 			return value1;
+		}
+
+		@Override
+		public void setInitialValue(Tuple2<K, T> value) {
+			initialValue = value;
+		}
+
+		@Override
+		public Tuple2<K, T> getInitialValue() {
+			return initialValue;
 		}
 	}
 }

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/drivers/AllReduceDriverTest.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/drivers/AllReduceDriverTest.java
@@ -15,25 +15,24 @@
 
 package eu.stratosphere.pact.runtime.task.drivers;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import eu.stratosphere.api.common.functions.GenericReduce;
 import eu.stratosphere.api.java.functions.ReduceFunction;
 import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.api.java.typeutils.TypeExtractor;
 import eu.stratosphere.pact.runtime.task.AllReduceDriver;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
-import eu.stratosphere.pact.runtime.test.util.DiscardingOutputCollector;
 import eu.stratosphere.pact.runtime.util.EmptyMutableObjectIterator;
 import eu.stratosphere.pact.runtime.util.RegularToMutableObjectIterator;
 import eu.stratosphere.types.IntValue;
 import eu.stratosphere.types.StringValue;
 import eu.stratosphere.types.TypeInformation;
 import eu.stratosphere.util.MutableObjectIterator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @SuppressWarnings("serial")
 public class AllReduceDriverTest {
@@ -42,178 +41,298 @@ public class AllReduceDriverTest {
 	public void testAllReduceDriverImmutableEmpty() {
 		try {
 			TestTaskContext<GenericReduce<Tuple2<String, Integer>>, Tuple2<String, Integer>> context =
-					new TestTaskContext<GenericReduce<Tuple2<String,Integer>>, Tuple2<String,Integer>>();
-			
+					new TestTaskContext<GenericReduce<Tuple2<String, Integer>>, Tuple2<String, Integer>>();
+
 			List<Tuple2<String, Integer>> data = DriverTestData.createReduceImmutableData();
 			TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(data.get(0));
 			MutableObjectIterator<Tuple2<String, Integer>> input = EmptyMutableObjectIterator.get();
+			GatheringCollector<Tuple2<String, Integer>> result = new GatheringCollector<Tuple2<String, Integer>>(typeInfo.createSerializer());
+
 			context.setDriverStrategy(DriverStrategy.ALL_REDUCE);
-			
 			context.setInput1(input, typeInfo.createSerializer());
-			context.setCollector(new DiscardingOutputCollector<Tuple2<String, Integer>>());
-			
-			AllReduceDriver<Tuple2<String, Integer>> driver = new AllReduceDriver<Tuple2<String,Integer>>();
+			context.setCollector(result);
+
+			AllReduceDriver<Tuple2<String, Integer>> driver = new AllReduceDriver<Tuple2<String, Integer>>();
 			driver.setup(context);
 			driver.prepare();
 			driver.run();
-		}
-		catch (Exception e) {
+
+			Assert.assertEquals("Expected no collect() for empty input", 0, result.getList().size());
+		} catch (Exception e) {
 			System.err.println(e.getMessage());
 			e.printStackTrace();
 			Assert.fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testAllReduceDriverImmutable() {
 		try {
-			{
-				TestTaskContext<GenericReduce<Tuple2<String, Integer>>, Tuple2<String, Integer>> context =
-						new TestTaskContext<GenericReduce<Tuple2<String,Integer>>, Tuple2<String,Integer>>();
-				
-				List<Tuple2<String, Integer>> data = DriverTestData.createReduceImmutableData();
-				TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(data.get(0));
-				MutableObjectIterator<Tuple2<String, Integer>> input = new RegularToMutableObjectIterator<Tuple2<String, Integer>>(data.iterator(), typeInfo.createSerializer());
-				
-				GatheringCollector<Tuple2<String, Integer>> result = new GatheringCollector<Tuple2<String,Integer>>(typeInfo.createSerializer());
-				
-				context.setDriverStrategy(DriverStrategy.ALL_REDUCE);
-				context.setInput1(input, typeInfo.createSerializer());
-				context.setCollector(result);
-				context.setUdf(new ConcatSumFirstReducer());
-				
-				AllReduceDriver<Tuple2<String, Integer>> driver = new AllReduceDriver<Tuple2<String,Integer>>();
-				driver.setup(context);
-				driver.prepare();
-				driver.run();
-				
-				Tuple2<String,Integer> res = result.getList().get(0);
-				
-				char[] foundString = res.f0.toCharArray();
-				Arrays.sort(foundString);
-				
-				char[] expectedString = "abcddeeeffff".toCharArray();
-				Arrays.sort(expectedString);
-				
-				Assert.assertArrayEquals(expectedString, foundString);
-				Assert.assertEquals(78, res.f1.intValue());
-			}
-			
-			{
-				TestTaskContext<GenericReduce<Tuple2<String, Integer>>, Tuple2<String, Integer>> context =
-						new TestTaskContext<GenericReduce<Tuple2<String,Integer>>, Tuple2<String,Integer>>();
-				
-				List<Tuple2<String, Integer>> data = DriverTestData.createReduceImmutableData();
-				TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(data.get(0));
-				MutableObjectIterator<Tuple2<String, Integer>> input = new RegularToMutableObjectIterator<Tuple2<String, Integer>>(data.iterator(), typeInfo.createSerializer());
-				
-				GatheringCollector<Tuple2<String, Integer>> result = new GatheringCollector<Tuple2<String,Integer>>(typeInfo.createSerializer());
-				
-				context.setDriverStrategy(DriverStrategy.ALL_REDUCE);
-				context.setInput1(input, typeInfo.createSerializer());
-				context.setCollector(result);
-				context.setUdf(new ConcatSumSecondReducer());
-				
-				AllReduceDriver<Tuple2<String, Integer>> driver = new AllReduceDriver<Tuple2<String,Integer>>();
-				driver.setup(context);
-				driver.prepare();
-				driver.run();
-				
-				Tuple2<String,Integer> res = result.getList().get(0);
-				
-				char[] foundString = res.f0.toCharArray();
-				Arrays.sort(foundString);
-				
-				char[] expectedString = "abcddeeeffff".toCharArray();
-				Arrays.sort(expectedString);
-				
-				Assert.assertArrayEquals(expectedString, foundString);
-				Assert.assertEquals(78, res.f1.intValue());
-			}
-		}
-		catch (Exception e) {
+			List<Tuple2<String, Integer>> data = DriverTestData.createReduceImmutableData();
+			TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(data.get(0));
+
+			ConcatSumFirstReducer udf1 = new ConcatSumFirstReducer();
+			ConcatSumSecondReducer udf2 = new ConcatSumSecondReducer();
+
+			String expectedString = "abcddeeeffff";
+			int expectedValue = 78;
+
+			verifyAllReduceDriver(data, typeInfo, udf1, expectedString, expectedValue);
+			verifyAllReduceDriver(data, typeInfo, udf2, expectedString, expectedValue);
+		} catch (Exception e) {
 			System.err.println(e.getMessage());
 			e.printStackTrace();
 			Assert.fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testAllReduceDriverMutable() {
 		try {
-			{
-				TestTaskContext<GenericReduce<Tuple2<StringValue, IntValue>>, Tuple2<StringValue, IntValue>> context =
-						new TestTaskContext<GenericReduce<Tuple2<StringValue, IntValue>>, Tuple2<StringValue, IntValue>>();
-				
-				List<Tuple2<StringValue, IntValue>> data = DriverTestData.createReduceMutableData();
-				TypeInformation<Tuple2<StringValue, IntValue>> typeInfo = TypeExtractor.getForObject(data.get(0));
-				MutableObjectIterator<Tuple2<StringValue, IntValue>> input = new RegularToMutableObjectIterator<Tuple2<StringValue, IntValue>>(data.iterator(), typeInfo.createSerializer());
-				
-				GatheringCollector<Tuple2<StringValue, IntValue>> result = new GatheringCollector<Tuple2<StringValue, IntValue>>(typeInfo.createSerializer());
-				
-				context.setDriverStrategy(DriverStrategy.ALL_REDUCE);
-				context.setInput1(input, typeInfo.createSerializer());
-				context.setCollector(result);
-				context.setUdf(new ConcatSumFirstMutableReducer());
-				
-				AllReduceDriver<Tuple2<StringValue, IntValue>> driver = new AllReduceDriver<Tuple2<StringValue, IntValue>>();
-				driver.setup(context);
-				driver.prepare();
-				driver.run();
-				
-				Tuple2<StringValue, IntValue> res = result.getList().get(0);
-				
-				char[] foundString = res.f0.getValue().toCharArray();
-				Arrays.sort(foundString);
-				
-				char[] expectedString = "abcddeeeffff".toCharArray();
-				Arrays.sort(expectedString);
-				
-				Assert.assertArrayEquals(expectedString, foundString);
-				Assert.assertEquals(78, res.f1.getValue());
-			}
-			{
-				TestTaskContext<GenericReduce<Tuple2<StringValue, IntValue>>, Tuple2<StringValue, IntValue>> context =
-						new TestTaskContext<GenericReduce<Tuple2<StringValue, IntValue>>, Tuple2<StringValue, IntValue>>();
-				
-				List<Tuple2<StringValue, IntValue>> data = DriverTestData.createReduceMutableData();
-				TypeInformation<Tuple2<StringValue, IntValue>> typeInfo = TypeExtractor.getForObject(data.get(0));
-				MutableObjectIterator<Tuple2<StringValue, IntValue>> input = new RegularToMutableObjectIterator<Tuple2<StringValue, IntValue>>(data.iterator(), typeInfo.createSerializer());
-				
-				GatheringCollector<Tuple2<StringValue, IntValue>> result = new GatheringCollector<Tuple2<StringValue, IntValue>>(typeInfo.createSerializer());
-				
-				context.setDriverStrategy(DriverStrategy.ALL_REDUCE);
-				context.setInput1(input, typeInfo.createSerializer());
-				context.setCollector(result);
-				context.setUdf(new ConcatSumSecondMutableReducer());
-				
-				AllReduceDriver<Tuple2<StringValue, IntValue>> driver = new AllReduceDriver<Tuple2<StringValue, IntValue>>();
-				driver.setup(context);
-				driver.prepare();
-				driver.run();
-				
-				Tuple2<StringValue, IntValue> res = result.getList().get(0);
-				
-				char[] foundString = res.f0.getValue().toCharArray();
-				Arrays.sort(foundString);
-				
-				char[] expectedString = "abcddeeeffff".toCharArray();
-				Arrays.sort(expectedString);
-				
-				Assert.assertArrayEquals(expectedString, foundString);
-				Assert.assertEquals(78, res.f1.getValue());
-			}
-		}
-		catch (Exception e) {
+			List<Tuple2<StringValue, IntValue>> data = DriverTestData.createReduceMutableData();
+			TypeInformation<Tuple2<StringValue, IntValue>> typeInfo = TypeExtractor.getForObject(data.get(0));
+
+			ConcatSumFirstMutableReducer udf1 = new ConcatSumFirstMutableReducer();
+			ConcatSumSecondMutableReducer udf2 = new ConcatSumSecondMutableReducer();
+
+			String expectedString = "abcddeeeffff";
+			int expectedValue = 78;
+
+			verifyAllReduceDriver(data, typeInfo, udf1, expectedString, expectedValue);
+			verifyAllReduceDriver(data, typeInfo, udf2, expectedString, expectedValue);
+		} catch (Exception e) {
 			System.err.println(e.getMessage());
 			e.printStackTrace();
 			Assert.fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testAllReduceDriverImmutableWithInitialValue() {
+		try {
+			{
+				// initial value only
+				List<Tuple2<String, Integer>> data = DriverTestData.createReduceImmutableData();
+
+				TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(data.get(0));
+
+				ConcatSumFirstReducer firstUdf = new ConcatSumFirstReducer();
+				firstUdf.setInitialValue(data.get(0));
+
+				ConcatSumSecondReducer secondUdf = new ConcatSumSecondReducer();
+				secondUdf.setInitialValue(data.get(0));
+
+				String expectedString = "a";
+				int expectedValue = 1;
+
+				verifyAllReduceDriver(Collections.EMPTY_LIST, typeInfo, firstUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(Collections.EMPTY_LIST, typeInfo, secondUdf, expectedString, expectedValue);
+			}
+
+			{
+				List<Tuple2<String, Integer>> firstData = DriverTestData.createReduceImmutableData();
+				List<Tuple2<String, Integer>> secondData = DriverTestData.createReduceImmutableData();
+
+				TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(firstData.get(0));
+
+				// initial value and single input
+				ConcatSumFirstReducer firstUdf = new ConcatSumFirstReducer();
+				firstUdf.setInitialValue(firstData.get(0));
+
+				ConcatSumSecondReducer secondUdf = new ConcatSumSecondReducer();
+				secondUdf.setInitialValue(secondData.get(0));
+
+				String expectedString = "aa";
+				int expectedValue = 2;
+
+				verifyAllReduceDriver(firstData.subList(0, 1), typeInfo, firstUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(secondData.subList(0, 1), typeInfo, secondUdf, expectedString, expectedValue);
+			}
+
+			{
+				// initial value and two inputs
+				List<Tuple2<String, Integer>> firstData = DriverTestData.createReduceImmutableData();
+				List<Tuple2<String, Integer>> secondData = DriverTestData.createReduceImmutableData();
+
+				TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(firstData.get(0));
+
+				ConcatSumFirstReducer firstUdf = new ConcatSumFirstReducer();
+				firstUdf.setInitialValue(firstData.get(0));
+
+				ConcatSumSecondReducer secondUdf = new ConcatSumSecondReducer();
+				secondUdf.setInitialValue(secondData.get(0));
+
+				String expectedString = "aab";
+				int expectedValue = 4;
+
+				verifyAllReduceDriver(firstData.subList(0, 2), typeInfo, firstUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(secondData.subList(0, 2), typeInfo, secondUdf, expectedString, expectedValue);
+			}
+
+			{
+				List<Tuple2<String, Integer>> firstData = DriverTestData.createReduceImmutableData();
+				List<Tuple2<String, Integer>> secondData = DriverTestData.createReduceImmutableData();
+
+				TypeInformation<Tuple2<String, Integer>> typeInfo = TypeExtractor.getForObject(firstData.get(0));
+
+				// initial value and all
+				ConcatSumFirstReducer firstUdf = new ConcatSumFirstReducer();
+				firstUdf.setInitialValue(firstData.get(0));
+
+				ConcatSumSecondReducer secondUdf = new ConcatSumSecondReducer();
+				secondUdf.setInitialValue(secondData.get(0));
+
+				String expectedString = "aabcddeeeffff";
+				int expectedValue = 79;
+
+				verifyAllReduceDriver(firstData, typeInfo, firstUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(secondData, typeInfo, secondUdf, expectedString, expectedValue);
+			}
+		} catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testAllReduceDriverMutableWithInitialValue() {
+		try {
+			{
+				List<Tuple2<StringValue, IntValue>> data = DriverTestData.createReduceMutableData();
+
+				TypeInformation<Tuple2<StringValue, IntValue>> typeInfo = TypeExtractor.getForObject(data.get(0));
+
+				// initial value only
+				ConcatSumFirstMutableReducer firstUdf = new ConcatSumFirstMutableReducer();
+				firstUdf.setInitialValue(data.get(0));
+
+				ConcatSumSecondMutableReducer secondUdf = new ConcatSumSecondMutableReducer();
+				secondUdf.setInitialValue(data.get(0));
+
+				String expectedString = "a";
+				int expectedValue = 1;
+
+				verifyAllReduceDriver(Collections.EMPTY_LIST, typeInfo, firstUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(Collections.EMPTY_LIST, typeInfo, secondUdf, expectedString, expectedValue);
+			}
+
+			{
+				List<Tuple2<StringValue, IntValue>> firstData = DriverTestData.createReduceMutableData();
+				List<Tuple2<StringValue, IntValue>> secondData = DriverTestData.createReduceMutableData();
+
+				TypeInformation<Tuple2<StringValue, IntValue>> typeInfo = TypeExtractor.getForObject(firstData.get(0));
+
+				// initial value and single data point
+				ConcatSumFirstMutableReducer firstUdf = new ConcatSumFirstMutableReducer();
+				firstUdf.setInitialValue(firstData.get(0));
+
+				ConcatSumSecondMutableReducer secondUdf = new ConcatSumSecondMutableReducer();
+				secondUdf.setInitialValue(secondData.get(0));
+
+				String expectedString = "aa";
+				int expectedValue = 2;
+
+				verifyAllReduceDriver(firstData.subList(0, 1), typeInfo, firstUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(secondData.subList(0, 1), typeInfo, secondUdf, expectedString, expectedValue);
+			}
+
+			{
+				List<Tuple2<StringValue, IntValue>> firstData = DriverTestData.createReduceMutableData();
+				List<Tuple2<StringValue, IntValue>> secondData = DriverTestData.createReduceMutableData();
+
+				TypeInformation<Tuple2<StringValue, IntValue>> typeInfo = TypeExtractor.getForObject(firstData.get(0));
+
+				// initial value and data points
+				ConcatSumFirstMutableReducer firstUdf = new ConcatSumFirstMutableReducer();
+				firstUdf.setInitialValue(firstData.get(0));
+
+				ConcatSumSecondMutableReducer secondUdf = new ConcatSumSecondMutableReducer();
+				secondUdf.setInitialValue(secondData.get(0));
+
+				String expectedString = "aab";
+				int expectedValue = 4;
+
+				verifyAllReduceDriver(firstData.subList(0, 2), typeInfo, secondUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(secondData.subList(0, 2), typeInfo, secondUdf, expectedString, expectedValue);
+			}
+
+			{
+				List<Tuple2<StringValue, IntValue>> firstData = DriverTestData.createReduceMutableData();
+				List<Tuple2<StringValue, IntValue>> secondData = DriverTestData.createReduceMutableData();
+
+				TypeInformation<Tuple2<StringValue, IntValue>> typeInfo = TypeExtractor.getForObject(firstData.get(0));
+
+				// initial value and all
+				ConcatSumFirstMutableReducer firstUdf = new ConcatSumFirstMutableReducer();
+				firstUdf.setInitialValue(firstData.get(0));
+
+				ConcatSumSecondMutableReducer secondUdf = new ConcatSumSecondMutableReducer();
+				secondUdf.setInitialValue(secondData.get(0));
+
+				String expectedString = "aabcddeeeffff";
+				int expectedValue = 79;
+
+				verifyAllReduceDriver(firstData.subList(0, firstData.size()), typeInfo, firstUdf, expectedString, expectedValue);
+				verifyAllReduceDriver(secondData.subList(0, secondData.size()), typeInfo, secondUdf, expectedString, expectedValue);
+			}
+		} catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	private <S, T> void verifyAllReduceDriver(List<Tuple2<S, T>> data, TypeInformation<Tuple2<S, T>> typeInfo,
+											ReduceFunction<Tuple2<S, T>> udf, String expectedString, int expectedInt)
+			throws Exception {
+
+		TestTaskContext<GenericReduce<Tuple2<S, T>>, Tuple2<S, T>> context =
+				new TestTaskContext<GenericReduce<Tuple2<S, T>>, Tuple2<S, T>>();
+
+		MutableObjectIterator<Tuple2<S, T>> input = new RegularToMutableObjectIterator<Tuple2<S, T>>(data.iterator(), typeInfo.createSerializer());
+
+		GatheringCollector<Tuple2<S, T>> result = new GatheringCollector<Tuple2<S, T>>(typeInfo.createSerializer());
+
+		context.setDriverStrategy(DriverStrategy.ALL_REDUCE);
+		context.setInput1(input, typeInfo.createSerializer());
+		context.setCollector(result);
+		context.setUdf(udf);
+
+		AllReduceDriver<Tuple2<S, T>> driver = new AllReduceDriver<Tuple2<S, T>>();
+		driver.setup(context);
+		driver.prepare();
+		driver.run();
+
+		Assert.assertEquals("Expected single collected result.", 1, result.getList().size());
+
+		Tuple2<S, T> res = result.getList().get(0);
+
+		char[] actualStringCharArray;
+		int actualInt;
+
+		if (res.f0.getClass() == StringValue.class) {
+			actualStringCharArray = ((StringValue) res.f0).getCharArray();
+			actualInt = ((IntValue) res.f1).getValue();
+		}
+		else {
+			actualStringCharArray = ((String) res.f0).toCharArray();
+			actualInt = (Integer) res.f1;
+		}
+
+		Arrays.sort(actualStringCharArray);
+
+		char[] expectedStringCharArray = expectedString.toCharArray();
+		Arrays.sort(expectedStringCharArray);
+
+		Assert.assertArrayEquals(expectedStringCharArray, actualStringCharArray);
+		Assert.assertEquals(expectedInt, actualInt);
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Test UDFs
 	// --------------------------------------------------------------------------------------------
-	
+
 	public static final class ConcatSumFirstReducer extends ReduceFunction<Tuple2<String, Integer>> {
 
 		@Override
@@ -223,9 +342,9 @@ public class AllReduceDriverTest {
 			return value1;
 		}
 	}
-	
+
 	public static final class ConcatSumSecondReducer extends ReduceFunction<Tuple2<String, Integer>> {
-		
+
 		@Override
 		public Tuple2<String, Integer> reduce(Tuple2<String, Integer> value1, Tuple2<String, Integer> value2) {
 			value2.f0 = value1.f0 + value2.f0;
@@ -233,7 +352,7 @@ public class AllReduceDriverTest {
 			return value2;
 		}
 	}
-	
+
 	public static final class ConcatSumFirstMutableReducer extends ReduceFunction<Tuple2<StringValue, IntValue>> {
 
 		@Override
@@ -243,7 +362,7 @@ public class AllReduceDriverTest {
 			return value1;
 		}
 	}
-	
+
 	public static final class ConcatSumSecondMutableReducer extends ReduceFunction<Tuple2<StringValue, IntValue>> {
 
 		@Override


### PR DESCRIPTION
This is an initial version of introducing an initial value to the reduce functions. Thanks to @fhueske for suggesting to add the initial value to `GenericReduce`.

It is only implemented for `AllReduce` (ungrouped reduce). Please give feedback. If everything is OK, I would continue (~ 1 hr) with the remaining reduce variants (grouped reduce, ungrouped groupreduce, and grouped groupreduce).
