### PR TITLE
FLINK-944 Changed serialization logic of CollectionInputFormat to use TypeSerializer

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/ByteArrayInputView.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/ByteArrayInputView.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.api.common.io;
+
+import eu.stratosphere.core.memory.DataInputView;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ * Wrapper to use ByteArrayInputStream with TypeSerializers
+ */
+public class ByteArrayInputView implements DataInputView{
+
+	private final ByteArrayInputStream byteArrayInputStream;
+	private final DataInputStream inputStream;
+
+	public ByteArrayInputView(byte[] buffer){
+		byteArrayInputStream = new ByteArrayInputStream(buffer);
+		inputStream = new DataInputStream(byteArrayInputStream);
+	}
+
+	@Override
+	public void skipBytesToRead(int numBytes) throws IOException {
+		inputStream.skipBytes(numBytes);
+	}
+
+	@Override
+	public void readFully(byte[] b) throws IOException {
+		inputStream.readFully(b);
+	}
+
+	@Override
+	public void readFully(byte[] b, int off, int len) throws IOException {
+		inputStream.readFully(b, off, len);
+	}
+
+	@Override
+	public int skipBytes(int n) throws IOException {
+		return inputStream.skipBytes(n);
+	}
+
+	@Override
+	public boolean readBoolean() throws IOException {
+		return inputStream.readBoolean();
+	}
+
+	@Override
+	public byte readByte() throws IOException {
+		return inputStream.readByte();
+	}
+
+	@Override
+	public int readUnsignedByte() throws IOException {
+		return inputStream.readUnsignedByte();
+	}
+
+	@Override
+	public short readShort() throws IOException {
+		return inputStream.readShort();
+	}
+
+	@Override
+	public int readUnsignedShort() throws IOException {
+		return inputStream.readUnsignedShort();
+	}
+
+	@Override
+	public char readChar() throws IOException {
+		return inputStream.readChar();
+	}
+
+	@Override
+	public int readInt() throws IOException {
+		return inputStream.readInt();
+	}
+
+	@Override
+	public long readLong() throws IOException {
+		return inputStream.readLong();
+	}
+
+	@Override
+	public float readFloat() throws IOException {
+		return inputStream.readFloat();
+	}
+
+	@Override
+	public double readDouble() throws IOException {
+		return inputStream.readDouble();
+	}
+
+	@Override
+	public String readLine() throws IOException {
+		return inputStream.readLine();
+	}
+
+	@Override
+	public String readUTF() throws IOException {
+		return inputStream.readUTF();
+	}
+}

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/ByteArrayOutputView.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/ByteArrayOutputView.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.api.common.io;
+
+import eu.stratosphere.core.memory.DataInputView;
+import eu.stratosphere.core.memory.DataOutputView;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Wrapper class to use ByteArrayOutputStream with TypeSerializers.
+ */
+public class ByteArrayOutputView implements DataOutputView {
+	private final ByteArrayOutputStream byteOutputStream;
+	private final DataOutputStream outputStream;
+
+	public ByteArrayOutputView(){
+		byteOutputStream = new ByteArrayOutputStream();
+		outputStream = new DataOutputStream(byteOutputStream);
+	}
+
+	public byte[] getByteArray(){
+		return byteOutputStream.toByteArray();
+	}
+
+	public void reset() {
+		byteOutputStream.reset();
+	}
+
+	@Override
+	public void skipBytesToWrite(int numBytes) throws IOException {
+		for(int i=0; i<numBytes; i++){
+			writeByte(0);
+		}
+	}
+
+	@Override
+	public void write(DataInputView source, int numBytes) throws IOException {
+		byte[] buffer = new byte[numBytes];
+		source.readFully(buffer);
+		outputStream.write(buffer);
+	}
+
+	@Override
+	public void write(int b) throws IOException {
+		outputStream.write(b);
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		outputStream.write(b);
+	}
+
+	@Override
+	public void write(byte[] b, int off, int len) throws IOException {
+		outputStream.write(b, off, len);
+	}
+
+	@Override
+	public void writeBoolean(boolean v) throws IOException {
+		outputStream.writeBoolean(v);
+	}
+
+	@Override
+	public void writeByte(int v) throws IOException {
+		outputStream.writeByte(v);
+	}
+
+	@Override
+	public void writeShort(int v) throws IOException {
+		outputStream.writeShort(v);
+	}
+
+	@Override
+	public void writeChar(int v) throws IOException {
+		outputStream.writeChar(v);
+	}
+
+	@Override
+	public void writeInt(int v) throws IOException {
+		outputStream.writeInt(v);
+	}
+
+	@Override
+	public void writeLong(long v) throws IOException {
+		outputStream.writeLong(v);
+	}
+
+	@Override
+	public void writeFloat(float v) throws IOException {
+		outputStream.writeFloat(v);
+	}
+
+	@Override
+	public void writeDouble(double v) throws IOException {
+		outputStream.writeDouble(v);
+	}
+
+	@Override
+	public void writeBytes(String s) throws IOException {
+		outputStream.writeBytes(s);
+	}
+
+	@Override
+	public void writeChars(String s) throws IOException {
+		outputStream.writeChars(s);
+	}
+
+	@Override
+	public void writeUTF(String s) throws IOException {
+		outputStream.writeUTF(s);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -362,7 +362,7 @@ public abstract class ExecutionEnvironment {
 	public <X> DataSource<X> fromCollection(Collection<X> data, TypeInformation<X> type) {
 		CollectionInputFormat.checkCollection(data, type.getTypeClass());
 		
-		return new DataSource<X>(this, new CollectionInputFormat<X>(data), type);
+		return new DataSource<X>(this, new CollectionInputFormat<X>(data, type.createSerializer()), type);
 	}
 	
 	/**

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CollectionInputFormatTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CollectionInputFormatTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.api.java.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import eu.stratosphere.api.java.typeutils.TypeExtractor;
+import eu.stratosphere.core.io.GenericInputSplit;
+import eu.stratosphere.types.TypeInformation;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CollectionInputFormatTest {
+	public static class ElementType{
+		private int id;
+
+		public ElementType(){
+			this(-1);
+		}
+
+		public ElementType(int id){
+			this.id = id;
+		}
+
+		public int getId(){return id;}
+
+		@Override
+		public boolean equals(Object obj){
+			if(obj != null && obj instanceof ElementType){
+				ElementType et = (ElementType) obj;
+
+				return et.getId() == this.getId();
+			}else {
+				return false;
+			}
+		}
+	}
+
+	@Test
+	public void testSerializability(){
+		Collection<ElementType> inputCollection = new ArrayList<ElementType>();
+		ElementType element1 = new ElementType(1);
+		ElementType element2 = new ElementType(2);
+		ElementType element3 = new ElementType(3);
+		inputCollection.add(element1);
+		inputCollection.add(element2);
+		inputCollection.add(element3);
+
+		TypeInformation<ElementType> info = (TypeInformation<ElementType>)TypeExtractor.createTypeInfo(ElementType
+				.class);
+
+		CollectionInputFormat<ElementType> inputFormat = new CollectionInputFormat<ElementType>(inputCollection,
+				info.createSerializer());
+
+		try{
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			ObjectOutputStream out = new ObjectOutputStream(buffer);
+
+			out.writeObject(inputFormat);
+
+			ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()));
+
+			Object serializationResult = in.readObject();
+
+			assertNotNull(serializationResult);
+			assertTrue(serializationResult instanceof CollectionInputFormat<?>);
+
+			CollectionInputFormat<ElementType> result = (CollectionInputFormat<ElementType>) serializationResult;
+
+			GenericInputSplit inputSplit = new GenericInputSplit();
+			inputFormat.open(inputSplit);
+			result.open(inputSplit);
+
+			while(!inputFormat.reachedEnd() && !result.reachedEnd()){
+				ElementType expectedElement = inputFormat.nextRecord(null);
+				ElementType actualElement = result.nextRecord(null);
+
+				assertEquals(expectedElement, actualElement);
+			}
+		}catch(IOException ex){
+			fail(ex.toString());
+		}catch(ClassNotFoundException ex){
+			fail(ex.toString());
+		}
+	}
+}


### PR DESCRIPTION
The CollectionInputFormat did not support collection elements which didn't implement the Serializable interface. By using the TypeSerializer generated from the TypeInformation, we can circumvent this problem. This allows to use arbitrary classes in a collection data source.
