### PR TITLE
[FLINK-943] Remove leading and ending double quotes from 'env.java.opts' config value

### DIFF
--- a/stratosphere-dist/src/main/stratosphere-bin/bin/config.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/config.sh
@@ -169,6 +169,9 @@ fi
 
 if [ -z "${STRATOSPHERE_ENV_JAVA_OPTS}" ]; then
     STRATOSPHERE_ENV_JAVA_OPTS=$(readFromConfig ${KEY_ENV_JAVA_OPTS} "${DEFAULT_ENV_JAVA_OPTS}" "${YAML_CONF}")
+
+    # Remove leading and ending double quotes (if present) of value
+    STRATOSPHERE_ENV_JAVA_OPTS="$( echo "${STRATOSPHERE_ENV_JAVA_OPTS}" | sed -e 's/^"//'  -e 's/"$//' )"
 fi
 
 if [ -z "${STRATOSPHERE_SSH_OPTS}" ]; then

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/jobmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/jobmanager.sh
@@ -72,7 +72,7 @@ case $STARTSTOP in
         rotateLogFile $out
 
         echo Starting job manager
-        $JAVA_RUN $JVM_ARGS $STRATOSPHERE_ENV_JAVA_OPTS "${log_setting[@]}" -classpath "$STRATOSPHERE_JM_CLASSPATH" eu.stratosphere.nephele.jobmanager.JobManager -executionMode $EXECUTIONMODE -configDir "$STRATOSPHERE_CONF_DIR"  > "$out" 2>&1 < /dev/null &
+        $JAVA_RUN $JVM_ARGS ${STRATOSPHERE_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "$STRATOSPHERE_JM_CLASSPATH" eu.stratosphere.nephele.jobmanager.JobManager -executionMode $EXECUTIONMODE -configDir "$STRATOSPHERE_CONF_DIR"  > "$out" 2>&1 < /dev/null &
         echo $! > $pid
     ;;
 

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/taskmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/taskmanager.sh
@@ -69,7 +69,7 @@ case $STARTSTOP in
         rotateLogFile $out
 
         echo Starting task manager on host $HOSTNAME
-        $JAVA_RUN $JVM_ARGS $STRATOSPHERE_ENV_JAVA_OPTS "${log_setting[@]}" -classpath "$STRATOSPHERE_TM_CLASSPATH" eu.stratosphere.nephele.taskmanager.TaskManager -configDir "$STRATOSPHERE_CONF_DIR" > "$out" 2>&1 < /dev/null &
+        $JAVA_RUN $JVM_ARGS ${STRATOSPHERE_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "$STRATOSPHERE_TM_CLASSPATH" eu.stratosphere.nephele.taskmanager.TaskManager -configDir "$STRATOSPHERE_CONF_DIR" > "$out" 2>&1 < /dev/null &
         echo $! > $pid
     ;;
 


### PR DESCRIPTION
This is [FLINK-943](https://issues.apache.org/jira/browse/FLINK-943).

The parsing works correctly but the leading/ending double quotes need to be removed before the value is given to the `java` run command, e.g. `java -Xmx1g "-D ..."` does not work.

I've tested: 1. with double quotes, 2. without double quotes, and 3. not set.
