### PR TITLE
[FLINK-949] Properly report GlobalBufferPool OutOfMemoryError to TaskManager

### DIFF
--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
@@ -283,9 +283,6 @@ public class TaskManager implements TaskOperationProtocol {
 
 		checkTempDirs(tmpDirPaths);
 
-		final int pageSize = GlobalConfiguration.getInteger(ConfigConstants.TASK_MANAGER_NETWORK_BUFFER_SIZE_KEY,
-				ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_BUFFER_SIZE);
-
 		int numBuffers = GlobalConfiguration.getInteger(
 				ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY,
 				ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_NUM_BUFFERS);
@@ -328,7 +325,7 @@ public class TaskManager implements TaskOperationProtocol {
 			channelManager = new ChannelManager(lookupService, localInstanceConnectionInfo, numBuffers, bufferSize, networkConnectionManager);
 		} catch (IOException ioe) {
 			LOG.error(StringUtils.stringifyException(ioe));
-			throw new Exception("Failed to instantiate channel manager. " + ioe.getMessage(), ioe);
+			throw new Exception("Failed to instantiate ChannelManager.", ioe);
 		}
 
 		{
@@ -344,6 +341,9 @@ public class TaskManager implements TaskOperationProtocol {
 						resources.getSizeOfPhysicalMemory(), memorySize * 1024L * 1024L);
 			}
 			this.hardwareDescription = resources;
+
+			final int pageSize = GlobalConfiguration.getInteger(ConfigConstants.TASK_MANAGER_NETWORK_BUFFER_SIZE_KEY,
+					ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_BUFFER_SIZE);
 
 			// Initialize the memory manager
 			LOG.info("Initializing memory manager with " + (resources.getSizeOfFreeMemory() >>> 20) + " megabytes of memory. " +

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/runtime/io/network/ChannelManager.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/runtime/io/network/ChannelManager.java
@@ -79,7 +79,11 @@ public class ChannelManager implements EnvelopeDispatcher, BufferProviderBroker 
 		this.channelLookupService = channelLookupService;
 		this.connectionInfo = connectionInfo;
 
-		this.globalBufferPool = new GlobalBufferPool(numNetworkBuffers, networkBufferSize);
+		try {
+			this.globalBufferPool = new GlobalBufferPool(numNetworkBuffers, networkBufferSize);
+		} catch (Throwable e) {
+			throw new IOException("Failed to instantiate GlobalBufferPool.", e);
+		}
 
 		this.networkConnectionManager = networkConnectionManager;
 		networkConnectionManager.start(this);


### PR DESCRIPTION
This is [FLINK-949](https://issues.apache.org/jira/browse/FLINK-949).

Travis seems to have problems with downloading dependencies from Maven central and hence the [builds fail/timeout](https://travis-ci.org/uce/incubator-flink/builds/27917216).
