### PR TITLE
Fixes a ContextClassloader bug

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/util/InstantiationUtil.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/util/InstantiationUtil.java
@@ -234,10 +234,13 @@ public class InstantiationUtil {
 	
 	public static Object deserializeObject(byte[] bytes, ClassLoader cl) throws IOException, ClassNotFoundException {
 		ObjectInputStream oois = null;
+		final ClassLoader old = Thread.currentThread().getContextClassLoader();
 		try {
+			Thread.currentThread().setContextClassLoader(cl);
 			oois = new ClassLoaderObjectInputStream(new ByteArrayInputStream(bytes), cl);
 			return oois.readObject();
 		} finally {
+			Thread.currentThread().setContextClassLoader(old);
 			if (oois != null) {
 				oois.close();
 			}


### PR DESCRIPTION
Fixes a bug where Thread.currentThread().getContextClassloader() does not return the user code class loader within object deserialization.

Code has been tested successfully on cluster with FLINK-777.
