### PR TITLE
[FLINK-971] Configure PooledByteBufAllocator in NettyConnectionManager

### DIFF
--- a/stratosphere-runtime/src/main/java/eu/stratosphere/runtime/io/network/netty/OutboundConnectionQueue.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/runtime/io/network/netty/OutboundConnectionQueue.java
@@ -42,7 +42,7 @@ public class OutboundConnectionQueue extends ChannelInboundHandlerAdapter implem
 	}
 
 	/**
-	 * Enqueues an envelope so be sent later.
+	 * Enqueues an envelope to be sent later.
 	 * <p/>
 	 * This method is always invoked by the task thread that wants the envelope sent.
 	 *


### PR DESCRIPTION
...instead of using the default allocator

Configuration:
- 0 heap arenas,
- n direct arenas (where n = num incoming + num outgoing network IO threads), and
- bufferSize << 1 bytes page size.

Additionally, `OutboundEnvelopeEncoder` directly implements `ChannelOutboundHandlerAdapter` instead of the
`MessageToByteEncoder<Envelope>` wrapper to have tighter control of memory allocations.
