### PR TITLE
[FLINK-996] Fix for union replacement

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
@@ -1195,7 +1195,7 @@ public class PactCompiler {
 	private static final class BinaryUnionReplacer implements Visitor<PlanNode> {
 		
 		private final Set<PlanNode> seenBefore = new HashSet<PlanNode>();
-		
+
 		@Override
 		public boolean preVisit(PlanNode visitable) {
 			if (this.seenBefore.add(visitable)) {
@@ -1217,43 +1217,20 @@ public class PactCompiler {
 				final Channel in2 = unionNode.getInput2();
 			
 				PlanNode newUnionNode;
-				
-				// if any input is cached, we keep this as a binary union and do not collapse it into a
-				// n-ary union
-//				if (in1.getTempMode().isCached() || in2.getTempMode().isCached()) {
-//					// replace this node by an explicit operator
-//					Channel cached, pipelined;
-//					if (in1.getTempMode().isCached()) {
-//						cached = in1;
-//						pipelined = in2;
-//					} else {
-//						cached = in2;
-//						pipelined = in1;
-//					}
-//					
-//					newUnionNode = new DualInputPlanNode(unionNode.getOriginalOptimizerNode(), cached, pipelined,
-//						DriverStrategy.UNION_WITH_CACHED);
-//					newUnionNode.initProperties(unionNode.getGlobalProperties(), new LocalProperties());
-//					
-//					in1.setTarget(newUnionNode);
-//					in2.setTarget(newUnionNode);
-//				} else {
-					// collect the union inputs to collapse this operator with 
-					// its collapsed predecessors. check whether an input is materialized to prevent
-					// collapsing
-					List<Channel> inputs = new ArrayList<Channel>();
-					collect(in1, inputs);
-					collect(in2, inputs);
-					
-					newUnionNode = new NAryUnionPlanNode(unionNode.getOptimizerNode(), inputs, unionNode.getGlobalProperties());
-					
-					// adjust the input channels to have their target point to the new union node
-					for (Channel c : inputs) {
-						c.setTarget(newUnionNode);
-					}
-//				}
-				
-				unionNode.getOutgoingChannels().get(0).swapUnionNodes(newUnionNode);
+
+				List<Channel> inputs = new ArrayList<Channel>();
+				collect(in1, inputs);
+				collect(in2, inputs);
+
+				newUnionNode = new NAryUnionPlanNode(unionNode.getOptimizerNode(), inputs, unionNode.getGlobalProperties());
+
+				for (Channel c : inputs) {
+					c.setTarget(newUnionNode);
+				}
+
+				for(Channel channel : unionNode.getOutgoingChannels()){
+					channel.swapUnionNodes(newUnionNode);
+				}
 			}
 		}
 		

--- a/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/UnionReplacementTest.java
+++ b/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/UnionReplacementTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.pact.compiler;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.IterativeDataSet;
+import eu.stratosphere.compiler.CompilerException;
+import eu.stratosphere.compiler.plan.OptimizedPlan;
+import eu.stratosphere.compiler.plantranslate.NepheleJobGraphGenerator;
+import org.junit.Test;
+import static org.junit.Assert.fail;
+
+public class UnionReplacementTest extends CompilerTestBase {
+
+	@Test
+	public void testUnionReplacement(){
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<String> input1 = env.fromElements("test1");
+		DataSet<String> input2 = env.fromElements("test2");
+
+		DataSet<String> union = input1.union(input2);
+
+		union.print();
+		union.print();
+
+		Plan plan = env.createProgramPlan();
+		try{
+			OptimizedPlan oPlan = this.compileNoStats(plan);
+			NepheleJobGraphGenerator jobGen = new NepheleJobGraphGenerator();
+			jobGen.compileJobGraph(oPlan);
+		}catch(CompilerException co){
+			co.printStackTrace();
+			fail("The Pact compiler is unable to compile this plan correctly.");
+		}
+	}
+}


### PR DESCRIPTION
The problem was that the BinaryUnionNodes were only replaced for the first output channel instead for all.
