### PR TITLE
[FLINK-1003] Added spread out scheduling strategy

### DIFF
--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/minicluster/NepheleMiniCluster.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/minicluster/NepheleMiniCluster.java
@@ -49,7 +49,7 @@ public class NepheleMiniCluster {
 
 	private static final int DEFAULT_TASK_MANAGER_NUM_SLOTS = -1;
 
-	private static final SchedulingStrategy DEFAULT_SCHEDULING_STRATEGY = SchedulingStrategy.FILLFIRST;
+	private static final SchedulingStrategy DEFAULT_SCHEDULING_STRATEGY = SchedulingStrategy.FillFirst;
 
 	// --------------------------------------------------------------------------------------------
 	
@@ -308,7 +308,7 @@ public class NepheleMiniCluster {
 
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, taskManagerNumSlots);
 
-		config.setInteger(ConfigConstants.SCHEDULING_STRATEGY, schedulingStrategy.ordinal());
+		config.setString(ConfigConstants.SCHEDULING_STRATEGY, schedulingStrategy.name());
 		
 		return config;
 	}

--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/minicluster/NepheleMiniCluster.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/minicluster/NepheleMiniCluster.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 
 import eu.stratosphere.nephele.ExecutionMode;
 import eu.stratosphere.nephele.instance.HardwareDescriptionFactory;
+import eu.stratosphere.nephele.instance.SchedulingStrategy;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -48,6 +49,8 @@ public class NepheleMiniCluster {
 
 	private static final int DEFAULT_TASK_MANAGER_NUM_SLOTS = -1;
 
+	private static final SchedulingStrategy DEFAULT_SCHEDULING_STRATEGY = SchedulingStrategy.FILLFIRST;
+
 	// --------------------------------------------------------------------------------------------
 	
 	private final Object startStopLock = new Object();
@@ -63,6 +66,8 @@ public class NepheleMiniCluster {
 	private int taskManagerNumSlots = DEFAULT_TASK_MANAGER_NUM_SLOTS;
 	
 	private long memorySize = DEFAULT_MEMORY_SIZE;
+
+	private SchedulingStrategy schedulingStrategy = DEFAULT_SCHEDULING_STRATEGY;
 	
 	private String configDir;
 
@@ -161,6 +166,10 @@ public class NepheleMiniCluster {
 
 	public int getTaskManagerNumSlots() { return taskManagerNumSlots; }
 
+	public void setSchedulingStrategy(SchedulingStrategy strategy) { this.schedulingStrategy = strategy; }
+
+	public SchedulingStrategy getSchedulingStrategy() { return this.schedulingStrategy; }
+
 	// ------------------------------------------------------------------------
 	// Life cycle and Job Submission
 	// ------------------------------------------------------------------------
@@ -180,7 +189,7 @@ public class NepheleMiniCluster {
 			} else {
 				Configuration conf = getMiniclusterDefaultConfig(jobManagerRpcPort, taskManagerRpcPort,
 					taskManagerDataPort, memorySize, hdfsConfigFile, lazyMemoryAllocation, defaultOverwriteFiles,
-						defaultAlwaysCreateDirectory, taskManagerNumSlots, numTaskTracker);
+						defaultAlwaysCreateDirectory, taskManagerNumSlots, numTaskTracker, schedulingStrategy);
 				GlobalConfiguration.includeConfiguration(conf);
 			}
 
@@ -245,7 +254,7 @@ public class NepheleMiniCluster {
 	public static Configuration getMiniclusterDefaultConfig(int jobManagerRpcPort, int taskManagerRpcPort,
 			int taskManagerDataPort, long memorySize, String hdfsConfigFile, boolean lazyMemory,
 			boolean defaultOverwriteFiles, boolean defaultAlwaysCreateDirectory,
-			int taskManagerNumSlots, int numTaskManager)
+			int taskManagerNumSlots, int numTaskManager, SchedulingStrategy schedulingStrategy)
 	{
 		final Configuration config = new Configuration();
 		
@@ -298,6 +307,8 @@ public class NepheleMiniCluster {
 		config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, numTaskManager);
 
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, taskManagerNumSlots);
+
+		config.setInteger(ConfigConstants.SCHEDULING_STRATEGY, schedulingStrategy.ordinal());
 		
 		return config;
 	}

--- a/stratosphere-core/src/main/java/eu/stratosphere/configuration/ConfigConstants.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/configuration/ConfigConstants.java
@@ -160,6 +160,9 @@ public final class ConfigConstants {
 	 */
 	public static final String JOBCLIENT_POLLING_INTERVAL_KEY = "jobclient.polling.interval";
 
+	/**
+	 * The parameter defining the scheduling strategy. Valid options are "FillFirst" and "SpreadOut"
+	 */
 	public static final String SCHEDULING_STRATEGY = "jobmanager.scheduling-strategy";
 
 	// ------------------------ Hadoop Configuration ------------------------
@@ -395,6 +398,11 @@ public final class ConfigConstants {
 	 * The default timeout for filesystem stream opening: infinite (means max long milliseconds).
 	 */
 	public static final int DEFAULT_FS_STREAM_OPENING_TIMEOUT = 0;
+
+	/**
+	 * The default scheduling strategy
+	 */
+	public static final String DEFAULT_SCHEDULING_STRATEGY = "FillFirst";
 
 	// ------------------------ File System Bahavior ------------------------
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/configuration/ConfigConstants.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/configuration/ConfigConstants.java
@@ -160,6 +160,8 @@ public final class ConfigConstants {
 	 */
 	public static final String JOBCLIENT_POLLING_INTERVAL_KEY = "jobclient.polling.interval";
 
+	public static final String SCHEDULING_STRATEGY = "jobmanager.scheduling-strategy";
+
 	// ------------------------ Hadoop Configuration ------------------------
 
 	/**
@@ -393,8 +395,7 @@ public final class ConfigConstants {
 	 * The default timeout for filesystem stream opening: infinite (means max long milliseconds).
 	 */
 	public static final int DEFAULT_FS_STREAM_OPENING_TIMEOUT = 0;
-	
-	
+
 	// ------------------------ File System Bahavior ------------------------
 
 	/**

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/DefaultInstanceManager.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/DefaultInstanceManager.java
@@ -178,16 +178,20 @@ public class DefaultInstanceManager implements InstanceManager {
 		final boolean runTimerAsDaemon = true;
 		new Timer(runTimerAsDaemon).schedule(cleanupStaleMachines, 1000, 1000);
 
-		int schedulingStrategyOrdinal = GlobalConfiguration.getInteger(ConfigConstants.SCHEDULING_STRATEGY, -1);
+		String schedulingStrategyStr = GlobalConfiguration.getString(ConfigConstants.SCHEDULING_STRATEGY,
+				ConfigConstants.DEFAULT_SCHEDULING_STRATEGY);
 
-		SchedulingStrategy resolvedStrategy = SchedulingStrategy.FILLFIRST;
+		SchedulingStrategy resolvedStrategy = null;
 
-		if(schedulingStrategyOrdinal != -1){
-			for(SchedulingStrategy s : SchedulingStrategy.values()){
-				if(s.ordinal() == schedulingStrategyOrdinal){
-					resolvedStrategy = s;
-				}
+		for(SchedulingStrategy s : SchedulingStrategy.values()){
+			if(s.name().equals(schedulingStrategyStr)){
+				resolvedStrategy = s;
+				break;
 			}
+		}
+
+		if(resolvedStrategy == null){
+			throw new RuntimeException("Scheduling strategy: " + schedulingStrategyStr + " is not supported.");
 		}
 
 		schedulingStrategy = resolvedStrategy;
@@ -343,7 +347,7 @@ public class DefaultInstanceManager implements InstanceManager {
 			int allocatedSlots = 0;
 
 			switch(schedulingStrategy){
-				case FILLFIRST:
+				case FillFirst:
 					while(clusterIterator.hasNext()) {
 						instance = clusterIterator.next();
 						while(instance.getNumberOfAvailableSlots() >0  && allocatedSlots < requiredSlots){
@@ -353,7 +357,7 @@ public class DefaultInstanceManager implements InstanceManager {
 						}
 					}
 					break;
-				case SPREADOUT:
+				case SpreadOut:
 					List<Instance> increasingLoad = new ArrayList<Instance>(this.registeredHosts.values());
 
 					if(increasingLoad.size() == 0){

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/DefaultInstanceManager.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/DefaultInstanceManager.java
@@ -391,17 +391,18 @@ public class DefaultInstanceManager implements InstanceManager {
 						allocatedResources.add(resource);
 						allocatedSlots++;
 
-						if(headInstance.getLoad() < instance.getLoad()){
-							index = 0;
-							instance = headInstance;
-						}else if(instance.getLoad() > nextLoad){
+						if(instance.getLoad() > nextLoad){
 							index++;
 							instance = increasingLoad.get(index);
-							if(increasingLoad.size() > index+1){
-								nextLoad = increasingLoad.get(index+1).getLoad();
-							}else{
-								nextLoad = 1.0;
-							}
+						}else if(headInstance.getLoad() < instance.getLoad()){
+							index = 0;
+							instance = headInstance;
+						}
+
+						if(increasingLoad.size() > index+1){
+							nextLoad = increasingLoad.get(index+1).getLoad();
+						}else{
+							nextLoad = 1.0;
 						}
 					}
 					break;

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/Instance.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/Instance.java
@@ -338,6 +338,8 @@ public class Instance extends NetworkNode {
 		}
 	}
 
+	public double getLoad() { return ((double)allocatedSlots.size())/numberOfSlots; }
+
 	public synchronized void releaseSlot(AllocationID allocationID) {
 		if(allocatedSlots.containsKey(allocationID)){
 			allocatedSlots.remove(allocationID);

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/SchedulingStrategy.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/SchedulingStrategy.java
@@ -14,5 +14,5 @@
 package eu.stratosphere.nephele.instance;
 
 public enum SchedulingStrategy {
-	FILLFIRST, SPREADOUT
+	FillFirst, SpreadOut
 }

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/SchedulingStrategy.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/SchedulingStrategy.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.nephele.instance;
+
+public enum SchedulingStrategy {
+	FILLFIRST, SPREADOUT
+}

--- a/stratosphere-test-utils/src/main/java/eu/stratosphere/test/util/AbstractTestBase.java
+++ b/stratosphere-test-utils/src/main/java/eu/stratosphere/test/util/AbstractTestBase.java
@@ -54,7 +54,7 @@ public abstract class AbstractTestBase {
 
 	protected static final int DEFAULT_NUM_TASK_TRACKER = 1;
 
-	protected static final SchedulingStrategy DEFAULT_SCHEDULING_STRATEGY = SchedulingStrategy.FILLFIRST;
+	protected static final SchedulingStrategy DEFAULT_SCHEDULING_STRATEGY = SchedulingStrategy.FillFirst;
 
 	protected final Configuration config;
 	

--- a/stratosphere-test-utils/src/main/java/eu/stratosphere/test/util/AbstractTestBase.java
+++ b/stratosphere-test-utils/src/main/java/eu/stratosphere/test/util/AbstractTestBase.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
+import eu.stratosphere.nephele.instance.SchedulingStrategy;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.log4j.Level;
@@ -53,6 +54,8 @@ public abstract class AbstractTestBase {
 
 	protected static final int DEFAULT_NUM_TASK_TRACKER = 1;
 
+	protected static final SchedulingStrategy DEFAULT_SCHEDULING_STRATEGY = SchedulingStrategy.FILLFIRST;
+
 	protected final Configuration config;
 	
 	protected NepheleMiniCluster executor;
@@ -62,6 +65,8 @@ public abstract class AbstractTestBase {
 	protected int taskManagerNumSlots = DEFAULT_TASK_MANAGER_NUM_SLOTS;
 
 	protected int numTaskTracker = DEFAULT_NUM_TASK_TRACKER;
+
+	protected SchedulingStrategy schedulingStrategy = DEFAULT_SCHEDULING_STRATEGY;
 
 	public AbstractTestBase(Configuration config) {
 		verifyJvmOptions();
@@ -88,6 +93,7 @@ public abstract class AbstractTestBase {
 		this.executor.setMemorySize(TASK_MANAGER_MEMORY_SIZE);
 		this.executor.setTaskManagerNumSlots(taskManagerNumSlots);
 		this.executor.setNumTaskTracker(this.numTaskTracker);
+		this.executor.setSchedulingStrategy(this.schedulingStrategy);
 		this.executor.start();
 	}
 
@@ -116,6 +122,11 @@ public abstract class AbstractTestBase {
 	public int getNumTaskTracker() { return numTaskTracker; }
 
 	public void setNumTaskTracker(int numTaskTracker) { this.numTaskTracker = numTaskTracker; }
+
+	public void setSchedulingStrategy(SchedulingStrategy schedulingStrategy) { this.schedulingStrategy =
+			schedulingStrategy; }
+
+	public SchedulingStrategy getSchedulingStrategy() { return this.schedulingStrategy; }
 
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleJavaPrograms/WordCountITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleJavaPrograms/WordCountITCase.java
@@ -15,6 +15,7 @@
 package eu.stratosphere.test.exampleJavaPrograms;
 
 import eu.stratosphere.example.java.wordcount.WordCount;
+import eu.stratosphere.nephele.instance.SchedulingStrategy;
 import eu.stratosphere.test.testdata.WordCountData;
 import eu.stratosphere.test.util.JavaProgramTestBase;
 
@@ -26,7 +27,8 @@ public class WordCountITCase extends JavaProgramTestBase {
 	public WordCountITCase(){
 		setDegreeOfParallelism(4);
 		setNumTaskTracker(2);
-		setTaskManagerNumSlots(2);
+		setTaskManagerNumSlots(4);
+		setSchedulingStrategy(SchedulingStrategy.SPREADOUT);
 	}
 
 	@Override

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleJavaPrograms/WordCountITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleJavaPrograms/WordCountITCase.java
@@ -28,7 +28,7 @@ public class WordCountITCase extends JavaProgramTestBase {
 		setDegreeOfParallelism(4);
 		setNumTaskTracker(2);
 		setTaskManagerNumSlots(4);
-		setSchedulingStrategy(SchedulingStrategy.SPREADOUT);
+		setSchedulingStrategy(SchedulingStrategy.SpreadOut);
 	}
 
 	@Override


### PR DESCRIPTION
The spread out scheduling strategy tries to keep the work load among the instances balanced. The scheduling strategy can be specified by the configuration parameter ```jobmanager.scheduling-strategy```. Valid options are ```SpreadOut``` and ```FillFirst```. The latter strategy is the old and default strategy.