### PR TITLE
[FLINK-984] Extension of the API for distinct for Key Expressions, additional testcases

### DIFF
--- a/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/DistinctCompilationTest.java
+++ b/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/DistinctCompilationTest.java
@@ -1,0 +1,204 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.pact.compiler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.operators.util.FieldList;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.functions.KeySelector;
+import eu.stratosphere.api.java.operators.DistinctOperator;
+import eu.stratosphere.api.java.tuple.Tuple2;
+import eu.stratosphere.compiler.plan.OptimizedPlan;
+import eu.stratosphere.compiler.plan.SingleInputPlanNode;
+import eu.stratosphere.compiler.plan.SinkPlanNode;
+import eu.stratosphere.compiler.plan.SourcePlanNode;
+import eu.stratosphere.pact.runtime.task.DriverStrategy;
+
+@SuppressWarnings("serial")
+public class DistinctCompilationTest extends CompilerTestBase implements java.io.Serializable {
+	
+	@Test
+	public void testDistinctPlain() {
+		try {
+			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+			env.setDegreeOfParallelism(8);
+			
+			DataSet<Tuple2<String, Double>> data = env.readCsvFile("file:///will/never/be/read").types(String.class, Double.class)
+				.name("source").setParallelism(6);
+			
+			data
+				.distinct().name("reducer")
+				.print().name("sink");
+			
+			Plan p = env.createProgramPlan();
+			OptimizedPlan op = compileNoStats(p);
+			
+			OptimizerPlanNodeResolver resolver = getOptimizerPlanNodeResolver(op);
+			
+			// get the original nodes
+			SourcePlanNode sourceNode = resolver.getNode("source");
+			SingleInputPlanNode reduceNode = resolver.getNode("reducer");
+			SinkPlanNode sinkNode = resolver.getNode("sink");
+			
+			// get the combiner
+			SingleInputPlanNode combineNode = (SingleInputPlanNode) reduceNode.getInput().getSource();
+			
+			// check wiring
+			assertEquals(sourceNode, combineNode.getInput().getSource());
+			assertEquals(reduceNode, sinkNode.getInput().getSource());
+			
+			// check that both reduce and combiner have the same strategy
+			assertEquals(DriverStrategy.SORTED_GROUP_REDUCE, reduceNode.getDriverStrategy());
+			assertEquals(DriverStrategy.SORTED_GROUP_COMBINE, combineNode.getDriverStrategy());
+			
+			// check the keys
+			assertEquals(new FieldList(0, 1), reduceNode.getKeys());
+			assertEquals(new FieldList(0, 1), combineNode.getKeys());
+			assertEquals(new FieldList(0, 1), reduceNode.getInput().getLocalStrategyKeys());
+			
+			// check DOP
+			assertEquals(6, sourceNode.getDegreeOfParallelism());
+			assertEquals(6, combineNode.getDegreeOfParallelism());
+			assertEquals(8, reduceNode.getDegreeOfParallelism());
+			assertEquals(8, sinkNode.getDegreeOfParallelism());
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail(e.getClass().getSimpleName() + " in test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testDistinctWithSelectorFunctionKey() {
+		try {
+			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+			env.setDegreeOfParallelism(8);
+			
+			DataSet<Tuple2<String, Double>> data = env.readCsvFile("file:///will/never/be/read").types(String.class, Double.class)
+				.name("source").setParallelism(6);
+			
+			data
+				.distinct(new KeySelector<Tuple2<String,Double>, String>() { 
+					public String getKey(Tuple2<String, Double> value) { return value.f0; }
+				}).name("reducer")
+				.print().name("sink");
+			
+			Plan p = env.createProgramPlan();
+			OptimizedPlan op = compileNoStats(p);
+			
+			OptimizerPlanNodeResolver resolver = getOptimizerPlanNodeResolver(op);
+			
+			// get the original nodes
+			SourcePlanNode sourceNode = resolver.getNode("source");
+			SingleInputPlanNode reduceNode = resolver.getNode("reducer");
+			SinkPlanNode sinkNode = resolver.getNode("sink");
+			
+			// get the combiner
+			SingleInputPlanNode combineNode = (SingleInputPlanNode) reduceNode.getInput().getSource();
+			
+			// get the key extractors and projectors
+			SingleInputPlanNode keyExtractor = (SingleInputPlanNode) combineNode.getInput().getSource();
+			SingleInputPlanNode keyProjector = (SingleInputPlanNode) sinkNode.getInput().getSource();
+			
+			// check wiring
+			assertEquals(sourceNode, keyExtractor.getInput().getSource());
+			assertEquals(keyProjector, sinkNode.getInput().getSource());
+			
+			// check that both reduce and combiner have the same strategy
+			assertEquals(DriverStrategy.SORTED_GROUP_REDUCE, reduceNode.getDriverStrategy());
+			assertEquals(DriverStrategy.SORTED_GROUP_COMBINE, combineNode.getDriverStrategy());
+			
+			// check the keys
+			assertEquals(new FieldList(0), reduceNode.getKeys());
+			assertEquals(new FieldList(0), combineNode.getKeys());
+			assertEquals(new FieldList(0), reduceNode.getInput().getLocalStrategyKeys());
+			
+			// check DOP
+			assertEquals(6, sourceNode.getDegreeOfParallelism());
+			assertEquals(6, keyExtractor.getDegreeOfParallelism());
+			assertEquals(6, combineNode.getDegreeOfParallelism());
+			
+			assertEquals(8, reduceNode.getDegreeOfParallelism());
+			assertEquals(8, keyProjector.getDegreeOfParallelism());
+			assertEquals(8, sinkNode.getDegreeOfParallelism());
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail(e.getClass().getSimpleName() + " in test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testDistinctWithFieldPositionKeyCombinable() {
+		try {
+			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+			env.setDegreeOfParallelism(8);
+			
+			DataSet<Tuple2<String, Double>> data = env.readCsvFile("file:///will/never/be/read").types(String.class, Double.class)
+				.name("source").setParallelism(6);
+			
+			DistinctOperator<Tuple2<String, Double>> reduced = data
+					.distinct(1).name("reducer");
+			
+			reduced.print().name("sink");
+			
+			Plan p = env.createProgramPlan();
+			OptimizedPlan op = compileNoStats(p);
+			
+			OptimizerPlanNodeResolver resolver = getOptimizerPlanNodeResolver(op);
+			
+			// get the original nodes
+			SourcePlanNode sourceNode = resolver.getNode("source");
+			SingleInputPlanNode reduceNode = resolver.getNode("reducer");
+			SinkPlanNode sinkNode = resolver.getNode("sink");
+			
+			// get the combiner
+			SingleInputPlanNode combineNode = (SingleInputPlanNode) reduceNode.getInput().getSource();
+			
+			// check wiring
+			assertEquals(sourceNode, combineNode.getInput().getSource());
+			assertEquals(reduceNode, sinkNode.getInput().getSource());
+			
+			// check that both reduce and combiner have the same strategy
+			assertEquals(DriverStrategy.SORTED_GROUP_REDUCE, reduceNode.getDriverStrategy());
+			assertEquals(DriverStrategy.SORTED_GROUP_COMBINE, combineNode.getDriverStrategy());
+			
+			// check the keys
+			assertEquals(new FieldList(1), reduceNode.getKeys());
+			assertEquals(new FieldList(1), combineNode.getKeys());
+			assertEquals(new FieldList(1), reduceNode.getInput().getLocalStrategyKeys());
+			
+			// check DOP
+			assertEquals(6, sourceNode.getDegreeOfParallelism());
+			assertEquals(6, combineNode.getDegreeOfParallelism());
+			assertEquals(8, reduceNode.getDegreeOfParallelism());
+			assertEquals(8, sinkNode.getDegreeOfParallelism());
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail(e.getClass().getSimpleName() + " in test: " + e.getMessage());
+		}
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -332,6 +332,23 @@ public abstract class DataSet<T> {
 	}
 	
 	/**
+	 * Returns a distinct set of a {@link DataSet} using field expressions. A field expression is either the name of a public field
+	 * or a getter method with parentheses of the {@link DataSet}S underlying type. A dot can be used to drill down
+	 * into objects, as in {@code "field1.getInnerField2()" }.
+	 * <p/>
+	 * The field expressions keys specify the fields of Tuples on which the decision is made if two Tuples are distinct or
+	 * not.
+	 * <p/>
+	 * Note: Field position keys can only be specified for Tuple DataSets.
+	 *
+	 * @param fields One or more field expressions on which the distinction of the DataSet is decided. 
+	 * @return A DistinctOperator that represents the distinct DataSet.
+	 */
+	public DistinctOperator<T> distinct(String... fields) {
+		return new DistinctOperator<T>(this, new Keys.ExpressionKeys<T>(fields, getType()));
+	}
+	
+	/**
 	 * Returns a distinct set of a {@link Tuple} {@link DataSet} using all fields of the tuple.
 	 * <p/>
 	 * Note: This operator can only be applied to Tuple DataSets.

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoField.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoField.java
@@ -18,7 +18,7 @@ import eu.stratosphere.types.TypeInformation;
 
 import java.lang.reflect.Field;
 
-class PojoField {
+public class PojoField {
 	public Field field;
 	public TypeInformation<?> type;
 

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoTypeInfo.java
@@ -167,4 +167,8 @@ public class PojoTypeInfo<T> extends TypeInformation<T> implements CompositeType
 
 		return new PojoComparator<T>(keyFields, fieldComparators, createSerializer(), typeClass);
 	}
+
+	public PojoField[] getFields() {
+		return fields;
+	}
 }

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/operator/DistinctOperatorTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/operator/DistinctOperatorTest.java
@@ -97,7 +97,7 @@ public class DistinctOperatorTest {
 		tupleDs.distinct();
 	}
 	
-	@Test(expected = InvalidProgramException.class)
+	@Test
 	public void testDistinctByKeyFields5() {
 		
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
@@ -106,7 +106,7 @@ public class DistinctOperatorTest {
 		
 		DataSet<CustomType> customDs = env.fromCollection(customTypeData);
 
-		// should not work, distinct without selector on custom types
+		// should work
 		customDs.distinct();
 	}
 	
@@ -142,6 +142,33 @@ public class DistinctOperatorTest {
 			Assert.fail();
 		}
 		
+	}
+	
+	@Test
+	public void testDistinctByKeyExpression1() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		this.customTypeData.add(new CustomType());
+		
+		try {
+			DataSet<CustomType> customDs = env.fromCollection(customTypeData);
+			// should work
+			customDs.distinct("myInt", "myLong");
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testDistinctByKeyExpression2() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		this.customTypeData.add(new CustomType());
+		
+		DataSet<CustomType> customDs = env.fromCollection(customTypeData);
+		// should not work, field does not exist
+		customDs.distinct("myIntBlub", "myLong");
 	}
 	
 

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/operators/translation/DistinctTranslationTests.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/operators/translation/DistinctTranslationTests.java
@@ -1,0 +1,268 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.api.java.operators.translation;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.operators.base.GenericDataSinkBase;
+import eu.stratosphere.api.common.operators.base.GenericDataSourceBase;
+import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
+import eu.stratosphere.api.common.operators.base.MapOperatorBase;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.functions.KeySelector;
+import eu.stratosphere.api.java.tuple.Tuple2;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
+import eu.stratosphere.api.java.typeutils.ValueTypeInfo;
+import eu.stratosphere.types.LongValue;
+import eu.stratosphere.types.StringValue;
+import eu.stratosphere.types.TypeInformation;
+
+@SuppressWarnings("serial")
+public class DistinctTranslationTests implements java.io.Serializable {
+
+	@Test
+	public void translateDistinctPlain() {
+		try {
+			final int DOP = 8;
+			ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(DOP);
+			
+			DataSet<Tuple3<Double, StringValue, LongValue>> initialData = getSourceDataSet(env);
+			
+			initialData.distinct().print();
+			
+			Plan p = env.createProgramPlan();
+			
+			GenericDataSinkBase<?> sink = p.getDataSinks().iterator().next();
+			
+			// currently distinct is translated to a GroupReduce
+			GroupReduceOperatorBase<?, ?, ?> reducer = (GroupReduceOperatorBase<?, ?, ?>) sink.getInput();
+			
+			// check types
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getInputType());
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getOutputType());
+			
+			// check keys
+			assertArrayEquals(new int[] {0, 1, 2}, reducer.getKeyColumns(0));
+			
+			// DOP was not configured on the operator
+			assertTrue(reducer.getDegreeOfParallelism() == 1 || reducer.getDegreeOfParallelism() == -1);
+			
+			assertTrue(reducer.getInput() instanceof GenericDataSourceBase<?, ?>);
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail("Test caused an error: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void translateDistinctPlain2() {
+		try {
+			final int DOP = 8;
+			ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(DOP);
+			
+			DataSet<CustomType> initialData = getSourcePojoDataSet(env);
+			
+			initialData.distinct().print();
+			
+			Plan p = env.createProgramPlan();
+			
+			GenericDataSinkBase<?> sink = p.getDataSinks().iterator().next();
+			
+			// currently distinct is translated to a GroupReduce
+			GroupReduceOperatorBase<?, ?, ?> reducer = (GroupReduceOperatorBase<?, ?, ?>) sink.getInput();
+			
+			// check types
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getInputType());
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getOutputType());
+			
+			// check keys
+			assertArrayEquals(new int[] {0}, reducer.getKeyColumns(0));
+			
+			// DOP was not configured on the operator
+			assertTrue(reducer.getDegreeOfParallelism() == 1 || reducer.getDegreeOfParallelism() == -1);
+			
+			assertTrue(reducer.getInput() instanceof GenericDataSourceBase<?, ?>);
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail("Test caused an error: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void translateDistinctPosition() {
+		try {
+			final int DOP = 8;
+			ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(DOP);
+			
+			DataSet<Tuple3<Double, StringValue, LongValue>> initialData = getSourceDataSet(env);
+			
+			initialData.distinct(1, 2).print();
+			
+			Plan p = env.createProgramPlan();
+			
+			GenericDataSinkBase<?> sink = p.getDataSinks().iterator().next();
+			
+			// currently distinct is translated to a GroupReduce
+			GroupReduceOperatorBase<?, ?, ?> reducer = (GroupReduceOperatorBase<?, ?, ?>) sink.getInput();
+			
+			// check types
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getInputType());
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getOutputType());
+			
+			// check keys
+			assertArrayEquals(new int[] {1, 2}, reducer.getKeyColumns(0));
+			
+			// DOP was not configured on the operator
+			assertTrue(reducer.getDegreeOfParallelism() == 1 || reducer.getDegreeOfParallelism() == -1);
+			
+			assertTrue(reducer.getInput() instanceof GenericDataSourceBase<?, ?>);
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail("Test caused an error: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void translateDistinctKeySelector() {
+		try {
+			final int DOP = 8;
+			ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(DOP);
+			
+			DataSet<Tuple3<Double, StringValue, LongValue>> initialData = getSourceDataSet(env);
+			
+			initialData.distinct(new KeySelector<Tuple3<Double,StringValue,LongValue>, StringValue>() {
+				public StringValue getKey(Tuple3<Double, StringValue, LongValue> value) {
+					return value.f1;
+				}
+			}).setParallelism(4).print();
+			
+			Plan p = env.createProgramPlan();
+			
+			GenericDataSinkBase<?> sink = p.getDataSinks().iterator().next();
+			
+			PlanUnwrappingReduceGroupOperator<?, ?, ?> reducer = (PlanUnwrappingReduceGroupOperator<?, ?, ?>) sink.getInput();
+			MapOperatorBase<?, ?, ?> keyExtractor = (MapOperatorBase<?, ?, ?>) reducer.getInput();
+			
+			// check the DOPs
+			assertEquals(1, keyExtractor.getDegreeOfParallelism());
+			assertEquals(4, reducer.getDegreeOfParallelism());
+			
+			// check types
+			TypeInformation<?> keyValueInfo = new TupleTypeInfo<Tuple2<StringValue, Tuple3<Double,StringValue,LongValue>>>(
+					new ValueTypeInfo<StringValue>(StringValue.class),
+					initialData.getType());
+			
+			assertEquals(initialData.getType(), keyExtractor.getOperatorInfo().getInputType());
+			assertEquals(keyValueInfo, keyExtractor.getOperatorInfo().getOutputType());
+			
+			assertEquals(keyValueInfo, reducer.getOperatorInfo().getInputType());
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getOutputType());
+			
+			// check keys
+			assertEquals(KeyExtractingMapper.class, keyExtractor.getUserCodeWrapper().getUserCodeClass());
+			
+			assertTrue(keyExtractor.getInput() instanceof GenericDataSourceBase<?, ?>);
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail("Test caused an error: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void translateDistinctExpressionKey() {
+		try {
+			final int DOP = 8;
+			ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(DOP);
+			
+			DataSet<CustomType> initialData = getSourcePojoDataSet(env);
+			
+			initialData.distinct("myInt").print();
+			
+			Plan p = env.createProgramPlan();
+			
+			GenericDataSinkBase<?> sink = p.getDataSinks().iterator().next();
+			
+			// currently distinct is translated to a GroupReduce
+			GroupReduceOperatorBase<?, ?, ?> reducer = (GroupReduceOperatorBase<?, ?, ?>) sink.getInput();
+			
+			// check types
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getInputType());
+			assertEquals(initialData.getType(), reducer.getOperatorInfo().getOutputType());
+			
+			// check keys
+			assertArrayEquals(new int[] {0}, reducer.getKeyColumns(0));
+			
+			// DOP was not configured on the operator
+			assertTrue(reducer.getDegreeOfParallelism() == 1 || reducer.getDegreeOfParallelism() == -1);
+			
+			assertTrue(reducer.getInput() instanceof GenericDataSourceBase<?, ?>);
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			fail("Test caused an error: " + e.getMessage());
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static final DataSet<Tuple3<Double, StringValue, LongValue>> getSourceDataSet(ExecutionEnvironment env) {
+		return env.fromElements(new Tuple3<Double, StringValue, LongValue>(3.141592, new StringValue("foobar"), new LongValue(77)))
+				.setParallelism(1);
+	}
+	
+	private static DataSet<CustomType> getSourcePojoDataSet(ExecutionEnvironment env) {
+		List<CustomType> data = new ArrayList<CustomType>();
+		data.add(new CustomType(1));
+		return env.fromCollection(data);
+	}
+	
+	private static class CustomType implements Serializable {
+		
+		private static final long serialVersionUID = 1L;
+		public int myInt;
+		@SuppressWarnings("unused")
+		public CustomType() {};
+		
+		public CustomType(int i) {
+			myInt = i;
+		}
+		
+		@Override
+		public String toString() {
+			return ""+myInt;
+		}
+	}
+}

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/DistinctITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/DistinctITCase.java
@@ -38,7 +38,7 @@ import eu.stratosphere.test.util.JavaProgramTestBase;
 @RunWith(Parameterized.class)
 public class DistinctITCase extends JavaProgramTestBase {
 	
-	private static int NUM_PROGRAMS = 5;
+	private static int NUM_PROGRAMS = 7;
 	
 	private int curProgId = config.getInteger("ProgramId", -1);
 	private String resultPath;
@@ -198,6 +198,63 @@ public class DistinctITCase extends JavaProgramTestBase {
 				return "1,1,Hi\n" +
 						"2,2,Hello\n" +
 						"3,2,Hello world\n";
+			}
+			case 6: {
+				
+				/*
+				 * check correctness of distinct on POJOs with expression key
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<CustomType> ds = CollectionDataSets.getCustomTypeDataSet(env);
+				DataSet<Tuple1<Integer>> reduceDs = ds
+						.distinct("myInt")
+						.map(new MapFunction<CollectionDataSets.CustomType, Tuple1<Integer>>() {
+							@Override
+							public Tuple1<Integer> map(CustomType value) throws Exception {
+								return new Tuple1<Integer>(value.myInt);
+							}
+						});
+				
+				reduceDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return "1\n" +
+						"2\n" +
+						"3\n" +
+						"4\n" +
+						"5\n" +
+						"6\n";
+				
+			}
+			case 7: {
+				
+				/*
+				 * check correctness of distinct on POJOs with expression key
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<CustomType> ds = CollectionDataSets.getSmallCustomTypeDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> reduceDs = ds
+						.distinct()
+						.map(new MapFunction<CollectionDataSets.CustomType, Tuple3<Integer, Long, String>>() {
+							@Override
+							public Tuple3<Integer, Long, String> map(CustomType value) throws Exception {
+								return new Tuple3<Integer, Long, String>(value.myInt, value.myLong, value.myString);
+							}
+						});
+				
+				reduceDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return "1,0,Hi\n" +
+						"2,1,Hello\n" +
+						"2,2,Hello world\n";
+				
 			}
 			default: 
 				throw new IllegalArgumentException("Invalid program id");


### PR DESCRIPTION
I extended the API for the distinct operator to also work on POJOs using either key expressions or by using plain distinct() selecting all public fields.
I also added some more testcases for the operator.
