### PR TITLE
Small fixes for running Hadoop OutputFormats with HadoopCompat layer

### DIFF
--- a/flink-addons/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopOutputFormat.java
+++ b/flink-addons/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopOutputFormat.java
@@ -100,15 +100,17 @@ public class HadoopOutputFormat<K extends Writable,V extends Writable> implement
 				+ Integer.toString(taskNumber + 1) 
 				+ "_0");
 		
+		this.jobConf.set("mapred.task.id", taskAttemptID.toString());
+		this.jobConf.setInt("mapred.task.partition", taskNumber + 1);
+		// for hadoop 2.2
+		this.jobConf.set("mapreduce.task.attempt.id", taskAttemptID.toString());
+		this.jobConf.setInt("mapreduce.task.partition", taskNumber + 1);
+		
 		try {
 			this.context = HadoopUtils.instantiateTaskAttemptContext(this.jobConf, taskAttemptID);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
-		
-		this.jobConf.set("mapred.task.id", taskAttemptID.toString());
-		// for hadoop 2.2
-		this.jobConf.set("mapreduce.task.attempt.id", taskAttemptID.toString());
 		
 		this.fileOutputCommitter = new FileOutputCommitter();
 		


### PR DESCRIPTION
This PR includes some fixes necessary to run a large Hadoop OutputFormat such as the HCatOutputFormat on HDFS. Since HCatOutputFormat uses a custom output file name the following exception is thrown which is now fixed:

``` java
eu.stratosphere.client.program.ProgramInvocationException: The program execution failed: java.lang.IllegalArgumentException: This method can only be called from within a Job
    at org.apache.hadoop.mapred.FileOutputFormat.getUniqueName(FileOutputFormat.java:286)
    at org.apache.hive.hcatalog.mapreduce.FileOutputFormatContainer.getRecordWriter(FileOutputFormatContainer.java:107)
    at org.apache.hive.hcatalog.mapreduce.HCatOutputFormat.getRecordWriter(HCatOutputFormat.java:246)
    at eu.stratosphere.hadoopcompatibility.mapreduce.HadoopOutputFormat.open(HadoopOutputFormat.java:122)
```

Furthermore there were some issues with HDFS that were also fixed with this PR.
