### PR TITLE
[FLINK-1042] Changed ClassLoader field to be transient.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/RuntimeStatefulSerializerFactory.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/RuntimeStatefulSerializerFactory.java
@@ -38,7 +38,7 @@ public final class RuntimeStatefulSerializerFactory<T> implements TypeSerializer
 	
 	private TypeSerializer<T> serializer;		// only for equality comparisons
 	
-	private ClassLoader loader;
+	private transient ClassLoader loader;
 
 	private Class<T> clazz;
 


### PR DESCRIPTION
Serialization of the `RuntimeStatefulSerializerFactory` fails because the field `ClassLoader loader` is not serializable. The fix makes the field `transient`.
