### PR TITLE
[FLINK-1070] Change return type of "getBroadcastVariable()" to List.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/MapFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/MapFunction.java
@@ -44,7 +44,7 @@ public interface MapFunction<T, O> extends Function, Serializable {
 	 * it into exactly one element.
 	 *
 	 * @param value The input value.
-	 * @returns  The transformed value
+	 * @return The transformed value
 	 *
 	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
 	 *                   to fail and may trigger recovery.

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
@@ -112,7 +112,7 @@ public interface RuntimeContext {
 	 * Returns the result bound to the broadcast variable identified by the 
 	 * given {@code name}.
 	 */
-	<RT> Collection<RT> getBroadcastVariable(String name);
+	<RT> List<RT> getBroadcastVariable(String name);
 
 	/**
 	 * Returns the distributed cache to get the local tmp file.

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/WrappingFunction.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/WrappingFunction.java
@@ -19,8 +19,8 @@
 package org.apache.flink.api.java.operators.translation;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
@@ -137,15 +137,9 @@ public abstract class WrappingFunction<T extends Function> extends AbstractRichF
 		}
 
 		@Override
-		public <RT> Collection<RT> getBroadcastVariable(String name) {
-			Collection<RT> refColl = context.getBroadcastVariable(name);
-			
-			ArrayList<RT> list = new ArrayList<RT>(refColl.size());
-			for (RT e : refColl) {
-				list.add(e);
-			}
-			
-			return list;
+		public <RT> List<RT> getBroadcastVariable(String name) {
+			List<RT> refColl = context.getBroadcastVariable(name);
+			return new ArrayList<RT>(refColl);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/RuntimeUDFContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/udf/RuntimeUDFContext.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.runtime.operators.udf;
 
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.FutureTask;
 
@@ -34,7 +34,7 @@ import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.core.fs.Path;
 
 /**
- *
+ * Implementation of the {@link RuntimeContext}, created by runtime UDF operators.
  */
 public class RuntimeUDFContext implements RuntimeContext {
 
@@ -48,7 +48,7 @@ public class RuntimeUDFContext implements RuntimeContext {
 
 	private HashMap<String, Accumulator<?, ?>> accumulators = new HashMap<String, Accumulator<?, ?>>();
 
-	private HashMap<String, Collection<?>> broadcastVars = new HashMap<String, Collection<?>>();
+	private HashMap<String, List<?>> broadcastVars = new HashMap<String, List<?>>();
 
 	public RuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex) {
 		this.name = name;
@@ -139,19 +139,19 @@ public class RuntimeUDFContext implements RuntimeContext {
 		return this.accumulators;
 	}
 
-	public void setBroadcastVariable(String name, Collection<?> value) {
+	public void setBroadcastVariable(String name, List<?> value) {
 		this.broadcastVars.put(name, value);
 	}
 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <RT> Collection<RT> getBroadcastVariable(String name) {
+	public <RT> List<RT> getBroadcastVariable(String name) {
 		if (!this.broadcastVars.containsKey(name)) {
 			throw new IllegalArgumentException("Trying to access an unbound broadcast variable '" 
 					+ name + "'.");
 		}
-		return (Collection<RT>) this.broadcastVars.get(name);
+		return (List<RT>) this.broadcastVars.get(name);
 	}
 
 	@Override


### PR DESCRIPTION
`List` is much better to work with than `Collection`. The internal representation was a list anyways.

The change breaks the binary compatibility, but not source compatibility, since `List<T>`can always be cast to `Collection<T>`.
