### PR TITLE
[FLINK-1150] Fix output size estimate of FilterNode.

### DIFF
--- a/flink-compiler/src/main/java/org/apache/flink/compiler/dag/FilterNode.java
+++ b/flink-compiler/src/main/java/org/apache/flink/compiler/dag/FilterNode.java
@@ -64,5 +64,6 @@ public class FilterNode extends SingleInputNode {
 	@Override
 	protected void computeOperatorSpecificDefaultEstimates(DataStatistics statistics) {
 		this.estimatedNumRecords = (long) (getPredecessorNode().getEstimatedNumRecords() * 0.5);
+		this.estimatedOutputSize = (long) (getPredecessorNode().getEstimatedOutputSize() * 0.5);
 	}
 }


### PR DESCRIPTION
FilterNode implicitly sets the estimated output size to unknown (-1) while adjusting the cardinality by a factor of 0.5.
This fix changes the estimated output size proportional to cardinality.
