### PR TITLE
[FLINK-1151] Adds BaseStatistics for CollectionDataSources

### DIFF
--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamrecord/StreamRecordSerializer.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamrecord/StreamRecordSerializer.java
@@ -84,6 +84,11 @@ public final class StreamRecordSerializer<T> extends TypeSerializer<StreamRecord
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 20 + typeSerializer.getMinimumLength();
+	}
 
 	@Override
 	public void serialize(StreamRecord<T> value, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -100,6 +100,14 @@ public abstract class TypeSerializer<T> implements Serializable {
 	 */
 	public abstract int getLength();
 	
+	/**
+	 * Gets the minimum length of the data type.
+	 * The minimum length might be used as a lower bound for size estimations.
+	 * 
+	 * @return The minimum length of the data type.
+	 */
+	public abstract int getMinimumLength();
+	
 	// --------------------------------------------------------------------------------------------
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanSerializer.java
@@ -60,6 +60,11 @@ public final class BooleanSerializer extends TypeSerializerSingleton<Boolean> {
 	public int getLength() {
 		return 1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(Boolean record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializer.java
@@ -64,6 +64,11 @@ public final class BooleanValueSerializer extends TypeSerializerSingleton<Boolea
 	public int getLength() {
 		return 1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(BooleanValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteSerializer.java
@@ -62,6 +62,11 @@ public final class ByteSerializer extends TypeSerializerSingleton<Byte> {
 	public int getLength() {
 		return 1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(Byte record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializer.java
@@ -62,6 +62,11 @@ public final class ByteValueSerializer extends TypeSerializerSingleton<ByteValue
 	public int getLength() {
 		return 1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(ByteValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharSerializer.java
@@ -62,6 +62,11 @@ public final class CharSerializer extends TypeSerializerSingleton<Character> {
 	public int getLength() {
 		return 2;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(Character record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharValueSerializer.java
@@ -61,6 +61,11 @@ public class CharValueSerializer extends TypeSerializerSingleton<CharValue> {
 	public int getLength() {
 		return 2;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(CharValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleSerializer.java
@@ -61,6 +61,11 @@ public final class DoubleSerializer extends TypeSerializerSingleton<Double> {
 	public int getLength() {
 		return 8;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(Double record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializer.java
@@ -64,6 +64,11 @@ public final class DoubleValueSerializer extends TypeSerializerSingleton<DoubleV
 	}
 
 	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
+
+	@Override
 	public void serialize(DoubleValue record, DataOutputView target) throws IOException {
 		record.write(target);
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatSerializer.java
@@ -63,6 +63,11 @@ public final class FloatSerializer extends TypeSerializerSingleton<Float> {
 	}
 
 	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
+	
+	@Override
 	public void serialize(Float record, DataOutputView target) throws IOException {
 		target.writeFloat(record.floatValue());
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializer.java
@@ -62,6 +62,11 @@ public class FloatValueSerializer extends TypeSerializerSingleton<FloatValue> {
 	public int getLength() {
 		return 4;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(FloatValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
@@ -88,6 +88,11 @@ public final class GenericArraySerializer<C> extends TypeSerializer<C[]> {
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(C[] value, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntSerializer.java
@@ -62,6 +62,11 @@ public final class IntSerializer extends TypeSerializerSingleton<Integer> {
 	public int getLength() {
 		return 4;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(Integer record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntValueSerializer.java
@@ -62,6 +62,11 @@ public final class IntValueSerializer extends TypeSerializerSingleton<IntValue> 
 	public int getLength() {
 		return 4;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(IntValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongSerializer.java
@@ -62,6 +62,11 @@ public final class LongSerializer extends TypeSerializerSingleton<Long> {
 	public int getLength() {
 		return 8;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(Long record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongValueSerializer.java
@@ -62,6 +62,11 @@ public final class LongValueSerializer extends TypeSerializerSingleton<LongValue
 	public int getLength() {
 		return 8;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(LongValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortSerializer.java
@@ -62,6 +62,11 @@ public final class ShortSerializer extends TypeSerializerSingleton<Short> {
 	public int getLength() {
 		return 2;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(Short record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializer.java
@@ -62,6 +62,11 @@ public final class ShortValueSerializer extends TypeSerializerSingleton<ShortVal
 	public int getLength() {
 		return 2;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(ShortValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringSerializer.java
@@ -62,6 +62,11 @@ public final class StringSerializer extends TypeSerializerSingleton<String> {
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 1;
+	}
 
 	@Override
 	public void serialize(String record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringValueSerializer.java
@@ -64,6 +64,11 @@ public final class StringValueSerializer extends TypeSerializerSingleton<StringV
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 1;
+	}
 
 	@Override
 	public void serialize(StringValue record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
@@ -68,6 +68,10 @@ public final class BooleanPrimitiveArraySerializer extends TypeSerializerSinglet
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(boolean[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
@@ -67,6 +67,10 @@ public final class BytePrimitiveArraySerializer extends TypeSerializerSingleton<
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(byte[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
@@ -68,6 +68,10 @@ public final class CharPrimitiveArraySerializer extends TypeSerializerSingleton<
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(char[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
@@ -68,6 +68,10 @@ public final class DoublePrimitiveArraySerializer extends TypeSerializerSingleto
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(double[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
@@ -68,6 +68,10 @@ public final class FloatPrimitiveArraySerializer extends TypeSerializerSingleton
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(float[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
@@ -68,6 +68,10 @@ public class IntPrimitiveArraySerializer extends TypeSerializerSingleton<int[]>{
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(int[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
@@ -68,6 +68,10 @@ public final class LongPrimitiveArraySerializer extends TypeSerializerSingleton<
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(long[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
@@ -68,6 +68,10 @@ public final class ShortPrimitiveArraySerializer extends TypeSerializerSingleton
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
 
 	@Override
 	public void serialize(short[] record, DataOutputView target) throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
@@ -71,6 +71,11 @@ public final class StringArraySerializer extends TypeSerializerSingleton<String[
 	}
 
 	@Override
+	public int getMinimumLength() {
+		return 4;
+	}
+	
+	@Override
 	public void serialize(String[] record, DataOutputView target) throws IOException {
 		if (record == null) {
 			throw new IllegalArgumentException("The record must not be null.");

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/record/RecordSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/record/RecordSerializer.java
@@ -82,6 +82,11 @@ public final class RecordSerializer extends TypeSerializer<Record> {
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		return 1;
+	}
+	
 	// --------------------------------------------------------------------------------------------
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CollectionInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CollectionInputFormat.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.apache.flink.api.common.io.GenericInputFormat;
 import org.apache.flink.api.common.io.NonParallelInput;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.io.GenericInputSplit;
 import org.apache.flink.core.memory.InputViewObjectInputStreamWrapper;
@@ -49,6 +50,7 @@ public class CollectionInputFormat<T> extends GenericInputFormat<T> implements N
 
 	
 	public CollectionInputFormat(Collection<T> dataSet, TypeSerializer<T> serializer) {
+		
 		if (dataSet == null) {
 			throw new NullPointerException();
 		}
@@ -74,6 +76,11 @@ public class CollectionInputFormat<T> extends GenericInputFormat<T> implements N
 	@Override
 	public T nextRecord(T record) throws IOException {
 		return this.iterator.next();
+	}
+	
+	@Override
+	public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
+		return new CollectionStatistics<T>(this.dataSet.size(), this.serializer.getMinimumLength());
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -127,5 +134,32 @@ public class CollectionInputFormat<T> extends GenericInputFormat<T> implements N
 							viewedAs.getCanonicalName());
 			}
 		}
+	}
+	
+	public static class CollectionStatistics<T> implements BaseStatistics {
+
+		private final long numRecords;
+		private final float recordWidth;
+		
+		public CollectionStatistics(long numRecords, float recordWidth) {
+			this.numRecords = numRecords;
+			this.recordWidth = recordWidth;
+		}
+		
+		@Override
+		public long getTotalInputSize() {
+			return (long)this.recordWidth * this.numRecords;
+		}
+
+		@Override
+		public long getNumberOfRecords() {
+			return this.numRecords;
+		}
+
+		@Override
+		public float getAverageRecordWidth() {
+			return recordWidth;
+		}
+		
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
@@ -104,6 +104,11 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return Math.max(reader.getSchema().getFixedSize(), 1);
+	}
 
 	@Override
 	public void serialize(T value, DataOutputView target) throws IOException {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
@@ -72,6 +72,11 @@ public class CopyableValueSerializer<T extends CopyableValue<T>> extends TypeSer
 		ensureInstanceInstantiated();
 		return instance.getBinaryLength();
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(T value, DataOutputView target) throws IOException {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoSerializer.java
@@ -91,6 +91,11 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 1;
+	}
 
 	@Override
 	public void serialize(T record, DataOutputView target) throws IOException {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -171,6 +171,14 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		return -1;
 	}
 
+	@Override
+	public int getMinimumLength() {
+		int minLen = 0;
+		for(TypeSerializer<?> s : this.fieldSerializers) {
+			minLen += s.getMinimumLength();
+		}
+		return minLen;
+	}
 
 	@Override
 	public void serialize(T value, DataOutputView target) throws IOException {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
@@ -118,6 +118,15 @@ public final class TupleSerializer<T extends Tuple> extends TupleSerializerBase<
 		return reuse;
 	}
 	
+	@Override
+	public int getMinimumLength() {
+		int minLen = 0;
+		for(TypeSerializer<?> s : this.fieldSerializers) {
+			minLen += s.getMinimumLength();
+		}
+		return minLen;
+	}
+	
 	private T instantiateRaw() {
 		try {
 			return tupleClass.newInstance();

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
@@ -70,7 +70,7 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 	public int getLength() {
 		return -1;
 	}
-
+	
 	public int getArity() {
 		return arity;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -87,6 +87,11 @@ public class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 1;
+	}
 
 	@Override
 	public void serialize(T value, DataOutputView target) throws IOException {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
@@ -65,6 +65,11 @@ public class WritableSerializer<T extends Writable> extends TypeSerializer<T> {
 	}
 	
 	@Override
+	public int getMinimumLength() {
+		return 1;
+	}
+	
+	@Override
 	public void serialize(T record, DataOutputView target) throws IOException {
 		record.write(target);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
@@ -71,6 +71,11 @@ public class IntListSerializer extends TypeSerializer<IntList> {
 	}
 
 	@Override
+	public int getMinimumLength() {
+		return 8;
+	}
+	
+	@Override
 	public void serialize(IntList record, DataOutputView target) throws IOException {
 		target.writeInt(record.getKey());
 		target.writeInt(record.getValue().length);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
@@ -64,6 +64,11 @@ public class IntPairSerializer extends TypeSerializer<IntPair> {
 	public int getLength() {
 		return 8;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(IntPair record, DataOutputView target) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
@@ -59,6 +59,11 @@ public class StringPairSerializer extends TypeSerializer<StringPair> {
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 2;
+	}
 
 	@Override
 	public void serialize(StringPair record, DataOutputView target) throws IOException {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassSerializer.scala
@@ -83,4 +83,12 @@ abstract class CaseClassSerializer[T <: Product](
       fields = new Array[AnyRef](arity)
     }
   }
+  
+  def getMinimumLength(): Int = {
+    var minLen = 0;
+    for(s <- fieldSerializers) {
+      minLen += s.getMinimumLength()
+    }
+    minLen
+  }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/nephele/customdanglingpagerank/types/VertexWithAdjacencyListSerializer.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/nephele/customdanglingpagerank/types/VertexWithAdjacencyListSerializer.java
@@ -68,6 +68,11 @@ public final class VertexWithAdjacencyListSerializer extends TypeSerializerSingl
 	public int getLength() {
 		return -1;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return 12;
+	}
 
 	@Override
 	public void serialize(VertexWithAdjacencyList record, DataOutputView target) throws IOException {

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/nephele/customdanglingpagerank/types/VertexWithRankAndDanglingSerializer.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/nephele/customdanglingpagerank/types/VertexWithRankAndDanglingSerializer.java
@@ -61,6 +61,11 @@ public final class VertexWithRankAndDanglingSerializer extends TypeSerializerSin
 	public int getLength() {
 		return 17;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(VertexWithRankAndDangling record, DataOutputView target) throws IOException {

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/nephele/customdanglingpagerank/types/VertexWithRankSerializer.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/nephele/customdanglingpagerank/types/VertexWithRankSerializer.java
@@ -60,6 +60,11 @@ public final class VertexWithRankSerializer extends TypeSerializerSingleton<Vert
 	public int getLength() {
 		return 16;
 	}
+	
+	@Override
+	public int getMinimumLength() {
+		return getLength();
+	}
 
 	@Override
 	public void serialize(VertexWithRank record, DataOutputView target) throws IOException {


### PR DESCRIPTION
Adds statistics for collection data sources based on collection size and serializer information.
Adds getMinimumLength() to TypeSerializer to get a lower bound for size estimates.