### PR TITLE
[FLINK-1139] Fix HadoopOutputFormat for DOP>1

### DIFF
--- a/flink-addons/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopOutputFormat.java
+++ b/flink-addons/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopOutputFormat.java
@@ -141,7 +141,8 @@ public class HadoopOutputFormat<K extends Writable,V extends Writable> implement
 		if (this.fileOutputCommitter.needsTaskCommit(this.context)) {
 			this.fileOutputCommitter.commitTask(this.context);
 		}
-		this.fileOutputCommitter.commitJob(this.jobContext);
+		// Job commit should be done after all the tasks are finished.
+//		this.fileOutputCommitter.commitJob(this.jobContext);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-addons/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapreduce/HadoopOutputFormat.java
+++ b/flink-addons/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapreduce/HadoopOutputFormat.java
@@ -158,7 +158,8 @@ public class HadoopOutputFormat<K extends Writable,V extends Writable> implement
 		if (this.fileOutputCommitter.needsTaskCommit(this.context)) {
 			this.fileOutputCommitter.commitTask(this.context);
 		}
-		this.fileOutputCommitter.commitJob(this.context);
+		// Job commit should be done after all the tasks are finished.
+//		this.fileOutputCommitter.commitJob(this.context);
 		
 		
 		Path outputPath = new Path(this.configuration.get("mapred.output.dir"));


### PR DESCRIPTION
This fix leaves the _temporary directory unremoved. It would be better if we could remove the temp directory after all tasks finished.
