### PR TITLE
[FLINK-1178] Changed type preference to ValueType, WritableType, CaseClassType

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
@@ -60,9 +60,9 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
             BoxedPrimitiveDescriptor(id, tpe, default, wrapper, box, unbox)
           case ListType(elemTpe, iter) =>
             analyzeList(id, tpe, elemTpe, iter)
-          case CaseClassType() => analyzeCaseClass(id, tpe)
           case ValueType() => ValueDescriptor(id, tpe)
           case WritableType() => WritableDescriptor(id, tpe)
+          case CaseClassType() => analyzeCaseClass(id, tpe)
           case JavaType() =>
             // It's a Java Class, let the TypeExtractor deal with it...
             c.warning(c.enclosingPosition, s"Type $tpe is a java class. Will be analyzed by " +


### PR DESCRIPTION
Case class which implement the Value or Writable interface are now treated as one of those types. This allows to add custom serialization logic to case classes.
