### PR TITLE
Another round to remove final modifier to private methods because it is not needed

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/web/WebInterfaceServer.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/web/WebInterfaceServer.java
@@ -259,7 +259,7 @@ public class WebInterfaceServer {
 	 * @throws IOException
 	 *         Thrown, if the directory could not be created, or if one of the checks failed.
 	 */
-	private final void checkAndCreateDirectories(File f, boolean needWritePermission) throws IOException {
+	private void checkAndCreateDirectories(File f, boolean needWritePermission) throws IOException {
 		String dir = f.getAbsolutePath();
 
 		// check if it exists and it is not a directory

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -586,13 +586,13 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 		}
 	}
 	
-	private final void setResult(byte[] buffer, int offset, int len) {
+	private void setResult(byte[] buffer, int offset, int len) {
 		this.currBuffer = buffer;
 		this.currOffset = offset;
 		this.currLen = len;
 	}
 
-	private final boolean fillBuffer() throws IOException {
+	private boolean fillBuffer() throws IOException {
 		// special case for reading the whole split.
 		if(this.splitLength == FileInputFormat.READ_WHOLE_SPLIT_FLAG) {
 			int read = this.stream.read(this.readBuffer, 0, readBuffer.length);

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -785,7 +785,7 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 		/**
 		 * Double checked procedure setting the abort flag and closing the stream.
 		 */
-		private final void abortWait() {
+		private void abortWait() {
 			this.aborted = true;
 			final FSDataInputStream inStream = this.fdis;
 			this.fdis = null;

--- a/flink-core/src/main/java/org/apache/flink/types/Record.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Record.java
@@ -370,7 +370,7 @@ public final class Record implements Value, CopyableValue<Record> {
 	 * @param offset The offset in the binary string.
 	 * @param limit The limit in the binary string.
 	 */
-	private final <T extends Value> void deserialize(T target, int offset, int limit, int fieldNumber) {
+	private <T extends Value> void deserialize(T target, int offset, int limit, int fieldNumber) {
 		final InternalDeSerializer serializer = this.serializer;
 		serializer.memory = this.binaryData;
 		serializer.position = offset;
@@ -419,20 +419,20 @@ public final class Record implements Value, CopyableValue<Record> {
 		internallySetField(num, value);
 	}
 	
-	private final void internallySetField(int fieldNum, Value value) {
+	private void internallySetField(int fieldNum, Value value) {
 		// check if we modify an existing field
 		this.offsets[fieldNum] = value != null ? MODIFIED_INDICATOR_OFFSET : NULL_INDICATOR_OFFSET;
 		this.writeFields[fieldNum] = value;
 		markModified(fieldNum);
 	}
 	
-	private final void markModified(int field) {
+	private void markModified(int field) {
 		if (this.firstModifiedPos > field) {
 			this.firstModifiedPos = field;
 		}
 	}
 	
-	private final boolean isModified() {
+	private boolean isModified() {
 		return this.firstModifiedPos != Integer.MAX_VALUE;
 	}
 	
@@ -1001,7 +1001,7 @@ public final class Record implements Value, CopyableValue<Record> {
 		this.firstModifiedPos = Integer.MAX_VALUE;
 	}
 	
-	private final void serializeHeader(final InternalDeSerializer serializer, final int[] offsets, final int numFields) {
+	private void serializeHeader(final InternalDeSerializer serializer, final int[] offsets, final int numFields) {
 		try {
 			if (numFields > 0) {
 				int slp = serializer.position;	// track the last position of the serializer
@@ -1102,7 +1102,7 @@ public final class Record implements Value, CopyableValue<Record> {
 		initFields(data, 0, len);
 	}
 	
-	private final void initFields(final byte[] data, final int begin, final int len) {
+	private void initFields(final byte[] data, final int begin, final int len) {
 		try {
 			// read number of fields, variable length encoded reverse at the back
 			int pos = begin + len - 2;
@@ -1734,7 +1734,7 @@ public final class Record implements Value, CopyableValue<Record> {
 			this.position = count;
 		}
 		
-		private final void writeValLenIntBackwards(int value) throws IOException {
+		private void writeValLenIntBackwards(int value) throws IOException {
 			if (this.position > this.memory.length - 4) {
 				resize(4);
 			}
@@ -1766,7 +1766,7 @@ public final class Record implements Value, CopyableValue<Record> {
 			}
 		}
 		
-		private final void resize(int minCapacityAdd) throws IOException {
+		private void resize(int minCapacityAdd) throws IOException {
 			try {
 				final int newLen = Math.max(this.memory.length * 2, this.memory.length + minCapacityAdd);
 				final byte[] nb = new byte[newLen];

--- a/flink-core/src/main/java/org/apache/flink/types/StringValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/StringValue.java
@@ -717,7 +717,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	//                                      Utilities
 	// --------------------------------------------------------------------------------------------
 
-	private final void ensureSize(int size) {
+	private void ensureSize(int size) {
 		if (this.value.length < size) {
 			this.value = new char[size];
 		}
@@ -726,7 +726,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	/**
 	 * Grow and retain content.
 	 */
-	private final void grow(int size) {
+	private void grow(int size) {
 		if (this.value.length < size) {
 			char[] value = new char[ Math.max(this.value.length * 3 / 2, size)];
 			System.arraycopy(this.value, 0, value, 0, this.len);
@@ -738,7 +738,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	//                           Static Helpers for String Serialization
 	// --------------------------------------------------------------------------------------------
 	
-	public static final String readString(DataInput in) throws IOException {
+	public static String readString(DataInput in) throws IOException {
 		// the length we read is offset by one, because a length of zero indicates a null value
 		int len = in.readUnsignedByte();
 		

--- a/flink-core/src/test/java/org/apache/flink/types/RecordTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/RecordTest.java
@@ -776,7 +776,7 @@ public class RecordTest {
 		}
 	}
 	
-	private final void testUnionFieldsForValues(Value[] rec1fields, Value[] rec2fields, Random rnd)
+	private void testUnionFieldsForValues(Value[] rec1fields, Value[] rec2fields, Random rnd)
 	{
 		// fully in binary sync
 		Record rec1 = createRecord(rec1fields);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
@@ -142,7 +142,7 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 	}
 	
 	
-	private final void checkAvroInitialized() {
+	private void checkAvroInitialized() {
 		if (this.reader == null) {
 			this.reader = new ReflectDatumReader<T>(type);
 			this.writer = new ReflectDatumWriter<T>(type);
@@ -151,7 +151,7 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 		}
 	}
 	
-	private final void checkKryoInitialized() {
+	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
 			this.kryo.setAsmEnabled(true);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
@@ -97,7 +97,7 @@ public class CopyableValueSerializer<T extends CopyableValue<T>> extends TypeSer
 	
 	// --------------------------------------------------------------------------------------------
 	
-	private final void ensureInstanceInstantiated() {
+	private void ensureInstanceInstantiated() {
 		if (instance == null) {
 			instance = createInstance();
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenericTypeComparator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenericTypeComparator.java
@@ -159,7 +159,7 @@ public class GenericTypeComparator<T extends Comparable<T>> extends TypeComparat
 		return new GenericTypeComparator<T>(this);
 	}
 
-	private final void checkKryoInitialized() {
+	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
 			this.kryo.setAsmEnabled(true);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoSerializer.java
@@ -151,7 +151,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 	
 	// --------------------------------------------------------------------------------------------
 
-	private final void checkKryoInitialized() {
+	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
 			this.kryo.setAsmEnabled(true);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueComparator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueComparator.java
@@ -135,7 +135,7 @@ public class ValueComparator<T extends Value & Comparable<T>> extends TypeCompar
 		return new ValueComparator<T>(ascendingComparison, type);
 	}
 	
-	private final void checkKryoInitialized() {
+	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
 			this.kryo.setAsmEnabled(true);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -114,7 +114,7 @@ public class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 		this.copyInstance.write(target);
 	}
 	
-	private final void checkKryoInitialized() {
+	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
 			this.kryo.setAsmEnabled(true);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableComparator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableComparator.java
@@ -159,7 +159,7 @@ public class WritableComparator<T extends Writable & Comparable<T>> extends Type
 	
 	// --------------------------------------------------------------------------------------------
 	
-	private final void checkKryoInitialized() {
+	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
 			this.kryo.setAsmEnabled(true);
@@ -167,13 +167,13 @@ public class WritableComparator<T extends Writable & Comparable<T>> extends Type
 		}
 	}
 	
-	private final void ensureReferenceInstantiated() {
+	private void ensureReferenceInstantiated() {
 		if (reference == null) {
 			reference = InstantiationUtil.instantiate(type, Writable.class);
 		}
 	}
 	
-	private final void ensureTempReferenceInstantiated() {
+	private void ensureTempReferenceInstantiated() {
 		if (tempReference == null) {
 			tempReference = InstantiationUtil.instantiate(type, Writable.class);
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
@@ -99,13 +99,13 @@ public class WritableSerializer<T extends Writable> extends TypeSerializer<T> {
 	
 	// --------------------------------------------------------------------------------------------
 	
-	private final void ensureInstanceInstantiated() {
+	private void ensureInstanceInstantiated() {
 		if (copyInstance == null) {
 			copyInstance = createInstance();
 		}
 	}
 	
-	private final void checkKryoInitialized() {
+	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
 			this.kryo.setAsmEnabled(true);

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericArraySerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericArraySerializerTest.java
@@ -144,7 +144,7 @@ abstract public class AbstractGenericArraySerializerTest {
 		}
 	}
 
-	private final <T> void runTests(T[]... instances) {
+	private <T> void runTests(T[]... instances) {
 		try {
 			@SuppressWarnings("unchecked")
 			Class<T> type = (Class<T>) instances[0][0].getClass();
@@ -158,7 +158,7 @@ abstract public class AbstractGenericArraySerializerTest {
 		}
 	}
 	
-	private final <T> void runTests(Class<T> type, TypeSerializer<T> componentSerializer, T[]... instances) {
+	private <T> void runTests(Class<T> type, TypeSerializer<T> componentSerializer, T[]... instances) {
 		try {
 			if (type == null || componentSerializer == null || instances == null || instances.length == 0) {
 				throw new IllegalArgumentException();
@@ -178,7 +178,7 @@ abstract public class AbstractGenericArraySerializerTest {
 		}
 	}
 	
-	private final <T> GenericArraySerializer<T> createSerializer(Class<T> type, TypeSerializer<T> componentSerializer) {
+	private <T> GenericArraySerializer<T> createSerializer(Class<T> type, TypeSerializer<T> componentSerializer) {
 		return new GenericArraySerializer<T>(type, componentSerializer);
 	}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericTypeComparatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericTypeComparatorTest.java
@@ -98,7 +98,7 @@ abstract public class AbstractGenericTypeComparatorTest {
 
 	// ------------------------------------------------------------------------
 
-	private final <T> void runTests(T... sortedTestData) {
+	private <T> void runTests(T... sortedTestData) {
 		ComparatorTestInstance<T> testBase = new ComparatorTestInstance<T>(sortedTestData);
 		testBase.testAll();
 	}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericTypeSerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericTypeSerializerTest.java
@@ -115,7 +115,7 @@ abstract public class AbstractGenericTypeSerializerTest {
 		}
 	}
 
-	private final <T> void runTests(T... instances) {
+	private <T> void runTests(T... instances) {
 		if (instances == null || instances.length == 0) {
 			throw new IllegalArgumentException();
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/KryoVersusAvroMinibenchmark.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/KryoVersusAvroMinibenchmark.java
@@ -393,7 +393,7 @@ public class KryoVersusAvroMinibenchmark {
 		}
 		
 		
-		private final void resize(int minCapacityAdd) throws IOException {
+		private void resize(int minCapacityAdd) throws IOException {
 			try {
 				final int newLen = Math.max(this.buffer.length * 2, this.buffer.length + minCapacityAdd);
 				final byte[] nb = new byte[newLen];

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTest.java
@@ -206,7 +206,7 @@ public class TupleSerializerTest {
 		runTests(testTuples);
 	}
 
-	private final <T extends Tuple> void runTests(T... instances) {
+	private <T extends Tuple> void runTests(T... instances) {
 		try {
 			TupleTypeInfo<T> tupleTypeInfo = (TupleTypeInfo<T>) TypeExtractor.getForObject(instances[0]);
 			TypeSerializer<T> serializer = tupleTypeInfo.createSerializer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/ChannelWriterOutputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/ChannelWriterOutputView.java
@@ -209,7 +209,7 @@ public final class ChannelWriterOutputView extends AbstractPagedOutputView {
 		return next;
 	}
 	
-	private final void writeSegment(MemorySegment segment, int writePosition, boolean lastSegment) throws IOException
+	private void writeSegment(MemorySegment segment, int writePosition, boolean lastSegment) throws IOException
 	{
 		segment.putShort(0, HEADER_MAGIC_NUMBER);
 		segment.putShort(HEADER_FLAGS_OFFSET, lastSegment ? FLAG_LAST_BLOCK : 0);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/serialization/DataOutputSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/serialization/DataOutputSerializer.java
@@ -243,7 +243,7 @@ public class DataOutputSerializer implements DataOutputView {
 	}
 	
 	
-	private final void resize(int minCapacityAdd) throws IOException {
+	private void resize(int minCapacityAdd) throws IOException {
 		try {
 			final int newLen = Math.max(this.buffer.length * 2, this.buffer.length + minCapacityAdd);
 			final byte[] nb = new byte[newLen];

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
@@ -542,7 +542,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T>{
 		}
 	}
 
-	private final void insertBucketEntryFromStart(InMemoryPartition<T> p, MemorySegment bucket, 
+	private void insertBucketEntryFromStart(InMemoryPartition<T> p, MemorySegment bucket,
 			int bucketInSegmentPos, int hashCode, long pointer)
 	throws IOException
 	{
@@ -639,7 +639,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T>{
 		}
 	}
 	
-	private final void insertBucketEntryFromSearch(InMemoryPartition<T> partition, MemorySegment originalBucket, MemorySegment currentBucket, int originalBucketOffset, int currentBucketOffset, int countInCurrentBucket, long currentForwardPointer, int hashCode, long pointer) throws IOException {
+	private void insertBucketEntryFromSearch(InMemoryPartition<T> partition, MemorySegment originalBucket, MemorySegment currentBucket, int originalBucketOffset, int currentBucketOffset, int countInCurrentBucket, long currentForwardPointer, int hashCode, long pointer) throws IOException {
 		boolean checkForResize = false;
 		if (countInCurrentBucket < NUM_ENTRIES_PER_BUCKET) {
 			// we are good in our current bucket, put the values

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashPartition.java
@@ -585,7 +585,7 @@ public class HashPartition<BT, PT> extends AbstractPagedInputView implements See
 			}
 		}
 		
-		private final void finalizeSegment(MemorySegment seg, int bytesUsed) {
+		private void finalizeSegment(MemorySegment seg, int bytesUsed) {
 		}
 	}
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/PartialOrderPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/PartialOrderPriorityQueue.java
@@ -197,7 +197,7 @@ public class PartialOrderPriorityQueue<T> extends AbstractQueue<T> implements Qu
 		size = 0;
 	}
 
-	private final void upHeap() {
+	private void upHeap() {
 		int i = size;
 		T node = heap[i]; // save bottom node
 		int j = i >>> 1;
@@ -209,7 +209,7 @@ public class PartialOrderPriorityQueue<T> extends AbstractQueue<T> implements Qu
 		heap[i] = node; // install saved node
 	}
 
-	private final void downHeap() {
+	private void downHeap() {
 		int i = 1;
 		T node = heap[i]; // save top node
 		int j = i << 1; // find smaller child

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
@@ -1017,7 +1017,7 @@ public class TaskConfig {
 	//                                    Miscellaneous
 	// --------------------------------------------------------------------------------------------
 	
-	private final void setTypeSerializerFactory(TypeSerializerFactory<?> factory, 
+	private void setTypeSerializerFactory(TypeSerializerFactory<?> factory,
 			String classNameKey, String parametersPrefix)
 	{
 		// sanity check the factory type
@@ -1030,7 +1030,7 @@ public class TaskConfig {
 		factory.writeParametersToConfig(parameters);
 	}
 	
-	private final <T> TypeSerializerFactory<T> getTypeSerializerFactory(String classNameKey, String parametersPrefix, ClassLoader cl) {
+	private <T> TypeSerializerFactory<T> getTypeSerializerFactory(String classNameKey, String parametersPrefix, ClassLoader cl) {
 		// check the class name
 		final String className = this.config.getString(classNameKey, null);
 		if (className == null) {
@@ -1066,7 +1066,7 @@ public class TaskConfig {
 		return factory;
 	}
 	
-	private final void setTypeComparatorFactory(TypeComparatorFactory<?> factory, 
+	private void setTypeComparatorFactory(TypeComparatorFactory<?> factory,
 			String classNameKey, String parametersPrefix)
 	{
 		// sanity check the factory type
@@ -1079,7 +1079,7 @@ public class TaskConfig {
 		factory.writeParametersToConfig(parameters);
 	}
 	
-	private final <T> TypeComparatorFactory<T> getTypeComparatorFactory(String classNameKey, String parametersPrefix, ClassLoader cl) {
+	private <T> TypeComparatorFactory<T> getTypeComparatorFactory(String classNameKey, String parametersPrefix, ClassLoader cl) {
 		// check the class name
 		final String className = this.config.getString(classNameKey, null);
 		if (className == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerPerformanceBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerPerformanceBenchmark.java
@@ -108,7 +108,7 @@ public class IOManagerPerformanceBenchmark
 		}
 	}
 
-	private final void testChannelWithSegments(int numSegments) throws Exception
+	private void testChannelWithSegments(int numSegments) throws Exception
 	{
 		final List<MemorySegment> memory = this.memManager.allocatePages(memoryOwner, numSegments);
 		final Channel.ID channel = this.ioManager.createChannel();
@@ -245,7 +245,7 @@ public class IOManagerPerformanceBenchmark
 		
 	}
 		
-	private final void speedTestStream(int bufferSize) throws IOException {
+	private void speedTestStream(int bufferSize) throws IOException {
 		final Channel.ID tmpChannel = ioManager.createChannel();
 		final IntegerRecord rec = new IntegerRecord(0);
 		
@@ -340,7 +340,7 @@ public class IOManagerPerformanceBenchmark
 	}
 		
 	@SuppressWarnings("resource")
-	private final void speedTestNIO(int bufferSize, boolean direct) throws IOException
+	private void speedTestNIO(int bufferSize, boolean direct) throws IOException
 	{
 		final Channel.ID tmpChannel = ioManager.createChannel();
 		


### PR DESCRIPTION
Remove final modifier to private methods because it is not needed. 
Those methods are final by default.
