### PR TITLE
Improve error messages in case of invalid file paths or URIs

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -209,9 +209,16 @@ public abstract class FileSystem {
 				}
 				catch (URISyntaxException e) {
 					// we tried to repair it, but could not. report the scheme error
-					throw new IOException("FileSystem: Scheme is null. file:// or hdfs:// are example schemes. "
-							+ "Failed for " + uri.toString() + ".");
+					throw new IOException("The file URI '" + uri.toString() + "' is not valid. "
+							+ " File URIs need to specify aboslute file paths.");
 				}
+			}
+			
+			if (uri.getScheme().equals("file") && uri.getAuthority() != null && !uri.getAuthority().isEmpty()) {
+				String supposedUri = "file:///" + uri.getAuthority() + uri.getPath();
+				
+				throw new IOException("Found local file path with authority '" + uri.getAuthority() + "' in path '"
+						+ uri.toString() + "'. Hint: Did you forget a slash? (correct path would be '" + supposedUri + "')");
 			}
 
 			final FSKey key = new FSKey(uri.getScheme(), uri.getAuthority());
@@ -224,7 +231,7 @@ public abstract class FileSystem {
 			// Try to create a new file system
 			if (!FSDIRECTORY.containsKey(uri.getScheme())) {
 				throw new IOException("No file system found with scheme " + uri.getScheme()
-				+ ". Failed for " + uri.toString() + ".");
+						+ ", referenced in file URI '" + uri.toString() + "'.");
 			}
 
 			Class<? extends FileSystem> fsClass = null;

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -101,11 +101,11 @@ public class LocalFileSystem extends FileSystem {
 		final File path = pathToFile(f);
 		if (path.exists()) {
 			return new LocalFileStatus(pathToFile(f), this);
-		} else {
+		}
+		else {
 			throw new FileNotFoundException("File " + f + " does not exist or the user running "
 					+ "Flink ('"+System.getProperty("user.name")+"') has insufficient permissions to access it.");
 		}
-
 	}
 
 


### PR DESCRIPTION
Gives hints for cases when the most probable error cause is a forgotten slash '/'.
Improves message on non-qualified file URIs
