### PR TITLE
[FLINK-1203] Deactivate fork reuse in tests ()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ under the License.
 			 forkCount is not exposed as a property. With this we can set
 			 it on the "mvn" commandline in travis. -->
 		<flink.forkCount>1.5C</flink.forkCount>
-		<flink.reuseForks>true</flink.reuseForks>
+		<flink.reuseForks>false</flink.reuseForks>
 		<slf4j.version>1.7.7</slf4j.version>
 		<guava.version>17.0</guava.version>
 	</properties>


### PR DESCRIPTION
Works around a potential surefire bug where we see confused class cast exceptions

```
java.lang.ClassCastException: org.apache.flink.api.common.operators.base.DeltaIterationBase cannot be cast to org.apache.flink.api.common.operators.base.GroupReduceOperatorBase
    at org.apache.flink.api.scala.operators.translation.DistinctTranslationTest.testCombinable(DistinctTranslationTest.scala:39)
```
