### PR TITLE
[FLINK-1213] Add .gitattributes to normalize EOL character.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat text eol=crlf


### PR DESCRIPTION
Flink has Windows batch files and Linux user, Mac OSX user and Windows user can edit those files. So I think we should normalize EOL character of batch files using .gitattributes.
