### PR TITLE
[FLINK-1217] Keepalive option should be set to sockets in Client and Server

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/ipc/Client.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/ipc/Client.java
@@ -304,6 +304,7 @@ public class Client {
 					try {
 						this.socket = socketFactory.createSocket();
 						this.socket.setTcpNoDelay(tcpNoDelay);
+						this.socket.setKeepAlive(true);
 						// connection time out is 20s
 						NetUtils.connect(this.socket, remoteId.getAddress(), 20000);
 						this.socket.setSoTimeout(pingInterval);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/ipc/Server.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/ipc/Server.java
@@ -424,6 +424,7 @@ public abstract class Server {
 
 				channel.configureBlocking(false);
 				channel.socket().setTcpNoDelay(tcpNoDelay);
+				channel.socket().setKeepAlive(true);
 				SelectionKey readKey = channel.register(selector, SelectionKey.OP_READ);
 				c = new Connection(readKey, channel, System.currentTimeMillis());
 				readKey.attach(c);


### PR DESCRIPTION
Sockets in Client and Server is not set keepalive option.
I think we should set keepalive option to socket to detect hang or network disconnection.
