### PR TITLE
[Flink-1142] Log information about IOManager temp directories.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -85,6 +85,10 @@ directory. A directory may be listed multiple times to have the I/O manager use
 multiple threads for it (for example if it is physically stored on a very fast
 disc or RAID) (DEFAULT: The system's tmp dir).
 
+- `taskmanager.tmp.dirs.threshold`: Threshold (in MB) for the temporary file 
+directories. Directories with less storage left will be removed from the 
+list of directories for temporary files. (DEFAULT: 100 MB)
+
 - `jobmanager.web.port`: Port of the JobManager's web interface (DEFAULT: 8081).
 
 - `fs.overwrite-files`: Specifies whether file output writers should overwrite

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -91,6 +91,11 @@ public final class ConfigConstants {
 	 * The config parameter defining the directories for temporary files.
 	 */
 	public static final String TASK_MANAGER_TMP_DIR_KEY = "taskmanager.tmp.dirs";
+	
+	/**
+	 * The config parameter defining the threshold (in MB) for the temporary file directories.
+	 */
+	public static final String TASK_MANAGER_TMP_DIR_THRESHOLD_KEY = "taskmanager.tmp.dirs.threshold";
 
 	/**
 	 * The config parameter defining the amount of memory to be allocated by the task manager's
@@ -362,6 +367,11 @@ public final class ConfigConstants {
 	 * The default directory for temporary files of the task manager.
 	 */
 	public static final String DEFAULT_TASK_MANAGER_TMP_PATH = System.getProperty("java.io.tmpdir");
+	
+	/**
+	 * The default value for the threshold (in MB) of the temporary file directories in the taskmanager.
+	 */
+	public static final int DEFAULT_TASK_MANAGER_TMP_DIR_THRESHOLD = 100;
 	
 	/**
 	 * The default fraction of the free memory allocated by the task manager's memory manager.

--- a/flink-dist/src/main/flink-bin/conf/flink-conf.yaml
+++ b/flink-dist/src/main/flink-bin/conf/flink-conf.yaml
@@ -65,6 +65,15 @@ webclient.port: 8080
 #
 # taskmanager.tmp.dirs: /tmp
 
+# Storage threshold (in MB) for directories for temporary files.
+#
+# If the usable space in a directory is smaller than this threshold it will be
+# removed from the list of directories for temporary files.
+#
+# If not specified, the default value (100 MB) is taken.
+#
+# taskmanager.tmp.dirs.threshold: 100
+
 # Path to the Hadoop configuration directory.
 #
 # This configuration is used when writing into HDFS. Unless specified otherwise,


### PR DESCRIPTION
Log the percentage of available space on the disk (total, free, percentage)
Remove those from the list with less than the defined threshold (with a WARN-message)
