### PR TITLE
[scala] Self-contained build for scala examples

### DIFF
--- a/flink-examples/flink-scala-examples/pom.xml
+++ b/flink-examples/flink-scala-examples/pom.xml
@@ -170,122 +170,91 @@ under the License.
 				</configuration>
 			</plugin>
 			
+			<!-- get default data from flink-java-examples package -->
+			<plugin>
+         			<groupId>org.apache.maven.plugins</groupId>
+         			<artifactId>maven-dependency-plugin</artifactId>
+         			<version>2.9</version>
+         			<executions>
+           				<execution>
+             					<id>unpack</id>
+             					<phase>prepare-package</phase>
+             					<goals>
+               						<goal>unpack</goal>
+             					</goals>
+             					<configuration>
+               						<artifactItems>
+                 						<artifactItem>
+                   							<groupId>org.apache.flink</groupId>
+                   							<artifactId>flink-java-examples</artifactId>
+                   							<version>${project.version}</version>
+                   							<type>jar</type>
+                   							<overWrite>false</overWrite>
+                   							<outputDirectory>${project.build.directory}/classes</outputDirectory>
+                   							<includes>**/util/*Data*.class</includes>
+						                </artifactItem>
+               						</artifactItems>
+             					</configuration>
+           				</execution>
+         			</executions>
+       			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<executions>
-					<!-- These examples are currently not self-contained
-
+					
+					<!-- KMeans -->
 					<execution>
 						<id>KMeans</id>
 						<phase>package</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
-		
+
 						<configuration>
 							<classifier>KMeans</classifier>
+
 							<archive>
 								<manifestEntries>
-									<program-class>org.apache.flink.examples.scala.datamining.KMeans</program-class>
+									<program-class>org.apache.flink.examples.scala.clustering.KMeans</program-class>
 								</manifestEntries>
 							</archive>
-		
+
 							<includes>
-								<include>**/datamining/KMeans*.class</include>
-							</includes>
-						</configuration>
-					</execution>
-		
-					<execution>
-						<id>ComputeEdgeDegrees</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-		
-						<configuration>
-							<classifier>ComputeEdgeDegrees</classifier>
-		
-							<archive>
-								<manifestEntries>
-									<program-class>org.apache.flink.examples.scala.graph.ComputeEdgeDegrees</program-class>
-								</manifestEntries>
-							</archive>
-		
-							<includes>
-								<include>**/graph/ComputeEdgeDegrees*.class</include>
-							</includes>
-						</configuration>
-					</execution>
-		
-					<execution>
-						<id>EnumTrianglesOnEdgesWithDegrees</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-		
-						<configuration>
-							<classifier>EnumTrianglesOnEdgesWithDegrees</classifier>
-		
-							<archive>
-								<manifestEntries>
-									<program-class>org.apache.flink.examples.scala.graph.EnumTrianglesOnEdgesWithDegrees</program-class>
-								</manifestEntries>
-							</archive>
-		
-							<includes>
-								<include>**/graph/EnumTrianglesOnEdgesWithDegrees*.class</include>
-							</includes>
-						</configuration>
-					</execution>
-		
-					<execution>
-						<id>TPCHQuery3</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-		
-						<configuration>
-							<classifier>TPCHQuery3</classifier>
-		
-							<archive>
-								<manifestEntries>
-									<program-class>org.apache.flink.examples.scala.relational.TPCHQuery3</program-class>
-								</manifestEntries>
-							</archive>
-		
-							<includes>
-								<include>**/relational/TPCHQuery3*.class</include>
+								<include>**/scala/clustering/KMeans.class</include>
+								<include>**/scala/clustering/KMeans$*.class</include>
+								<include>**/java/clustering/util/KMeansDataGenerator.class</include>
+								<include>**/java/clustering/util/KMeansData.class</include>
 							</includes>
 						</configuration>
 					</execution>
 
+					<!-- Transitive Closure -->
 					<execution>
-						<id>WordCount</id>
+						<id>TransitiveClosure</id>
 						<phase>package</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
-		
 						<configuration>
-							<classifier>WordCount</classifier>
-		
+							<classifier>TransitiveClosure</classifier>
+				
 							<archive>
 								<manifestEntries>
-									<program-class>org.apache.flink.examples.scala.wordcount.WordCount</program-class>
+									<program-class>org.apache.flink.examples.scala.graph.TransitiveClosureNaive</program-class>
 								</manifestEntries>
 							</archive>
-		
+				
 							<includes>
-								<include>**/wordcount/WordCount*.class</include>
-								<include>**/wordcount/util/WordCountData.class</include>
+								<include>**/scala/graph/TransitiveClosureNaive.class</include>
+								<include>**/scala/graph/TransitiveClosureNaive$*.class</include>
+								<include>**/java/graph/util/ConnectedComponentsData.class</include>
 							</includes>
 						</configuration>
 					</execution>
-					
+
+					<!-- Connected Components -->
 					<execution>
 						<id>ConnectedComponents</id>
 						<phase>package</phase>
@@ -294,40 +263,190 @@ under the License.
 						</goals>
 						<configuration>
 							<classifier>ConnectedComponents</classifier>
+
 							<archive>
 								<manifestEntries>
 									<program-class>org.apache.flink.examples.scala.graph.ConnectedComponents</program-class>
 								</manifestEntries>
 							</archive>
+
 							<includes>
-								DOES NOT WORK <include>**/graph/ConnectedComponents*.class</include>
+								<include>**/scala/graph/ConnectedComponents.class</include>
+								<include>**/scala/graph/ConnectedComponents$*.class</include>
+								<include>**/java/graph/util/ConnectedComponentsData.class</include>
 							</includes>
 						</configuration>
 					</execution>
 					
+					<!-- EnumTriangles Basic -->
 					<execution>
-						<id>TransitiveClosureNaive</id>
+						<id>EnumTrianglesBasic</id>
 						<phase>package</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
-
 						<configuration>
-							<classifier>TransitiveClosureNaive</classifier>
+							<classifier>EnumTrianglesBasic</classifier>
 
 							<archive>
 								<manifestEntries>
-									<program-class>org.apache.flink.examples.scala.graph.TransitiveClosureNaive</program-class>
+									<program-class>org.apache.flink.examples.scala.graph.EnumTrianglesBasic</program-class>
 								</manifestEntries>
 							</archive>
 
 							<includes>
-								<include>**/wordcount/TransitiveClosureNaive*.class</include>
-								  DOES NOT WORK <include>**/java/graph/util/ConnectedComponentsData.class</include>
+								<include>**/scala/graph/EnumTrianglesBasic.class</include>
+								<include>**/scala/graph/EnumTrianglesBasic$*.class</include>
+								<include>**/java/graph/util/EnumTrianglesData.class</include>
 							</includes>
 						</configuration>
 					</execution>
-					-->
+					
+					<!-- EnumTriangles Opt -->
+					<execution>
+						<id>EnumTrianglesOpt</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>EnumTrianglesOpt</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.examples.scala.graph.EnumTrianglesOpt</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>**/scala/graph/EnumTrianglesOpt.class</include>
+								<include>**/scala/graph/EnumTrianglesOpt$*.class</include>
+								<include>**/java/graph/util/EnumTrianglesData.class</include>
+							</includes>
+						</configuration>
+					</execution>
+					
+					<!-- PageRank Basic-->
+					<execution>
+						<id>PageRankBasic</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>PageRankBasic</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.examples.scala.graph.PageRankBasic</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>**/scala/graph/PageRankBasic.class</include>
+								<include>**/scala/graph/PageRankBasic$*.class</include>
+								<include>**/java/graph/util/PageRankData.class</include>
+							</includes>
+						</configuration>
+					</execution>
+					
+					<!-- These queries are currently not self-contained -->
+
+					<!-- TPC-H Query 10 -->
+
+					<!--
+					<execution>
+						<id>TPCHQuery10</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>TPCHQuery10</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.examples.scala.relational.TPCHQuery10</program-class>
+								</manifestEntries>
+							</archive>
+							<includes>
+								<include>**/scala/relational/TPCHQuery10.class</include>
+								<include>**/scala/relational/TPCHQuery10$*.class</include>
+							</includes>
+						</configuration>
+					</execution> -->
+				
+					<!-- TPC-H Query 3 -->
+					<!--
+					<execution>
+						<id>TPCHQuery3</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>TPCHQuery3</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.examples.scala.relational.TPCHQuery3</program-class>
+								</manifestEntries>
+							</archive>
+							<includes>
+								<include>**/scala/relational/TPCHQuery3.class</include>
+								<include>**/scala/relational/TPCHQuery3$*.class</include>
+							</includes>
+						</configuration>
+					</execution> -->
+		
+					<!-- WebLogAnalysis -->
+					<execution>
+						<id>WebLogAnalysis</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>WebLogAnalysis</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.examples.scala.relational.WebLogAnalysis</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>**/scala/relational/WebLogAnalysis.class</include>
+								<include>**/scala/relational/WebLogAnalysis$*.class</include>
+								<include>**/java/relational/util/WebLogData.class</include>
+								<include>**/java/relational/util/WebLogDataGenerator.class</include>
+							</includes>
+						</configuration>
+					</execution>
+
+					<!-- WordCount -->
+					<execution>
+						<id>WordCount</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>WordCount</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.examples.scala.wordcount.WordCount</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>**/scala/wordcount/WordCount.class</include>
+								<include>**/scala/wordcount/WordCount$*.class</include>
+								<include>**/java/wordcount/util/WordCountData.class</include>
+							</includes>
+						</configuration>
+					</execution>
 					
 				</executions>
 			</plugin>


### PR DESCRIPTION
The scala examples lack self-contained build, because the default data is located in the flink-java-examples jar. Here is a proposed solution for that.

@aljoscha, @rmetzger what do you think?

Cheers,

Marton
