### PR TITLE
[FLINK-1154] Quickfix to kill TaskManagers in YARN mode.

### DIFF
--- a/flink-addons/flink-yarn/src/main/java/org/apache/flink/yarn/Client.java
+++ b/flink-addons/flink-yarn/src/main/java/org/apache/flink/yarn/Client.java
@@ -343,7 +343,9 @@ public class Client {
 		// Create a local resource to point to the destination jar path
 		final FileSystem fs = FileSystem.get(conf);
 
-		if(fs.getScheme().startsWith("file")) {
+		// hard coded check for the GoogleHDFS client because its not overriding the getScheme() method.
+		if( !fs.getClass().getSimpleName().equals("GoogleHadoopFileSystem") &&
+				fs.getScheme().startsWith("file")) {
 			LOG.warn("The file system scheme is '" + fs.getScheme() + "'. This indicates that the "
 					+ "specified Hadoop configuration path is wrong and the sytem is using the default Hadoop configuration values."
 					+ "The Flink YARN client needs to store its files in a distributed file system");
@@ -628,7 +630,6 @@ public class Client {
 					+ "\tyarn logs -applicationId "+appReport.getApplicationId()+"\n"
 					+ "(It sometimes takes a few seconds until the logs are aggregated)");
 		}
-
 	}
 
 	private void printHelp() {

--- a/flink-addons/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-addons/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -212,7 +212,7 @@ public class Utils {
 		localResource.setSize(jarStat.getLen());
 		localResource.setTimestamp(jarStat.getModificationTime());
 		localResource.setType(LocalResourceType.FILE);
-		localResource.setVisibility(LocalResourceVisibility.PUBLIC);
+		localResource.setVisibility(LocalResourceVisibility.APPLICATION);
 	}
 
 	public static void setTokensFor(ContainerLaunchContext amContainer, Path[] paths, Configuration conf) throws IOException {

--- a/flink-addons/flink-yarn/src/main/java/org/apache/flink/yarn/appMaster/ApplicationMaster.java
+++ b/flink-addons/flink-yarn/src/main/java/org/apache/flink/yarn/appMaster/ApplicationMaster.java
@@ -521,6 +521,7 @@ public class ApplicationMaster implements YARNClientMasterProtocol {
 	
 	private void close() throws Exception {
 		if(!isClosed) {
+			jobManager.getInstanceManager().killTaskManagers();
 			jobManager.shutdown();
 			nmClient.close();
 			rmClient.close();

--- a/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
+++ b/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
@@ -52,5 +52,5 @@ log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4
 
 export FLINK_CONF_DIR
 
-$JAVA_RUN $JVM_ARGS -classpath $CC_CLASSPATH $log_setting org.apache.flink.yarn.Client -ship $bin/../ship/ -confDir $FLINK_CONF_DIR -j $FLINK_LIB_DIR/*yarn-uberjar.jar $*
+$JAVA_RUN $JVM_ARGS -classpath $CC_CLASSPATH:$HADOOP_CLASSPATH $log_setting org.apache.flink.yarn.Client -ship $bin/../ship/ -confDir $FLINK_CONF_DIR -j $FLINK_LIB_DIR/*yarn-uberjar.jar $*
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
@@ -130,6 +130,31 @@ public class Instance {
 		return !isDead;
 	}
 	
+	public void stopInstance() {
+		try {
+			final TaskOperationProtocol tmProxy = this.getTaskManagerProxy();
+			// start a thread for stopping the TM to avoid infinitive blocking.
+			Runnable r = new Runnable() {
+				@Override
+				public void run() {
+					try {
+						tmProxy.killTaskManager();
+					} catch (IOException e) {
+						if (Log.isDebugEnabled()) {
+							Log.debug("Error while stopping TaskManager", e);
+						}
+					}
+				}
+			};
+			Thread t = new Thread(r);
+			t.setDaemon(true); // do not prevent the JVM from stopping
+			t.start();
+		} catch (Exception e) {
+			if (Log.isDebugEnabled()) {
+				Log.debug("Error while stopping TaskManager", e);
+			}
+		}
+	}
 	public void markDead() {
 		if (isDead) {
 			return;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
@@ -102,6 +102,16 @@ public class InstanceManager {
 	public long getHeartbeatTimeout() {
 		return heartbeatTimeout;
 	}
+	
+	/**
+	 * This method is only used by the Flink YARN client to self-destruct a Flink cluster
+	 * by stopping the JVMs of the TaskManagers.
+	 */
+	public void killTaskManagers() {
+		for (Instance i : this.registeredHostsById.values()) {
+			i.stopInstance();
+		}
+	}
 
 	public void shutdown() {
 		synchronized (this.lock) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/protocols/TaskOperationProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/protocols/TaskOperationProtocol.java
@@ -36,5 +36,5 @@ public interface TaskOperationProtocol extends VersionedProtocol {
 
 	TaskOperationResult cancelTask(ExecutionAttemptID executionId) throws IOException;
 
-	
+	void killTaskManager() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManager.java
@@ -1297,4 +1297,10 @@ public class TaskManager implements TaskOperationProtocol {
 			return timeout;
 		}
 	}
+
+	@Override
+	public void killTaskManager() throws IOException {
+		LOG.info("Killing TaskManager");
+		System.exit(0); // returning 0 because the TM is not stopping in an error condition.
+	}
 }


### PR DESCRIPTION
I also added code to the YARN Client for making it work with the Google Storage file system wrapper. Only the Flink YARN client works with GCloud storage, not the runtime (See FLINK-1266).
