### PR TITLE
[FLINK-938] Auomatically configure the jobmanager address

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -763,13 +764,12 @@ public class CliFrontend {
 				// regular config file gives the address
 				String jobManagerAddress = configuration.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null);
 				
-				// verify that there is a jobmanager address and port in the configuration
+				// the configuration does not contain a jobmanager address
 				if (jobManagerAddress == null) {
-					System.out.println("Error: Found no configuration in the config directory '" +
-							getConfigurationDirectory() + "' that specifies the JobManager address.");
-					return null;
+					jobManagerAddress = InetAddress.getLocalHost().getHostName();
 				}
-				
+
+				// verify that there is a jobmanager rpc port in the configuration
 				int jobManagerPort;
 				try {
 					jobManagerPort = configuration.getInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, -1);

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -43,6 +43,6 @@ do
     read line || GOON=false
     if [ -n "$line" ]; then
         HOST=$( extractHostName $line)
-        ssh -n $FLINK_SSH_OPTS $HOST -- "nohup /bin/bash $FLINK_BIN_DIR/taskmanager.sh start &"
+        ssh -n $FLINK_SSH_OPTS $HOST -- "nohup /bin/bash $FLINK_BIN_DIR/taskmanager.sh start $HOSTNAME"
     fi
 done < "$HOSTLIST"

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -19,6 +19,7 @@
 
 
 STARTSTOP=$1
+DEFAULT_JOBMANAGER_ADDRESS=$2
 
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
@@ -77,7 +78,11 @@ case $STARTSTOP in
         rotateLogFile $out
 
         echo Starting task manager on host $HOSTNAME
-        $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "$FLINK_TM_CLASSPATH" org.apache.flink.runtime.taskmanager.TaskManager --configDir "$FLINK_CONF_DIR" > "$out" 2>&1 < /dev/null &
+        if [[ -z "$DEFAULT_JOBMANAGER_ADDRESS" ]]; then
+            $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "$FLINK_TM_CLASSPATH" org.apache.flink.runtime.taskmanager.TaskManager --configDir "$FLINK_CONF_DIR" > "$out" 2>&1 < /dev/null &
+        else
+            $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "$FLINK_TM_CLASSPATH" org.apache.flink.runtime.taskmanager.TaskManager --defaultJobManagerAdd "$DEFAULT_JOBMANAGER_ADDRESS" --configDir "$FLINK_CONF_DIR" > "$out" 2>&1 < /dev/null &
+        fi
         echo $! > $pid
     ;;
 

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -21,8 +21,8 @@
 # Common
 #==============================================================================
 
-# The jobmanager rpc address will be automatically set to hostname
-# if not specified here.
+# By default, the JobManager address will be set to the host
+# from which the start-cluster or the start-local script is called
 #
 # jobmanager.rpc.address: localhost
 

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -21,7 +21,10 @@
 # Common
 #==============================================================================
 
-jobmanager.rpc.address: localhost
+# The jobmanager rpc address will be automatically set to hostname
+# if not specified here.
+#
+# jobmanager.rpc.address: localhost
 
 jobmanager.rpc.port: 6123
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.jobmanager
 
 import java.io.{IOException, File}
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.TimeUnit
 
 import akka.actor._
@@ -517,6 +517,12 @@ object JobManager {
         val configuration = GlobalConfiguration.getConfiguration()
         if (config.configDir != null && new File(config.configDir).isDirectory) {
           configuration.setString(ConfigConstants.FLINK_BASE_DIR_PATH_KEY, config.configDir + "/..")
+        }
+
+        if (GlobalConfiguration.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY,
+          null) == null) {
+          configuration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY,
+            InetAddress.getLocalHost.getHostName)
         }
 
         val hostname = configuration.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -596,6 +596,10 @@ object TaskManager {
       opt[String]("tempDir") optional() action { (x, c) =>
         c.copy(tmpDir = x)
       } text ("Specify temporary directory.")
+
+      opt[String]("defaultJobManagerAdd") optional() action { (x, c) =>
+        c.copy(defaultJobManagerAdd = x)
+      } text ("Specify default jobmanager address.")
     }
 
 
@@ -609,6 +613,13 @@ object TaskManager {
           .TASK_MANAGER_TMP_DIR_KEY,
           null) == null) {
           configuration.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, config.tmpDir)
+        }
+
+        if (config.defaultJobManagerAdd != null && GlobalConfiguration.getString(ConfigConstants
+          .JOB_MANAGER_IPC_ADDRESS_KEY,
+          null) == null) {
+          configuration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY,
+            config.defaultJobManagerAdd)
         }
 
         val jobManagerHostname = configuration.getString(ConfigConstants

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManagerCLIConfiguration.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManagerCLIConfiguration.scala
@@ -18,4 +18,5 @@
 
 package org.apache.flink.runtime.taskmanager
 
-case class TaskManagerCLIConfiguration(configDir: String = null, tmpDir: String = null)
+case class TaskManagerCLIConfiguration(configDir: String = null, tmpDir: String = null,
+                                       defaultJobManagerAdd: String = null)


### PR DESCRIPTION
This PR is an alternativ approach to #48 without touching the config file.  Once this is merged, I'll close #48