### PR TITLE
[FLINK-998] Close TCP connections after destroying logical channels

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/LocalConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/LocalConnectionManager.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.runtime.io.network;
 
 import java.io.IOException;
@@ -28,7 +27,17 @@ public class LocalConnectionManager implements NetworkConnectionManager {
 	}
 
 	@Override
-	public void enqueue(Envelope envelope, RemoteReceiver receiver) throws IOException {
+	public void enqueue(Envelope envelope, RemoteReceiver receiver, boolean isFirstEnvelope) throws IOException {
+	}
+
+	@Override
+	public void close(RemoteReceiver receiver) {
+
+	}
+
+	@Override
+	public int getNumberOfActiveConnections() {
+		return 0;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkConnectionManager.java
@@ -25,7 +25,11 @@ public interface NetworkConnectionManager {
 
 	public void start(ChannelManager channelManager) throws IOException;
 
-	public void enqueue(Envelope envelope, RemoteReceiver receiver) throws IOException;
+	public void enqueue(Envelope envelope, RemoteReceiver receiver, boolean isFirstEnvelope) throws IOException;
+
+	public void close(RemoteReceiver receiver);
+
+	public int getNumberOfActiveConnections();
 
 	public void shutdown() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/AtomicDisposableReferenceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/AtomicDisposableReferenceCounter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+/**
+ * Atomic reference counter, which enters a "disposed" state after the reference
+ * count reaches 0.
+ */
+public class AtomicDisposableReferenceCounter {
+
+	private final Object lock = new Object();
+
+	private int referenceCounter;
+
+	private boolean isDisposed;
+
+	/**
+	 * Increments the reference count and returns whether it was successful.
+	 * <p>
+	 * If the method returns <code>false</code>, the counter has already been
+	 * disposed. Otherwise it returns <code>true</code>.
+	 */
+	public boolean incrementReferenceCounter() {
+		synchronized (lock) {
+			if (isDisposed) {
+				return false;
+			}
+
+			referenceCounter++;
+			return true;
+		}
+	}
+
+	/**
+	 * Decrements the reference count.
+	 * <p>
+	 * If the method returns <code>true</code>, the decrement operation disposed
+	 * the counter. Otherwise it returns <code>false</code>.
+	 */
+	public boolean decrementReferenceCounter() {
+		synchronized (lock) {
+			if (isDisposed) {
+				return false;
+			}
+
+			referenceCounter--;
+
+			if (referenceCounter == 0) {
+				isDisposed = true;
+			}
+
+			return isDisposed;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -126,8 +126,10 @@ public class NettyConnectionManagerTest {
 					// enqueue envelopes with ascending seq numbers
 					while (seqNum.get() < numToSendPerSubtask) {
 						try {
-							Envelope env = new Envelope(seqNum.getAndIncrement(), jobId, channelId);
-							senderConnManager.enqueue(env, receiver);
+							int sequenceNumber = seqNum.getAndIncrement();
+
+							Envelope env = new Envelope(sequenceNumber, jobId, channelId);
+							senderConnManager.enqueue(env, receiver, sequenceNumber == 0);
 						} catch (IOException e) {
 							throw new RuntimeException("Unexpected exception while enqueuing envelope.");
 						}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/AtomicDisposableReferenceCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/AtomicDisposableReferenceCounterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AtomicDisposableReferenceCounterTest {
+
+	@Test
+	public void testSerialIncrementAndDecrement() {
+		AtomicDisposableReferenceCounter counter = new AtomicDisposableReferenceCounter();
+
+		assertTrue(counter.incrementReferenceCounter());
+
+		assertTrue(counter.decrementReferenceCounter());
+
+		assertFalse(counter.incrementReferenceCounter());
+
+		assertFalse(counter.decrementReferenceCounter());
+	}
+
+	@Test
+	public void testConcurrentIncrementAndDecrement() throws InterruptedException, ExecutionException, TimeoutException {
+		final Random random = new Random();
+
+		final ExecutorService executor = Executors.newCachedThreadPool();
+
+		final MockIncrementer incrementer = new MockIncrementer();
+
+		final MockDecrementer decrementer = new MockDecrementer();
+
+		// Repeat this to provoke races
+		for (int i = 0; i < 256; i++) {
+			final AtomicDisposableReferenceCounter counter = new AtomicDisposableReferenceCounter();
+			incrementer.setCounter(counter);
+			decrementer.setCounter(counter);
+
+			counter.incrementReferenceCounter();
+
+			// Randomly decide which one should be first as the first task usually will win the race
+			boolean incrementFirst = random.nextBoolean();
+
+			Future<Boolean> success1 = executor.submit(incrementFirst ? incrementer : decrementer);
+			Future<Boolean> success2 = executor.submit(incrementFirst ? decrementer : incrementer);
+
+			// Only one of the two should win the race and return true
+			assertTrue(success1.get() ^ success2.get());
+		}
+	}
+
+	private static class MockIncrementer implements Callable<Boolean> {
+
+		private AtomicDisposableReferenceCounter counter;
+
+		void setCounter(AtomicDisposableReferenceCounter counter) {
+			this.counter = counter;
+		}
+
+		@Override
+		public Boolean call() throws Exception {
+			return counter.incrementReferenceCounter();
+		}
+	}
+
+	private static class MockDecrementer implements Callable<Boolean> {
+
+		private AtomicDisposableReferenceCounter counter;
+
+		void setCounter(AtomicDisposableReferenceCounter counter) {
+			this.counter = counter;
+		}
+
+		@Override
+		public Boolean call() throws Exception {
+			return counter.decrementReferenceCounter();
+		}
+	}
+}

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.test.util;
 
 import java.io.BufferedInputStream;
@@ -96,11 +95,16 @@ public abstract class AbstractTestBase {
 		try {
 			
 			int numUnreleasedBCVars = 0;
+
+			int numActiveConnections = 0;
+
 			{
 				TaskManager[] tms = executor.getTaskManagers();
+
 				if (tms != null) {
 					for (TaskManager tm : tms) {
 						numUnreleasedBCVars += tm.getBroadcastVariableManager().getNumberOfVariablesWithReferences();
+						numActiveConnections += tm.getChannelManager().getNetworkConnectionManager().getNumberOfActiveConnections();
 					}
 				}
 			}
@@ -113,12 +117,11 @@ public abstract class AbstractTestBase {
 			}
 			
 			Assert.assertEquals("Not all broadcast variables were released.", 0, numUnreleasedBCVars);
+			Assert.assertEquals("Not all network connections were released.", 0, numActiveConnections);
 		}
 		finally {
 			deleteAllTempFiles();
 		}
-		
-		
 	}
 
 	//------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountITCase.java
@@ -29,7 +29,7 @@ public class WordCountITCase extends JavaProgramTestBase {
 
 	public WordCountITCase(){
 //		setDegreeOfParallelism(4);
-//		setNumTaskTracker(2);
+//		setNumTaskManager(2);
 //		setTaskManagerNumSlots(2);
 	}
 


### PR DESCRIPTION
This commit introduces reference-counting to keep track of the InputChannel and OutputChannel instances, which share the same physical TCP connection. This is basically a backport from #254.

When the logical channels are released in the channel manager, the reference count will reach 0 and the respective TCP connection can safely be closed.

Furthermore, the debug thread in the OutboundConnectionQueue is properly shut down and all queued buffers are freed when the channel is closed or an Exception occurs.

I've tested it on a 4 node cluster with parallelism of 32 and the debug output thread showed that connections are closed successfully. I've also tested cancelling. It would be nice to review this thoroughly though. ;-)

PS: If everything is fine, we should definitely include this in the next release.
