### PR TITLE
Fixed java quickstart example

### DIFF
--- a/docs/java_api_quickstart.md
+++ b/docs/java_api_quickstart.md
@@ -128,7 +128,7 @@ public class WordCount {
 The operations are defined by specialized classes, here the LineSplitter class.
 
 ~~~java
-public class LineSplitter extends FlatMapFunction<String, Tuple2<String, Integer>> {
+public class LineSplitter implements FlatMapFunction<String, Tuple2<String, Integer>> {
 
   @Override
   public void flatMap(String value, Collector<Tuple2<String, Integer>> out) {


### PR DESCRIPTION
java complains about not expecting an interface here. Needs to be `implements` instead of `extends`.

Btw: is there a better way to contribute things like this than through github PR?
