### PR TITLE
[FLINK-1285][FLINK-1137] Make execution mode configurable

### DIFF
--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/CoReaderIterator.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/CoReaderIterator.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
+import org.apache.flink.runtime.plugable.ReusingDeserializationDelegate;
 
 /**
  * A CoReaderIterator wraps a {@link CoRecordReader} producing records of two
@@ -31,15 +32,15 @@ public class CoReaderIterator<T1, T2> {
 	private final CoRecordReader<DeserializationDelegate<T1>, DeserializationDelegate<T2>> reader; // the
 																									// source
 
-	protected final DeserializationDelegate<T1> delegate1;
-	protected final DeserializationDelegate<T2> delegate2;
+	protected final ReusingDeserializationDelegate<T1> delegate1;
+	protected final ReusingDeserializationDelegate<T2> delegate2;
 
 	public CoReaderIterator(
 			CoRecordReader<DeserializationDelegate<T1>, DeserializationDelegate<T2>> reader,
 			TypeSerializer<T1> serializer1, TypeSerializer<T2> serializer2) {
 		this.reader = reader;
-		this.delegate1 = new DeserializationDelegate<T1>(serializer1);
-		this.delegate2 = new DeserializationDelegate<T2>(serializer2);
+		this.delegate1 = new ReusingDeserializationDelegate<T1>(serializer1);
+		this.delegate2 = new ReusingDeserializationDelegate<T2>(serializer2);
 	}
 
 	public int next(T1 target1, T2 target2) throws IOException {

--- a/flink-addons/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/MockContext.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/MockContext.java
@@ -72,6 +72,17 @@ public class MockContext<IN, OUT> implements StreamTaskContext<OUT> {
 			}
 			return reuse;
 		}
+
+		@Override
+		public StreamRecord<IN> next() throws IOException {
+			if (listIterator.hasNext()) {
+				StreamRecord<IN> result = new StreamRecord<IN>();
+				result.setObject(listIterator.next());
+				return result;
+			} else {
+				 return null;
+			}
+		}
 	}
 
 	public List<OUT> getOutputs() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -37,7 +37,7 @@ public class ExecutionConfig implements Serializable {
 
 	// For future use...
 //	private boolean forceGenericSerializer = false;
-//	private boolean objectReuse = false;
+	private boolean objectReuse = false;
 
 	/**
 	 * Enables the ClosureCleaner. This analyzes user code functions and sets fields to null
@@ -143,17 +143,30 @@ public class ExecutionConfig implements Serializable {
 //		return forceGenericSerializer;
 //	}
 //
-//	public ExecutionConfig enableObjectReuse() {
-//		objectReuse = true;
-//		return this;
-//	}
-//
-//	public ExecutionConfig disableObjectReuse() {
-//		objectReuse = false;
-//		return this;
-//	}
-//
-//	public boolean isObjectReuseEnabled() {
-//		return objectReuse;
-//	}
+
+	/**
+	 * Enables reusing objects that Flink internally uses for deserialization and passing
+	 * data to user-code functions. Keep in mind that this can lead to bugs when the
+	 * user-code function of an operation is not aware of this behaviour.
+	 */
+	public ExecutionConfig enableObjectReuse() {
+		objectReuse = true;
+		return this;
+	}
+
+	/**
+	 * Disables reusing objects that Flink internally uses for deserialization and passing
+	 * data to user-code functions. @see #enableObjectReuse()
+	 */
+	public ExecutionConfig disableObjectReuse() {
+		objectReuse = false;
+		return this;
+	}
+
+	/**
+	 * Returns whether object reuse has been enabled or disabled. @see #enableObjectReuse()
+	 */
+	public boolean isObjectReuseEnabled() {
+		return objectReuse;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -69,14 +69,14 @@ public class Plan implements Visitable<Operator<?>> {
 	protected int defaultParallelism = DEFAULT_PARALELLISM;
 	
 	/**
-	 * The number of times failed tasks are re-executed.
-	 */
-	protected int numberOfExecutionRetries;
-
-	/**
 	 * Hash map for files in the distributed cache: registered name to cache entry.
 	 */
 	protected HashMap<String, DistributedCacheEntry> cacheFile = new HashMap<String, DistributedCacheEntry>();
+
+	/**
+	 * Config object for runtime execution parameters.
+	 */
+	protected ExecutionConfig executionConfig = new ExecutionConfig();
 
 	// ------------------------------------------------------------------------
 
@@ -264,20 +264,6 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 	
 	/**
-	 * Sets the number of times that failed tasks are re-executed. A value of zero
-	 * effectively disables fault tolerance. A value of {@code -1} indicates that the system
-	 * default value (as defined in the configuration) should be used.
-	 * 
-	 * @param numberOfExecutionRetries The number of times the system will try to re-execute failed tasks.
-	 */
-	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
-		if (numberOfExecutionRetries < -1) {
-			throw new IllegalArgumentException("The number of execution retries must be non-negative, or -1 (use system default)");
-		}
-		this.numberOfExecutionRetries = numberOfExecutionRetries;
-	}
-	
-	/**
 	 * Gets the number of times the system will try to re-execute failed tasks. A value
 	 * of {@code -1} indicates that the system default value (as defined in the configuration)
 	 * should be used.
@@ -285,7 +271,7 @@ public class Plan implements Visitable<Operator<?>> {
 	 * @return The number of times the system will try to re-execute failed tasks.
 	 */
 	public int getNumberOfExecutionRetries() {
-		return numberOfExecutionRetries;
+		return executionConfig.getNumberOfExecutionRetries();
 	}
 	
 	/**
@@ -297,7 +283,23 @@ public class Plan implements Visitable<Operator<?>> {
 	public String getPostPassClassName() {
 		return "org.apache.flink.compiler.postpass.RecordModelPostPass";
 	}
-	
+
+	/**
+	 * Sets the runtime config object.
+	 * @return
+	 */
+	public ExecutionConfig getExecutionConfig() {
+		return executionConfig;
+	}
+
+	/**
+	 * Gets the runtime config object.
+	 * @param executionConfig
+	 */
+	public void setExecutionConfig(ExecutionConfig executionConfig) {
+		this.executionConfig = executionConfig;
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/util/MutableObjectIterator.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MutableObjectIterator.java
@@ -21,16 +21,18 @@ import java.io.IOException;
 
 /**
  * A simple iterator interface. The key differences to the {@link java.util.Iterator} are that this
- * iterator accepts an object into which it can place the content if the object is mutable, and that
- * it consolidates the logic in a single <code>next()</code> function, rather than in two different
- * functions such as <code>hasNext()</code> and <code>next()</code>.
+ * iterator also as a <code>next()</code> method that </code>accepts an object into which it can
+ * place the content if the object is mutable, and that it consolidates the logic in a single
+ * <code>next()</code> function, rather than in two different functions such as
+ * <code>hasNext()</code> and <code>next()</code>.
  * 
  * @param <E> The element type of the collection iterated over.
  */
 public interface MutableObjectIterator<E> {
 	
 	/**
-	 * Gets the next element from the collection. The contents of that next element is put into the given target object.
+	 * Gets the next element from the collection. The contents of that next element is put into the
+	 * given target object.
 	 * 
 	 * @param reuse The target object into which to place next element if E is mutable.
 	 * @return The filled object or <code>null</code> if the iterator is exhausted
@@ -39,4 +41,14 @@ public interface MutableObjectIterator<E> {
 	 *                     serialization / deserialization logic
 	 */
 	public E next(E reuse) throws IOException;
+
+	/**
+	 * Gets the next element from the collection. The reader must create a new instance itself.
+	 *
+	 * @return The object or <code>null</code> if the iterator is exhausted
+	 *
+	 * @throws IOException Thrown, if a problem occurred in the underlying I/O layer or in the
+	 *                     serialization / deserialization logic
+	 */
+	public E next() throws IOException;
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -24,13 +24,12 @@ import org.apache.flink.api.common.operators.CollectionExecutor;
 
 public class CollectionEnvironment extends ExecutionEnvironment {
 
-	private boolean mutableObjectSafeMode = true;
-	
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
-		
-		CollectionExecutor exec = new CollectionExecutor(mutableObjectSafeMode);
+
+		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.
+		CollectionExecutor exec = new CollectionExecutor(!getConfig().isObjectReuseEnabled());
 		return exec.execute(p);
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -749,6 +749,7 @@ public abstract class ExecutionEnvironment {
 		if (getDegreeOfParallelism() > 0) {
 			plan.setDefaultParallelism(getDegreeOfParallelism());
 		}
+		plan.setExecutionConfig(getConfig());
 
 		try {
 			registerCachedFilesWithPlan(plan);

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextValueInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextValueInputFormat.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.util.Arrays;
 
+import com.google.common.base.Charsets;
 import org.apache.flink.api.common.io.DelimitedInputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
@@ -81,6 +82,10 @@ public class TextValueInputFormat extends DelimitedInputFormat<StringValue> {
 		
 		if (charsetName == null || !Charset.isSupported(charsetName)) {
 			throw new RuntimeException("Unsupported charset: " + charsetName);
+		}
+
+		if (charsetName.equalsIgnoreCase(Charsets.US_ASCII.name())) {
+			ascii = true;
 		}
 		
 		this.decoder = Charset.forName(charsetName).newDecoder();

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
@@ -96,10 +96,10 @@ public class ValueTypeInfo<T extends Value> extends TypeInformation<T> implement
 		}
 		
 		if (CopyableValue.class.isAssignableFrom(type)) {
-			return (TypeComparator<T>) new ValueComparator(sortOrderAscending, type);
+			return (TypeComparator<T>) new CopyableValueComparator(sortOrderAscending, type);
 		}
 		else {
-			return (TypeComparator<T>) new CopyableValueComparator(sortOrderAscending, type);
+			return (TypeComparator<T>) new ValueComparator(sortOrderAscending, type);
 		}
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
@@ -53,6 +53,7 @@ public final class TupleSerializer<T extends Tuple> extends TupleSerializerBase<
 
 	@Override
 	public T createInstance(Object[] fields) {
+
 		try {
 			T t = tupleClass.newInstance();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/broadcast/BroadcastVariableMaterialization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/broadcast/BroadcastVariableMaterialization.java
@@ -30,7 +30,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.runtime.io.network.api.MutableReader;
 import org.apache.flink.runtime.operators.RegularPactTask;
 import org.apache.flink.runtime.operators.util.ReaderIterator;
-import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,10 +95,11 @@ public class BroadcastVariableMaterialization<T, C> {
 
 		try {
 			@SuppressWarnings("unchecked")
-			final MutableReader<DeserializationDelegate<T>> typedReader = (MutableReader<DeserializationDelegate<T>>) reader;
+			final MutableReader typedReader = (MutableReader) reader;
 			@SuppressWarnings("unchecked")
 			final TypeSerializer<T> serializer = ((TypeSerializerFactory<T>) serializerFactory).getSerializer();
-			
+
+			@SuppressWarnings("unchecked")
 			final ReaderIterator<T> readerIterator = new ReaderIterator<T>(typedReader, serializer);
 			
 			if (materializer) {
@@ -111,7 +111,7 @@ public class BroadcastVariableMaterialization<T, C> {
 				ArrayList<T> data = new ArrayList<T>();
 				
 				T element;
-				while ((element = readerIterator.next(serializer.createInstance())) != null) {
+				while ((element = readerIterator.next()) != null) {
 					data.add(element);
 				}
 				

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/ChannelReaderInputViewIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/ChannelReaderInputViewIterator.java
@@ -92,4 +92,18 @@ public class ChannelReaderInputViewIterator<E> implements MutableObjectIterator<
 			return null;
 		}
 	}
+
+	@Override
+	public E next() throws IOException
+	{
+		try {
+			return this.accessors.deserialize(this.inView);
+		} catch (EOFException eofex) {
+			final List<MemorySegment> freeMem = this.inView.close();
+			if (this.freeMemTarget != null) {
+				this.freeMemTarget.addAll(freeMem);
+			}
+			return null;
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.operators;
 
+import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.io.CleanupWhenUnsuccessful;
@@ -38,7 +39,6 @@ import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
 import org.apache.flink.runtime.operators.util.CloseableInputProvider;
 import org.apache.flink.runtime.operators.util.ReaderIterator;
 import org.apache.flink.runtime.operators.util.TaskConfig;
-import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.util.MutableObjectIterator;
 
 /**
@@ -334,9 +334,8 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 		
 		this.inputTypeSerializerFactory = this.config.getInputSerializer(0, getUserCodeClassLoader());
 		
-		MutableReader<DeserializationDelegate<?>> reader = (MutableReader<DeserializationDelegate<?>>) inputReader;
 		@SuppressWarnings({ "rawtypes" })
-		final MutableObjectIterator<?> iter = new ReaderIterator(reader, this.inputTypeSerializerFactory.getSerializer());
+		final MutableObjectIterator<?> iter = new ReaderIterator(inputReader, this.inputTypeSerializerFactory.getSerializer());
 		this.reader = (MutableObjectIterator<IT>)iter;
 		
 		// final sanity check

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MapDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MapDriver.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.operators;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
@@ -41,12 +42,17 @@ public class MapDriver<IT, OT> implements PactDriver<MapFunction<IT, OT>, OT> {
 	private PactTaskContext<MapFunction<IT, OT>, OT> taskContext;
 	
 	private volatile boolean running;
+
+	private boolean objectReuseEnabled = false;
 	
 	
 	@Override
 	public void setup(PactTaskContext<MapFunction<IT, OT>, OT> context) {
 		this.taskContext = context;
 		this.running = true;
+
+		ExecutionConfig executionConfig = taskContext.getExecutionConfig();
+		this.objectReuseEnabled = executionConfig.isObjectReuseEnabled();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MatchDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MatchDriver.java
@@ -22,6 +22,7 @@ package org.apache.flink.runtime.operators;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.operators.hash.NonReusingBuildFirstHashMatchIterator;
 import org.apache.flink.runtime.operators.hash.NonReusingBuildSecondHashMatchIterator;
+import org.apache.flink.runtime.operators.sort.NonReusingMergeMatchIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
@@ -32,7 +33,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashMatchIterator;
 import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashMatchIterator;
-import org.apache.flink.runtime.operators.sort.MergeMatchIterator;
+import org.apache.flink.runtime.operators.sort.ReusingMergeMatchIterator;
 import org.apache.flink.runtime.operators.util.JoinTaskIterator;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.util.Collector;
@@ -125,7 +126,7 @@ public class MatchDriver<IT1, IT2, OT> implements PactDriver<FlatJoinFunction<IT
 		if (this.objectReuseEnabled) {
 			switch (ls) {
 				case MERGE:
-					this.matchIterator = new MergeMatchIterator<IT1, IT2, OT>(in1, in2, serializer1, comparator1, serializer2, comparator2, pairComparatorFactory.createComparator12(comparator1, comparator2), memoryManager, ioManager, numPages, this.taskContext.getOwningNepheleTask());
+					this.matchIterator = new ReusingMergeMatchIterator<IT1, IT2, OT>(in1, in2, serializer1, comparator1, serializer2, comparator2, pairComparatorFactory.createComparator12(comparator1, comparator2), memoryManager, ioManager, numPages, this.taskContext.getOwningNepheleTask());
 
 					break;
 				case HYBRIDHASH_BUILD_FIRST:
@@ -140,7 +141,7 @@ public class MatchDriver<IT1, IT2, OT> implements PactDriver<FlatJoinFunction<IT
 		} else {
 			switch (ls) {
 				case MERGE:
-					this.matchIterator = new MergeMatchIterator<IT1, IT2, OT>(in1, in2, serializer1, comparator1, serializer2, comparator2, pairComparatorFactory.createComparator12(comparator1, comparator2), memoryManager, ioManager, numPages, this.taskContext.getOwningNepheleTask());
+					this.matchIterator = new NonReusingMergeMatchIterator<IT1, IT2, OT>(in1, in2, serializer1, comparator1, serializer2, comparator2, pairComparatorFactory.createComparator12(comparator1, comparator2), memoryManager, ioManager, numPages, this.taskContext.getOwningNepheleTask());
 
 					break;
 				case HYBRIDHASH_BUILD_FIRST:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/PactTaskContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/PactTaskContext.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.operators;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -43,7 +44,9 @@ import org.apache.flink.util.MutableObjectIterator;
 public interface PactTaskContext<S, OT> {
 	
 	TaskConfig getTaskConfig();
-	
+
+	ExecutionConfig getExecutionConfig();
+
 	ClassLoader getUserCodeClassLoader();
 	
 	MemoryManager getMemoryManager();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.operators;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.functions.ReduceFunction;
@@ -51,6 +52,8 @@ public class ReduceDriver<T> implements PactDriver<ReduceFunction<T>, T> {
 	private TypeComparator<T> comparator;
 	
 	private volatile boolean running;
+
+	private boolean objectReuseEnabled = false;
 
 	// ------------------------------------------------------------------------
 
@@ -88,6 +91,13 @@ public class ReduceDriver<T> implements PactDriver<ReduceFunction<T>, T> {
 		this.serializer = this.taskContext.<T>getInputSerializer(0).getSerializer();
 		this.comparator = this.taskContext.getDriverComparator(0);
 		this.input = this.taskContext.getInput(0);
+
+		ExecutionConfig executionConfig = taskContext.getExecutionConfig();
+		this.objectReuseEnabled = executionConfig.isObjectReuseEnabled();
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("ReduceDriver object reuse: " + (this.objectReuseEnabled ? "ENABLED" : "DISABLED") + ".");
+		}
 	}
 
 	@Override
@@ -104,26 +114,60 @@ public class ReduceDriver<T> implements PactDriver<ReduceFunction<T>, T> {
 		final ReduceFunction<T> function = this.taskContext.getStub();
 		
 		final Collector<T> output = this.taskContext.getOutputCollector();
-		
-		T value = input.next(serializer.createInstance());
-		
-		// iterate over key groups
-		while (this.running && value != null) {
-			comparator.setReference(value);
-			T res = value;
-			
-			// iterate within a key group
-			while ((value = input.next(serializer.createInstance())) != null) {
-				if (comparator.equalToReference(value)) {
-					// same group, reduce
-					res = function.reduce(res, value);
-				} else {
-					// new key group
-					break;
+
+		if (objectReuseEnabled) {
+			// We only need two objects. The user function is expected to return
+			// the first input as the result. The output value is also expected
+			// to have the same key fields as the input elements.
+
+			T reuse1 = serializer.createInstance();
+			T reuse2 = serializer.createInstance();
+
+			T value = input.next(reuse1);
+
+			// iterate over key groups
+			while (this.running && value != null) {
+				comparator.setReference(value);
+				T res = value;
+
+				// iterate within a key group
+				while ((value = input.next(reuse2)) != null) {
+					if (comparator.equalToReference(value)) {
+						// same group, reduce
+						res = function.reduce(res, value);
+					} else {
+						// new key group
+						break;
+					}
+				}
+
+				output.collect(res);
+
+				if (value != null) {
+					value = serializer.copy(value, reuse1);
 				}
 			}
-			
-			output.collect(res);
+		} else {
+			T value = input.next(serializer.createInstance());
+
+			// iterate over key groups
+			while (this.running && value != null) {
+				comparator.setReference(value);
+				T res = value;
+
+				// iterate within a key group
+				while ((value = input.next(serializer.createInstance())) != null) {
+					if (comparator.equalToReference(value)) {
+						// same group, reduce
+						res = function.reduce(res, value);
+					} else {
+						// new key group
+						break;
+					}
+				}
+
+				output.collect(res);
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.operators.chaining;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.runtime.execution.Environment;
@@ -43,9 +44,13 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
 	
 	private DistributedRuntimeUDFContext udfContext;
 
+	protected ExecutionConfig executionConfig;
+
+	protected boolean objectReuseEnabled = false;
+
 	
 	public void setup(TaskConfig config, String taskName, Collector<OT> outputCollector,
-			AbstractInvokable parent, ClassLoader userCodeClassLoader)
+			AbstractInvokable parent, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig)
 	{
 		this.config = config;
 		this.taskName = taskName;
@@ -59,6 +64,9 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
 			this.udfContext = new DistributedRuntimeUDFContext(taskName, env.getCurrentNumberOfSubtasks(), 
 					env.getIndexInSubtaskGroup(), userCodeClassLoader, env.getCopyTask());
 		}
+
+		this.executionConfig = executionConfig;
+		this.objectReuseEnabled = executionConfig.isObjectReuseEnabled();
 
 		setup(parent);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
@@ -1238,6 +1238,27 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T>{
 			}
 		}
 
+		@Override
+		public T next() throws IOException {
+			// This is just a copy of the above, I wanted to keep the two separate,
+			// in case we change something later. Plus, it keeps the diff clean... :D
+			if(done || this.table.closed.get()) {
+				return null;
+			} else if(!cache.isEmpty()) {
+				return cache.remove(cache.size()-1);
+			} else {
+				while(!done && cache.isEmpty()) {
+					done = !fillCache();
+				}
+				if(!done) {
+					return cache.remove(cache.size()-1);
+				} else {
+					return null;
+				}
+			}
+		}
+
+
 		/**
 		 * utility function that inserts all entries from a bucket and its overflow buckets into the cache
 		 * 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashMatchIteratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashMatchIteratorBase.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.operators.hash;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+
+import java.util.List;
+
+/**
+ * Common methods for all Hash Join Iterators.
+ */
+public class HashMatchIteratorBase {
+	public <BT, PT> MutableHashTable<BT, PT> getHashJoin(
+			TypeSerializer<BT> buildSideSerializer,
+			TypeComparator<BT> buildSideComparator,
+			TypeSerializer<PT> probeSideSerializer,
+			TypeComparator<PT> probeSideComparator,
+			TypePairComparator<PT, BT> pairComparator,
+			MemoryManager memManager,
+			IOManager ioManager,
+			AbstractInvokable ownerTask,
+			double memoryFraction) throws MemoryAllocationException {
+
+		final int numPages = memManager.computeNumberOfPages(memoryFraction);
+		final List<MemorySegment> memorySegments = memManager.allocatePages(ownerTask, numPages);
+		return new MutableHashTable<BT, PT>(buildSideSerializer, probeSideSerializer, buildSideComparator, probeSideComparator, pairComparator, memorySegments, ioManager);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InMemoryPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InMemoryPartition.java
@@ -235,6 +235,11 @@ public class InMemoryPartition<T> {
 		this.readView.setReadPosition(pointer);
 		return this.serializer.deserialize(reuse, this.readView);
 	}
+
+	public T readRecordAt(long pointer) throws IOException {
+		this.readView.setReadPosition(pointer);
+		return this.serializer.deserialize(this.readView);
+	}
 	
 	/**
 	 * UNSAFE!! overwrites record

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashMatchIterator.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.hash;
+
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.util.JoinTaskIterator;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
+
+import java.io.IOException;
+import java.util.List;
+
+
+/**
+ * An implementation of the {@link org.apache.flink.runtime.operators.util.JoinTaskIterator} that uses a hybrid-hash-join
+ * internally to match the records with equal key. The build side of the hash is the first input of the match.
+ * This implementation DOES NOT reuse objects.
+ */
+public class NonReusingBuildFirstHashMatchIterator<V1, V2, O> extends HashMatchIteratorBase implements JoinTaskIterator<V1, V2, O> {
+
+	protected final MutableHashTable<V1, V2> hashJoin;
+
+	protected final TypeSerializer<V2> probeSideSerializer;
+
+	private final MemoryManager memManager;
+
+	private final MutableObjectIterator<V1> firstInput;
+
+	private final MutableObjectIterator<V2> secondInput;
+
+	private volatile boolean running = true;
+
+	// --------------------------------------------------------------------------------------------
+
+	public NonReusingBuildFirstHashMatchIterator(
+			MutableObjectIterator<V1> firstInput,
+			MutableObjectIterator<V2> secondInput,
+			TypeSerializer<V1> serializer1,
+			TypeComparator<V1> comparator1,
+			TypeSerializer<V2> serializer2,
+			TypeComparator<V2> comparator2,
+			TypePairComparator<V2, V1> pairComparator,
+			MemoryManager memManager, IOManager ioManager,
+			AbstractInvokable ownerTask,
+			double memoryFraction)
+	throws MemoryAllocationException
+	{		
+		this.memManager = memManager;
+		this.firstInput = firstInput;
+		this.secondInput = secondInput;
+		this.probeSideSerializer = serializer2;
+
+		this.hashJoin = getHashJoin(serializer1, comparator1, serializer2, comparator2,
+				pairComparator, memManager, ioManager, ownerTask, memoryFraction);
+	}
+	
+	// --------------------------------------------------------------------------------------------
+	
+	@Override
+	public void open() throws IOException, MemoryAllocationException, InterruptedException {
+		this.hashJoin.open(this.firstInput, this.secondInput);
+	}
+	
+
+	@Override
+	public void close() {
+		// close the join
+		this.hashJoin.close();
+		
+		// free the memory
+		final List<MemorySegment> segments = this.hashJoin.getFreedMemory();
+		this.memManager.release(segments);
+	}
+
+	@Override
+	public final boolean callWithNextKey(FlatJoinFunction<V1, V2, O> matchFunction, Collector<O> collector)
+	throws Exception
+	{
+		if (this.hashJoin.nextRecord())
+		{
+			// we have a next record, get the iterators to the probe and build side values
+			final MutableHashTable.HashBucketIterator<V1, V2> buildSideIterator = this.hashJoin.getBuildSideIterator();
+			V1 nextBuildSideRecord;
+			
+			// get the first build side value
+			if ((nextBuildSideRecord = buildSideIterator.next()) != null) {
+				V1 tmpRec;
+				final V2 probeRecord = this.hashJoin.getCurrentProbeRecord();
+				
+				// check if there is another build-side value
+				if ((tmpRec = buildSideIterator.next()) != null) {
+					// more than one build-side value --> copy the probe side
+					V2 probeCopy;
+					probeCopy = this.probeSideSerializer.copy(probeRecord);
+					
+					// call match on the first pair
+					matchFunction.join(nextBuildSideRecord, probeCopy, collector);
+					
+					// call match on the second pair
+					probeCopy = this.probeSideSerializer.copy(probeRecord);
+					matchFunction.join(tmpRec, probeCopy, collector);
+					
+					while (this.running && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
+						// call match on the next pair
+						// make sure we restore the value of the probe side record
+						probeCopy = this.probeSideSerializer.copy(probeRecord);
+						matchFunction.join(nextBuildSideRecord, probeCopy, collector);
+					}
+				}
+				else {
+					// only single pair matches
+					matchFunction.join(nextBuildSideRecord, probeRecord, collector);
+				}
+			}
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public void abort() {
+		this.running = false;
+		this.hashJoin.abort();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstReOpenableHashMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstReOpenableHashMatchIterator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.hash;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.util.MutableObjectIterator;
+
+import java.io.IOException;
+import java.util.List;
+
+public class NonReusingBuildFirstReOpenableHashMatchIterator<V1, V2, O> extends NonReusingBuildFirstHashMatchIterator<V1, V2, O> {
+
+
+	private final ReOpenableMutableHashTable<V1, V2> reopenHashTable;
+
+	public NonReusingBuildFirstReOpenableHashMatchIterator(
+			MutableObjectIterator<V1> firstInput,
+			MutableObjectIterator<V2> secondInput,
+			TypeSerializer<V1> serializer1,
+			TypeComparator<V1> comparator1,
+			TypeSerializer<V2> serializer2,
+			TypeComparator<V2> comparator2,
+			TypePairComparator<V2, V1> pairComparator,
+			MemoryManager memManager,
+			IOManager ioManager,
+			AbstractInvokable ownerTask,
+			double memoryFraction)
+		throws MemoryAllocationException
+	{
+		super(firstInput, secondInput, serializer1, comparator1, serializer2,
+				comparator2, pairComparator, memManager, ioManager, ownerTask,
+				memoryFraction);
+		reopenHashTable = (ReOpenableMutableHashTable<V1, V2>) hashJoin;
+	}
+
+	@Override
+	public <BT, PT> MutableHashTable<BT, PT> getHashJoin(TypeSerializer<BT> buildSideSerializer, TypeComparator<BT> buildSideComparator,
+			TypeSerializer<PT> probeSideSerializer, TypeComparator<PT> probeSideComparator,
+			TypePairComparator<PT, BT> pairComparator,
+			MemoryManager memManager, IOManager ioManager, AbstractInvokable ownerTask, double memoryFraction)
+	throws MemoryAllocationException
+	{
+		final int numPages = memManager.computeNumberOfPages(memoryFraction);
+		final List<MemorySegment> memorySegments = memManager.allocatePages(ownerTask, numPages);
+		return new ReOpenableMutableHashTable<BT, PT>(buildSideSerializer, probeSideSerializer, buildSideComparator, probeSideComparator, pairComparator, memorySegments, ioManager);
+	}
+
+	/**
+	 * Set new input for probe side
+	 * @throws java.io.IOException
+	 */
+	public void reopenProbe(MutableObjectIterator<V2> probeInput) throws IOException {
+		reopenHashTable.reopenProbe(probeInput);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondReOpenableHashMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondReOpenableHashMatchIterator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.hash;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.util.MutableObjectIterator;
+
+import java.io.IOException;
+import java.util.List;
+
+public class NonReusingBuildSecondReOpenableHashMatchIterator<V1, V2, O> extends NonReusingBuildSecondHashMatchIterator<V1, V2, O> {
+
+
+	private final ReOpenableMutableHashTable<V2, V1> reopenHashTable;
+
+	public NonReusingBuildSecondReOpenableHashMatchIterator(
+			MutableObjectIterator<V1> firstInput,
+			MutableObjectIterator<V2> secondInput,
+			TypeSerializer<V1> serializer1,
+			TypeComparator<V1> comparator1,
+			TypeSerializer<V2> serializer2,
+			TypeComparator<V2> comparator2,
+			TypePairComparator<V1, V2> pairComparator,
+			MemoryManager memManager,
+			IOManager ioManager,
+			AbstractInvokable ownerTask,
+			double memoryFraction)
+		throws MemoryAllocationException
+	{
+		super(firstInput, secondInput, serializer1, comparator1, serializer2,
+				comparator2, pairComparator, memManager, ioManager, ownerTask, memoryFraction);
+		reopenHashTable = (ReOpenableMutableHashTable<V2, V1>) hashJoin;
+	}
+
+	@Override
+	public <BT, PT> MutableHashTable<BT, PT> getHashJoin(
+			TypeSerializer<BT> buildSideSerializer,
+			TypeComparator<BT> buildSideComparator,
+			TypeSerializer<PT> probeSideSerializer, TypeComparator<PT> probeSideComparator,
+			TypePairComparator<PT, BT> pairComparator,
+			MemoryManager memManager, IOManager ioManager, AbstractInvokable ownerTask, double memoryFraction)
+	throws MemoryAllocationException
+	{
+		final int numPages = memManager.computeNumberOfPages(memoryFraction);
+		final List<MemorySegment> memorySegments = memManager.allocatePages(ownerTask, numPages);
+		return new ReOpenableMutableHashTable<BT, PT>(buildSideSerializer, probeSideSerializer, buildSideComparator, probeSideComparator, pairComparator, memorySegments, ioManager);
+	}
+
+	/**
+	 * Set new input for probe side
+	 * @throws java.io.IOException
+	 */
+	public void reopenProbe(MutableObjectIterator<V1> probeInput) throws IOException {
+		reopenHashTable.reopenProbe(probeInput);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashMatchIterator.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.hash;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.util.JoinTaskIterator;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
+
+
+/**
+ * An implementation of the {@link org.apache.flink.runtime.operators.util.JoinTaskIterator} that uses a hybrid-hash-join
+ * internally to match the records with equal key. The build side of the hash is the first input of the match.
+ */
+public class ReusingBuildFirstHashMatchIterator<V1, V2, O> extends HashMatchIteratorBase implements JoinTaskIterator<V1, V2, O> {
+	
+	protected final MutableHashTable<V1, V2> hashJoin;
+	
+	private final V1 nextBuildSideObject;
+
+	private final V1 tempBuildSideRecord;
+
+	protected final TypeSerializer<V2> probeSideSerializer;
+	
+	private final MemoryManager memManager;
+	
+	private final MutableObjectIterator<V1> firstInput;
+	
+	private final MutableObjectIterator<V2> secondInput;
+	
+	private volatile boolean running = true;
+	
+	// --------------------------------------------------------------------------------------------
+	
+	public ReusingBuildFirstHashMatchIterator(
+			MutableObjectIterator<V1> firstInput,
+			MutableObjectIterator<V2> secondInput,
+			TypeSerializer<V1> serializer1,
+			TypeComparator<V1> comparator1,
+			TypeSerializer<V2> serializer2,
+			TypeComparator<V2> comparator2,
+			TypePairComparator<V2, V1> pairComparator,
+			MemoryManager memManager,
+			IOManager ioManager,
+			AbstractInvokable ownerTask,
+			double memoryFraction)
+	throws MemoryAllocationException
+	{		
+		this.memManager = memManager;
+		this.firstInput = firstInput;
+		this.secondInput = secondInput;
+		this.probeSideSerializer = serializer2;
+		
+		this.nextBuildSideObject = serializer1.createInstance();
+		this.tempBuildSideRecord = serializer1.createInstance();
+
+		this.hashJoin = getHashJoin(serializer1, comparator1, serializer2,
+				comparator2, pairComparator, memManager, ioManager, ownerTask, memoryFraction);
+	}
+	
+	// --------------------------------------------------------------------------------------------
+	
+	@Override
+	public void open() throws IOException, MemoryAllocationException, InterruptedException {
+		this.hashJoin.open(this.firstInput, this.secondInput);
+	}
+	
+
+	@Override
+	public void close() {
+		// close the join
+		this.hashJoin.close();
+		
+		// free the memory
+		final List<MemorySegment> segments = this.hashJoin.getFreedMemory();
+		this.memManager.release(segments);
+	}
+
+	@Override
+	public final boolean callWithNextKey(FlatJoinFunction<V1, V2, O> matchFunction, Collector<O> collector)
+	throws Exception
+	{
+		if (this.hashJoin.nextRecord())
+		{
+			// we have a next record, get the iterators to the probe and build side values
+			final MutableHashTable.HashBucketIterator<V1, V2> buildSideIterator = this.hashJoin.getBuildSideIterator();
+			V1 nextBuildSideRecord = this.nextBuildSideObject;
+			
+			// get the first build side value
+			if ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null) {
+				V1 tmpRec = this.tempBuildSideRecord;
+				final V2 probeRecord = this.hashJoin.getCurrentProbeRecord();
+				
+				// check if there is another build-side value
+				if ((tmpRec = buildSideIterator.next(tmpRec)) != null) {
+
+					// call match on the first pair
+					matchFunction.join(nextBuildSideRecord, probeRecord, collector);
+					
+					// call match on the second pair
+					matchFunction.join(tmpRec, probeRecord, collector);
+					
+					while (this.running && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
+						// call match on the next pair
+						// make sure we restore the value of the probe side record
+						matchFunction.join(nextBuildSideRecord, probeRecord, collector);
+					}
+				}
+				else {
+					// only single pair matches
+					matchFunction.join(nextBuildSideRecord, probeRecord, collector);
+				}
+			}
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public void abort() {
+		this.running = false;
+		this.hashJoin.abort();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstReOpenableHashMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstReOpenableHashMatchIterator.java
@@ -32,16 +32,18 @@ import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.util.MutableObjectIterator;
 
-public class BuildFirstReOpenableHashMatchIterator<V1, V2, O> extends BuildFirstHashMatchIterator<V1, V2, O> {
+public class ReusingBuildFirstReOpenableHashMatchIterator<V1, V2, O> extends ReusingBuildFirstHashMatchIterator<V1, V2, O> {
 
 	
 	private final ReOpenableMutableHashTable<V1, V2> reopenHashTable;
 	
-	public BuildFirstReOpenableHashMatchIterator(
+	public ReusingBuildFirstReOpenableHashMatchIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
-			TypeSerializer<V1> serializer1, TypeComparator<V1> comparator1,
-			TypeSerializer<V2> serializer2, TypeComparator<V2> comparator2,
+			TypeSerializer<V1> serializer1,
+			TypeComparator<V1> comparator1,
+			TypeSerializer<V2> serializer2,
+			TypeComparator<V2> comparator2,
 			TypePairComparator<V2, V1> pairComparator,
 			MemoryManager memManager,
 			IOManager ioManager,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondReOpenableHashMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondReOpenableHashMatchIterator.java
@@ -32,16 +32,18 @@ import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.util.MutableObjectIterator;
 
-public class BuildSecondReOpenableHashMatchIterator<V1, V2, O> extends BuildSecondHashMatchIterator<V1, V2, O> {
+public class ReusingBuildSecondReOpenableHashMatchIterator<V1, V2, O> extends ReusingBuildSecondHashMatchIterator<V1, V2, O> {
 
 	
 	private final ReOpenableMutableHashTable<V2, V1> reopenHashTable;
 	
-	public BuildSecondReOpenableHashMatchIterator(
+	public ReusingBuildSecondReOpenableHashMatchIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
-			TypeSerializer<V1> serializer1, TypeComparator<V1> comparator1,
-			TypeSerializer<V2> serializer2, TypeComparator<V2> comparator2,
+			TypeSerializer<V1> serializer1,
+			TypeComparator<V1> comparator1,
+			TypeSerializer<V2> serializer2,
+			TypeComparator<V2> comparator2,
 			TypePairComparator<V1, V2> pairComparator,
 			MemoryManager memManager,
 			IOManager ioManager,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/AbstractBlockResettableIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/AbstractBlockResettableIterator.java
@@ -173,4 +173,14 @@ abstract class AbstractBlockResettableIterator<T> implements MemoryBlockIterator
 			return null;
 		}
 	}
+
+	protected T getNextRecord() throws IOException {
+		if (this.numRecordsReturned < this.numRecordsInBuffer) {
+			this.numRecordsReturned++;
+			return this.serializer.deserialize(this.readView);
+		} else {
+			return null;
+		}
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIterator.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.resettable;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Implementation of an iterator that fetches a block of data into main memory and offers resettable
+ * access to the data in that block.
+ * 
+ */
+public class ReusingBlockResettableIterator<T> extends NonReusingBlockResettableIterator<T> {
+
+	public static final Logger LOG = LoggerFactory.getLogger(ReusingBlockResettableIterator.class);
+
+	private final T reuseElement;
+
+	// ------------------------------------------------------------------------
+
+	public ReusingBlockResettableIterator(MemoryManager memoryManager, Iterator<T> input,
+			TypeSerializer<T> serializer, int numPages,
+			AbstractInvokable ownerTask)
+	throws MemoryAllocationException
+	{
+		this(memoryManager, serializer, numPages, ownerTask);
+		this.input = input;
+	}
+
+	public ReusingBlockResettableIterator(MemoryManager memoryManager, TypeSerializer<T>
+			serializer, int numPages, AbstractInvokable ownerTask)
+	throws MemoryAllocationException
+	{
+		super(memoryManager, serializer, numPages, ownerTask);
+		
+		this.reuseElement = serializer.createInstance();
+	}
+	
+	// ------------------------------------------------------------------------
+	
+	@Override
+	public boolean hasNext() {
+		try {
+			if (this.nextElement == null) {
+				if (this.readPhase) {
+					// read phase, get next element from buffer
+					T tmp = getNextRecord(this.reuseElement);
+					if (tmp != null) {
+						this.nextElement = tmp;
+						return true;
+					} else {
+						return false;
+					}
+				} else {
+					if (this.input.hasNext()) {
+						final T next = this.input.next();
+						if (writeNextRecord(next)) {
+							this.nextElement = next;
+							return true;
+						} else {
+							this.leftOverElement = next;
+							return false;
+						}
+					} else {
+						this.noMoreBlocks = true;
+						return false;
+					}
+				}
+			} else {
+				return true;
+			}
+		} catch (IOException ioex) {
+			throw new RuntimeException("Error (de)serializing record in block resettable iterator.", ioex);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMerger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMerger.java
@@ -43,7 +43,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.util.EmptyMutableObjectIterator;
-import org.apache.flink.runtime.util.KeyGroupedIterator;
+import org.apache.flink.runtime.util.ReusingKeyGroupedIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 import org.apache.flink.util.TraversableOnceException;
@@ -453,7 +453,7 @@ public class CombiningUnilateralSortMerger<E> extends UnilateralSortMerger<E> {
 
 			// the list with the target iterators
 			final MergeIterator<E> mergeIterator = getMergingIterator(channelIDs, readBuffers, channelAccesses);
-			final KeyGroupedIterator<E> groupedIter = new KeyGroupedIterator<E>(mergeIterator, this.serializer, this.comparator2);
+			final ReusingKeyGroupedIterator<E> groupedIter = new ReusingKeyGroupedIterator<E>(mergeIterator, this.serializer, this.comparator2);
 
 			// create a new channel writer
 			final FileIOChannel.ID mergedChannelID = this.ioManager.createChannel();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
@@ -358,6 +358,33 @@ public final class FixedLengthRecordSorter<T> implements InMemorySorter<T> {
 					return null;
 				}
 			}
+
+			@Override
+			public T next() {
+				if (this.currentTotal < this.numTotal) {
+
+					if (this.currentInSegment >= this.numPerSegment) {
+						this.currentInSegment = 0;
+						this.currentSegmentIndex++;
+						this.in.set(sortBuffer.get(this.currentSegmentIndex), 0);
+					}
+
+					this.currentTotal++;
+					this.currentInSegment++;
+
+					try {
+						// This might blow up in our face, but we ignore the readWithNormalization/
+						// writeWithNormalization methods for now.
+						return this.comp.readWithKeyDenormalization(null, this.in);
+					}
+					catch (IOException ioe) {
+						throw new RuntimeException(ioe);
+					}
+				}
+				else {
+					return null;
+				}
+			}
 		};
 	}
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
@@ -373,9 +373,7 @@ public final class FixedLengthRecordSorter<T> implements InMemorySorter<T> {
 					this.currentInSegment++;
 
 					try {
-						// This might blow up in our face, but we ignore the readWithNormalization/
-						// writeWithNormalization methods for now.
-						return this.comp.readWithKeyDenormalization(null, this.in);
+						return this.comp.readWithKeyDenormalization(serializer.createInstance(), this.in);
 					}
 					catch (IOException ioe) {
 						throw new RuntimeException(ioe);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeIterator.java
@@ -93,6 +93,35 @@ public class MergeIterator<E> implements MutableObjectIterator<E> {
 		}
 	}
 
+	/**
+	 * Gets the next smallest element, with respect to the definition of order implied by
+	 * the {@link TypeSerializer} provided to this iterator.
+	 *
+	 * @return True, if the iterator had another element, false otherwise.
+	 *
+	 * @see org.apache.flink.util.MutableObjectIterator#next(java.lang.Object)
+	 */
+	@Override
+	public E next() throws IOException
+	{
+		if (this.heap.size() > 0) {
+			// get the smallest element
+			final HeadStream<E> top = this.heap.peek();
+			E result = this.serializer.copy(top.getHead());
+
+			// read an element
+			if (!top.nextHead()) {
+				this.heap.poll();
+			} else {
+				this.heap.adjustTop();
+			}
+			return result;
+		}
+		else {
+			return null;
+		}
+	}
+
 	// ============================================================================================
 	//                      Internal Classes that wrap the sorted input streams
 	// ============================================================================================

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/MergeMatchIterator.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.resettable.BlockResettableIterator;
 import org.apache.flink.runtime.operators.resettable.SpillingResettableIterator;
 import org.apache.flink.runtime.operators.util.JoinTaskIterator;
-import org.apache.flink.runtime.util.KeyGroupedIterator;
+import org.apache.flink.runtime.util.ReusingKeyGroupedIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 
@@ -56,9 +56,9 @@ public class MergeMatchIterator<T1, T2, O> implements JoinTaskIterator<T1, T2, O
 	
 	private TypePairComparator<T1, T2> comp;
 	
-	private KeyGroupedIterator<T1> iterator1;
+	private ReusingKeyGroupedIterator<T1> iterator1;
 
-	private KeyGroupedIterator<T2> iterator2;
+	private ReusingKeyGroupedIterator<T2> iterator2;
 	
 	private final TypeSerializer<T1> serializer1;
 	
@@ -104,8 +104,8 @@ public class MergeMatchIterator<T1, T2, O> implements JoinTaskIterator<T1, T2, O
 		this.memoryManager = memoryManager;
 		this.ioManager = ioManager;
 		
-		this.iterator1 = new KeyGroupedIterator<T1>(input1, this.serializer1, comparator1.duplicate());
-		this.iterator2 = new KeyGroupedIterator<T2>(input2, this.serializer2, comparator2.duplicate());
+		this.iterator1 = new ReusingKeyGroupedIterator<T1>(input1, this.serializer1, comparator1.duplicate());
+		this.iterator2 = new ReusingKeyGroupedIterator<T2>(input2, this.serializer2, comparator2.duplicate());
 		
 		final int numPagesForSpiller = numMemoryPages > 20 ? 2 : 1;
 		this.blockIt = new BlockResettableIterator<T2>(this.memoryManager, this.serializer2,
@@ -190,8 +190,8 @@ public class MergeMatchIterator<T1, T2, O> implements JoinTaskIterator<T1, T2, O
 		
 		// here, we have a common key! call the match function with the cross product of the
 		// values
-		final KeyGroupedIterator<T1>.ValuesIterator values1 = this.iterator1.getValues();
-		final KeyGroupedIterator<T2>.ValuesIterator values2 = this.iterator2.getValues();
+		final ReusingKeyGroupedIterator<T1>.ValuesIterator values1 = this.iterator1.getValues();
+		final ReusingKeyGroupedIterator<T2>.ValuesIterator values2 = this.iterator2.getValues();
 		
 		final T1 firstV1 = values1.next();
 		final T2 firstV2 = values2.next();	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NonReusingMergeMatchIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NonReusingMergeMatchIterator.java
@@ -1,0 +1,424 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.sort;
+
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.resettable.NonReusingBlockResettableIterator;
+import org.apache.flink.runtime.operators.resettable.SpillingResettableIterator;
+import org.apache.flink.runtime.operators.util.JoinTaskIterator;
+import org.apache.flink.runtime.util.NonReusingKeyGroupedIterator;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+
+/**
+ * An implementation of the {@link org.apache.flink.runtime.operators.util.JoinTaskIterator} that realizes the
+ * matching through a sort-merge join strategy.
+ */
+public class NonReusingMergeMatchIterator<T1, T2, O> implements JoinTaskIterator<T1, T2, O> {
+
+	/**
+	 * The log used by this iterator to log messages.
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(NonReusingMergeMatchIterator.class);
+
+	// --------------------------------------------------------------------------------------------
+
+	private TypePairComparator<T1, T2> comp;
+
+	private NonReusingKeyGroupedIterator<T1> iterator1;
+
+	private NonReusingKeyGroupedIterator<T2> iterator2;
+
+	private final TypeSerializer<T1> serializer1;
+
+	private final TypeSerializer<T2> serializer2;
+
+	private final NonReusingBlockResettableIterator<T2> blockIt;				// for N:M cross products with same key
+
+	private final List<MemorySegment> memoryForSpillingIterator;
+
+	private final MemoryManager memoryManager;
+
+	private final IOManager ioManager;
+
+	// --------------------------------------------------------------------------------------------
+
+	public NonReusingMergeMatchIterator(
+			MutableObjectIterator<T1> input1,
+			MutableObjectIterator<T2> input2,
+			TypeSerializer<T1> serializer1, TypeComparator<T1> comparator1,
+			TypeSerializer<T2> serializer2, TypeComparator<T2> comparator2,
+			TypePairComparator<T1, T2> pairComparator,
+			MemoryManager memoryManager,
+			IOManager ioManager,
+			int numMemoryPages,
+			AbstractInvokable parentTask)
+	throws MemoryAllocationException
+	{
+		if (numMemoryPages < 2) {
+			throw new IllegalArgumentException("Merger needs at least 2 memory pages.");
+		}
+
+		this.comp = pairComparator;
+		this.serializer1 = serializer1;
+		this.serializer2 = serializer2;
+
+		this.memoryManager = memoryManager;
+		this.ioManager = ioManager;
+
+		this.iterator1 = new NonReusingKeyGroupedIterator<T1>(input1, this.serializer1, comparator1.duplicate());
+		this.iterator2 = new NonReusingKeyGroupedIterator<T2>(input2, this.serializer2, comparator2.duplicate());
+
+		final int numPagesForSpiller = numMemoryPages > 20 ? 2 : 1;
+		this.blockIt = new NonReusingBlockResettableIterator<T2>(this.memoryManager, this.serializer2,
+			(numMemoryPages - numPagesForSpiller), parentTask);
+		this.memoryForSpillingIterator = memoryManager.allocatePages(parentTask, numPagesForSpiller);
+	}
+
+
+	@Override
+	public void open() throws IOException {}
+
+
+	@Override
+	public void close() {
+		if (this.blockIt != null) {
+			try {
+				this.blockIt.close();
+			}
+			catch (Throwable t) {
+				LOG.error("Error closing block memory iterator: " + t.getMessage(), t);
+			}
+		}
+
+		this.memoryManager.release(this.memoryForSpillingIterator);
+	}
+
+
+	@Override
+	public void abort() {
+		close();
+	}
+
+	/**
+	 * Calls the <code>JoinFunction#match()</code> method for all two key-value pairs that share the same key and come
+	 * from different inputs. The output of the <code>match()</code> method is forwarded.
+	 * <p>
+	 * This method first zig-zags between the two sorted inputs in order to find a common
+	 * key, and then calls the match stub with the cross product of the values.
+	 *
+	 * @throws Exception Forwards all exceptions from the user code and the I/O system.
+	 *
+	 * @see org.apache.flink.runtime.operators.util.JoinTaskIterator#callWithNextKey(org.apache.flink.api.common.functions.FlatJoinFunction, org.apache.flink.util.Collector)
+	 */
+	@Override
+	public boolean callWithNextKey(final FlatJoinFunction<T1, T2, O> matchFunction, final Collector<O> collector)
+	throws Exception
+	{
+		if (!this.iterator1.nextKey() || !this.iterator2.nextKey()) {
+			// consume all remaining keys (hack to prevent remaining inputs during iterations, lets get rid of this soon)
+			while (this.iterator1.nextKey());
+			while (this.iterator2.nextKey());
+			
+			return false;
+		}
+
+		final TypePairComparator<T1, T2> comparator = this.comp;
+		comparator.setReference(this.iterator1.getCurrent());
+		T2 current2 = this.iterator2.getCurrent();
+				
+		// zig zag
+		while (true) {
+			// determine the relation between the (possibly composite) keys
+			final int comp = comparator.compareToReference(current2);
+			
+			if (comp == 0) {
+				break;
+			}
+			
+			if (comp < 0) {
+				if (!this.iterator2.nextKey()) {
+					return false;
+				}
+				current2 = this.iterator2.getCurrent();
+			}
+			else {
+				if (!this.iterator1.nextKey()) {
+					return false;
+				}
+				comparator.setReference(this.iterator1.getCurrent());
+			}
+		}
+		
+		// here, we have a common key! call the match function with the cross product of the
+		// values
+		final NonReusingKeyGroupedIterator<T1>.ValuesIterator values1 = this.iterator1.getValues();
+		final NonReusingKeyGroupedIterator<T2>.ValuesIterator values2 = this.iterator2.getValues();
+		
+		final T1 firstV1 = values1.next();
+		final T2 firstV2 = values2.next();	
+			
+		final boolean v1HasNext = values1.hasNext();
+		final boolean v2HasNext = values2.hasNext();
+
+		// check if one side is already empty
+		// this check could be omitted if we put this in MatchTask.
+		// then we can derive the local strategy (with build side).
+		
+		if (v1HasNext) {
+			if (v2HasNext) {
+				// both sides contain more than one value
+				// TODO: Decide which side to spill and which to block!
+				crossMwithNValues(firstV1, values1, firstV2, values2, matchFunction, collector);
+			} else {
+				crossSecond1withNValues(firstV2, firstV1, values1, matchFunction, collector);
+			}
+		} else {
+			if (v2HasNext) {
+				crossFirst1withNValues(firstV1, firstV2, values2, matchFunction, collector);
+			} else {
+				// both sides contain only one value
+				matchFunction.join(firstV1, firstV2, collector);
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Crosses a single value from the first input with N values, all sharing a common key.
+	 * Effectively realizes a <i>1:N</i> match (join).
+	 * 
+	 * @param val1 The value form the <i>1</i> side.
+	 * @param firstValN The first of the values from the <i>N</i> side.
+	 * @param valsN Iterator over remaining <i>N</i> side values.
+	 *          
+	 * @throws Exception Forwards all exceptions thrown by the stub.
+	 */
+	private void crossFirst1withNValues(final T1 val1, final T2 firstValN,
+			final Iterator<T2> valsN, final FlatJoinFunction<T1, T2, O> matchFunction, final Collector<O> collector)
+	throws Exception
+	{
+		T1 copy1 = this.serializer1.copy(val1);
+		matchFunction.join(copy1, firstValN, collector);
+		
+		// set copy and match first element
+		boolean more = true;
+		do {
+			final T2 nRec = valsN.next();
+			
+			if (valsN.hasNext()) {
+				copy1 = this.serializer1.copy(val1);
+				matchFunction.join(copy1, nRec, collector);
+			} else {
+				matchFunction.join(val1, nRec, collector);
+				more = false;
+			}
+		}
+		while (more);
+	}
+	
+	/**
+	 * Crosses a single value from the second side with N values, all sharing a common key.
+	 * Effectively realizes a <i>N:1</i> match (join).
+	 * 
+	 * @param val1 The value form the <i>1</i> side.
+	 * @param firstValN The first of the values from the <i>N</i> side.
+	 * @param valsN Iterator over remaining <i>N</i> side values.
+	 *          
+	 * @throws Exception Forwards all exceptions thrown by the stub.
+	 */
+	private void crossSecond1withNValues(T2 val1, T1 firstValN,
+			Iterator<T1> valsN, FlatJoinFunction<T1, T2, O> matchFunction, Collector<O> collector)
+	throws Exception
+	{
+		T2 copy2 = this.serializer2.copy(val1);
+		matchFunction.join(firstValN, copy2, collector);
+		
+		// set copy and match first element
+		boolean more = true;
+		do {
+			final T1 nRec = valsN.next();
+			
+			if (valsN.hasNext()) {
+				copy2 = this.serializer2.copy(val1);
+				matchFunction.join(nRec, copy2, collector);
+			} else {
+				matchFunction.join(nRec, val1, collector);
+				more = false;
+			}
+		}
+		while (more);
+	}
+	
+	/**
+	 * @param firstV1
+	 * @param spillVals
+	 * @param firstV2
+	 * @param blockVals
+	 */
+	private void crossMwithNValues(final T1 firstV1, Iterator<T1> spillVals,
+			final T2 firstV2, final Iterator<T2> blockVals,
+			final FlatJoinFunction<T1, T2, O> matchFunction, final Collector<O> collector)
+	throws Exception
+	{
+		// ==================================================
+		// We have one first (head) element from both inputs (firstV1 and firstV2)
+		// We have an iterator for both inputs.
+		// we make the V1 side the spilling side and the V2 side the blocking side.
+		// In order to get the full cross product without unnecessary spilling, we do the
+		// following:
+		// 1) cross the heads
+		// 2) cross the head of the spilling side against the first block of the blocking side
+		// 3) cross the iterator of the spilling side with the head of the block side
+		// 4) cross the iterator of the spilling side with the first block
+		// ---------------------------------------------------
+		// If the blocking side has more than one block, we really need to make the spilling side fully
+		// resettable. For each further block on the block side, we do:
+		// 5) cross the head of the spilling side with the next block
+		// 6) cross the spilling iterator with the next block.
+		
+		// match the first values first
+		T1 copy1 = this.serializer1.copy(firstV1);
+		T2 blockHeadCopy = this.serializer2.copy(firstV2);
+		T1 spillHeadCopy = null;
+
+
+		// --------------- 1) Cross the heads -------------------
+		matchFunction.join(copy1, firstV2, collector);
+		
+		// for the remaining values, we do a block-nested-loops join
+		SpillingResettableIterator<T1> spillIt = null;
+		
+		try {
+			// create block iterator on the second input
+			this.blockIt.reopen(blockVals);
+			
+			// ------------- 2) cross the head of the spilling side with the first block ------------------
+			while (this.blockIt.hasNext()) {
+				final T2 nextBlockRec = this.blockIt.next();
+				copy1 = this.serializer1.copy(firstV1);
+				matchFunction.join(copy1, nextBlockRec, collector);
+			}
+			this.blockIt.reset();
+			
+			// spilling is required if the blocked input has data beyond the current block.
+			// in that case, create the spilling iterator
+			final Iterator<T1> leftSideIter;
+			final boolean spillingRequired = this.blockIt.hasFurtherInput();
+			if (spillingRequired)
+			{
+				// more data than would fit into one block. we need to wrap the other side in a spilling iterator
+				// create spilling iterator on first input
+				spillIt = new SpillingResettableIterator<T1>(spillVals, this.serializer1,
+						this.memoryManager, this.ioManager, this.memoryForSpillingIterator);
+				leftSideIter = spillIt;
+				spillIt.open();
+				
+				spillHeadCopy = this.serializer1.copy(firstV1);
+			}
+			else {
+				leftSideIter = spillVals;
+			}
+			
+			// cross the values in the v1 iterator against the current block
+			
+			while (leftSideIter.hasNext()) {
+				final T1 nextSpillVal = leftSideIter.next();
+				copy1 = this.serializer1.copy(nextSpillVal);
+				
+				
+				// -------- 3) cross the iterator of the spilling side with the head of the block side --------
+				T2 copy2 = this.serializer2.copy(blockHeadCopy);
+				matchFunction.join(copy1, copy2, collector);
+				
+				// -------- 4) cross the iterator of the spilling side with the first block --------
+				while (this.blockIt.hasNext()) {
+					T2 nextBlockRec = this.blockIt.next();
+					
+					// get instances of key and block value
+					copy1 = this.serializer1.copy(nextSpillVal);
+					matchFunction.join(copy1, nextBlockRec, collector);
+				}
+				// reset block iterator
+				this.blockIt.reset();
+			}
+			
+			// if everything from the block-side fit into a single block, we are done.
+			// note that in this special case, we did not create a spilling iterator at all
+			if (!spillingRequired) {
+				return;
+			}
+			
+			// here we are, because we have more blocks on the block side
+			// loop as long as there are blocks from the blocked input
+			while (this.blockIt.nextBlock())
+			{
+				// rewind the spilling iterator
+				spillIt.reset();
+				
+				// ------------- 5) cross the head of the spilling side with the next block ------------
+				while (this.blockIt.hasNext()) {
+					copy1 = this.serializer1.copy(spillHeadCopy);
+					final T2 nextBlockVal = blockIt.next();
+					matchFunction.join(copy1, nextBlockVal, collector);
+				}
+				this.blockIt.reset();
+				
+				// -------- 6) cross the spilling iterator with the next block. ------------------
+				while (spillIt.hasNext())
+				{
+					// get value from resettable iterator
+					final T1 nextSpillVal = spillIt.next();
+					// cross value with block values
+					while (this.blockIt.hasNext()) {
+						// get instances of key and block value
+						final T2 nextBlockVal = this.blockIt.next();
+						copy1 = this.serializer1.copy(nextSpillVal);
+						matchFunction.join(copy1, nextBlockVal, collector);
+					}
+					
+					// reset block iterator
+					this.blockIt.reset();
+				}
+				// reset v1 iterator
+				spillIt.reset();
+			}
+		}
+		finally {
+			if (spillIt != null) {
+				this.memoryForSpillingIterator.addAll(spillIt.close());
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIterator.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.sort;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.operators.util.CoGroupTaskIterator;
+import org.apache.flink.runtime.util.ReusingKeyGroupedIterator;
+import org.apache.flink.util.MutableObjectIterator;
+
+
+public class ReusingSortMergeCoGroupIterator<T1, T2> implements CoGroupTaskIterator<T1, T2> {
+
+	private static enum MatchStatus {
+		NONE_REMAINED, FIRST_REMAINED, SECOND_REMAINED, FIRST_EMPTY, SECOND_EMPTY
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private MatchStatus matchStatus;
+
+	private Iterable<T1> firstReturn;
+
+	private Iterable<T2> secondReturn;
+
+	private TypePairComparator<T1, T2> comp;
+
+	private ReusingKeyGroupedIterator<T1> iterator1;
+
+	private ReusingKeyGroupedIterator<T2> iterator2;
+
+	// --------------------------------------------------------------------------------------------
+
+	public ReusingSortMergeCoGroupIterator(
+			MutableObjectIterator<T1> input1,
+			MutableObjectIterator<T2> input2, TypeSerializer<T1>
+			serializer1, TypeComparator<T1> groupingComparator1,
+			TypeSerializer<T2> serializer2,
+			TypeComparator<T2> groupingComparator2,
+			TypePairComparator<T1, T2> pairComparator)
+	{
+
+		this.comp = pairComparator;
+
+		this.iterator1 = new ReusingKeyGroupedIterator<T1>(input1, serializer1, groupingComparator1);
+		this.iterator2 = new ReusingKeyGroupedIterator<T2>(input2, serializer2, groupingComparator2);
+	}
+
+	@Override
+	public void open() {}
+
+	@Override
+	public void close() {}
+
+
+	@Override
+	public Iterable<T1> getValues1() {
+		return this.firstReturn;
+	}
+
+
+	@Override
+	public Iterable<T2> getValues2() {
+		return this.secondReturn;
+	}
+
+
+	@Override
+	public boolean next() throws IOException {
+		boolean firstEmpty = true;
+		boolean secondEmpty = true;
+
+		if (this.matchStatus != MatchStatus.FIRST_EMPTY) {
+			if (this.matchStatus == MatchStatus.FIRST_REMAINED) {
+				// comparator is still set correctly
+				firstEmpty = false;
+			} else {
+				if (this.iterator1.nextKey()) {
+					this.comp.setReference(this.iterator1.getCurrent());
+					firstEmpty = false;
+				}
+			}
+		}
+
+		if (this.matchStatus != MatchStatus.SECOND_EMPTY) {
+			if (this.matchStatus == MatchStatus.SECOND_REMAINED) {
+				secondEmpty = false;
+			} else {
+				if (iterator2.nextKey()) {
+					secondEmpty = false;
+				}
+			}
+		}
+
+		if (firstEmpty && secondEmpty) {
+			// both inputs are empty
+			return false;
+		}
+		else if (firstEmpty && !secondEmpty) {
+			// input1 is empty, input2 not
+			this.firstReturn = Collections.emptySet();
+			this.secondReturn = this.iterator2.getValues();
+			this.matchStatus = MatchStatus.FIRST_EMPTY;
+			return true;
+		}
+		else if (!firstEmpty && secondEmpty) {
+			// input1 is not empty, input 2 is empty
+			this.firstReturn = this.iterator1.getValues();
+			this.secondReturn = Collections.emptySet();
+			this.matchStatus = MatchStatus.SECOND_EMPTY;
+			return true;
+		}
+		else {
+			// both inputs are not empty
+			final int comp = this.comp.compareToReference(this.iterator2.getCurrent());
+
+			if (0 == comp) {
+				// keys match
+				this.firstReturn = this.iterator1.getValues();
+				this.secondReturn = this.iterator2.getValues();
+				this.matchStatus = MatchStatus.NONE_REMAINED;
+			}
+			else if (0 < comp) {
+				// key1 goes first
+				this.firstReturn = this.iterator1.getValues();
+				this.secondReturn = Collections.emptySet();
+				this.matchStatus = MatchStatus.SECOND_REMAINED;
+			}
+			else {
+				// key 2 goes first
+				this.firstReturn = Collections.emptySet();
+				this.secondReturn = this.iterator2.getValues();
+				this.matchStatus = MatchStatus.FIRST_REMAINED;
+			}
+			return true;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/plugable/DeserializationDelegate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/plugable/DeserializationDelegate.java
@@ -15,45 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.apache.flink.runtime.plugable;
 
-import java.io.IOException;
-
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.io.IOReadableWritable;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
 
+public interface DeserializationDelegate<T> extends IOReadableWritable {
+	void setInstance(T instance);
 
-public class DeserializationDelegate<T> implements IOReadableWritable {
-	
-	private T instance;
-	
-	private final TypeSerializer<T> serializer;
-	
-
-	public DeserializationDelegate(TypeSerializer<T> serializer) {
-		this.serializer = serializer;
-	}
-
-	
-	public void setInstance(T instance) {
-		this.instance = instance;
-	}
-
-	public T getInstance() {
-		return instance;
-	}
-
-	@Override
-	public void write(DataOutputView out) throws IOException {
-		throw new IllegalStateException("Serialization method called on DeserializationDelegate.");
-	}
-
-	@Override
-	public void read(DataInputView in) throws IOException {
-		this.instance = this.serializer.deserialize(this.instance, in);
-	}
+	T getInstance();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/plugable/NonReusingDeserializationDelegate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/plugable/NonReusingDeserializationDelegate.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,41 +17,41 @@
  */
 
 
-package org.apache.flink.runtime.io.disk;
-
-import java.io.EOFException;
-import java.io.IOException;
+package org.apache.flink.runtime.plugable;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.util.MutableObjectIterator;
+import org.apache.flink.core.memory.DataOutputView;
 
-public class InputViewIterator<E> implements MutableObjectIterator<E>
-{
-	private DataInputView inputView;
+import java.io.IOException;
 
-	private final TypeSerializer<E> serializer;
 
-	public InputViewIterator(DataInputView inputView, TypeSerializer<E> serializer) {
-		this.inputView = inputView;
+public class NonReusingDeserializationDelegate<T> implements DeserializationDelegate<T> {
+
+	private T instance;
+
+	private final TypeSerializer<T> serializer;
+
+
+	public NonReusingDeserializationDelegate(TypeSerializer<T> serializer) {
 		this.serializer = serializer;
 	}
+	
+	public void setInstance(T instance) {
+		this.instance = instance;
+	}
 
-	@Override
-	public E next(E reuse) throws IOException {
-		try {
-			return this.serializer.deserialize(reuse, this.inputView);
-		} catch (EOFException e) {
-			return null;
-		}
+	public T getInstance() {
+		return instance;
 	}
 
 	@Override
-	public E next() throws IOException {
-		try {
-			return this.serializer.deserialize(this.inputView);
-		} catch (EOFException e) {
-			return null;
-		}
+	public void write(DataOutputView out) throws IOException {
+		throw new IllegalStateException("Serialization method called on DeserializationDelegate.");
+	}
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		this.instance = this.serializer.deserialize(in);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/EmptyMutableObjectIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/EmptyMutableObjectIterator.java
@@ -54,4 +54,15 @@ public final class EmptyMutableObjectIterator<E> implements MutableObjectIterato
 	public E next(E target) {
 		return null;
 	}
+
+	/**
+	 * Always returns null.
+	 *
+	 * @see MutableObjectIterator#next()
+	 */
+	@Override
+	public E next() {
+		return null;
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonReusingMutableToRegularIteratorWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonReusingMutableToRegularIteratorWrapper.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,34 +19,35 @@
 
 package org.apache.flink.runtime.util;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.util.MutableObjectIterator;
 import org.apache.flink.util.TraversableOnceException;
 
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
 /**
- * This class wraps a {@link MutableObjectIterator} into a regular {@link Iterator}.
- * Internally, it uses two record instances which it uses alternating. That way,
- * whenever hasNext() returns (possibly with false), the previous obtained record is 
- * still valid and cannot have been overwritten internally.
+ * This class wraps a {@link org.apache.flink.util.MutableObjectIterator} into a regular
+ * {@link java.util.Iterator}. It will always create new instances and not reuse objects.
  */
-public class MutableToRegularIteratorWrapper<T> implements Iterator<T>, Iterable<T> {
-	
+public class NonReusingMutableToRegularIteratorWrapper<T> implements Iterator<T>, Iterable<T> {
+
 	private final MutableObjectIterator<T> source;
-	
-	private T current, next;
-	
+
+	private T current;
+
 	private boolean currentIsAvailable;
-	
+
 	private boolean iteratorAvailable = true;
 
-	public MutableToRegularIteratorWrapper(MutableObjectIterator<T> source, TypeSerializer<T> serializer) {
+	private TypeSerializer<T> serializer;
+
+	public NonReusingMutableToRegularIteratorWrapper(MutableObjectIterator<T> source,
+			TypeSerializer<T> serializer) {
 		this.source = source;
-		this.current = serializer.createInstance();
-		this.next = serializer.createInstance();
+		this.current = null;
+		this.serializer = serializer;
 	}
 
 	@Override
@@ -55,14 +56,7 @@ public class MutableToRegularIteratorWrapper<T> implements Iterator<T>, Iterable
 			return true;
 		} else {
 			try {
-				// we always use two records such that whenever hasNext() returns (possibly with false),
-				// the previous record is always still valid.
-				if ((next = source.next(next)) != null) {
-					
-					T tmp = current;
-					current = next;
-					next = tmp;
-					
+				if ((current = source.next()) != null) {
 					currentIsAvailable = true;
 					return true;
 				} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/RegularToMutableObjectIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/RegularToMutableObjectIterator.java
@@ -47,4 +47,13 @@ public class RegularToMutableObjectIterator<T> implements MutableObjectIterator<
 			return null;
 		}
 	}
+
+	@Override
+	public T next() {
+		if (this.iterator.hasNext()) {
+			return this.serializer.copy(this.iterator.next());
+		} else {
+			return null;
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ReusingMutableToRegularIteratorWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ReusingMutableToRegularIteratorWrapper.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.MutableObjectIterator;
+import org.apache.flink.util.TraversableOnceException;
+
+/**
+ * This class wraps a {@link MutableObjectIterator} into a regular {@link Iterator}.
+ * Internally, it uses two record instances which it uses alternating. That way,
+ * whenever hasNext() returns (possibly with false), the previous obtained record is 
+ * still valid and cannot have been overwritten internally.
+ */
+public class ReusingMutableToRegularIteratorWrapper<T> implements Iterator<T>, Iterable<T> {
+	
+	private final MutableObjectIterator<T> source;
+	
+	private T current, next;
+	
+	private boolean currentIsAvailable;
+	
+	private boolean iteratorAvailable = true;
+
+	public ReusingMutableToRegularIteratorWrapper(MutableObjectIterator<T> source,
+			TypeSerializer<T> serializer) {
+		this.source = source;
+		this.current = serializer.createInstance();
+		this.next = serializer.createInstance();
+	}
+
+	@Override
+	public boolean hasNext() {
+		if (currentIsAvailable) {
+			return true;
+		} else {
+			try {
+				// we always use two records such that whenever hasNext() returns (possibly with false),
+				// the previous record is always still valid.
+				if ((next = source.next(next)) != null) {
+					
+					T tmp = current;
+					current = next;
+					next = tmp;
+					
+					currentIsAvailable = true;
+					return true;
+				} else {
+					return false;
+				}
+			} catch (IOException ioex) {
+				throw new RuntimeException("Error reading next record: " + ioex.getMessage(), ioex);
+			}
+		}
+	}
+
+	@Override
+	public T next() {
+		if (currentIsAvailable || hasNext()) {
+			currentIsAvailable = false;
+			return current;
+		} else {
+			throw new NoSuchElementException();
+		}
+	}
+
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		if (iteratorAvailable) {
+			iteratorAvailable = false;
+			return this;
+		}
+		else {
+			throw new TraversableOnceException();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CachedMatchTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CachedMatchTaskTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.RichFlatJoinFunction;
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
@@ -56,8 +57,8 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 	private final List<Record> outList = new ArrayList<Record>();
 	
 	
-	public CachedMatchTaskTest() {
-		super(HASH_MEM, 2, SORT_MEM);
+	public CachedMatchTaskTest(ExecutionConfig config) {
+		super(config, HASH_MEM, 2, SORT_MEM);
 	}
 	
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CoGroupTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CoGroupTaskExternalITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.operators;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.RichCoGroupFunction;
@@ -45,8 +46,8 @@ public class CoGroupTaskExternalITCase extends DriverTestBase<CoGroupFunction<Re
 	
 	private final CountingOutputCollector output = new CountingOutputCollector();
 	
-	public CoGroupTaskExternalITCase() {
-		super(0, 2, SORT_MEM);
+	public CoGroupTaskExternalITCase(ExecutionConfig config) {
+		super(config, 0, 2, SORT_MEM);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CoGroupTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CoGroupTaskTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.operators;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.RichCoGroupFunction;
@@ -52,8 +53,8 @@ public class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Reco
 	private final CountingOutputCollector output = new CountingOutputCollector();
 	
 	
-	public CoGroupTaskTest() {
-		super(0, 2, SORT_MEM);
+	public CoGroupTaskTest(ExecutionConfig config) {
+		super(config, 0, 2, SORT_MEM);
 	}
 	
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskExternalITCase.java
@@ -22,6 +22,7 @@ package org.apache.flink.runtime.operators;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
@@ -46,8 +47,8 @@ public class CombineTaskExternalITCase extends DriverTestBase<RichGroupReduceFun
 	private final RecordComparator comparator = new RecordComparator(
 		new int[]{0}, (Class<? extends Key<?>>[])new Class[]{ IntValue.class });
 
-	public CombineTaskExternalITCase() {
-		super(COMBINE_MEM, 0);
+	public CombineTaskExternalITCase(ExecutionConfig config) {
+		super(config, COMBINE_MEM, 0);
 
 		combine_frac = (double)COMBINE_MEM/this.getMemoryManager().getMemorySize();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
@@ -49,8 +50,8 @@ public class CombineTaskTest extends DriverTestBase<RichGroupReduceFunction<Reco
 	private final RecordComparator comparator = new RecordComparator(
 		new int[]{0}, (Class<? extends Key<?>>[])new Class[]{ IntValue.class });
 
-	public CombineTaskTest() {
-		super(COMBINE_MEM, 0);
+	public CombineTaskTest(ExecutionConfig config) {
+		super(config, COMBINE_MEM, 0);
 
 		combine_frac = (double)COMBINE_MEM/this.getMemoryManager().getMemorySize();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CrossTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CrossTaskExternalITCase.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.operators;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 
 import org.apache.flink.api.common.functions.CrossFunction;
@@ -37,8 +38,8 @@ public class CrossTaskExternalITCase extends DriverTestBase<CrossFunction<Record
 	
 	private final CountingOutputCollector output = new CountingOutputCollector();
 
-	public CrossTaskExternalITCase() {
-		super(CROSS_MEM, 0);
+	public CrossTaskExternalITCase(ExecutionConfig config) {
+		super(config, CROSS_MEM, 0);
 		cross_frac = (double)CROSS_MEM/this.getMemoryManager().getMemorySize();
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CrossTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CrossTaskTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.operators;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.apache.flink.api.common.functions.CrossFunction;
 import org.apache.flink.runtime.operators.testutils.DelayingInfinitiveInputIterator;
@@ -39,8 +40,8 @@ public class CrossTaskTest extends DriverTestBase<CrossFunction<Record, Record, 
 	
 	private final CountingOutputCollector output = new CountingOutputCollector();
 
-	public CrossTaskTest() {
-		super(CROSS_MEM, 0);
+	public CrossTaskTest(ExecutionConfig config) {
+		super(config, CROSS_MEM, 0);
 
 		cross_frac = (double)CROSS_MEM/this.getMemoryManager().getMemorySize();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/MapTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/MapTaskTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.functions.GenericCollectorMap;
@@ -45,8 +46,8 @@ public class MapTaskTest extends DriverTestBase<GenericCollectorMap<Record, Reco
 	private final CountingOutputCollector output = new CountingOutputCollector();
 	
 	
-	public MapTaskTest() {
-		super(0, 0);
+	public MapTaskTest(ExecutionConfig config) {
+		super(config, 0, 0);
 	}
 	
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/MatchTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/MatchTaskExternalITCase.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.operators;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
@@ -55,8 +56,8 @@ public class MatchTaskExternalITCase extends DriverTestBase<FlatJoinFunction<Rec
 	
 	private final CountingOutputCollector output = new CountingOutputCollector();
 	
-	public MatchTaskExternalITCase() {
-		super(HASH_MEM, 2, SORT_MEM);
+	public MatchTaskExternalITCase(ExecutionConfig config) {
+		super(config, HASH_MEM, 2, SORT_MEM);
 		bnljn_frac = (double)BNLJN_MEM/this.getMemoryManager().getMemorySize();
 		hash_frac = (double)HASH_MEM/this.getMemoryManager().getMemorySize();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/MatchTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/MatchTaskTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
 import org.apache.flink.api.common.typeutils.record.RecordPairComparatorFactory;
@@ -66,8 +67,8 @@ public class MatchTaskTest extends DriverTestBase<FlatJoinFunction<Record, Recor
 	private final List<Record> outList = new ArrayList<Record>();
 	
 	
-	public MatchTaskTest() {
-		super(HASH_MEM, NUM_SORTER, SORT_MEM);
+	public MatchTaskTest(ExecutionConfig config) {
+		super(config, HASH_MEM, NUM_SORTER, SORT_MEM);
 		bnljn_frac = (double)BNLJN_MEM/this.getMemoryManager().getMemorySize();
 		hash_frac = (double)HASH_MEM/this.getMemoryManager().getMemorySize();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskExternalITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +49,8 @@ public class ReduceTaskExternalITCase extends DriverTestBase<RichGroupReduceFunc
 	private final List<Record> outList = new ArrayList<Record>();
 	
 	
-	public ReduceTaskExternalITCase() {
-		super(0, 1, 3*1024*1024);
+	public ReduceTaskExternalITCase(ExecutionConfig config) {
+		super(config, 0, 1, 3*1024*1024);
 	}
 	
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,8 +53,8 @@ public class ReduceTaskTest extends DriverTestBase<RichGroupReduceFunction<Recor
 	
 	private final List<Record> outList = new ArrayList<Record>();
 
-	public ReduceTaskTest() {
-		super(0, 1, 3*1024*1024);
+	public ReduceTaskTest(ExecutionConfig config) {
+		super(config, 0, 1, 3*1024*1024);
 	}
 	
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.operators.drivers;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
@@ -58,6 +59,8 @@ public class TestTaskContext<S, T> implements PactTaskContext<S, T> {
 	private Collector<T> outputCollector;
 	
 	private MemoryManager memoryManager;
+
+	private ExecutionConfig executionConfig = new ExecutionConfig();
 
 	// --------------------------------------------------------------------------------------------
 	//  Constructors
@@ -130,6 +133,11 @@ public class TestTaskContext<S, T> implements PactTaskContext<S, T> {
 	@Override
 	public TaskConfig getTaskConfig() {
 		return this.config;
+	}
+
+	@Override
+	public ExecutionConfig getExecutionConfig() {
+		return executionConfig;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
@@ -1433,6 +1433,20 @@ public class HashTableITCase {
 				return null;
 			}
 		}
+
+		@Override
+		public Record next() {
+			if (this.numLeft > 0) {
+				this.numLeft--;
+				Record result = new Record(2);
+				result.setField(0, this.key);
+				result.setField(1, this.value);
+				return result;
+			}
+			else {
+				return null;
+			}
+		}
 	}
 	
 	// ============================================================================================
@@ -1466,6 +1480,22 @@ public class HashTableITCase {
 				return null;
 			}
 		}
+
+		@Override
+		public IntPair next() {
+			if (this.numLeft > 0) {
+				this.numLeft--;
+
+				IntPair result = new IntPair();
+				result.setKey(this.key);
+				result.setValue(this.value);
+				return result;
+			}
+			else {
+				return null;
+			}
+		}
+
 	}
 	
 	// ============================================================================================

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
@@ -1,0 +1,778 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.hash;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.record.RecordComparator;
+import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
+import org.apache.flink.api.common.typeutils.record.RecordSerializer;
+import org.apache.flink.api.java.record.functions.JoinFunction;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.runtime.operators.testutils.TestData;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.runtime.operators.testutils.UniformIntPairGenerator;
+import org.apache.flink.runtime.operators.testutils.UnionIterator;
+import org.apache.flink.runtime.operators.testutils.types.IntPair;
+import org.apache.flink.runtime.operators.testutils.types.IntPairComparator;
+import org.apache.flink.runtime.operators.testutils.types.IntPairSerializer;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.types.NullKeyFieldException;
+import org.apache.flink.types.Record;
+import org.apache.flink.types.Value;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+@SuppressWarnings({"serial", "deprecation"})
+public class NonReusingHashMatchIteratorITCase {
+	
+	private static final int MEMORY_SIZE = 16000000;		// total memory
+
+	private static final int INPUT_1_SIZE = 20000;
+	private static final int INPUT_2_SIZE = 1000;
+
+	private static final long SEED1 = 561349061987311L;
+	private static final long SEED2 = 231434613412342L;
+	
+	private final AbstractInvokable parentTask = new DummyInvokable();
+
+	private IOManager ioManager;
+	private MemoryManager memoryManager;
+	
+	private TypeSerializer<Record> recordSerializer;
+	private TypeComparator<Record> record1Comparator;
+	private TypeComparator<Record> record2Comparator;
+	private TypePairComparator<Record, Record> recordPairComparator;
+	
+	private TypeSerializer<IntPair> pairSerializer;
+	private TypeComparator<IntPair> pairComparator;
+	private TypePairComparator<IntPair, Record> pairRecordPairComparator;
+	private TypePairComparator<Record, IntPair> recordPairPairComparator;
+
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void beforeTest() {
+		this.recordSerializer = RecordSerializer.get();
+		
+		this.record1Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
+		this.record2Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
+		
+		this.recordPairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {TestData.Key.class});
+		
+		this.pairSerializer = new IntPairSerializer();
+		this.pairComparator = new IntPairComparator();
+		this.pairRecordPairComparator = new IntPairRecordPairComparator();
+		this.recordPairPairComparator = new RecordIntPairPairComparator();
+		
+		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.ioManager = new IOManagerAsync();
+	}
+
+	@After
+	public void afterTest() {
+		if (this.ioManager != null) {
+			this.ioManager.shutdown();
+			if (!this.ioManager.isProperlyShutDown()) {
+				Assert.fail("I/O manager failed to properly shut down.");
+			}
+			this.ioManager = null;
+		}
+		
+		if (this.memoryManager != null) {
+			Assert.assertTrue("Memory Leak: Not all memory has been returned to the memory manager.",
+				this.memoryManager.verifyEmpty());
+			this.memoryManager.shutdown();
+			this.memoryManager = null;
+		}
+	}
+
+
+	@Test
+	public void testBuildFirst() {
+		try {
+			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			
+			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+				collectRecordData(input1),
+				collectRecordData(input2));
+			
+			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+	
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+			input1.reset();
+			input2.reset();
+	
+			// compare with iterator values
+			NonReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
+					new NonReusingBuildFirstHashMatchIterator<Record, Record, Record>(
+						input1, input2, this.recordSerializer, this.record1Comparator, 
+						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+						this.memoryManager, ioManager, this.parentTask, 1.0);
+			
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testBuildFirstWithHighNumberOfCommonKeys()
+	{
+		// the size of the left and right inputs
+		final int INPUT_1_SIZE = 200;
+		final int INPUT_2_SIZE = 100;
+		
+		final int INPUT_1_DUPLICATES = 10;
+		final int INPUT_2_DUPLICATES = 2000;
+		final int DUPLICATE_KEY = 13;
+		
+		try {
+			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			
+			final TestData.GeneratorIterator gen1Iter = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.GeneratorIterator gen2Iter = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			final TestData.ConstantValueIterator const1Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
+			final TestData.ConstantValueIterator const2Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
+			
+			final List<MutableObjectIterator<Record>> inList1 = new ArrayList<MutableObjectIterator<Record>>();
+			inList1.add(gen1Iter);
+			inList1.add(const1Iter);
+			
+			final List<MutableObjectIterator<Record>> inList2 = new ArrayList<MutableObjectIterator<Record>>();
+			inList2.add(gen2Iter);
+			inList2.add(const2Iter);
+			
+			MutableObjectIterator<Record> input1 = new UnionIterator<Record>(inList1);
+			MutableObjectIterator<Record> input2 = new UnionIterator<Record>(inList2);
+			
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+				collectRecordData(input1),
+				collectRecordData(input2));
+			
+			// re-create the whole thing for actual processing
+			
+			// reset the generators and iterators
+			generator1.reset();
+			generator2.reset();
+			const1Iter.reset();
+			const2Iter.reset();
+			gen1Iter.reset();
+			gen2Iter.reset();
+			
+			inList1.clear();
+			inList1.add(gen1Iter);
+			inList1.add(const1Iter);
+			
+			inList2.clear();
+			inList2.add(gen2Iter);
+			inList2.add(const2Iter);
+	
+			input1 = new UnionIterator<Record>(inList1);
+			input2 = new UnionIterator<Record>(inList2);
+			
+			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+	
+			NonReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
+					new NonReusingBuildFirstHashMatchIterator<Record, Record, Record>(
+						input1, input2, this.recordSerializer, this.record1Comparator, 
+						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+						this.memoryManager, ioManager, this.parentTask, 1.0);
+
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testBuildSecond() {
+		try {
+			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			
+			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+				collectRecordData(input1),
+				collectRecordData(input2));
+			
+			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+	
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+			input1.reset();
+			input2.reset();
+	
+			// compare with iterator values			
+			NonReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
+				new NonReusingBuildSecondHashMatchIterator<Record, Record, Record>(
+					input1, input2, this.recordSerializer, this.record1Comparator, 
+					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+					this.memoryManager, ioManager, this.parentTask, 1.0);
+
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testBuildSecondWithHighNumberOfCommonKeys()
+	{
+		// the size of the left and right inputs
+		final int INPUT_1_SIZE = 200;
+		final int INPUT_2_SIZE = 100;
+		
+		final int INPUT_1_DUPLICATES = 10;
+		final int INPUT_2_DUPLICATES = 2000;
+		final int DUPLICATE_KEY = 13;
+		
+		try {
+			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			
+			final TestData.GeneratorIterator gen1Iter = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.GeneratorIterator gen2Iter = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			final TestData.ConstantValueIterator const1Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
+			final TestData.ConstantValueIterator const2Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
+			
+			final List<MutableObjectIterator<Record>> inList1 = new ArrayList<MutableObjectIterator<Record>>();
+			inList1.add(gen1Iter);
+			inList1.add(const1Iter);
+			
+			final List<MutableObjectIterator<Record>> inList2 = new ArrayList<MutableObjectIterator<Record>>();
+			inList2.add(gen2Iter);
+			inList2.add(const2Iter);
+			
+			MutableObjectIterator<Record> input1 = new UnionIterator<Record>(inList1);
+			MutableObjectIterator<Record> input2 = new UnionIterator<Record>(inList2);
+			
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+				collectRecordData(input1),
+				collectRecordData(input2));
+			
+			// re-create the whole thing for actual processing
+			
+			// reset the generators and iterators
+			generator1.reset();
+			generator2.reset();
+			const1Iter.reset();
+			const2Iter.reset();
+			gen1Iter.reset();
+			gen2Iter.reset();
+			
+			inList1.clear();
+			inList1.add(gen1Iter);
+			inList1.add(const1Iter);
+			
+			inList2.clear();
+			inList2.add(gen2Iter);
+			inList2.add(const2Iter);
+	
+			input1 = new UnionIterator<Record>(inList1);
+			input2 = new UnionIterator<Record>(inList2);
+			
+			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+
+			NonReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
+				new NonReusingBuildSecondHashMatchIterator<Record, Record, Record>(
+					input1, input2, this.recordSerializer, this.record1Comparator, 
+					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+					this.memoryManager, ioManager, this.parentTask, 1.0);
+			
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testBuildFirstWithMixedDataTypes() {
+		try {
+			MutableObjectIterator<IntPair> input1 = new UniformIntPairGenerator(500, 40, false);
+			
+			final Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+				collectIntPairData(input1),
+				collectRecordData(input2));
+			
+			final FlatJoinFunction<IntPair, Record, Record> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+	
+			// reset the generators
+			input1 = new UniformIntPairGenerator(500, 40, false);
+			generator2.reset();
+			input2.reset();
+	
+			// compare with iterator values
+			NonReusingBuildSecondHashMatchIterator<IntPair, Record, Record> iterator =
+					new NonReusingBuildSecondHashMatchIterator<IntPair, Record, Record>(
+						input1, input2, this.pairSerializer, this.pairComparator,
+						this.recordSerializer, this.record2Comparator, this.pairRecordPairComparator,
+						this.memoryManager, this.ioManager, this.parentTask, 1.0);
+			
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testBuildSecondWithMixedDataTypes() {
+		try {
+			MutableObjectIterator<IntPair> input1 = new UniformIntPairGenerator(500, 40, false);
+			
+			final Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+				collectIntPairData(input1),
+				collectRecordData(input2));
+			
+			final FlatJoinFunction<IntPair, Record, Record> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+	
+			// reset the generators
+			input1 = new UniformIntPairGenerator(500, 40, false);
+			generator2.reset();
+			input2.reset();
+	
+			// compare with iterator values
+			NonReusingBuildFirstHashMatchIterator<IntPair, Record, Record> iterator =
+					new NonReusingBuildFirstHashMatchIterator<IntPair, Record, Record>(
+						input1, input2, this.pairSerializer, this.pairComparator, 
+						this.recordSerializer, this.record2Comparator, this.recordPairPairComparator,
+						this.memoryManager, this.ioManager, this.parentTask, 1.0);
+			
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	// --------------------------------------------------------------------------------------------
+	//                                    Utilities
+	// --------------------------------------------------------------------------------------------
+
+	
+	
+	static Map<TestData.Key, Collection<RecordMatch>> matchRecordValues(
+			Map<TestData.Key, Collection<TestData.Value>> leftMap,
+			Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	{
+		Map<TestData.Key, Collection<RecordMatch>> map = new HashMap<TestData.Key, Collection<RecordMatch>>();
+
+		for (TestData.Key key : leftMap.keySet()) {
+			Collection<TestData.Value> leftValues = leftMap.get(key);
+			Collection<TestData.Value> rightValues = rightMap.get(key);
+
+			if (rightValues == null) {
+				continue;
+			}
+
+			if (!map.containsKey(key)) {
+				map.put(key, new ArrayList<RecordMatch>());
+			}
+
+			Collection<RecordMatch> matchedValues = map.get(key);
+
+			for (TestData.Value leftValue : leftValues) {
+				for (TestData.Value rightValue : rightValues) {
+					matchedValues.add(new RecordMatch(leftValue, rightValue));
+				}
+			}
+		}
+
+		return map;
+	}
+	
+	static Map<TestData.Key, Collection<RecordIntPairMatch>> matchRecordIntPairValues(
+		Map<Integer, Collection<Integer>> leftMap,
+		Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	{
+		final Map<TestData.Key, Collection<RecordIntPairMatch>> map = new HashMap<TestData.Key, Collection<RecordIntPairMatch>>();
+	
+		for (Integer i : leftMap.keySet()) {
+			
+			final TestData.Key key = new TestData.Key(i.intValue());
+			
+			final Collection<Integer> leftValues = leftMap.get(i);
+			final Collection<TestData.Value> rightValues = rightMap.get(key);
+	
+			if (rightValues == null) {
+				continue;
+			}
+	
+			if (!map.containsKey(key)) {
+				map.put(key, new ArrayList<RecordIntPairMatch>());
+			}
+	
+			final Collection<RecordIntPairMatch> matchedValues = map.get(key);
+	
+			for (Integer v : leftValues) {
+				for (TestData.Value val : rightValues) {
+					matchedValues.add(new RecordIntPairMatch(v, val));
+				}
+			}
+		}
+	
+		return map;
+	}
+
+	
+	static Map<TestData.Key, Collection<TestData.Value>> collectRecordData(MutableObjectIterator<Record> iter)
+	throws Exception
+	{
+		Map<TestData.Key, Collection<TestData.Value>> map = new HashMap<TestData.Key, Collection<TestData.Value>>();
+		Record pair = new Record();
+		
+		while ((pair = iter.next(pair)) != null) {
+
+			TestData.Key key = pair.getField(0, TestData.Key.class);
+			if (!map.containsKey(key)) {
+				map.put(new TestData.Key(key.getKey()), new ArrayList<TestData.Value>());
+			}
+
+			Collection<TestData.Value> values = map.get(key);
+			values.add(new TestData.Value(pair.getField(1, TestData.Value.class).getValue()));
+		}
+
+		return map;
+	}
+	
+	static Map<Integer, Collection<Integer>> collectIntPairData(MutableObjectIterator<IntPair> iter)
+	throws Exception
+	{
+		Map<Integer, Collection<Integer>> map = new HashMap<Integer, Collection<Integer>>();
+		IntPair pair = new IntPair();
+		
+		while ((pair = iter.next(pair)) != null) {
+
+			final int key = pair.getKey();
+			final int value = pair.getValue();
+			if (!map.containsKey(key)) {
+				map.put(key, new ArrayList<Integer>());
+			}
+
+			Collection<Integer> values = map.get(key);
+			values.add(value);
+		}
+
+		return map;
+	}
+
+	/**
+	 * Private class used for storage of the expected matches in a hash-map.
+	 */
+	static class RecordMatch {
+		
+		private final Value left;
+		private final Value right;
+
+		public RecordMatch(Value left, Value right) {
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			RecordMatch o = (RecordMatch) obj;
+			return this.left.equals(o.left) && this.right.equals(o.right);
+		}
+		
+		@Override
+		public int hashCode() {
+			return this.left.hashCode() ^ this.right.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return left + ", " + right;
+		}
+	}
+	
+	/**
+	 * Private class used for storage of the expected matches in a hash-map.
+	 */
+	static class RecordIntPairMatch
+	{
+		private final int left;
+		private final Value right;
+
+		public RecordIntPairMatch(int left, Value right) {
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			RecordIntPairMatch o = (RecordIntPairMatch) obj;
+			return this.left == o.left && this.right.equals(o.right);
+		}
+		
+		@Override
+		public int hashCode() {
+			return this.left ^ this.right.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return left + ", " + right;
+		}
+	}
+	
+	static final class RecordMatchRemovingJoin extends JoinFunction
+	{
+		private final Map<TestData.Key, Collection<RecordMatch>> toRemoveFrom;
+		
+		protected RecordMatchRemovingJoin(Map<TestData.Key, Collection<RecordMatch>> map) {
+			this.toRemoveFrom = map;
+		}
+		
+		@Override
+		public void join(Record rec1, Record rec2, Collector<Record> out) throws Exception
+		{
+			TestData.Key key = rec1.getField(0, TestData.Key.class);
+			TestData.Value value1 = rec1.getField(1, TestData.Value.class);
+			TestData.Value value2 = rec2.getField(1, TestData.Value.class);
+			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.getField(0, TestData.Key.class));
+			Collection<RecordMatch> matches = this.toRemoveFrom.get(key);
+			if (matches == null) {
+				Assert.fail("Match " + key + " - " + value1 + ":" + value2 + " is unexpected.");
+			}
+			
+			Assert.assertTrue("Produced match was not contained: " + key + " - " + value1 + ":" + value2,
+				matches.remove(new RecordMatch(value1, value2)));
+			
+			if (matches.isEmpty()) {
+				this.toRemoveFrom.remove(key);
+			}
+		}
+	}
+	
+	static final class RecordIntPairMatchRemovingMatcher extends AbstractRichFunction implements FlatJoinFunction<IntPair, Record, Record>
+	{
+		private final Map<TestData.Key, Collection<RecordIntPairMatch>> toRemoveFrom;
+		
+		protected RecordIntPairMatchRemovingMatcher(Map<TestData.Key, Collection<RecordIntPairMatch>> map) {
+			this.toRemoveFrom = map;
+		}
+		
+		@Override
+		public void join(IntPair rec1, Record rec2, Collector<Record> out) throws Exception
+		{
+			final int k = rec1.getKey();
+			final int v = rec1.getValue(); 
+			
+			final TestData.Key key = rec2.getField(0, TestData.Key.class);
+			final TestData.Value value = rec2.getField(1, TestData.Value.class);
+			
+			Assert.assertTrue("Key does not match for matching IntPair Record combination.", k == key.getKey()); 
+			
+			Collection<RecordIntPairMatch> matches = this.toRemoveFrom.get(key);
+			if (matches == null) {
+				Assert.fail("Match " + key + " - " + v + ":" + value + " is unexpected.");
+			}
+			
+			Assert.assertTrue("Produced match was not contained: " + key + " - " + v + ":" + value,
+				matches.remove(new RecordIntPairMatch(v, value)));
+			
+			if (matches.isEmpty()) {
+				this.toRemoveFrom.remove(key);
+			}
+		}
+	}
+	
+	static final class IntPairRecordPairComparator extends TypePairComparator<IntPair, Record>
+	{
+		private int reference;
+		
+		@Override
+		public void setReference(IntPair reference) {
+			this.reference = reference.getKey();	
+		}
+
+		@Override
+		public boolean equalToReference(Record candidate) {
+			try {
+				final IntValue i = candidate.getField(0, IntValue.class);
+				return i.getValue() == this.reference;
+			} catch (NullPointerException npex) {
+				throw new NullKeyFieldException();
+			}
+		}
+
+		@Override
+		public int compareToReference(Record candidate) {
+			try {
+				final IntValue i = candidate.getField(0, IntValue.class);
+				return i.getValue() - this.reference;
+			} catch (NullPointerException npex) {
+				throw new NullKeyFieldException();
+			}
+		}
+	}
+	
+	static final class RecordIntPairPairComparator extends TypePairComparator<Record, IntPair>
+	{
+		private int reference;
+		
+		@Override
+		public void setReference(Record reference) {
+			this.reference = reference.getField(0, IntValue.class).getValue();
+		}
+
+		@Override
+		public boolean equalToReference(IntPair candidate) {
+			return this.reference == candidate.getKey();
+		}
+
+		@Override
+		public int compareToReference(IntPair candidate) {
+			return candidate.getKey() - this.reference;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,16 +18,6 @@
 
 
 package org.apache.flink.runtime.operators.hash;
-
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
@@ -43,19 +33,20 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
-import org.apache.flink.runtime.operators.hash.HashMatchIteratorITCase.RecordMatch;
-import org.apache.flink.runtime.operators.hash.HashMatchIteratorITCase.RecordMatchRemovingJoin;
 import org.apache.flink.runtime.operators.hash.HashTableITCase.ConstantsKeyValuePairsIterator;
 import org.apache.flink.runtime.operators.hash.MutableHashTable.HashBucketIterator;
+import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase.RecordMatch;
+import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase
+		.RecordMatchRemovingJoin;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
-import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.runtime.operators.testutils.TestData.Generator;
-import org.apache.flink.runtime.operators.testutils.TestData.Key;
 import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
 import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.runtime.operators.testutils.TestData.Key;
+import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
+import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.Collector;
@@ -65,34 +56,44 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static org.junit.Assert.fail;
+
 /**
  * Test specialized hash join that keeps the build side data (in memory and on hard disk)
  * This is used for iterative tasks.
  */
 @SuppressWarnings("deprecation")
-public class ReOpenableHashTableITCase {
-	
+public class NonReusingReOpenableHashTableITCase {
+
 	private static final int PAGE_SIZE = 8 * 1024;
 	private static final long MEMORY_SIZE = PAGE_SIZE * 1000; // 100 Pages.
 
 	private static final long SEED1 = 561349061987311L;
 	private static final long SEED2 = 231434613412342L;
-	
+
 	private static final int NUM_PROBES = 3; // number of reopenings of hash join
-	
+
 	private final AbstractInvokable parentTask = new DummyInvokable();
 
 	private IOManager ioManager;
 	private MemoryManager memoryManager;
-	
+
 	private TypeSerializer<Record> recordSerializer;
 	private TypeComparator<Record> record1Comparator;
 	private TypeComparator<Record> record2Comparator;
 	private TypePairComparator<Record, Record> recordPairComparator;
-	
-	
-	
-	
+
+
+
+
 	private static final AbstractInvokable MEM_OWNER = new DummyInvokable();
 	private TypeSerializer<Record> recordBuildSideAccesssor;
 	private TypeSerializer<Record> recordProbeSideAccesssor;
@@ -105,21 +106,21 @@ public class ReOpenableHashTableITCase {
 	public void beforeTest()
 	{
 		this.recordSerializer = RecordSerializer.get();
-		
-		this.record1Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
-		this.record2Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
-		this.recordPairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {TestData.Key.class});
-		
-		
+
+		this.record1Comparator = new RecordComparator(new int[] {0}, new Class[] {Key.class});
+		this.record2Comparator = new RecordComparator(new int[] {0}, new Class[] {Key.class});
+		this.recordPairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {Key.class});
+
+
 		final int[] keyPos = new int[] {0};
 		final Class<? extends Key>[] keyType = (Class<? extends Key>[]) new Class[] { IntValue.class };
-		
+
 		this.recordBuildSideAccesssor = RecordSerializer.get();
 		this.recordProbeSideAccesssor = RecordSerializer.get();
 		this.recordBuildSideComparator = new RecordComparator(keyPos, keyType);
 		this.recordProbeSideComparator = new RecordComparator(keyPos, keyType);
 		this.pactRecordComparator = new HashTableITCase.RecordPairComparatorFirstInt();
-		
+
 		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE,1, PAGE_SIZE);
 		this.ioManager = new IOManagerAsync();
 	}
@@ -134,7 +135,7 @@ public class ReOpenableHashTableITCase {
 			}
 			this.ioManager = null;
 		}
-		
+
 		if (this.memoryManager != null) {
 			Assert.assertTrue("Memory Leak: Not all memory has been returned to the memory manager.",
 				this.memoryManager.verifyEmpty());
@@ -142,21 +143,21 @@ public class ReOpenableHashTableITCase {
 			this.memoryManager = null;
 		}
 	}
-	
-	
+
+
 	/**
-	 * Test behavior with overflow buckets (Overflow buckets must be initialized correctly 
+	 * Test behavior with overflow buckets (Overflow buckets must be initialized correctly
 	 * if the input is reopened again)
 	 */
 	@Test
 	public void testOverflow() {
-		
+
 		int buildSize = 1000;
 		int probeSize = 1000;
 		try {
 			Generator bgen = new Generator(SEED1, 200, 1024, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
 			Generator pgen = new Generator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
-			
+
 			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
 			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
 			doTest(buildInput,probeInput, bgen, pgen);
@@ -166,19 +167,19 @@ public class ReOpenableHashTableITCase {
 			Assert.fail("An exception occurred during the test: " + e.getMessage());
 		}
 	}
-	
+
 	/**
 	 * Verify proper operation if the build side is spilled to disk.
 	 */
 	@Test
 	public void testDoubleProbeSpilling() {
-		
+
 		int buildSize = 1000;
 		int probeSize = 1000;
 		try {
 			Generator bgen = new Generator(SEED1, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
 			Generator pgen = new Generator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
-			
+
 			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
 			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
 			doTest(buildInput,probeInput, bgen, pgen);
@@ -188,23 +189,23 @@ public class ReOpenableHashTableITCase {
 			Assert.fail("An exception occurred during the test: " + e.getMessage());
 		}
 	}
-	
+
 	/**
 	 * This test case verifies that hybrid hash join is able to handle multiple probe phases
 	 * when the build side fits completely into memory.
 	 */
 	@Test
 	public void testDoubleProbeInMemory() {
-		
+
 		int buildSize = 1000;
 		int probeSize = 1000;
 		try {
 			Generator bgen = new Generator(SEED1, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
 			Generator pgen = new Generator(SEED2, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
-			
+
 			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
 			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
-			
+
 			doTest(buildInput,probeInput, bgen, pgen);
 		}
 		catch (Exception e) {
@@ -212,23 +213,21 @@ public class ReOpenableHashTableITCase {
 			Assert.fail("An exception occurred during the test: " + e.getMessage());
 		}
 	}
-	
+
 	private void doTest(TestData.GeneratorIterator buildInput, TestData.GeneratorIterator probeInput, Generator bgen, Generator pgen) throws Exception {
 		// collect expected data
-		final Map<TestData.Key, Collection<RecordMatch>> expectedFirstMatchesMap = HashMatchIteratorITCase.matchRecordValues(
-			HashMatchIteratorITCase.collectRecordData(buildInput),
-			HashMatchIteratorITCase.collectRecordData(probeInput));
-		
-		final List<Map<TestData.Key, Collection<RecordMatch>>> expectedNMatchesMapList = new ArrayList<Map<Key,Collection<RecordMatch>>>(NUM_PROBES);
+		final Map<Key, Collection<RecordMatch>> expectedFirstMatchesMap = NonReusingHashMatchIteratorITCase.matchRecordValues(NonReusingHashMatchIteratorITCase.collectRecordData(buildInput), NonReusingHashMatchIteratorITCase.collectRecordData(probeInput));
+
+		final List<Map<Key, Collection<RecordMatch>>> expectedNMatchesMapList = new ArrayList<Map<Key,Collection<RecordMatch>>>(NUM_PROBES);
 		final JoinFunction[] nMatcher = new RecordMatchRemovingJoin[NUM_PROBES];
 		for(int i = 0; i < NUM_PROBES; i++) {
-			Map<TestData.Key, Collection<RecordMatch>> tmp;
+			Map<Key, Collection<RecordMatch>> tmp;
 			expectedNMatchesMapList.add(tmp = deepCopy(expectedFirstMatchesMap));
 			nMatcher[i] = new RecordMatchRemovingJoin(tmp);
 		}
-		
+
 		final JoinFunction firstMatcher = new RecordMatchRemovingJoin(expectedFirstMatchesMap);
-		
+
 		final Collector<Record> collector = new DiscardingOutputCollector<Record>();
 
 		// reset the generators
@@ -238,23 +237,23 @@ public class ReOpenableHashTableITCase {
 		probeInput.reset();
 
 		// compare with iterator values
-		BuildFirstReOpenableHashMatchIterator<Record, Record, Record> iterator = 
-				new BuildFirstReOpenableHashMatchIterator<Record, Record, Record>(
-						buildInput, probeInput, this.recordSerializer, this.record1Comparator, 
+		NonReusingBuildFirstReOpenableHashMatchIterator<Record, Record, Record> iterator =
+				new NonReusingBuildFirstReOpenableHashMatchIterator<Record, Record, Record>(
+						buildInput, probeInput, this.recordSerializer, this.record1Comparator,
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0);
-		
+
 		iterator.open();
 		// do first join with both inputs
 		while (iterator.callWithNextKey(firstMatcher, collector));
 
 		// assert that each expected match was seen for the first input
-		for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedFirstMatchesMap.entrySet()) {
+		for (Entry<Key, Collection<RecordMatch>> entry : expectedFirstMatchesMap.entrySet()) {
 			if (!entry.getValue().isEmpty()) {
 				Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 			}
 		}
-		
+
 		for(int i = 0; i < NUM_PROBES; i++) {
 			pgen.reset();
 			probeInput.reset();
@@ -262,24 +261,24 @@ public class ReOpenableHashTableITCase {
 			iterator.reopenProbe(probeInput);
 			// .. and do second join
 			while (iterator.callWithNextKey(nMatcher[i], collector));
-			
+
 			// assert that each expected match was seen for the second input
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedNMatchesMapList.get(i).entrySet()) {
+			for (Entry<Key, Collection<RecordMatch>> entry : expectedNMatchesMapList.get(i).entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
 			}
 		}
-		
+
 		iterator.close();
 	}
-	
+
 	//
 	//
 	//	Tests taken from HahTableITCase!
 	//
 	//
-	
+
 	private final MutableObjectIterator<Record> getProbeInput(final int numKeys,
 			final int probeValsPerKey, final int repeatedValue1, final int repeatedValue2) {
 		MutableObjectIterator<Record> probe1 = new UniformRecordGenerator(numKeys, probeValsPerKey, true);
@@ -291,7 +290,7 @@ public class ReOpenableHashTableITCase {
 		probes.add(probe3);
 		return new UnionIterator<Record>(probes);
 	}
-	
+
 	@Test
 	public void testSpillingHashJoinWithMassiveCollisions() throws IOException
 	{
@@ -301,11 +300,11 @@ public class ReOpenableHashTableITCase {
 		final int REPEATED_VALUE_2 = 92882;
 		final int REPEATED_VALUE_COUNT_BUILD = 200000;
 		final int REPEATED_VALUE_COUNT_PROBE = 5;
-		
+
 		final int NUM_KEYS = 1000000;
 		final int BUILD_VALS_PER_KEY = 3;
 		final int PROBE_VALS_PER_KEY = 10;
-		
+
 		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
 		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
 		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
@@ -315,9 +314,9 @@ public class ReOpenableHashTableITCase {
 		builds.add(build2);
 		builds.add(build3);
 		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
-	
-		
-		
+
+
+
 
 		// allocate the memory for the HashTable
 		List<MemorySegment> memSegments;
@@ -328,17 +327,17 @@ public class ReOpenableHashTableITCase {
 			fail("Memory for the Join could not be provided.");
 			return;
 		}
-		
+
 		// create the map for validating the results
 		HashMap<Integer, Long> map = new HashMap<Integer, Long>(NUM_KEYS);
-		
+
 		// ----------------------------------------------------------------------------------------
-		
+
 		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
-		
+
 		for(int probe = 0; probe < NUM_PROBES; probe++) {
 			// create a probe input that gives 10 million pairs with 10 values sharing a key
 			MutableObjectIterator<Record> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
@@ -347,21 +346,21 @@ public class ReOpenableHashTableITCase {
 			} else {
 				join.reopenProbe(probeInput);
 			}
-		
+
 			Record record;
 			final Record recordReuse = new Record();
 
 			while (join.nextRecord())
 			{
 				int numBuildValues = 0;
-		
+
 				final Record probeRec = join.getCurrentProbeRecord();
 				int key = probeRec.getField(0, IntValue.class).getValue();
-				
+
 				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
 				if ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues = 1;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue()); 
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
 				}
 				else {
 					fail("No build side values found for a probe key.");
@@ -370,7 +369,7 @@ public class ReOpenableHashTableITCase {
 					numBuildValues++;
 					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
 				}
-				
+
 				Long contained = map.get(key);
 				if (contained == null) {
 					contained = Long.valueOf(numBuildValues);
@@ -378,33 +377,33 @@ public class ReOpenableHashTableITCase {
 				else {
 					contained = Long.valueOf(contained.longValue() + numBuildValues);
 				}
-				
+
 				map.put(key, contained);
 			}
 		}
-		
+
 		join.close();
-		
+
 		Assert.assertEquals("Wrong number of keys", NUM_KEYS, map.size());
-		for (Map.Entry<Integer, Long> entry : map.entrySet()) {
+		for (Entry<Integer, Long> entry : map.entrySet()) {
 			long val = entry.getValue();
 			int key = entry.getKey();
-	
+
 			if( key == REPEATED_VALUE_1 || key == REPEATED_VALUE_2) {
-				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key,
 							(PROBE_VALS_PER_KEY + REPEATED_VALUE_COUNT_PROBE) * (BUILD_VALS_PER_KEY + REPEATED_VALUE_COUNT_BUILD) * NUM_PROBES, val);
 			} else {
-				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key,
 							PROBE_VALS_PER_KEY * BUILD_VALS_PER_KEY * NUM_PROBES, val);
 			}
 		}
-		
-		
+
+
 		// ----------------------------------------------------------------------------------------
-		
+
 		this.memoryManager.release(join.getFreedMemory());
 	}
-	
+
 	/*
 	 * This test is basically identical to the "testSpillingHashJoinWithMassiveCollisions" test, only that the number
 	 * of repeated values (causing bucket collisions) are large enough to make sure that their target partition no longer
@@ -419,11 +418,11 @@ public class ReOpenableHashTableITCase {
 		final int REPEATED_VALUE_2 = 92882;
 		final int REPEATED_VALUE_COUNT_BUILD = 200000;
 		final int REPEATED_VALUE_COUNT_PROBE = 5;
-		
+
 		final int NUM_KEYS = 1000000;
 		final int BUILD_VALS_PER_KEY = 3;
 		final int PROBE_VALS_PER_KEY = 10;
-		
+
 		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
 		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
 		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
@@ -433,7 +432,7 @@ public class ReOpenableHashTableITCase {
 		builds.add(build2);
 		builds.add(build3);
 		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
-	
+
 
 		// allocate the memory for the HashTable
 		List<MemorySegment> memSegments;
@@ -444,14 +443,14 @@ public class ReOpenableHashTableITCase {
 			fail("Memory for the Join could not be provided.");
 			return;
 		}
-		
+
 		// create the map for validating the results
 		HashMap<Integer, Long> map = new HashMap<Integer, Long>(NUM_KEYS);
-		
+
 		// ----------------------------------------------------------------------------------------
-		
+
 		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
-				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager);
 		for(int probe = 0; probe < NUM_PROBES; probe++) {
@@ -466,16 +465,16 @@ public class ReOpenableHashTableITCase {
 			final Record recordReuse = new Record();
 
 			while (join.nextRecord())
-			{	
+			{
 				int numBuildValues = 0;
-				
+
 				final Record probeRec = join.getCurrentProbeRecord();
 				int key = probeRec.getField(0, IntValue.class).getValue();
-				
+
 				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
 				if ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues = 1;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue()); 
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
 				}
 				else {
 					fail("No build side values found for a probe key.");
@@ -484,7 +483,7 @@ public class ReOpenableHashTableITCase {
 					numBuildValues++;
 					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
 				}
-				
+
 				Long contained = map.get(key);
 				if (contained == null) {
 					contained = Long.valueOf(numBuildValues);
@@ -492,36 +491,36 @@ public class ReOpenableHashTableITCase {
 				else {
 					contained = Long.valueOf(contained.longValue() + numBuildValues);
 				}
-				
+
 				map.put(key, contained);
 			}
 		}
-		
+
 		join.close();
 		Assert.assertEquals("Wrong number of keys", NUM_KEYS, map.size());
-		for (Map.Entry<Integer, Long> entry : map.entrySet()) {
+		for (Entry<Integer, Long> entry : map.entrySet()) {
 			long val = entry.getValue();
 			int key = entry.getKey();
-	
+
 			if( key == REPEATED_VALUE_1 || key == REPEATED_VALUE_2) {
-				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key,
 							(PROBE_VALS_PER_KEY + REPEATED_VALUE_COUNT_PROBE) * (BUILD_VALS_PER_KEY + REPEATED_VALUE_COUNT_BUILD) * NUM_PROBES, val);
 			} else {
-				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key,
 							PROBE_VALS_PER_KEY * BUILD_VALS_PER_KEY * NUM_PROBES, val);
 			}
 		}
-		
-		
+
+
 		// ----------------------------------------------------------------------------------------
-		
+
 		this.memoryManager.release(join.getFreedMemory());
 	}
-	
-	
+
+
 	static Map<Key, Collection<RecordMatch>> deepCopy(Map<Key, Collection<RecordMatch>> expectedSecondMatchesMap) {
 		Map<Key, Collection<RecordMatch>> copy = new HashMap<Key, Collection<RecordMatch>>(expectedSecondMatchesMap.size());
-		for(Map.Entry<Key, Collection<RecordMatch>> entry : expectedSecondMatchesMap.entrySet()) {
+		for(Entry<Key, Collection<RecordMatch>> entry : expectedSecondMatchesMap.entrySet()) {
 			List<RecordMatch> matches = new ArrayList<RecordMatch>(entry.getValue().size());
 			for(RecordMatch m : entry.getValue()) {
 				matches.add(m);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
@@ -63,7 +63,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 @SuppressWarnings({"serial", "deprecation"})
-public class HashMatchIteratorITCase {
+public class ReusingHashMatchIteratorITCase {
 	
 	private static final int MEMORY_SIZE = 16000000;		// total memory
 
@@ -151,8 +151,8 @@ public class HashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			BuildFirstHashMatchIterator<Record, Record, Record> iterator = 
-					new BuildFirstHashMatchIterator<Record, Record, Record>(
+			ReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
+					new ReusingBuildFirstHashMatchIterator<Record, Record, Record>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 						this.memoryManager, ioManager, this.parentTask, 1.0);
@@ -238,8 +238,8 @@ public class HashMatchIteratorITCase {
 			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
 	
-			BuildFirstHashMatchIterator<Record, Record, Record> iterator = 
-					new BuildFirstHashMatchIterator<Record, Record, Record>(
+			ReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
+					new ReusingBuildFirstHashMatchIterator<Record, Record, Record>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 						this.memoryManager, ioManager, this.parentTask, 1.0);
@@ -287,8 +287,8 @@ public class HashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values			
-			BuildSecondHashMatchIterator<Record, Record, Record> iterator = 
-				new BuildSecondHashMatchIterator<Record, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
+				new ReusingBuildSecondHashMatchIterator<Record, Record, Record>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0);
@@ -374,8 +374,8 @@ public class HashMatchIteratorITCase {
 			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
 	
-			BuildSecondHashMatchIterator<Record, Record, Record> iterator = 
-				new BuildSecondHashMatchIterator<Record, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
+				new ReusingBuildSecondHashMatchIterator<Record, Record, Record>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0);
@@ -421,8 +421,8 @@ public class HashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			BuildSecondHashMatchIterator<IntPair, Record, Record> iterator = 
-					new BuildSecondHashMatchIterator<IntPair, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<IntPair, Record, Record> iterator =
+					new ReusingBuildSecondHashMatchIterator<IntPair, Record, Record>(
 						input1, input2, this.pairSerializer, this.pairComparator,
 						this.recordSerializer, this.record2Comparator, this.pairRecordPairComparator,
 						this.memoryManager, this.ioManager, this.parentTask, 1.0);
@@ -468,8 +468,8 @@ public class HashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			BuildFirstHashMatchIterator<IntPair, Record, Record> iterator = 
-					new BuildFirstHashMatchIterator<IntPair, Record, Record>(
+			ReusingBuildFirstHashMatchIterator<IntPair, Record, Record> iterator =
+					new ReusingBuildFirstHashMatchIterator<IntPair, Record, Record>(
 						input1, input2, this.pairSerializer, this.pairComparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairPairComparator,
 						this.memoryManager, this.ioManager, this.parentTask, 1.0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingReOpenableHashTableITCase.java
@@ -1,0 +1,532 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.hash;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.record.RecordComparator;
+import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
+import org.apache.flink.api.common.typeutils.record.RecordSerializer;
+import org.apache.flink.api.java.record.functions.JoinFunction;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.hash.ReusingHashMatchIteratorITCase.RecordMatch;
+import org.apache.flink.runtime.operators.hash.ReusingHashMatchIteratorITCase.RecordMatchRemovingJoin;
+import org.apache.flink.runtime.operators.hash.HashTableITCase.ConstantsKeyValuePairsIterator;
+import org.apache.flink.runtime.operators.hash.MutableHashTable.HashBucketIterator;
+import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.runtime.operators.testutils.TestData;
+import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
+import org.apache.flink.runtime.operators.testutils.UnionIterator;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator;
+import org.apache.flink.runtime.operators.testutils.TestData.Key;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.types.Record;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test specialized hash join that keeps the build side data (in memory and on hard disk)
+ * This is used for iterative tasks.
+ */
+@SuppressWarnings("deprecation")
+public class ReusingReOpenableHashTableITCase {
+	
+	private static final int PAGE_SIZE = 8 * 1024;
+	private static final long MEMORY_SIZE = PAGE_SIZE * 1000; // 100 Pages.
+
+	private static final long SEED1 = 561349061987311L;
+	private static final long SEED2 = 231434613412342L;
+	
+	private static final int NUM_PROBES = 3; // number of reopenings of hash join
+	
+	private final AbstractInvokable parentTask = new DummyInvokable();
+
+	private IOManager ioManager;
+	private MemoryManager memoryManager;
+	
+	private TypeSerializer<Record> recordSerializer;
+	private TypeComparator<Record> record1Comparator;
+	private TypeComparator<Record> record2Comparator;
+	private TypePairComparator<Record, Record> recordPairComparator;
+	
+	
+	
+	
+	private static final AbstractInvokable MEM_OWNER = new DummyInvokable();
+	private TypeSerializer<Record> recordBuildSideAccesssor;
+	private TypeSerializer<Record> recordProbeSideAccesssor;
+	private TypeComparator<Record> recordBuildSideComparator;
+	private TypeComparator<Record> recordProbeSideComparator;
+	private TypePairComparator<Record, Record> pactRecordComparator;
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void beforeTest()
+	{
+		this.recordSerializer = RecordSerializer.get();
+		
+		this.record1Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
+		this.record2Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
+		this.recordPairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {TestData.Key.class});
+		
+		
+		final int[] keyPos = new int[] {0};
+		final Class<? extends Key>[] keyType = (Class<? extends Key>[]) new Class[] { IntValue.class };
+		
+		this.recordBuildSideAccesssor = RecordSerializer.get();
+		this.recordProbeSideAccesssor = RecordSerializer.get();
+		this.recordBuildSideComparator = new RecordComparator(keyPos, keyType);
+		this.recordProbeSideComparator = new RecordComparator(keyPos, keyType);
+		this.pactRecordComparator = new HashTableITCase.RecordPairComparatorFirstInt();
+		
+		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE,1, PAGE_SIZE);
+		this.ioManager = new IOManagerAsync();
+	}
+
+	@After
+	public void afterTest()
+	{
+		if (this.ioManager != null) {
+			this.ioManager.shutdown();
+			if (!this.ioManager.isProperlyShutDown()) {
+				Assert.fail("I/O manager failed to properly shut down.");
+			}
+			this.ioManager = null;
+		}
+		
+		if (this.memoryManager != null) {
+			Assert.assertTrue("Memory Leak: Not all memory has been returned to the memory manager.",
+				this.memoryManager.verifyEmpty());
+			this.memoryManager.shutdown();
+			this.memoryManager = null;
+		}
+	}
+	
+	
+	/**
+	 * Test behavior with overflow buckets (Overflow buckets must be initialized correctly 
+	 * if the input is reopened again)
+	 */
+	@Test
+	public void testOverflow() {
+		
+		int buildSize = 1000;
+		int probeSize = 1000;
+		try {
+			Generator bgen = new Generator(SEED1, 200, 1024, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
+			Generator pgen = new Generator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			
+			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
+			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
+			doTest(buildInput,probeInput, bgen, pgen);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	/**
+	 * Verify proper operation if the build side is spilled to disk.
+	 */
+	@Test
+	public void testDoubleProbeSpilling() {
+		
+		int buildSize = 1000;
+		int probeSize = 1000;
+		try {
+			Generator bgen = new Generator(SEED1, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			Generator pgen = new Generator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			
+			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
+			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
+			doTest(buildInput,probeInput, bgen, pgen);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	/**
+	 * This test case verifies that hybrid hash join is able to handle multiple probe phases
+	 * when the build side fits completely into memory.
+	 */
+	@Test
+	public void testDoubleProbeInMemory() {
+		
+		int buildSize = 1000;
+		int probeSize = 1000;
+		try {
+			Generator bgen = new Generator(SEED1, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			Generator pgen = new Generator(SEED2, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			
+			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
+			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
+			
+			doTest(buildInput,probeInput, bgen, pgen);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	private void doTest(TestData.GeneratorIterator buildInput, TestData.GeneratorIterator probeInput, Generator bgen, Generator pgen) throws Exception {
+		// collect expected data
+		final Map<TestData.Key, Collection<RecordMatch>> expectedFirstMatchesMap = ReusingHashMatchIteratorITCase.matchRecordValues(ReusingHashMatchIteratorITCase.collectRecordData(buildInput), ReusingHashMatchIteratorITCase.collectRecordData(probeInput));
+		
+		final List<Map<TestData.Key, Collection<RecordMatch>>> expectedNMatchesMapList = new ArrayList<Map<Key,Collection<RecordMatch>>>(NUM_PROBES);
+		final JoinFunction[] nMatcher = new RecordMatchRemovingJoin[NUM_PROBES];
+		for(int i = 0; i < NUM_PROBES; i++) {
+			Map<TestData.Key, Collection<RecordMatch>> tmp;
+			expectedNMatchesMapList.add(tmp = deepCopy(expectedFirstMatchesMap));
+			nMatcher[i] = new RecordMatchRemovingJoin(tmp);
+		}
+		
+		final JoinFunction firstMatcher = new RecordMatchRemovingJoin(expectedFirstMatchesMap);
+		
+		final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+
+		// reset the generators
+		bgen.reset();
+		pgen.reset();
+		buildInput.reset();
+		probeInput.reset();
+
+		// compare with iterator values
+		ReusingBuildFirstReOpenableHashMatchIterator<Record, Record, Record> iterator =
+				new ReusingBuildFirstReOpenableHashMatchIterator<Record, Record, Record>(
+						buildInput, probeInput, this.recordSerializer, this.record1Comparator, 
+					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+					this.memoryManager, ioManager, this.parentTask, 1.0);
+		
+		iterator.open();
+		// do first join with both inputs
+		while (iterator.callWithNextKey(firstMatcher, collector));
+
+		// assert that each expected match was seen for the first input
+		for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedFirstMatchesMap.entrySet()) {
+			if (!entry.getValue().isEmpty()) {
+				Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+			}
+		}
+		
+		for(int i = 0; i < NUM_PROBES; i++) {
+			pgen.reset();
+			probeInput.reset();
+			// prepare ..
+			iterator.reopenProbe(probeInput);
+			// .. and do second join
+			while (iterator.callWithNextKey(nMatcher[i], collector));
+			
+			// assert that each expected match was seen for the second input
+			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedNMatchesMapList.get(i).entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		
+		iterator.close();
+	}
+	
+	//
+	//
+	//	Tests taken from HahTableITCase!
+	//
+	//
+	
+	private final MutableObjectIterator<Record> getProbeInput(final int numKeys,
+			final int probeValsPerKey, final int repeatedValue1, final int repeatedValue2) {
+		MutableObjectIterator<Record> probe1 = new UniformRecordGenerator(numKeys, probeValsPerKey, true);
+		MutableObjectIterator<Record> probe2 = new ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
+		MutableObjectIterator<Record> probe3 = new ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
+		List<MutableObjectIterator<Record>> probes = new ArrayList<MutableObjectIterator<Record>>();
+		probes.add(probe1);
+		probes.add(probe2);
+		probes.add(probe3);
+		return new UnionIterator<Record>(probes);
+	}
+	
+	@Test
+	public void testSpillingHashJoinWithMassiveCollisions() throws IOException
+	{
+		// the following two values are known to have a hash-code collision on the initial level.
+		// we use them to make sure one partition grows over-proportionally large
+		final int REPEATED_VALUE_1 = 40559;
+		final int REPEATED_VALUE_2 = 92882;
+		final int REPEATED_VALUE_COUNT_BUILD = 200000;
+		final int REPEATED_VALUE_COUNT_PROBE = 5;
+		
+		final int NUM_KEYS = 1000000;
+		final int BUILD_VALS_PER_KEY = 3;
+		final int PROBE_VALS_PER_KEY = 10;
+		
+		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
+		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
+		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
+		MutableObjectIterator<Record> build3 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
+		List<MutableObjectIterator<Record>> builds = new ArrayList<MutableObjectIterator<Record>>();
+		builds.add(build1);
+		builds.add(build2);
+		builds.add(build3);
+		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
+	
+		
+		
+
+		// allocate the memory for the HashTable
+		List<MemorySegment> memSegments;
+		try {
+			memSegments = this.memoryManager.allocatePages(MEM_OWNER, 896);
+		}
+		catch (MemoryAllocationException maex) {
+			fail("Memory for the Join could not be provided.");
+			return;
+		}
+		
+		// create the map for validating the results
+		HashMap<Integer, Long> map = new HashMap<Integer, Long>(NUM_KEYS);
+		
+		// ----------------------------------------------------------------------------------------
+		
+		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
+				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
+				memSegments, ioManager);
+		
+		for(int probe = 0; probe < NUM_PROBES; probe++) {
+			// create a probe input that gives 10 million pairs with 10 values sharing a key
+			MutableObjectIterator<Record> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
+			if(probe == 0) {
+				join.open(buildInput, probeInput);
+			} else {
+				join.reopenProbe(probeInput);
+			}
+		
+			Record record;
+			final Record recordReuse = new Record();
+
+			while (join.nextRecord())
+			{
+				int numBuildValues = 0;
+		
+				final Record probeRec = join.getCurrentProbeRecord();
+				int key = probeRec.getField(0, IntValue.class).getValue();
+				
+				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
+				if ((record = buildSide.next(recordReuse)) != null) {
+					numBuildValues = 1;
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue()); 
+				}
+				else {
+					fail("No build side values found for a probe key.");
+				}
+				while ((record = buildSide.next(record)) != null) {
+					numBuildValues++;
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+				}
+				
+				Long contained = map.get(key);
+				if (contained == null) {
+					contained = Long.valueOf(numBuildValues);
+				}
+				else {
+					contained = Long.valueOf(contained.longValue() + numBuildValues);
+				}
+				
+				map.put(key, contained);
+			}
+		}
+		
+		join.close();
+		
+		Assert.assertEquals("Wrong number of keys", NUM_KEYS, map.size());
+		for (Map.Entry<Integer, Long> entry : map.entrySet()) {
+			long val = entry.getValue();
+			int key = entry.getKey();
+	
+			if( key == REPEATED_VALUE_1 || key == REPEATED_VALUE_2) {
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+							(PROBE_VALS_PER_KEY + REPEATED_VALUE_COUNT_PROBE) * (BUILD_VALS_PER_KEY + REPEATED_VALUE_COUNT_BUILD) * NUM_PROBES, val);
+			} else {
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+							PROBE_VALS_PER_KEY * BUILD_VALS_PER_KEY * NUM_PROBES, val);
+			}
+		}
+		
+		
+		// ----------------------------------------------------------------------------------------
+		
+		this.memoryManager.release(join.getFreedMemory());
+	}
+	
+	/*
+	 * This test is basically identical to the "testSpillingHashJoinWithMassiveCollisions" test, only that the number
+	 * of repeated values (causing bucket collisions) are large enough to make sure that their target partition no longer
+	 * fits into memory by itself and needs to be repartitioned in the recursion again.
+	 */
+	@Test
+	public void testSpillingHashJoinWithTwoRecursions() throws IOException
+	{
+		// the following two values are known to have a hash-code collision on the first recursion level.
+		// we use them to make sure one partition grows over-proportionally large
+		final int REPEATED_VALUE_1 = 40559;
+		final int REPEATED_VALUE_2 = 92882;
+		final int REPEATED_VALUE_COUNT_BUILD = 200000;
+		final int REPEATED_VALUE_COUNT_PROBE = 5;
+		
+		final int NUM_KEYS = 1000000;
+		final int BUILD_VALS_PER_KEY = 3;
+		final int PROBE_VALS_PER_KEY = 10;
+		
+		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
+		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
+		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
+		MutableObjectIterator<Record> build3 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
+		List<MutableObjectIterator<Record>> builds = new ArrayList<MutableObjectIterator<Record>>();
+		builds.add(build1);
+		builds.add(build2);
+		builds.add(build3);
+		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
+	
+
+		// allocate the memory for the HashTable
+		List<MemorySegment> memSegments;
+		try {
+			memSegments = this.memoryManager.allocatePages(MEM_OWNER, 896);
+		}
+		catch (MemoryAllocationException maex) {
+			fail("Memory for the Join could not be provided.");
+			return;
+		}
+		
+		// create the map for validating the results
+		HashMap<Integer, Long> map = new HashMap<Integer, Long>(NUM_KEYS);
+		
+		// ----------------------------------------------------------------------------------------
+		
+		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
+				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
+				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
+				memSegments, ioManager);
+		for(int probe = 0; probe < NUM_PROBES; probe++) {
+			// create a probe input that gives 10 million pairs with 10 values sharing a key
+			MutableObjectIterator<Record> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
+			if(probe == 0) {
+				join.open(buildInput, probeInput);
+			} else {
+				join.reopenProbe(probeInput);
+			}
+			Record record;
+			final Record recordReuse = new Record();
+
+			while (join.nextRecord())
+			{	
+				int numBuildValues = 0;
+				
+				final Record probeRec = join.getCurrentProbeRecord();
+				int key = probeRec.getField(0, IntValue.class).getValue();
+				
+				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
+				if ((record = buildSide.next(recordReuse)) != null) {
+					numBuildValues = 1;
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue()); 
+				}
+				else {
+					fail("No build side values found for a probe key.");
+				}
+				while ((record = buildSide.next(recordReuse)) != null) {
+					numBuildValues++;
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+				}
+				
+				Long contained = map.get(key);
+				if (contained == null) {
+					contained = Long.valueOf(numBuildValues);
+				}
+				else {
+					contained = Long.valueOf(contained.longValue() + numBuildValues);
+				}
+				
+				map.put(key, contained);
+			}
+		}
+		
+		join.close();
+		Assert.assertEquals("Wrong number of keys", NUM_KEYS, map.size());
+		for (Map.Entry<Integer, Long> entry : map.entrySet()) {
+			long val = entry.getValue();
+			int key = entry.getKey();
+	
+			if( key == REPEATED_VALUE_1 || key == REPEATED_VALUE_2) {
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+							(PROBE_VALS_PER_KEY + REPEATED_VALUE_COUNT_PROBE) * (BUILD_VALS_PER_KEY + REPEATED_VALUE_COUNT_BUILD) * NUM_PROBES, val);
+			} else {
+				Assert.assertEquals("Wrong number of values in per-key cross product for key " + key, 
+							PROBE_VALS_PER_KEY * BUILD_VALS_PER_KEY * NUM_PROBES, val);
+			}
+		}
+		
+		
+		// ----------------------------------------------------------------------------------------
+		
+		this.memoryManager.release(join.getFreedMemory());
+	}
+	
+	
+	static Map<Key, Collection<RecordMatch>> deepCopy(Map<Key, Collection<RecordMatch>> expectedSecondMatchesMap) {
+		Map<Key, Collection<RecordMatch>> copy = new HashMap<Key, Collection<RecordMatch>>(expectedSecondMatchesMap.size());
+		for(Map.Entry<Key, Collection<RecordMatch>> entry : expectedSecondMatchesMap.entrySet()) {
+			List<RecordMatch> matches = new ArrayList<RecordMatch>(entry.getValue().size());
+			for(RecordMatch m : entry.getValue()) {
+				matches.add(m);
+			}
+			copy.put(entry.getKey(), matches);
+		}
+		return copy;
+	}
+	
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIteratorTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
-import org.apache.flink.runtime.operators.resettable.BlockResettableIterator;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.Record;
@@ -38,7 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 
-public class BlockResettableIteratorTest
+public class NonReusingBlockResettableIteratorTest
 {
 	private static final int MEMORY_CAPACITY = 3 * 128 * 1024;
 	
@@ -85,7 +84,7 @@ public class BlockResettableIteratorTest
 	{
 		final AbstractInvokable memOwner = new DummyInvokable();
 		// create the resettable Iterator
-		final BlockResettableIterator<Record> iterator = new BlockResettableIterator<Record>(
+		final NonReusingBlockResettableIterator<Record> iterator = new NonReusingBlockResettableIterator<Record>(
 				this.memman, this.reader, this.serializer, 1, memOwner);
 		// open the iterator
 		iterator.open();
@@ -124,7 +123,7 @@ public class BlockResettableIteratorTest
 	{
 		final AbstractInvokable memOwner = new DummyInvokable();
 		// create the resettable Iterator
-		final BlockResettableIterator<Record> iterator = new BlockResettableIterator<Record>(
+		final NonReusingBlockResettableIterator<Record> iterator = new NonReusingBlockResettableIterator<Record>(
 				this.memman, this.reader, this.serializer, 2, memOwner);
 		// open the iterator
 		iterator.open();
@@ -164,7 +163,7 @@ public class BlockResettableIteratorTest
 	{
 		final AbstractInvokable memOwner = new DummyInvokable();
 		// create the resettable Iterator
-		final BlockResettableIterator<Record> iterator = new BlockResettableIterator<Record>(
+		final NonReusingBlockResettableIterator<Record> iterator = new NonReusingBlockResettableIterator<Record>(
 				this.memman, this.reader, this.serializer, 12, memOwner);
 		// open the iterator
 		iterator.open();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIteratorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.resettable;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.record.RecordSerializer;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.types.Record;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+
+public class ReusingBlockResettableIteratorTest
+{
+	private static final int MEMORY_CAPACITY = 3 * 128 * 1024;
+	
+	private static final int NUM_VALUES = 20000;
+	
+	private MemoryManager memman;
+
+	private Iterator<Record> reader;
+
+	private List<Record> objects;
+	
+	private final TypeSerializer<Record> serializer = RecordSerializer.get();
+
+	@Before
+	public void startup() {
+		// set up IO and memory manager
+		this.memman = new DefaultMemoryManager(MEMORY_CAPACITY, 1);
+		
+		// create test objects
+		this.objects = new ArrayList<Record>(20000);
+		for (int i = 0; i < NUM_VALUES; ++i) {
+			this.objects.add(new Record(new IntValue(i)));
+		}
+		
+		// create the reader
+		this.reader = objects.iterator();
+	}
+	
+	@After
+	public void shutdown() {
+		this.objects = null;
+		
+		// check that the memory manager got all segments back
+		if (!this.memman.verifyEmpty()) {
+			Assert.fail("A memory leak has occurred: Not all memory was properly returned to the memory manager.");
+		}
+		
+		this.memman.shutdown();
+		this.memman = null;
+	}
+
+	@Test
+	public void testSerialBlockResettableIterator() throws Exception
+	{
+		final AbstractInvokable memOwner = new DummyInvokable();
+		// create the resettable Iterator
+		final ReusingBlockResettableIterator<Record> iterator = new ReusingBlockResettableIterator<Record>(
+				this.memman, this.reader, this.serializer, 1, memOwner);
+		// open the iterator
+		iterator.open();
+		
+		// now test walking through the iterator
+		int lower = 0;
+		int upper = 0;
+		do {
+			lower = upper;
+			upper = lower;
+			// find the upper bound
+			while (iterator.hasNext()) {
+				Record target = iterator.next();
+				int val = target.getField(0, IntValue.class).getValue();
+				Assert.assertEquals(upper++, val);
+			}
+			// now reset the buffer a few times
+			for (int i = 0; i < 5; ++i) {
+				iterator.reset();
+				int count = 0;
+				while (iterator.hasNext()) {
+					Record target = iterator.next();
+					int val = target.getField(0, IntValue.class).getValue();
+					Assert.assertEquals(lower + (count++), val);
+				}
+				Assert.assertEquals(upper - lower, count);
+			}
+		} while (iterator.nextBlock());
+		Assert.assertEquals(NUM_VALUES, upper);
+		// close the iterator
+		iterator.close();
+	}
+
+	@Test
+	public void testDoubleBufferedBlockResettableIterator() throws Exception
+	{
+		final AbstractInvokable memOwner = new DummyInvokable();
+		// create the resettable Iterator
+		final ReusingBlockResettableIterator<Record> iterator = new ReusingBlockResettableIterator<Record>(
+				this.memman, this.reader, this.serializer, 2, memOwner);
+		// open the iterator
+		iterator.open();
+		
+		// now test walking through the iterator
+		int lower = 0;
+		int upper = 0;
+		do {
+			lower = upper;
+			upper = lower;
+			// find the upper bound
+			while (iterator.hasNext()) {
+				Record target = iterator.next();
+				int val = target.getField(0, IntValue.class).getValue();
+				Assert.assertEquals(upper++, val);
+			}
+			// now reset the buffer a few times
+			for (int i = 0; i < 5; ++i) {
+				iterator.reset();
+				int count = 0;
+				while (iterator.hasNext()) {
+					Record target = iterator.next();
+					int val = target.getField(0, IntValue.class).getValue();
+					Assert.assertEquals(lower + (count++), val);
+				}
+				Assert.assertEquals(upper - lower, count);
+			}
+		} while (iterator.nextBlock());
+		Assert.assertEquals(NUM_VALUES, upper);
+		
+		// close the iterator
+		iterator.close();
+	}
+
+	@Test
+	public void testTwelveFoldBufferedBlockResettableIterator() throws Exception
+	{
+		final AbstractInvokable memOwner = new DummyInvokable();
+		// create the resettable Iterator
+		final ReusingBlockResettableIterator<Record> iterator = new ReusingBlockResettableIterator<Record>(
+				this.memman, this.reader, this.serializer, 12, memOwner);
+		// open the iterator
+		iterator.open();
+		
+		// now test walking through the iterator
+		int lower = 0;
+		int upper = 0;
+		do {
+			lower = upper;
+			upper = lower;
+			// find the upper bound
+			while (iterator.hasNext()) {
+				Record target = iterator.next();
+				int val = target.getField(0, IntValue.class).getValue();
+				Assert.assertEquals(upper++, val);
+			}
+			// now reset the buffer a few times
+			for (int i = 0; i < 5; ++i) {
+				iterator.reset();
+				int count = 0;
+				while (iterator.hasNext()) {
+					Record target = iterator.next();
+					int val = target.getField(0, IntValue.class).getValue();
+					Assert.assertEquals(lower + (count++), val);
+				}
+				Assert.assertEquals(upper - lower, count);
+			}
+		} while (iterator.nextBlock());
+		Assert.assertEquals(NUM_VALUES, upper);
+		
+		// close the iterator
+		iterator.close();
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
@@ -44,7 +44,7 @@ import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.TestData.Key;
 import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
 import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
-import org.apache.flink.runtime.util.KeyGroupedIterator;
+import org.apache.flink.runtime.util.ReusingKeyGroupedIterator;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.Collector;
@@ -336,7 +336,7 @@ public class CombiningUnilateralSortMergerITCase {
 	
 	private static Iterator<Integer> getReducingIterator(MutableObjectIterator<Record> data, TypeSerializer<Record> serializer, TypeComparator<Record> comparator) {
 		
-		final KeyGroupedIterator<Record> groupIter = new KeyGroupedIterator<Record>(data, serializer, comparator);
+		final ReusingKeyGroupedIterator<Record> groupIter = new ReusingKeyGroupedIterator<Record>(data, serializer, comparator);
 		
 		return new Iterator<Integer>() {
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringSortingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringSortingITCase.java
@@ -274,6 +274,11 @@ public class MassiveStringSortingITCase {
 		public String next(String reuse) throws IOException {
 			return reader.readLine();
 		}
+
+		@Override
+		public String next() throws IOException {
+			return reader.readLine();
+		}
 	}
 	
 	private static final class StringTupleReaderMutableObjectIterator implements MutableObjectIterator<Tuple2<String, String[]>> {
@@ -295,6 +300,20 @@ public class MassiveStringSortingITCase {
 			reuse.f0 = parts[0];
 			reuse.f1 = parts;
 			return reuse;
+		}
+
+		@Override
+		public Tuple2<String, String[]> next() throws IOException {
+			String line = reader.readLine();
+			if (line == null) {
+				return null;
+			}
+
+			String[] parts = line.split(" ");
+			Tuple2<String, String[]> result = new Tuple2<String, String[]>();
+			result.f0 = parts[0];
+			result.f1 = parts;
+			return result;
 		}
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringValueSortingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringValueSortingITCase.java
@@ -279,6 +279,11 @@ public class MassiveStringValueSortingITCase {
 			reuse.setValue(line);
 			return reuse;
 		}
+
+		@Override
+		public StringValue next() throws IOException {
+			return next(new StringValue());
+		}
 	}
 	
 	private static final class StringValueTupleReaderMutableObjectIterator implements MutableObjectIterator<Tuple2<StringValue, StringValue[]>> {
@@ -305,6 +310,11 @@ public class MassiveStringValueSortingITCase {
 			}
 			
 			return reuse;
+		}
+
+		@Override
+		public Tuple2<StringValue, StringValue[]> next() throws IOException {
+			return next(new Tuple2<StringValue, StringValue[]>(new StringValue(), new StringValue[0]));
 		}
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
@@ -77,6 +77,23 @@ public class MergeIteratorTest
 					return null;
 				}
 			}
+
+			@Override
+			public Record next()
+			{
+				if (current < keys.length) {
+					key.setKey(keys[current]);
+					value.setValue(values[current]);
+					current++;
+					Record result = new Record(2);
+					result.setField(0, key);
+					result.setField(1, value);
+					return result;
+				}
+				else {
+					return null;
+				}
+			}
 		};
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,6 @@
 
 
 package org.apache.flink.runtime.operators.sort;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
@@ -44,9 +35,18 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 /**
  */
-public class SortMergeCoGroupIteratorITCase
+public class NonReusingSortMergeCoGroupIteratorITCase
 {
 	// the size of the left and right inputs
 	private static final int INPUT_1_SIZE = 20000;
@@ -106,7 +106,7 @@ public class SortMergeCoGroupIteratorITCase
 			generator2.reset();
 	
 			// compare with iterator values
-			SortMergeCoGroupIterator<Record, Record> iterator =	new SortMergeCoGroupIterator<Record, Record>(
+			NonReusingSortMergeCoGroupIterator<Record, Record> iterator =	new NonReusingSortMergeCoGroupIterator<Record, Record>(
 					this.reader1, this.reader2, this.serializer1, this.comparator1, this.serializer2, this.comparator2,
 					this.pairComparator);
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeMatchIteratorITCase.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.sort;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.record.RecordComparator;
+import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
+import org.apache.flink.api.common.typeutils.record.RecordSerializer;
+import org.apache.flink.api.java.record.functions.JoinFunction;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.runtime.operators.testutils.TestData;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.types.Record;
+import org.apache.flink.types.Value;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@SuppressWarnings("deprecation")
+public class NonReusingSortMergeMatchIteratorITCase {
+	
+	// total memory
+	private static final int MEMORY_SIZE = 1024 * 1024 * 16;
+	private static final int PAGES_FOR_BNLJN = 2;
+
+	// the size of the left and right inputs
+	private static final int INPUT_1_SIZE = 20000;
+
+	private static final int INPUT_2_SIZE = 1000;
+
+	// random seeds for the left and right input data generators
+	private static final long SEED1 = 561349061987311L;
+
+	private static final long SEED2 = 231434613412342L;
+	
+	// dummy abstract task
+	private final AbstractInvokable parentTask = new DummyInvokable();
+
+	private IOManager ioManager;
+	private MemoryManager memoryManager;
+	
+	private TypeSerializer<Record> serializer1;
+	private TypeSerializer<Record> serializer2;
+	private TypeComparator<Record> comparator1;
+	private TypeComparator<Record> comparator2;
+	private TypePairComparator<Record, Record> pairComparator;
+	
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void beforeTest() {
+		this.serializer1 = RecordSerializer.get();
+		this.serializer2 = RecordSerializer.get();
+		this.comparator1 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
+		this.comparator2 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
+		this.pairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[]{TestData.Key.class});
+		
+		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.ioManager = new IOManagerAsync();
+	}
+
+	@After
+	public void afterTest() {
+		if (this.ioManager != null) {
+			this.ioManager.shutdown();
+			if (!this.ioManager.isProperlyShutDown()) {
+				Assert.fail("I/O manager failed to properly shut down.");
+			}
+			this.ioManager = null;
+		}
+		
+		if (this.memoryManager != null) {
+			Assert.assertTrue("Memory Leak: Not all memory has been returned to the memory manager.",
+				this.memoryManager.verifyEmpty());
+			this.memoryManager.shutdown();
+			this.memoryManager = null;
+		}
+	}
+
+
+	
+	@Test
+	public void testMerge() {
+		try {
+			
+			final TestData.Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			final TestData.Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+
+			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<Match>> expectedMatchesMap = matchValues(
+				collectData(input1),
+				collectData(input2));
+			
+			final JoinFunction matcher = new MatchRemovingMatcher(expectedMatchesMap);
+			
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+	
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+			input1.reset();
+			input2.reset();
+	
+			// compare with iterator values
+			NonReusingMergeMatchIterator<Record, Record, Record> iterator =
+				new NonReusingMergeMatchIterator<Record, Record, Record>(
+					input1, input2, this.serializer1, this.comparator1, this.serializer2, this.comparator2,
+					this.pairComparator, this.memoryManager, this.ioManager, PAGES_FOR_BNLJN, this.parentTask);
+	
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<Match>> entry : expectedMatchesMap.entrySet()) {
+				Assert.assertTrue("Collection for key " + entry.getKey() + " is not empty", entry.getValue().isEmpty());
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testMergeWithHighNumberOfCommonKeys()
+	{
+		// the size of the left and right inputs
+		final int INPUT_1_SIZE = 200;
+		final int INPUT_2_SIZE = 100;
+		
+		final int INPUT_1_DUPLICATES = 10;
+		final int INPUT_2_DUPLICATES = 4000;
+		final int DUPLICATE_KEY = 13;
+		
+		try {
+			final TestData.Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			final TestData.Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			
+			final TestData.GeneratorIterator gen1Iter = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.GeneratorIterator gen2Iter = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			
+			final TestData.ConstantValueIterator const1Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
+			final TestData.ConstantValueIterator const2Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
+			
+			final List<MutableObjectIterator<Record>> inList1 = new ArrayList<MutableObjectIterator<Record>>();
+			inList1.add(gen1Iter);
+			inList1.add(const1Iter);
+			
+			final List<MutableObjectIterator<Record>> inList2 = new ArrayList<MutableObjectIterator<Record>>();
+			inList2.add(gen2Iter);
+			inList2.add(const2Iter);
+			
+			MutableObjectIterator<Record> input1 = new MergeIterator<Record>(inList1, serializer1, comparator1.duplicate());
+			MutableObjectIterator<Record> input2 = new MergeIterator<Record>(inList2, serializer2, comparator2.duplicate());
+			
+			// collect expected data
+			final Map<TestData.Key, Collection<Match>> expectedMatchesMap = matchValues(
+				collectData(input1),
+				collectData(input2));
+			
+			// re-create the whole thing for actual processing
+			
+			// reset the generators and iterators
+			generator1.reset();
+			generator2.reset();
+			const1Iter.reset();
+			const2Iter.reset();
+			gen1Iter.reset();
+			gen2Iter.reset();
+			
+			inList1.clear();
+			inList1.add(gen1Iter);
+			inList1.add(const1Iter);
+			
+			inList2.clear();
+			inList2.add(gen2Iter);
+			inList2.add(const2Iter);
+	
+			input1 = new MergeIterator<Record>(inList1, serializer1, comparator1.duplicate());
+			input2 = new MergeIterator<Record>(inList2, serializer2, comparator2.duplicate());
+			
+			final JoinFunction matcher = new MatchRemovingMatcher(expectedMatchesMap);
+			
+			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+	
+			
+			// we create this sort-merge iterator with little memory for the block-nested-loops fall-back to make sure it
+			// needs to spill for the duplicate keys
+			NonReusingMergeMatchIterator<Record, Record, Record> iterator =
+				new NonReusingMergeMatchIterator<Record, Record, Record>(
+					input1, input2, this.serializer1, this.comparator1, this.serializer2, this.comparator2,
+					this.pairComparator, this.memoryManager, this.ioManager, PAGES_FOR_BNLJN, this.parentTask);
+	
+			iterator.open();
+			
+			while (iterator.callWithNextKey(matcher, collector));
+			
+			iterator.close();
+	
+			// assert that each expected match was seen
+			for (Entry<TestData.Key, Collection<Match>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+	
+	
+	
+	// --------------------------------------------------------------------------------------------
+	//                                    Utilities
+	// --------------------------------------------------------------------------------------------
+
+	private Map<TestData.Key, Collection<Match>> matchValues(
+			Map<TestData.Key, Collection<TestData.Value>> leftMap,
+			Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	{
+		Map<TestData.Key, Collection<Match>> map = new HashMap<TestData.Key, Collection<Match>>();
+
+		for (TestData.Key key : leftMap.keySet()) {
+			Collection<TestData.Value> leftValues = leftMap.get(key);
+			Collection<TestData.Value> rightValues = rightMap.get(key);
+
+			if (rightValues == null) {
+				continue;
+			}
+
+			if (!map.containsKey(key)) {
+				map.put(key, new ArrayList<Match>());
+			}
+
+			Collection<Match> matchedValues = map.get(key);
+
+			for (TestData.Value leftValue : leftValues) {
+				for (TestData.Value rightValue : rightValues) {
+					matchedValues.add(new Match(leftValue, rightValue));
+				}
+			}
+		}
+
+		return map;
+	}
+
+	
+	private Map<TestData.Key, Collection<TestData.Value>> collectData(MutableObjectIterator<Record> iter)
+	throws Exception
+	{
+		Map<TestData.Key, Collection<TestData.Value>> map = new HashMap<TestData.Key, Collection<TestData.Value>>();
+		Record pair = new Record();
+		
+		while ((pair = iter.next(pair)) != null) {
+			TestData.Key key = pair.getField(0, TestData.Key.class);
+			
+			if (!map.containsKey(key)) {
+				map.put(new TestData.Key(key.getKey()), new ArrayList<TestData.Value>());
+			}
+
+			Collection<TestData.Value> values = map.get(key);
+			values.add(new TestData.Value(pair.getField(1, TestData.Value.class).getValue()));
+		}
+
+		return map;
+	}
+
+	/**
+	 * Private class used for storage of the expected matches in a hashmap.
+	 */
+	private static class Match {
+		private final Value left;
+
+		private final Value right;
+
+		public Match(Value left, Value right) {
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			Match o = (Match) obj;
+			return this.left.equals(o.left) && this.right.equals(o.right);
+		}
+		
+		@Override
+		public int hashCode() {
+			return this.left.hashCode() ^ this.right.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return left + ", " + right;
+		}
+	}
+	
+	private static final class MatchRemovingMatcher extends JoinFunction {
+		private static final long serialVersionUID = 1L;
+		
+		private final Map<TestData.Key, Collection<Match>> toRemoveFrom;
+		
+		protected MatchRemovingMatcher(Map<TestData.Key, Collection<Match>> map) {
+			this.toRemoveFrom = map;
+		}
+		
+		@Override
+		public void join(Record rec1, Record rec2, Collector<Record> out) throws Exception {
+			TestData.Key key = rec1.getField(0, TestData.Key.class);
+			TestData.Value value1 = rec1.getField(1, TestData.Value.class);
+			TestData.Value value2 = rec2.getField(1, TestData.Value.class);
+			
+			Collection<Match> matches = this.toRemoveFrom.get(key);
+			if (matches == null) {
+				Assert.fail("Match " + key + " - " + value1 + ":" + value2 + " is unexpected.");
+			}
+			
+			boolean contained = matches.remove(new Match(value1, value2));
+			if (!contained) {
+				Assert.fail("Produced match was not contained: " + key + " - " + value1 + ":" + value2);
+			}
+			if (matches.isEmpty()) {
+				this.toRemoveFrom.remove(key);
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIteratorITCase.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.operators.sort;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.record.RecordComparator;
+import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
+import org.apache.flink.api.common.typeutils.record.RecordSerializer;
+import org.apache.flink.runtime.operators.testutils.TestData;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.types.Record;
+import org.apache.flink.util.MutableObjectIterator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ */
+public class ReusingSortMergeCoGroupIteratorITCase
+{
+	// the size of the left and right inputs
+	private static final int INPUT_1_SIZE = 20000;
+
+	private static final int INPUT_2_SIZE = 1000;
+
+	// random seeds for the left and right input data generators
+	private static final long SEED1 = 561349061987311L;
+
+	private static final long SEED2 = 231434613412342L;
+
+	// left and right input data generators
+	private Generator generator1;
+
+	private Generator generator2;
+
+	// left and right input RecordReader mocks
+	private MutableObjectIterator<Record> reader1;
+
+	private MutableObjectIterator<Record> reader2;
+	
+	
+	private TypeSerializer<Record> serializer1;
+	private TypeSerializer<Record> serializer2;
+	private TypeComparator<Record> comparator1;
+	private TypeComparator<Record> comparator2;
+	private TypePairComparator<Record, Record> pairComparator;
+
+
+	@SuppressWarnings("unchecked")
+	@Before
+	public void beforeTest() {
+		this.serializer1 = RecordSerializer.get();
+		this.serializer2 = RecordSerializer.get();
+		this.comparator1 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
+		this.comparator2 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
+		this.pairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[]{TestData.Key.class});
+	}
+	
+	@Test
+	public void testMerge() {
+		try {
+			
+			generator1 = new Generator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			generator2 = new Generator(SEED2, 500, 2048, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+
+			reader1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
+			reader2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+
+			// collect expected data
+			Map<TestData.Key, Collection<TestData.Value>> expectedValuesMap1 = collectData(generator1, INPUT_1_SIZE);
+			Map<TestData.Key, Collection<TestData.Value>> expectedValuesMap2 = collectData(generator2, INPUT_2_SIZE);
+			Map<TestData.Key, List<Collection<TestData.Value>>> expectedCoGroupsMap = coGroupValues(expectedValuesMap1, expectedValuesMap2);
+	
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+	
+			// compare with iterator values
+			ReusingSortMergeCoGroupIterator<Record, Record> iterator =	new ReusingSortMergeCoGroupIterator<Record, Record>(
+					this.reader1, this.reader2, this.serializer1, this.comparator1, this.serializer2, this.comparator2,
+					this.pairComparator);
+	
+			iterator.open();
+			
+			final TestData.Key key = new TestData.Key();
+			while (iterator.next())
+			{
+				Iterator<Record> iter1 = iterator.getValues1().iterator();
+				Iterator<Record> iter2 = iterator.getValues2().iterator();
+				
+				TestData.Value v1 = null;
+				TestData.Value v2 = null;
+				
+				if (iter1.hasNext()) {
+					Record rec = iter1.next();
+					rec.getFieldInto(0, key);
+					v1 = rec.getField(1, TestData.Value.class);
+				}
+				else if (iter2.hasNext()) {
+					Record rec = iter2.next();
+					rec.getFieldInto(0, key);
+					v2 = rec.getField(1, TestData.Value.class);
+				}
+				else {
+					Assert.fail("No input on both sides.");
+				}
+	
+				// assert that matches for this key exist
+				Assert.assertTrue("No matches for key " + key, expectedCoGroupsMap.containsKey(key));
+				
+				Collection<TestData.Value> expValues1 = expectedCoGroupsMap.get(key).get(0);
+				Collection<TestData.Value> expValues2 = expectedCoGroupsMap.get(key).get(1);
+				
+				if (v1 != null) {
+					expValues1.remove(v1);
+				}
+				else {
+					expValues2.remove(v2);
+				}
+				
+				while(iter1.hasNext()) {
+					Record rec = iter1.next();
+					Assert.assertTrue("Value not in expected set of first input", expValues1.remove(rec.getField(1, TestData.Value.class)));
+				}
+				Assert.assertTrue("Expected set of first input not empty", expValues1.isEmpty());
+				
+				while(iter2.hasNext()) {
+					Record rec = iter2.next();
+					Assert.assertTrue("Value not in expected set of second input", expValues2.remove(rec.getField(1, TestData.Value.class)));
+				}
+				Assert.assertTrue("Expected set of second input not empty", expValues2.isEmpty());
+	
+				expectedCoGroupsMap.remove(key);
+			}
+			iterator.close();
+	
+			Assert.assertTrue("Expected key set not empty", expectedCoGroupsMap.isEmpty());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	
+	private Map<TestData.Key, List<Collection<TestData.Value>>> coGroupValues(
+			Map<TestData.Key, Collection<TestData.Value>> leftMap,
+			Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	{
+		Map<TestData.Key, List<Collection<TestData.Value>>> map = new HashMap<TestData.Key, List<Collection<TestData.Value>>>(1000);
+
+		Set<TestData.Key> keySet = new HashSet<TestData.Key>(leftMap.keySet());
+		keySet.addAll(rightMap.keySet());
+		
+		for (TestData.Key key : keySet) {
+			Collection<TestData.Value> leftValues = leftMap.get(key);
+			Collection<TestData.Value> rightValues = rightMap.get(key);
+			ArrayList<Collection<TestData.Value>> list = new ArrayList<Collection<TestData.Value>>(2);
+			
+			if (leftValues == null) {
+				list.add(new ArrayList<TestData.Value>(0));
+			} else {
+				list.add(leftValues);
+			}
+			
+			if (rightValues == null) {
+				list.add(new ArrayList<TestData.Value>(0));
+			} else {
+				list.add(rightValues);
+			}
+			
+			map.put(key, list);
+		}
+		return map;
+	}
+
+	private Map<TestData.Key, Collection<TestData.Value>> collectData(Generator iter, int num)
+	throws Exception
+	{
+		Map<TestData.Key, Collection<TestData.Value>> map = new HashMap<TestData.Key, Collection<TestData.Value>>();
+		Record pair = new Record();
+		
+		for (int i = 0; i < num; i++) {
+			iter.next(pair);
+			TestData.Key key = pair.getField(0, TestData.Key.class);
+			
+			if (!map.containsKey(key)) {
+				map.put(new TestData.Key(key.getKey()), new ArrayList<TestData.Value>());
+			}
+
+			Collection<TestData.Value> values = map.get(key);
+			values.add(new TestData.Value(pair.getField(1, TestData.Value.class).getValue()));
+		}
+		return map;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DelayingInfinitiveInputIterator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DelayingInfinitiveInputIterator.java
@@ -37,5 +37,13 @@ public class DelayingInfinitiveInputIterator extends InfiniteInputIterator
 		catch (InterruptedException e) { }
 		return super.next(reuse);
 	}
-	
+
+	@Override
+	public Record next() {
+		try {
+			Thread.sleep(delay);
+		}
+		catch (InterruptedException e) { }
+		return super.next();
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/InfiniteInputIterator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/InfiniteInputIterator.java
@@ -37,4 +37,13 @@ public class InfiniteInputIterator implements MutableObjectIterator<Record>
 		reuse.setField(1, val2);
 		return reuse;
 	}
+
+	@Override
+	public Record next() {
+		Record result = new Record(2);
+		result.setField(0, val1);
+		result.setField(1, val2);
+		return result;
+	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MutableObjectIteratorWrapper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MutableObjectIteratorWrapper.java
@@ -50,4 +50,17 @@ public class MutableObjectIteratorWrapper implements MutableObjectIterator<Recor
 		}
 	}
 
+	@Override
+	public Record next() throws IOException {
+		if (this.source.hasNext()) {
+			Record result = new Record();
+			this.source.next().copyTo(result);
+			return result;
+		}
+		else {
+			return null;
+		}
+	}
+
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/RandomIntPairGenerator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/RandomIntPairGenerator.java
@@ -56,6 +56,18 @@ public class RandomIntPairGenerator implements MutableObjectIterator<IntPair>
 			return null;
 		}
 	}
+
+	@Override
+	public IntPair next() {
+		if (this.count++ < this.numRecords) {
+			IntPair result = new IntPair();
+			result.setKey(this.rnd.nextInt());
+			result.setValue(this.rnd.nextInt());
+			return result;
+		} else {
+			return null;
+		}
+	}
 	
 	public void reset() {
 		this.rnd = new Random(this.seed);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TestData.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TestData.java
@@ -181,6 +181,17 @@ public final class TestData {
 			return reuse;
 		}
 
+		public Record next() {
+			this.key.setKey(keyMode == KeyMode.SORTED ? ++counter : Math.abs(random.nextInt() % keyMax) + 1);
+			if (this.valueMode != ValueMode.CONSTANT) {
+				this.value.setValue(randomString());
+			}
+			Record result = new Record(2);
+			result.setField(0, this.key);
+			result.setField(1, this.value);
+			return result;
+		}
+
 		public boolean next(org.apache.flink.types.Value[] target) {
 			this.key.setKey(keyMode == KeyMode.SORTED ? ++counter : Math.abs(random.nextInt() % keyMax) + 1);
 			// TODO change this to something proper
@@ -264,6 +275,17 @@ public final class TestData {
 				return null;
 			}
 		}
+
+		@Override
+		public Record next() {
+			if (counter < numberOfRecords) {
+				counter++;
+				return generator.next();
+			}
+			else {
+				return null;
+			}
+		}
 		
 		public void reset() {
 			this.counter = 0;
@@ -306,7 +328,23 @@ public final class TestData {
 				return null;
 			}
 		}
-		
+
+		@Override
+		public Record next() {
+			if (pos < this.numPairs) {
+				this.value.setValue(this.valueValue + ' ' + pos);
+				Record result = new Record(2);
+				result.setField(0, this.key);
+				result.setField(1, this.value);
+				pos++;
+				return result;
+			}
+			else {
+				return null;
+			}
+		}
+
+
 		public void reset() {
 			this.pos = 0;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UniformIntPairGenerator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UniformIntPairGenerator.java
@@ -67,4 +67,37 @@ public class UniformIntPairGenerator implements MutableObjectIterator<IntPair>
 		
 		return target;
 	}
+
+	@Override
+	public IntPair next() {
+		IntPair result = new IntPair();
+		if(!repeatKey) {
+			if(valCnt >= numVals) {
+				return null;
+			}
+
+			result.setKey(keyCnt++);
+			result.setValue(valCnt);
+
+			if(keyCnt == numKeys) {
+				keyCnt = 0;
+				valCnt++;
+			}
+		} else {
+			if(keyCnt >= numKeys) {
+				return null;
+			}
+
+			result.setKey(keyCnt);
+			result.setValue(valCnt++);
+
+			if(valCnt == numVals) {
+				valCnt = 0;
+				keyCnt++;
+			}
+		}
+
+		return result;
+	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UniformRecordGenerator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UniformRecordGenerator.java
@@ -81,4 +81,38 @@ public class UniformRecordGenerator implements MutableObjectIterator<Record> {
 		reuse.updateBinaryRepresenation();
 		return reuse;
 	}
+
+	@Override
+	public Record next() {
+		if(!repeatKey) {
+			if(valCnt >= numVals+startVal) {
+				return null;
+			}
+
+			key.setValue(keyCnt++);
+			value.setValue(valCnt);
+
+			if(keyCnt == numKeys+startKey) {
+				keyCnt = startKey;
+				valCnt++;
+			}
+		} else {
+			if(keyCnt >= numKeys+startKey) {
+				return null;
+			}
+			key.setValue(keyCnt);
+			value.setValue(valCnt++);
+
+			if(valCnt == numVals+startVal) {
+				valCnt = startVal;
+				keyCnt++;
+			}
+		}
+
+		Record result = new Record(2);
+		result.setField(0, this.key);
+		result.setField(1, this.value);
+		result.updateBinaryRepresenation();
+		return result;
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UniformStringPairGenerator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UniformStringPairGenerator.java
@@ -69,4 +69,37 @@ public class UniformStringPairGenerator implements MutableObjectIterator<StringP
 		return target;
 	}
 
+	@Override
+	public StringPair next() throws IOException {
+		StringPair result = new StringPair();
+		if(!repeatKey) {
+			if(valCnt >= numVals) {
+				return null;
+			}
+
+			result.setKey(Integer.toString(keyCnt++));
+			result.setValue(Integer.toBinaryString(valCnt));
+
+			if(keyCnt == numKeys) {
+				keyCnt = 0;
+				valCnt++;
+			}
+		} else {
+			if(keyCnt >= numKeys) {
+				return null;
+			}
+
+			result.setKey(Integer.toString(keyCnt));
+			result.setValue(Integer.toBinaryString(valCnt++));
+
+			if(valCnt == numVals) {
+				valCnt = 0;
+				keyCnt++;
+			}
+		}
+
+		return result;
+	}
+
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnionIterator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnionIterator.java
@@ -57,4 +57,22 @@ public class UnionIterator<E> implements MutableObjectIterator<E>
 			}
 		}
 	}
+
+	@Override
+	public E next() throws IOException
+	{
+		E targetStaging = this.currentSource.next();
+		if (targetStaging != null) {
+			return targetStaging;
+		} else {
+			if (this.nextSources.size() > 0) {
+				this.currentSource = this.nextSources.remove(0);
+				return next();
+			}
+			else {
+				return null;
+			}
+		}
+	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashMatchIterator;
 import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashMatchIterator;
-import org.apache.flink.runtime.operators.sort.MergeMatchIterator;
+import org.apache.flink.runtime.operators.sort.ReusingMergeMatchIterator;
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -143,8 +143,8 @@ public class HashVsSortMiniBenchmark {
 			final MutableObjectIterator<Record> sortedInput2 = sorter2.getIterator();
 			
 			// compare with iterator values
-			MergeMatchIterator<Record, Record, Record> iterator = 
-				new MergeMatchIterator<Record, Record, Record>(sortedInput1, sortedInput2, 
+			ReusingMergeMatchIterator<Record, Record, Record> iterator =
+				new ReusingMergeMatchIterator<Record, Record, Record>(sortedInput1, sortedInput2,
 						this.serializer1.getSerializer(), this.comparator1, this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
 						this.memoryManager, this.ioManager, MEMORY_PAGES_FOR_MERGE, this.parentTask);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
@@ -30,8 +30,8 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
-import org.apache.flink.runtime.operators.hash.BuildFirstHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.BuildSecondHashMatchIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashMatchIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashMatchIterator;
 import org.apache.flink.runtime.operators.sort.MergeMatchIterator;
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
@@ -183,8 +183,8 @@ public class HashVsSortMiniBenchmark {
 			long start = System.nanoTime();
 			
 			// compare with iterator values
-			final BuildFirstHashMatchIterator<Record, Record, Record> iterator = 
-					new BuildFirstHashMatchIterator<Record, Record, Record>(
+			final ReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
+					new ReusingBuildFirstHashMatchIterator<Record, Record, Record>(
 						input1, input2, this.serializer1.getSerializer(), this.comparator1, 
 							this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
 							this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE);
@@ -222,8 +222,8 @@ public class HashVsSortMiniBenchmark {
 			long start = System.nanoTime();
 			
 			// compare with iterator values
-			BuildSecondHashMatchIterator<Record, Record, Record> iterator = 
-					new BuildSecondHashMatchIterator<Record, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
+					new ReusingBuildSecondHashMatchIterator<Record, Record, Record>(
 						input1, input2, this.serializer1.getSerializer(), this.comparator1, 
 						this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
 						this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/KeyGroupedIteratorImmutableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/KeyGroupedIteratorImmutableTest.java
@@ -78,6 +78,20 @@ public class KeyGroupedIteratorImmutableTest {
 					return null;
 				}
 			}
+
+			@Override
+			public Record next() throws IOException {
+				if (it.hasNext()) {
+					IntStringPair pair = it.next();
+					Record result = new Record(2);
+					result.setField(0, pair.getInteger());
+					result.setField(1, pair.getString());
+					return result;
+				}
+				else {
+					return null;
+				}
+			}
 		};
 		
 		final RecordSerializer serializer = RecordSerializer.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/KeyGroupedIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/KeyGroupedIteratorTest.java
@@ -79,6 +79,21 @@ public class KeyGroupedIteratorTest {
 					return null;
 				}
 			}
+
+			@Override
+			public Record next() throws IOException {
+				if (it.hasNext()) {
+					IntStringPair pair = it.next();
+					Record result = new Record(2);
+					result.setField(0, pair.getInteger());
+					result.setField(1, pair.getString());
+					return result;
+				}
+				else {
+					return null;
+				}
+			}
+
 		};
 		
 		final RecordSerializer serializer = RecordSerializer.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/NonReusingKeyGroupedIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/NonReusingKeyGroupedIteratorTest.java
@@ -37,11 +37,11 @@ import org.junit.Test;
  * Test for the safe key grouped iterator, which advances in windows containing the same key and provides a sub-iterator
  * over the records with the same key.
  */
-public class KeyGroupedIteratorImmutableTest {
+public class NonReusingKeyGroupedIteratorTest {
 	
 	private MutableObjectIterator<Record> sourceIter;		// the iterator that provides the input
 	
-	private KeyGroupedIteratorImmutable<Record> psi;					// the grouping iterator, progressing in key steps
+	private NonReusingKeyGroupedIterator<Record> psi;					// the grouping iterator, progressing in key steps
 	
 	@Before
 	public void setup()
@@ -98,7 +98,7 @@ public class KeyGroupedIteratorImmutableTest {
 		@SuppressWarnings("unchecked")
 		final RecordComparator comparator = new RecordComparator(new int[] {0}, new Class[] {IntValue.class});
 		
-		this.psi = new KeyGroupedIteratorImmutable<Record>(this.sourceIter, serializer, comparator);
+		this.psi = new NonReusingKeyGroupedIterator<Record>(this.sourceIter, serializer, comparator);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ReusingKeyGroupedIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ReusingKeyGroupedIteratorTest.java
@@ -25,7 +25,6 @@ import java.util.NoSuchElementException;
 
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
 import org.apache.flink.api.common.typeutils.record.RecordSerializer;
-import org.apache.flink.runtime.util.KeyGroupedIterator;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.Record;
 import org.apache.flink.types.StringValue;
@@ -39,11 +38,11 @@ import org.junit.Test;
  * Test for the key grouped iterator, which advances in windows containing the same key and provides a sub-iterator
  * over the records with the same key.
  */
-public class KeyGroupedIteratorTest {
+public class ReusingKeyGroupedIteratorTest {
 	
 	private MutableObjectIterator<Record> sourceIter;		// the iterator that provides the input
 	
-	private KeyGroupedIterator<Record> psi;						// the grouping iterator, progressing in key steps
+	private ReusingKeyGroupedIterator<Record> psi;						// the grouping iterator, progressing in key steps
 	
 	@Before
 	public void setup() {
@@ -100,7 +99,7 @@ public class KeyGroupedIteratorTest {
 		@SuppressWarnings("unchecked")
 		final RecordComparator comparator = new RecordComparator(new int[] {0}, new Class[] {IntValue.class});
 		
-		this.psi = new KeyGroupedIterator<Record>(this.sourceIter, serializer, comparator);
+		this.psi = new ReusingKeyGroupedIterator<Record>(this.sourceIter, serializer, comparator);
 	}
 
 	@Test

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/CoGroupConnectedComponentsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/CoGroupConnectedComponentsITCase.java
@@ -100,7 +100,7 @@ public class CoGroupConnectedComponentsITCase extends RecordAPITestBase {
 			}
 			Record old = current.next();
 			long oldId = old.getField(1, LongValue.class).getValue();
-			
+
 			long minimumComponentID = Long.MAX_VALUE;
 
 			while (candidates.hasNext()) {
@@ -110,7 +110,7 @@ public class CoGroupConnectedComponentsITCase extends RecordAPITestBase {
 					minimumComponentID = candidateComponentID;
 				}
 			}
-			
+
 			if (minimumComponentID < oldId) {
 				newComponentId.setValue(minimumComponentID);
 				old.setField(1, newComponentId);

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/DependencyConnectedComponentsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/DependencyConnectedComponentsITCase.java
@@ -57,6 +57,9 @@ public class DependencyConnectedComponentsITCase extends JavaProgramTestBase {
 	
 	@Override
 	protected void preSubmit() throws Exception {
+		verticesInput.clear();
+		edgesInput.clear();
+
 		// vertices input
 		verticesInput.add(new Tuple2<Long, Long>(1l,1l));
 		verticesInput.add(new Tuple2<Long, Long>(2l,2l));

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/ReduceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/ReduceITCase.java
@@ -244,29 +244,6 @@ public class ReduceITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testReduceWithUDFThatReturnsTheSecondInputObject() throws Exception {
-		/*
-		 * Reduce with UDF that returns the second input object (check mutable object handling)
-		 */
-
-		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-
-		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-		DataSet<Tuple3<Integer, Long, String>> reduceDs = ds.
-				groupBy(1).reduce(new InputReturningTuple3Reduce());
-
-		reduceDs.writeAsCsv(resultPath);
-		env.execute();
-
-		expected = "1,1,Hi\n" +
-				"5,2,Hi again!\n" +
-				"15,3,Hi again!\n" +
-				"34,4,Hi again!\n" +
-				"65,5,Hi again!\n" +
-				"111,6,Hi again!\n";
-	}
-
-	@Test
 	public void testReduceATupleReturningKeySelector() throws Exception {
 		/*
 		 * Reduce with a Tuple-returning KeySelector
@@ -448,20 +425,6 @@ public class ReduceITCase extends MultipleProgramsTestBase {
 			out.myLong = in1.myLong + in2.myLong;
 			out.myString = "Hello!";
 			return out;
-		}
-	}
-	
-	public static class InputReturningTuple3Reduce implements ReduceFunction<Tuple3<Integer, Long, String>> {
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public Tuple3<Integer, Long, String> reduce(
-				Tuple3<Integer, Long, String> in1,
-				Tuple3<Integer, Long, String> in2) throws Exception {
-
-			in2.f0 = in1.f0 + in2.f0;
-			in2.f2 = "Hi again!";
-			return in2;
 		}
 	}
 	

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ObjectReuseITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ObjectReuseITCase.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.operators;
+
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.util.Collector;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * These check whether the object-reuse execution mode does really reuse objects.
+ */
+@RunWith(Parameterized.class)
+public class ObjectReuseITCase extends JavaProgramTestBase {
+
+	private static int NUM_PROGRAMS = 3;
+
+	private int curProgId = config.getInteger("ProgramId", -1);
+	private String resultPath;
+	private String expectedResult;
+
+	public ObjectReuseITCase(Configuration config) {
+		super(config);
+	}
+	
+	@Override
+	protected void preSubmit() throws Exception {
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		expectedResult = Progs.runProgram(curProgId, resultPath);
+	}
+	
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(expectedResult, resultPath);
+	}
+
+	@Override
+	protected boolean skipCollectionExecution() {
+		return true;
+	}
+
+	
+	@Parameters
+	public static Collection<Object[]> getConfigurations() throws FileNotFoundException, IOException {
+
+		LinkedList<Configuration> tConfigs = new LinkedList<Configuration>();
+
+		for(int i=1; i <= NUM_PROGRAMS; i++) {
+			Configuration config = new Configuration();
+			config.setInteger("ProgramId", i);
+			tConfigs.add(config);
+		}
+		
+		return toParameterList(tConfigs);
+	}
+	
+	private static class Progs {
+		
+		public static String runProgram(int progId, String resultPath) throws Exception {
+			
+			switch(progId) {
+
+			case 1: {
+
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				env.getConfig().enableObjectReuse();
+
+				DataSet<Tuple2<String, Integer>> input = env.fromElements(
+						new Tuple2<String, Integer>("a", 1),
+						new Tuple2<String, Integer>("a", 2),
+						new Tuple2<String, Integer>("a", 3),
+						new Tuple2<String, Integer>("a", 4),
+						new Tuple2<String, Integer>("a", 50));
+
+				DataSet<Tuple2<String, Integer>> result = input.groupBy(0).reduce(new ReduceFunction<Tuple2<String, Integer>>() {
+
+					@Override
+					public Tuple2<String, Integer> reduce(Tuple2<String, Integer> value1, Tuple2<String, Integer> value2) throws
+							Exception {
+						value2.f1 += value1.f1;
+						return value2;
+					}
+
+				});
+
+				result.writeAsCsv(resultPath);
+				env.execute();
+
+				// return expected result
+				return "a,100\n";
+
+			}
+
+			case 2: {
+
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				env.getConfig().enableObjectReuse();
+
+				DataSet<Tuple2<String, Integer>> input = env.fromElements(
+						new Tuple2<String, Integer>("a", 1),
+						new Tuple2<String, Integer>("a", 2),
+						new Tuple2<String, Integer>("a", 3),
+						new Tuple2<String, Integer>("a", 4),
+						new Tuple2<String, Integer>("a", 50));
+
+				DataSet<Tuple2<String, Integer>> result = input.reduce(new ReduceFunction<Tuple2<String, Integer>>() {
+
+					@Override
+					public Tuple2<String, Integer> reduce(
+							Tuple2<String, Integer> value1,
+							Tuple2<String, Integer> value2) throws Exception {
+						value2.f1 += value1.f1;
+						return value2;
+					}
+
+				});
+
+				result.writeAsCsv(resultPath);
+				env.execute();
+
+				// return expected result
+				return "a,100\n";
+
+			}
+
+			case 3: {
+
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				env.getConfig().enableObjectReuse();
+
+				DataSet<Tuple2<String, Integer>> input = env.fromElements(
+						new Tuple2<String, Integer>("a", 1),
+						new Tuple2<String, Integer>("a", 2),
+						new Tuple2<String, Integer>("a", 3),
+						new Tuple2<String, Integer>("a", 4),
+						new Tuple2<String, Integer>("a", 5));
+
+				DataSet<Tuple2<String, Integer>> result = input.reduceGroup(new GroupReduceFunction<Tuple2<String, Integer>, Tuple2<String, Integer>>() {
+
+					@Override
+					public void reduce(Iterable<Tuple2<String, Integer>> values, Collector<Tuple2<String, Integer>> out) throws Exception {
+						List<Tuple2<String, Integer>> list = new ArrayList<Tuple2<String, Integer>>();
+						for (Tuple2<String, Integer> val : values) {
+							list.add(val);
+						}
+
+						for (Tuple2<String, Integer> val : list) {
+							out.collect(val);
+						}
+					}
+
+				});
+
+				result.writeAsCsv(resultPath);
+				env.execute();
+
+				// return expected result
+				return "a,4\n" +
+						"a,4\n" +
+						"a,5\n" +
+						"a,5\n" +
+						"a,5\n";
+
+			}
+
+			case 4: {
+
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				env.getConfig().enableObjectReuse();
+
+				DataSet<Tuple2<String, Integer>> input = env.fromElements(
+						new Tuple2<String, Integer>("a", 1),
+						new Tuple2<String, Integer>("a", 2),
+						new Tuple2<String, Integer>("a", 3),
+						new Tuple2<String, Integer>("a", 4),
+						new Tuple2<String, Integer>("a", 5));
+
+				DataSet<Tuple2<String, Integer>> result = input.reduceGroup(new GroupReduceFunction<Tuple2<String, Integer>, Tuple2<String, Integer>>() {
+
+					@Override
+					public void reduce(Iterable<Tuple2<String, Integer>> values, Collector<Tuple2<String, Integer>> out) throws Exception {
+						List<Tuple2<String, Integer>> list = new ArrayList<Tuple2<String, Integer>>();
+						for (Tuple2<String, Integer> val : values) {
+							list.add(val);
+						}
+
+						for (Tuple2<String, Integer> val : list) {
+							out.collect(val);
+						}
+					}
+
+				});
+
+				result.writeAsCsv(resultPath);
+				env.execute();
+
+				// return expected result
+				return "a,4\n" +
+						"a,4\n" +
+						"a,5\n" +
+						"a,5\n" +
+						"a,5\n";
+
+			}
+
+			default:
+				throw new IllegalArgumentException("Invalid program id");
+			}
+			
+		}
+	
+	}
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/misc/MassiveCaseClassSortingITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/misc/MassiveCaseClassSortingITCase.scala
@@ -216,6 +216,16 @@ class StringTupleReader(val reader: BufferedReader) extends MutableObjectIterato
     val parts = line.split(" ")
     StringTuple(parts(0), parts(1), parts)
   }
+
+  override def next(): StringTuple = {
+    val line = reader.readLine()
+    if (line == null) {
+      return null
+    }
+    val parts = line.split(" ")
+    StringTuple(parts(0), parts(1), parts)
+  }
+
 }
 
 class DummyInvokable extends AbstractInvokable {


### PR DESCRIPTION
These commits enhance the MutableObjectIterator with a next() method that creates a new object for every call.

The ExecutionEnvironment is updated to have an ExecutionConfig. This allows changing of execution parameters, such as whether the ClosureCleaner should be used and whether objects should be reused.

All Drivers are updated to support both object-reuse mode and non-object-reuse mode. Before, some operators did reuse (map, join...) while some (reduce) had a hidden non-reuse mode. Right now, the reuse mode is set per-job, if necessary, this could also be done on a more fine-grained basis.

Documentation is still missing. I want to do that in a separate commit. Also, I'm waiting for a cluster to run some tests to see what the impact is of using object-reuse vs. non-object-reuse.