### PR TITLE
Improvement on Type Hints for Java API

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/DualInputSemanticProperties.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/DualInputSemanticProperties.java
@@ -56,8 +56,7 @@ public class DualInputSemanticProperties extends SemanticProperties {
 
 	
 	public DualInputSemanticProperties() {
-		super();
-		this.init();
+		init();
 	}
 	
 	/**
@@ -251,9 +250,19 @@ public class DualInputSemanticProperties extends SemanticProperties {
 	 */
 	@Override
 	public void clearProperties() {
-		this.init();
 		super.clearProperties();
+		init();
 	}
+	
+	@Override
+	public boolean isEmpty() {
+		return super.isEmpty() &&
+				(forwardedFields1 == null || forwardedFields1.isEmpty()) &&
+				(forwardedFields2 == null || forwardedFields2.isEmpty()) &&
+				(readFields1 == null || readFields1.size() == 0) &&
+				(readFields2 == null || readFields2.size() == 0);
+	}
+	
 	
 	private void init() {
 		this.forwardedFields1 = new HashMap<Integer,FieldSet>();
@@ -261,5 +270,4 @@ public class DualInputSemanticProperties extends SemanticProperties {
 		this.readFields1 = null;
 		this.readFields2 = null;
 	}
-		
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/SemanticProperties.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/SemanticProperties.java
@@ -30,10 +30,9 @@ public abstract class SemanticProperties implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 
-	/**
-	 * Set of fields that are written in the destination record(s).
-	 */
+	/** Set of fields that are written in the destination record(s).*/
 	private FieldSet writtenFields;
+	
 	
 	/**
 	 * Adds, to the existing information, field(s) that are written in
@@ -71,10 +70,10 @@ public abstract class SemanticProperties implements Serializable {
 	 * Clears the object.
 	 */
 	public void clearProperties() {
-		this.init();
+		this.writtenFields = null;
 	}
 	
-	private void init() {
-		this.writtenFields = null;
+	public boolean isEmpty() {
+		return this.writtenFields == null || this.writtenFields.size() == 0;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/SingleInputSemanticProperties.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/SingleInputSemanticProperties.java
@@ -27,23 +27,18 @@ import org.apache.flink.api.common.operators.util.FieldSet;
  * Container for the semantic properties associated to a single input operator.
  */
 public class SingleInputSemanticProperties extends SemanticProperties {
+	
 	private static final long serialVersionUID = 1L;
 	
-	/**
-	 * Mapping from fields in the source record(s) to fields in the destination
-	 * record(s).  
-	 */
+	/**Mapping from fields in the source record(s) to fields in the destination record(s). */
 	private Map<Integer,FieldSet> forwardedFields;
 	
-	/**
-	 * Set of fields that are read in the source record(s).
-	 */
+	/** Set of fields that are read in the source record(s).*/
 	private FieldSet readFields;
 
 	
 	public SingleInputSemanticProperties() {
-		super();
-		this.init();
+		init();
 	}
 	
 	/**
@@ -140,8 +135,15 @@ public class SingleInputSemanticProperties extends SemanticProperties {
 	 */
 	@Override
 	public void clearProperties() {
-		this.init();
 		super.clearProperties();
+		init();
+	}
+	
+	@Override
+	public boolean isEmpty() {
+		return super.isEmpty() &&
+				(forwardedFields == null || forwardedFields.isEmpty()) &&
+				(readFields == null || readFields.size() == 0);
 	}
 	
 	private void init() {
@@ -205,6 +207,11 @@ public class SingleInputSemanticProperties extends SemanticProperties {
 		@Override
 		public void setWrittenFields(FieldSet writtenFields) {
 			throw new UnsupportedOperationException();
+		}
+		
+		@Override
+		public boolean isEmpty() {
+			return false;
 		}
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.common.functions.Partitioner;
@@ -91,7 +92,7 @@ public abstract class DataSet<T> {
 	
 	private final ExecutionEnvironment context;
 	
-	private final TypeInformation<T> type;
+	private TypeInformation<T> type;
 	
 	
 	protected DataSet(ExecutionEnvironment context, TypeInformation<T> type) {
@@ -99,12 +100,16 @@ public abstract class DataSet<T> {
 			throw new NullPointerException("context is null");
 		}
 
-		if (type == null) {
-			throw new NullPointerException("type is null");
-		}
-		
 		this.context = context;
 		this.type = type;
+	}
+
+	protected void setType(TypeInformation<T> type) {
+		this.type = type;
+	}
+	
+	protected boolean isTypeValid() {
+		return type != null;
 	}
 
 	/**
@@ -126,6 +131,11 @@ public abstract class DataSet<T> {
 	 * @see TypeInformation
 	 */
 	public TypeInformation<T> getType() {
+		if (type == null) {
+			throw new InvalidTypesException("The return type could not be determined automatically. "
+					+ "See the log for more information. "
+					+ "Please provide type information manually.");
+		}
 		return this.type;
 	}
 	
@@ -150,7 +160,7 @@ public abstract class DataSet<T> {
 			throw new NullPointerException("Map function must not be null.");
 		}
 
-		TypeInformation<R> resultType = TypeExtractor.getMapReturnTypes(mapper, this.getType());
+		TypeInformation<R> resultType = TypeExtractor.getMapReturnTypes(mapper, getType());
 
 		return new MapOperator<T, R>(this, resultType, mapper, Utils.getCallLocationName());
 	}
@@ -179,7 +189,7 @@ public abstract class DataSet<T> {
 		if (mapPartition == null) {
 			throw new NullPointerException("MapPartition function must not be null.");
 		}
-		TypeInformation<R> resultType = TypeExtractor.getMapPartitionReturnTypes(mapPartition, this.getType());
+		TypeInformation<R> resultType = TypeExtractor.getMapPartitionReturnTypes(mapPartition, getType());
 		return new MapPartitionOperator<T, R>(this, resultType, mapPartition, Utils.getCallLocationName());
 	}
 	
@@ -200,7 +210,7 @@ public abstract class DataSet<T> {
 			throw new NullPointerException("FlatMap function must not be null.");
 		}
 
-		TypeInformation<R> resultType = TypeExtractor.getFlatMapReturnTypes(flatMapper, this.getType());
+		TypeInformation<R> resultType = TypeExtractor.getFlatMapReturnTypes(flatMapper, getType());
 		return new FlatMapOperator<T, R>(this, resultType, flatMapper, Utils.getCallLocationName());
 	}
 	
@@ -355,7 +365,7 @@ public abstract class DataSet<T> {
 		if (reducer == null) {
 			throw new NullPointerException("GroupReduce function must not be null.");
 		}
-		TypeInformation<R> resultType = TypeExtractor.getGroupReduceReturnTypes(reducer, this.getType());
+		TypeInformation<R> resultType = TypeExtractor.getGroupReduceReturnTypes(reducer, getType());
 		return new GroupReduceOperator<T, R>(this, resultType, reducer, Utils.getCallLocationName());
 	}
 
@@ -387,12 +397,11 @@ public abstract class DataSet<T> {
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public ReduceOperator<T> minBy(int... fields)  {
-		if(!type.isTupleType()) {
+		if(!getType().isTupleType()) {
 			throw new InvalidProgramException("DataSet#minBy(int...) only works on Tuple types.");
 		}
 
-		return new ReduceOperator<T>(this, new SelectByMinFunction(
-				(TupleTypeInfo) type, fields), Utils.getCallLocationName());
+		return new ReduceOperator<T>(this, new SelectByMinFunction((TupleTypeInfo) getType(), fields), Utils.getCallLocationName());
 	}
 	
 	/**
@@ -423,12 +432,12 @@ public abstract class DataSet<T> {
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public ReduceOperator<T> maxBy(int... fields)  {
-		if(!type.isTupleType()) {
+		if(!getType().isTupleType()) {
 			throw new InvalidProgramException("DataSet#maxBy(int...) only works on Tuple types.");
 		}
 
 		return new ReduceOperator<T>(this, new SelectByMaxFunction(
-				(TupleTypeInfo) type, fields), Utils.getCallLocationName());
+				(TupleTypeInfo) getType(), fields), Utils.getCallLocationName());
 	}
 
 	/**
@@ -459,7 +468,7 @@ public abstract class DataSet<T> {
 	 * @return A DistinctOperator that represents the distinct DataSet.
 	 */
 	public <K> DistinctOperator<T> distinct(KeySelector<T, K> keyExtractor) {
-		TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, type);
+		TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, getType());
 		return new DistinctOperator<T>(this, new Keys.SelectorFunctionKeys<T, K>(keyExtractor, getType(), keyType), Utils.getCallLocationName());
 	}
 	
@@ -531,7 +540,7 @@ public abstract class DataSet<T> {
 	 * @see DataSet
 	 */
 	public <K> UnsortedGrouping<T> groupBy(KeySelector<T, K> keyExtractor) {
-		TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, type);
+		TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, getType());
 		return new UnsortedGrouping<T>(this, new Keys.SelectorFunctionKeys<T, K>(keyExtractor, getType(), keyType));
 	}
 	
@@ -969,8 +978,8 @@ public abstract class DataSet<T> {
 	 * @see KeySelector
 	 */
 	public <K extends Comparable<K>> PartitionOperator<T> partitionByHash(KeySelector<T, K> keyExtractor) {
-		final TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, type);
-		return new PartitionOperator<T>(this, PartitionMethod.HASH, new Keys.SelectorFunctionKeys<T, K>(keyExtractor, this.getType(), keyType), Utils.getCallLocationName());
+		final TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, getType());
+		return new PartitionOperator<T>(this, PartitionMethod.HASH, new Keys.SelectorFunctionKeys<T, K>(keyExtractor, getType(), keyType), Utils.getCallLocationName());
 	}
 	
 	/**
@@ -1016,8 +1025,8 @@ public abstract class DataSet<T> {
 	 * @see KeySelector
 	 */
 	public <K extends Comparable<K>> PartitionOperator<T> partitionCustom(Partitioner<K> partitioner, KeySelector<T, K> keyExtractor) {
-		final TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, type);
-		return new PartitionOperator<T>(this, new Keys.SelectorFunctionKeys<T, K>(keyExtractor, this.getType(), keyType), partitioner, Utils.getCallLocationName());
+		final TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, getType());
+		return new PartitionOperator<T>(this, new Keys.SelectorFunctionKeys<T, K>(keyExtractor, getType(), keyType), partitioner, Utils.getCallLocationName());
 	}
 	
 	/**
@@ -1069,7 +1078,7 @@ public abstract class DataSet<T> {
 		return output(tof);
 	}
 	
-/**
+	/**
 	 * Writes a DataSet as a text file to the specified location.<br/>
 	 * For each element of the DataSet the result of {@link TextFormatter#format(Object)} is written.
 	 *
@@ -1168,7 +1177,7 @@ public abstract class DataSet<T> {
 	
 	@SuppressWarnings("unchecked")
 	private <X extends Tuple> DataSink<T> internalWriteAsCsv(Path filePath, String rowDelimiter, String fieldDelimiter, WriteMode wm) {
-		Validate.isTrue(this.type.isTupleType(), "The writeAsCsv() method can only be used on data sets of tuples.");
+		Validate.isTrue(getType().isTupleType(), "The writeAsCsv() method can only be used on data sets of tuples.");
 		CsvOutputFormat<X> of = new CsvOutputFormat<X>(filePath, rowDelimiter, fieldDelimiter);
 		if(wm != null) {
 			of.setWriteMode(wm);
@@ -1251,10 +1260,10 @@ public abstract class DataSet<T> {
 		
 		// configure the type if needed
 		if (outputFormat instanceof InputTypeConfigurable) {
-			((InputTypeConfigurable) outputFormat).setInputType(this.type);
+			((InputTypeConfigurable) outputFormat).setInputType(getType());
 		}
 		
-		DataSink<T> sink = new DataSink<T>(this, outputFormat, this.type);
+		DataSink<T> sink = new DataSink<T>(this, outputFormat, getType());
 		this.context.registerDataSink(sink);
 		return sink;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/FunctionAnnotation.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/FunctionAnnotation.java
@@ -1,5 +1,4 @@
-
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupOperator.java
@@ -123,6 +123,13 @@ public class CoGroupOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OU
 		this.keys1 = keys1;
 		this.keys2 = keys2;
 		
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+	
+	@Override
+	protected void updateTypeDependentProperties() {
 		extractSemanticAnnotationsFromUdf(function.getClass());
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupOperator.java
@@ -122,15 +122,11 @@ public class CoGroupOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OU
 
 		this.keys1 = keys1;
 		this.keys2 = keys2;
-		
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	@Override
-	protected void updateTypeDependentProperties() {
-		extractSemanticAnnotationsFromUdf(function.getClass());
+	protected CoGroupFunction<I1, I2, OUT> getFunction() {
+		return function;
 	}
 
 	protected Keys<I1> getKeys1() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
@@ -63,6 +63,13 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 		this.function = function;
 		this.defaultName = defaultName;
 
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+	
+	@Override
+	protected void updateTypeDependentProperties() {
 		if (!(function instanceof ProjectCrossFunction)) {
 			extractSemanticAnnotationsFromUdf(function.getClass());
 		} else {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
@@ -51,6 +51,7 @@ import com.google.common.base.Preconditions;
 public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT, CrossOperator<I1, I2, OUT>> {
 
 	private final CrossFunction<I1, I2, OUT> function;
+	
 	private final String defaultName;
 
 	public CrossOperator(DataSet<I1> input1, DataSet<I2> input2,
@@ -62,24 +63,15 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 
 		this.function = function;
 		this.defaultName = defaultName;
-
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	@Override
-	protected void updateTypeDependentProperties() {
-		if (!(function instanceof ProjectCrossFunction)) {
-			extractSemanticAnnotationsFromUdf(function.getClass());
-		} else {
-			generateProjectionProperties(((ProjectCrossFunction<?, ?, ?>) function));
-		}
+	protected CrossFunction<I1, I2, OUT> getFunction() {
+		return function;
 	}
-
-	public void generateProjectionProperties(ProjectCrossFunction<?, ?, ?> pcf) {
-		DualInputSemanticProperties props = SemanticPropUtil.createProjectionPropertiesDual(pcf.getFields(), pcf.getIsFromFirst());
-		setSemanticProperties(props);
+	
+	private String getDefaultName() {
+		return defaultName;
 	}
 
 	@Override
@@ -119,7 +111,7 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 		private final DataSet<I2> input2;
 
 		public DefaultCross(DataSet<I1> input1, DataSet<I2> input2, String defaultName) {
-			super(input1, input2, (CrossFunction<I1, I2, Tuple2<I1, I2>>) new DefaultCrossFunction<I1, I2>(),
+			super(input1, input2, new DefaultCrossFunction<I1, I2>(),
 					new TupleTypeInfo<Tuple2<I1, I2>>(input1.getType(), input2.getType()), defaultName);
 
 			if (input1 == null || input2 == null) {
@@ -144,7 +136,8 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 			if (function == null) {
 				throw new NullPointerException("Cross function must not be null.");
 			}
-			TypeInformation<R> returnType = TypeExtractor.getCrossReturnTypes(function, input1.getType(), input2.getType());
+			TypeInformation<R> returnType = TypeExtractor.getCrossReturnTypes(function, input1.getType(), input2.getType(),
+					super.getDefaultName(), true);
 			return new CrossOperator<I1, I2, R>(input1, input2, function, returnType, Utils.getCallLocationName());
 		}
 		
@@ -228,6 +221,11 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 			this.crossProjection = crossProjection;
 		}
 
+		@Override
+		protected ProjectCrossFunction<I1, I2, OUT> getFunction() {
+			return (ProjectCrossFunction<I1, I2, OUT>) super.getFunction();
+		}
+		
 		/**
 		 * Continues a ProjectCross transformation and adds fields of the first cross input to the projection.<br/>
 		 * If the first cross input is a {@link Tuple} {@link DataSet}, fields can be selected by their index.
@@ -284,10 +282,6 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 
 		/**
 		 * Deprecated method only kept for compatibility.
-		 *
-		 * @param types
-		 *
-		 * @return
 		 */
 		@SuppressWarnings({ "hiding", "unchecked" })
 		@Deprecated
@@ -314,6 +308,12 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 		@Override
 		public CrossOperator<I1, I2, OUT> withConstantSetSecond(String... constantSetSecond) {
 			throw new InvalidProgramException("The semantic properties (constant fields and forwarded fields) are automatically calculated.");
+		}
+		
+		@Override
+		protected DualInputSemanticProperties extractSemanticAnnotationsFromUdf(Class<?> udfClass) {
+			// we do not extract anything, but construct the properties from the projection
+			return SemanticPropUtil.createProjectionPropertiesDual(getFunction().getFields(), getFunction().getIsFromFirst());
 		}
 	}
 
@@ -604,11 +604,9 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 	// GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 
 		/**
-		 * Chooses a projectTupleX according to the length of {@link CrossProjection#fieldIndexes} 
+		 * Chooses a projectTupleX according to the length of {@link org.apache.flink.api.java.operators.CrossOperator.CrossProjection#fieldIndexes} 
 		 * 
 		 * @return The projected DataSet.
-		 * 
-		 * @see ProjectCross
 		 */
 		@SuppressWarnings("unchecked")
 		public <OUT extends Tuple> ProjectCross<I1, I2, OUT> projectTupleX() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
@@ -57,8 +57,6 @@ public class DistinctOperator<T> extends SingleInputOperator<T, T, DistinctOpera
 		// if keys is null distinction is done on all tuple fields
 		if (keys == null) {
 			if (input.getType() instanceof CompositeType) {
-
-				CompositeType<?> cType = (CompositeType<?>) input.getType();
 				keys = new Keys.ExpressionKeys<T>(new String[] {Keys.ExpressionKeys.SELECT_ALL_CHAR }, input.getType());
 			}
 			else {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/FilterOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/FilterOperator.java
@@ -41,6 +41,14 @@ public class FilterOperator<T> extends SingleInputUdfOperator<T, T, FilterOperat
 		
 		this.function = function;
 		this.defaultName = defaultName;
+
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+	
+	@Override
+	protected void updateTypeDependentProperties() {
 		extractSemanticAnnotationsFromUdf(function.getClass());
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/FilterOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/FilterOperator.java
@@ -41,15 +41,11 @@ public class FilterOperator<T> extends SingleInputUdfOperator<T, T, FilterOperat
 		
 		this.function = function;
 		this.defaultName = defaultName;
-
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	@Override
-	protected void updateTypeDependentProperties() {
-		extractSemanticAnnotationsFromUdf(function.getClass());
+	protected FilterFunction<T> getFunction() {
+		return function;
 	}
 	
 	@Override
@@ -59,17 +55,17 @@ public class FilterOperator<T> extends SingleInputUdfOperator<T, T, FilterOperat
 		
 		// create operator
 		PlanFilterOperator<T> po = new PlanFilterOperator<T>(function, name, getInputType());
-		// set input
 		po.setInput(input);
+		
 		// set dop
-		if(this.getParallelism() > 0) {
+		if (getParallelism() > 0) {
 			// use specified dop
-			po.setDegreeOfParallelism(this.getParallelism());
+			po.setDegreeOfParallelism(getParallelism());
 		} else {
 			// if no dop has been specified, use dop of input operator to enable chaining
 			po.setDegreeOfParallelism(input.getDegreeOfParallelism());
 		}
-				
+		
 		return po;
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/FlatMapOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/FlatMapOperator.java
@@ -43,6 +43,14 @@ public class FlatMapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, Fl
 		
 		this.function = function;
 		this.defaultName = defaultName;
+
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+	
+	@Override
+	protected void updateTypeDependentProperties() {
 		extractSemanticAnnotationsFromUdf(function.getClass());
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/FlatMapOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/FlatMapOperator.java
@@ -43,15 +43,11 @@ public class FlatMapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, Fl
 		
 		this.function = function;
 		this.defaultName = defaultName;
-
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	@Override
-	protected void updateTypeDependentProperties() {
-		extractSemanticAnnotationsFromUdf(function.getClass());
+	protected FlatMapFunction<IN, OUT> getFunction() {
+		return function;
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
@@ -83,7 +83,16 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 
 		checkCombinability();
 
-		extractSemanticAnnotationsFromUdf(function.getClass());
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+
+	@Override
+	protected void updateTypeDependentProperties() {
+		if (grouper != null) {
+			extractSemanticAnnotationsFromUdf(function.getClass());
+		}
 	}
 
 	private void checkCombinability() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
@@ -82,17 +82,6 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 		this.defaultName = defaultName;
 
 		checkCombinability();
-
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
-	}
-
-	@Override
-	protected void updateTypeDependentProperties() {
-		if (grouper != null) {
-			extractSemanticAnnotationsFromUdf(function.getClass());
-		}
 	}
 
 	private void checkCombinability() {
@@ -100,6 +89,12 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 				function.getClass().getAnnotation(RichGroupReduceFunction.Combinable.class) != null) {
 			this.combinable = true;
 		}
+	}
+	
+	
+	@Override
+	protected GroupReduceFunction<IN, OUT> getFunction() {
+		return function;
 	}
 
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.api.java.operators;
 
-
 import java.security.InvalidParameterException;
 import java.util.Arrays;
 
 import com.google.common.base.Preconditions;
+
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
@@ -200,10 +200,6 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			
 			this.function = function;
 			this.joinLocationName = joinLocationName;
-
-			if (isTypeValid()) {
-				updateTypeDependentProperties();
-			}
 		}
 
 		public EquiJoin(DataSet<I1> input1, DataSet<I2> input2,
@@ -219,49 +215,21 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			}
 
 			this.function = generatedFunction;
-
-			if (isTypeValid()) {
-				updateTypeDependentProperties();
-			}
+		}
+		
+		@Override
+		protected FlatJoinFunction<I1, I2, OUT> getFunction() {
+			return function;
 		}
 
 		@Override
-		protected void updateTypeDependentProperties() {
-			if (!(function instanceof ProjectFlatJoinFunction)) {
-				if (function instanceof WrappingFunction) {
-					extractSemanticAnnotationsFromUdf(((WrappingFunction<?>) function).getWrappedFunction().getClass());
-				}
-				else {
-					extractSemanticAnnotationsFromUdf(function.getClass());
-				}
+		protected DualInputSemanticProperties extractSemanticAnnotationsFromUdf(Class<?> udfClass) {
+			if (function instanceof DefaultJoin.WrappingFlatJoinFunction) {
+				return super.extractSemanticAnnotationsFromUdf(((WrappingFunction<?>) function).getWrappedFunction().getClass());
 			} else {
-				generateProjectionProperties(((ProjectFlatJoinFunction<?, ?, ?>) function));
+				return super.extractSemanticAnnotationsFromUdf(function.getClass());
 			}
 		}
-
-		public void generateProjectionProperties(ProjectFlatJoinFunction<?, ?, ?> pjf) {
-			DualInputSemanticProperties props = SemanticPropUtil.createProjectionPropertiesDual(pjf.getFields(), pjf.getIsFromFirst());
-			setSemanticProperties(props);
-		}
-
-		// TODO
-//		public EquiJoin<I1, I2, OUT> leftOuter() {
-//			this.preserve1 = true;
-//			return this;
-//		}
-
-		// TODO
-//		public EquiJoin<I1, I2, OUT> rightOuter() {
-//			this.preserve2 = true;
-//			return this;
-//		}
-		
-		// TODO
-//		public EquiJoin<I1, I2, OUT> fullOuter() {
-//			this.preserve1 = true;
-//			this.preserve2 = true;
-//			return this;
-//		}
 		
 		@Override
 		protected JoinOperatorBase<?, ?, OUT, ?> translateToDataFlow(Operator<I1> input1, Operator<I2> input2) {
@@ -657,6 +625,11 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			
 			this.joinProj = joinProj;
 		}
+		
+		@Override
+		protected ProjectFlatJoinFunction<I1, I2, OUT> getFunction() {
+			return (ProjectFlatJoinFunction<I1, I2, OUT>) super.getFunction();
+		}
 
 		/**
 		 * Continues a ProjectJoin transformation and adds fields of the first join input to the projection.<br/>
@@ -716,8 +689,6 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		 * Deprecated method only kept for compatibility.
 		 *
 		 * @param types
-		 *
-		 * @return
 		 */
 		@SuppressWarnings({ "unchecked", "hiding" })
 		@Deprecated
@@ -745,6 +716,13 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		public JoinOperator<I1, I2, OUT> withConstantSetSecond(String... constantSetSecond) {
 			throw new InvalidProgramException("The semantic properties (constant fields and forwarded fields) are automatically calculated.");
 		}
+		
+		@Override
+		protected DualInputSemanticProperties extractSemanticAnnotationsFromUdf(Class<?> udfClass) {
+			// we do not extract the annotation, we construct the properties from the projection#
+			return SemanticPropUtil.createProjectionPropertiesDual(getFunction().getFields(), getFunction().getIsFromFirst());
+		}
+
 	}
 	
 //	@SuppressWarnings("unused")
@@ -1292,11 +1270,12 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 	// GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 
 		/**
-		 * Chooses a projectTupleX according to the length of {@link JoinProjection#fieldIndexes} 
+		 * Chooses a projectTupleX according to the length of
+		 * {@link org.apache.flink.api.java.operators.JoinOperator.JoinProjection#fieldIndexes} 
 		 * 
 		 * @return The projected DataSet.
 		 * 
-		 * @see ProjectJoin
+		 * @see org.apache.flink.api.java.operators.JoinOperator.ProjectJoin
 		 */
 		@SuppressWarnings("unchecked")
 		public <OUT extends Tuple> ProjectJoin<I1, I2, OUT> projectTupleX() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/Keys.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/Keys.java
@@ -76,6 +76,9 @@ public abstract class Keys<T> {
 			if (keyExtractor == null) {
 				throw new NullPointerException("Key extractor must not be null.");
 			}
+			if (keyType == null) {
+				throw new NullPointerException("Key type must not be null.");
+			}
 
 			this.keyExtractor = keyExtractor;
 			this.keyType = keyType;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
@@ -45,6 +45,14 @@ public class MapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, MapOpe
 		
 		this.defaultName = defaultName;
 		this.function = function;
+
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+	
+	@Override
+	protected void updateTypeDependentProperties() {
 		extractSemanticAnnotationsFromUdf(function.getClass());
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
@@ -45,15 +45,11 @@ public class MapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, MapOpe
 		
 		this.defaultName = defaultName;
 		this.function = function;
-
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	@Override
-	protected void updateTypeDependentProperties() {
-		extractSemanticAnnotationsFromUdf(function.getClass());
+	protected MapFunction<IN, OUT> getFunction() {
+		return function;
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/MapPartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/MapPartitionOperator.java
@@ -45,6 +45,14 @@ public class MapPartitionOperator<IN, OUT> extends SingleInputUdfOperator<IN, OU
 		
 		this.function = function;
 		this.defaultName = defaultName;
+
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+	
+	@Override
+	protected void updateTypeDependentProperties() {
 		extractSemanticAnnotationsFromUdf(function.getClass());
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/MapPartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/MapPartitionOperator.java
@@ -45,15 +45,11 @@ public class MapPartitionOperator<IN, OUT> extends SingleInputUdfOperator<IN, OU
 		
 		this.function = function;
 		this.defaultName = defaultName;
-
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	@Override
-	protected void updateTypeDependentProperties() {
-		extractSemanticAnnotationsFromUdf(function.getClass());
+	protected MapPartitionFunction<IN, OUT> getFunction() {
+		return function;
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/PartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/PartitionOperator.java
@@ -40,7 +40,7 @@ import com.google.common.base.Preconditions;
  *
  * @param <T> The type of the data being partitioned.
  */
-public class PartitionOperator<T> extends SingleInputUdfOperator<T, T, PartitionOperator<T>> {
+public class PartitionOperator<T> extends SingleInputOperator<T, T, PartitionOperator<T>> {
 	
 	private final Keys<T> pKeys;
 	private final PartitionMethod pMethod;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/ProjectOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/ProjectOperator.java
@@ -101,10 +101,6 @@ public class ProjectOperator<IN, OUT extends Tuple>
 	}
 	/**
 	 * Deprecated method only kept for compatibility.
-	 *
-	 * @param types
-	 *
-	 * @return
 	 */
 	@SuppressWarnings({ "unchecked", "hiding" })
 	@Deprecated
@@ -180,11 +176,12 @@ public class ProjectOperator<IN, OUT extends Tuple>
 	// GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 
 		/**
-		 * Chooses a projectTupleX according to the length of {@link Projection#fieldIndexes} 
+		 * Chooses a projectTupleX according to the length of
+		 * {@link org.apache.flink.api.java.operators.ProjectOperator.Projection#fieldIndexes} 
 		 * 
 		 * @return The projected DataSet.
 		 * 
-		 * @see Projection
+		 * @see org.apache.flink.api.java.operators.ProjectOperator.Projection
 		 */
 		@SuppressWarnings("unchecked")
 		public <OUT extends Tuple> ProjectOperator<T, OUT> projectTupleX() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/ReduceOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/ReduceOperator.java
@@ -62,7 +62,9 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		this.grouper = null;
 		this.defaultName = defaultName;
 		
-		extractSemanticAnnotationsFromUdf(function.getClass());
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
 	}
 	
 	
@@ -73,6 +75,13 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		this.grouper = input;
 		this.defaultName = defaultName;
 		
+		if (isTypeValid()) {
+			updateTypeDependentProperties();
+		}
+	}
+	
+	@Override
+	protected void updateTypeDependentProperties() {
 		extractSemanticAnnotationsFromUdf(function.getClass());
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/ReduceOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/ReduceOperator.java
@@ -61,10 +61,6 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		this.function = function;
 		this.grouper = null;
 		this.defaultName = defaultName;
-		
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	
@@ -74,15 +70,11 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		this.function = function;
 		this.grouper = input;
 		this.defaultName = defaultName;
-		
-		if (isTypeValid()) {
-			updateTypeDependentProperties();
-		}
 	}
 	
 	@Override
-	protected void updateTypeDependentProperties() {
-		extractSemanticAnnotationsFromUdf(function.getClass());
+	protected ReduceFunction<IN> getFunction() {
+		return function;
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputUdfOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputUdfOperator.java
@@ -24,12 +24,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.operators.SingleInputSemanticProperties;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.functions.SemanticPropUtil;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.api.java.DataSet;
 
 /**
  * The <tt>SingleInputUdfOperator</tt> is the base class of all unary operators that execute
@@ -69,6 +72,11 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(udfClass);
 		SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingle(annotations, getInputType(), getResultType());
 		setSemanticProperties(sp);
+	}
+
+	protected void updateTypeDependentProperties() {
+		// can be overwritten in subclasses for actions that depend on the return type
+		// which may not be available immediately (e.g. if type is missing at instantiation)
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -129,6 +137,119 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
 		return returnType;
+	}
+	
+	/**
+	 * Adds a type information hint about the return type of this operator. 
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler
+	 * throws away generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes a type information string that will be parsed. A type information string can contain the following
+	 * types:
+	 *
+	 * <ul>
+	 * <li>Basic types such as <code>Integer</code>, <code>String</code>, etc.
+	 * <li>Basic type arrays such as <code>Integer[]</code>,
+	 * <code>String[]</code>, etc.
+	 * <li>Tuple types such as <code>Tuple1&lt;TYPE0&gt;</code>,
+	 * <code>Tuple2&lt;TYPE0, TYPE1&gt;</code>, etc.</li>
+	 * <li>Pojo types such as <code>org.my.MyPojo&lt;myFieldName=TYPE0,myFieldName2=TYPE1&gt;</code>, etc.</li>
+	 * <li>Generic types such as <code>java.lang.Class</code>, etc.
+	 * <li>Custom type arrays such as <code>org.my.CustomClass[]</code>,
+	 * <code>org.my.CustomClass$StaticInnerClass[]</code>, etc.
+	 * <li>Value types such as <code>DoubleValue</code>,
+	 * <code>StringValue</code>, <code>IntegerValue</code>, etc.</li>
+	 * <li>Tuple array types such as <code>Tuple2&lt;TYPE0,TYPE1&gt;[], etc.</code></li>
+	 * <li>Writable types such as <code>Writable&lt;org.my.CustomWritable&gt;</code></li>
+	 * <li>Enum types such as <code>Enum&lt;org.my.CustomEnum&gt;</code></li>
+	 * </ul>
+	 *
+	 * Example:
+	 * <code>"Tuple2&lt;String,Tuple2&lt;Integer,org.my.MyJob$Pojo&lt;word=String&gt;&gt;&gt;"</code>
+	 *
+	 * @param typeInfoString
+	 *            type information string to be parsed
+	 * @return This operator with a given return type hint.
+	 */
+	public O returns(String typeInfoString) {
+		if (typeInfoString == null) {
+			throw new IllegalArgumentException("Type information string must not be null.");
+		}
+		return returns(TypeInfoParser.<OUT>parse(typeInfoString));
+	}
+	
+	/**
+	 * Adds a type information hint about the return type of this operator. 
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler
+	 * throws away generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes an instance of {@link org.apache.flink.api.common.typeinfo.TypeInformation} such as:
+	 * 
+	 * <ul>
+	 * <li>{@link org.apache.flink.api.common.typeinfo.BasicTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.TupleTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.PojoTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.WritableTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.ValueTypeInfo}</li>
+	 * <li>etc.</li>
+	 * </ul>
+	 *
+	 * @param typeInfo
+	 *            type information as a return type hint
+	 * @return This operator with a given return type hint.
+	 */
+	public O returns(TypeInformation<OUT> typeInfo) {
+		if (typeInfo == null) {
+			throw new IllegalArgumentException("Type information must not be null.");
+		}
+		setType(typeInfo);
+		updateTypeDependentProperties();
+		@SuppressWarnings("unchecked")
+		O returnType = (O) this;
+		return returnType;
+	}
+	
+	/**
+	 * Adds a type information hint about the return type of this operator. 
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler
+	 * throws away generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes a class that will be analyzed by Flink's type extraction capabilities.
+	 * 
+	 * <p>
+	 * Examples for classes are:
+	 * <ul>
+	 * <li>Basic types such as <code>Integer.class</code>, <code>String.class</code>, etc.</li>
+	 * <li>POJOs such as <code>MyPojo.class</code></li>
+	 * <li>Classes that <b>extend</b> tuples. Classes like <code>Tuple1.class</code>,<code>Tuple2.class</code>, etc. are <b>not</b> sufficient.</li>
+	 * <li>Arrays such as <code>String[].class</code>, etc.</li>
+	 * </ul>
+	 *
+	 * @param typeClazz
+	 *            class as a return type hint
+	 * @return This operator with a given return type hint.
+	 */
+	@SuppressWarnings("unchecked")
+	public O returns(Class<OUT> typeClazz) {
+		if (typeClazz == null) {
+			throw new IllegalArgumentException("Type class must not be null.");
+		}
+		
+		TypeInformation<OUT> ti = (TypeInformation<OUT>) TypeExtractor.createTypeInfo(typeClazz);
+		if (ti == null) {
+			throw new InvalidTypesException("The given class is not suited for providing necessary type information.");
+		}
+		return returns(ti);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputUdfOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputUdfOperator.java
@@ -209,7 +209,7 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 		if (typeInfo == null) {
 			throw new IllegalArgumentException("Type information must not be null.");
 		}
-		setType(typeInfo);
+		fillInType(typeInfo);
 		updateTypeDependentProperties();
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
@@ -235,21 +235,23 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 	 * <li>Arrays such as <code>String[].class</code>, etc.</li>
 	 * </ul>
 	 *
-	 * @param typeClazz
+	 * @param typeClass
 	 *            class as a return type hint
 	 * @return This operator with a given return type hint.
 	 */
 	@SuppressWarnings("unchecked")
-	public O returns(Class<OUT> typeClazz) {
-		if (typeClazz == null) {
+	public O returns(Class<OUT> typeClass) {
+		if (typeClass == null) {
 			throw new IllegalArgumentException("Type class must not be null.");
 		}
 		
-		TypeInformation<OUT> ti = (TypeInformation<OUT>) TypeExtractor.createTypeInfo(typeClazz);
-		if (ti == null) {
-			throw new InvalidTypesException("The given class is not suited for providing necessary type information.");
+		try {
+			TypeInformation<OUT> ti = (TypeInformation<OUT>) TypeExtractor.createTypeInfo(typeClass);
+			return returns(ti);
 		}
-		return returns(ti);
+		catch (InvalidTypesException e) {
+			throw new InvalidTypesException("The given class is not suited for providing necessary type information.", e);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputUdfOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputUdfOperator.java
@@ -251,7 +251,7 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 		if (typeInfo == null) {
 			throw new IllegalArgumentException("Type information must not be null.");
 		}
-		setType(typeInfo);
+		fillInType(typeInfo);
 		updateTypeDependentProperties();
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
@@ -277,21 +277,23 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 	 * <li>Arrays such as <code>String[].class</code>, etc.</li>
 	 * </ul>
 	 *
-	 * @param typeClazz
+	 * @param typeClass
 	 *            class as a return type hint
 	 * @return This operator with a given return type hint.
 	 */
 	@SuppressWarnings("unchecked")
-	public O returns(Class<OUT> typeClazz) {
-		if (typeClazz == null) {
+	public O returns(Class<OUT> typeClass) {
+		if (typeClass == null) {
 			throw new IllegalArgumentException("Type class must not be null.");
 		}
 		
-		TypeInformation<OUT> ti = (TypeInformation<OUT>) TypeExtractor.createTypeInfo(typeClazz);
-		if (ti == null) {
-			throw new InvalidTypesException("The given class is not suited for providing necessary type information.");
+		try {
+			TypeInformation<OUT> ti = (TypeInformation<OUT>) TypeExtractor.createTypeInfo(typeClass);
+			return returns(ti);
 		}
-		return returns(ti);
+		catch (InvalidTypesException e) {
+			throw new InvalidTypesException("The given class is not suited for providing necessary type information.", e);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputUdfOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputUdfOperator.java
@@ -24,10 +24,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.operators.DualInputSemanticProperties;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.functions.SemanticPropUtil;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.api.java.DataSet;
 
@@ -74,6 +77,11 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 					getInput1Type(), getInput2Type(), getResultType());
 
 		setSemanticProperties(dsp);
+	}
+	
+	protected void updateTypeDependentProperties() {
+		// can be overwritten in subclasses for actions that depend on the return type
+		// which may not be available immediately (e.g. if type is missing at instantiation)
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -171,6 +179,119 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 
 		O returnType = (O) this;
 		return returnType;
+	}
+	
+	/**
+	 * Adds a type information hint about the return type of this operator. 
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler
+	 * throws away generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes a type information string that will be parsed. A type information string can contain the following
+	 * types:
+	 *
+	 * <ul>
+	 * <li>Basic types such as <code>Integer</code>, <code>String</code>, etc.
+	 * <li>Basic type arrays such as <code>Integer[]</code>,
+	 * <code>String[]</code>, etc.
+	 * <li>Tuple types such as <code>Tuple1&lt;TYPE0&gt;</code>,
+	 * <code>Tuple2&lt;TYPE0, TYPE1&gt;</code>, etc.</li>
+	 * <li>Pojo types such as <code>org.my.MyPojo&lt;myFieldName=TYPE0,myFieldName2=TYPE1&gt;</code>, etc.</li>
+	 * <li>Generic types such as <code>java.lang.Class</code>, etc.
+	 * <li>Custom type arrays such as <code>org.my.CustomClass[]</code>,
+	 * <code>org.my.CustomClass$StaticInnerClass[]</code>, etc.
+	 * <li>Value types such as <code>DoubleValue</code>,
+	 * <code>StringValue</code>, <code>IntegerValue</code>, etc.</li>
+	 * <li>Tuple array types such as <code>Tuple2&lt;TYPE0,TYPE1&gt;[], etc.</code></li>
+	 * <li>Writable types such as <code>Writable&lt;org.my.CustomWritable&gt;</code></li>
+	 * <li>Enum types such as <code>Enum&lt;org.my.CustomEnum&gt;</code></li>
+	 * </ul>
+	 *
+	 * Example:
+	 * <code>"Tuple2&lt;String,Tuple2&lt;Integer,org.my.MyJob$Pojo&lt;word=String&gt;&gt;&gt;"</code>
+	 *
+	 * @param typeInfoString
+	 *            type information string to be parsed
+	 * @return This operator with a given return type hint.
+	 */
+	public O returns(String typeInfoString) {
+		if (typeInfoString == null) {
+			throw new IllegalArgumentException("Type information string must not be null.");
+		}
+		return returns(TypeInfoParser.<OUT>parse(typeInfoString));
+	}
+	
+	/**
+	 * Adds a type information hint about the return type of this operator. 
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler
+	 * throws away generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes an instance of {@link org.apache.flink.api.common.typeinfo.TypeInformation} such as:
+	 * 
+	 * <ul>
+	 * <li>{@link org.apache.flink.api.common.typeinfo.BasicTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.TupleTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.PojoTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.WritableTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.ValueTypeInfo}</li>
+	 * <li>etc.</li>
+	 * </ul>
+	 *
+	 * @param typeInfo
+	 *            type information as a return type hint
+	 * @return This operator with a given return type hint.
+	 */
+	public O returns(TypeInformation<OUT> typeInfo) {
+		if (typeInfo == null) {
+			throw new IllegalArgumentException("Type information must not be null.");
+		}
+		setType(typeInfo);
+		updateTypeDependentProperties();
+		@SuppressWarnings("unchecked")
+		O returnType = (O) this;
+		return returnType;
+	}
+	
+	/**
+	 * Adds a type information hint about the return type of this operator. 
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler
+	 * throws away generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes a class that will be analyzed by Flink's type extraction capabilities.
+	 * 
+	 * <p>
+	 * Examples for classes are:
+	 * <ul>
+	 * <li>Basic types such as <code>Integer.class</code>, <code>String.class</code>, etc.</li>
+	 * <li>POJOs such as <code>MyPojo.class</code></li>
+	 * <li>Classes that <b>extend</b> tuples. Classes like <code>Tuple1.class</code>,<code>Tuple2.class</code>, etc. are <b>not</b> sufficient.</li>
+	 * <li>Arrays such as <code>String[].class</code>, etc.</li>
+	 * </ul>
+	 *
+	 * @param typeClazz
+	 *            class as a return type hint
+	 * @return This operator with a given return type hint.
+	 */
+	@SuppressWarnings("unchecked")
+	public O returns(Class<OUT> typeClazz) {
+		if (typeClazz == null) {
+			throw new IllegalArgumentException("Type class must not be null.");
+		}
+		
+		TypeInformation<OUT> ti = (TypeInformation<OUT>) TypeExtractor.createTypeInfo(typeClazz);
+		if (ti == null) {
+			throw new InvalidTypesException("The given class is not suited for providing necessary type information.");
+		}
+		return returns(ti);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/UnionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/UnionOperator.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.Union;
 import org.apache.flink.api.java.DataSet;
@@ -31,6 +31,7 @@ import org.apache.flink.api.java.DataSet;
 public class UnionOperator<T> extends TwoInputOperator<T, T, T, UnionOperator<T>> {
 
 	private final String unionLocationName;
+	
 	/**
 	 * Create an operator that produces the union of the two given data sets.
 	 * 
@@ -39,6 +40,11 @@ public class UnionOperator<T> extends TwoInputOperator<T, T, T, UnionOperator<T>
 	 */
 	public UnionOperator(DataSet<T> input1, DataSet<T> input2, String unionLocationName) {
 		super(input1, input2, input1.getType());
+		
+		if (!input1.getType().equals(input2.getType())) {
+			throw new InvalidProgramException("Cannot union inputs of different types. Input1=" 
+					+ input1.getType() + ", input2=" + input2.getType());
+		}
 		
 		this.unionLocationName = unionLocationName;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
+
+	private String functionName;
+	private InvalidTypesException typeException;
+
+	public MissingTypeInfo(String functionName) {
+		this(functionName, new InvalidTypesException("An unknown error occured."));
+	}
+
+	public MissingTypeInfo(String functionName, InvalidTypesException typeException) {
+		this.functionName = functionName;
+		this.typeException = typeException;
+	}
+
+	public String getFunctionName() {
+		return functionName;
+	}
+
+	public InvalidTypesException getTypeException() {
+		return typeException;
+	}
+
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 0;
+	}
+
+	@Override
+	public Class<InvalidTypesException> getTypeClass() {
+		return InvalidTypesException.class;
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return false;
+	}
+
+	@Override
+	public TypeSerializer<InvalidTypesException> createSerializer() {
+		throw new UnsupportedOperationException("A serializer for missing type information does not exist.");
+	}
+
+	@Override
+	public int getTotalFields() {
+		return 0;
+	}
+
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
@@ -22,11 +22,16 @@ import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+/**
+ * A special type information signifying that the type extraction failed. It contains
+ * additional error information.
+ */
 public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
 
 	private String functionName;
 	private InvalidTypesException typeException;
 
+	
 	public MissingTypeInfo(String functionName) {
 		this(functionName, new InvalidTypesException("An unknown error occured."));
 	}
@@ -35,7 +40,9 @@ public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
 		this.functionName = functionName;
 		this.typeException = typeException;
 	}
-
+	
+	// --------------------------------------------------------------------------------------------
+	
 	public String getFunctionName() {
 		return functionName;
 	}
@@ -44,39 +51,40 @@ public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
 		return typeException;
 	}
 
+	// --------------------------------------------------------------------------------------------
+	
 	@Override
 	public boolean isBasicType() {
-		return false;
+		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
 	}
 
 	@Override
 	public boolean isTupleType() {
-		return false;
+		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
 	}
 
 	@Override
 	public int getArity() {
-		return 0;
+		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
 	}
 
 	@Override
 	public Class<InvalidTypesException> getTypeClass() {
-		return InvalidTypesException.class;
+		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
 	}
 
 	@Override
 	public boolean isKeyType() {
-		return false;
+		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
 	}
 
 	@Override
 	public TypeSerializer<InvalidTypesException> createSerializer() {
-		throw new UnsupportedOperationException("A serializer for missing type information does not exist.");
+		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
 	}
 
 	@Override
 	public int getTotalFields() {
-		return 0;
+		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
 	}
-
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
@@ -102,18 +102,6 @@ public class PojoTypeInfo<T> extends CompositeType<T>{
 	public boolean isKeyType() {
 		return Comparable.class.isAssignableFrom(typeClass);
 	}
-
-
-	@Override
-	public String toString() {
-		List<String> fieldStrings = new ArrayList<String>();
-		for (PojoField field : fields) {
-			fieldStrings.add(field.field.getName() + ": " + field.type.toString());
-		}
-		return "PojoType<" + typeClass.getCanonicalName()
-				+ ", fields = [" + Joiner.on(", ").join(fieldStrings) + "]"
-				+ ">";
-	}
 	
 	@Override
 	public void getKey(String fieldExpression, int offset, List<FlatFieldDescriptor> result) {
@@ -238,4 +226,26 @@ public class PojoTypeInfo<T> extends CompositeType<T>{
 		return new PojoSerializer<T>(this.typeClass, fieldSerializers, reflectiveFields);
 	}
 
+	// --------------------------------------------------------------------------------------------
+	
+	@Override
+	public boolean equals(Object obj) {
+		return (obj instanceof PojoTypeInfo) && ((PojoTypeInfo<?>) obj).typeClass == this.typeClass;
+	}
+	
+	@Override
+	public int hashCode() {
+		return typeClass.hashCode() + 1387562934;
+	}
+	
+	@Override
+	public String toString() {
+		List<String> fieldStrings = new ArrayList<String>();
+		for (PojoField field : fields) {
+			fieldStrings.add(field.field.getName() + ": " + field.type.toString());
+		}
+		return "PojoType<" + typeClass.getCanonicalName()
+				+ ", fields = [" + Joiner.on(", ").join(fieldStrings) + "]"
+				+ ">";
+	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -75,7 +75,7 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	/**
 	 * Recursively add all fields in this tuple type. We need this in particular to get all
 	 * the types.
-	 * @param keyId
+	 * @param startKeyId
 	 * @param keyFields
 	 */
 	public void addAllFields(int startKeyId, List<FlatFieldDescriptor> keyFields) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -130,55 +130,93 @@ public class TypeExtractor {
 	
 	@SuppressWarnings("unchecked")
 	private static <IN, OUT> TypeInformation<OUT> getUnaryOperatorReturnType(Function function, Class<?> baseClass, boolean hasIterable, boolean hasCollector, TypeInformation<IN> inType) {
+		TypeInformation<OUT> ti = null;
 		final Method m = FunctionUtils.checkAndExtractLambdaMethod(function);
 		if (m != null) {
-			// check for lambda type erasure
-			validateLambdaGenericParameters(m);
-			
 			// parameters must be accessed from behind, since JVM can add additional parameters e.g. when using local variables inside lambda function
 			final int paramLen = m.getGenericParameterTypes().length - 1;
 			final Type input = (hasCollector)? m.getGenericParameterTypes()[paramLen - 1] : m.getGenericParameterTypes()[paramLen];
-			validateInputType((hasIterable)?removeGenericWrapper(input) : input, inType);
-			if(function instanceof ResultTypeQueryable) {
-				return ((ResultTypeQueryable<OUT>) function).getProducedType();
+			
+			// validate input only if it has not been type erased
+			if (!isTypeErased(input)) {
+				validateInputType((hasIterable)? removeGenericWrapper(input) : input, inType);
 			}
-			return new TypeExtractor().privateCreateTypeInfo((hasCollector)? removeGenericWrapper(m.getGenericParameterTypes()[paramLen]) : m.getGenericReturnType(), inType, null);
+			
+			if (function instanceof ResultTypeQueryable) {
+				ti = ((ResultTypeQueryable<OUT>) function).getProducedType();
+			}
+			else {
+				final Type returnType = (hasCollector)? removeGenericWrapper(m.getGenericParameterTypes()[paramLen]) : m.getGenericReturnType();
+				if (!isTypeErased(returnType)) {
+					ti = new TypeExtractor().privateCreateTypeInfo(returnType, inType, null);
+				}
+				else {
+					LOG.warn("The generic type parameters of '" + function.getClass() + "' are missing. \n"
+							+ "It seems that your compiler has not stored them into the .class file. \n"
+							+ "Currently, only the Eclipse JDT compiler preserves the type information necessary to use the lambdas feature type-safely. \n"
+							+ "See the documentation for more information about how to compile jobs containing lambda expressions. "
+							+ "Alternatively, you can provide type information manually.");
+				}
+			}
 		}
 		else {
 			validateInputType(baseClass, function.getClass(), 0, inType);
-			if(function instanceof ResultTypeQueryable) {
-				return ((ResultTypeQueryable<OUT>) function).getProducedType();
+			if (function instanceof ResultTypeQueryable) {
+				ti = ((ResultTypeQueryable<OUT>) function).getProducedType();
 			}
-			return new TypeExtractor().privateCreateTypeInfo(baseClass, function.getClass(), 1, inType, null);
+			else {
+				ti = new TypeExtractor().privateCreateTypeInfo(baseClass, function.getClass(), 1, inType, null);
+			}
 		}
+		return ti;
 	}
 	
 	@SuppressWarnings("unchecked")
 	private static <IN1, IN2, OUT> TypeInformation<OUT> getBinaryOperatorReturnType(Function function, Class<?> baseClass, boolean hasIterables, boolean hasCollector, TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
+		TypeInformation<OUT> ti = null;
 		final Method m = FunctionUtils.checkAndExtractLambdaMethod(function);
 		if (m != null) {
-			// check for lambda type erasure
-			validateLambdaGenericParameters(m);
-			
 			// parameters must be accessed from behind, since JVM can add additional parameters e.g. when using local variables inside lambda function
 			final int paramLen = m.getGenericParameterTypes().length - 1;
 			final Type input1 = (hasCollector)? m.getGenericParameterTypes()[paramLen - 2] : m.getGenericParameterTypes()[paramLen - 1];
 			final Type input2 = (hasCollector)? m.getGenericParameterTypes()[paramLen - 1] : m.getGenericParameterTypes()[paramLen];
-			validateInputType((hasIterables)? removeGenericWrapper(input1) : input1, in1Type);
-			validateInputType((hasIterables)? removeGenericWrapper(input2) : input2, in2Type);
-			if(function instanceof ResultTypeQueryable) {
-				return ((ResultTypeQueryable<OUT>) function).getProducedType();
+			
+			// validate input only if it has not been type erasured
+			if (!isTypeErased(input1)) {
+				validateInputType((hasIterables)? removeGenericWrapper(input1) : input1, in1Type);
 			}
-			return new TypeExtractor().privateCreateTypeInfo((hasCollector)? removeGenericWrapper(m.getGenericParameterTypes()[paramLen]) : m.getGenericReturnType(), in1Type, in2Type);
+			if (!isTypeErased(input2)) {
+				validateInputType((hasIterables)? removeGenericWrapper(input2) : input2, in2Type);
+			}
+			
+			if (function instanceof ResultTypeQueryable) {
+				ti = ((ResultTypeQueryable<OUT>) function).getProducedType();
+			}
+			else {
+				final Type returnType = (hasCollector)? removeGenericWrapper(m.getGenericParameterTypes()[paramLen]) : m.getGenericReturnType();
+				if (!isTypeErased(returnType)) {
+					ti = new TypeExtractor().privateCreateTypeInfo(returnType, in1Type, in2Type);
+				}
+				else {
+					LOG.warn("The generic type parameters of '" + function.getClass() + "' are missing. \n"
+							+ "It seems that your compiler has not stored them into the .class file. \n"
+							+ "Currently, only the Eclipse JDT compiler preserves the type information necessary to use the lambdas feature type-safely. \n"
+							+ "See the documentation for more information about how to compile jobs containing lambda expressions. "
+							+ "Alternatively, you can provide type information manually.");
+				}
+			}
 		}
 		else {
 			validateInputType(baseClass, function.getClass(), 0, in1Type);
 			validateInputType(baseClass, function.getClass(), 1, in2Type);
-			if(function instanceof ResultTypeQueryable) {
-				return ((ResultTypeQueryable<OUT>) function).getProducedType();
+			if (function instanceof ResultTypeQueryable) {
+				ti = ((ResultTypeQueryable<OUT>) function).getProducedType();
 			}
-			return new TypeExtractor().privateCreateTypeInfo(baseClass, function.getClass(), 2, in1Type, in2Type);
+			else {
+				ti = new TypeExtractor().privateCreateTypeInfo(baseClass, function.getClass(), 2, in1Type, in2Type);
+			}
 		}
+		return ti;
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -186,12 +224,20 @@ public class TypeExtractor {
 	// --------------------------------------------------------------------------------------------
 	
 	public static TypeInformation<?> createTypeInfo(Type t) {
-		return new TypeExtractor().privateCreateTypeInfo(t);
+		TypeInformation<?> ti = new TypeExtractor().privateCreateTypeInfo(t);
+		if (ti == null) {
+			throw new InvalidTypesException("Could not extract type information.");
+		}
+		return ti;
 	}
 	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> createTypeInfo(Class<?> baseClass, Class<?> clazz, int returnParamPos,
 			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
-		return new TypeExtractor().privateCreateTypeInfo(baseClass, clazz, returnParamPos, in1Type, in2Type);
+		TypeInformation<OUT> ti =  new TypeExtractor().privateCreateTypeInfo(baseClass, clazz, returnParamPos, in1Type, in2Type);
+		if (ti == null) {
+			throw new InvalidTypesException("Could not extract type information.");
+		}
+		return ti;
 	}
 	
 	// ----------------------------------- private methods ----------------------------------------
@@ -279,7 +325,8 @@ public class TypeExtractor {
 			
 			// check if immediate child of Tuple has generics
 			if (curT instanceof Class<?>) {
-				throw new InvalidTypesException("Tuple needs to be parameterized by using generics.");
+				LOG.warn("Tuple '" + curT.toString()  + "' is not parameterized. Please provide type information manually.");
+				return null;
 			}
 			
 			typeHierarchy.add(curT);
@@ -309,14 +356,20 @@ public class TypeExtractor {
 					
 					// variable could not be determined
 					if (tupleSubTypes[i] == null) {
-						throw new InvalidTypesException("Type of TypeVariable '" + ((TypeVariable<?>) subtypes[i]).getName() + "' in '"
+						LOG.warn("Type of TypeVariable '" + ((TypeVariable<?>) subtypes[i]).getName() + "' in '"
 								+ ((TypeVariable<?>) subtypes[i]).getGenericDeclaration()
 								+ "' could not be determined. This is most likely a type erasure problem. "
 								+ "The type extraction currently supports types with generic variables only in cases where "
-								+ "all variables in the return type can be deduced from the input type(s).");
+								+ "all variables in the return type can be deduced from the input type(s). "
+								+ "Please provide type information manually.");
+						return null; // mark entire tuple as invalid
 					}
 				} else {
 					tupleSubTypes[i] = createTypeInfoWithTypeHierarchy(new ArrayList<Type>(typeHierarchy), subtypes[i], in1Type, in2Type);
+					
+					if(tupleSubTypes[i] == null) {
+						return null; // mark entire tuple as invalid
+					}
 				}
 			}
 			
@@ -350,10 +403,12 @@ public class TypeExtractor {
 				if (typeInfo != null) {
 					return typeInfo;
 				} else {
-					throw new InvalidTypesException("Type of TypeVariable '" + ((TypeVariable<?>) t).getName() + "' in '"
+					LOG.warn("Type of TypeVariable '" + ((TypeVariable<?>) t).getName() + "' in '"
 							+ ((TypeVariable<?>) t).getGenericDeclaration() + "' could not be determined. This is most likely a type erasure problem. "
 							+ "The type extraction currently supports types with generic variables only in cases where "
-							+ "all variables in the return type can be deduced from the input type(s).");
+							+ "all variables in the return type can be deduced from the input type(s). "
+							+ "Please provide type information manually.");
+					return null;
 				}
 			}
 		}
@@ -399,21 +454,10 @@ public class TypeExtractor {
 			return privateGetForClass((Class<OUT>) t, new ArrayList<Type>());
 		}
 		
-		throw new InvalidTypesException("Type Information could not be created.");
+		LOG.warn("Type information could not be created. Please provide type information manually.");
+		return null;
 	}
 	
-	private int countFieldsInClass(Class<?> clazz) {
-		int fieldCount = 0;
-		for(Field field : clazz.getFields()) { // get all fields
-			if(	!Modifier.isStatic(field.getModifiers()) &&
-				!Modifier.isTransient(field.getModifiers())
-				) {
-				fieldCount++;
-			}
-		}
-		return fieldCount;
-	}
-
 	private <IN1, IN2> TypeInformation<?> createTypeInfoFromInputs(TypeVariable<?> returnTypeVar, ArrayList<Type> returnTypeHierarchy, 
 			TypeInformation<IN1> in1TypeInfo, TypeInformation<IN2> in2TypeInfo) {
 
@@ -526,8 +570,7 @@ public class TypeExtractor {
 			return parameter;
 		}
 		
-		throw new IllegalArgumentException("The types of the interface " + baseClass.getName() + " could not be inferred. " + 
-						"Support for synthetic interfaces, lambdas, and generic types is limited at this point.");
+		return null;
 	}
 	
 	private static Type getParameterTypeFromGenericType(Class<?> baseClass, ArrayList<Type> typeHierarchy, Type t, int pos) {
@@ -581,13 +624,11 @@ public class TypeExtractor {
 	
 	@SuppressWarnings("unchecked")
 	private static void validateInfo(ArrayList<Type> typeHierarchy, Type type, TypeInformation<?> typeInfo) {
-		
-		if (type == null) {
-			throw new InvalidTypesException("Unknown Error. Type is null.");
-		}
-		
 		if (typeInfo == null) {
 			throw new InvalidTypesException("Unknown Error. TypeInformation is null.");
+		}
+		if (type == null) {
+			throw new InvalidTypesException("Unknown Error. Type is null.");
 		}
 		
 		if (!(type instanceof TypeVariable<?>)) {
@@ -753,6 +794,18 @@ public class TypeExtractor {
 	//  Utility methods
 	// --------------------------------------------------------------------------------------------
 	
+	private int countFieldsInClass(Class<?> clazz) {
+		int fieldCount = 0;
+		for (Field field : clazz.getFields()) { // get all fields
+			if (!Modifier.isStatic(field.getModifiers()) &&
+				!Modifier.isTransient(field.getModifiers())
+				) {
+				fieldCount++;
+			}
+		}
+		return fieldCount;
+	}
+	
 	private static Type removeGenericWrapper(Type t) {
 		if(t instanceof ParameterizedType 	&& 
 				(Collector.class.isAssignableFrom(typeToClass(t))
@@ -761,29 +814,17 @@ public class TypeExtractor {
 		}
 		return t;
 	}
-	
-	private static void validateLambdaGenericParameters(Method m) {
-		// check the arguments
-		for (Type t : m.getGenericParameterTypes()) {
-			validateLambdaGenericParameter(t);
-		}
 
-		// check the return type
-		validateLambdaGenericParameter(m.getGenericReturnType());
-	}
-
-	private static void validateLambdaGenericParameter(Type t) {
+	private static boolean isTypeErased(Type t) {
 		if(!(t instanceof Class)) {
-			return;
+			return false;
 		}
 		final Class<?> clazz = (Class<?>) t;
 
 		if(clazz.getTypeParameters().length > 0) {
-			throw new InvalidTypesException("The generic type parameters of '" + clazz.getSimpleName() + "' are missing. \n"
-					+ "It seems that your compiler has not stored them into the .class file. \n"
-					+ "Currently, only the Eclipse JDT compiler preserves the type information necessary to use the lambdas feature type-safely. \n"
-					+ "See the documentation for more information about how to compile jobs containing lambda expressions.");
+			return true;
 		}
+		return false;
 	}
 	
 	private static String encodePrimitiveClass(Class<?> primitiveClass) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -60,7 +60,12 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
+/**
+ * A utility for reflection analysis on classes, to determine the return type of implementations of transformation
+ * functions.
+ */
 public class TypeExtractor {
+	
 	private static final Logger LOG = LoggerFactory.getLogger(TypeExtractor.class);
 
 	// We need this to detect recursive types and not get caught
@@ -76,60 +81,142 @@ public class TypeExtractor {
 	// --------------------------------------------------------------------------------------------
 	
 	public static <IN, OUT> TypeInformation<OUT> getMapReturnTypes(MapFunction<IN, OUT> mapInterface, TypeInformation<IN> inType) {
-		return getUnaryOperatorReturnType((Function) mapInterface, MapFunction.class, false, false, inType);
+		return getMapReturnTypes(mapInterface, inType, null, false);
 	}
 	
-	public static <IN, OUT> TypeInformation<OUT> getFlatMapReturnTypes(FlatMapFunction<IN, OUT> flatMapInterface, TypeInformation<IN> inType) {
-		return getUnaryOperatorReturnType((Function) flatMapInterface, FlatMapFunction.class, false, true, inType);
+	public static <IN, OUT> TypeInformation<OUT> getMapReturnTypes(MapFunction<IN, OUT> mapInterface, TypeInformation<IN> inType,
+			String functionName, boolean allowMissing)
+	{
+		return getUnaryOperatorReturnType((Function) mapInterface, MapFunction.class, false, false, inType, functionName, allowMissing);
 	}
+	
+
+	public static <IN, OUT> TypeInformation<OUT> getFlatMapReturnTypes(FlatMapFunction<IN, OUT> flatMapInterface, TypeInformation<IN> inType) {
+		return getFlatMapReturnTypes(flatMapInterface, inType, null, false);
+	}
+	
+	public static <IN, OUT> TypeInformation<OUT> getFlatMapReturnTypes(FlatMapFunction<IN, OUT> flatMapInterface, TypeInformation<IN> inType,
+			String functionName, boolean allowMissing)
+	{
+		return getUnaryOperatorReturnType((Function) flatMapInterface, FlatMapFunction.class, false, true, inType, functionName, allowMissing);
+	}
+	
 	
 	public static <IN, OUT> TypeInformation<OUT> getMapPartitionReturnTypes(MapPartitionFunction<IN, OUT> mapPartitionInterface, TypeInformation<IN> inType) {
-		return getUnaryOperatorReturnType((Function) mapPartitionInterface, MapPartitionFunction.class, true, true, inType);
+		return getMapPartitionReturnTypes(mapPartitionInterface, inType, null, false);
 	}
 	
-	public static <IN, OUT> TypeInformation<OUT> getGroupReduceReturnTypes(GroupReduceFunction<IN, OUT> groupReduceInterface,
-			TypeInformation<IN> inType) {
-		return getUnaryOperatorReturnType((Function) groupReduceInterface, GroupReduceFunction.class, true, true, inType);
+	public static <IN, OUT> TypeInformation<OUT> getMapPartitionReturnTypes(MapPartitionFunction<IN, OUT> mapPartitionInterface, TypeInformation<IN> inType,
+			String functionName, boolean allowMissing)
+	{
+		return getUnaryOperatorReturnType((Function) mapPartitionInterface, MapPartitionFunction.class, true, true, inType, functionName, allowMissing);
+	}
+	
+	
+	public static <IN, OUT> TypeInformation<OUT> getGroupReduceReturnTypes(GroupReduceFunction<IN, OUT> groupReduceInterface, TypeInformation<IN> inType) {
+		return getGroupReduceReturnTypes(groupReduceInterface, inType, null, false);
+	}
+	
+	public static <IN, OUT> TypeInformation<OUT> getGroupReduceReturnTypes(GroupReduceFunction<IN, OUT> groupReduceInterface, TypeInformation<IN> inType,
+			String functionName, boolean allowMissing)
+	{
+		return getUnaryOperatorReturnType((Function) groupReduceInterface, GroupReduceFunction.class, true, true, inType, functionName, allowMissing);
+	}
+	
+	
+	public static <IN1, IN2, OUT> TypeInformation<OUT> getFlatJoinReturnTypes(FlatJoinFunction<IN1, IN2, OUT> joinInterface,
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type)
+	{
+		return getFlatJoinReturnTypes(joinInterface, in1Type, in2Type, null, false);
 	}
 	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> getFlatJoinReturnTypes(FlatJoinFunction<IN1, IN2, OUT> joinInterface,
-			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
-		return getBinaryOperatorReturnType((Function) joinInterface, FlatJoinFunction.class, false, true, in1Type, in2Type);
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type, String functionName, boolean allowMissing)
+	{
+		return getBinaryOperatorReturnType((Function) joinInterface, FlatJoinFunction.class, false, true,
+				in1Type, in2Type, functionName, allowMissing);
+	}
+	
+	
+	public static <IN1, IN2, OUT> TypeInformation<OUT> getJoinReturnTypes(JoinFunction<IN1, IN2, OUT> joinInterface,
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type)
+	{
+		return getJoinReturnTypes(joinInterface, in1Type, in2Type, null, false);
 	}
 	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> getJoinReturnTypes(JoinFunction<IN1, IN2, OUT> joinInterface,
-			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
-		return getBinaryOperatorReturnType((Function) joinInterface, JoinFunction.class, false, false, in1Type, in2Type);
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type, String functionName, boolean allowMissing)
+	{
+		return getBinaryOperatorReturnType((Function) joinInterface, JoinFunction.class, false, false,
+				in1Type, in2Type, functionName, allowMissing);
+	}
+	
+	
+	public static <IN1, IN2, OUT> TypeInformation<OUT> getCoGroupReturnTypes(CoGroupFunction<IN1, IN2, OUT> coGroupInterface,
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type)
+	{
+		return getCoGroupReturnTypes(coGroupInterface, in1Type, in2Type, null, false);
 	}
 	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> getCoGroupReturnTypes(CoGroupFunction<IN1, IN2, OUT> coGroupInterface,
-			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
-		return getBinaryOperatorReturnType((Function) coGroupInterface, CoGroupFunction.class, true, true, in1Type, in2Type);
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type, String functionName, boolean allowMissing)
+	{
+		return getBinaryOperatorReturnType((Function) coGroupInterface, CoGroupFunction.class, true, true,
+				in1Type, in2Type, functionName, allowMissing);
+	}
+	
+	
+	public static <IN1, IN2, OUT> TypeInformation<OUT> getCrossReturnTypes(CrossFunction<IN1, IN2, OUT> crossInterface,
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type)
+	{
+		return getCrossReturnTypes(crossInterface, in1Type, in2Type, null, false);
 	}
 	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> getCrossReturnTypes(CrossFunction<IN1, IN2, OUT> crossInterface,
-			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
-		return getBinaryOperatorReturnType((Function) crossInterface, CrossFunction.class, false, false, in1Type, in2Type);
+			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type, String functionName, boolean allowMissing)
+	{
+		return getBinaryOperatorReturnType((Function) crossInterface, CrossFunction.class, false, false,
+				in1Type, in2Type, functionName, allowMissing);
 	}
+	
 	
 	public static <IN, OUT> TypeInformation<OUT> getKeySelectorTypes(KeySelector<IN, OUT> selectorInterface, TypeInformation<IN> inType) {
-		return getUnaryOperatorReturnType((Function) selectorInterface, KeySelector.class, false, false, inType);
+		return getKeySelectorTypes(selectorInterface, inType, null, false);
 	}
 	
+	public static <IN, OUT> TypeInformation<OUT> getKeySelectorTypes(KeySelector<IN, OUT> selectorInterface,
+			TypeInformation<IN> inType, String functionName, boolean allowMissing)
+	{
+		return getUnaryOperatorReturnType((Function) selectorInterface, KeySelector.class, false, false, inType, functionName, allowMissing);
+	}
+	
+	
 	public static <T> TypeInformation<T> getPartitionerTypes(Partitioner<T> partitioner) {
+		return getPartitionerTypes(partitioner, null, false);
+	}
+	
+	public static <T> TypeInformation<T> getPartitionerTypes(Partitioner<T> partitioner, String functionName, boolean allowMissing) {
 		return new TypeExtractor().privateCreateTypeInfo(Partitioner.class, partitioner.getClass(), 0, null, null);
 	}
 	
+	
 	@SuppressWarnings("unchecked")
 	public static <IN> TypeInformation<IN> getInputFormatTypes(InputFormat<IN, ?> inputFormatInterface) {
-		if(inputFormatInterface instanceof ResultTypeQueryable) {
+		if (inputFormatInterface instanceof ResultTypeQueryable) {
 			return ((ResultTypeQueryable<IN>) inputFormatInterface).getProducedType();
 		}
 		return new TypeExtractor().privateCreateTypeInfo(InputFormat.class, inputFormatInterface.getClass(), 0, null, null);
 	}
 	
+	// --------------------------------------------------------------------------------------------
+	//  Generic extraction methods
+	// --------------------------------------------------------------------------------------------
+	
 	@SuppressWarnings("unchecked")
-	private static <IN, OUT> TypeInformation<OUT> getUnaryOperatorReturnType(Function function, Class<?> baseClass, boolean hasIterable, boolean hasCollector, TypeInformation<IN> inType) {
+	private static <IN, OUT> TypeInformation<OUT> getUnaryOperatorReturnType(Function function, Class<?> baseClass, 
+			boolean hasIterable, boolean hasCollector, TypeInformation<IN> inType,
+			String functionName, boolean allowMissing)
+	{
 		TypeInformation<OUT> ti = null;
 
 		final Method m = FunctionUtils.checkAndExtractLambdaMethod(function);
@@ -162,7 +249,11 @@ public class TypeExtractor {
 				}
 			}
 			catch (InvalidTypesException e) {
-				ti = (TypeInformation<OUT>) new MissingTypeInfo(function.toString(), e);
+				if (allowMissing) {
+					ti = (TypeInformation<OUT>) new MissingTypeInfo(functionName != null ? functionName : function.toString(), e);
+				} else {
+					throw e;
+				}
 			}
 		}
 		else {
@@ -177,18 +268,31 @@ public class TypeExtractor {
 				}
 			}
 			catch (InvalidTypesException e) {
-				ti = (TypeInformation<OUT>) new MissingTypeInfo(function.toString(), e);
+				if (allowMissing) {
+					ti = (TypeInformation<OUT>) new MissingTypeInfo(functionName != null ? functionName : function.toString(), e);
+				} else {
+					throw e;
+				}
 			}
 		}
 
-		if (ti == null) {
+		if (ti != null) {
+			return ti;
+		}
+		else if (allowMissing) {
 			return (TypeInformation<OUT>) new MissingTypeInfo(function.toString());
 		}
-		return ti;
+		else {
+			throw new InvalidTypesException("Could not determine the return type of the function "
+					+ (functionName != null ? functionName : function.toString()));
+		}
 	}
 	
 	@SuppressWarnings("unchecked")
-	private static <IN1, IN2, OUT> TypeInformation<OUT> getBinaryOperatorReturnType(Function function, Class<?> baseClass, boolean hasIterables, boolean hasCollector, TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
+	private static <IN1, IN2, OUT> TypeInformation<OUT> getBinaryOperatorReturnType(Function function, Class<?> baseClass,
+			boolean hasIterables, boolean hasCollector, TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type,
+			String functionName, boolean allowMissing)
+	{
 		TypeInformation<OUT> ti = null;
 
 		final Method m = FunctionUtils.checkAndExtractLambdaMethod(function);
@@ -225,7 +329,11 @@ public class TypeExtractor {
 				}
 			}
 			catch (InvalidTypesException e) {
-				ti = (TypeInformation<OUT>) new MissingTypeInfo(function.toString(), e);
+				if (allowMissing) {
+					ti = (TypeInformation<OUT>) new MissingTypeInfo(functionName != null ? functionName : function.toString(), e);
+				} else {
+					throw e;
+				}
 			}
 		}
 		else {
@@ -241,14 +349,24 @@ public class TypeExtractor {
 				}
 			}
 			catch (InvalidTypesException e) {
-				ti = (TypeInformation<OUT>) new MissingTypeInfo(function.toString(), e);
+				if (allowMissing) {
+					ti = (TypeInformation<OUT>) new MissingTypeInfo(functionName != null ? functionName : function.toString(), e);
+				} else {
+					throw e;
+				}
 			}
 		}
 
-		if (ti == null) {
+		if (ti != null) {
+			return ti;
+		}
+		else if (allowMissing) {
 			return (TypeInformation<OUT>) new MissingTypeInfo(function.toString());
 		}
-		return ti;
+		else {
+			throw new InvalidTypesException("Could not determine the return type of the function "
+					+ (functionName != null ? functionName : function.toString()));
+		}
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -854,29 +972,28 @@ public class TypeExtractor {
 	}
 	
 	private static String encodePrimitiveClass(Class<?> primitiveClass) {
-		final String name = primitiveClass.getName();
-		if (name.equals("boolean")) {
+		if (primitiveClass == boolean.class) {
 			return "Z";
 		}
-		else if (name.equals("byte")) {
+		else if (primitiveClass == byte.class) {
 			return "B";
 		}
-		else if (name.equals("char")) {
+		else if (primitiveClass == char.class) {
 			return "C";
 		}
-		else if (name.equals("double")) {
+		else if (primitiveClass == double.class) {
 			return "D";
 		}
-		else if (name.equals("float")) {
+		else if (primitiveClass == float.class) {
 			return "F";
 		}
-		else if (name.equals("int")) {
+		else if (primitiveClass == int.class) {
 			return "I";
 		}
-		else if (name.equals("long")) {
+		else if (primitiveClass == long.class) {
 			return "J";
 		}
-		else if (name.equals("short")) {
+		else if (primitiveClass == short.class) {
 			return "S";
 		}
 		throw new InvalidTypesException();
@@ -1042,7 +1159,6 @@ public class TypeExtractor {
 	 * @param f field to check
 	 * @param clazz class of field
 	 * @param typeHierarchy type hierarchy for materializing generic types
-	 * @return
 	 */
 	private boolean isValidPojoField(Field f, Class<?> clazz, ArrayList<Type> typeHierarchy) {
 		if(Modifier.isPublic(f.getModifiers())) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
@@ -43,6 +43,7 @@ public class WritableSerializer<T extends Writable> extends TypeSerializer<T> {
 		this.typeClass = typeClass;
 	}
 	
+	@SuppressWarnings("unchecked")
 	@Override
 	public T createInstance() {
 		if(typeClass == NullWritable.class) {

--- a/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/DistinctTranslationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/DistinctTranslationTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("serial")
-public class DistrinctTranslationTest {
+public class DistinctTranslationTest {
 
 	@Test
 	public void testCombinable() {

--- a/flink-java/src/test/java/org/apache/flink/api/java/record/CoGroupWrappingFunctionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/record/CoGroupWrappingFunctionTest.java
@@ -44,7 +44,7 @@ import org.apache.flink.types.Record;
 import org.apache.flink.util.Collector;
 import org.junit.Test;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({ "serial", "deprecation" })
 public class CoGroupWrappingFunctionTest {
 
 	@SuppressWarnings("unchecked")

--- a/flink-java/src/test/java/org/apache/flink/api/java/record/ReduceWrappingFunctionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/record/ReduceWrappingFunctionTest.java
@@ -43,7 +43,7 @@ import org.apache.flink.types.Record;
 import org.apache.flink.util.Collector;
 import org.junit.Test;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({ "serial", "deprecation" })
 public class ReduceWrappingFunctionTest {
 
 	@SuppressWarnings("unchecked")

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/PojoTypeExtractionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/PojoTypeExtractionTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType.FlatFieldDescriptor;
-import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -53,6 +52,7 @@ import com.google.common.collect.HashMultiset;
 public class PojoTypeExtractionTest {
 
 	public static class HasDuplicateField extends WC {
+		@SuppressWarnings("unused")
 		private int count; // duplicate
 	}
 	
@@ -558,6 +558,6 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testGetterSetterWithVertex() {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		DataSet<VertexTyped> set = env.fromElements(new VertexTyped(0L, 3.0), new VertexTyped(1L, 1.0));
+		env.fromElements(new VertexTyped(0L, 3.0), new VertexTyped(1L, 1.0));
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -626,7 +626,7 @@ public class TypeExtractorTest {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
-	public void testMissingTupleGenericsException() {
+	public void testMissingTupleGenerics() {
 		RichMapFunction<?, ?> function = new RichMapFunction<String, Tuple2>() {
 			private static final long serialVersionUID = 1L;
 
@@ -636,12 +636,8 @@ public class TypeExtractorTest {
 			}
 		};
 
-		try {
-			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
-			Assert.fail("exception expected");
-		} catch (InvalidTypesException e) {
-			// right
-		}
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
+		Assert.assertEquals(ti, null);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -795,12 +791,8 @@ public class TypeExtractorTest {
 			}
 		};
 
-		try {
-			TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"));
-			Assert.fail("exception expected");
-		} catch (InvalidTypesException e) {
-			// right
-		}
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"));
+		Assert.assertEquals(ti, null);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -893,15 +885,11 @@ public class TypeExtractorTest {
 	}
 
 	@Test
-	public void testFunctionDependingOnInputException() {
+	public void testFunctionDependingOnUnknownInput() {
 		IdentityMapper3<Boolean, String> function = new IdentityMapper3<Boolean, String>();
 
-		try {
-			TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
-			Assert.fail("exception expected");
-		} catch (InvalidTypesException e) {
-			// right
-		}
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
+		Assert.assertEquals(ti, null);
 	}
 
 	public class IdentityMapper4<D> extends IdentityMapper<D> {
@@ -1366,15 +1354,10 @@ public class TypeExtractorTest {
 	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
-	public void testTypeErasureException() {
-		try {
-			TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
+	public void testTypeErasure() {
+		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
 					(TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"));
-			Assert.fail("exception expected");
-		}
-		catch (InvalidTypesException e) {
-			// right
-		}
+		Assert.assertEquals(ti, null);
 	}
 
 	public static class MyQueryableMapper<A> extends RichMapFunction<String, A> implements ResultTypeQueryable<A> {

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple9;
 import org.apache.flink.api.java.typeutils.EnumTypeInfo;
+import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -637,7 +638,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
-		Assert.assertEquals(ti, null);
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -652,12 +653,8 @@ public class TypeExtractorTest {
 			}
 		};
 
-		try {
-			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
-			Assert.fail("exception expected");
-		} catch (InvalidTypesException e) {
-			// right
-		}
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 	}
 
 	public static class SameTypeVariable<X> extends Tuple2<X, X> {
@@ -792,7 +789,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"));
-		Assert.assertEquals(ti, null);
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -889,7 +886,7 @@ public class TypeExtractorTest {
 		IdentityMapper3<Boolean, String> function = new IdentityMapper3<Boolean, String>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
-		Assert.assertEquals(ti, null);
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 	}
 
 	public class IdentityMapper4<D> extends IdentityMapper<D> {
@@ -1060,12 +1057,8 @@ public class TypeExtractorTest {
 			}
 		};
 		
-		try {
-			TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.STRING_TYPE_INFO);
-			Assert.fail("exception expected");
-		} catch (InvalidTypesException e) {
-			// good
-		}
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.STRING_TYPE_INFO);
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 
 		RichMapFunction<String, ?> function2 = new RichMapFunction<String, AbstractClass>() {
 			private static final long serialVersionUID = 1L;
@@ -1076,12 +1069,8 @@ public class TypeExtractorTest {
 			}
 		};
 
-		try {
-			TypeExtractor.getMapReturnTypes(function2, BasicTypeInfo.STRING_TYPE_INFO);
-			Assert.fail("exception expected");
-		} catch (InvalidTypesException e) {
-			// slick!
-		}
+		TypeInformation<?> ti2 = TypeExtractor.getMapReturnTypes(function2, BasicTypeInfo.STRING_TYPE_INFO);
+		Assert.assertTrue(ti2 instanceof MissingTypeInfo);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1096,12 +1085,8 @@ public class TypeExtractorTest {
 			}
 		};
 
-		try {
-			TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInfoParser.parse("StringValue"));
-			Assert.fail("exception expected");
-		} catch (InvalidTypesException e) {
-			// bam! go type extractor!
-		}
+		TypeInformation<?> ti =TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInfoParser.parse("StringValue"));
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1357,7 +1342,7 @@ public class TypeExtractorTest {
 	public void testTypeErasure() {
 		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
 					(TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"));
-		Assert.assertEquals(ti, null);
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 	}
 
 	public static class MyQueryableMapper<A> extends RichMapFunction<String, A> implements ResultTypeQueryable<A> {

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -637,8 +637,16 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"), "name", true);
 		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		
+		try {
+			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
+			Assert.fail("Expected an exception");
+		}
+		catch (InvalidTypesException e) {
+			// expected
+		}
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -653,8 +661,16 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"), "name", true);
 		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		
+		try {
+			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
+			Assert.fail("Expected an exception");
+		}
+		catch (InvalidTypesException e) {
+			// expected
+		}
 	}
 
 	public static class SameTypeVariable<X> extends Tuple2<X, X> {
@@ -788,8 +804,16 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"), "name", true);
 		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		
+		try {
+			TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"));
+			Assert.fail("Expected an exception");
+		}
+		catch (InvalidTypesException e) {
+			// expected
+		}
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -885,8 +909,16 @@ public class TypeExtractorTest {
 	public void testFunctionDependingOnUnknownInput() {
 		IdentityMapper3<Boolean, String> function = new IdentityMapper3<Boolean, String>();
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO, "name", true);
 		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		
+		try {
+			TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
+			Assert.fail("Expected an exception");
+		}
+		catch (InvalidTypesException e) {
+			// expected
+		}
 	}
 
 	public class IdentityMapper4<D> extends IdentityMapper<D> {
@@ -1057,7 +1089,7 @@ public class TypeExtractorTest {
 			}
 		};
 		
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.STRING_TYPE_INFO);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.STRING_TYPE_INFO, null, true);
 		Assert.assertTrue(ti instanceof MissingTypeInfo);
 
 		RichMapFunction<String, ?> function2 = new RichMapFunction<String, AbstractClass>() {
@@ -1069,7 +1101,7 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti2 = TypeExtractor.getMapReturnTypes(function2, BasicTypeInfo.STRING_TYPE_INFO);
+		TypeInformation<?> ti2 = TypeExtractor.getMapReturnTypes(function2, BasicTypeInfo.STRING_TYPE_INFO, null, true);
 		Assert.assertTrue(ti2 instanceof MissingTypeInfo);
 	}
 
@@ -1085,8 +1117,16 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti =TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInfoParser.parse("StringValue"));
+		TypeInformation<?> ti =TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInfoParser.parse("StringValue"), "name", true);
 		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		
+		try {
+			TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInfoParser.parse("StringValue"));
+			Assert.fail("Expected an exception");
+		}
+		catch (InvalidTypesException e) {
+			// expected
+		}
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1341,8 +1381,18 @@ public class TypeExtractorTest {
 	@Test
 	public void testTypeErasure() {
 		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
-					(TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"));
+					(TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"), "name", true);
 		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		
+		try {
+			TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
+					(TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"));
+			
+			Assert.fail("Expected an exception");
+		}
+		catch (InvalidTypesException e) {
+			// expected
+		}
 	}
 
 	public static class MyQueryableMapper<A> extends RichMapFunction<String, A> implements ResultTypeQueryable<A> {

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import static org.junit.Assert.*;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.junit.Test;
+
+public class PojoTypeInfoTest {
+
+	@Test
+	public void testEquals() {
+		try {
+			TypeInformation<TestPojo> info1 = TypeExtractor.getForClass(TestPojo.class);
+			TypeInformation<TestPojo> info2 = TypeExtractor.getForClass(TestPojo.class);
+			
+			assertTrue(info1 instanceof PojoTypeInfo);
+			assertTrue(info2 instanceof PojoTypeInfo);
+			
+			assertTrue(info1.equals(info2));
+			assertTrue(info1.hashCode() == info2.hashCode());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+	
+	public static final class TestPojo {
+		
+		public int someInt;
+		
+		private String aString;
+		
+		public Double[] doubleArray;
+		
+		
+		public void setaString(String aString) {
+			this.aString = aString;
+		}
+		
+		public String getaString() {
+			return aString;
+		}
+	}
+}

--- a/flink-java8/src/test/java/org/apache/flink/api/java/type/lambdas/LambdaExtractionTest.java
+++ b/flink-java8/src/test/java/org/apache/flink/api/java/type/lambdas/LambdaExtractionTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
@@ -127,7 +128,7 @@ public class LambdaExtractionTest {
 		MapFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i) -> null;
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -140,7 +141,7 @@ public class LambdaExtractionTest {
 		FlatMapFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i, o) -> {};
 
 		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -153,7 +154,7 @@ public class LambdaExtractionTest {
 		MapPartitionFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i, o) -> {};
 
 		TypeInformation<?> ti = TypeExtractor.getMapPartitionReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -166,7 +167,7 @@ public class LambdaExtractionTest {
 		GroupReduceFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i, o) -> {};
 
 		TypeInformation<?> ti = TypeExtractor.getGroupReduceReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -179,7 +180,7 @@ public class LambdaExtractionTest {
 		FlatJoinFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2, o) -> {};
 
 		TypeInformation<?> ti = TypeExtractor.getFlatJoinReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -192,7 +193,7 @@ public class LambdaExtractionTest {
 		JoinFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2) -> null;
 
 		TypeInformation<?> ti = TypeExtractor.getJoinReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -205,7 +206,7 @@ public class LambdaExtractionTest {
 		CoGroupFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2, o) -> {};
 
 		TypeInformation<?> ti = TypeExtractor.getCoGroupReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -218,7 +219,7 @@ public class LambdaExtractionTest {
 		CrossFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2) -> null;
 
 		TypeInformation<?> ti = TypeExtractor.getCrossReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -231,7 +232,7 @@ public class LambdaExtractionTest {
 		KeySelector<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i) -> null;
 
 		TypeInformation<?> ti = TypeExtractor.getKeySelectorTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		if (ti != null) {
+		if (!(ti instanceof MissingTypeInfo)) {
 			Assert.assertTrue(ti.isTupleType());
 			Assert.assertEquals(2, ti.getArity());
 			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
@@ -243,8 +244,8 @@ public class LambdaExtractionTest {
 	@Test
 	public void testLambdaTypeErasure() {
 		MapFunction<Tuple1, Tuple1> f = (i) -> null;
-
-		Assert.assertNull(TypeExtractor.getMapReturnTypes(f, TypeInfoParser.parse("Tuple1<String>")));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(f, TypeInfoParser.parse("Tuple1<String>"));
+		Assert.assertTrue(ti instanceof MissingTypeInfo);
 	}
 
 }

--- a/flink-java8/src/test/java/org/apache/flink/api/java/type/lambdas/LambdaExtractionTest.java
+++ b/flink-java8/src/test/java/org/apache/flink/api/java/type/lambdas/LambdaExtractionTest.java
@@ -54,23 +54,23 @@ public class LambdaExtractionTest {
 				@Override
 				public Integer map(String value) { return Integer.parseInt(value); }
 			};
-			
+
 			MapFunction<?, ?> anonymousFromClass = new RichMapFunction<String, Integer>() {
 				@Override
 				public Integer map(String value) { return Integer.parseInt(value); }
 			};
-			
+
 			MapFunction<?, ?> fromProperClass = new StaticMapper();
-			
+
 			MapFunction<?, ?> fromDerived = new ToTuple<Integer>() {
 				@Override
 				public Tuple2<Integer, Long> map(Integer value) {
 					return new Tuple2<Integer, Long>(value, 1L);
 				}
 			};
-			
+
 			MapFunction<String, Integer> lambda = (str) -> Integer.parseInt(str);
-			
+
 			assertNull(FunctionUtils.checkAndExtractLambdaMethod(anonymousFromInterface));
 			assertNull(FunctionUtils.checkAndExtractLambdaMethod(anonymousFromClass));
 			assertNull(FunctionUtils.checkAndExtractLambdaMethod(fromProperClass));
@@ -83,158 +83,168 @@ public class LambdaExtractionTest {
 			fail(e.getMessage());
 		}
 	}
-	
-	public static class StaticMapper implements MapFunction<String, Integer> {
 
+	public static class StaticMapper implements MapFunction<String, Integer> {
 		@Override
 		public Integer map(String value) { return Integer.parseInt(value); }
 	}
-	
-	public interface ToTuple<T> extends MapFunction<T, Tuple2<T, Long>> {
 
+	public interface ToTuple<T> extends MapFunction<T, Tuple2<T, Long>> {
 		@Override
 		public Tuple2<T, Long> map(T value) throws Exception;
 	}
-	
+
 	private static final MapFunction<String, Integer> STATIC_LAMBDA = (str) -> Integer.parseInt(str);
-	
+
 	public static class MyClass {
 		private String s = "mystring";
-		
+
 		public MapFunction<Integer, String> getMapFunction() {
 			return (i) -> s;
 		}
 	}
-	
+
 	@Test
 	public void testLambdaWithMemberVariable() {		
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(new MyClass().getMapFunction(), TypeInfoParser.parse("Integer"));
 		Assert.assertEquals(ti, BasicTypeInfo.STRING_TYPE_INFO);
 	}
-	
+
 	@Test
 	public void testLambdaWithLocalVariable() {
 		String s = "mystring";
 		final int k = 24;
 		int j = 26;
-		
+
 		MapFunction<Integer, String> f = (i) -> s + k + j;
-		
+
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(f, TypeInfoParser.parse("Integer"));
 		Assert.assertEquals(ti, BasicTypeInfo.STRING_TYPE_INFO);
 	}
-	
+
 	@Test
 	public void testMapLambda() {
 		MapFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i) -> null;
-		
+
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testFlatMapLambda() {
 		FlatMapFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i, o) -> {};
-		
+
 		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testMapPartitionLambda() {
 		MapPartitionFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i, o) -> {};
-		
+
 		TypeInformation<?> ti = TypeExtractor.getMapPartitionReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testGroupReduceLambda() {
 		GroupReduceFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i, o) -> {};
-		
+
 		TypeInformation<?> ti = TypeExtractor.getGroupReduceReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testFlatJoinLambda() {
 		FlatJoinFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2, o) -> {};
-		
+
 		TypeInformation<?> ti = TypeExtractor.getFlatJoinReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testJoinLambda() {
 		JoinFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2) -> null;
-		
+
 		TypeInformation<?> ti = TypeExtractor.getJoinReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testCoGroupLambda() {
 		CoGroupFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2, o) -> {};
-		
+
 		TypeInformation<?> ti = TypeExtractor.getCoGroupReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testCrossLambda() {
 		CrossFunction<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, Double>, Tuple2<Tuple1<Integer>, String>> f = (i1, i2) -> null;
-		
+
 		TypeInformation<?> ti = TypeExtractor.getCrossReturnTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"), TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Double>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@Test
 	public void testKeySelectorLambda() {
 		KeySelector<Tuple2<Tuple1<Integer>, Boolean>, Tuple2<Tuple1<Integer>, String>> f = (i) -> null;
-		
+
 		TypeInformation<?> ti = TypeExtractor.getKeySelectorTypes(f, TypeInfoParser.parse("Tuple2<Tuple1<Integer>, Boolean>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		if (ti != null) {
+			Assert.assertTrue(ti.isTupleType());
+			Assert.assertEquals(2, ti.getArity());
+			Assert.assertTrue(((TupleTypeInfo<?>) ti).getTypeAt(0).isTupleType());
+			Assert.assertEquals(((TupleTypeInfo<?>) ti).getTypeAt(1), BasicTypeInfo.STRING_TYPE_INFO);
+		}
 	}
-	
+
 	@SuppressWarnings("rawtypes")
 	@Test
-	public void testLambdaTypeErasureException() {
+	public void testLambdaTypeErasure() {
 		MapFunction<Tuple1, Tuple1> f = (i) -> null;
-		
-		try {
-			TypeExtractor.getMapReturnTypes(f, TypeInfoParser.parse("Tuple1<String>"));
-			Assert.fail();
-		}
-		catch (InvalidTypesException e) {
-			// ok
-		}
+
+		Assert.assertNull(TypeExtractor.getMapReturnTypes(f, TypeInfoParser.parse("Tuple1<String>")));
 	}
-	
+
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/TypeHintITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/TypeHintITCase.java
@@ -122,17 +122,9 @@ public class TypeHintITCase extends JavaProgramTestBase {
 
 				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
 				@SuppressWarnings({ "rawtypes", "unchecked" })
-				DataSet<Object> identityMapDs = ds.
-				flatMap(new FlatMapFunction<Tuple3<Integer, Long, String>, Object>() {
-					private static final long serialVersionUID = 1L;
-
-					@Override
-					public void flatMap(
-							Tuple3<Integer, Long, String> value,
-							Collector<Object> out) throws Exception {
-						out.collect(value.f0);
-					}
-				}).returns((Class) Integer.class);
+				DataSet<Integer> identityMapDs = ds.
+				flatMap(new FlatMapper<Tuple3<Integer, Long, String>, Integer>())
+				.returns((Class) Integer.class);
 				identityMapDs.writeAsText(resultPath);
 				env.execute();
 
@@ -156,6 +148,16 @@ public class TypeHintITCase extends JavaProgramTestBase {
 		@Override
 		public V map(T value) throws Exception {
 			return (V) value;
+		}
+	}
+	
+	public static class FlatMapper<T, V> implements FlatMapFunction<T, V> {
+		private static final long serialVersionUID = 1L;
+
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		@Override
+		public void flatMap(T value, Collector<V> out) throws Exception {
+			out.collect((V) ((Tuple3)value).f0);
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/TypeHintITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/TypeHintITCase.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.javaApiOperators;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.test.javaApiOperators.util.CollectionDataSets;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.util.Collector;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TypeHintITCase extends JavaProgramTestBase {
+
+	private static int NUM_PROGRAMS = 3;
+
+	private int curProgId = config.getInteger("ProgramId", -1);
+	private String resultPath;
+	private String expectedResult;
+
+	public TypeHintITCase(Configuration config) {
+		super(config);
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		resultPath = getTempDirPath("result");
+	}
+	@Override
+	protected void testProgram() throws Exception {
+		expectedResult = TypeHintProgs.runProgram(curProgId, resultPath);
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(expectedResult, resultPath);
+	}
+
+	@Parameters
+	public static Collection<Object[]> getConfigurations() throws FileNotFoundException, IOException {
+
+		LinkedList<Configuration> tConfigs = new LinkedList<Configuration>();
+
+		for(int i=1; i <= NUM_PROGRAMS; i++) {
+			Configuration config = new Configuration();
+			config.setInteger("ProgramId", i);
+			tConfigs.add(config);
+		}
+
+		return toParameterList(tConfigs);
+	}
+
+	private static class TypeHintProgs {
+
+		public static String runProgram(int progId, String resultPath) throws Exception {
+			switch(progId) {
+			// Test identity map with missing types and string type hint
+			case 1: {
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
+						.map(new Mapper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>>())
+						.returns("Tuple3<Integer, Long, String>");
+				identityMapDs.writeAsText(resultPath);
+				env.execute();
+
+				// return expected result
+				return "(2,2,Hello)\n" +
+				"(3,2,Hello world)\n" +
+				"(1,1,Hi)\n";
+			}
+			// Test identity map with missing types and type information type hint
+			case 2: {
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
+						// all following generics get erased during compilation
+						.map(new Mapper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>>())
+						.returns(new TupleTypeInfo<Tuple3<Integer, Long, String>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO));
+				identityMapDs.writeAsText(resultPath);
+				env.execute();
+
+				// return expected result
+				return "(2,2,Hello)\n" +
+				"(3,2,Hello world)\n" +
+				"(1,1,Hi)\n";
+			}
+			// Test flat map with class type hint
+			case 3: {
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+				@SuppressWarnings({ "rawtypes", "unchecked" })
+				DataSet<Object> identityMapDs = ds.
+				flatMap(new FlatMapFunction<Tuple3<Integer, Long, String>, Object>() {
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public void flatMap(
+							Tuple3<Integer, Long, String> value,
+							Collector<Object> out) throws Exception {
+						out.collect(value.f0);
+					}
+				}).returns((Class) Integer.class);
+				identityMapDs.writeAsText(resultPath);
+				env.execute();
+
+				// return expected result
+				return "2\n" +
+				"3\n" +
+				"1\n";
+			}
+			default: 
+				throw new IllegalArgumentException("Invalid program id");
+			}
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	public static class Mapper<T, V> implements MapFunction<T, V> {
+		private static final long serialVersionUID = 1L;
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public V map(T value) throws Exception {
+			return (V) value;
+		}
+	}
+
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/ScalaAPICompletenessTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/ScalaAPICompletenessTest.scala
@@ -57,6 +57,10 @@ class ScalaAPICompletenessTest {
       "org.apache.flink.api.java.ExecutionEnvironment.localExecutionIsAllowed",
       "org.apache.flink.api.java.ExecutionEnvironment.setDefaultLocalParallelism",
 
+      // TypeHints are only needed for Java API, Scala API doesn't need them
+      "org.apache.flink.api.java.operators.SingleInputUdfOperator.returns",
+      "org.apache.flink.api.java.operators.TwoInputUdfOperator.returns",
+
       // This is really just a mapper, which in Scala can easily expressed as a map lambda
       "org.apache.flink.api.java.DataSet.writeAsFormattedText",
 


### PR DESCRIPTION
This buils upon pull request #203 by @twalthr 
The additions here are
 - Make MissingTypeInfo optional in TypeExtractor (by default still throws exception)
 - Simplified deferred evaluation of type dependend code by making evaluations lazy
 - Add call location function names to MissingTypeInfo error messages.
 - Improvements on other error messages.