### PR TITLE
[FLINK-1320] Add an off-heap variant of the managed memory

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -141,6 +141,14 @@ JVM's heap space for internal data buffers, leaving 20% of the JVM's heap space
 free for objects created by user-defined functions. (DEFAULT: 0.7)
 This parameter is only evaluated, if `taskmanager.memory.size` is not set.
 
+- `taskmanager.memory.allocateDirectly`: If set to true, the task manager will
+allocate memory outside of the JVM heap (DEFAULT: false). When memory is allocated
+outside the JVM heap, it is not subject to the garbage collector. Also, the data
+does not have to be copied out of the JVM to exchange it with other processes.
+Depending on the user program, this can increase the performance of the runtime.
+The amount of memory allocated must be set by specifying `taskmanager.memory.size`.
+Otherwise, a fraction of the heap memory will be used as a reference to determine
+the size of the memory (`taskmanager.memory.fraction`).
 
 ## Full Reference
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -101,6 +101,11 @@ public final class ConfigConstants {
 	 * by {@link #TASK_MANAGER_MEMORY_FRACTION_KEY}.
 	 */
 	public static final String TASK_MANAGER_MEMORY_SIZE_KEY = "taskmanager.memory.size";
+
+	/**
+	 * The config parameter defining the memory allocation method (JVM heap or direct).
+	 */
+	public static final String TASK_MANAGER_MEMORY_DIRECT_ALLOCATION_KEY = "taskmanager.memory.directAllocation";
 	
 	/**
 	 * The config parameter defining the fraction of free memory allocated by the memory manager.
@@ -417,6 +422,11 @@ public final class ConfigConstants {
 	 * The default directory for temporary files of the task manager.
 	 */
 	public static final String DEFAULT_TASK_MANAGER_TMP_PATH = System.getProperty("java.io.tmpdir");
+
+	/**
+	 * The default flag whether memory should be allocated in JVM heap or directly.
+	 */
+	public static final boolean DEFAULT_TASK_MANAGER_MEMORY_DIRECT_ALLOCATION = false;
 	
 	/**
 	 * The default fraction of the free memory allocated by the task manager's memory manager.

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -1,0 +1,549 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+
+//
+//  TESTS NEEDED
+//
+//  - All get and put method for primitives
+//    - in range aligned address
+//    - in range unaligned address
+//    - out of range (< 0 pos and >= size pos)
+//    - on disposed buffer in range
+//    - on disposed buffer out of range (< 0 pos and >= size pos)
+// 
+//  - get and put methods with byte buffers :
+//    - with direct byte buffers
+//    - with heap byte buffers
+//    - with sliced direct byte buffers
+//    - with sliced heap byte buffers
+//    - out of range and in range
+//
+//
+//
+
+/**
+ * This class uses in parts code from Java's direct byte buffer API.
+ * 
+ * The use in this class two crucial additions:
+ *  - It uses collapsed checks for range check and memory segment disposal.
+ *  - It offers absolute positioning methods for byte array put/get methods, to guarantee thread safe use.
+ *  
+ * In addition, the code that uses this class should make sure that only one implementation class is ever loaded -
+ * Either the {@link HeapMemorySegment}, or this DirectMemorySegment. That way, all the abstract methods in the
+ * MemorySegment base class have only one loaded actual implementation. This is easy for the JIT to recognize through
+ * class hierarchy analysis, or by identifying that the invocations are monomorphic (all go to the same concrete
+ * method implementation). Under this precondition, the JIT can perfectly inline methods.
+ * 
+ * This is harder to do and control with byte buffers, where different code paths use different versions of the class
+ * (heap, direct, mapped) and thus virtual method invocations are polymorphic and are not as easily inlined.
+ */
+public final class DirectMemorySegment extends MemorySegment {
+	
+	/** The direct byte buffer that allocated the memory */
+	private final ByteBuffer buffer;
+	
+	/** The address to the off-heap data */
+	private long address;
+	
+	/** The address one byte after the last addressable byte.
+	 *  This is address + size while the segment is not disposed */
+	private final long addressLimit;
+	
+	/** The size in bytes of the memory segment */
+	private final int size;
+	
+	// -------------------------------------------------------------------------
+	//                             Constructors
+	// -------------------------------------------------------------------------
+
+	public DirectMemorySegment(int size) {
+		this(ByteBuffer.allocateDirect(size));
+	}
+
+	public DirectMemorySegment(ByteBuffer buffer) {
+		if (buffer == null || !buffer.isDirect()) {
+			throw new IllegalArgumentException();
+		}
+		
+		this.buffer = buffer;
+		this.size = buffer.capacity();
+		this.address = getAddress(buffer);
+		this.addressLimit = this.address + size;
+		
+		if (address >= Long.MAX_VALUE - Integer.MAX_VALUE) {
+			throw new RuntimeException("Segment initialized with too large address: " + address);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	//                        MemorySegment Accessors
+	// -------------------------------------------------------------------------
+	
+
+	@Override
+	public final boolean isFreed() {
+		return this.address <= this.addressLimit;
+	}
+
+	public final void free() {
+		// this ensures we can place no more data and trigger
+		// the checks for the freed segment
+		this.address = this.addressLimit + 1;
+	}
+	
+	@Override
+	public final int size() {
+		return this.size;
+	}
+
+	@Override
+	public ByteBuffer wrap(int offset, int length) {
+		if (offset < 0 || offset > this.size || offset > this.size - length) {
+			throw new IndexOutOfBoundsException();
+		}
+		
+		this.buffer.limit(offset + length);
+		this.buffer.position(offset);
+		
+		return this.buffer;
+	}
+
+
+	// ------------------------------------------------------------------------
+	//                    Random Access get() and put() methods
+	// ------------------------------------------------------------------------
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final byte get(int index) {
+		
+		final long pos = address + index;
+		if (index >= 0 && pos < addressLimit) {
+			return UNSAFE.getByte(pos);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void put(int index, byte b) {
+		
+		final long pos = address + index;
+		if (index >= 0 && pos < addressLimit) {
+			UNSAFE.putByte(pos, b);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	public final void get(int index, byte[] dst) {
+		get(index, dst, 0, dst.length);
+	}
+
+	@Override
+	public final void put(int index, byte[] src) {
+		put(index, src, 0, src.length);
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void get(int index, byte[] dst, int offset, int length) {
+		
+		// check the byte array offset and length
+		if ((offset | length | (offset + length) | (dst.length - (offset + length))) < 0) {
+			throw new IndexOutOfBoundsException();
+		}
+		
+		long pos = address + index;
+		
+		if (index >= 0 && pos < addressLimit - length) {
+			long arrayAddress = BYTE_ARRAY_BASE_OFFSET + offset;
+			
+			// the copy must proceed in batches not too large, because the JVM may
+			// poll for points that are safe for GC (moving the array and changing its address)
+			while (length > 0) {
+				long toCopy = (length > COPY_PER_BATCH) ? COPY_PER_BATCH : length;
+				UNSAFE.copyMemory(null, pos, dst, arrayAddress, toCopy);
+				length -= toCopy;
+				pos += toCopy;
+				arrayAddress += toCopy;
+			}
+		}
+		else if (address <= 0) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void put(int index, byte[] src, int offset, int length) {
+		// check the byte array offset and length
+		if ((offset | length | (offset + length) | (src.length - (offset + length))) < 0) {
+			throw new IndexOutOfBoundsException();
+		}
+		
+		long pos = address + index;
+		
+		if (index >= 0 && pos < addressLimit - length) {
+		
+			long arrayAddress = BYTE_ARRAY_BASE_OFFSET + offset;
+			while (length > 0) {
+				long toCopy = (length > COPY_PER_BATCH) ? COPY_PER_BATCH : length;
+				UNSAFE.copyMemory(src, arrayAddress, null, pos, toCopy);
+				length -= toCopy;
+				pos += toCopy;
+				arrayAddress += toCopy;
+			}
+		}
+		else if (address <= 0) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	public final boolean getBoolean(int index) {
+		return get(index) != 0;
+	}
+
+	@Override
+	public final void putBoolean(int index, boolean value) {
+		put(index, (byte) (value ? 1 : 0));
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final char getChar(int index) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 2) {
+			return UNSAFE.getChar(pos);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putChar(int index, char value) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 2) {
+			UNSAFE.putChar(pos, value);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final short getShort(int index) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 2) {
+			return UNSAFE.getShort(pos);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putShort(int index, short value) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 2) {
+			UNSAFE.putShort(pos, value);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final int getInt(int index) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 4) {
+			return UNSAFE.getInt(pos);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putInt(int index, int value) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 4) {
+			UNSAFE.putInt(pos, value);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final long getLong(int index) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 8) {
+			return UNSAFE.getLong(pos);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putLong(int index, long value) {
+		final long pos = address + index;
+		if (index >= 0 && pos <= addressLimit - 8) {
+			UNSAFE.putLong(pos, value);
+		}
+		else if (address > addressLimit) {
+			throw new IllegalStateException("disposed");
+		}
+		else {
+			// index is in fact invalid
+			throw new IndexOutOfBoundsException();
+		}
+	}
+	
+	// -------------------------------------------------------------------------
+	//                     Bulk Read and Write Methods
+	// -------------------------------------------------------------------------
+	
+	@Override
+	public final void get(DataOutput out, int offset, int length) throws IOException {
+		throw new UnsupportedOperationException("not implemented");
+	}
+
+	@Override
+	public final void put(DataInput in, int offset, int length) throws IOException {
+		throw new UnsupportedOperationException("not implemented");
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final void get(int offset, ByteBuffer target, int numBytes) {
+		
+		// check the byte array offset and length
+		if ((offset | numBytes | (offset + numBytes) | (size - (offset + numBytes))) < 0) {
+			throw new IndexOutOfBoundsException();
+		}
+		
+		final int targetOffset = target.position();
+		final int remaining = target.remaining();
+		
+		if (remaining < numBytes) {
+			throw new BufferOverflowException();
+		}
+		
+		if (target.isDirect()) {
+			// copy to the target memory directly
+			final long targetPointer = getAddress(target) + targetOffset;
+			final long sourcePointer = address + offset;
+			
+			if (sourcePointer <= addressLimit - numBytes) {
+				UNSAFE.copyMemory(sourcePointer, targetPointer, numBytes);
+			}
+			else if (address > addressLimit) {
+				throw new IllegalStateException("disposed");
+			}
+			else {
+				throw new IndexOutOfBoundsException();
+			}
+		}
+		else if (target.hasArray()) {
+			// move directly into the byte array
+			get(offset, target.array(), targetOffset + target.arrayOffset(), numBytes);
+			
+			// this must be after the get() call to ensue that the byte buffer is not
+			// modified in case the call fails
+			target.position(targetOffset + numBytes);
+		}
+		else {
+			// neither heap buffer nor direct buffer
+			while (target.hasRemaining()) {
+				target.put(get(offset++));
+			}
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final void put(int offset, ByteBuffer source, int numBytes) {
+		
+		// check the byte array offset and length
+		if ((offset | numBytes | (offset + numBytes) | (size - (offset + numBytes))) < 0) {
+			throw new IndexOutOfBoundsException();
+		}
+		
+		final int sourceOffset = source.position();
+		final int remaining = source.remaining();
+		
+		if (remaining < numBytes) {
+			throw new BufferUnderflowException();
+		}
+		
+		if (source.isDirect()) {
+			// copy to the target memory directly
+			final long sourcePointer = getAddress(source) + sourceOffset;
+			final long targetPointer = address + offset;
+			
+			if (sourcePointer <= addressLimit - numBytes) {
+				UNSAFE.copyMemory(sourcePointer, targetPointer, numBytes);
+			}
+			else if (address > addressLimit) {
+				throw new IllegalStateException("disposed");
+			}
+			else {
+				throw new IndexOutOfBoundsException();
+			}
+		}
+		else if (source.hasArray()) {
+			// move directly into the byte array
+			put(offset, source.array(), sourceOffset + source.arrayOffset(), numBytes);
+			
+			// this must be after the get() call to ensue that the byte buffer is not
+			// modified in case the call fails
+			source.position(sourceOffset + numBytes);
+		}
+		else {
+			// neither heap buffer nor direct buffer
+			while (source.hasRemaining()) {
+				put(offset++, source.get());
+			}
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final void copyTo(int offset, MemorySegment target, int targetOffset, int numBytes) {
+		if (target.getClass() == DirectMemorySegment.class) {
+			DirectMemorySegment directOther = (DirectMemorySegment) target;
+			
+			final long thisPointer = address + offset;
+			final long otherPointer = directOther.address + targetOffset;
+			
+			if (numBytes >= 0 && thisPointer <= addressLimit - numBytes && otherPointer <= directOther.addressLimit - numBytes) {
+				UNSAFE.copyMemory(thisPointer, otherPointer, numBytes);
+			}
+			else if (address > addressLimit || directOther.address > directOther.addressLimit) {
+				throw new IllegalStateException("disposed");
+			}
+			else {
+				throw new IndexOutOfBoundsException();
+			}
+		}
+		else {
+			throw new IllegalArgumentException("Can only copy to other direct memory segments");
+		}
+	}
+	
+	// --------------------------------------------------------------------------------------------
+	//                     Utilities for native memory accesses and checks
+	// --------------------------------------------------------------------------------------------
+	
+	@SuppressWarnings("restriction")
+	private static final sun.misc.Unsafe UNSAFE = MemoryUtils.UNSAFE;
+	
+	@SuppressWarnings("restriction")
+	private static final long BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+	
+	private static final long COPY_PER_BATCH = 1024 * 1024;
+	
+	private static final Field ADDRESS_FIELD;
+	
+	static {
+		try {
+			ADDRESS_FIELD = java.nio.Buffer.class.getDeclaredField("address");
+			ADDRESS_FIELD.setAccessible(true);
+		}
+		catch (Throwable t) {
+			throw new RuntimeException("Cannot initialize DirectMemorySegment - direct memory not supported by Flink");
+		}
+	}
+	
+	private static long getAddress(ByteBuffer buf) {
+		try {
+			return (Long) ADDRESS_FIELD.get(buf);
+		} catch (Throwable t) {
+			throw new RuntimeException("Could not access direct byte buffer address.", t);
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -62,10 +62,10 @@ import java.nio.ByteBuffer;
  * This is harder to do and control with byte buffers, where different code paths use different versions of the class
  * (heap, direct, mapped) and thus virtual method invocations are polymorphic and are not as easily inlined.
  */
-public final class DirectMemorySegment extends MemorySegment {
+public class DirectMemorySegment extends MemorySegment {
 	
 	/** The direct byte buffer that allocated the memory */
-	private final ByteBuffer buffer;
+	protected final ByteBuffer buffer;
 	
 	/** The address to the off-heap data */
 	private long address;

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -369,12 +369,30 @@ public class DirectMemorySegment extends MemorySegment {
 	
 	@Override
 	public final void get(DataOutput out, int offset, int length) throws IOException {
-		throw new UnsupportedOperationException("not implemented");
+		while(length >= 8) {
+			out.writeLong(getLong(offset));
+			offset += 8;
+			length -= 8;
+		}
+		while(length > 0) {
+			out.writeByte(get(offset));
+			offset++;
+			length--;
+		}
 	}
 
 	@Override
 	public final void put(DataInput in, int offset, int length) throws IOException {
-		throw new UnsupportedOperationException("not implemented");
+		while(length >= 8) {
+			putLong(offset, in.readLong());
+			offset += 8;
+			length -= 8;
+		}
+		while(length > 0) {
+			put(offset, in.readByte());
+			offset++;
+			length--;
+		}
 	}
 	
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -67,7 +67,7 @@ public class DirectMemorySegment extends MemorySegment {
 
 	public DirectMemorySegment(ByteBuffer buffer) {
 		if (buffer == null || !buffer.isDirect()) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Can't initialize from non-direct ByteBuffer.");
 		}
 		
 		this.buffer = buffer;

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -26,26 +26,6 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
-//
-//  TESTS NEEDED
-//
-//  - All get and put method for primitives
-//    - in range aligned address
-//    - in range unaligned address
-//    - out of range (< 0 pos and >= size pos)
-//    - on disposed buffer in range
-//    - on disposed buffer out of range (< 0 pos and >= size pos)
-// 
-//  - get and put methods with byte buffers :
-//    - with direct byte buffers
-//    - with heap byte buffers
-//    - with sliced direct byte buffers
-//    - with sliced heap byte buffers
-//    - out of range and in range
-//
-//
-//
-
 /**
  * This class uses in parts code from Java's direct byte buffer API.
  * 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -193,7 +193,7 @@ public final class DirectMemorySegment extends MemorySegment {
 		
 		long pos = address + index;
 		
-		if (index >= 0 && pos < addressLimit - length) {
+		if (index >= 0 && pos <= addressLimit - length) {
 			long arrayAddress = BYTE_ARRAY_BASE_OFFSET + offset;
 			
 			// the copy must proceed in batches not too large, because the JVM may
@@ -225,7 +225,7 @@ public final class DirectMemorySegment extends MemorySegment {
 		
 		long pos = address + index;
 		
-		if (index >= 0 && pos < addressLimit - length) {
+		if (index >= 0 && pos <= addressLimit - length) {
 		
 			long arrayAddress = BYTE_ARRAY_BASE_OFFSET + offset;
 			while (length > 0) {

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -127,7 +127,7 @@ public class DirectMemorySegment extends MemorySegment {
 			return UNSAFE.getByte(pos);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -144,7 +144,7 @@ public class DirectMemorySegment extends MemorySegment {
 			UNSAFE.putByte(pos, b);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -187,7 +187,7 @@ public class DirectMemorySegment extends MemorySegment {
 			}
 		}
 		else if (address <= 0) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -217,7 +217,7 @@ public class DirectMemorySegment extends MemorySegment {
 			}
 		}
 		else if (address <= 0) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -243,7 +243,7 @@ public class DirectMemorySegment extends MemorySegment {
 			return UNSAFE.getChar(pos);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -259,7 +259,7 @@ public class DirectMemorySegment extends MemorySegment {
 			UNSAFE.putChar(pos, value);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -275,7 +275,7 @@ public class DirectMemorySegment extends MemorySegment {
 			return UNSAFE.getShort(pos);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -291,7 +291,7 @@ public class DirectMemorySegment extends MemorySegment {
 			UNSAFE.putShort(pos, value);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -307,7 +307,7 @@ public class DirectMemorySegment extends MemorySegment {
 			return UNSAFE.getInt(pos);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -323,7 +323,7 @@ public class DirectMemorySegment extends MemorySegment {
 			UNSAFE.putInt(pos, value);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -339,7 +339,7 @@ public class DirectMemorySegment extends MemorySegment {
 			return UNSAFE.getLong(pos);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -355,7 +355,7 @@ public class DirectMemorySegment extends MemorySegment {
 			UNSAFE.putLong(pos, value);
 		}
 		else if (address > addressLimit) {
-			throw new IllegalStateException("disposed");
+			throw new IllegalStateException("This segment has been freed.");
 		}
 		else {
 			// index is in fact invalid
@@ -420,7 +420,7 @@ public class DirectMemorySegment extends MemorySegment {
 				UNSAFE.copyMemory(sourcePointer, targetPointer, numBytes);
 			}
 			else if (address > addressLimit) {
-				throw new IllegalStateException("disposed");
+				throw new IllegalStateException("This segment has been freed.");
 			}
 			else {
 				throw new IndexOutOfBoundsException();
@@ -467,7 +467,7 @@ public class DirectMemorySegment extends MemorySegment {
 				UNSAFE.copyMemory(sourcePointer, targetPointer, numBytes);
 			}
 			else if (address > addressLimit) {
-				throw new IllegalStateException("disposed");
+				throw new IllegalStateException("This segment has been freed.");
 			}
 			else {
 				throw new IndexOutOfBoundsException();
@@ -502,7 +502,7 @@ public class DirectMemorySegment extends MemorySegment {
 				UNSAFE.copyMemory(thisPointer, otherPointer, numBytes);
 			}
 			else if (address > addressLimit || directOther.address > directOther.addressLimit) {
-				throw new IllegalStateException("disposed");
+				throw new IllegalStateException("This segment has been freed.");
 			}
 			else {
 				throw new IndexOutOfBoundsException();
@@ -581,7 +581,7 @@ public class DirectMemorySegment extends MemorySegment {
 			ADDRESS_FIELD.setAccessible(true);
 		}
 		catch (Throwable t) {
-			throw new RuntimeException("Cannot initialize DirectMemorySegment - direct memory not supported by Flink");
+			throw new RuntimeException("Cannot initialize DirectMemorySegment - direct memory not supported by the JVM.");
 		}
 	}
 	

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -107,7 +107,7 @@ public final class DirectMemorySegment extends MemorySegment {
 
 	@Override
 	public final boolean isFreed() {
-		return this.address <= this.addressLimit;
+		return this.address > this.addressLimit;
 	}
 
 	public final void free() {

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DirectMemorySegment.java
@@ -514,7 +514,55 @@ public final class DirectMemorySegment extends MemorySegment {
 			throw new IllegalArgumentException("Can only copy to other direct memory segments");
 		}
 	}
-	
+
+	@Override
+	// CAUTION: current implementation works only when data is stored in big endian format
+	public int compare(MemorySegment seg2, int offset1, int offset2, int len) {
+		while(len >= 8) {
+			long b1 = this.getLong(offset1);
+			long b2 = seg2.getLong(offset2);
+			int cmp = Long.compare(b1, b2);
+			if (cmp != 0) {
+				return cmp;
+			}
+			offset1 += 8;
+			offset2 += 8;
+			len -= 8;
+		}
+		while(len > 0) {
+			byte b1 = this.get(offset1);
+			byte b2 = seg2.get(offset2);
+			int cmp = Byte.compare(b1, b2);
+			if (cmp != 0) {
+				return cmp;
+			}
+			offset1++;
+			offset2++;
+			len--;
+		}
+		return 0;
+	}
+
+	@Override
+	public void swapBytes(MemorySegment seg2, int offset1, int offset2, int len) {
+		while(len >= 8) {
+			long tmp = this.getLong(offset1);
+			this.putLong(offset1, seg2.getLong(offset2));
+			seg2.putLong(offset2, tmp);
+			offset1+=8;
+			offset2+=8;
+			len-=8;
+		}
+		while(len > 0) {
+			byte tmp = this.get(offset1);
+			this.put(offset1, seg2.get(offset2));
+			seg2.put(offset2, tmp);
+			offset1++;
+			offset2++;
+			len--;
+		}
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//                     Utilities for native memory accesses and checks
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * This class represents a piece of memory allocated from the memory manager. The segment is backed
+ * by a byte array and features random put and get methods for the basic types that are stored in a byte-wise
+ * fashion in the memory.
+ * 
+ * <p>
+ * 
+ * Comments on the implementation: We make heavy use of operations that are supported by native
+ * instructions, to achieve a high efficiency. Multi byte types (int, long, float, double, ...)
+ * are read and written with "unsafe" native commands. Little-endian to big-endian conversion and
+ * vice versa are done using the static <i>reverseBytes</i> methods in the boxing data types
+ * (for example {@link Integer#reverseBytes(int)}). On x86/amd64, these are translated by the
+ * jit compiler to <i>bswap</i> intrinsic commands.
+ * 
+ * Below is an example of the code generated for the {@link HeapMemorySegment#putLongBigEndian(int, long)}
+ * function by the just-in-time compiler. The code is grabbed from an oracle jvm 7 using the
+ * hotspot disassembler library (hsdis32.dll) and the jvm command
+ * <i>-XX:+UnlockDiagnosticVMOptions -XX:CompileCommand=print,*UnsafeMemorySegment.putLongBigEndian</i>.
+ * Note that this code realizes both the byte order swapping and the reinterpret cast access to
+ * get a long from the byte array.
+ * 
+ * <pre>
+ * [Verified Entry Point]
+ *   0x00007fc403e19920: sub    $0x18,%rsp
+ *   0x00007fc403e19927: mov    %rbp,0x10(%rsp)    ;*synchronization entry
+ *                                                 ; - org.apache.flink.runtime.memory.UnsafeMemorySegment::putLongBigEndian@-1 (line 652)
+ *   0x00007fc403e1992c: mov    0xc(%rsi),%r10d    ;*getfield memory
+ *                                                 ; - org.apache.flink.runtime.memory.UnsafeMemorySegment::putLong@4 (line 611)
+ *                                                 ; - org.apache.flink.runtime.memory.UnsafeMemorySegment::putLongBigEndian@12 (line 653)
+ *   0x00007fc403e19930: bswap  %rcx
+ *   0x00007fc403e19933: shl    $0x3,%r10
+ *   0x00007fc403e19937: movslq %edx,%r11
+ *   0x00007fc403e1993a: mov    %rcx,0x10(%r10,%r11,1)  ;*invokevirtual putLong
+ *                                                 ; - org.apache.flink.runtime.memory.UnsafeMemorySegment::putLong@14 (line 611)
+ *                                                 ; - org.apache.flink.runtime.memory.UnsafeMemorySegment::putLongBigEndian@12 (line 653)
+ *   0x00007fc403e1993f: add    $0x10,%rsp
+ *   0x00007fc403e19943: pop    %rbp
+ *   0x00007fc403e19944: test   %eax,0x5ba76b6(%rip)        # 0x00007fc4099c1000
+ *                                                 ;   {poll_return}
+ *   0x00007fc403e1994a: retq 
+ * </pre>
+ */
+public final class HeapMemorySegment extends MemorySegment {
+	
+	// flag to enable / disable boundary checks. Note that the compiler eliminates the
+	// code paths of the checks (as dead code) when this constant is set to false.
+	private static final boolean CHECKED = true;
+	
+	/** The array in which the data is stored. */
+	protected byte[] memory;
+	
+	/** Wrapper for I/O requests. */
+	protected ByteBuffer wrapper;
+	
+	// -------------------------------------------------------------------------
+	//                             Constructors
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Creates a new memory segment that represents the data in the given byte array.
+	 * 
+	 * @param memory The byte array that holds the data.
+	 */
+	public HeapMemorySegment(byte[] memory) {
+		this.memory = memory;
+	}
+
+	// -------------------------------------------------------------------------
+	//                        MemorySegment Accessors
+	// -------------------------------------------------------------------------
+	
+
+	@Override
+	public final boolean isFreed() {
+		return this.memory == null;
+	}
+
+	public final void free() {
+		this.wrapper = null;
+		this.memory = null;
+	}
+	
+	@Override
+	public final int size() {
+		return this.memory.length;
+	}
+
+	@Override
+	public ByteBuffer wrap(int offset, int length) {
+		if (offset > this.memory.length || offset > this.memory.length - length) {
+			throw new IndexOutOfBoundsException();
+		}
+		
+		if (this.wrapper == null) {
+			this.wrapper = ByteBuffer.wrap(this.memory, offset, length);
+		}
+		else {
+			this.wrapper.limit(offset + length);
+			this.wrapper.position(offset);
+		}
+		
+		return this.wrapper;
+	}
+
+
+	// ------------------------------------------------------------------------
+	//                    Random Access get() and put() methods
+	// ------------------------------------------------------------------------
+
+	// --------------------------------------------------------------------------------------------
+	// WARNING: Any code for range checking must take care to avoid integer overflows. The position
+	// integer may go up to <code>Integer.MAX_VALUE</tt>. Range checks that work after the principle
+	// <code>position + 3 &lt; end</code> may fail because <code>position + 3</code> becomes negative.
+	// A safe solution is to subtract the delta from the limit, for example
+	// <code>position &lt; end - 3</code>. Since all indices are always positive, and the integer domain
+	// has one more negative value than positive values, this can never cause an underflow.
+	// --------------------------------------------------------------------------------------------
+
+
+	@Override
+	public final byte get(int index) {
+		return this.memory[index];
+	}
+
+	@Override
+	public final void put(int index, byte b) {
+		this.memory[index] = b;
+	}
+
+	@Override
+	public final void get(int index, byte[] dst) {
+		get(index, dst, 0, dst.length);
+	}
+
+	@Override
+	public final void put(int index, byte[] src) {
+		put(index, src, 0, src.length);
+	}
+
+	@Override
+	public final void get(int index, byte[] dst, int offset, int length) {
+		// system arraycopy does the boundary checks anyways, no need to check extra
+		System.arraycopy(this.memory, index, dst, offset, length);
+	}
+
+	@Override
+	public final void put(int index, byte[] src, int offset, int length) {
+		// system arraycopy does the boundary checks anyways, no need to check extra
+		System.arraycopy(src, offset, this.memory, index, length);
+	}
+
+	@Override
+	public final boolean getBoolean(int index) {
+		return this.memory[index] != 0;
+	}
+
+	@Override
+	public final void putBoolean(int index, boolean value) {
+		this.memory[index] = (byte) (value ? 1 : 0);
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final char getChar(int index) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 2) {
+				return UNSAFE.getChar(this.memory, BASE_OFFSET + index);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			return UNSAFE.getChar(this.memory, BASE_OFFSET + index);
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putChar(int index, char value) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 2) {
+				UNSAFE.putChar(this.memory, BASE_OFFSET + index, value);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			UNSAFE.putChar(this.memory, BASE_OFFSET + index, value);
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final short getShort(int index) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 2) {
+				return UNSAFE.getShort(this.memory, BASE_OFFSET + index);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			return UNSAFE.getShort(this.memory, BASE_OFFSET + index);
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putShort(int index, short value) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 2) {
+				UNSAFE.putShort(this.memory, BASE_OFFSET + index, value);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			UNSAFE.putShort(this.memory, BASE_OFFSET + index, value);
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final int getInt(int index) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 4) {
+				return UNSAFE.getInt(this.memory, BASE_OFFSET + index);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			return UNSAFE.getInt(this.memory, BASE_OFFSET + index);
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putInt(int index, int value) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 4) {
+				UNSAFE.putInt(this.memory, BASE_OFFSET + index, value);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			UNSAFE.putInt(this.memory, BASE_OFFSET + index, value);
+		}
+	}
+	
+	@Override
+	@SuppressWarnings("restriction")
+	public final long getLong(int index) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 8) {
+				return UNSAFE.getLong(this.memory, BASE_OFFSET + index);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			return UNSAFE.getLong(this.memory, BASE_OFFSET + index);
+		}
+	}
+
+	@Override
+	@SuppressWarnings("restriction")
+	public final void putLong(int index, long value) {
+		if (CHECKED) {
+			if (index >= 0 && index <= this.memory.length - 8) {
+				UNSAFE.putLong(this.memory, BASE_OFFSET + index, value);
+			} else {
+				throw new IndexOutOfBoundsException();
+			}
+		} else {
+			UNSAFE.putLong(this.memory, BASE_OFFSET + index, value);
+		}
+	}
+	
+	// -------------------------------------------------------------------------
+	//                     Bulk Read and Write Methods
+	// -------------------------------------------------------------------------
+	
+	@Override
+	public final void get(DataOutput out, int offset, int length) throws IOException {
+		out.write(this.memory, offset, length);
+	}
+
+	@Override
+	public final void put(DataInput in, int offset, int length) throws IOException {
+		in.readFully(this.memory, offset, length);
+	}
+	
+	@Override
+	public final void get(int offset, ByteBuffer target, int numBytes) {
+		// ByteBuffer performs the boundy checks
+		target.put(this.memory, offset, numBytes);
+	}
+	
+	@Override
+	public final void put(int offset, ByteBuffer source, int numBytes) {
+		// ByteBuffer performs the boundy checks
+		source.get(this.memory, offset, numBytes);
+	}
+	
+	@Override
+	public final void copyTo(int offset, MemorySegment target, int targetOffset, int numBytes) {
+		// system arraycopy does the boundary checks anyways, no need to check extra
+		System.arraycopy(this.memory, offset, ((HeapMemorySegment) target).memory, targetOffset, numBytes);
+	}
+	
+	// -------------------------------------------------------------------------
+	//                      Comparisons & Swapping
+	// -------------------------------------------------------------------------
+	
+//	public final int compare(MemorySegment seg1, MemorySegment seg2, int offset1, int offset2, int len) {
+//		final byte[] b1 = seg1.memory;
+//		final byte[] b2 = seg2.memory;
+//		
+//		int val = 0;
+//		for (int pos = 0; pos < len && (val = (b1[offset1 + pos] & 0xff) - (b2[offset2 + pos] & 0xff)) == 0; pos++);
+//		return val;
+//	}
+//	
+//	public final void swapBytes(MemorySegment seg1, MemorySegment seg2, byte[] tempBuffer, int offset1, int offset2, int len) {
+//		// system arraycopy does the boundary checks anyways, no need to check extra
+//		System.arraycopy(seg1.memory, offset1, tempBuffer, 0, len);
+//		System.arraycopy(seg2.memory, offset2, seg1.memory, offset1, len);
+//		System.arraycopy(tempBuffer, 0, seg2.memory, offset2, len);
+//	}
+	
+	// --------------------------------------------------------------------------------------------
+	//                     Utilities for native memory accesses and checks
+	// --------------------------------------------------------------------------------------------
+	
+	@SuppressWarnings("restriction")
+	private static final sun.misc.Unsafe UNSAFE = MemoryUtils.UNSAFE;
+	
+	@SuppressWarnings("restriction")
+	private static final long BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+}

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
@@ -65,7 +65,7 @@ import java.nio.ByteBuffer;
  *   0x00007fc403e1994a: retq 
  * </pre>
  */
-public final class HeapMemorySegment extends MemorySegment {
+public class HeapMemorySegment extends MemorySegment {
 	
 	// flag to enable / disable boundary checks. Note that the compiler eliminates the
 	// code paths of the checks (as dead code) when this constant is set to false.
@@ -332,21 +332,23 @@ public final class HeapMemorySegment extends MemorySegment {
 	//                      Comparisons & Swapping
 	// -------------------------------------------------------------------------
 	
-//	public final int compare(MemorySegment seg1, MemorySegment seg2, int offset1, int offset2, int len) {
-//		final byte[] b1 = seg1.memory;
-//		final byte[] b2 = seg2.memory;
-//		
-//		int val = 0;
-//		for (int pos = 0; pos < len && (val = (b1[offset1 + pos] & 0xff) - (b2[offset2 + pos] & 0xff)) == 0; pos++);
-//		return val;
-//	}
-//	
-//	public final void swapBytes(MemorySegment seg1, MemorySegment seg2, byte[] tempBuffer, int offset1, int offset2, int len) {
-//		// system arraycopy does the boundary checks anyways, no need to check extra
-//		System.arraycopy(seg1.memory, offset1, tempBuffer, 0, len);
-//		System.arraycopy(seg2.memory, offset2, seg1.memory, offset1, len);
-//		System.arraycopy(tempBuffer, 0, seg2.memory, offset2, len);
-//	}
+	public static int compare(MemorySegment seg1, MemorySegment seg2, int offset1, int offset2, int len) {
+		final byte[] b1 = ((HeapMemorySegment)seg1).memory;
+		final byte[] b2 = ((HeapMemorySegment)seg2).memory;
+
+		int val = 0;
+		for (int pos = 0; pos < len && (val = (b1[offset1 + pos] & 0xff) - (b2[offset2 + pos] & 0xff)) == 0; pos++);
+		return val;
+	}
+
+	public static void swapBytes(MemorySegment seg1, MemorySegment seg2, byte[] tempBuffer, int offset1, int offset2, int len) {
+		final byte[] b1 = ((HeapMemorySegment)seg1).memory;
+		final byte[] b2 = ((HeapMemorySegment)seg2).memory;
+		// system arraycopy does the boundary checks anyways, no need to check extra
+		System.arraycopy(b1, offset1, tempBuffer, 0, len);
+		System.arraycopy(b2, offset2, b1, offset1, len);
+		System.arraycopy(tempBuffer, 0, b2, offset2, len);
+	}
 	
 	// --------------------------------------------------------------------------------------------
 	//                     Utilities for native memory accesses and checks

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
@@ -331,9 +331,10 @@ public class HeapMemorySegment extends MemorySegment {
 	// -------------------------------------------------------------------------
 	//                      Comparisons & Swapping
 	// -------------------------------------------------------------------------
-	
-	public static int compare(MemorySegment seg1, MemorySegment seg2, int offset1, int offset2, int len) {
-		final byte[] b1 = ((HeapMemorySegment)seg1).memory;
+
+	// CAUTION: current implementation works only when data is stored in big endian format
+	public int compare(MemorySegment seg2, int offset1, int offset2, int len) {
+		final byte[] b1 = this.memory;
 		final byte[] b2 = ((HeapMemorySegment)seg2).memory;
 
 		int val = 0;
@@ -341,13 +342,23 @@ public class HeapMemorySegment extends MemorySegment {
 		return val;
 	}
 
-	public static void swapBytes(MemorySegment seg1, MemorySegment seg2, byte[] tempBuffer, int offset1, int offset2, int len) {
-		final byte[] b1 = ((HeapMemorySegment)seg1).memory;
-		final byte[] b2 = ((HeapMemorySegment)seg2).memory;
-		// system arraycopy does the boundary checks anyways, no need to check extra
-		System.arraycopy(b1, offset1, tempBuffer, 0, len);
-		System.arraycopy(b2, offset2, b1, offset1, len);
-		System.arraycopy(tempBuffer, 0, b2, offset2, len);
+	public void swapBytes(MemorySegment seg2, int offset1, int offset2, int len) {
+		while(len >= 8) {
+			long tmp = this.getLong(offset1);
+			this.putLong(offset1, seg2.getLong(offset2));
+			seg2.putLong(offset2, tmp);
+			offset1 += 8;
+			offset2 += 8;
+			len -= 8;
+		}
+		while(len > 0) {
+			byte tmp = this.get(offset1);
+			this.put(offset1, seg2.get(offset2));
+			seg2.put(offset2, tmp);
+			offset1++;
+			offset2++;
+			len--;
+		}
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -817,4 +817,5 @@ public abstract class MemorySegment {
 //	public abstract int compare(MemorySegment seg1, MemorySegment seg2, int offset1, int offset2, int len);
 //	
 //	public abstract void swapBytes(MemorySegment seg1, MemorySegment seg2, byte[] tempBuffer, int offset1, int offset2, int len);
+
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -813,9 +813,24 @@ public abstract class MemorySegment {
 	// -------------------------------------------------------------------------
 	//                      Comparisons & Swapping
 	// -------------------------------------------------------------------------
-	
-//	public abstract int compare(MemorySegment seg1, MemorySegment seg2, int offset1, int offset2, int len);
-//	
-//	public abstract void swapBytes(MemorySegment seg1, MemorySegment seg2, byte[] tempBuffer, int offset1, int offset2, int len);
+
+	/**
+	 * Compares two memory segment regions
+	 * @return 0 if equal, -1 if seg1 < seg2, 1 otherwise
+	 * @param seg2 Segment to compare this segment with
+	 * @param offset1 Offset of this segment to start comparing
+	 * @param offset2 Offset of seg2 to start comparing
+	 * @param len Length of the compared memory region
+	 */
+	public abstract int compare(MemorySegment seg2, int offset1, int offset2, int len);
+
+	/**
+	 * Swaps bytes between two memory segments
+	 * @param seg2 Segment to swap bytes with
+	 * @param offset1 Offset of this segment to start swapping
+	 * @param offset2 Offset of seg2 to start swapping
+	 * @param len Length of the swapped memory region
+	 */
+	public abstract void swapBytes(MemorySegment seg2, int offset1, int offset2, int len);
 
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -31,6 +31,11 @@ import java.nio.ByteOrder;
 public abstract class MemorySegment {
 	
 	private static final boolean LITTLE_ENDIAN = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
+
+	/**
+	 * Frees the memory of the memory segment for reuse but does not necessarily delete the memory.
+	 */
+	public abstract void free();
 	
 	/**
 	 * Checks whether this memory segment has already been freed. In that case, the

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.*;
 
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.junit.Assert;
 import org.junit.Test;
@@ -237,7 +238,7 @@ public abstract class ComparatorTestBase<T> {
 	
 	// Help Function for setting up a memory segment and normalize the keys of the data array in it
 	public MemorySegment setupNormalizedKeysMemSegment(T[] data, int normKeyLen, TypeComparator<T> comparator) {
-		MemorySegment memSeg = new MemorySegment(new byte[2048]);
+		MemorySegment memSeg = new HeapMemorySegment(new byte[2048]);
 
 		// Setup normalized Keys in the memory segment
 		int offset = 0;
@@ -293,7 +294,7 @@ public abstract class ComparatorTestBase<T> {
 			MemorySegment memSeg2 = setupNormalizedKeysMemSegment(data, normKeyLen, comparator);
 
 			for (int i = 0; i < data.length; i++) {
-				assertTrue(MemorySegment.compare(memSeg1, memSeg2, i * normKeyLen, i * normKeyLen, normKeyLen) == 0);
+				assertTrue(HeapMemorySegment.compare(memSeg1, memSeg2, i * normKeyLen, i * normKeyLen, normKeyLen) == 0);
 			}
 		} catch (Exception e) {
 			System.err.println(e.getMessage());
@@ -342,14 +343,14 @@ public abstract class ComparatorTestBase<T> {
 				for (int h = l + 1; h < data.length; h++) {
 					int cmp;
 					if (greater) {
-						cmp = MemorySegment.compare(memSegLow, memSegHigh, l * normKeyLen, h * normKeyLen, normKeyLen);
+						cmp = HeapMemorySegment.compare(memSegLow, memSegHigh, l * normKeyLen, h * normKeyLen, normKeyLen);
 						if (fullyDetermines) {
 							assertTrue(cmp < 0);
 						} else {
 							assertTrue(cmp <= 0);
 						}
 					} else {
-						cmp = MemorySegment.compare(memSegHigh, memSegLow, h * normKeyLen, l * normKeyLen, normKeyLen);
+						cmp = HeapMemorySegment.compare(memSegHigh, memSegLow, h * normKeyLen, l * normKeyLen, normKeyLen);
 						if (fullyDetermines) {
 							assertTrue(cmp > 0);
 						} else {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
@@ -294,7 +294,7 @@ public abstract class ComparatorTestBase<T> {
 			MemorySegment memSeg2 = setupNormalizedKeysMemSegment(data, normKeyLen, comparator);
 
 			for (int i = 0; i < data.length; i++) {
-				assertTrue(HeapMemorySegment.compare(memSeg1, memSeg2, i * normKeyLen, i * normKeyLen, normKeyLen) == 0);
+				assertTrue(memSeg1.compare(memSeg2, i * normKeyLen, i * normKeyLen, normKeyLen) == 0);
 			}
 		} catch (Exception e) {
 			System.err.println(e.getMessage());
@@ -343,14 +343,14 @@ public abstract class ComparatorTestBase<T> {
 				for (int h = l + 1; h < data.length; h++) {
 					int cmp;
 					if (greater) {
-						cmp = HeapMemorySegment.compare(memSegLow, memSegHigh, l * normKeyLen, h * normKeyLen, normKeyLen);
+						cmp = memSegLow.compare(memSegHigh, l * normKeyLen, h * normKeyLen, normKeyLen);
 						if (fullyDetermines) {
 							assertTrue(cmp < 0);
 						} else {
 							assertTrue(cmp <= 0);
 						}
 					} else {
-						cmp = HeapMemorySegment.compare(memSegHigh, memSegLow, h * normKeyLen, l * normKeyLen, normKeyLen);
+						cmp = memSegHigh.compare(memSegLow, h * normKeyLen, l * normKeyLen, normKeyLen);
 						if (fullyDetermines) {
 							assertTrue(cmp > 0);
 						} else {

--- a/flink-core/src/test/java/org/apache/flink/types/NormalizableKeyTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/NormalizableKeyTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.junit.Assert;
 
 import org.apache.flink.core.memory.MemorySegment;
@@ -136,7 +137,7 @@ public class NormalizableKeyTest {
 	private <T extends Comparable<T>> void assertNormalizableKey(NormalizableKey<T> key1, NormalizableKey<T> key2, int len) {
 		
 		byte[] normalizedKeys = new byte[2*len];
-		MemorySegment wrapper = new MemorySegment(normalizedKeys);
+		MemorySegment wrapper = new HeapMemorySegment(normalizedKeys);
 		
 		key1.copyNormalizedKey(wrapper, 0, len);
 		key2.copyNormalizedKey(wrapper, len, len);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/AdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/AdaptiveSpanningRecordDeserializer.java
@@ -209,21 +209,21 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 
 		@Override
 		public final short readShort() throws IOException {
-			final short v = this.segment.getShort(this.position);
+			final short v = this.segment.getShortBigEndian(this.position);
 			this.position += 2;
 			return v;
 		}
 
 		@Override
 		public final int readUnsignedShort() throws IOException {
-			final int v = this.segment.getShort(this.position) & 0xffff;
+			final int v = this.segment.getShortBigEndian(this.position) & 0xffff;
 			this.position += 2;
 			return v;
 		}
 
 		@Override
 		public final char readChar() throws IOException  {
-			final char v = this.segment.getChar(this.position);
+			final char v = this.segment.getCharBigEndian(this.position);
 			this.position += 2;
 			return v;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.api.serialization;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.event.task.AbstractEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -86,7 +87,7 @@ public class EventSerializer {
 	public static Buffer toBuffer(AbstractEvent event) {
 		final ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(event);
 
-		final Buffer buffer = new Buffer(new MemorySegment(serializedEvent.array()), RECYCLER, false);
+		final Buffer buffer = new Buffer(new HeapMemorySegment(serializedEvent.array()), RECYCLER, false);
 		buffer.setSize(serializedEvent.remaining());
 
 		return buffer;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +66,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 
 		try {
 			for (int i = 0; i < numberOfSegmentsToAllocate; i++) {
-				availableMemorySegments.add(new MemorySegment(new byte[segmentSize]));
+				availableMemorySegments.add(new HeapMemorySegment(new byte[segmentSize]));
 			}
 		}
 		catch (OutOfMemoryError err) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
@@ -218,7 +218,7 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 				byte[] byteArray = new byte[bufferOrEvent.getSize()];
 				bufferOrEvent.getNettyBuffer().readBytes(byteArray);
 
-				Buffer buffer = new Buffer(new MemorySegment(byteArray), EventSerializer.RECYCLER, false);
+				Buffer buffer = new Buffer(new HeapMemorySegment(byteArray), EventSerializer.RECYCLER, false);
 
 				inputChannel.onBuffer(buffer, bufferOrEvent.sequenceNumber);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/AbstractPagedInputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/AbstractPagedInputView.java
@@ -280,7 +280,7 @@ public abstract class AbstractPagedInputView implements DataInputView {
 	@Override
 	public short readShort() throws IOException {
 		if (this.positionInSegment < this.limitInSegment - 1) {
-			final short v = this.currentSegment.getShort(this.positionInSegment);
+			final short v = this.currentSegment.getShortBigEndian(this.positionInSegment);
 			this.positionInSegment += 2;
 			return v;
 		}
@@ -296,7 +296,7 @@ public abstract class AbstractPagedInputView implements DataInputView {
 	@Override
 	public int readUnsignedShort() throws IOException {
 		if (this.positionInSegment < this.limitInSegment - 1) {
-			final int v = this.currentSegment.getShort(this.positionInSegment) & 0xffff;
+			final int v = this.currentSegment.getShortBigEndian(this.positionInSegment) & 0xffff;
 			this.positionInSegment += 2;
 			return v;
 		}
@@ -312,7 +312,7 @@ public abstract class AbstractPagedInputView implements DataInputView {
 	@Override
 	public char readChar() throws IOException  {
 		if (this.positionInSegment < this.limitInSegment - 1) {
-			final char v = this.currentSegment.getChar(this.positionInSegment);
+			final char v = this.currentSegment.getCharBigEndian(this.positionInSegment);
 			this.positionInSegment += 2;
 			return v;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/AbstractPagedOutputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/AbstractPagedOutputView.java
@@ -228,7 +228,7 @@ public abstract class AbstractPagedOutputView implements DataOutputView {
 	@Override
 	public void writeShort(int v) throws IOException {
 		if (this.positionInSegment < this.segmentSize - 1) {
-			this.currentSegment.putShort(this.positionInSegment, (short) v);
+			this.currentSegment.putShortBigEndian(this.positionInSegment, (short) v);
 			this.positionInSegment += 2;
 		}
 		else if (this.positionInSegment == this.segmentSize) {
@@ -244,7 +244,7 @@ public abstract class AbstractPagedOutputView implements DataOutputView {
 	@Override
 	public void writeChar(int v) throws IOException {
 		if (this.positionInSegment < this.segmentSize - 1) {
-			this.currentSegment.putChar(this.positionInSegment, (char) v);
+			this.currentSegment.putCharBigEndian(this.positionInSegment, (char) v);
 			this.positionInSegment += 2;
 		}
 		else if (this.positionInSegment == this.segmentSize) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/DefaultMemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/DefaultMemoryManager.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 
 public class DefaultMemoryManager implements MemoryManager {
 	
@@ -391,6 +392,7 @@ public class DefaultMemoryManager implements MemoryManager {
 	public long roundDownToPageSizeMultiple(long numBytes) {
 		return numBytes & this.roundingMask;
 	}
+
 	
 	// ------------------------------------------------------------------------
 	
@@ -417,7 +419,7 @@ public class DefaultMemoryManager implements MemoryManager {
 	
 	// ------------------------------------------------------------------------
 	
-	private static final class DefaultMemorySegment extends MemorySegment {
+	private static final class DefaultMemorySegment extends HeapMemorySegment {
 		
 		private AbstractInvokable owner;
 		

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/DirectMemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/DirectMemoryManager.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.runtime.memorymanager;
+
+import org.apache.flink.core.memory.DirectMemorySegment;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Collection;
+import java.util.Iterator;
+
+/*
+ * This class represents the direct memory manager in Flink. It allocates a fixed number of memory segments outside of
+ * the java virtual machine.
+ * It is nearly identical to the DirectMemoryManager which can be enabled through the config. Essentially, this is because
+ * of the native type byte[] which is used for the free segments. Using a Byte[] wrapper would impose an unnecessary
+ * overhead.
+ */
+public class DirectMemoryManager implements MemoryManager {
+
+	/**
+	 * The default memory page size. Currently set to 32 KiBytes.
+	 */
+	public static final int DEFAULT_PAGE_SIZE = 32 * 1024;
+
+	/**
+	 * The minimal memory page size. Currently set to 4 KiBytes.
+	 */
+	public static final int MIN_PAGE_SIZE = 4 * 1024;
+
+	/**
+	 * The Logger.
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(DirectMemoryManager.class);
+
+	// --------------------------------------------------------------------------------------------
+
+	private final Object lock = new Object();	 	// The lock used on the shared structures.
+
+	private final ArrayDeque<ByteBuffer> freeSegments;	// the free memory segments
+
+	private final HashMap<AbstractInvokable, Set<DefaultMemorySegment>> allocatedSegments;
+
+	private final long roundingMask;		// mask used to round down sizes to multiples of the page size
+
+	private final int pageSize;				// the page size, in bytes
+
+	private final int pageSizeBits;			// the number of bits that the power-of-two page size corresponds to
+
+	private final int totalNumPages;		// The initial total size, for verification.
+
+	private boolean isShutDown;				// flag whether the close() has already been invoked.
+
+	/**
+	 * Number of slots of the task manager
+	 */
+	private final int numberOfSlots;
+
+	private final long memorySize;
+
+	// ------------------------------------------------------------------------
+	// Constructors / Destructors
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a memory manager with the given capacity, using the default page size.
+	 *
+	 * @param memorySize The total size of the memory to be managed by this memory manager.
+	 */
+	public DirectMemoryManager(long memorySize, int numberOfSlots) {
+		this(memorySize, numberOfSlots, DEFAULT_PAGE_SIZE);
+	}
+
+	/**
+	 * Creates a memory manager with the given capacity and given page size.
+	 *
+	 * @param memorySize The total size of the memory to be managed by this memory manager.
+	 * @param pageSize The size of the pages handed out by the memory manager.
+	 */
+	public DirectMemoryManager(long memorySize, int numberOfSlots, int pageSize) {
+		// sanity checks
+		if (memorySize <= 0) {
+			throw new IllegalArgumentException("Size of total memory must be positive.");
+		}
+		if (pageSize < MIN_PAGE_SIZE) {
+			throw new IllegalArgumentException("The page size must be at least " + MIN_PAGE_SIZE + " bytes.");
+		}
+		if ((pageSize & (pageSize - 1)) != 0) {
+			// not a power of two
+			throw new IllegalArgumentException("The given page size is not a power of two.");
+		}
+
+		this.memorySize = memorySize;
+
+		this.numberOfSlots = numberOfSlots;
+
+		// assign page size and bit utilities
+		this.pageSize = pageSize;
+		this.roundingMask = ~((long) (pageSize - 1));
+		int log = 0;
+		while ((pageSize = pageSize >>> 1) != 0) {
+			log++;
+		}
+		this.pageSizeBits = log;
+
+		this.totalNumPages = getNumPages(memorySize);
+		if (this.totalNumPages < 1) {
+			throw new IllegalArgumentException("The given amount of memory amounted to less than one page.");
+		}
+
+		// initialize the free segments and allocated segments tracking structures
+		this.freeSegments = new ArrayDeque<ByteBuffer>(this.totalNumPages);
+		this.allocatedSegments = new HashMap<AbstractInvokable, Set<DefaultMemorySegment>>();
+
+
+		// add the full chunks
+		for (int i = 0; i < this.totalNumPages; i++) {
+			// allocate memory of the specified size
+			this.freeSegments.add(ByteBuffer.allocateDirect(this.pageSize));
+		}
+	}
+
+	@Override
+	public void shutdown() {
+		// -------------------- BEGIN CRITICAL SECTION -------------------
+		synchronized (this.lock)
+		{
+			if (!this.isShutDown) {
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("Shutting down MemoryManager instance " + toString());
+				}
+
+				// mark as shutdown and release memory
+				this.isShutDown = true;
+				this.freeSegments.clear();
+
+				// go over all allocated segments and release them
+				for (Set<DefaultMemorySegment> segments : this.allocatedSegments.values()) {
+					for (DefaultMemorySegment seg : segments) {
+						seg.destroy();
+					}
+				}
+			}
+		}
+		// -------------------- END CRITICAL SECTION -------------------
+	}
+
+	public boolean verifyEmpty() {
+		synchronized (this.lock) {
+			return this.freeSegments.size() == this.totalNumPages;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//                 MemoryManager interface implementation
+	// ------------------------------------------------------------------------
+
+	@Override
+	public List<MemorySegment> allocatePages(AbstractInvokable owner, int numPages) throws MemoryAllocationException {
+		final ArrayList<MemorySegment> segs = new ArrayList<MemorySegment>(numPages);
+		allocatePages(owner, segs, numPages);
+		return segs;
+	}
+
+	@Override
+	public void allocatePages(AbstractInvokable owner, List<MemorySegment> target, int numPages)
+			throws MemoryAllocationException
+	{
+		// sanity check
+		if (owner == null) {
+			throw new IllegalAccessError("The memory owner must not be null.");
+		}
+
+		// reserve array space, if applicable
+		if (target instanceof ArrayList) {
+			((ArrayList<MemorySegment>) target).ensureCapacity(numPages);
+		}
+
+		// -------------------- BEGIN CRITICAL SECTION -------------------
+		synchronized (this.lock)
+		{
+			if (this.isShutDown) {
+				throw new IllegalStateException("Memory manager has been shut down.");
+			}
+
+			if (numPages > this.freeSegments.size()) {
+				throw new MemoryAllocationException("Could not allocate " + numPages + " pages. Only " +
+						this.freeSegments.size() + " pages are remaining.");
+			}
+
+			Set<DefaultMemorySegment> segmentsForOwner = this.allocatedSegments.get(owner);
+			if (segmentsForOwner == null) {
+				segmentsForOwner = new HashSet<DefaultMemorySegment>(4 * numPages / 3 + 1);
+				this.allocatedSegments.put(owner, segmentsForOwner);
+			}
+
+			for (int i = numPages; i > 0; i--) {
+				ByteBuffer buffer = this.freeSegments.poll();
+				final DefaultMemorySegment segment = new DefaultMemorySegment(owner, buffer);
+				target.add(segment);
+				segmentsForOwner.add(segment);
+			}
+		}
+		// -------------------- END CRITICAL SECTION -------------------
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public void release(MemorySegment segment) {
+		// check if segment is null or has already been freed
+		if (segment == null || segment.isFreed() || !(segment instanceof DefaultMemorySegment)) {
+			return;
+		}
+
+		final DefaultMemorySegment defSeg = (DefaultMemorySegment) segment;
+		final AbstractInvokable owner = defSeg.owner;
+
+		// -------------------- BEGIN CRITICAL SECTION -------------------
+		synchronized (this.lock)
+		{
+			if (this.isShutDown) {
+				throw new IllegalStateException("Memory manager has been shut down.");
+			}
+
+			// remove the reference in the map for the owner
+			try {
+				Set<DefaultMemorySegment> segsForOwner = this.allocatedSegments.get(owner);
+
+				if (segsForOwner != null) {
+					segsForOwner.remove(defSeg);
+					if (segsForOwner.isEmpty()) {
+						this.allocatedSegments.remove(owner);
+					}
+				}
+			}
+			catch (Throwable t) {
+				LOG.error("Error removing book-keeping reference to allocated memory segment.", t);
+			}
+			finally {
+				// release the memory in any case
+				ByteBuffer buffer = defSeg.destroy();
+				this.freeSegments.add(buffer);
+			}
+		}
+		// -------------------- END CRITICAL SECTION -------------------
+	}
+
+	@Override
+	public <T extends MemorySegment> void release(Collection<T> segments) {
+
+		// sanity checks
+		if (segments == null) {
+			return;
+		}
+
+		// -------------------- BEGIN CRITICAL SECTION -------------------
+		synchronized (this.lock)
+		{
+			if (this.isShutDown) {
+				throw new IllegalStateException("Memory manager has been shut down.");
+			}
+
+			final Iterator<T> segmentsIterator = segments.iterator();
+
+			AbstractInvokable lastOwner = null;
+			Set<DefaultMemorySegment> segsForOwner = null;
+
+			// go over all segments
+			while (segmentsIterator.hasNext()) {
+
+				final MemorySegment seg = segmentsIterator.next();
+				if (seg.isFreed()) {
+					continue;
+				}
+
+				final DefaultMemorySegment defSeg = (DefaultMemorySegment) seg;
+				final AbstractInvokable owner = defSeg.owner;
+
+				try {
+					// get the list of segments by this owner only if it is a different owner than for
+					// the previous one (or it is the first segment)
+					if (lastOwner != owner) {
+						lastOwner = owner;
+						segsForOwner = this.allocatedSegments.get(owner);
+					}
+
+					// remove the segment from the list
+					if (segsForOwner != null) {
+						segsForOwner.remove(defSeg);
+						if (segsForOwner.isEmpty()) {
+							this.allocatedSegments.remove(owner);
+						}
+					}
+				}
+				catch (Throwable t) {
+					LOG.error("Error removing book-keeping reference to allocated memory segment.", t);
+				}
+				finally {
+					// release the memory in any case
+					ByteBuffer buffer = defSeg.destroy();
+					this.freeSegments.add(buffer);
+				}
+			}
+
+			segments.clear();
+		}
+		// -------------------- END CRITICAL SECTION -------------------
+	}
+
+	@Override
+	public void releaseAll(AbstractInvokable owner) {
+		// -------------------- BEGIN CRITICAL SECTION -------------------
+		synchronized (this.lock)
+		{
+			if (this.isShutDown) {
+				throw new IllegalStateException("Memory manager has been shut down.");
+			}
+
+			// get all segments
+			final Set<DefaultMemorySegment> segments = this.allocatedSegments.remove(owner);
+
+			// all segments may have been freed previously individually
+			if (segments == null || segments.isEmpty()) {
+				return;
+			}
+
+			// free each segment
+			for (DefaultMemorySegment seg : segments) {
+				final ByteBuffer buffer = seg.destroy();
+				this.freeSegments.add(buffer);
+			}
+
+			segments.clear();
+		}
+		// -------------------- END CRITICAL SECTION -------------------
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public int getPageSize() {
+		return this.pageSize;
+	}
+
+	@Override
+	public long getMemorySize() {
+		return this.memorySize;
+	}
+
+	@Override
+	public int computeNumberOfPages(double fraction) {
+		return getRelativeNumPages(fraction);
+	}
+
+	@Override
+	public long computeMemorySize(double fraction) {
+		return this.pageSize*computeNumberOfPages(fraction);
+	}
+
+	@Override
+	public long roundDownToPageSizeMultiple(long numBytes) {
+		return numBytes & this.roundingMask;
+	}
+
+	// ------------------------------------------------------------------------
+
+	private final int getNumPages(long numBytes) {
+		if (numBytes < 0) {
+			throw new IllegalArgumentException("The number of bytes to allocate must not be negative.");
+		}
+
+		final long numPages = numBytes >>> this.pageSizeBits;
+		if (numPages <= Integer.MAX_VALUE) {
+			return (int) numPages;
+		} else {
+			throw new IllegalArgumentException("The given number of bytes correstponds to more than MAX_INT pages.");
+		}
+	}
+
+	private final int getRelativeNumPages(double fraction){
+		if (fraction <= 0 || fraction > 1) {
+			throw new IllegalArgumentException("The fraction of memory to allocate must within (0, 1].");
+		}
+
+		return (int)(this.totalNumPages * fraction / this.numberOfSlots);
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static final class DefaultMemorySegment extends DirectMemorySegment {
+
+		private AbstractInvokable owner;
+
+		DefaultMemorySegment(AbstractInvokable owner, ByteBuffer memory) {
+			super(memory);
+			this.owner = owner;
+		}
+
+		ByteBuffer destroy() {
+			// "free" segment but keep underlying ByteBuffer
+			this.free();
+			return this.buffer;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/HeapMemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/HeapMemoryManager.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 import org.apache.flink.core.memory.HeapMemorySegment;
 
-public class DefaultMemoryManager implements MemoryManager {
+public class HeapMemoryManager implements MemoryManager {
 	
 	/**
 	 * The default memory page size. Currently set to 32 KiBytes.
@@ -50,7 +50,7 @@ public class DefaultMemoryManager implements MemoryManager {
 	/**
 	 * The Logger.
 	 */
-	private static final Logger LOG = LoggerFactory.getLogger(DefaultMemoryManager.class);
+	private static final Logger LOG = LoggerFactory.getLogger(HeapMemoryManager.class);
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -86,7 +86,7 @@ public class DefaultMemoryManager implements MemoryManager {
 	 * 
 	 * @param memorySize The total size of the memory to be managed by this memory manager.
 	 */
-	public DefaultMemoryManager(long memorySize, int numberOfSlots) {
+	public HeapMemoryManager(long memorySize, int numberOfSlots) {
 		this(memorySize, numberOfSlots, DEFAULT_PAGE_SIZE);
 	}
 
@@ -96,7 +96,7 @@ public class DefaultMemoryManager implements MemoryManager {
 	 * @param memorySize The total size of the memory to be managed by this memory manager.
 	 * @param pageSize The size of the pages handed out by the memory manager.
 	 */
-	public DefaultMemoryManager(long memorySize, int numberOfSlots, int pageSize) {
+	public HeapMemoryManager(long memorySize, int numberOfSlots, int pageSize) {
 		// sanity checks
 		if (memorySize <= 0) {
 			throw new IllegalArgumentException("Size of total memory must be positive.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/HeapMemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/HeapMemoryManager.java
@@ -35,6 +35,12 @@ import java.util.Set;
 
 import org.apache.flink.core.memory.HeapMemorySegment;
 
+/*
+ * This class represents the default memory manager in Flink. It allocates a fixed number of memory segments.
+ * It is nearly identical to the DirectMemoryManager which can be enabled through the config. Essentially, this is because
+ * of the native type byte[] which is used for the free segments. Using a Byte[] wrapper would impose an unnecessary
+ * overhead.
+ */
 public class HeapMemoryManager implements MemoryManager {
 	
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView;
 import org.apache.flink.runtime.memorymanager.AbstractPagedInputView;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView;
 import org.apache.flink.runtime.memorymanager.AbstractPagedInputView;
@@ -283,7 +282,7 @@ public final class FixedLengthRecordSorter<T> implements InMemorySorter<T> {
 		final MemorySegment segI = this.sortBuffer.get(bufferNumI);
 		final MemorySegment segJ = this.sortBuffer.get(bufferNumJ);
 		
-		int val = MemorySegment.compare(segI, segJ, segmentOffsetI, segmentOffsetJ, this.numKeyBytes);
+		int val = segI.compare(segJ, segmentOffsetI, segmentOffsetJ, this.numKeyBytes);
 		return this.useNormKeyUninverted ? val : -val;
 	}
 
@@ -298,7 +297,7 @@ public final class FixedLengthRecordSorter<T> implements InMemorySorter<T> {
 		final MemorySegment segI = this.sortBuffer.get(bufferNumI);
 		final MemorySegment segJ = this.sortBuffer.get(bufferNumJ);
 		
-		MemorySegment.swapBytes(segI, segJ, this.swapBuffer, segmentOffsetI, segmentOffsetJ, this.recordSize);
+		segI.swapBytes(segJ, segmentOffsetI, segmentOffsetJ, this.recordSize);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java
@@ -59,8 +59,6 @@ public final class NormalizedKeySorter<T> implements InMemorySorter<T> {
 	//                               Members
 	// ------------------------------------------------------------------------
 
-	private final byte[] swapBuffer;
-	
 	private final TypeSerializer<T> serializer;
 	
 	private final TypeComparator<T> comparator;
@@ -176,8 +174,7 @@ public final class NormalizedKeySorter<T> implements InMemorySorter<T> {
 		this.indexEntrySize = this.numKeyBytes + OFFSET_LEN;
 		this.indexEntriesPerSegment = segmentSize / this.indexEntrySize;
 		this.lastIndexEntryOffset = (this.indexEntriesPerSegment - 1) * this.indexEntrySize;
-		this.swapBuffer = new byte[this.indexEntrySize];
-		
+
 		// set to initial state
 		this.currentSortIndexSegment = nextMemorySegment();
 		this.sortIndex.add(this.currentSortIndexSegment);
@@ -377,7 +374,7 @@ public final class NormalizedKeySorter<T> implements InMemorySorter<T> {
 		final MemorySegment segI = this.sortIndex.get(bufferNumI);
 		final MemorySegment segJ = this.sortIndex.get(bufferNumJ);
 		
-		int val = MemorySegment.compare(segI, segJ, segmentOffsetI + OFFSET_LEN, segmentOffsetJ + OFFSET_LEN, this.numKeyBytes);
+		int val = segI.compare(segJ, segmentOffsetI + OFFSET_LEN, segmentOffsetJ + OFFSET_LEN, this.numKeyBytes);
 		
 		if (val != 0 || this.normalizedKeyFullyDetermines) {
 			return this.useNormKeyUninverted ? val : -val;
@@ -400,7 +397,7 @@ public final class NormalizedKeySorter<T> implements InMemorySorter<T> {
 		final MemorySegment segI = this.sortIndex.get(bufferNumI);
 		final MemorySegment segJ = this.sortIndex.get(bufferNumJ);
 		
-		MemorySegment.swapBytes(segI, segJ, this.swapBuffer, segmentOffsetI, segmentOffsetJ, this.indexEntrySize);
+		segI.swapBytes(segJ, segmentOffsetI, segmentOffsetJ, this.indexEntrySize);
 	}
 
 	@Override

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -44,7 +44,7 @@ import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.io.network.netty.NettyConfig
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID
 import org.apache.flink.runtime.jobmanager.JobManager
-import org.apache.flink.runtime.memorymanager.HeapMemoryManager
+import org.apache.flink.runtime.memorymanager.{DirectMemoryManager, HeapMemoryManager}
 import org.apache.flink.runtime.messages.JobManagerMessages.UpdateTaskExecutionState
 import org.apache.flink.runtime.messages.Messages.{Disconnect, Acknowledge}
 import org.apache.flink.runtime.messages.RegistrationMessages.{AlreadyRegistered, RefuseRegistration, AcknowledgeRegistration, RegisterTaskManager}
@@ -111,7 +111,19 @@ class TaskManager(val connectionInfo: InstanceConnectionInfo,
   var registrationAttempts: Int = 0
 
   val ioManager = new IOManagerAsync(tmpDirPaths)
-  val memoryManager = new HeapMemoryManager(memorySize, numberOfSlots, pageSize)
+
+  val useDirectMemoryAllocation = GlobalConfiguration.getBoolean(
+    ConfigConstants.TASK_MANAGER_MEMORY_DIRECT_ALLOCATION_KEY,
+    ConfigConstants.DEFAULT_TASK_MANAGER_MEMORY_DIRECT_ALLOCATION)
+  val memoryManager =
+    if (useDirectMemoryAllocation) {
+      log.debug("Using direct (off-heap) memory allocation.")
+      new DirectMemoryManager(memorySize, numberOfSlots, pageSize)
+    } else {
+      log.debug("Using heap memory allocation.")
+      new HeapMemoryManager(memorySize, numberOfSlots, pageSize)
+    }
+
   val bcVarManager = new BroadcastVariableManager();
   val hardwareDescription = HardwareDescription.extractFromSystem(memoryManager.getMemorySize)
   val fileCache = new FileCache()

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -44,7 +44,7 @@ import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.io.network.netty.NettyConfig
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID
 import org.apache.flink.runtime.jobmanager.JobManager
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager
 import org.apache.flink.runtime.messages.JobManagerMessages.UpdateTaskExecutionState
 import org.apache.flink.runtime.messages.Messages.{Disconnect, Acknowledge}
 import org.apache.flink.runtime.messages.RegistrationMessages.{AlreadyRegistered, RefuseRegistration, AcknowledgeRegistration, RegisterTaskManager}
@@ -111,8 +111,8 @@ class TaskManager(val connectionInfo: InstanceConnectionInfo,
   var registrationAttempts: Int = 0
 
   val ioManager = new IOManagerAsync(tmpDirPaths)
-  val memoryManager = new DefaultMemoryManager(memorySize, numberOfSlots, pageSize)
-  val bcVarManager = new BroadcastVariableManager()
+  val memoryManager = new HeapMemoryManager(memorySize, numberOfSlots, pageSize)
+  val bcVarManager = new BroadcastVariableManager();
   val hardwareDescription = HardwareDescription.extractFromSystem(memoryManager.getMemorySize)
   val fileCache = new FileCache()
   val runningTasks = scala.collection.mutable.HashMap[ExecutionAttemptID, Task]()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/ChannelViewsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/ChannelViewsTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -78,7 +78,7 @@ public class ChannelViewsTest
 
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1, MEMORY_PAGE_SIZE);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1, MEMORY_PAGE_SIZE);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SpillingBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SpillingBufferTest.java
@@ -25,11 +25,10 @@ import java.util.ArrayList;
 import org.junit.Assert;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.io.disk.SpillingBuffer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.ListMemorySegmentSource;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -70,7 +69,7 @@ public class SpillingBufferTest {
 
 	@Before
 	public void beforeTest() {
-		memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerITCase.java
@@ -34,7 +34,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memory.HeapMemoryManagerTest;
+import org.apache.flink.runtime.memory.MemoryManagerTest;
 import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 
 /**
@@ -81,7 +81,7 @@ public class IOManagerITCase {
 	@Test
 	public void parallelChannelsTest() throws Exception {
 		final Random rnd = new Random(SEED);
-		final AbstractInvokable memOwner = new HeapMemoryManagerTest.DummyInvokable();
+		final AbstractInvokable memOwner = new MemoryManagerTest.DummyInvokable();
 		
 		FileIOChannel.ID[] ids = new FileIOChannel.ID[NUM_CHANNELS];
 		BlockChannelWriter[] writers = new BlockChannelWriter[NUM_CHANNELS];

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerITCase.java
@@ -34,8 +34,8 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memory.DefaultMemoryManagerTest;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memory.HeapMemoryManagerTest;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 
 /**
  * Integration test case for the I/O manager.
@@ -54,11 +54,11 @@ public class IOManagerITCase {
 
 	private IOManager ioManager;
 
-	private DefaultMemoryManager memoryManager;
+	private HeapMemoryManager memoryManager;
 
 	@Before
 	public void beforeTest() {
-		memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		ioManager = new IOManagerAsync();
 	}
 
@@ -81,7 +81,7 @@ public class IOManagerITCase {
 	@Test
 	public void parallelChannelsTest() throws Exception {
 		final Random rnd = new Random(SEED);
-		final AbstractInvokable memOwner = new DefaultMemoryManagerTest.DummyInvokable();
+		final AbstractInvokable memOwner = new HeapMemoryManagerTest.DummyInvokable();
 		
 		FileIOChannel.ID[] ids = new FileIOChannel.ID[NUM_CHANNELS];
 		BlockChannelWriter[] writers = new BlockChannelWriter[NUM_CHANNELS];

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerPerformanceBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerPerformanceBenchmark.java
@@ -40,7 +40,7 @@ import org.apache.flink.core.memory.InputViewDataInputStreamWrapper;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memory.HeapMemoryManagerTest;
+import org.apache.flink.runtime.memory.MemoryManagerTest;
 import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.types.IntegerRecord;
 import org.junit.After;
@@ -66,7 +66,7 @@ public class IOManagerPerformanceBenchmark {
 	private static final int NUM_INTS_WRITTEN = 100000000;
 	
 	
-	private static final AbstractInvokable memoryOwner = new HeapMemoryManagerTest.DummyInvokable();
+	private static final AbstractInvokable memoryOwner = new MemoryManagerTest.DummyInvokable();
 	
 	private HeapMemoryManager memManager;
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerPerformanceBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerPerformanceBenchmark.java
@@ -39,15 +39,9 @@ import org.slf4j.LoggerFactory;
 import org.apache.flink.core.memory.InputViewDataInputStreamWrapper;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
-import org.apache.flink.runtime.io.disk.iomanager.BlockChannelReader;
-import org.apache.flink.runtime.io.disk.iomanager.BlockChannelWriter;
-import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
-import org.apache.flink.runtime.io.disk.iomanager.ChannelReaderInputView;
-import org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memory.DefaultMemoryManagerTest;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memory.HeapMemoryManagerTest;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.types.IntegerRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -72,16 +66,16 @@ public class IOManagerPerformanceBenchmark {
 	private static final int NUM_INTS_WRITTEN = 100000000;
 	
 	
-	private static final AbstractInvokable memoryOwner = new DefaultMemoryManagerTest.DummyInvokable();
+	private static final AbstractInvokable memoryOwner = new HeapMemoryManagerTest.DummyInvokable();
 	
-	private DefaultMemoryManager memManager;
+	private HeapMemoryManager memManager;
 	
 	private IOManager ioManager;
 	
 	
 	@Before
 	public void startup() {
-		memManager = new DefaultMemoryManager(MEMORY_SIZE,1);
+		memManager = new HeapMemoryManager(MEMORY_SIZE,1);
 		ioManager = new IOManagerAsync();
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerTest.java
@@ -20,6 +20,11 @@ package org.apache.flink.runtime.io.disk.iomanager;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel.ID;
+import org.apache.flink.runtime.memory.HeapMemoryManagerTest.DummyInvokable;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerTest.java
@@ -20,11 +20,6 @@ package org.apache.flink.runtime.io.disk.iomanager;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel.ID;
-import org.apache.flink.runtime.memory.HeapMemoryManagerTest.DummyInvokable;
-import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/reader/IteratorWrappingMockSingleInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/reader/IteratorWrappingMockSingleInputGate.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.io.network.api.reader;
 
 import org.apache.flink.core.io.IOReadableWritable;
-import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordSerializer;
@@ -70,7 +70,7 @@ public class IteratorWrappingMockSingleInputGate<T extends IOReadableWritable> e
 			@Override
 			public Buffer answer(InvocationOnMock invocationOnMock) throws Throwable {
 				if (inputIterator.next(reuse) != null) {
-					final Buffer buffer = new Buffer(new MemorySegment(new byte[bufferSize]), mock(BufferRecycler.class));
+					final Buffer buffer = new Buffer(new HeapMemorySegment(new byte[bufferSize]), mock(BufferRecycler.class));
 					serializer.setNextBuffer(buffer);
 					serializer.addRecord(reuse);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/PagedViewsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/PagedViewsTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.io.network.api.serialization;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.api.serialization.types.SerializationTestType;
 import org.apache.flink.runtime.io.network.api.serialization.types.SerializationTestTypeFactory;
@@ -375,7 +376,7 @@ public class PagedViewsTest {
 		private final int segmentSize;
 
 		private TestOutputView(int segmentSize) {
-			super(new MemorySegment(new byte[segmentSize]), segmentSize, 0);
+			super(new HeapMemorySegment(new byte[segmentSize]), segmentSize, 0);
 
 			this.segmentSize = segmentSize;
 		}
@@ -383,7 +384,7 @@ public class PagedViewsTest {
 		@Override
 		protected MemorySegment nextSegment(MemorySegment current, int positionInCurrent) throws IOException {
 			segments.add(new SegmentWithPosition(current, positionInCurrent));
-			return new MemorySegment(new byte[segmentSize]);
+			return new HeapMemorySegment(new byte[segmentSize]);
 		}
 
 		public void close() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.runtime.io.network.api.serialization;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.api.serialization.types.SerializationTestType;
 import org.apache.flink.runtime.io.network.api.serialization.types.SerializationTestTypeFactory;
 import org.apache.flink.runtime.io.network.api.serialization.types.Util;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.serialization.SpillingAdaptiveSpanningRecordDeserializer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -126,7 +127,7 @@ public class SpanningRecordSerializationTest {
 	{
 		final int SERIALIZATION_OVERHEAD = 4; // length encoding
 
-		final Buffer buffer = new Buffer(new MemorySegment(new byte[segmentSize]), mock(BufferRecycler.class));
+		final Buffer buffer = new Buffer(new HeapMemorySegment(new byte[segmentSize]), mock(BufferRecycler.class));
 
 		final ArrayDeque<SerializationTestType> serializedRecords = new ArrayDeque<SerializationTestType>();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializerTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.io.network.api.serialization;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -41,7 +44,7 @@ public class SpanningRecordSerializerTest {
 		final int SEGMENT_SIZE = 16;
 
 		final SpanningRecordSerializer<SerializationTestType> serializer = new SpanningRecordSerializer<SerializationTestType>();
-		final Buffer buffer = new Buffer(new MemorySegment(new byte[SEGMENT_SIZE]), mock(BufferRecycler.class));
+		final Buffer buffer = new Buffer(new HeapMemorySegment(new byte[SEGMENT_SIZE]), mock(BufferRecycler.class));
 		final SerializationTestType randomIntRecord = Util.randomRecord(SerializationTestTypeFactory.INT);
 
 		Assert.assertFalse(serializer.hasData());
@@ -75,7 +78,7 @@ public class SpanningRecordSerializerTest {
 		final int SEGMENT_SIZE = 11;
 
 		final SpanningRecordSerializer<SerializationTestType> serializer = new SpanningRecordSerializer<SerializationTestType>();
-		final Buffer buffer = new Buffer(new MemorySegment(new byte[SEGMENT_SIZE]), mock(BufferRecycler.class));
+		final Buffer buffer = new Buffer(new HeapMemorySegment(new byte[SEGMENT_SIZE]), mock(BufferRecycler.class));
 
 		try {
 			Assert.assertEquals(RecordSerializer.SerializationResult.FULL_RECORD, serializer.setNextBuffer(buffer));
@@ -201,7 +204,7 @@ public class SpanningRecordSerializerTest {
 		final int SERIALIZATION_OVERHEAD = 4; // length encoding
 
 		final SpanningRecordSerializer<SerializationTestType> serializer = new SpanningRecordSerializer<SerializationTestType>();
-		final Buffer buffer = new Buffer(new MemorySegment(new byte[segmentSize]), mock(BufferRecycler.class));
+		final Buffer buffer = new Buffer(new HeapMemorySegment(new byte[segmentSize]), mock(BufferRecycler.class));
 
 		// -------------------------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class BufferTest {
 
 	@Test
 	public void testSetGetSize() {
-		final MemorySegment segment = new MemorySegment(new byte[1024]);
+		final MemorySegment segment = new HeapMemorySegment(new byte[1024]);
 		final BufferRecycler recycler = Mockito.mock(BufferRecycler.class);
 
 		Buffer buffer = new Buffer(segment, recycler);
@@ -58,7 +59,7 @@ public class BufferTest {
 
 	@Test
 	public void testExceptionAfterRecycle() throws Throwable {
-		final MemorySegment segment = new MemorySegment(new byte[1024]);
+		final MemorySegment segment = new HeapMemorySegment(new byte[1024]);
 		final BufferRecycler recycler = Mockito.mock(BufferRecycler.class);
 
 		final Buffer buffer = new Buffer(segment, recycler);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.runtime.event.task.IntegerTaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -52,7 +52,7 @@ public class NettyMessageSerializationTest {
 	@Test
 	public void testEncodeDecode() {
 		{
-			Buffer buffer = spy(new Buffer(new MemorySegment(new byte[1024]), mock(BufferRecycler.class)));
+			Buffer buffer = spy(new Buffer(new HeapMemorySegment(new byte[1024]), mock(BufferRecycler.class)));
 			ByteBuffer nioBuffer = buffer.getNioBuffer();
 
 			for (int i = 0; i < 1024; i += 4) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/HeapMemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/HeapMemoryManagerTest.java
@@ -27,13 +27,13 @@ import org.junit.Assert;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DefaultMemoryManagerTest
+public class HeapMemoryManagerTest
 {
 	private static final long RANDOM_SEED = 643196033469871L;
 
@@ -43,14 +43,14 @@ public class DefaultMemoryManagerTest
 	
 	private static final int NUM_PAGES = MEMORY_SIZE / PAGE_SIZE;
 
-	private DefaultMemoryManager memoryManager;
+	private HeapMemoryManager memoryManager;
 
 	private Random random;
 
 	@Before
 	public void setUp()
 	{
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, PAGE_SIZE);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, PAGE_SIZE);
 		this.random = new Random(RANDOM_SEED);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -33,7 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class HeapMemoryManagerTest
+public class MemoryManagerTest
 {
 	private static final long RANDOM_SEED = 643196033469871L;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentTest.java
@@ -81,7 +81,7 @@ public class MemorySegmentTest {
 	@Before
 	public void setUp() {
 		try {
-			this.segment = this.manager.allocatePages(new HeapMemoryManagerTest.DummyInvokable(), 1).get(0);
+			this.segment = this.manager.allocatePages(new MemoryManagerTest.DummyInvokable(), 1).get(0);
 			this.random = new Random(RANDOM_SEED);
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentTest.java
@@ -30,7 +30,7 @@ import java.util.Random;
 import org.apache.flink.core.memory.HeapMemorySegment;
 import org.junit.Assert;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +43,7 @@ public class MemorySegmentTest {
 
 	public static final int PAGE_SIZE = 1024 * 512;
 
-	private DefaultMemoryManager manager;
+	private HeapMemoryManager manager;
 
 	private MemorySegment segment;
 
@@ -52,8 +52,8 @@ public class MemorySegmentTest {
 	@Before
 	public void setUp() throws Exception{
 		try {
-			this.manager = new DefaultMemoryManager(MANAGED_MEMORY_SIZE, 1, PAGE_SIZE);
-			this.segment = manager.allocatePages(new DefaultMemoryManagerTest.DummyInvokable(), 1).get(0);
+			this.manager = new HeapMemoryManager(MANAGED_MEMORY_SIZE, 1, PAGE_SIZE);
+			this.segment = manager.allocatePages(new HeapMemoryManagerTest.DummyInvokable(), 1).get(0);
 			this.random = new Random(RANDOM_SEED);
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.junit.Assert;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
@@ -549,7 +550,7 @@ public class MemorySegmentTest {
 	@Test
 	public void testByteBufferWrapping() {
 		try {
-			MemorySegment seg = new MemorySegment(new byte[1024]);
+			MemorySegment seg = new HeapMemorySegment(new byte[1024]);
 			
 			ByteBuffer buf1 = seg.wrap(13, 47);
 			assertEquals(13, buf1.position());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.DriverStrategy;
 import org.apache.flink.runtime.operators.PactTaskContext;
@@ -69,7 +69,7 @@ public class TestTaskContext<S, T> implements PactTaskContext<S, T> {
 	public TestTaskContext() {}
 	
 	public TestTaskContext(long memoryInBytes) {
-		this.memoryManager = new DefaultMemoryManager(memoryInBytes,1 ,32 * 1024);
+		this.memoryManager = new HeapMemoryManager(memoryInBytes,1 ,32 * 1024);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
@@ -36,7 +36,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.hash.MutableHashTable.HashBucketIterator;
@@ -96,7 +96,7 @@ public class HashTableITCase {
 		this.pairProbeSideComparator = new IntPairComparator();
 		this.pairComparator = new IntPairPairComparator();
 		
-		this.memManager = new DefaultMemoryManager(32 * 1024 * 1024,1);
+		this.memManager = new HeapMemoryManager(32 * 1024 * 1024,1);
 		this.ioManager = new IOManagerAsync();
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTablePerformanceComparison.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTablePerformanceComparison.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -216,7 +217,7 @@ public class HashTablePerformanceComparison {
 		List<MemorySegment> memory = new ArrayList<MemorySegment>();
 		
 		for (int i = 0; i < numPages; i++) {
-			memory.add(new MemorySegment(new byte[pageSize]));
+			memory.add(new HeapMemorySegment(new byte[pageSize]));
 		}
 		
 		return memory;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/MemoryHashTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/MemoryHashTableTest.java
@@ -26,6 +26,7 @@ import java.util.Random;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.operators.hash.AbstractHashTableProber;
 import org.apache.flink.runtime.operators.hash.AbstractMutableHashTable;
@@ -747,7 +748,7 @@ public class MemoryHashTableTest {
 		List<MemorySegment> memory = new ArrayList<MemorySegment>();
 		
 		for (int i = 0; i < numPages; i++) {
-			memory.add(new MemorySegment(new byte[pageSize]));
+			memory.add(new HeapMemorySegment(new byte[pageSize]));
 		}
 		
 		return memory;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
@@ -31,7 +31,7 @@ import org.apache.flink.api.java.record.functions.JoinFunction;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -104,7 +104,7 @@ public class NonReusingHashMatchIteratorITCase {
 		this.pairRecordPairComparator = new IntPairRecordPairComparator();
 		this.recordPairPairComparator = new RecordIntPairPairComparator();
 		
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
@@ -30,7 +30,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.hash.HashTableITCase.ConstantsKeyValuePairsIterator;
@@ -121,7 +121,7 @@ public class NonReusingReOpenableHashTableITCase {
 		this.recordProbeSideComparator = new RecordComparator(keyPos, keyType);
 		this.pactRecordComparator = new HashTableITCase.RecordPairComparatorFirstInt();
 
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE,1, PAGE_SIZE);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE,1, PAGE_SIZE);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
@@ -38,7 +38,7 @@ import org.apache.flink.api.java.record.functions.JoinFunction;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -104,7 +104,7 @@ public class ReusingHashMatchIteratorITCase {
 		this.pairRecordPairComparator = new IntPairRecordPairComparator();
 		this.recordPairPairComparator = new RecordIntPairPairComparator();
 		
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingReOpenableHashTableITCase.java
@@ -40,7 +40,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryAllocationException;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.hash.ReusingHashMatchIteratorITCase.RecordMatch;
@@ -120,7 +120,7 @@ public class ReusingReOpenableHashTableITCase {
 		this.recordProbeSideComparator = new RecordComparator(keyPos, keyType);
 		this.pactRecordComparator = new HashTableITCase.RecordPairComparatorFirstInt();
 		
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE,1, PAGE_SIZE);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE,1, PAGE_SIZE);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/BlockResettableMutableObjectIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/BlockResettableMutableObjectIteratorTest.java
@@ -26,9 +26,8 @@ import org.junit.Assert;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
-import org.apache.flink.runtime.operators.resettable.BlockResettableMutableObjectIterator;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.MutableObjectIteratorWrapper;
 import org.apache.flink.types.IntValue;
@@ -57,7 +56,7 @@ public class BlockResettableMutableObjectIteratorTest
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new DefaultMemoryManager(MEMORY_CAPACITY, 1);
+		this.memman = new HeapMemoryManager(MEMORY_CAPACITY, 1);
 		
 		// create test objects
 		this.objects = new ArrayList<Record>(20000);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIteratorTest.java
@@ -27,7 +27,7 @@ import org.junit.Assert;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.IntValue;
@@ -54,7 +54,7 @@ public class NonReusingBlockResettableIteratorTest
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new DefaultMemoryManager(MEMORY_CAPACITY, 1);
+		this.memman = new HeapMemoryManager(MEMORY_CAPACITY, 1);
 		
 		// create test objects
 		this.objects = new ArrayList<Record>(20000);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/ReusingBlockResettableIteratorTest.java
@@ -22,7 +22,7 @@ package org.apache.flink.runtime.operators.resettable;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.IntValue;
@@ -54,7 +54,7 @@ public class ReusingBlockResettableIteratorTest
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new DefaultMemoryManager(MEMORY_CAPACITY, 1);
+		this.memman = new HeapMemoryManager(MEMORY_CAPACITY, 1);
 		
 		// create test objects
 		this.objects = new ArrayList<Record>(20000);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableIteratorTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeutils.base.IntValueSerializer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.IntValue;
@@ -56,7 +56,7 @@ public class SpillingResettableIteratorTest {
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new DefaultMemoryManager(MEMORY_CAPACITY, 32 * 1024);
+		this.memman = new HeapMemoryManager(MEMORY_CAPACITY, 32 * 1024);
 		this.ioman = new IOManagerAsync();
 
 		// create test objects

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableMutableObjectIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/resettable/SpillingResettableMutableObjectIteratorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.MutableObjectIteratorWrapper;
@@ -56,7 +56,7 @@ public class SpillingResettableMutableObjectIteratorTest {
 	@Before
 	public void startup() {
 		// set up IO and memory manager
-		this.memman = new DefaultMemoryManager(MEMORY_CAPACITY, 32 * 1024);
+		this.memman = new HeapMemoryManager(MEMORY_CAPACITY, 32 * 1024);
 		this.ioman = new IOManagerAsync();
 
 		// create test objects

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
@@ -37,7 +37,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -80,7 +80,7 @@ public class CombiningUnilateralSortMergerITCase {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 		
 		this.serializerFactory = RecordSerializerFactory.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeutils.record.RecordSerializerFactory;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.RandomIntPairGenerator;
@@ -82,7 +82,7 @@ public class ExternalSortITCase {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 		
 		this.pactRecordSerializer = RecordSerializerFactory.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorterTest.java
@@ -25,9 +25,7 @@ import java.util.Random;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
-import org.apache.flink.runtime.operators.sort.FixedLengthRecordSorter;
-import org.apache.flink.runtime.operators.sort.QuickSort;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.RandomIntPairGenerator;
 import org.apache.flink.runtime.operators.testutils.UniformIntPairGenerator;
@@ -51,7 +49,7 @@ public class FixedLengthRecordSorterTest
 	
 	private static final int MEMORY_PAGE_SIZE = 32 * 1024; 
 
-	private DefaultMemoryManager memoryManager;
+	private HeapMemoryManager memoryManager;
 	
 	private TypeSerializer<IntPair> serializer;
 	
@@ -60,7 +58,7 @@ public class FixedLengthRecordSorterTest
 
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, MEMORY_PAGE_SIZE);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, MEMORY_PAGE_SIZE);
 		this.serializer = new IntPairSerializer();
 		this.comparator = new IntPairComparator();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerITCase.java
@@ -45,7 +45,7 @@ import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.Value;
 import org.apache.flink.util.MutableObjectIterator;
@@ -62,7 +62,7 @@ public class LargeRecordHandlerITCase {
 		final int NUM_RECORDS = 10;
 		
 		try {
-			final DefaultMemoryManager memMan = new DefaultMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
+			final HeapMemoryManager memMan = new HeapMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> initialMemory = memMan.allocatePages(owner, 6);
@@ -203,7 +203,7 @@ public class LargeRecordHandlerITCase {
 		FileIOChannel.ID channel = null;
 		
 		try {
-			final DefaultMemoryManager memMan = new DefaultMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
+			final HeapMemoryManager memMan = new HeapMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> memory = memMan.allocatePages(owner, NUM_PAGES);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.Test;
@@ -49,7 +49,7 @@ public class LargeRecordHandlerTest {
 		final int NUM_PAGES = 50;
 		
 		try {
-			final DefaultMemoryManager memMan = new DefaultMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
+			final HeapMemoryManager memMan = new HeapMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
 			final AbstractInvokable owner = new DummyInvokable();
 			final List<MemorySegment> memory = memMan.allocatePages(owner, NUM_PAGES);
 			
@@ -101,7 +101,7 @@ public class LargeRecordHandlerTest {
 		final int NUM_RECORDS = 25000;
 		
 		try {
-			final DefaultMemoryManager memMan = new DefaultMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
+			final HeapMemoryManager memMan = new HeapMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> initialMemory = memMan.allocatePages(owner, 6);
@@ -189,7 +189,7 @@ public class LargeRecordHandlerTest {
 		final int NUM_RECORDS = 25000;
 		
 		try {
-			final DefaultMemoryManager memMan = new DefaultMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
+			final HeapMemoryManager memMan = new HeapMemoryManager(NUM_PAGES * PAGE_SIZE, 1, PAGE_SIZE);
 			final AbstractInvokable owner = new DummyInvokable();
 			
 			final List<MemorySegment> initialMemory = memMan.allocatePages(owner, 6);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringSortingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringSortingITCase.java
@@ -37,7 +37,7 @@ import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.MutableObjectIterator;
@@ -81,7 +81,7 @@ public class MassiveStringSortingITCase {
 			BufferedReader verifyReader = null;
 			
 			try {
-				MemoryManager mm = new DefaultMemoryManager(1024 * 1024, 1);
+				MemoryManager mm = new HeapMemoryManager(1024 * 1024, 1);
 				IOManager ioMan = new IOManagerAsync();
 					
 				TypeSerializer<String> serializer = StringSerializer.INSTANCE;
@@ -171,7 +171,7 @@ public class MassiveStringSortingITCase {
 			BufferedReader verifyReader = null;
 			
 			try {
-				MemoryManager mm = new DefaultMemoryManager(1024 * 1024, 1);
+				MemoryManager mm = new HeapMemoryManager(1024 * 1024, 1);
 				IOManager ioMan = new IOManagerAsync();
 					
 				TupleTypeInfo<Tuple2<String, String[]>> typeInfo = (TupleTypeInfo<Tuple2<String, String[]>>) (TupleTypeInfo<?>) TypeInfoParser.parse("Tuple2<String, String[]>");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringValueSortingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MassiveStringValueSortingITCase.java
@@ -37,7 +37,7 @@ import org.apache.flink.api.java.typeutils.runtime.CopyableValueSerializer;
 import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.types.StringValue;
@@ -81,7 +81,7 @@ public class MassiveStringValueSortingITCase {
 			BufferedReader verifyReader = null;
 			
 			try {
-				MemoryManager mm = new DefaultMemoryManager(1024 * 1024, 1);
+				MemoryManager mm = new HeapMemoryManager(1024 * 1024, 1);
 				IOManager ioMan = new IOManagerAsync();
 					
 				TypeSerializer<StringValue> serializer = new CopyableValueSerializer<StringValue>(StringValue.class);
@@ -172,7 +172,7 @@ public class MassiveStringValueSortingITCase {
 			BufferedReader verifyReader = null;
 			
 			try {
-				MemoryManager mm = new DefaultMemoryManager(1024 * 1024, 1);
+				MemoryManager mm = new HeapMemoryManager(1024 * 1024, 1);
 				IOManager ioMan = new IOManagerAsync();
 					
 				TupleTypeInfo<Tuple2<StringValue, StringValue[]>> typeInfo = (TupleTypeInfo<Tuple2<StringValue, StringValue[]>>) (TupleTypeInfo<?>)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeMatchIteratorITCase.java
@@ -35,7 +35,7 @@ import org.apache.flink.api.java.record.functions.JoinFunction;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -91,7 +91,7 @@ public class NonReusingSortMergeMatchIteratorITCase {
 		this.comparator2 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
 		this.pairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[]{TestData.Key.class});
 		
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
@@ -25,9 +25,7 @@ import java.util.Random;
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
 import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
-import org.apache.flink.runtime.operators.sort.NormalizedKeySorter;
-import org.apache.flink.runtime.operators.sort.QuickSort;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.TestData.Key;
@@ -57,12 +55,12 @@ public class NormalizedKeySorterTest
 	
 	private static final int MEMORY_PAGE_SIZE = 32 * 1024; 
 
-	private DefaultMemoryManager memoryManager;
+	private HeapMemoryManager memoryManager;
 
 
 	@Before
 	public void beforeTest() {
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, MEMORY_PAGE_SIZE);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, MEMORY_PAGE_SIZE);
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeMatchIteratorITCase.java
@@ -28,7 +28,7 @@ import org.apache.flink.api.java.record.functions.JoinFunction;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -91,7 +91,7 @@ public class ReusingSortMergeMatchIteratorITCase {
 		this.comparator2 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
 		this.pairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[]{TestData.Key.class});
 
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, 1);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -37,7 +37,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.PactDriver;
 import org.apache.flink.runtime.operators.PactTaskContext;
@@ -104,7 +104,7 @@ public class DriverTestBase<S extends Function> implements PactTaskContext<S, Re
 		this.perSortMem = perSortMemory;
 		this.perSortFractionMem = (double)perSortMemory/totalMem;
 		this.ioManager = new IOManagerAsync();
-		this.memManager = totalMem > 0 ? new DefaultMemoryManager(totalMem,1) : null;
+		this.memManager = totalMem > 0 ? new HeapMemoryManager(totalMem,1) : null;
 		
 		this.inputs = new ArrayList<MutableObjectIterator<Record>>();
 		this.comparators = new ArrayList<TypeComparator<Record>>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -22,7 +22,7 @@ package org.apache.flink.runtime.operators.testutils;
 import akka.actor.ActorRef;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -114,7 +114,7 @@ public class MockEnvironment implements Environment {
 
 				@Override
 				public Buffer answer(InvocationOnMock invocationOnMock) throws Throwable {
-					return new Buffer(new MemorySegment(new byte[bufferSize]), mock(BufferRecycler.class));
+					return new Buffer(new HeapMemorySegment(new byte[bufferSize]), mock(BufferRecycler.class));
 				}
 			});
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -38,7 +38,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.JobID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.MutableObjectIterator;
@@ -85,7 +85,7 @@ public class MockEnvironment implements Environment {
 		this.inputs = new LinkedList<InputGate>();
 		this.outputs = new LinkedList<BufferWriter>();
 
-		this.memManager = new DefaultMemoryManager(memorySize, 1);
+		this.memManager = new HeapMemoryManager(memorySize, 1);
 		this.ioManager = new IOManagerAsync();
 		this.inputSplitProvider = inputSplitProvider;
 		this.bufferSize = bufferSize;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
@@ -28,7 +28,7 @@ import org.apache.flink.api.java.record.functions.JoinFunction;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashMatchIterator;
 import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashMatchIterator;
@@ -94,7 +94,7 @@ public class HashVsSortMiniBenchmark {
 		this.comparator2 = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
 		this.pairComparator11 = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {TestData.Key.class});
 		
-		this.memoryManager = new DefaultMemoryManager(MEMORY_SIZE, PAGE_SIZE);
+		this.memoryManager = new HeapMemoryManager(MEMORY_SIZE, PAGE_SIZE);
 		this.ioManager = new IOManagerAsync();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/DataInputOutputSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/DataInputOutputSerializerTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.util;
 
+import org.apache.flink.core.memory.HeapMemorySegment;
 import org.junit.Assert;
 
 import org.apache.flink.core.memory.MemorySegment;
@@ -38,7 +39,7 @@ public class DataInputOutputSerializerTest {
 		SerializationTestType randomInt = Util.randomRecord(SerializationTestTypeFactory.INT);
 
 		DataOutputSerializer serializer = new DataOutputSerializer(randomInt.length());
-		MemorySegment segment = new MemorySegment(new byte[randomInt.length()]);
+		MemorySegment segment = new HeapMemorySegment(new byte[randomInt.length()]);
 
 		try {
 			// empty buffer, read buffer should be empty

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/misc/MassiveCaseClassSortingITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/misc/MassiveCaseClassSortingITCase.scala
@@ -28,7 +28,7 @@ import java.io.BufferedReader
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync
 import java.io.FileReader
 import org.apache.flink.util.MutableObjectIterator
-import org.apache.flink.runtime.memorymanager.DefaultMemoryManager
+import org.apache.flink.runtime.memorymanager.HeapMemoryManager
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger
@@ -89,7 +89,7 @@ class MassiveCaseClassSortingITCase {
           0,
           new ExecutionConfig)
         
-        val mm = new DefaultMemoryManager(1024 * 1024, 1)
+        val mm = new HeapMemoryManager(1024 * 1024, 1)
         val ioMan = new IOManagerAsync()
         
         sorter = new UnilateralSortMerger[StringTuple](mm, ioMan, inputIterator,

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/CaseClassComparatorTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/CaseClassComparatorTest.scala
@@ -25,12 +25,10 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.core.memory.DataInputView
+import org.apache.flink.core.memory.{HeapMemorySegment, DataInputView, MemorySegment, DataOutputView}
 import java.io.IOException
 import org.apache.flink.api.common.typeutils.TypeComparator
 import com.amazonaws.services.sqs.model.UnsupportedOperationException
-import org.apache.flink.core.memory.MemorySegment
-import org.apache.flink.core.memory.DataOutputView
 import org.mockito.Mockito
 import org.apache.flink.runtime.operators.sort.NormalizedKeySorter
 import java.util.List
@@ -80,7 +78,7 @@ class CaseClassComparatorTest {
       val numMemSegs = 20
       val memory : List[MemorySegment] = new ArrayList[MemorySegment](numMemSegs)
       for (i <- 1 to numMemSegs) {
-        memory.add(new MemorySegment(new Array[Byte](32*1024)))
+        memory.add(new HeapMemorySegment(new Array[Byte](32*1024)))
       }
       
       val sorter : NormalizedKeySorter[CaseTestClass] = new NormalizedKeySorter[CaseTestClass](


### PR DESCRIPTION
The MemorySegment class has been converted into an abstract class. Its old JVM
heap implementation can now be found in HeapMemorySegment. In addition, an
implementation which uses direct (outside the JVM heap) memory allocation can be
found in DirectMemorySegment. Both of the classes use the sun.misc.Unsafe class
which modifies the memory directly. This method is unsafe in the sense that any
incorrectly written bytes may crash the JVM. By default, both classes perform
boundary checks when writing to the memory.

The DefaultMemoryManager has been renamed to HeapMemoryManager. In addition, a
DirectMemoryManager has been added. The classes' main difference is the queue
freeSegments which holds the memory segments. In the HeapMemoryManager, the
queue holds byte arrays while in the DirectMemoryManager, the queue holds
ByteBuffers.

The direct (off-heap) memory management is enabled for the task manager when the
config entry "taskmanager.memory.directAllocation" is set to "true". Like for
the heap memory management, if "taskmanager.memory.size" is set to a value
greater 0, the amount of memory in mega bytes will be allocated for the memory
allocation. Otherwise, a fraction (0.7) of the task manager JVM heap will be
used to determine the amount of memory to allocate. As of now, the user has to
take care to properly adjust the task manager's heap memory size (as configured
in "taskmanager.heap.mb") when using direct (off-heap) memory allocation.

The tests for all classes have been changed to test both classes.