### PR TITLE
FLINK-1402 - Remove Serializable extends from InputFormat interface

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputFormat.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.common.io;
 
 import java.io.IOException;
-import java.io.Serializable;
 
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
@@ -60,7 +59,7 @@ import org.apache.flink.core.io.InputSplitSource;
  * @param <OT> The type of the produced records.
  * @param <T> The type of input split.
  */
-public interface InputFormat<OT, T extends InputSplit> extends InputSplitSource<T>, Serializable {
+public interface InputFormat<OT, T extends InputSplit> extends InputSplitSource<T> {
 	
 	/**
 	 * Configures this input format. Since input formats are instantiated generically and hence parameterless, 

--- a/flink-core/src/main/java/org/apache/flink/core/io/InputSplitSource.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/InputSplitSource.java
@@ -18,13 +18,15 @@
 
 package org.apache.flink.core.io;
 
+import java.io.Serializable;
+
 /**
  * InputSplitSources create {@link InputSplit}s that define portions of data to be produced
  * by {@link org.apache.flink.api.common.io.InputFormat}s.
  *
  * @param <T> The type of the input splits created by the source.
  */
-public interface InputSplitSource<T extends InputSplit> extends java.io.Serializable {
+public interface InputSplitSource<T extends InputSplit> extends Serializable {
 
 	/**
 	 * Computes the input splits. The given minimum number of splits is a hint as to how


### PR DESCRIPTION
FLINK-1402
Remove Serializable extends from InputFormat interface since the InputSplitSource interface already extend the Serializable