### PR TITLE
Update incubator-flink name in the merge pull tools to flink.

### DIFF
--- a/tools/merge_flink_pr.py
+++ b/tools/merge_flink_pr.py
@@ -55,8 +55,8 @@ JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "pwendell")
 # ASF JIRA password
 JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "1234")
 
-GITHUB_BASE = "https://github.com/apache/incubator-flink/pull"
-GITHUB_API_BASE = "https://api.github.com/repos/apache/incubator-flink"
+GITHUB_BASE = "https://github.com/apache/flink/pull"
+GITHUB_API_BASE = "https://api.github.com/repos/apache/flink"
 JIRA_BASE = "https://issues.apache.org/jira/browse"
 JIRA_API_BASE = "https://issues.apache.org/jira"
 # Prefix added to temporary branches

--- a/tools/merge_pull_request.sh.template
+++ b/tools/merge_pull_request.sh.template
@@ -18,7 +18,7 @@
 #
 
 # the directory where you have your flink code
-export FLINK_HOME="/home/robert/projects/flink/incubator-flink"
+export FLINK_HOME="/home/robert/projects/flink"
 # Remote name which points to the Gihub site
 export PR_REMOTE_NAME="github_flink"
 # Remote name which points to Apache git


### PR DESCRIPTION
Currently, the merge scripts in tools/ directory still have incubator-flink instead of flink.

This PR updates the name from incubator-flink to flink.