### PR TITLE
[FLINK-1147][Java API] TypeInference on POJOs

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeInfoParser.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeInfoParser.java
@@ -157,6 +157,7 @@ public class TypeInfoParser {
 					} else {
 						arrayClazz = Class.forName("[L" + TUPLE_PACKAGE + "." + className + ";");
 					}
+					sb.delete(0, 2);
 					returnType = ObjectArrayTypeInfo.getInfoFor(arrayClazz, new TupleTypeInfo(clazz, types));
 				} else if (sb.length() < 1 || sb.charAt(0) != '[') {
 					returnType = new TupleTypeInfo(clazz, types);
@@ -291,10 +292,8 @@ public class TypeInfoParser {
 					String fieldName = fieldMatcher.group(1);
 					sb.delete(0, fieldName.length() + 1);
 
-					Field field = null;
-					try {
-						field = clazz.getDeclaredField(fieldName);
-					} catch (Exception e) {
+					Field field = TypeExtractor.getDeclaredField(clazz, fieldName);
+					if (field == null) {
 						throw new IllegalArgumentException("Field '" + fieldName + "'could not be accessed.");
 					}
 					fields.add(new PojoField(field, parse(sb)));

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -1260,7 +1260,7 @@ public class TypeExtractorTest {
 	public static class InType extends MyObject<String> {}
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
-	public void testParamertizedCustomObject() {
+	public void testParameterizedPojo() {
 		RichMapFunction<?, ?> function = new RichMapFunction<InType, MyObject<String>>() {
 			private static final long serialVersionUID = 1L;
 
@@ -1618,6 +1618,24 @@ public class TypeExtractorTest {
 	public void testInputInference3() {
 		EdgeMapper3<Boolean, String> em = new EdgeMapper3<Boolean, String>();
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) em, TypeInfoParser.parse("Tuple3<Boolean,Boolean,String>"));
+		Assert.assertTrue(ti.isBasicType());
+		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
+	}
+	
+	public static class EdgeMapper4<K, V> implements MapFunction<Edge<K, V>[], V> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public V map(Edge<K, V>[] value) throws Exception {
+			return null;
+		}
+	}
+	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testInputInference4() {
+		EdgeMapper4<Boolean, String> em = new EdgeMapper4<Boolean, String>();
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) em, TypeInfoParser.parse("Tuple3<Boolean,Boolean,String>[]"));
 		Assert.assertTrue(ti.isBasicType());
 		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
 	}


### PR DESCRIPTION
The TypeExtractor now also fully supports generic POJOs and tries to get missing types by using type inference.

Functions can look like:

```
MapFunction<PojoWithGenerics<Long, T>, PojoWithGenerics<T,T>>
MapFunction<Tuple2<E, D>, PojoTuple<E, D, D>>
MapFunction<PojoTuple<E, D, D>, Tuple2<E, D>>
```

POJOs can contain fields such as:
```
public PojoWithGenerics<Z, Z> field;
public Z[] field;
public Tuple1<Z>[] field;
```

If you have ideas for other test cases, I'm happy to implement them.