### PR TITLE
[FLINK-1369] [types] Add support for Subclasses, Interfaces, Abstract Classes

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -339,7 +339,7 @@ public abstract class SerializerTestBase<T> {
 			try {
 				ser2 = SerializationUtils.clone(ser1);
 			} catch (SerializationException e) {
-				fail("The serializer is not serializable.");
+				fail("The serializer is not serializable: " + e);
 				return;
 			}
 			

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -54,6 +54,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.ValueTypeInfo;
+import org.apache.flink.api.java.typeutils.runtime.KryoSerializer;
+import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.util.NumberSequenceIterator;
@@ -197,6 +199,16 @@ public abstract class ExecutionEnvironment {
 	 */
 	public String getIdString() {
 		return this.executionId.toString();
+	}
+
+	/**
+	 * Registers the given type. When using subclasses of POJOs inside user functions, the system
+	 * can efficiently serialize these after registration. This must be called before creating
+	 * operations that use subclasses of POJOs.
+	 */
+	public void registerType(Class<?> clazz) {
+		PojoSerializer.registerType(clazz);
+		KryoSerializer.registerType(clazz);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -22,27 +22,54 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 
 public final class PojoSerializer<T> extends TypeSerializer<T> {
 
+	// We store classes that the user registers here. When a PojoSerializer is created
+	// it will copy the list of registered classes.
+	private static Set<Class<?>> staticRegisteredClasses = new HashSet<Class<?>>();
+
+	// Flags for the header
+	private static byte IS_NULL = 1;
+	private static byte IS_SUBCLASS = 2;
+	private static byte IS_TAGGED_SUBCLASS = 4;
+
 	private static final long serialVersionUID = 1L;
 
 	private final Class<T> clazz;
 
-	private final TypeSerializer<Object>[] fieldSerializers;
+	private TypeSerializer<Object>[] fieldSerializers;
 
 	// We need to handle these ourselves in writeObject()/readObject()
 	private transient Field[] fields;
 
-	private final int numFields;
+	private int numFields;
 
 	private final boolean stateful;
+
+	private transient Map<Class<?>, TypeSerializer> subclassSerializerCache;
+	private transient ClassLoader cl;
+
+	private Map<Class<?>, Integer> registeredClasses;
+
+	private TypeSerializer[] registeredSerializers;
 
 
 	@SuppressWarnings("unchecked")
@@ -64,6 +91,32 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			}
 		}
 		this.stateful = stateful;
+
+		cl = Thread.currentThread().getContextClassLoader();
+
+		subclassSerializerCache = new HashMap<Class<?>, TypeSerializer>();
+
+		// We only want those classes that are not our own class and are actually sub-classes.
+		List<Class<?>> cleanedTaggedClasses = new ArrayList<Class<?>>(staticRegisteredClasses.size());
+		for (Class<?> registeredClass: staticRegisteredClasses) {
+			if (registeredClass.equals(clazz)) {
+				continue;
+			}
+			if (!clazz.isAssignableFrom(registeredClass)) {
+				continue;
+			}
+			cleanedTaggedClasses.add(registeredClass);
+
+		}
+		registeredClasses = new LinkedHashMap<Class<?>, Integer>(cleanedTaggedClasses.size());
+		registeredSerializers = new TypeSerializer[cleanedTaggedClasses.size()];
+
+		int id = 0;
+		for (Class<?> registeredClass: cleanedTaggedClasses) {
+			registeredClasses.put(registeredClass, id);
+			registeredSerializers[id] = TypeExtractor.createTypeInfo(registeredClass).createSerializer();
+			id++;
+		}
 	}
 
 	private void writeObject(ObjectOutputStream out)
@@ -79,9 +132,9 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 	private void readObject(ObjectInputStream in)
 			throws IOException, ClassNotFoundException {
 		in.defaultReadObject();
-		int numKeyFields = in.readInt();
-		fields = new Field[numKeyFields];
-		for (int i = 0; i < numKeyFields; i++) {
+		int numFields = in.readInt();
+		fields = new Field[numFields];
+		for (int i = 0; i < numFields; i++) {
 			Class<?> clazz = (Class<?>)in.readObject();
 			String fieldName = in.readUTF();
 			fields[i] = null;
@@ -100,8 +153,51 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 						+ " (" + fieldName + ")");
 			}
 		}
+
+		cl = Thread.currentThread().getContextClassLoader();
+		subclassSerializerCache = new HashMap<Class<?>, TypeSerializer>();
 	}
-	
+
+	private TypeSerializer getSubclassSerializer(Class<?> subclass) {
+		TypeSerializer<?> result = subclassSerializerCache.get(subclass);
+		if (result == null) {
+			result = TypeExtractor.createTypeInfo(subclass).createSerializer();
+			if (!(result instanceof PojoSerializer)) {
+				throw new RuntimeException("Subclass " + subclass + " cannot be analyzed as POJO TypeInfo.");
+			}
+			PojoSerializer<?> subclassSerializer = (PojoSerializer<?>) result;
+			subclassSerializer.removeBaseFields(this);
+			subclassSerializerCache.put(subclass, result);
+
+		}
+		return result;
+	}
+
+	private boolean hasField(Field f) {
+		for (Field field: fields) {
+			if (f.equals(field)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void removeBaseFields(PojoSerializer<?> baseSerializer) {
+		List<Field> newFields = new ArrayList<Field>();
+		List<TypeSerializer<Object>> newFieldSerializers = new ArrayList<TypeSerializer<Object>>();
+
+		for (int i = 0; i < numFields; i++) {
+			if (!baseSerializer.hasField(fields[i])) {
+				newFields.add(fields[i]);
+				newFieldSerializers.add(fieldSerializers[i]);
+			}
+		}
+
+		fields = newFields.toArray(new Field[newFields.size()]);
+		fieldSerializers = newFieldSerializers.toArray(new TypeSerializer[newFieldSerializers.size()]);
+		numFields = fields.length;
+	}
 	
 	@Override
 	public boolean isImmutableType() {
@@ -116,13 +212,12 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 	
 	@Override
 	public T createInstance() {
+		if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) {
+			return null;
+		}
 		try {
 			T t = clazz.newInstance();
-		
-			for (int i = 0; i < numFields; i++) {
-				fields[i].set(t, fieldSerializers[i].createInstance());
-			}
-			
+			initializeFields(t);
 			return t;
 		}
 		catch (Exception e) {
@@ -130,11 +225,26 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		}
 	}
 
+	protected void initializeFields(T t) {
+		for (int i = 0; i < numFields; i++) {
+			try {
+				fields[i].set(t, fieldSerializers[i].createInstance());
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException("Cannot initialize fields.", e);
+			}
+		}
+	}
+
 	@Override
+	@SuppressWarnings("unchecked")
 	public T copy(T from) {
+		if (from == null) {
+			return null;
+		}
+
 		T target;
 		try {
-			target = clazz.newInstance();
+			target = (T) from.getClass().newInstance();
 		}
 		catch (Throwable t) {
 			throw new RuntimeException("Cannot instantiate class.", t);
@@ -149,11 +259,29 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		catch (IllegalAccessException e) {
 			throw new RuntimeException("Error during POJO copy, this should not happen since we check the fields before.");
 		}
+
+		// If the class is actually a subclass, also copy the subclass fields.
+		Class<?> subclass = from.getClass();
+		if (!(clazz == subclass)) {
+			TypeSerializer subclassSerializer = getSubclassSerializer(subclass);
+			subclassSerializer.copy(from, target);
+		}
 		return target;
 	}
 	
 	@Override
+	@SuppressWarnings("unchecked")
 	public T copy(T from, T reuse) {
+		if (from == null) {
+			return null;
+		}
+
+		Class<?> fromClass = from.getClass();
+		if (reuse == null || fromClass != reuse.getClass()) {
+			// cannot reuse, do a non-reuse copy
+			return copy(from);
+		}
+
 		try {
 			for (int i = 0; i < numFields; i++) {
 				Object copy = fieldSerializers[i].copy(fields[i].get(from), fields[i].get(reuse));
@@ -163,6 +291,13 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			throw new RuntimeException("Error during POJO copy, this should not happen since we check the fields" +
 					"before.");
 		}
+
+		// If the class is actually a subclass, also copy the subclass fields.
+		if (clazz != fromClass) {
+			TypeSerializer subclassSerializer = getSubclassSerializer(fromClass);
+			subclassSerializer.copy(from, reuse);
+		}
+
 		return reuse;
 	}
 
@@ -173,14 +308,39 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public void serialize(T value, DataOutputView target) throws IOException {
+		int flags = 0;
 		// handle null values
 		if (value == null) {
-			target.writeBoolean(true);
+			flags |= IS_NULL;
+			target.writeByte(flags);
 			return;
-		} else {
-			target.writeBoolean(false);
 		}
+
+		Integer subclassTag = -1;
+		Class<?> actualClass = value.getClass();
+		TypeSerializer subclassSerializer = null;
+		if (clazz != actualClass) {
+			subclassTag = registeredClasses.get(actualClass);
+			if (subclassTag != null) {
+				flags |= IS_TAGGED_SUBCLASS;
+				subclassSerializer = registeredSerializers[subclassTag];
+			} else {
+				flags |= IS_SUBCLASS;
+				subclassSerializer = getSubclassSerializer(actualClass);
+			}
+		}
+
+		target.writeByte(flags);
+
+		if ((flags & IS_SUBCLASS) != 0) {
+			target.writeUTF(actualClass.getName());
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			target.writeByte(subclassTag);
+		}
+
+
 		try {
 			for (int i = 0; i < numFields; i++) {
 				Object o = fields[i].get(value);
@@ -195,25 +355,50 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			throw new RuntimeException("Error during POJO copy, this should not happen since we check the fields" +
 					"before.");
 		}
+
+		// Serialize subclass fields as well.
+		if (subclassSerializer != null) {
+			subclassSerializer.serialize(value, target);
+		}
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public T deserialize(DataInputView source) throws IOException {
-		boolean isNull = source.readBoolean();
-		if(isNull) {
+		int flags = source.readByte();
+		if((flags & IS_NULL) != 0) {
 			return null;
 		}
+
 		T target;
-		try {
-			target = clazz.newInstance();
+
+		Class<?> actualSubclass = null;
+		TypeSerializer subclassSerializer = null;
+
+		if ((flags & IS_SUBCLASS) != 0) {
+			String subclassName = source.readUTF();
+			try {
+				actualSubclass = Class.forName(subclassName, true, cl);
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Cannot instantiate class.", e);
+			}
+			subclassSerializer = getSubclassSerializer(actualSubclass);
+			target = (T) subclassSerializer.createInstance();
+			// also initialize fields for which the subclass serializer is not responsible
+			initializeFields(target);
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			int subclassTag = source.readByte();
+			subclassSerializer = registeredSerializers[subclassTag];
+			target = (T) subclassSerializer.createInstance();
+			// also initialize fields for which the subclass serializer is not responsible
+			initializeFields(target);
+		} else {
+			target = createInstance();
 		}
-		catch (Throwable t) {
-			throw new RuntimeException("Cannot instantiate class.", t);
-		}
-		
+
 		try {
 			for (int i = 0; i < numFields; i++) {
-				isNull = source.readBoolean();
+				boolean isNull = source.readBoolean();
 				if(isNull) {
 					fields[i].set(target, null);
 				} else {
@@ -225,19 +410,59 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			throw new RuntimeException("Error during POJO copy, this should not happen since we check the fields" +
 					"before.");
 		}
+
+		if (subclassSerializer != null) {
+			subclassSerializer.deserialize(target, source);
+		}
 		return target;
 	}
 	
 	@Override
+	@SuppressWarnings("unchecked")
 	public T deserialize(T reuse, DataInputView source) throws IOException {
+
 		// handle null values
-		boolean isNull = source.readBoolean();
-		if (isNull) {
+		int flags = source.readByte();
+		if((flags & IS_NULL) != 0) {
 			return null;
 		}
+
+		Class<?> subclass = null;
+		TypeSerializer subclassSerializer = null;
+		if ((flags & IS_SUBCLASS) != 0) {
+			String subclassName = source.readUTF();
+			try {
+				subclass = Class.forName(subclassName, true, cl);
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Cannot instantiate class.", e);
+			}
+			subclassSerializer = getSubclassSerializer(subclass);
+
+			if (reuse == null || subclass != reuse.getClass()) {
+				// cannot reuse
+				reuse = (T) subclassSerializer.createInstance();
+				// also initialize fields for which the subclass serializer is not responsible
+				initializeFields(reuse);
+			}
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			int subclassTag = source.readByte();
+			subclassSerializer = registeredSerializers[subclassTag];
+
+			if (reuse == null || ((PojoSerializer)subclassSerializer).clazz != reuse.getClass()) {
+				// cannot reuse
+				reuse = (T) subclassSerializer.createInstance();
+				// also initialize fields for which the subclass serializer is not responsible
+				initializeFields(reuse);
+			}
+		} else {
+			if (reuse == null || clazz != reuse.getClass()) {
+				reuse = createInstance();
+			}
+		}
+
 		try {
 			for (int i = 0; i < numFields; i++) {
-				isNull = source.readBoolean();
+				boolean isNull = source.readBoolean();
 				if(isNull) {
 					fields[i].set(reuse, null);
 				} else {
@@ -249,16 +474,49 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			throw new RuntimeException("Error during POJO copy, this should not happen since we check the fields" +
 					"before.");
 		}
+
+		if (subclassSerializer != null) {
+			subclassSerializer.deserialize(reuse, source);
+		}
+
 		return reuse;
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		// copy the Non-Null/Null tag
-		target.writeBoolean(source.readBoolean());
+		// copy the flags
+		int flags = source.readByte();
+		target.writeByte(flags);
+
+		if ((flags & IS_NULL) != 0) {
+			// is a null value, nothing further to copy
+			return;
+		}
+
+		TypeSerializer<?> subclassSerializer = null;
+		if ((flags & IS_SUBCLASS) != 0) {
+			String className = source.readUTF();
+			target.writeUTF(className);
+			try {
+				Class<?> subclass = Class.forName(className, true, Thread.currentThread()
+						.getContextClassLoader());
+				subclassSerializer = getSubclassSerializer(subclass);
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Cannot instantiate class.", e);
+			}
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			int subclassTag = source.readByte();
+			target.writeByte(subclassTag);
+			subclassSerializer = registeredSerializers[subclassTag];
+		}
+
 		for (int i = 0; i < numFields; i++) {
 			target.writeBoolean(source.readBoolean());
 			fieldSerializers[i].copy(source, target);
+		}
+
+		if (subclassSerializer != null) {
+			subclassSerializer.copy(source, target);
 		}
 	}
 	
@@ -282,5 +540,14 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		else {
 			return false;
 		}
+	}
+
+	public static void registerType(Class<?> clazz) {
+		TypeInformation<?> type = TypeExtractor.createTypeInfo(clazz);
+		if (!(type instanceof PojoTypeInfo)) {
+			throw new IllegalArgumentException("Class " + clazz + " could not be analyzed as a POJO type."
+					+ "A type is considered a POJO if all its fields are public, or have both getters and setters defined");
+		}
+		staticRegisteredClasses.add(clazz);
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassComparatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassComparatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.operators.Keys.ExpressionKeys;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.junit.Assert;
+
+import java.util.Arrays;
+
+
+public class PojoSubclassComparatorTest extends ComparatorTestBase<PojoContainingTuple> {
+	TypeInformation<PojoContainingTuple> type = TypeExtractor.getForClass(PojoContainingTuple.class);
+	
+	PojoContainingTuple[] data = new PojoContainingTuple[]{
+		new Subclass(1, 1L, 1L, 17L),
+		new Subclass(2, 2L, 2L, 42L),
+		new Subclass(8519, 85190L, 85190L, 117L),
+		new Subclass(8520, 85191L, 85191L, 93L),
+	};
+
+	@Override
+	protected TypeComparator<PojoContainingTuple> createComparator(boolean ascending) {
+		Assert.assertTrue(type instanceof CompositeType);
+		CompositeType<PojoContainingTuple> cType = (CompositeType<PojoContainingTuple>) type;
+		ExpressionKeys<PojoContainingTuple> keys = new ExpressionKeys<PojoContainingTuple>(new String[] {"theTuple.*"}, cType);
+		boolean[] orders = new boolean[keys.getNumberOfKeyFields()];
+		Arrays.fill(orders, ascending);
+		return cType.createComparator(keys.computeLogicalKeyPositions(), orders, 0);
+	}
+
+	@Override
+	protected TypeSerializer<PojoContainingTuple> createSerializer() {
+		return type.createSerializer();
+	}
+
+	@Override
+	protected PojoContainingTuple[] getSortedTestData() {
+		return data;
+	}
+
+	public static class Subclass extends PojoContainingTuple {
+
+		public long additionalField;
+
+		public Subclass() {
+		}
+
+		public Subclass(int i, long l1, long l2, long additionalField) {
+			super(i, l1, l2);
+			this.additionalField = additionalField;
+		}
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import com.google.common.base.Objects;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * A test for the {@link PojoSerializer}.
+ */
+public class PojoSubclassSerializerTest extends SerializerTestBase<PojoSubclassSerializerTest.TestUserClassBase> {
+	private TypeInformation<TestUserClassBase> type = TypeExtractor.getForClass(TestUserClassBase.class);
+
+	@Override
+	protected TypeSerializer<TestUserClassBase> createSerializer() {
+		// only register one of the two child classes
+		PojoSerializer.registerType(TestUserClass1.class);
+		TypeSerializer<TestUserClassBase> serializer = type.createSerializer();
+		assert(serializer instanceof PojoSerializer);
+		return serializer;
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<TestUserClassBase> getTypeClass() {
+		return TestUserClassBase.class;
+	}
+
+	@Override
+	protected TestUserClassBase[] getTestData() {
+		Random rnd = new Random(874597969123412341L);
+
+		return new TestUserClassBase[]{
+				new TestUserClass1(rnd.nextInt(), "foo", rnd.nextLong()),
+				new TestUserClass2(rnd.nextInt(), "bar", rnd.nextFloat())
+		};
+
+	}
+
+	@Override
+	@Test
+	public void testInstantiate() {
+		// don't do anything, since the PojoSerializer with subclass will return null
+	}
+
+	// User code class for testing the serializer
+	public static abstract class TestUserClassBase {
+		public int dumm1;
+		public String dumm2;
+
+
+		public TestUserClassBase() {
+		}
+
+		public TestUserClassBase(int dumm1, String dumm2) {
+			this.dumm1 = dumm1;
+			this.dumm2 = dumm2;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(dumm1, dumm2);
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof TestUserClassBase)) {
+				return false;
+			}
+			TestUserClassBase otherTUC = (TestUserClassBase) other;
+			if (dumm1 != otherTUC.dumm1) {
+				return false;
+			}
+			if (!dumm2.equals(otherTUC.dumm2)) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	public static class TestUserClass1 extends TestUserClassBase {
+		public long dumm3;
+
+		public TestUserClass1() {
+		}
+
+		public TestUserClass1(int dumm1, String dumm2, long dumm3) {
+			super(dumm1, dumm2);
+			this.dumm3 = dumm3;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof TestUserClass1)) {
+				return false;
+			}
+			TestUserClass1 otherTUC = (TestUserClass1) other;
+			if (dumm1 != otherTUC.dumm1) {
+				return false;
+			}
+			if (!dumm2.equals(otherTUC.dumm2)) {
+				return false;
+			}
+			if (dumm3 != otherTUC.dumm3) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	public static class TestUserClass2 extends TestUserClassBase {
+		public float dumm4;
+
+		public TestUserClass2() {
+		}
+
+		public TestUserClass2(int dumm1, String dumm2, float dumm4) {
+			super(dumm1, dumm2);
+			this.dumm4 = dumm4;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof TestUserClass2)) {
+				return false;
+			}
+			TestUserClass2 otherTUC = (TestUserClass2) other;
+			if (dumm1 != otherTUC.dumm1) {
+				return false;
+			}
+			if (!dumm2.equals(otherTUC.dumm2)) {
+				return false;
+			}
+			if (dumm4 != otherTUC.dumm4) {
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/SubclassFromInterfaceSerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/SubclassFromInterfaceSerializerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import com.google.common.base.Objects;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * Testing the serialization of classes which are subclasses of a class that implements an interface.
+ */
+public class SubclassFromInterfaceSerializerTest extends SerializerTestBase<SubclassFromInterfaceSerializerTest.TestUserInterface> {
+	private TypeInformation<TestUserInterface> type = TypeExtractor.getForClass(TestUserInterface.class);
+
+	@Override
+	protected TypeSerializer<TestUserInterface> createSerializer() {
+		// only register one of the two child classes
+		PojoSerializer.registerType(TestUserClass2.class);
+		TypeSerializer<TestUserInterface> serializer = type.createSerializer();
+		assert(serializer instanceof KryoSerializer);
+		return serializer;
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<TestUserInterface> getTypeClass() {
+		return TestUserInterface.class;
+	}
+
+	@Override
+	protected TestUserInterface[] getTestData() {
+		Random rnd = new Random(874597969123412341L);
+
+		return new TestUserInterface[]{
+				new TestUserClass1(rnd.nextInt(), "foo", rnd.nextLong()),
+				new TestUserClass2(rnd.nextInt(), "bar", rnd.nextFloat())
+		};
+
+	}
+
+	@Override
+	@Test
+	public void testInstantiate() {
+		// don't do anything, since the PojoSerializer with subclass will return null
+	}
+
+	public interface TestUserInterface {}
+
+	// User code class for testing the serializer
+	public static class TestUserClassBase implements TestUserInterface {
+		public int dumm1;
+		public String dumm2;
+
+
+		public TestUserClassBase() {
+		}
+
+		public TestUserClassBase(int dumm1, String dumm2) {
+			this.dumm1 = dumm1;
+			this.dumm2 = dumm2;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(dumm1, dumm2);
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof TestUserClassBase)) {
+				return false;
+			}
+			TestUserClassBase otherTUC = (TestUserClassBase) other;
+			if (dumm1 != otherTUC.dumm1) {
+				return false;
+			}
+			if (!dumm2.equals(otherTUC.dumm2)) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	public static class TestUserClass1 extends TestUserClassBase {
+		public long dumm3;
+
+		public TestUserClass1() {
+		}
+
+		public TestUserClass1(int dumm1, String dumm2, long dumm3) {
+			super(dumm1, dumm2);
+			this.dumm3 = dumm3;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof TestUserClass1)) {
+				return false;
+			}
+			TestUserClass1 otherTUC = (TestUserClass1) other;
+			if (dumm1 != otherTUC.dumm1) {
+				return false;
+			}
+			if (!dumm2.equals(otherTUC.dumm2)) {
+				return false;
+			}
+			if (dumm3 != otherTUC.dumm3) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	public static class TestUserClass2 extends TestUserClassBase {
+		public float dumm4;
+
+		public TestUserClass2() {
+		}
+
+		public TestUserClass2(int dumm1, String dumm2, float dumm4) {
+			super(dumm1, dumm2);
+			this.dumm4 = dumm4;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof TestUserClass2)) {
+				return false;
+			}
+			TestUserClass2 otherTUC = (TestUserClass2) other;
+			if (dumm1 != otherTUC.dumm1) {
+				return false;
+			}
+			if (!dumm2.equals(otherTUC.dumm2)) {
+				return false;
+			}
+			if (dumm4 != otherTUC.dumm4) {
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult}
 import org.apache.flink.api.java.io._
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.java.typeutils.runtime.PojoSerializer
 import org.apache.flink.api.java.typeutils.{ValueTypeInfo, TupleTypeInfoBase}
 import org.apache.flink.api.scala.operators.ScalaCsvInputFormat
 import org.apache.flink.core.fs.Path
@@ -119,6 +120,15 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def getIdString: String = {
     javaEnv.getIdString
+  }
+
+  /**
+   * Registers the given type. When using subclasses of POJOs inside user functions, the system
+   * can efficiently serialize these after registration. This must be called before creating
+   * operations that use subclasses of POJOs.
+   */
+  def registerType(clazz: Class[_]) {
+    javaEnv.registerType(clazz)
   }
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
@@ -272,8 +272,12 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
       def unapply(tpe: Type): Option[Type] = tpe match {
         case _ if tpe <:< typeOf[BitSet] => Some(typeOf[Int])
 
-        case _ if tpe <:< typeOf[SortedMap[_, _]] => None
-        case _ if tpe <:< typeOf[SortedSet[_]] => None
+        case _ if tpe <:< typeOf[SortedMap[_, _]] =>
+          c.error(c.enclosingPosition, "SortedMap is not supported right now.")
+          None
+        case _ if tpe <:< typeOf[SortedSet[_]] =>
+          c.error(c.enclosingPosition, "SortedMap is not supported right now.")
+          None
 
         case _ if tpe <:< typeOf[TraversableOnce[_]] =>
 //          val traversable = tpe.baseClasses

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountSubclassInterfacePOJOITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountSubclassInterfacePOJOITCase.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.exampleJavaPrograms;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.test.testdata.WordCountData;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+
+@SuppressWarnings("serial")
+public class WordCountSubclassInterfacePOJOITCase extends JavaProgramTestBase implements Serializable {
+	private static final long serialVersionUID = 1L;
+	protected String textPath;
+	protected String resultPath;
+
+
+	@Override
+	protected void preSubmit() throws Exception {
+		textPath = createTempFile("text.txt", WordCountData.TEXT);
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<String> text = env.readTextFile(textPath);
+
+		DataSet<WCBase> counts = text
+				.flatMap(new Tokenizer())
+				.groupBy("word")
+				.reduce(new ReduceFunction<WCBase>() {
+					private static final long serialVersionUID = 1L;
+					public WCBase reduce(WCBase value1, WCBase value2) {
+						WC wc1 = (WC) value1;
+						WC wc2 = (WC) value2;
+						int c = wc1.secretCount.getCount() + wc2.secretCount.getCount();
+						wc1.secretCount.setCount(c);
+						return wc1;
+					}
+				})
+				.map(new MapFunction<WCBase, WCBase>() {
+					@Override
+					public WCBase map(WCBase value) throws Exception {
+						WC wc = (WC) value;
+						wc.count = wc.secretCount.getCount();
+						return wc;
+					}
+				});
+
+		counts.writeAsText(resultPath);
+
+		env.execute("WordCount with custom data types example");
+	}
+
+	public static final class Tokenizer implements FlatMapFunction<String, WCBase> {
+
+		@Override
+		public void flatMap(String value, Collector<WCBase> out) {
+			// normalize and split the line
+			String[] tokens = value.toLowerCase().split("\\W+");
+			// emit the pairs
+			for (String token : tokens) {
+				if (token.length() > 0) {
+					out.collect(new WC(token, 1));
+				}
+			}
+		}
+	}
+
+	public static abstract class WCBase {
+		public String word;
+		public int count;
+
+		public WCBase(String w, int c) {
+			this.word = w;
+			this.count = c;
+		}
+		@Override
+		public String toString() {
+			return word+" "+count;
+		}
+	}
+
+	public static interface CrazyCounter {
+		public int getCount();
+		public void setCount(int c);
+	}
+
+	public static class CrazyCounterImpl implements CrazyCounter {
+		public int countz;
+
+		public CrazyCounterImpl() {
+		}
+
+		public CrazyCounterImpl(int c) {
+			this.countz = c;
+		}
+
+		@Override
+		public int getCount() {
+			return countz;
+		}
+
+		@Override
+		public void setCount(int c) {
+			this.countz = c;
+		}
+
+	}
+
+	public static class WC extends WCBase {
+		public CrazyCounter secretCount;
+
+		public WC() {
+			super(null, 0);
+		}
+
+		public WC(String w, int c) {
+			super(w, 0);
+			this.secretCount = new CrazyCounterImpl(c);
+		}
+
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountSubclassPOJOITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountSubclassPOJOITCase.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.exampleJavaPrograms;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.test.testdata.WordCountData;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+
+@SuppressWarnings("serial")
+public class WordCountSubclassPOJOITCase extends JavaProgramTestBase implements Serializable {
+	private static final long serialVersionUID = 1L;
+	protected String textPath;
+	protected String resultPath;
+
+	
+	@Override
+	protected void preSubmit() throws Exception {
+		textPath = createTempFile("text.txt", WordCountData.TEXT);
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
+	}
+	
+	@Override
+	protected void testProgram() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<String> text = env.readTextFile(textPath);
+
+		DataSet<WCBase> counts = text
+				.flatMap(new Tokenizer())
+				.groupBy("word")
+				.reduce(new ReduceFunction<WCBase>() {
+					private static final long serialVersionUID = 1L;
+					public WCBase reduce(WCBase value1, WCBase value2) {
+						WC wc1 = (WC) value1;
+						WC wc2 = (WC) value2;
+						return new WC(value1.word, wc1.secretCount + wc2.secretCount);
+					}
+				})
+				.map(new MapFunction<WCBase, WCBase>() {
+					@Override
+					public WCBase map(WCBase value) throws Exception {
+						WC wc = (WC) value;
+						wc.count = wc.secretCount;
+						return wc;
+					}
+				});
+
+		counts.writeAsText(resultPath);
+
+		env.execute("WordCount with custom data types example");
+	}
+
+	public static final class Tokenizer implements FlatMapFunction<String, WCBase> {
+
+		@Override
+		public void flatMap(String value, Collector<WCBase> out) {
+			// normalize and split the line
+			String[] tokens = value.toLowerCase().split("\\W+");
+			// emit the pairs
+			for (String token : tokens) {
+				if (token.length() > 0) {
+					out.collect(new WC(token, 1));
+				}
+			}
+		}
+	}
+
+	public static abstract class WCBase {
+		public String word;
+		public int count;
+
+		public WCBase(String w, int c) {
+			this.word = w;
+			this.count = c;
+		}
+		@Override
+		public String toString() {
+			return word+" "+count;
+		}
+	}
+
+	public static class WC extends WCBase {
+
+		public int secretCount;
+
+		public WC() {
+			super(null, 0);
+		}
+
+		public WC(String w, int c) {
+			super(w, 0);
+			this.secretCount = c;
+		}
+	}
+	
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
@@ -55,12 +55,14 @@ class TraversableSerializerTest {
     runTests(testData)
   }
 
-  @Test(expected = classOf[InvalidTypesException])
+  /*
+  @Test
   def testSortedMap(): Unit = {
     // SortedSet is not supported right now.
     val testData = Array(SortedMap("Hello" -> 1, "World" -> 2), SortedMap("Foo" -> 42))
     runTests(testData)
   }
+  */
 
   @Test
   def testSet(): Unit = {
@@ -68,12 +70,14 @@ class TraversableSerializerTest {
     runTests(testData)
   }
 
-  @Test(expected = classOf[InvalidTypesException])
+  /*
+  @Test
   def testSortedSet(): Unit = {
     // SortedSet is not supported right now.
     val testData = Array(SortedSet(1,2,3), SortedSet(2,3))
     runTests(testData)
   }
+  */
 
   @Test
   def testBitSet(): Unit = {


### PR DESCRIPTION
This PR rebased PR #236 to the current master.
Some tests were failing and I had a closer look. The original PR handled interfaces and abstract classes without member variables as POJO types. However, POJO types without members cannot be handled correctly and do also not have members that can be referenced as keys or fields.
I changed the logic such that interfaces and abstract classes without members are handled as GenericTypes.

I'm not so familiar with the TypeExtractor, so it would be good if someone else could have a quick look.