### PR TITLE
[FLINK-1165] No createCollectionsEnvironment in Java API

### DIFF
--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
@@ -73,7 +72,7 @@ public class CollectionExecutionExample {
 	}
 	public static void main(String[] args) throws Exception {
 		// initialize a new Collection-based execution environment
-		final ExecutionEnvironment env = new CollectionEnvironment();
+		final ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 		
 		// create objects for users and emails
 		User[] usersArray = { new User(1, "Peter"), new User(2, "John"), new User(3, "Bill") };

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
@@ -72,7 +72,7 @@ public class CollectionExecutionExample {
 	}
 	public static void main(String[] args) throws Exception {
 		// initialize a new Collection-based execution environment
-		final ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+		final ExecutionEnvironment env = ExecutionEnvironment.createCollectionEnvironment();
 		
 		// create objects for users and emails
 		User[] usersArray = { new User(1, "Peter"), new User(2, "John"), new User(3, "Bill") };

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -843,7 +843,7 @@ public abstract class ExecutionEnvironment {
 	// --------------------------------------------------------------------------------------------
 	//  Instantiation of Execution Contexts
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Creates an execution environment that represents the context in which the program is currently executed.
 	 * If the program is invoked standalone, this method returns a local execution environment, as returned by
@@ -856,7 +856,19 @@ public abstract class ExecutionEnvironment {
 		return contextEnvironmentFactory == null ? 
 				createLocalEnvironment() : contextEnvironmentFactory.createExecutionEnvironment();
 	}
-	
+
+	/**
+	 * Createa a {@link CollectionEnvironment} that uses Java Collections underneath. This will execute in a
+	 * single thread in the current JVM. It is very fast but will fail if the data does not fit into
+	 * memory. Degree of parallelism will always be 1. This is useful during implementation and for debugging.
+	 * @return A Collection Environment
+	 */
+	public static CollectionEnvironment createCollectionsEnvironment(){
+		CollectionEnvironment ce = new CollectionEnvironment();
+		ce.setDegreeOfParallelism(1);
+		return ce;
+	}
+
 	/**
 	 * Creates a {@link LocalEnvironment}. The local execution environment will run the program in a
 	 * multi-threaded fashion in the same JVM as the environment was created in. The default degree of

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -858,12 +858,12 @@ public abstract class ExecutionEnvironment {
 	}
 
 	/**
-	 * Createa a {@link CollectionEnvironment} that uses Java Collections underneath. This will execute in a
+	 * Creates a {@link CollectionEnvironment} that uses Java Collections underneath. This will execute in a
 	 * single thread in the current JVM. It is very fast but will fail if the data does not fit into
 	 * memory. Degree of parallelism will always be 1. This is useful during implementation and for debugging.
 	 * @return A Collection Environment
 	 */
-	public static CollectionEnvironment createCollectionsEnvironment(){
+	public static CollectionEnvironment createCollectionEnvironment(){
 		CollectionEnvironment ce = new CollectionEnvironment();
 		ce.setDegreeOfParallelism(1);
 		return ce;

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
@@ -37,7 +37,7 @@ public class CollectionExecutionAccumulatorsTest {
 		try {
 			final int NUM_ELEMENTS = 100;
 			
-			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionEnvironment();
 			
 			env.generateSequence(1, NUM_ELEMENTS)
 				.map(new CountingMapper())

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.*;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOuputFormat;
 import org.apache.flink.configuration.Configuration;
@@ -38,7 +37,7 @@ public class CollectionExecutionAccumulatorsTest {
 		try {
 			final int NUM_ELEMENTS = 100;
 			
-			ExecutionEnvironment env = new CollectionEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 			
 			env.generateSequence(1, NUM_ELEMENTS)
 				.map(new CountingMapper())

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionIterationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionIterationTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
@@ -45,7 +44,7 @@ public class CollectionExecutionIterationTest implements java.io.Serializable {
 	@Test
 	public void testBulkIteration() {
 		try {
-			ExecutionEnvironment env = new CollectionEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 			
 			IterativeDataSet<Integer> iteration = env.fromElements(1).iterate(10);
 			
@@ -68,7 +67,7 @@ public class CollectionExecutionIterationTest implements java.io.Serializable {
 	@Test
 	public void testBulkIterationWithTerminationCriterion() {
 		try {
-			ExecutionEnvironment env = new CollectionEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 			
 			IterativeDataSet<Integer> iteration = env.fromElements(1).iterate(100);
 			
@@ -99,7 +98,7 @@ public class CollectionExecutionIterationTest implements java.io.Serializable {
 	@Test
 	public void testDeltaIteration() {
 		try {
-			ExecutionEnvironment env = new CollectionEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 
 			@SuppressWarnings("unchecked")
 			DataSet<Tuple2<Integer, Integer>> solInput = env.fromElements(

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionIterationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionIterationTest.java
@@ -44,7 +44,7 @@ public class CollectionExecutionIterationTest implements java.io.Serializable {
 	@Test
 	public void testBulkIteration() {
 		try {
-			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionEnvironment();
 			
 			IterativeDataSet<Integer> iteration = env.fromElements(1).iterate(10);
 			
@@ -67,7 +67,7 @@ public class CollectionExecutionIterationTest implements java.io.Serializable {
 	@Test
 	public void testBulkIterationWithTerminationCriterion() {
 		try {
-			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionEnvironment();
 			
 			IterativeDataSet<Integer> iteration = env.fromElements(1).iterate(100);
 			
@@ -98,7 +98,7 @@ public class CollectionExecutionIterationTest implements java.io.Serializable {
 	@Test
 	public void testDeltaIteration() {
 		try {
-			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionEnvironment();
 
 			@SuppressWarnings("unchecked")
 			DataSet<Tuple2<Integer, Integer>> solInput = env.fromElements(

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionWithBroadcastVariableTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionWithBroadcastVariableTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import org.apache.flink.api.common.functions.RichCrossFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
@@ -43,7 +42,7 @@ public class CollectionExecutionWithBroadcastVariableTest {
 	@Test
 	public void testUnaryOp() {
 		try {
-			ExecutionEnvironment env = new CollectionEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 			
 			DataSet<String> bcData = env.fromElements(SUFFIX);
 			
@@ -69,7 +68,7 @@ public class CollectionExecutionWithBroadcastVariableTest {
 	@Test
 	public void testBinaryOp() {
 		try {
-			ExecutionEnvironment env = new CollectionEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 			
 			DataSet<String> bcData = env.fromElements(SUFFIX);
 			DataSet<String> inData = env.fromElements(TEST_DATA);

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionWithBroadcastVariableTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionWithBroadcastVariableTest.java
@@ -42,7 +42,7 @@ public class CollectionExecutionWithBroadcastVariableTest {
 	@Test
 	public void testUnaryOp() {
 		try {
-			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionEnvironment();
 			
 			DataSet<String> bcData = env.fromElements(SUFFIX);
 			
@@ -68,7 +68,7 @@ public class CollectionExecutionWithBroadcastVariableTest {
 	@Test
 	public void testBinaryOp() {
 		try {
-			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+			ExecutionEnvironment env = ExecutionEnvironment.createCollectionEnvironment();
 			
 			DataSet<String> bcData = env.fromElements(SUFFIX);
 			DataSet<String> inData = env.fromElements(TEST_DATA);

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -488,12 +488,12 @@ object ExecutionEnvironment {
   }
 
   /**
-   * Createa an execution environment that uses Java Collections underneath. This will execute in a
+   * Creates an execution environment that uses Java Collections underneath. This will execute in a
    * single thread in the current JVM. It is very fast but will fail if the data does not fit into
    * memory. This is useful during implementation and for debugging.
    * @return
    */
-  def createCollectionsEnvironment: ExecutionEnvironment = {
+  def createCollectionEnvironment: ExecutionEnvironment = {
     new ExecutionEnvironment(new CollectionEnvironment)
   }
 


### PR DESCRIPTION
This commit adds a new method to ExecutionEnvironment to create a
CollectionEnvironment, and applies the method to cases where a
CollectionEnvironment() may be needed