### PR TITLE
[FLINK-1372] [runtime] Fix akka logging

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -345,11 +345,6 @@ public final class ConfigConstants {
 	public static final String AKKA_LOG_LIFECYCLE_EVENTS = "akka.log.lifecycle.events";
 
 	/**
-	 * Log level for akka
-	 */
-	public static final String AKKA_LOG_LEVEL = "akka.loglevel";
-
-	/**
 	 * Timeout for all blocking calls
 	 */
 	public static final String AKKA_ASK_TIMEOUT = "akka.ask.timeout";
@@ -596,8 +591,6 @@ public final class ConfigConstants {
 	public static boolean DEFAULT_AKKA_LOG_LIFECYCLE_EVENTS = false;
 
 	public static String DEFAULT_AKKA_FRAMESIZE = "10485760b";
-
-	public static String DEFAULT_AKKA_LOG_LEVEL = "ERROR";
 
 	public static int DEFAULT_AKKA_ASK_TIMEOUT = 100;
 	

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -80,15 +80,9 @@ object AkkaUtils {
 
     val logLifecycleEvents = if (lifecycleEvents) "on" else "off"
 
-    val logLevel = configuration.getString(ConfigConstants.AKKA_LOG_LEVEL,
-      ConfigConstants.DEFAULT_AKKA_LOG_LEVEL)
-
     val configString =
       s"""
          |akka {
-         |  loglevel = $logLevel
-         |  stdout-loglevel = $logLevel
-         |
          |  log-dead-letters = $logLifecycleEvents
          |  log-dead-letters-during-shutdown = $logLifecycleEvents
          |
@@ -144,15 +138,9 @@ object AkkaUtils {
 
     val logLifecycleEvents = if (lifecycleEvents) "on" else "off"
 
-    val logLevel = configuration.getString(ConfigConstants.AKKA_LOG_LEVEL,
-      ConfigConstants.DEFAULT_AKKA_LOG_LEVEL)
-
     val configString =
       s"""
          |akka {
-         |  loglevel = $logLevel
-         |  stdout-loglevel = $logLevel
-         |
          |  log-dead-letters = $logLifecycleEvents
          |  log-dead-letters-during-shutdown = $logLifecycleEvents
          |
@@ -204,12 +192,16 @@ object AkkaUtils {
       |
       |  loggers = ["akka.event.slf4j.Slf4jLogger"]
       |  logger-startup-timeout = 30s
-      |  loglevel = "WARNING"
-      |  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+      |  loglevel = "DEBUG"
       |  stdout-loglevel = "WARNING"
       |  jvm-exit-on-fatal-error = off
       |  log-config-on-start = off
+      |
       |  serialize-messages = on
+      |
+      |  debug {
+      |   lifecycle = on
+      |  }
       |}
     """.stripMargin
   }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -46,8 +46,7 @@ object TestingUtils {
     s"""akka.daemonic = on
       |akka.test.timefactor = 10
       |akka.loggers = ["akka.event.slf4j.Slf4jLogger"]
-      |akka.loglevel = "OFF"
-      |akka.logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+      |akka.loglevel = "DEBUG"
       |akka.stdout-loglevel = "OFF"
       |akka.jvm-exit-on-fata-error = off
       |akka.log-config-on-start = off


### PR DESCRIPTION
Fixes logging settings. The logging is now exclusively controlled by the logging properties provided to the system and thus removes akka.loglevel config parameter.

The JobManager and TaskManager now log their startup settings properly.