### PR TITLE
[FLINK-1353] Fixes the Execution to use the configured Akka timeout value

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -22,7 +22,6 @@ import akka.actor.ActorRef;
 import akka.dispatch.OnComplete;
 import akka.pattern.Patterns;
 import akka.util.Timeout;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.PartitionInfo;
@@ -46,7 +45,6 @@ import scala.concurrent.duration.FiniteDuration;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -89,29 +87,29 @@ public class Execution implements Serializable {
 	
 	private static final int NUM_CANCEL_CALL_TRIES = 3;
 
-	public static FiniteDuration timeout = new FiniteDuration(ConfigConstants
-			.DEFAULT_AKKA_ASK_TIMEOUT, TimeUnit.SECONDS);
-	
 	// --------------------------------------------------------------------------------------------
-	
+
 	private final ExecutionVertex vertex;
-	
+
 	private final ExecutionAttemptID attemptId;
-	
+
 	private final long[] stateTimestamps;
-	
+
 	private final int attemptNumber;
-	
-	
+
+	public FiniteDuration timeout;
+
+
 	private volatile ExecutionState state = CREATED;
-	
+
 	private volatile AllocatedSlot assignedResource;  // once assigned, never changes
 	
 	private volatile Throwable failureCause;          // once assigned, never changes
 	
 	// --------------------------------------------------------------------------------------------
 	
-	public Execution(ExecutionVertex vertex, int attemptNumber, long startTimestamp) {
+	public Execution(ExecutionVertex vertex, int attemptNumber, long startTimestamp,
+					FiniteDuration timeout) {
 		this.vertex = checkNotNull(vertex);
 		this.attemptId = new ExecutionAttemptID();
 		checkArgument(attemptNumber >= 0);
@@ -119,6 +117,8 @@ public class Execution implements Serializable {
 
 		this.stateTimestamps = new long[ExecutionState.values().length];
 		markTimestamp(ExecutionState.CREATED, startTimestamp);
+
+		this.timeout = timeout;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.slf4j.Logger;
+import scala.concurrent.duration.FiniteDuration;
 
 
 public class ExecutionJobVertex implements Serializable {
@@ -73,11 +74,13 @@ public class ExecutionJobVertex implements Serializable {
 	private transient InputSplitAssigner splitAssigner;
 	
 	
-	public ExecutionJobVertex(ExecutionGraph graph, AbstractJobVertex jobVertex, int defaultParallelism) throws JobException {
-		this(graph, jobVertex, defaultParallelism, System.currentTimeMillis());
+	public ExecutionJobVertex(ExecutionGraph graph, AbstractJobVertex jobVertex,
+							int defaultParallelism, FiniteDuration timeout) throws JobException {
+		this(graph, jobVertex, defaultParallelism, timeout, System.currentTimeMillis());
 	}
 	
-	public ExecutionJobVertex(ExecutionGraph graph, AbstractJobVertex jobVertex, int defaultParallelism, long createTimestamp)
+	public ExecutionJobVertex(ExecutionGraph graph, AbstractJobVertex jobVertex,
+							int defaultParallelism, FiniteDuration timeout, long createTimestamp)
 			throws JobException
 	{
 		if (graph == null || jobVertex == null) {
@@ -113,7 +116,7 @@ public class ExecutionJobVertex implements Serializable {
 		
 		// create all task vertices
 		for (int i = 0; i < numTaskVertices; i++) {
-			ExecutionVertex vertex = new ExecutionVertex(this, i, this.producedDataSets, createTimestamp);
+			ExecutionVertex vertex = new ExecutionVertex(this, i, this.producedDataSets, timeout, createTimestamp);
 			this.taskVertices[i] = vertex;
 		}
 		

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.akka
 
 import java.io.IOException
-import java.util.concurrent.Callable
+import java.util.concurrent.{TimeUnit, Callable}
 
 import akka.actor.{ActorSelection, ActorRef, ActorSystem}
 import akka.pattern.{Patterns, ask => akkaAsk}
@@ -29,7 +29,8 @@ import scala.concurrent.{ExecutionContext, Future, Await}
 import scala.concurrent.duration._
 
 object AkkaUtils {
-  val DEFAULT_TIMEOUT: FiniteDuration = 1 minute
+  val DEFAULT_TIMEOUT: FiniteDuration =
+    FiniteDuration(ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT, TimeUnit.SECONDS);
 
   val INF_TIMEOUT = 21474835 seconds
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -56,8 +56,6 @@ class JobManager(val configuration: Configuration)
   implicit val timeout = FiniteDuration(configuration.getInteger(ConfigConstants.AKKA_ASK_TIMEOUT,
     ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT), TimeUnit.SECONDS)
 
-  Execution.timeout = timeout
-
   log.info(s"Starting job manager at ${self.path}.")
 
   checkJavaVersion
@@ -147,7 +145,7 @@ class JobManager(val configuration: Configuration)
 
             val (executionGraph, jobInfo) = currentJobs.getOrElseUpdate(jobGraph.getJobID(),
               (new ExecutionGraph(jobGraph.getJobID, jobGraph.getName,
-                jobGraph.getJobConfiguration, jobGraph.getUserJarBlobKeys, userCodeLoader),
+                jobGraph.getJobConfiguration, timeout, jobGraph.getUserJarBlobKeys, userCodeLoader),
                 JobInfo(sender, System.currentTimeMillis())))
 
             val jobNumberRetries = if (jobGraph.getNumberOfExecutionRetries >= 0) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.executiongraph;
 
 import java.util.Arrays;
 
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,10 +44,14 @@ public class AllVerticesIteratorTest {
 			
 			ExecutionGraph eg = Mockito.mock(ExecutionGraph.class);
 					
-			ExecutionJobVertex ejv1 = new ExecutionJobVertex(eg, v1, 1);
-			ExecutionJobVertex ejv2 = new ExecutionJobVertex(eg, v2, 1);
-			ExecutionJobVertex ejv3 = new ExecutionJobVertex(eg, v3, 1);
-			ExecutionJobVertex ejv4 = new ExecutionJobVertex(eg, v4, 1);
+			ExecutionJobVertex ejv1 = new ExecutionJobVertex(eg, v1, 1,
+					AkkaUtils.DEFAULT_TIMEOUT());
+			ExecutionJobVertex ejv2 = new ExecutionJobVertex(eg, v2, 1,
+					AkkaUtils.DEFAULT_TIMEOUT());
+			ExecutionJobVertex ejv3 = new ExecutionJobVertex(eg, v3, 1,
+					AkkaUtils.DEFAULT_TIMEOUT());
+			ExecutionJobVertex ejv4 = new ExecutionJobVertex(eg, v4, 1,
+					AkkaUtils.DEFAULT_TIMEOUT());
 			
 			AllVerticesIterator iter = new AllVerticesIterator(Arrays.asList(ejv1, ejv2, ejv3, ejv4).iterator());
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -97,7 +98,7 @@ public class ExecutionGraphConstructionTest {
 		
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -135,7 +136,7 @@ public class ExecutionGraphConstructionTest {
 		
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2, v3));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -196,7 +197,7 @@ public class ExecutionGraphConstructionTest {
 		
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2, v3));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -444,7 +445,7 @@ public class ExecutionGraphConstructionTest {
 		
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -494,7 +495,7 @@ public class ExecutionGraphConstructionTest {
 		
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2, v3, v5, v4));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 			fail("Attached wrong jobgraph");
@@ -549,7 +550,7 @@ public class ExecutionGraphConstructionTest {
 			
 			List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 			try {
 				eg.attachJobGraph(ordered);
 			}
@@ -588,7 +589,8 @@ public class ExecutionGraphConstructionTest {
 			
 			List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2, v3));
 
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+					AkkaUtils.DEFAULT_TIMEOUT());
 
 			try {
 				eg.attachJobGraph(ordered);
@@ -653,7 +655,8 @@ public class ExecutionGraphConstructionTest {
 			
 			JobGraph jg = new JobGraph(jobId, jobName, v1, v2, v3, v4, v5, v6, v7, v8);
 			
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+					AkkaUtils.DEFAULT_TIMEOUT());
 			eg.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 			
 			// check the v1 / v2 co location hints ( assumes parallelism(v1) >= parallelism(v2) )

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -30,12 +30,14 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import akka.actor.Actor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.testkit.JavaTestKit;
 import akka.testkit.TestActorRef;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.PartitionConsumerDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.PartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -98,7 +100,8 @@ public class ExecutionGraphDeploymentTest {
 			v3.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
 			v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
 
-			ExecutionGraph eg = new ExecutionGraph(jobId, "some job", new Configuration());
+			ExecutionGraph eg = new ExecutionGraph(jobId, "some job", new Configuration(),
+					AkkaUtils.DEFAULT_TIMEOUT());
 
 			List<AbstractJobVertex> ordered = Arrays.asList(v1, v2, v3, v4);
 
@@ -108,7 +111,7 @@ public class ExecutionGraphDeploymentTest {
 			ExecutionVertex vertex = ejv.getTaskVertices()[3];
 
 			// create synchronous task manager
-			final TestActorRef<?> simpleTaskManager = TestActorRef.create(system,
+			final TestActorRef<? extends Actor> simpleTaskManager = TestActorRef.create(system,
 					Props.create(ExecutionGraphTestUtils
 							.SimpleAcknowledgingTaskManager.class));
 
@@ -304,7 +307,8 @@ public class ExecutionGraphDeploymentTest {
 		v2.setInvokableClass(RegularPactTask.class);
 
 		// execution graph that executes actions synchronously
-		ExecutionGraph eg = new ExecutionGraph(jobId, "some job", new Configuration());
+		ExecutionGraph eg = new ExecutionGraph(jobId, "some job", new Configuration(),
+				AkkaUtils.DEFAULT_TIMEOUT());
 		eg.setQueuedSchedulingAllowed(false);
 
 		List<AbstractJobVertex> ordered = Arrays.asList(v1, v2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -30,6 +30,7 @@ import akka.actor.ActorRef;
 import akka.actor.UntypedActor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.AllocatedSlot;
@@ -149,9 +150,11 @@ public class ExecutionGraphTestUtils {
 		AbstractJobVertex ajv = new AbstractJobVertex("TestVertex", id);
 		ajv.setInvokableClass(mock(AbstractInvokable.class).getClass());
 		
-		ExecutionGraph graph = new ExecutionGraph(new JobID(), "test job", new Configuration());
+		ExecutionGraph graph = new ExecutionGraph(new JobID(), "test job", new Configuration(),
+				AkkaUtils.DEFAULT_TIMEOUT());
 		
-		ExecutionJobVertex ejv = spy(new ExecutionJobVertex(graph, ajv, 1));
+		ExecutionJobVertex ejv = spy(new ExecutionJobVertex(graph, ajv, 1,
+				AkkaUtils.DEFAULT_TIMEOUT()));
 		
 		Answer<Void> noop = new Answer<Void>() {
 			@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
@@ -29,6 +29,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.testkit.JavaTestKit;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.instance.AllocatedSlot;
 import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
 import org.apache.flink.runtime.jobgraph.JobID;
@@ -64,7 +65,8 @@ public class ExecutionStateProgressTest {
 			ajv.setParallelism(3);
 			ajv.setInvokableClass(mock(AbstractInvokable.class).getClass());
 			
-			ExecutionGraph graph = new ExecutionGraph(jid, "test job", new Configuration());
+			ExecutionGraph graph = new ExecutionGraph(jid, "test job", new Configuration(),
+					AkkaUtils.DEFAULT_TIMEOUT());
 			graph.attachJobGraph(Arrays.asList(ajv));
 			
 			setGraphStatus(graph, JobStatus.RUNNING);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -34,6 +34,7 @@ import akka.actor.UntypedActor;
 import akka.japi.Creator;
 import akka.testkit.JavaTestKit;
 
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.AllocatedSlot;
@@ -74,7 +75,8 @@ public class ExecutionVertexCancelTest {
 			final JobVertexID jid = new JobVertexID();
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 			
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			
@@ -100,7 +102,8 @@ public class ExecutionVertexCancelTest {
 			final JobVertexID jid = new JobVertexID();
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 			
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			
 			setVertexState(vertex, ExecutionState.SCHEDULED);
 			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
@@ -133,7 +136,8 @@ public class ExecutionVertexCancelTest {
 
 				final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-				final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+				final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+						AkkaUtils.DEFAULT_TIMEOUT());
 				final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 				setVertexState(vertex, ExecutionState.SCHEDULED);
@@ -205,7 +209,8 @@ public class ExecutionVertexCancelTest {
 
 					final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+							AkkaUtils.DEFAULT_TIMEOUT());
 					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 					setVertexState(vertex, ExecutionState.SCHEDULED);
@@ -282,7 +287,8 @@ public class ExecutionVertexCancelTest {
 					final JobVertexID jid = new JobVertexID();
 					final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+							AkkaUtils.DEFAULT_TIMEOUT());
 					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 					final TestActorRef<? extends Actor> taskManager = TestActorRef.create(system,
@@ -329,7 +335,8 @@ public class ExecutionVertexCancelTest {
 					final JobVertexID jid = new JobVertexID();
 					final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+							AkkaUtils.DEFAULT_TIMEOUT());
 					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 					final ActorRef taskManager = TestActorRef.create(system, Props.create(new
@@ -384,7 +391,8 @@ public class ExecutionVertexCancelTest {
 					final JobVertexID jid = new JobVertexID();
 					final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+							AkkaUtils.DEFAULT_TIMEOUT());
 					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 					final ActorRef taskManager = TestActorRef.create(system,Props.create(new
@@ -426,7 +434,8 @@ public class ExecutionVertexCancelTest {
 					final JobVertexID jid = new JobVertexID();
 					final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+							AkkaUtils.DEFAULT_TIMEOUT());
 
 					final ActorRef taskManager = TestActorRef.create(system, Props.create(new
 							CancelSequenceTaskManagerCreator()));
@@ -468,7 +477,8 @@ public class ExecutionVertexCancelTest {
 					final JobVertexID jid = new JobVertexID();
 					final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+							AkkaUtils.DEFAULT_TIMEOUT());
 					final ExecutionAttemptID execID = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 					final ActorRef taskManager = system.actorOf(
@@ -513,7 +523,8 @@ public class ExecutionVertexCancelTest {
 			final JobVertexID jid = new JobVertexID();
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			setVertexState(vertex, ExecutionState.CANCELED);
 			
 			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
@@ -557,7 +568,8 @@ public class ExecutionVertexCancelTest {
 			
 			// scheduling while canceling is an illegal state transition
 			try {
-				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+						AkkaUtils.DEFAULT_TIMEOUT());
 				setVertexState(vertex, ExecutionState.CANCELING);
 				
 				Scheduler scheduler = mock(Scheduler.class);
@@ -570,7 +582,8 @@ public class ExecutionVertexCancelTest {
 			
 			// deploying while in canceling state is illegal (should immediately go to canceled)
 			try {
-				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+						AkkaUtils.DEFAULT_TIMEOUT());
 				setVertexState(vertex, ExecutionState.CANCELING);
 				
 				Instance instance = getInstance(ActorRef.noSender());
@@ -584,7 +597,8 @@ public class ExecutionVertexCancelTest {
 			
 			// fail while canceling
 			{
-				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+						AkkaUtils.DEFAULT_TIMEOUT());
 				
 				Instance instance = getInstance(ActorRef.noSender());
 				AllocatedSlot slot = instance.allocateSlot(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -27,6 +27,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.testkit.JavaTestKit;
 import akka.testkit.TestActorRef;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.AllocatedSlot;
 import org.apache.flink.runtime.instance.Instance;
@@ -67,7 +68,8 @@ public class ExecutionVertexDeploymentTest {
 			
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 			
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			vertex.deployToSlot(slot);
@@ -109,7 +111,8 @@ public class ExecutionVertexDeploymentTest {
 			
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 			
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			
@@ -152,7 +155,8 @@ public class ExecutionVertexDeploymentTest {
 			
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 			
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			
@@ -206,7 +210,8 @@ public class ExecutionVertexDeploymentTest {
 			
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 			
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			
@@ -241,7 +246,8 @@ public class ExecutionVertexDeploymentTest {
 			final AllocatedSlot slot = instance.allocateSlot(new JobID());
 
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			
@@ -289,7 +295,8 @@ public class ExecutionVertexDeploymentTest {
 
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			vertex.deployToSlot(slot);
@@ -327,7 +334,8 @@ public class ExecutionVertexDeploymentTest {
 			final JobVertexID jid = new JobVertexID();
 
 			final ExecutionJobVertex ejv = getExecutionVertex(jid);
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			final ExecutionAttemptID eid = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 			final TestActorRef simpleTaskManager = TestActorRef.create(system, Props.create(new

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -28,6 +28,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.testkit.JavaTestKit;
 import akka.testkit.TestActorRef;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.AllocatedSlot;
 import org.apache.flink.runtime.instance.Instance;
@@ -69,7 +70,8 @@ public class ExecutionVertexSchedulingTest {
 			assertFalse(slot.isReleased());
 			
 			final ExecutionJobVertex ejv = getExecutionVertex(new JobVertexID());
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			
 			Scheduler scheduler = mock(Scheduler.class);
 			when(scheduler.scheduleImmediately(Matchers.any(ScheduledUnit.class))).thenReturn(slot);
@@ -101,7 +103,8 @@ public class ExecutionVertexSchedulingTest {
 			final SlotAllocationFuture future = new SlotAllocationFuture();
 			
 			final ExecutionJobVertex ejv = getExecutionVertex(new JobVertexID());
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			
 			Scheduler scheduler = mock(Scheduler.class);
 			when(scheduler.scheduleQueued(Matchers.any(ScheduledUnit.class))).thenReturn(future);
@@ -136,7 +139,8 @@ public class ExecutionVertexSchedulingTest {
 			final AllocatedSlot slot = instance.allocateSlot(new JobID());
 			
 			final ExecutionJobVertex ejv = getExecutionVertex(new JobVertexID());
-			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0]);
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.DEFAULT_TIMEOUT());
 			
 			Scheduler scheduler = mock(Scheduler.class);
 			when(scheduler.scheduleImmediately(Matchers.any(ScheduledUnit.class))).thenReturn(slot);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class PointwisePatternTest {
 	
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -90,7 +91,7 @@ public class PointwisePatternTest {
 	
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -126,7 +127,7 @@ public class PointwisePatternTest {
 	
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -163,7 +164,7 @@ public class PointwisePatternTest {
 	
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -198,7 +199,7 @@ public class PointwisePatternTest {
 	
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -253,7 +254,7 @@ public class PointwisePatternTest {
 	
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -299,7 +300,7 @@ public class PointwisePatternTest {
 	
 		List<AbstractJobVertex> ordered = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg);
+		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.DEFAULT_TIMEOUT());
 		try {
 			eg.attachJobGraph(ordered);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobID;
@@ -67,7 +68,8 @@ public class VertexSlotSharingTest {
 			
 			List<AbstractJobVertex> vertices = new ArrayList<AbstractJobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 			
-			ExecutionGraph eg = new ExecutionGraph(new JobID(), "test job", new Configuration());
+			ExecutionGraph eg = new ExecutionGraph(new JobID(), "test job", new Configuration(),
+					AkkaUtils.DEFAULT_TIMEOUT());
 			eg.attachJobGraph(vertices);
 			
 			// verify that the vertices are all in the same slot sharing group

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph
 import akka.actor.{Props, ActorSystem}
 import akka.testkit.{TestKit}
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.jobgraph.{JobStatus, JobID, JobGraph, AbstractJobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
@@ -54,7 +55,8 @@ with Matchers with BeforeAndAfterAll {
 
         val jobGraph = new JobGraph("Pointwise job", sender)
 
-        val eg = new ExecutionGraph(new JobID(), "test job", new Configuration())
+        val eg = new ExecutionGraph(new JobID(), "test job", new Configuration(),
+          AkkaUtils.DEFAULT_TIMEOUT)
         eg.setNumberOfRetriesLeft(0)
         eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources)
 
@@ -97,7 +99,8 @@ with Matchers with BeforeAndAfterAll {
 
         val jobGraph = new JobGraph("Pointwise job", sender)
 
-        val eg = new ExecutionGraph(new JobID(), "Test job", new Configuration())
+        val eg = new ExecutionGraph(new JobID(), "Test job", new Configuration(),
+          AkkaUtils.DEFAULT_TIMEOUT)
         eg.setNumberOfRetriesLeft(1)
         eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources)
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph
 import akka.actor.{Props, ActorSystem}
 import akka.testkit.TestKit
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils
 .SimpleAcknowledgingTaskManager
 import org.apache.flink.runtime.jobgraph.{JobStatus, JobID, JobGraph, AbstractJobVertex}
@@ -57,7 +58,8 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
 
         val jobGraph = new JobGraph("Pointwise job", sender)
 
-        val eg = new ExecutionGraph(new JobID(), "test job", new Configuration())
+        val eg = new ExecutionGraph(new JobID(), "test job", new Configuration(),
+          AkkaUtils.DEFAULT_TIMEOUT)
         eg.setNumberOfRetriesLeft(0)
         eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources)
 


### PR DESCRIPTION
Loops through the JobManager's timeout value to the Execution to make the timeout for the Execution configurable.