### PR TITLE
[FLINK-1352] [runtime] Fix buggy registration of TaskManager to JobManager

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -170,6 +170,11 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_DEBUG_MEMORY_USAGE_LOG_INTERVAL_MS = "taskmanager.debug.memory.logIntervalMs";
 
 	/**
+	 *
+	 */
+	public static final String TASK_MANAGER_MAX_REGISTRATION_DURATION = "taskmanager.maxRegistrationDuration";
+
+	/**
 	 * Parameter for the maximum fan for out-of-core algorithms.
 	 * Corresponds to the maximum fan-in for merge-sorts and the maximum fan-out
 	 * for hybrid hash joins. 
@@ -488,6 +493,11 @@ public final class ConfigConstants {
 	 * The default number of task slots per task manager
 	 */
 	public static final int DEFAULT_TASK_MANAGER_NUM_TASK_SLOTS = -1;
+
+	/**
+	 * The default task manager's maximum registration duration
+	 */
+	public static final String DEFAULT_TASK_MANAGER_MAX_REGISTRATION_DURATION = "Inf";
 	
 	/**
 	 * The default value for the JobClient's polling interval. 2 Seconds.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
@@ -226,6 +226,10 @@ public class InstanceManager {
 			return new HashSet<Instance>(registeredHostsById.values());
 		}
 	}
+
+	public Instance getRegisteredInstance(ActorRef ref) {
+		return registeredHostsByConnection.get(ref);
+	}
 	
 	// --------------------------------------------------------------------------------------------
 	

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -122,10 +122,16 @@ class JobManager(val configuration: Configuration)
       val instanceID = instanceManager.registerTaskManager(taskManager, connectionInfo,
         hardwareInformation, numberOfSlots)
 
-      // to be notified when the taskManager is no longer reachable
-      context.watch(taskManager)
+      // TaskManager is already registered
+      if(instanceID == null){
+        val instanceID = instanceManager.getRegisteredInstance(taskManager).getId
+        taskManager ! AlreadyRegistered(instanceID, libraryCacheManager.getBlobServerPort)
+      } else {
+        // to be notified when the taskManager is no longer reachable
+        context.watch(taskManager)
 
-      taskManager ! AcknowledgeRegistration(instanceID, libraryCacheManager.getBlobServerPort)
+        taskManager ! AcknowledgeRegistration(instanceID, libraryCacheManager.getBlobServerPort)
+      }
     }
 
     case RequestNumberRegisteredTaskManager => {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/RegistrationMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/RegistrationMessages.scala
@@ -43,4 +43,20 @@ object RegistrationMessages {
    */
   case class AcknowledgeRegistration(instanceID: InstanceID, blobPort: Int)
 
+  /**
+   * Denotes that the TaskManager has already been registered at the JobManager.
+   *
+   * @param instanceID
+   * @param blobPort
+   */
+  case class AlreadyRegistered(instanceID: InstanceID, blobPort: Int)
+
+  /**
+   * Denotes the unsuccessful registration of a task manager at the job manager. This is the
+   * response triggered by the [[RegisterTaskManager]] message.
+   *
+   * @param reason Reason why the task manager registration was refused
+   */
+  case class RefuseRegistration(reason: String)
+
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManagerConfiguration.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManagerConfiguration.scala
@@ -18,10 +18,10 @@
 
 package org.apache.flink.runtime.taskmanager
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 case class TaskManagerConfiguration(numberOfSlots: Int, memorySize: Long, pageSize: Int,
                                     tmpDirPaths: Array[String], cleanupInterval: Long,
                                     memoryLogggingIntervalMs: Option[Long],
                                     profilingInterval: Option[Long],
-                                    timeout: FiniteDuration)
+                                    timeout: FiniteDuration, maxRegistrationDuration: Duration)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.jobgraph.{AbstractJobVertex, DistributionPattern
 import org.apache.flink.runtime.jobmanager.Tasks.{BlockingReceiver, Sender}
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
 import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultFailed, SubmissionSuccess, SubmitJob}
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.{AllVerticesRunning, WaitForAllVerticesToBeRunningOrFinished}
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingUtils
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -71,6 +71,7 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
           expectMsg(SubmissionSuccess(jobGraph.getJobID))
 
           jm ! WaitForAllVerticesToBeRunningOrFinished(jobID)
+
           expectMsg(AllVerticesRunning(jobID))
 
           //kill task manager

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerRegistrationITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerRegistrationITCase.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager
+
+import java.net.InetAddress
+
+import akka.actor._
+import akka.testkit.{TestKit, ImplicitSender}
+import org.apache.flink.runtime.instance.{InstanceID, HardwareDescription, InstanceConnectionInfo}
+import org.apache.flink.runtime.messages.RegistrationMessages.{AlreadyRegistered,
+RefuseRegistration, AcknowledgeRegistration, RegisterTaskManager}
+import org.apache.flink.runtime.messages.TaskManagerMessages.Heartbeat
+import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+class TaskManagerRegistrationITCase(_system: ActorSystem) extends TestKit(_system) with
+ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  "The JobManager" should {
+    "notify already registered TaskManagers" in {
+
+      val jm = TestingUtils.startTestingJobManager
+
+      val connectionInfo = new InstanceConnectionInfo(InetAddress.getLocalHost,1)
+      val hardwareDescription = HardwareDescription.extractFromSystem(10)
+
+      try {
+        within(TestingUtils.TESTING_DURATION) {
+          jm ! RegisterTaskManager(connectionInfo, hardwareDescription, 1)
+          jm ! RegisterTaskManager(connectionInfo, hardwareDescription, 1)
+
+          expectMsgType[AcknowledgeRegistration]
+          expectMsgType[AlreadyRegistered]
+        }
+      } finally {
+        jm ! Kill
+      }
+    }
+  }
+
+  "The TaskManager" should {
+    "shutdown if its registration is refused by the JobManager" in {
+
+      val tm = TestingUtils.startTestingTaskManager(self)
+
+      watch(tm)
+
+      try{
+        within(TestingUtils.TESTING_DURATION) {
+          expectMsgType[RegisterTaskManager]
+          tm ! RefuseRegistration("Testing connection refusal")
+
+          expectTerminated(tm)
+        }
+      }
+    }
+
+    "ignore RefuseRegistration messages after it has been successfully registered" in {
+
+      val tm = TestingUtils.startTestingTaskManager(self)
+
+      try {
+        within(TestingUtils.TESTING_DURATION) {
+          expectMsgType[RegisterTaskManager]
+
+          tm ! AcknowledgeRegistration(new InstanceID(), 42)
+
+          tm ! RefuseRegistration("Should be ignored")
+
+          // Check if the TaskManager is still alive
+          tm ! Identify
+
+          expectMsgPF() {
+            // wait for actor identity
+            case x: ActorIdentity => true
+            // ignore heartbeats
+            case h: Heartbeat => false
+          }
+        }
+      } finally {
+        tm ! Kill
+      }
+    }
+  }
+}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
@@ -133,6 +133,18 @@ object Tasks {
   }
 
   class BlockingOnceReceiver extends Receiver {
+    import BlockingOnceReceiver.blocking
+
+    override def invoke(): Unit = {
+      if(blocking) {
+        val o = new Object
+        o.synchronized{
+          o.wait()
+        }
+      } else {
+        super.invoke()
+      }
+    }
 
   }
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -18,8 +18,9 @@
 
 package org.apache.flink.runtime.testingUtils
 
+import akka.actor.ActorRef
 import org.apache.flink.runtime.executiongraph.ExecutionGraph
-import org.apache.flink.runtime.jobgraph.JobID
+import org.apache.flink.runtime.jobgraph.{JobStatus, JobID}
 
 object TestingJobManagerMessages {
 
@@ -39,4 +40,12 @@ object TestingJobManagerMessages {
   case class AllVerticesRunning(jobID: JobID)
 
   case class NotifyWhenJobRemoved(jobID: JobID)
+
+  case class RequestWorkingTaskManager(jobID: JobID)
+  case class WorkingTaskManager(taskManager: ActorRef)
+
+  case class NotifyWhenJobStatus(jobID: JobID, state: JobStatus)
+  case class JobStatusIs(jobID: JobID, state: JobStatus)
+
+  case object NotifyListeners
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -44,10 +44,12 @@ object TestingUtils {
     val ioRWSerializerClass = classOf[IOReadableWritableSerializer].getCanonicalName
     val ioRWClass = classOf[IOReadableWritable].getCanonicalName
 
+    val logLevel = AkkaUtils.getLogLevel
+
     s"""akka.daemonic = on
       |akka.test.timefactor = 10
       |akka.loggers = ["akka.event.slf4j.Slf4jLogger"]
-      |akka.loglevel = "DEBUG"
+      |akka.loglevel = $logLevel
       |akka.stdout-loglevel = "OFF"
       |akka.jvm-exit-on-fata-error = off
       |akka.log-config-on-start = off

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMaster.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMaster.scala
@@ -39,6 +39,7 @@ object ApplicationMaster {
 
   val CONF_FILE = "flink-conf.yaml"
   val MODIFIED_CONF_FILE = "flink-conf-modified.yaml"
+  val MAX_REGISTRATION_DURATION = "5 minutes"
 
   def main(args: Array[String]): Unit ={
     val yarnClientUsername = System.getenv(FlinkYarnClient.ENV_CLIENT_USERNAME)
@@ -146,6 +147,9 @@ object ApplicationMaster {
       output.println(
         s"${ConfigConstants.DEFAULT_PARALLELIZATION_DEGREE_KEY}: ${slots*taskManagerCount}")
     }
+
+    output.println(s"${ConfigConstants.TASK_MANAGER_MAX_REGISTRATION_DURATION}: " +
+      s"$MAX_REGISTRATION_DURATION")
 
     // add dynamic properties
     val dynamicProperties = CliFrontend.getDynamicProperties(dynamicPropertiesEncodedString)


### PR DESCRIPTION
The JobManager sends now RefusedRegistration messages to the TaskManager if the registration failed or the TaskManager is already registered. If the TaskManager receives a RefusedRegistration message and is not already registered it will shutdown. Otherwise it will simply ignore the RefusedRegistration message.