### PR TITLE
[FLINK-1330] [build] Build creates a link in the root directory to the build target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 .DS_Store
 _site
 docs/api
+build-target

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -436,6 +436,37 @@ under the License.
 					</gitDescribe>
 				</configuration>
 			</plugin>
+
+			<!-- create a symbolic link to the build target in the root directory -->
+			<plugin>
+				<groupId>com.pyx4j</groupId>
+				<artifactId>maven-junction-plugin</artifactId>
+				<version>1.0.3</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>link</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>unlink</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>unlink</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<links>
+						<link>
+							<dst>${basedir}/../build-target</dst>
+							<src>${project.basedir}/target/flink-${project.version}-bin/flink-${project.version}</src>
+						</link>
+					</links>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
The sym link allows you to find the target directory of the build fast. It looks like this
```
lrwxrwxrwx  1 user group    84 Jan 24 12:13 build-target -> /data/repositories/flink/flink-dist/target/flink-0.9-SNAPSHOT-bin/flink-0.9-SNAPSHOT/
drwxrwxr-x  9 user group 4096 Jan 24 11:25 docs/
drwxrwxr-x 12 user group 4096 Jan 24 11:55 flink-addons/
drwxrwxr-x  5 user group 4096 Jan 24 11:54 flink-clients/
drwxrwxr-x  5 user group 4096 Jan 24 11:54 flink-compiler/
...
```