### PR TITLE
[FLINK-1434] [FLINK-1401] Streaming support added for webclient

### DIFF
--- a/flink-addons/flink-streaming/flink-streaming-core/pom.xml
+++ b/flink-addons/flink-streaming/flink-streaming-core/pom.xml
@@ -48,6 +48,12 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+        
+	        <dependency>
+			<groupId>org.apache.sling</groupId>
+			<artifactId>org.apache.sling.commons.json</artifactId>
+			<version>2.0.6</version>
+        	</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
@@ -212,19 +212,22 @@ public class StreamGraph {
 	 *            Max waiting time for next record
 	 */
 	public void addIterationTail(String vertexName, String iterationTail, Integer iterationID,
-			int parallelism, long waitTime) {
+			long waitTime) {
 
 		if (bufferTimeouts.get(iterationTail) == 0) {
 			throw new RuntimeException("Buffer timeout 0 at iteration tail is not supported.");
 		}
 
-		addVertex(vertexName, StreamIterationTail.class, null, null, parallelism);
+		addVertex(vertexName, StreamIterationTail.class, null, null, getParallelism(iterationTail));
 
 		iterationIds.put(vertexName, iterationID);
 		iterationIDtoTailName.put(iterationID, vertexName);
 
 		setSerializersFrom(iterationTail, vertexName);
 		iterationTimeouts.put(iterationIDtoTailName.get(iterationID), waitTime);
+
+		setParallelism(iterationIDtoHeadName.get(iterationID), getParallelism(iterationTail));
+		setBufferTimeout(iterationIDtoHeadName.get(iterationID), bufferTimeouts.get(iterationTail));
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("ITERATION SINK: {}", vertexName);
@@ -362,21 +365,6 @@ public class StreamGraph {
 			}
 		}
 		operatorStates.put(veretxName, states);
-	}
-
-	/**
-	 * Sets the parallelism and buffertimeout of the iteration head of the given
-	 * iteration id to the parallelism given.
-	 * 
-	 * @param iterationID
-	 *            ID of the iteration
-	 * @param iterationTail
-	 *            ID of the iteration tail
-	 */
-	public void setIterationSourceSettings(String iterationID, String iterationTail) {
-		setParallelism(iterationIDtoHeadName.get(iterationID),
-				operatorParallelisms.get(iterationTail));
-		setBufferTimeout(iterationIDtoHeadName.get(iterationID), bufferTimeouts.get(iterationTail));
 	}
 
 	/**

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
@@ -141,13 +141,13 @@ public class StreamingJobGraphGenerator {
 		}
 	}
 
-	private String createChainedName(String vertexName, List<String> chainedOutputs) {
+	private String createChainedName(String vertexID, List<String> chainedOutputs) {
+		String vertexName = streamGraph.getOperatorName(vertexID);
 		if (chainedOutputs.size() > 1) {
 			List<String> outputChainedNames = new ArrayList<String>();
 			for (String chainable : chainedOutputs) {
 				outputChainedNames.add(chainedNames.get(chainable));
 			}
-
 			return vertexName + " -> (" + StringUtils.join(outputChainedNames, ", ") + ")";
 		} else if (chainedOutputs.size() == 1) {
 			return vertexName + " -> " + chainedNames.get(chainedOutputs.get(0));
@@ -162,7 +162,10 @@ public class StreamingJobGraphGenerator {
 		AbstractJobVertex vertex = new AbstractJobVertex(chainedNames.get(vertexName));
 
 		vertex.setInvokableClass(streamGraph.getJobVertexClass(vertexName));
-		vertex.setParallelism(streamGraph.getParallelism(vertexName));
+		if (streamGraph.getParallelism(vertexName) > 0) {
+			vertex.setParallelism(streamGraph.getParallelism(vertexName));
+		}
+
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Parallelism set: {} for {}", streamGraph.getParallelism(vertexName),
 					vertexName);

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
@@ -244,7 +244,7 @@ public class ConnectedDataStream<IN1, IN2> {
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.createTypeInfo(CoMapFunction.class,
 				coMapper.getClass(), 2, null, null);
 
-		return addCoFunction("coMap", outTypeInfo, new CoMapInvokable<IN1, IN2, OUT>(
+		return addCoFunction("Co-Map", outTypeInfo, new CoMapInvokable<IN1, IN2, OUT>(
 				clean(coMapper)));
 
 	}
@@ -269,7 +269,7 @@ public class ConnectedDataStream<IN1, IN2> {
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.createTypeInfo(CoFlatMapFunction.class,
 				coFlatMapper.getClass(), 2, null, null);
 
-		return addCoFunction("coFlatMap", outTypeInfo, new CoFlatMapInvokable<IN1, IN2, OUT>(
+		return addCoFunction("Co-Flat Map", outTypeInfo, new CoFlatMapInvokable<IN1, IN2, OUT>(
 				clean(coFlatMapper)));
 	}
 
@@ -294,7 +294,7 @@ public class ConnectedDataStream<IN1, IN2> {
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.createTypeInfo(CoReduceFunction.class,
 				coReducer.getClass(), 2, null, null);
 
-		return addCoFunction("coReduce", outTypeInfo, getReduceInvokable(clean(coReducer)));
+		return addCoFunction("Co-Reduce", outTypeInfo, getReduceInvokable(clean(coReducer)));
 
 	}
 
@@ -361,7 +361,7 @@ public class ConnectedDataStream<IN1, IN2> {
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.createTypeInfo(CoWindowFunction.class,
 				coWindowFunction.getClass(), 2, null, null);
 
-		return addCoFunction("coWindowReduce", outTypeInfo, new CoWindowInvokable<IN1, IN2, OUT>(
+		return addCoFunction("Co-Window", outTypeInfo, new CoWindowInvokable<IN1, IN2, OUT>(
 				clean(coWindowFunction), windowSize, slideInterval, timestamp1, timestamp2));
 
 	}
@@ -390,7 +390,7 @@ public class ConnectedDataStream<IN1, IN2> {
 			throw new IllegalArgumentException("Slide interval must be positive");
 		}
 
-		return addCoFunction("coWindowReduce", outTypeInfo, new CoWindowInvokable<IN1, IN2, OUT>(
+		return addCoFunction("Co-Window", outTypeInfo, new CoWindowInvokable<IN1, IN2, OUT>(
 				clean(coWindowFunction), windowSize, slideInterval, timestamp1, timestamp2));
 
 	}

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1095,16 +1095,6 @@ public class DataStream<OUT> {
 		return returnStream;
 	}
 
-	protected <R> DataStream<OUT> addIterationSource(Integer iterationID, long waitTime) {
-
-		DataStream<R> returnStream = new DataStreamSource<R>(environment, "iterationSource", null,
-				null, true);
-
-		streamGraph.addIterationHead(returnStream.getId(), this.getId(), iterationID,
-				degreeOfParallelism, waitTime);
-
-		return this.copy();
-	}
 
 	/**
 	 * Method for passing user defined invokables along with the type
@@ -1131,11 +1121,6 @@ public class DataStream<OUT> {
 				operatorName, returnStream.getParallelism());
 
 		connectGraph(inputStream, returnStream.getId(), 0);
-
-		if (inputStream instanceof IterativeDataStream) {
-			IterativeDataStream<OUT> iterativeStream = (IterativeDataStream<OUT>) inputStream;
-			returnStream.addIterationSource(iterativeStream.iterationID, iterativeStream.waitTime);
-		}
 
 		return returnStream;
 	}

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/GroupedDataStream.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/GroupedDataStream.java
@@ -66,7 +66,7 @@ public class GroupedDataStream<OUT> extends DataStream<OUT> {
 	 */
 	@Override
 	public SingleOutputStreamOperator<OUT, ?> reduce(ReduceFunction<OUT> reducer) {
-		return transform("groupReduce", getType(), new GroupedReduceInvokable<OUT>(clean(reducer),
+		return transform("Grouped Reduce", getType(), new GroupedReduceInvokable<OUT>(clean(reducer),
 				keySelector));
 	}
 
@@ -186,7 +186,7 @@ public class GroupedDataStream<OUT> extends DataStream<OUT> {
 		GroupedReduceInvokable<OUT> invokable = new GroupedReduceInvokable<OUT>(clean(aggregate),
 				keySelector);
 
-		SingleOutputStreamOperator<OUT, ?> returnStream = transform("groupReduce", getType(),
+		SingleOutputStreamOperator<OUT, ?> returnStream = transform("Grouped Aggregation", getType(),
 				invokable);
 
 		return returnStream;

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/StreamProjection.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/StreamProjection.java
@@ -83,7 +83,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple1<T0>> outType = (TypeInformation<Tuple1<T0>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType, new ProjectInvokable<IN, Tuple1<T0>>(
+		return dataStream.transform("Projection", outType, new ProjectInvokable<IN, Tuple1<T0>>(
 				fieldIndexes, outType));
 	}
 
@@ -111,7 +111,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple2<T0, T1>> outType = (TypeInformation<Tuple2<T0, T1>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple2<T0, T1>>(fieldIndexes, outType));
 	}
 
@@ -141,7 +141,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple3<T0, T1, T2>> outType = (TypeInformation<Tuple3<T0, T1, T2>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple3<T0, T1, T2>>(fieldIndexes, outType));
 	}
 
@@ -173,7 +173,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple4<T0, T1, T2, T3>> outType = (TypeInformation<Tuple4<T0, T1, T2, T3>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple4<T0, T1, T2, T3>>(fieldIndexes, outType));
 	}
 
@@ -206,7 +206,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple5<T0, T1, T2, T3, T4>> outType = (TypeInformation<Tuple5<T0, T1, T2, T3, T4>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple5<T0, T1, T2, T3, T4>>(fieldIndexes, outType));
 	}
 
@@ -243,7 +243,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple6<T0, T1, T2, T3, T4, T5>> outType = (TypeInformation<Tuple6<T0, T1, T2, T3, T4, T5>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple6<T0, T1, T2, T3, T4, T5>>(fieldIndexes, outType));
 	}
 
@@ -283,7 +283,7 @@ public class StreamProjection<IN> {
 		TypeInformation<Tuple7<T0, T1, T2, T3, T4, T5, T6>> outType = (TypeInformation<Tuple7<T0, T1, T2, T3, T4, T5, T6>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
-				.transform("projection", outType,
+				.transform("Projection", outType,
 						new ProjectInvokable<IN, Tuple7<T0, T1, T2, T3, T4, T5, T6>>(fieldIndexes,
 								outType));
 	}
@@ -325,7 +325,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> outType = (TypeInformation<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(fieldIndexes,
 						outType));
 	}
@@ -369,7 +369,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> outType = (TypeInformation<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(fieldIndexes,
 						outType));
 	}
@@ -415,7 +415,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> outType = (TypeInformation<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(
 						fieldIndexes, outType));
 	}
@@ -465,7 +465,7 @@ public class StreamProjection<IN> {
 		@SuppressWarnings("unchecked")
 		TypeInformation<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> outType = (TypeInformation<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>) extractFieldTypes(
 				fieldIndexes, types, inTypeInfo);
-		return dataStream.transform("projection", outType,
+		return dataStream.transform("Projection", outType,
 				new ProjectInvokable<IN, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(
 						fieldIndexes, outType));
 	}
@@ -519,7 +519,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(
 								fieldIndexes, outType));
@@ -576,7 +576,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(
 								fieldIndexes, outType));
@@ -635,7 +635,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(
 								fieldIndexes, outType));
@@ -697,7 +697,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(
 								fieldIndexes, outType));
@@ -761,7 +761,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(
 								fieldIndexes, outType));
@@ -827,7 +827,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(
 								fieldIndexes, outType));
@@ -895,7 +895,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(
 								fieldIndexes, outType));
@@ -966,7 +966,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(
 								fieldIndexes, outType));
@@ -1039,7 +1039,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(
 								fieldIndexes, outType));
@@ -1115,7 +1115,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(
 								fieldIndexes, outType));
@@ -1193,7 +1193,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(
 								fieldIndexes, outType));
@@ -1274,7 +1274,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>>(
 								fieldIndexes, outType));
@@ -1357,7 +1357,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 						outType,
 						new ProjectInvokable<IN, Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>>(
 								fieldIndexes, outType));
@@ -1442,7 +1442,7 @@ public class StreamProjection<IN> {
 				fieldIndexes, types, inTypeInfo);
 		return dataStream
 				.transform(
-						"projection",
+						"Projection",
 
 						outType,
 						new ProjectInvokable<IN, Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>>(

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/WindowedDataStream.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/WindowedDataStream.java
@@ -231,7 +231,7 @@ public class WindowedDataStream<OUT> {
 	 * @return The transformed DataStream
 	 */
 	public SingleOutputStreamOperator<OUT, ?> reduce(ReduceFunction<OUT> reduceFunction) {
-		return dataStream.transform("WindowReduce", getType(),
+		return dataStream.transform("Window-Reduce", getType(),
 				getReduceInvokable(reduceFunction));
 	}
 
@@ -279,7 +279,7 @@ public class WindowedDataStream<OUT> {
 	public <R> SingleOutputStreamOperator<R, ?> reduceGroup(
 			GroupReduceFunction<OUT, R> reduceFunction, TypeInformation<R> outType) {
 
-		return dataStream.transform("WindowReduce", outType,
+		return dataStream.transform("Window-Reduce", outType,
 				getReduceGroupInvokable(reduceFunction));
 	}
 
@@ -507,7 +507,7 @@ public class WindowedDataStream<OUT> {
 	private SingleOutputStreamOperator<OUT, ?> aggregate(AggregationFunction<OUT> aggregator) {
 		StreamInvokable<OUT, OUT> invokable = getReduceInvokable(aggregator);
 
-		SingleOutputStreamOperator<OUT, ?> returnStream = dataStream.transform("windowReduce",
+		SingleOutputStreamOperator<OUT, ?> returnStream = dataStream.transform("Window-Aggregation",
 				getType(), invokable);
 
 		return returnStream;

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.environment;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.client.program.Client;
+import org.apache.flink.client.program.Client.OptimizerPlanEnvironment;
+import org.apache.flink.client.program.PackagedProgram.PreviewPlanEnvironment;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.GlobalConfiguration;
+
+public class StreamPlanEnvironment extends StreamExecutionEnvironment {
+
+	private ExecutionEnvironment env;
+
+	protected StreamPlanEnvironment(ExecutionEnvironment env) {
+		super();
+		this.env = env;
+
+		int dop = env.getDegreeOfParallelism();
+		if (dop > 0) {
+			setDegreeOfParallelism(dop);
+		} else {
+			setDegreeOfParallelism(GlobalConfiguration.getInteger(
+					ConfigConstants.DEFAULT_PARALLELIZATION_DEGREE_KEY,
+					ConfigConstants.DEFAULT_PARALLELIZATION_DEGREE));
+		}
+	}
+
+	@Override
+	public void execute() throws Exception {
+		execute("");
+	}
+
+	@Override
+	public void execute(String jobName) throws Exception {
+
+		streamGraph.setJobName(jobName);
+
+		if (env instanceof OptimizerPlanEnvironment) {
+			((OptimizerPlanEnvironment) env).setPlan(streamGraph);
+		} else if (env instanceof PreviewPlanEnvironment) {
+			((PreviewPlanEnvironment) env).setPreview(streamGraph.getStreamingPlanAsJSON());
+		}
+		throw new Client.ProgramAbortException();
+	}
+}

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/StreamInvokable.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/StreamInvokable.java
@@ -179,4 +179,8 @@ public abstract class StreamInvokable<IN, OUT> implements Serializable {
 	public static enum ChainingStrategy {
 		ALWAYS, NEVER, HEAD;
 	}
+
+	public Function getUserFunction() {
+		return userFunction;
+	}
 }

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/partitioner/FieldsPartitioner.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/partitioner/FieldsPartitioner.java
@@ -35,7 +35,7 @@ public class FieldsPartitioner<T> extends StreamPartitioner<T> {
 	KeySelector<T, ?> keySelector;
 
 	public FieldsPartitioner(KeySelector<T, ?> keySelector) {
-		super(PartitioningStrategy.FIELDS);
+		super(PartitioningStrategy.GROUPBY);
 		this.keySelector = keySelector;
 	}
 

--- a/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/partitioner/StreamPartitioner.java
+++ b/flink-addons/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/partitioner/StreamPartitioner.java
@@ -27,7 +27,7 @@ public abstract class StreamPartitioner<T> implements
 
 	public enum PartitioningStrategy {
 
-		FORWARD, DISTRIBUTE, SHUFFLE, BROADCAST, GLOBAL, FIELDS;
+		FORWARD, DISTRIBUTE, SHUFFLE, BROADCAST, GLOBAL, GROUPBY;
 
 	}
 

--- a/flink-addons/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-addons/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -203,6 +203,15 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def execute(jobName: String) = javaEnv.execute(jobName)
 
+  /**
+   * Creates the plan with which the system will execute the program, and
+   * returns it as a String using a JSON representation of the execution data
+   * flow graph. Note that this needs to be called, before the plan is
+   * executed.
+   *
+   */
+  def getExecutionPlan() = javaEnv.getStreamGraph().getStreamingPlanAsJSON();
+
 }
 
 object StreamExecutionEnvironment {

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -103,7 +103,7 @@ public class RemoteExecutor extends PlanExecutor {
 		JobWithJars p = new JobWithJars(plan, this.jarFiles);
 		Client c = new Client(this.address, new Configuration(), p.getUserCodeClassLoader());
 		
-		OptimizedPlan op = c.getOptimizedPlan(p, -1);
+		OptimizedPlan op = (OptimizedPlan) c.getOptimizedPlan(p, -1);
 		PlanJSONDumpGenerator jsonGen = new PlanJSONDumpGenerator();
 		return jsonGen.getOptimizerPlanAsJSON(op);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -59,7 +59,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	public String getExecutionPlan() throws Exception {
 		Plan p = createProgramPlan("unnamed job");
 		
-		OptimizedPlan op = this.client.getOptimizedPlan(p, getDegreeOfParallelism());
+		OptimizedPlan op = (OptimizedPlan) this.client.getOptimizedPlan(p, getDegreeOfParallelism());
 		
 		PlanJSONDumpGenerator gen = new PlanJSONDumpGenerator();
 		return gen.getOptimizerPlanAsJSON(op);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanCreationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanCreationTest.java
@@ -45,7 +45,7 @@ public class ExecutionPlanCreationTest {
 			InetSocketAddress mockJmAddress = new InetSocketAddress(mockAddress, 12345);
 			
 			Client client = new Client(mockJmAddress, new Configuration(), getClass().getClassLoader());
-			OptimizedPlan op = client.getOptimizedPlan(prg, -1);
+			OptimizedPlan op = (OptimizedPlan) client.getOptimizedPlan(prg, -1);
 			assertNotNull(op);
 			
 			PlanJSONDumpGenerator dumper = new PlanJSONDumpGenerator();

--- a/flink-compiler/src/main/java/org/apache/flink/compiler/plan/FlinkPlan.java
+++ b/flink-compiler/src/main/java/org/apache/flink/compiler/plan/FlinkPlan.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.compiler.plan;
+
+/**
+ * A common interface for compiled Flink plans for both batch and streaming
+ * processing programs.
+ * 
+ */
+public interface FlinkPlan {
+
+}

--- a/flink-compiler/src/main/java/org/apache/flink/compiler/plan/OptimizedPlan.java
+++ b/flink-compiler/src/main/java/org/apache/flink/compiler/plan/OptimizedPlan.java
@@ -30,7 +30,7 @@ import org.apache.flink.util.Visitor;
  * It works on this representation during its optimization. Finally, this plan is translated to a schedule
  * for the nephele runtime system.
  */
-public class OptimizedPlan implements Visitable<PlanNode> {
+public class OptimizedPlan implements FlinkPlan, Visitable<PlanNode>  {
 	
 	/**
 	 * The data sources in the plan.

--- a/flink-compiler/src/main/java/org/apache/flink/compiler/plan/StreamingPlan.java
+++ b/flink-compiler/src/main/java/org/apache/flink/compiler/plan/StreamingPlan.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.compiler.plan;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+
+/**
+ * Abstract class representing Flink Streaming plans
+ * 
+ */
+public abstract class StreamingPlan implements FlinkPlan {
+
+	public abstract JobGraph getJobGraph();
+
+	public abstract String getStreamingPlanAsJSON();
+
+	public abstract void dumpStreamingPlanAsJSON(File file) throws IOException;
+
+}


### PR DESCRIPTION
This pull request enables the Flink webclient to execute streaming programs, and also adds support for plan visualisation for streaming programs. 

The main modification was to add a common interface for both batch and streaming optimized plans, called FlinkPlan. Both OptimizedPlan and StreamingPlan implements this common interface.

The methods in the Client, PackagedProgram and webclient have been modified to detect whether it is a Streaming or a Batch plan and take actions accordingly.

These should be refined later when we bring the streaming package out of the flink-addons, hopefully for the 0.9 release.

I also added a simple JSON plan generator for streaming programs.