### PR TITLE
[FLINK-1460] fix typos

### DIFF
--- a/flink-compiler/src/test/java/org/apache/flink/compiler/java/PartitionOperatorTest.java
+++ b/flink-compiler/src/test/java/org/apache/flink/compiler/java/PartitionOperatorTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.junit.Test;
 
 @SuppressWarnings("serial")
-public class PartitioningOperatorTest extends CompilerTestBase {
+public class PartitionOperatorTest extends CompilerTestBase {
 
 	@Test
 	public void testPartitionOperatorPreservesFields() {

--- a/flink-compiler/src/test/java/org/apache/flink/compiler/java/PartitioningOperatorTest.java
+++ b/flink-compiler/src/test/java/org/apache/flink/compiler/java/PartitioningOperatorTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class PartitioningOperatorTest extends CompilerTestBase {
 
 	@Test
-	public void testPartitiongOperatorPreservesFields() {
+	public void testPartitionOperatorPreservesFields() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 			

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/ml/LinearRegression.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/ml/LinearRegression.scala
@@ -31,8 +31,8 @@ import scala.collection.JavaConverters._
  * This example implements a basic Linear Regression  to solve the y = theta0 + theta1*x problem
  * using batch gradient descent algorithm.
  *
- * Linear Regression with BGD(batch gradient descent) algorithm is an iterative clustering
- * algorithm and works as follows:
+ * Linear Regression with BGD(batch gradient descent) algorithm is an iterative algorithm and
+ * works as follows:
  *
  * Giving a data set and target set, the BGD try to find out the best parameters for the data set
  * to fit the target set.

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/compiler/PartitionOperatorTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/compiler/PartitionOperatorTranslationTest.scala
@@ -29,7 +29,7 @@ import org.apache.flink.api.common.functions.Partitioner
 class PartitionOperatorTranslationTest extends CompilerTestBase {
 
   @Test
-  def testPartitiongOperatorPreservesFields() {
+  def testPartitionOperatorPreservesFields() {
     try {
       val env = ExecutionEnvironment.getExecutionEnvironment
       


### PR DESCRIPTION
Fix some typos. Also fix some inconsistent uses of **partition operator** and **partitioning operator** in the codebase.