### PR TITLE
[FLINK-1471][java-api] Fixes wrong input validation if function has no generics

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -688,7 +688,7 @@ public class TypeExtractor {
 		try {
 			inType = getParameterType(baseClass, typeHierarchy, clazz, inputParamPos);
 		}
-		catch (Exception e) {
+		catch (IllegalArgumentException e) {
 			return; // skip input validation e.g. for raw types
 		}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -680,10 +680,20 @@ public class TypeExtractor {
 		}
 	}
 	
-	private static void validateInputType(Class<?> baseClass, Class<?> clazz, int inputParamPos, TypeInformation<?> inType) {
+	private static void validateInputType(Class<?> baseClass, Class<?> clazz, int inputParamPos, TypeInformation<?> inTypeInfo) {
 		ArrayList<Type> typeHierarchy = new ArrayList<Type>();
+
+		// try to get generic parameter
+		Type inType;
 		try {
-			validateInfo(typeHierarchy, getParameterType(baseClass, typeHierarchy, clazz, inputParamPos), inType);
+			inType = getParameterType(baseClass, typeHierarchy, clazz, inputParamPos);
+		}
+		catch (Exception e) {
+			return; // skip input validation e.g. for raw types
+		}
+
+		try {
+			validateInfo(typeHierarchy, inType, inTypeInfo);
 		}
 		catch(InvalidTypesException e) {
 			throw new InvalidTypesException("Input mismatch: " + e.getMessage());

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -1730,8 +1730,31 @@ public class TypeExtractorTest {
 				+ ">>>", ti.toString());
 		
 		// generic array
-		// TODO depends on #315
-		//ti = TypeExtractor.getMapReturnTypes((MapFunction) new MapperWithMultiDimGenericArray<String>(), TypeInfoParser.parse("String[][][]"));
-		//Assert.assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<ObjectArrayTypeInfo<Java Tuple1<String>>>>",);
+		ti = TypeExtractor.getMapReturnTypes((MapFunction) new MapperWithMultiDimGenericArray<String>(), TypeInfoParser.parse("String[][][]"));
+		Assert.assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<ObjectArrayTypeInfo<Java Tuple1<String>>>>", ti.toString());
+	}
+
+	@SuppressWarnings("rawtypes")
+	public static class MapWithResultTypeQueryable implements MapFunction, ResultTypeQueryable {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public TypeInformation getProducedType() {
+			return BasicTypeInfo.STRING_TYPE_INFO;
+		}
+
+		@Override
+		public Object map(Object value) throws Exception {
+			return null;
+		}
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testInputMismatchWithRawFuntion() {
+		MapFunction<?, ?> function = new MapWithResultTypeQueryable();
+
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction)function, BasicTypeInfo.INT_TYPE_INFO);
+		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
 	}
 }


### PR DESCRIPTION
FLINK-1471 was not implemented properly. See also #354.

This PR skips the input validation if no generic parameters are available.