### PR TITLE
[FLINK-1481] Fixes flakey JobManagerITCase

### DIFF
--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -34,6 +34,7 @@ import scheduler.{NoResourceAvailableException, SlotSharingGroup}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.Random
 
 @RunWith(classOf[JUnitRunner])
 class JobManagerITCase(_system: ActorSystem) extends TestKit(_system) with ImplicitSender with
@@ -369,6 +370,9 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
       sender.setInvokableClass(classOf[SometimesExceptionSender])
       receiver.setInvokableClass(classOf[Receiver])
 
+      // set failing senders
+      SometimesExceptionSender.failingSenders = Seq.fill(10)(Random.nextInt(num_tasks)).toSet
+
       sender.setParallelism(num_tasks)
       receiver.setParallelism(num_tasks)
 
@@ -473,6 +477,10 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
 
       sender.setInvokableClass(classOf[SometimesInstantiationErrorSender])
       receiver.setInvokableClass(classOf[Receiver])
+
+      // set the failing sender tasks
+      SometimesInstantiationErrorSender.failingSenders =
+        Seq.fill(10)(Random.nextInt(num_tasks)).toSet
 
       sender.setParallelism(num_tasks)
       receiver.setParallelism(num_tasks)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
@@ -223,13 +223,18 @@ object Tasks {
     }
 
     override def invoke(): Unit = {
-      if(Math.random() < 0.05){
+      // this only works if the TaskManager runs in the same JVM as the test case
+      if(SometimesExceptionSender.failingSenders.contains(this.getIndexInSubtaskGroup)){
         throw new Exception("Test exception")
       }else{
         val o = new Object()
         o.synchronized(o.wait())
       }
     }
+  }
+
+  object SometimesExceptionSender {
+    var failingSenders = Set[Int](0)
   }
 
   class ExceptionReceiver extends AbstractInvokable {
@@ -253,7 +258,9 @@ object Tasks {
   }
 
   class SometimesInstantiationErrorSender extends AbstractInvokable{
-    if(Math.random < 0.05){
+
+    // this only works if the TaskManager runs in the same JVM as the test case
+    if(SometimesInstantiationErrorSender.failingSenders.contains(this.getIndexInSubtaskGroup)){
       throw new RuntimeException("Test exception in constructor")
     }
 
@@ -265,6 +272,10 @@ object Tasks {
       val o = new Object()
       o.synchronized(o.wait())
     }
+  }
+
+  object SometimesInstantiationErrorSender {
+    var failingSenders = Set[Int](0)
   }
 
   class BlockingReceiver extends AbstractInvokable {


### PR DESCRIPTION
The sometimes failing sender tasks are now guaranteed to have at least one task which fails.