### PR TITLE
[FLINK-1484] Adds explicit disconnect message for TaskManagers

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -201,8 +201,6 @@ object AkkaUtils {
 
     val logLifecycleEvents = if (lifecycleEvents) "on" else "off"
 
-    val logLevel = getLogLevel
-
     val configString =
       s"""
          |akka {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -149,6 +149,13 @@ object TaskManagerMessages {
    * @param cause reason for the external failure
    */
   case class FailTask(executionID: ExecutionAttemptID, cause: Throwable)
+
+  /**
+   * Disconnects the TaskManager from the registered JobManager
+   *
+   * @param reason
+   */
+  case class Disconnected(reason: String)
   
   // --------------------------------------------------------------------------
   // Utility methods to allow simpler case object access from Java

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -51,4 +51,9 @@ object TestingJobManagerMessages {
 
   case class NotifyWhenTaskManagerTerminated(taskManager: ActorRef)
   case class TaskManagerTerminated(taskManager: ActorRef)
+
+  case class ThrowException(msg: String)
+
+  case class NotifyWhenTaskManagerRegistered(num: Int)
+  case class TaskManagerRegistered(num: Int)
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
@@ -22,7 +22,7 @@ import akka.actor.{Terminated, ActorRef}
 import org.apache.flink.runtime.ActorLogMessages
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
 import org.apache.flink.runtime.jobgraph.JobID
-import org.apache.flink.runtime.messages.TaskManagerMessages.UnregisterTask
+import org.apache.flink.runtime.messages.TaskManagerMessages.{Disconnected, UnregisterTask}
 import org.apache.flink.runtime.taskmanager.TaskManager
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobRemoved
 import org.apache.flink.runtime.ActorLogMessages
@@ -60,7 +60,7 @@ trait TestingTaskManager extends ActorLogMessages {
       
     case UnregisterTask(executionID) =>
       super.receiveWithLogMessages(UnregisterTask(executionID))
-      waitForRemoval.get(executionID) match {
+      waitForRemoval.remove(executionID) match {
         case Some(actors) => for(actor <- actors) actor ! true
         case None =>
       }
@@ -77,7 +77,7 @@ trait TestingTaskManager extends ActorLogMessages {
         case None => sender ! ResponseNumActiveConnections(0)
       }
 
-  case NotifyWhenJobRemoved(jobID) =>
+    case NotifyWhenJobRemoved(jobID) =>
       if(runningTasks.values.exists(_.getJobID == jobID)){
         val set = waitForJobRemoval.getOrElse(jobID, Set())
         waitForJobRemoval += (jobID -> (set + sender))
@@ -92,7 +92,7 @@ trait TestingTaskManager extends ActorLogMessages {
 
     case CheckIfJobRemoved(jobID) =>
       if(runningTasks.values.forall(_.getJobID != jobID)){
-        waitForJobRemoval.get(jobID) match {
+        waitForJobRemoval.remove(jobID) match {
           case Some(listeners) => listeners foreach (_ ! true)
           case None =>
         }
@@ -108,7 +108,18 @@ trait TestingTaskManager extends ActorLogMessages {
     case msg@Terminated(jobManager) =>
       super.receiveWithLogMessages(msg)
 
-      waitForJobManagerToBeTerminated.get(jobManager.path.name) foreach {
+      waitForJobManagerToBeTerminated.remove(jobManager.path.name) foreach {
+        _ foreach {
+          _ ! JobManagerTerminated(jobManager)
+        }
+      }
+
+    case msg: Disconnected =>
+      val jobManager = currentJobManager
+
+      super.receiveWithLogMessages(msg)
+
+      waitForJobManagerToBeTerminated.remove(jobManager.path.name) foreach {
         _ foreach {
           _ ! JobManagerTerminated(jobManager)
         }


### PR DESCRIPTION
In case of a JobManager restart, which can be caused by an uncaught exception, all connected TaskManager are notified by a ```Disconnected``` message. This message triggers the cleanup of the TaskManagers and makes them try to reconnect to the JobManager.

This PR also includes a test case to verify the afore-mentioned behaviour.