### PR TITLE
[FLINK-1486] add print method for prefixing a user defined string

### DIFF
--- a/docs/programming_guide.md
+++ b/docs/programming_guide.md
@@ -1823,8 +1823,10 @@ DataSet:
   are obtained by calling a user-defined *format()* method for each element.
 - `writeAsCsv(...)` / `CsvOutputFormat` - Writes tuples as comma-separated value files. Row and field
   delimiters are configurable. The value for each field comes from the *toString()* method of the objects.
-- `print()` / `printToErr()` - Prints the *toString()* value of each element on the
-  standard out / strandard error stream.
+- `print()` / `printToErr()` / `print(String msg)` / `printToErr(String msg)` - Prints the *toString()* value
+of each element on the standard out / strandard error stream. Optionally, a prefix (msg) can be provided which is
+prepended to the output. This can help to distinguish between different calls to *print*. If the parallelism is
+greater than 1, the output will also be prepended with the identifier of the task which produced the output.
 - `write()` / `FileOutputFormat` - Method and base class for custom file outputs. Supports
   custom object-to-bytes conversion.
 - `output()`/ `OutputFormat` - Most generic output method, for data sinks that are not file based

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1349,6 +1349,17 @@ public abstract class DataSet<T> {
 	public DataSink<T> print() {
 		return output(new PrintingOutputFormat<T>(false));
 	}
+
+	/**
+	 * Writes a DataSet to the standard output stream (stdout).<br/>
+	 * For each element of the DataSet the result of {@link Object#toString()} is written.
+	 *
+	 *  @param sinkIdentifier The string to prefix the output with.
+	 *  @return The DataSink that writes the DataSet.
+	 */
+	public DataSink<T> print(String sinkIdentifier) {
+		return output(new PrintingOutputFormat<T>(sinkIdentifier, false));
+	}
 	
 	/**
 	 * Writes a DataSet to the standard error stream (stderr).<br/>
@@ -1358,6 +1369,17 @@ public abstract class DataSet<T> {
 	 */
 	public DataSink<T> printToErr() {
 		return output(new PrintingOutputFormat<T>(true));
+	}
+
+	/**
+	 * Writes a DataSet to the standard error stream (stderr).<br/>
+	 * For each element of the DataSet the result of {@link Object#toString()} is written.
+	 *
+	 * @param sinkIdentifier The string to prefix the output with.
+	 * @return The DataSink that writes the DataSet.
+	 */
+	public DataSink<T> printToErr(String sinkIdentifier) {
+		return output(new PrintingOutputFormat<T>(sinkIdentifier, true));
 	}
 	
 	/**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -1333,11 +1333,30 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   }
 
   /**
-   * Writes a DataSet to the standard error stream (stderr).This uses [[AnyRef.toString]] on
+   * *
+   * Writes a DataSet to the standard output stream (stdout) with a sink identifier prefixed.
+   * This uses [[AnyRef.toString]] on each element.
+   * @param sinkIdentifier The string to prefix the output with.
+   */
+  def print(sinkIdentifier: String): DataSink[T] = {
+    output(new PrintingOutputFormat[T](sinkIdentifier, false))
+  }
+
+  /**
+   * Writes a DataSet to the standard error stream (stderr). This uses [[AnyRef.toString]] on
    * each element.
    */
   def printToErr(): DataSink[T] = {
     output(new PrintingOutputFormat[T](true))
+  }
+
+  /**
+   * Writes a DataSet to the standard error stream (stderr) with a sink identifier prefixed.
+   * This uses [[AnyRef.toString]] on each element.
+   * @param sinkIdentifier The string to prefix the output with.
+   */
+  def printToErr(sinkIdentifier: String): DataSink[T] = {
+      output(new PrintingOutputFormat[T](sinkIdentifier, true))
   }
 }
 


### PR DESCRIPTION
- extend API to include a print(String sinkIdentifier) method
- change PrintingOutputformat to include the sink identifier
- if appropriate, print sink identifier and task id