### PR TITLE
[FLINK-1179] Add button to JobManager web interface to request stack trace of a TaskManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceID.java
@@ -25,4 +25,11 @@ import org.apache.flink.runtime.AbstractID;
  */
 public class InstanceID extends AbstractID {
 	private static final long serialVersionUID = 1L;
+
+	public InstanceID() {
+	}
+
+	public InstanceID(byte[] bytes) {
+		super(bytes);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
@@ -227,6 +227,10 @@ public class InstanceManager {
 		}
 	}
 
+	public Instance getRegisteredInstanceById(InstanceID instanceID) {
+		return registeredHostsById.get(instanceID);
+	}
+
 	public Instance getRegisteredInstance(ActorRef ref) {
 		return registeredHostsByConnection.get(ref);
 	}

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -28,11 +28,13 @@ function loadTaskmanagers(json) {
 	$("#taskmanagerTable").empty();
 	var table = "<table class=\"table table-bordered table-hover table-striped\">";
 	table += "<tr><th>Node</th><th>Ipc Port</th><th>Data Port</th><th>Seconds since last Heartbeat</th>" +
-			"<th>Number of Slots</th><th>Available Slots</th><th>CPU Cores</th><th>Physical Memory (mb)</th><th>TaskManager Heapsize (mb)</th><th>Managed Memory (mb)</th></tr>";
+			"<th>Number of Slots</th><th>Available Slots</th><th>CPU Cores</th><th>Physical Memory (mb)</th><th>TaskManager Heapsize (mb)</th>" +
+            "<th>Managed Memory (mb)</th><th>Show Stacktrace</th></tr>";
 	for (var i = 0; i < json.taskmanagers.length; i++) {
 		var tm = json.taskmanagers[i]
 		table += "<tr><td>"+tm.inetAdress+"</td><td>"+tm.ipcPort+"</td><td>"+tm.dataPort+"</td><td>"+tm.timeSinceLastHeartbeat+"</td>" +
-				"<td>"+tm.slotsNumber+"</td><td>"+tm.freeSlots+"</td><td>"+tm.cpuCores+"</td><td>"+tm.physicalMemory+"</td><td>"+tm.freeMemory+"</td><td>"+tm.managedMemory+"</td></tr>";
+				"<td>"+tm.slotsNumber+"</td><td>"+tm.freeSlots+"</td><td>"+tm.cpuCores+"</td><td>"+tm.physicalMemory+"</td><td>"+tm.freeMemory+"</td>" +
+                "<td>"+tm.managedMemory+"</td><td><a href=\"javascript:showStacktraceOfTaskmanager('"+ tm.instanceID +"')\">Show</a></td></tr>";
 	}
 	table += "</table>";
 	$("#taskmanagerTable").append(table);
@@ -48,3 +50,20 @@ function pollTaskmanagers() {
 	}, 10000);
 }
 
+function showStacktraceOfTaskmanager(instanceId) {
+    $.ajax({
+        url: "setupInfo?get=stackTrace&instanceID=" + instanceId,
+        type: "GET",
+        cache: false,
+        dataType: "json",
+        success: function(json) {
+            var html = "<h2>Stack Trace of TaskManager ("+ instanceId +")</h2>";
+            if ("stackTrace" in json) {
+                html += "<pre>" + json.stackTrace + "</pre>";
+            } else if ("errorMessage" in json) {
+                html += "<pre>" + json.errorMessage + "</pre>";
+            }
+            $("#taskManagerStackTrace").html(html);
+        }
+    });
+}

--- a/flink-runtime/src/main/resources/web-docs-infoserver/taskmanagers.html
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/taskmanagers.html
@@ -111,6 +111,7 @@ under the License.
 	          <div class="table-responsive" id="taskmanagerTable">
 	          </div>
 	      </div>
+          <div class="col-lg-12" id="taskManagerStackTrace"></div>
         </div><!-- /.row -->
 
       </div><!-- /#page-wrapper -->

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -39,7 +39,7 @@ import org.apache.flink.runtime.jobmanager.accumulators.AccumulatorManager
 import org.apache.flink.runtime.jobmanager.scheduler.{Scheduler => FlinkScheduler}
 import org.apache.flink.runtime.messages.JobManagerMessages._
 import org.apache.flink.runtime.messages.RegistrationMessages._
-import org.apache.flink.runtime.messages.TaskManagerMessages.{NextInputSplit, Heartbeat}
+import org.apache.flink.runtime.messages.TaskManagerMessages.{SendStackTrace, StackTrace, NextInputSplit, Heartbeat}
 import org.apache.flink.runtime.profiling.ProfilingUtils
 import org.slf4j.LoggerFactory
 import scala.concurrent.Future
@@ -348,6 +348,10 @@ Actor with ActorLogMessages with ActorLogging {
 
     case Heartbeat(instanceID) =>
       instanceManager.reportHeartBeat(instanceID)
+
+    case RequestStackTrace(instanceID) =>
+      val taskManager = instanceManager.getRegisteredInstanceById(instanceID).getTaskManager
+      taskManager forward SendStackTrace
 
     case Terminated(taskManager) =>
       log.info("Task manager {} terminated.", taskManager.path)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.messages
 
 import org.apache.flink.runtime.accumulators.AccumulatorEvent
 import org.apache.flink.runtime.executiongraph.{ExecutionAttemptID, ExecutionGraph}
-import org.apache.flink.runtime.instance.Instance
+import org.apache.flink.runtime.instance.{InstanceID, Instance}
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobID, JobStatus, JobVertexID}
 import org.apache.flink.runtime.taskmanager.TaskExecutionState
 
@@ -313,6 +313,13 @@ object JobManagerMessages {
       taskManagers.asJavaCollection
     }
   }
+
+  /**
+   * Requests stack trace messages of the task manager
+   *
+   * @param instanceID Instance ID of the task manager
+   */
+  case class RequestStackTrace(instanceID: InstanceID)
 
   /**
    * Requests the current state of the job manager

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -95,6 +95,15 @@ object TaskManagerMessages {
   case class Heartbeat(instanceID: InstanceID)
 
   /**
+   * Sends StackTrace Message of an instance with [[instanceID]]. This message is a response to
+   * [[org.apache.flink.runtime.messages.TaskManagerMessages.SendStackTrace]].
+   *
+   * @param instanceID
+   * @param stackTrace
+   */
+  case class StackTrace(instanceID: InstanceID, stackTrace: String)
+
+  /**
    * Requests a notification from the task manager as soon as the task manager has been
    * registered at the job manager. Once the task manager is registered at the job manager a
    * [[RegisteredAtJobManager]] message will be sent to the sender.
@@ -121,6 +130,11 @@ object TaskManagerMessages {
    * Logs the current memory usage as debug level output.
    */
   case object LogMemoryUsage
+
+  /**
+   * Makes the task manager sending a stack trace message to the sender.
+   */
+  case object SendStackTrace
 
   /**
    * Fail the specified task externally

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -300,6 +300,15 @@ import scala.collection.JavaConverters._
     case LogMemoryUsage =>
       logMemoryStats()
 
+    case SendStackTrace =>
+      val traces = Thread.getAllStackTraces.asScala
+      val stackTraceStr = traces.map((trace: (Thread, Array[StackTraceElement])) => {
+        val (thread, elements) = trace
+        "Thread: " + thread.getName + '\n' + elements.mkString("\n")
+      }).mkString("\n\n")
+
+      sender ! StackTrace(instanceID, stackTraceStr)
+
     case NotifyWhenRegisteredAtJobManager =>
       if (registered) {
         sender ! RegisteredAtJobManager


### PR DESCRIPTION
This PR contains following changes:
* Add public constructors of `org.apache.flink.runtime.instance.InstanceID` for sending instance ID from web interface to job manager
* Add a helper method called `getRegisteredInstanceById(InstanceID)` into `org.apache.flink.runtime.instance.InstanceManager` for finding Akka Actor from instance ID
* Add akka messages called `RequestStackTrace`, `SendStackTrace` and `StackTrace`
* Modify a task manager page in web interface of job manager to request and show stack trace of a task manager

The following image is a screenshot of web interface of job manager.

![screen shot 2015-02-08 at 3 49 51 pm](https://cloud.githubusercontent.com/assets/1941681/6095765/9293e996-afaf-11e4-9e8e-4dcd69ce595b.png)
