### PR TITLE
[FLINK-1489] Fixes blocking scheduleOrUpdateConsumers message calls

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/PartialPartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/PartialPartitionInfo.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionEdge;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.instance.InstanceConnectionInfo;
+import org.apache.flink.runtime.io.network.RemoteAddress;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+/**
+ * This class contains the partial partition info which is created if the consumer instance is not
+ * yet clear. Once the instance on which the consumer runs is known, the complete partition info
+ * can be computed.
+ */
+public class PartialPartitionInfo {
+	private final IntermediateDataSetID intermediateDataSetID;
+
+	private final IntermediateResultPartitionID partitionID;
+
+	private final ExecutionAttemptID producerExecutionID;
+
+	private final InstanceConnectionInfo producerInstanceConnectionInfo;
+
+	private final int partitionConnectionIndex;
+
+	public PartialPartitionInfo(IntermediateDataSetID intermediateDataSetID,
+								IntermediateResultPartitionID partitionID,
+								ExecutionAttemptID executionID,
+								InstanceConnectionInfo producerInstanceConnectionInfo,
+								int partitionConnectionIndex) {
+		this.intermediateDataSetID = intermediateDataSetID;
+		this.partitionID = partitionID;
+		this.producerExecutionID = executionID;
+		this.producerInstanceConnectionInfo = producerInstanceConnectionInfo;
+		this.partitionConnectionIndex = partitionConnectionIndex;
+	}
+
+	public PartitionInfo createPartitionInfo(Execution consumerExecution) throws IllegalStateException {
+		if(consumerExecution != null){
+			PartitionInfo.PartitionLocation producerLocation;
+
+			RemoteAddress resolvedProducerAddress;
+
+			if(consumerExecution.getAssignedResourceLocation().equals(
+					producerInstanceConnectionInfo)) {
+				resolvedProducerAddress = null;
+				producerLocation = PartitionInfo.PartitionLocation.LOCAL;
+			} else {
+				resolvedProducerAddress = new RemoteAddress(producerInstanceConnectionInfo,
+						partitionConnectionIndex);
+
+				producerLocation = PartitionInfo.PartitionLocation.REMOTE;
+			}
+
+			return new PartitionInfo(partitionID, producerExecutionID, producerLocation,
+					resolvedProducerAddress);
+
+		} else {
+			throw new RuntimeException("Cannot create partition info, because consumer execution " +
+					"is null.");
+		}
+	}
+
+	public IntermediateDataSetID getIntermediateDataSetID() {
+		return intermediateDataSetID;
+	}
+
+	public static PartialPartitionInfo fromEdge(final ExecutionEdge edge){
+		IntermediateResultPartition partition = edge.getSource();
+		IntermediateResultPartitionID partitionID = edge.getSource().getPartitionId();
+
+		IntermediateDataSetID intermediateDataSetID = partition.getIntermediateResult().getId();
+
+		Execution producer = partition.getProducer().getCurrentExecutionAttempt();
+		ExecutionAttemptID producerExecutionID = producer.getAttemptId();
+
+		return new PartialPartitionInfo(intermediateDataSetID, partitionID, producerExecutionID,
+				producer.getAssignedResourceLocation(),
+				partition.getIntermediateResult().getConnectionIndex());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/PartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/PartitionInfo.java
@@ -130,7 +130,8 @@ public class PartitionInfo implements IOReadableWritable, Serializable {
 
 		// The producer needs to be running, otherwise the consumer might request a partition,
 		// which has not been registered yet.
-		if (producerSlot != null && producerState == ExecutionState.RUNNING) {
+		if (producerSlot != null && (producerState == ExecutionState.RUNNING ||
+			producerState == ExecutionState.FINISHED)) {
 			if (producerSlot.getInstance().equals(consumerSlot.getInstance())) {
 				producerLocation = PartitionLocation.LOCAL;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -20,17 +20,23 @@ package org.apache.flink.runtime.executiongraph;
 
 import akka.actor.ActorRef;
 import akka.dispatch.OnComplete;
+import static akka.dispatch.Futures.future;
+
+import akka.dispatch.OnFailure;
 import akka.pattern.Patterns;
 import akka.util.Timeout;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.deployment.PartialPartitionInfo;
 import org.apache.flink.runtime.deployment.PartitionInfo;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Instance;
+import org.apache.flink.runtime.io.network.RemoteAddress;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
@@ -39,6 +45,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotAllocationFuture;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotAllocationFutureAction;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
+import org.apache.flink.runtime.messages.TaskManagerMessages.TaskOperationResult;
 import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 
@@ -46,7 +53,10 @@ import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -316,21 +326,26 @@ public class Execution implements Serializable {
 						markFailed(failure);
 					}
 					else {
-						TaskManagerMessages.TaskOperationResult result = (TaskManagerMessages.TaskOperationResult) success;
 						if (success == null) {
 							markFailed(new Exception("Failed to deploy the task to slot " + slot + ": TaskOperationResult was null"));
 						}
-						else if (!result.executionID().equals(attemptId)) {
-							markFailed(new Exception("Answer execution id does not match the request execution id."));
-						}
-						else if (result.success()) {
-							switchToRunning();
-						}
-						else {
-							// deployment failed :(
-							markFailed(new Exception("Failed to deploy the task " +
-									getVertexWithAttempt() + " to slot " + slot + ": " + result
-									.description()));
+
+						if(success instanceof TaskOperationResult) {
+							TaskOperationResult result = (TaskOperationResult) success;
+
+							if (!result.executionID().equals(attemptId)) {
+								markFailed(new Exception("Answer execution id does not match the request execution id."));
+							} else if (result.success()) {
+								switchToRunning();
+							} else {
+								// deployment failed :(
+								markFailed(new Exception("Failed to deploy the task " +
+										getVertexWithAttempt() + " to slot " + slot + ": " + result
+										.description()));
+							}
+						}else {
+							markFailed(new Exception("Failed to deploy the task to slot " + slot +
+									": Response was not of type TaskOperationResult"));
 						}
 					}
 				}
@@ -401,11 +416,9 @@ public class Execution implements Serializable {
 	}
 
 	// TODO This leads to many unnecessary RPC calls in most cases
-	boolean scheduleOrUpdateConsumers(List<List<ExecutionEdge>> consumers) throws Exception {
-		boolean success = true;
-
+	void scheduleOrUpdateConsumers(List<List<ExecutionEdge>> consumers) {
 		if (consumers.size() != 1) {
-			throw new IllegalStateException("Only one consumer is supported currently.");
+			fail(new IllegalStateException("Only one consumer is supported currently."));
 		}
 
 		final List<ExecutionEdge> consumer = consumers.get(0);
@@ -416,32 +429,66 @@ public class Execution implements Serializable {
 			final ExecutionState consumerState = consumerVertex.getExecutionState();
 
 			if (consumerState == CREATED) {
-				if (state == RUNNING) {
-					if (!consumerVertex.scheduleForExecution(consumerVertex.getExecutionGraph().getScheduler(), false)) {
-						success = false;
+				consumerVertex.cachePartitionInfo(PartialPartitionInfo.fromEdge(edge));
+
+				future(new Callable<Boolean>(){
+					@Override
+					public Boolean call() throws Exception {
+						try {
+							consumerVertex.scheduleForExecution(
+								consumerVertex.getExecutionGraph().getScheduler(), false);
+						} catch (Exception exception) {
+							fail(new IllegalStateException("Could not schedule consumer " +
+									"vertex " + consumerVertex, exception));
+						}
+
+						return true;
 					}
-				}
-				else {
-					success = false;
+				}, AkkaUtils.globalExecutionContext());
+
+				// double check to resolve race conditions
+				if(consumerVertex.getExecutionState() == RUNNING){
+					consumerVertex.sendPartitionInfos();
 				}
 			}
 			else if (consumerState == RUNNING) {
 				SimpleSlot consumerSlot = consumerVertex.getCurrentAssignedResource();
-				ExecutionAttemptID consumerExecutionId = consumerVertex.getCurrentExecutionAttempt().getAttemptId();
+				ExecutionAttemptID consumerExecutionId = consumerVertex.
+						getCurrentExecutionAttempt().getAttemptId();
 
-				PartitionInfo partitionInfo = PartitionInfo.fromEdge(edge, consumerSlot);
+				IntermediateResultPartitionID partitionID = edge.getSource().getPartitionId();
+				int connectionIndex = edge.getSource().getIntermediateResult().getConnectionIndex();
 
-				if (!sendUpdateTaskRpcCall(consumerSlot, consumerExecutionId, edge.getSource().getIntermediateResult().getId(), partitionInfo)) {
-					success = false;
+				PartitionInfo.PartitionLocation producerLocation;
+				RemoteAddress producerAddress = null;
+
+				if(consumerSlot.getInstance().getInstanceConnectionInfo().equals(
+						getAssignedResourceLocation())) {
+					producerLocation = PartitionInfo.PartitionLocation.LOCAL;
+				} else {
+					producerLocation = PartitionInfo.PartitionLocation.REMOTE;
+					producerAddress = new RemoteAddress(getAssignedResourceLocation(),
+							connectionIndex);
 				}
 
+				PartitionInfo partitionInfo = new PartitionInfo(partitionID, attemptId,
+						producerLocation, producerAddress);
+
+				TaskManagerMessages.UpdateTask updateTaskMessage =
+						new TaskManagerMessages.UpdateTaskSinglePartitionInfo(consumerExecutionId,
+								edge.getSource().getIntermediateResult().getId(), partitionInfo);
+
+				sendUpdateTaskRpcCall(consumerSlot, updateTaskMessage);
 			}
 			else if (consumerState == SCHEDULED || consumerState == DEPLOYING) {
-				success = false;
+				consumerVertex.cachePartitionInfo(PartialPartitionInfo.fromEdge(edge));
+
+				// double check to resolve race conditions
+				if(consumerVertex.getExecutionState() == RUNNING){
+					consumerVertex.sendPartitionInfos();
+				}
 			}
 		}
-
-		return success;
 	}
 
 	/**
@@ -548,6 +595,32 @@ public class Execution implements Serializable {
 		}
 	}
 
+	void sendPartitionInfos() {
+		ConcurrentLinkedQueue<PartialPartitionInfo> partialPartitionInfos =
+				vertex.getPartialPartitionInfos();
+
+		// check if the ExecutionVertex has already been archived and thus cleared the
+		// partial partition infos queue
+		if(partialPartitionInfos != null) {
+
+			PartialPartitionInfo partialPartitionInfo;
+
+			List<IntermediateDataSetID> resultIDs = new ArrayList<IntermediateDataSetID>();
+			List<PartitionInfo> partitionInfos = new ArrayList<PartitionInfo>();
+
+			while ((partialPartitionInfo = partialPartitionInfos.poll()) != null) {
+				resultIDs.add(partialPartitionInfo.getIntermediateDataSetID());
+				partitionInfos.add(partialPartitionInfo.createPartitionInfo(this));
+			}
+
+			TaskManagerMessages.UpdateTask updateTaskMessage =
+					TaskManagerMessages.createUpdateTaskMultiplePartitionInfos(attemptId, resultIDs,
+							partitionInfos);
+
+			sendUpdateTaskRpcCall(assignedResource, updateTaskMessage);
+		}
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Internal Actions
 	// --------------------------------------------------------------------------------------------
@@ -614,6 +687,7 @@ public class Execution implements Serializable {
 	private boolean switchToRunning() {
 
 		if (transitionState(DEPLOYING, RUNNING)) {
+			sendPartitionInfos();
 			return true;
 		}
 		else {
@@ -671,7 +745,7 @@ public class Execution implements Serializable {
 				if(failure != null){
 					fail(new Exception("Task could not be canceled.", failure));
 				}else{
-					TaskManagerMessages.TaskOperationResult result = (TaskManagerMessages.TaskOperationResult)success;
+					TaskOperationResult result = (TaskOperationResult)success;
 					if(!result.success()){
 						LOG.debug("Cancel task call did not find task. Probably akka message call" +
 								" race.");
@@ -700,21 +774,20 @@ public class Execution implements Serializable {
 		}
 	}
 
-	private boolean sendUpdateTaskRpcCall(final SimpleSlot consumerSlot, final ExecutionAttemptID executionId, final IntermediateDataSetID resultId, final PartitionInfo partitionInfo) throws Exception {
+	private void sendUpdateTaskRpcCall(final SimpleSlot consumerSlot,
+									final TaskManagerMessages.UpdateTask updateTaskMsg) {
 		final Instance instance = consumerSlot.getInstance();
 
-		final TaskManagerMessages.TaskOperationResult result = AkkaUtils.ask(
-				instance.getTaskManager(), new TaskManagerMessages.UpdateTask(executionId, resultId, partitionInfo), timeout);
+		Future<Object> futureUpdate = Patterns.ask(instance.getTaskManager(), updateTaskMsg,
+				new Timeout(timeout));
 
-		if (!result.success()) {
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Update task {} was unsuccessful (maybe an RPC race): {}", executionId, result.description());
+		futureUpdate.onFailure(new OnFailure() {
+			@Override
+			public void onFailure(Throwable failure) throws Throwable {
+				fail(new IllegalStateException("Update task on instance " + instance +
+						" failed due to:", failure));
 			}
-
-			return false;
-		}
-
-		return true;
+		}, AkkaUtils.globalExecutionContext());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -521,14 +521,20 @@ public class ExecutionGraph implements Serializable {
 		}
 	}
 
-	public boolean scheduleOrUpdateConsumers(ExecutionAttemptID executionId, int partitionIndex) throws Exception {
+	public void scheduleOrUpdateConsumers(ExecutionAttemptID executionId, int partitionIndex) {
 		Execution execution = currentExecutions.get(executionId);
 
-		if (execution == null) {
-			throw new IllegalStateException("Cannot find execution for execution ID " + executionId);
-		}
 
-		return execution.getVertex().scheduleOrUpdateConsumers(partitionIndex);
+		if (execution == null) {
+			fail(new IllegalStateException("Cannot find execution for execution ID " +
+					executionId));
+		}
+		else if(execution.getVertex() == null){
+			fail(new IllegalStateException("Execution with execution ID " + executionId +
+				" has no vertex assigned."));
+		} else {
+			execution.getVertex().scheduleOrUpdateConsumers(partitionIndex);
+		}
 	}
 
 	public Map<ExecutionAttemptID, Execution> getRegisteredExecutions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network;
 
 import akka.actor.ActorRef;
+import akka.util.Timeout;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.api.reader.BufferReader;
 import org.apache.flink.runtime.io.network.api.writer.BufferWriter;
@@ -47,6 +48,8 @@ public class NetworkEnvironment {
 
 	private static final Logger LOG = LoggerFactory.getLogger(NetworkEnvironment.class);
 
+	private final ActorRef taskManager;
+
 	private final ActorRef jobManager;
 
 	private final FiniteDuration jobManagerTimeout;
@@ -64,7 +67,10 @@ public class NetworkEnvironment {
 	/**
 	 * Initializes all network I/O components.
 	 */
-	public NetworkEnvironment(ActorRef jobManager, FiniteDuration jobManagerTimeout, NetworkEnvironmentConfiguration config) throws IOException {
+	public NetworkEnvironment(ActorRef taskManager, ActorRef jobManager,
+							FiniteDuration jobManagerTimeout,
+							NetworkEnvironmentConfiguration config) throws IOException {
+		this.taskManager = checkNotNull(taskManager);
 		this.jobManager = checkNotNull(jobManager);
 		this.jobManagerTimeout = checkNotNull(jobManagerTimeout);
 
@@ -96,12 +102,16 @@ public class NetworkEnvironment {
 		}
 	}
 
+	public ActorRef getTaskManager() {
+		return taskManager;
+	}
+
 	public ActorRef getJobManager() {
 		return jobManager;
 	}
 
-	public FiniteDuration getJobManagerTimeout() {
-		return jobManagerTimeout;
+	public Timeout getJobManagerTimeout() {
+		return new Timeout(jobManagerTimeout);
 	}
 
 	public void registerTask(Task task) throws IOException {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/client/JobClient.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/client/JobClient.scala
@@ -171,11 +171,10 @@ object JobClient{
     var waitForAnswer = true
     var answer: JobExecutionResult = null
 
-    val result =(jobClient ? SubmitJobAndWait(jobGraph, listenToEvents = listenToStatusEvents))(
-      AkkaUtils.INF_TIMEOUT).mapTo[JobExecutionResult]
-
     while(waitForAnswer) {
       try {
+        val result =(jobClient ? SubmitJobAndWait(jobGraph, listenToEvents = listenToStatusEvents))(
+          timeout).mapTo[JobExecutionResult]
         answer = Await.result(result, timeout)
         waitForAnswer = false
       } catch {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState
  * The job manager specific messages
  */
 object JobManagerMessages {
-
   /**
    * Submits a job to the job manager. If [[registerForEvents]] is true,
    * then the sender will be registered as listener for the state change messages. If [[detached]]

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages
+
+object Messages {
+
+  case object Acknowledge
+
+}


### PR DESCRIPTION
Replaces the blocking calls with futures which in case of an exception let the respective task fail. Furthermore, the PartitionInfos are buffered on the JobManager in case that some of the consumers are not yet scheduled. Once the state of the consumers switched to running, all buffered partition infos are sent to the consumers.