### PR TITLE
[FLINK-1533] [runtime] Fixes NPE in the scheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -432,17 +432,23 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 				// root SharedSlot
 				SharedSlot sharedSlot = instanceToUse.allocateSharedSlot(vertex.getJobId(), groupAssignment, groupID);
 
-				// If constraint != null, then slot nested in a SharedSlot nested in sharedSlot
-				// If constraint == null, then slot nested in sharedSlot
-				SimpleSlot slot = groupAssignment.addSharedSlotAndAllocateSubSlot(sharedSlot, locality, groupID, constraint);
-
 				// if the instance has further available slots, re-add it to the set of available resources.
 				if (instanceToUse.hasResourcesAvailable()) {
 					this.instancesWithAvailableResources.add(instanceToUse);
 				}
 
-				if (slot != null) {
-					return slot;
+				if(sharedSlot != null){
+					// If constraint != null, then slot nested in a SharedSlot nested in sharedSlot
+					// If constraint == null, then slot nested in sharedSlot
+					SimpleSlot slot = groupAssignment.addSharedSlotAndAllocateSubSlot(sharedSlot,
+							locality, groupID, constraint);
+
+					if(slot != null){
+						return slot;
+					} else {
+						// release shared slot
+						sharedSlot.releaseSlot();
+					}
 				}
 			}
 			catch (InstanceDiedException e) {


### PR DESCRIPTION
Adds checks to the method ```Scheduler.getFreeSubSlotForTask``` to handle failed shared slot allocations. Before the slot was given to the ```SlotSharingGroupAssignment``` without checking that it is not null. Consequently, a NullPointerException could occur in the ```SlotSharingGroupAssignment```.