### PR TITLE
[builds] Print Java process stack traces of stalled builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp
 _site
 docs/api
 build-target
+tools/watchdog*

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,11 @@ before_script:
 
 # we have to manually set the forkCount because maven thinks that the travis
 # machine has 32 cores
-script: "mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
+#script: "mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
+
+# We run mvn and monitor its output. If there is no output for the specified number of seconds, we
+# print the stack traces of all running Java processes.
+script: "./tools/travis_mvn_watchdog.sh 300"
 
 # deploy if the first job is successful; should be replaced by an after_all_success if travis finally supports it
 after_success: 

--- a/pom.xml
+++ b/pom.xml
@@ -1044,6 +1044,8 @@ under the License.
 						<exclude>docs/_site/**</exclude>
 						<exclude>**/scalastyle-output.xml</exclude>
 						<exclude>build-target/**</exclude>
+						<!-- Tools: watchdog -->
+						<exclude>tools/watchdog*</exclude>
 					</excludes>
 				</configuration>
 			</plugin>

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+HERE="`dirname \"$0\"`"				# relative
+HERE="`( cd \"$HERE\" && pwd )`" 	# absolutized and normalized
+if [ -z "$HERE" ] ; then
+	# error; for some reason, the path is not accessible
+	# to the script (e.g. permissions re-evaled after suid)
+	exit 1  # fail
+fi
+
+# =============================================================================
+# CONFIG
+# =============================================================================
+
+# Number of seconds w/o output before printing a stack trace and killing $MVN
+MAX_NO_OUTPUT=${1:-300}
+
+# Number of seconds to sleep before checking the output again
+SLEEP_TIME=20
+
+# Maven command to run
+MVN="mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
+
+MVN_PID="${HERE}/watchdog.mvn.pid"
+MVN_EXIT="${HERE}/watchdog.mvn.exit"
+MVN_OUT="${HERE}/watchdog.mvn.out"
+TRACE_OUT="${HERE}/watchdog.trace.out"
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+print_stacktraces () {
+	echo "=============================================================================="
+	echo "The following Java processes are running (JPS)"
+	echo "=============================================================================="
+
+	jps
+
+	local pids=( $(jps | awk '{print $1}') )
+
+	for pid in "${pids[@]}"; do
+		echo "=============================================================================="
+		echo "Printing stack trace of Java process ${pid}"
+		echo "=============================================================================="
+
+		jstack $pid
+	done
+}
+
+mod_time () {
+	if [[ `uname` == 'Darwin' ]]; then
+		eval $(stat -s $MVN_OUT)
+		echo $st_mtime
+	else
+		echo `stat -c "%Y" $MVN_OUT`
+	fi
+}
+
+the_time() {
+	echo `date +%s`
+}
+
+watchdog () {
+	touch $MVN_OUT
+
+	while true; do
+		sleep $SLEEP_TIME
+
+		time_diff=$((`the_time` - `mod_time`))
+
+		if [ $time_diff -ge $MAX_NO_OUTPUT ]; then
+			echo "=============================================================================="
+			echo "Maven produced no output for ${MAX_NO_OUTPUT} seconds."
+			echo "=============================================================================="
+
+			print_stacktraces | tee $TRACE_OUT
+
+			kill $(<$MVN_PID)
+
+			exit 1
+		fi
+	done
+}
+
+# =============================================================================
+# WATCHDOG
+# =============================================================================
+
+# Start watching $MVN_OUT
+watchdog &
+
+WD_PID=$!
+
+echo "STARTED watchdog (${WD_PID})."
+
+# Make sure to be in project root
+cd $HERE/../
+
+echo "RUNNING ${MVN} command."
+
+# Run $MVN and pipe output to $MVN_OUT for the watchdog. The PID is written to $MVN_PID to
+# allow the watchdog to kill $MVN if it is not producing any output anymore. $MVN_EXIT contains
+# the exit code. This is important for Travis' build life-cycle (success/failure).
+( $MVN & PID=$! ; echo $PID >&3 ; wait $PID ; echo $? >&4 ) 3>$MVN_PID 4>$MVN_EXIT | tee $MVN_OUT
+
+echo "Trying to KILL watchdog (${WD_PID})."
+
+# Make sure to kill the watchdog in any case after $MVN has completed
+( kill $WD_PID 2>&1 ) > /dev/null
+
+EXIT_CODE=$(<$MVN_EXIT)
+
+echo "MVN exited with EXIT CODE: ${EXIT_CODE}."
+
+rm $MVN_PID
+rm $MVN_EXIT
+
+exit $EXIT_CODE


### PR DESCRIPTION
After discussion with @rmetzger we came up with the following idea to manually monitor stalled builds and to print the Java process stack traces if they do stall.

Furthermore, a stalling build is killed with a != 0 exit code and really fails the Travis build instead of just timing it out.

For testing, I've a branch where I block a test on purpose. The output can be found here: https://travis-ci.org/uce/incubator-flink/jobs/50491750

```
==============================================================================
Maven produced no output for 300 seconds.
==============================================================================
==============================================================================
The following Java processes are running (JPS)
==============================================================================
21670 Jps
12703 surefirebooter5726841031685552603.jar
2220 Launcher
==============================================================================
Printing stack trace of Java process 12703
==============================================================================
2015-02-12 14:14:42
Full thread dump OpenJDK 64-Bit Server VM (23.25-b01 mixed mode):

"Attach Listener" daemon prio=10 tid=0x00007f4e18001000 nid=0x54ed runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Low Memory Detector" daemon prio=10 tid=0x00007f4e64112000 nid=0x31d2 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"C2 CompilerThread1" daemon prio=10 tid=0x00007f4e64110000 nid=0x31ce waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"C2 CompilerThread0" daemon prio=10 tid=0x00007f4e6410d000 nid=0x31cd waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Signal Dispatcher" daemon prio=10 tid=0x00007f4e6410b000 nid=0x31cb runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE

"Finalizer" daemon prio=10 tid=0x00007f4e640b8800 nid=0x31c8 in Object.wait() [0x00007f4e32fee000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	- waiting on <0x00000000d23275e0> (a java.lang.ref.ReferenceQueue$Lock)
	at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:133)
	- locked <0x00000000d23275e0> (a java.lang.ref.ReferenceQueue$Lock)
	at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:149)
	at java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:189)

"Reference Handler" daemon prio=10 tid=0x00007f4e640b6800 nid=0x31c7 in Object.wait() [0x00007f4e330ef000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	- waiting on <0x00000000d23273a0> (a java.lang.ref.Reference$Lock)
	at java.lang.Object.wait(Object.java:502)
	at java.lang.ref.Reference$ReferenceHandler.run(Reference.java:133)
	- locked <0x00000000d23273a0> (a java.lang.ref.Reference$Lock)

"main" prio=10 tid=0x00007f4e64009800 nid=0x31a4 in Object.wait() [0x00007f4e6b98c000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	- waiting on <0x00000000f1c81e18> (a org.apache.flink.api.common.io.BinaryInputFormatTest)
	at java.lang.Object.wait(Object.java:502)
	at org.apache.flink.api.common.io.BinaryInputFormatTest.testCreateInputSplitsWithOneFile(BinaryInputFormatTest.java:51)
	- locked <0x00000000f1c81e18> (a org.apache.flink.api.common.io.BinaryInputFormatTest)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:622)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)

"VM Thread" prio=10 tid=0x00007f4e640a7800 nid=0x31c2 runnable 

"GC task thread#0 (ParallelGC)" prio=10 tid=0x00007f4e64017000 nid=0x31a8 runnable 

"GC task thread#1 (ParallelGC)" prio=10 tid=0x00007f4e64019000 nid=0x31ac runnable 

"GC task thread#2 (ParallelGC)" prio=10 tid=0x00007f4e6401b000 nid=0x31af runnable 

"GC task thread#3 (ParallelGC)" prio=10 tid=0x00007f4e6401c800 nid=0x31b1 runnable 

"GC task thread#4 (ParallelGC)" prio=10 tid=0x00007f4e6401e800 nid=0x31b3 runnable 

"GC task thread#5 (ParallelGC)" prio=10 tid=0x00007f4e64020800 nid=0x31b5 runnable 

"GC task thread#6 (ParallelGC)" prio=10 tid=0x00007f4e64022000 nid=0x31b7 runnable 

"GC task thread#7 (ParallelGC)" prio=10 tid=0x00007f4e64024000 nid=0x31b9 runnable 

"GC task thread#8 (ParallelGC)" prio=10 tid=0x00007f4e64026000 nid=0x31bb runnable 

"GC task thread#9 (ParallelGC)" prio=10 tid=0x00007f4e64027800 nid=0x31be runnable 

"GC task thread#10 (ParallelGC)" prio=10 tid=0x00007f4e64029800 nid=0x31bf runnable 

"GC task thread#11 (ParallelGC)" prio=10 tid=0x00007f4e6402b800 nid=0x31c0 runnable 

"GC task thread#12 (ParallelGC)" prio=10 tid=0x00007f4e6402d800 nid=0x31c1 runnable 

"VM Periodic Task Thread" prio=10 tid=0x00007f4e6411c800 nid=0x31d4 waiting on condition 

JNI global references: 146
```

The stack trace is very helpful in pointing to the problem for stalled builds.