### PR TITLE
[builds] Notify dev@f.a.o about travis-ci build status changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ git:
   depth: 10
 
 notifications:
+  email:
+    recipients:
+      - dev@flink.apache.org
+    on_success: change
+    on_failure: change
+
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/d70a7e674cb9354c77b2


### PR DESCRIPTION
Related discussion [about how to notice failing master faster](http://apache-flink-incubator-mailing-list-archive.1008284.n3.nabble.com/Master-not-building-and-how-to-notice-it-faster-in-the-future-td3375.html).

With this Travis config, we will get an email to dev@f.a.o for every status change from success => failure and failure => success.

We could also just notify on failures. Feedback is welcome.

If we want to merge this, we have to make sure that builds@travis-ci.org is allowed to post to our dev mailing list.