### PR TITLE
[FLINK-1549] Adds proper exception handling to YarnJobManager

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -526,14 +526,14 @@ public class CliFrontend {
 
 			Object result = null;
 
-			try{
+			try {
 				result = Await.result(response, getAkkaTimeout());
 			} catch (Exception exception) {
 				throw new IOException("Could not retrieve running jobs from job manager.",
 						exception);
 			}
 
-			if(!(result instanceof RunningJobs)){
+			if (!(result instanceof RunningJobs)) {
 				throw new RuntimeException("ReqeustRunningJobs requires a response of type " +
 						"RunningJobs. Instead the response is of type " + result.getClass() + ".");
 			} else {

--- a/flink-clients/src/main/java/org/apache/flink/client/FlinkYarnSessionCli.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/FlinkYarnSessionCli.java
@@ -407,8 +407,10 @@ public class FlinkYarnSessionCli {
 
 			runInteractiveCli(yarnCluster);
 
-			LOG.info("Command Line Interface requested session shutdown");
-			yarnCluster.shutdown();
+			if(!yarnCluster.hasBeenStopped()) {
+				LOG.info("Command Line Interface requested session shutdown");
+				yarnCluster.shutdown();
+			}
 
 			try {
 				yarnPropertiesFile.delete();

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -114,7 +114,7 @@ class JobManager(val configuration: Configuration,
     log.info(s"Stopping job manager ${self.path}.")
 
     archive ! PoisonPill
-    profiler.map( ref => ref ! PoisonPill )
+    profiler.foreach( ref => ref ! PoisonPill )
 
     for((e,_) <- currentJobs.values){
       e.fail(new Exception("The JobManager is shutting down."))

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
@@ -103,7 +103,7 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 		// start application client
 		LOG.info("Start application client.");
 
-		applicationClient = actorSystem.actorOf(Props.create(ApplicationClient.class));
+		applicationClient = actorSystem.actorOf(Props.create(ApplicationClient.class), "applicationClient");
 
 		// instruct ApplicationClient to start a periodical status polling
 		applicationClient.tell(new Messages.LocalRegisterClient(jobManagerHost + ":" + jobManagerPort), applicationClient);

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationClient.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationClient.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn
 
 import akka.actor._
+import akka.pattern.ask
 import org.apache.flink.configuration.GlobalConfiguration
 import org.apache.flink.runtime.ActorLogMessages
 import org.apache.flink.runtime.akka.AkkaUtils
@@ -59,6 +60,9 @@ class ApplicationClient extends Actor with ActorLogMessages with ActorLogging {
     }
 
     pollingTimer = None
+
+    // Terminate the whole actor system because there is only the application client running
+    context.system.shutdown()
   }
 
   override def receiveWithLogMessages: Receive = {
@@ -73,6 +77,8 @@ class ApplicationClient extends Actor with ActorLogMessages with ActorLogging {
         case Failure(t) =>
           log.error(t, "Registration at JobManager/ApplicationMaster failed. Shutting " +
             "ApplicationClient down.")
+
+          // we could not connect to the job manager --> poison ourselves
           self ! PoisonPill
       }
 
@@ -82,7 +88,11 @@ class ApplicationClient extends Actor with ActorLogMessages with ActorLogging {
       // the message came from the FlinkYarnCluster. We send the message to the JobManager.
       // it is important not to forward the message because the JobManager is storing the
       // sender as the Application Client (this class).
-      jm ! RegisterClient
+      (jm ? RegisterClient(self))(timeout).onFailure{
+        case t: Throwable =>
+          log.error(t, "Could not register at the job manager.")
+          self ! PoisonPill
+      }
 
       // schedule a periodic status report from the JobManager
       // request the number of task managers and slots from the job manager
@@ -91,7 +101,7 @@ class ApplicationClient extends Actor with ActorLogMessages with ActorLogging {
 
     case msg: StopYarnSession =>
       log.info("Stop yarn session.")
-      stopMessageReceiver = Some(sender())
+      stopMessageReceiver = Some(sender)
       yarnJobManager foreach {
         _ forward msg
       }
@@ -102,9 +112,8 @@ class ApplicationClient extends Actor with ActorLogMessages with ActorLogging {
       stopMessageReceiver foreach {
         _ ! JobManagerStopped
       }
-      // stop ourselves
-      context.system.shutdown()
-
+      // poison ourselves
+      self ! PoisonPill
 
     // handle the responses from the PollYarnClusterStatus messages to the yarn job mgr
     case status: FlinkYarnClusterStatus =>

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/Messages.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/Messages.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.yarn.api.records.FinalApplicationStatus
 object Messages {
   case class YarnMessage(message: String, date: Date = new Date())
   case class ApplicationMasterStatus(numTaskManagers: Int, numSlots: Int)
-  case object RegisterClient
+  case class RegisterClient(client: ActorRef)
 
   case class StopYarnSession(status: FinalApplicationStatus)
   case object JobManagerStopped

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
@@ -26,6 +26,7 @@ import akka.actor.ActorRef
 import org.apache.flink.configuration.ConfigConstants
 import org.apache.flink.runtime.ActorLogMessages
 import org.apache.flink.runtime.jobmanager.{WithWebServer, JobManager}
+import org.apache.flink.runtime.messages.Messages.Acknowledge
 import org.apache.flink.runtime.yarn.FlinkYarnClusterStatus
 import org.apache.flink.yarn.Messages._
 import org.apache.flink.yarn.appMaster.YarnTaskManagerRunner
@@ -42,6 +43,7 @@ import org.apache.hadoop.yarn.util.Records
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.Try
 
 
 trait YarnJobManager extends ActorLogMessages {
@@ -69,7 +71,7 @@ trait YarnJobManager extends ActorLogMessages {
 
   def receiveYarnMessages: Receive = {
     case StopYarnSession(status) =>
-      log.info("Stopping YARN Session.")
+      log.info("Stopping YARN JobManager with status {}.", status)
 
       instanceManager.getAllRegisteredInstances.asScala foreach {
         instance =>
@@ -78,123 +80,41 @@ trait YarnJobManager extends ActorLogMessages {
 
       rmClientOption foreach {
         rmClient =>
-          rmClient.unregisterApplicationMaster(status, "", "")
-          rmClient.close()
+          Try(rmClient.unregisterApplicationMaster(status, "", "")).recover{
+            case t: Throwable => log.error(t, "Could not unregister the application master.")
+          }
+
+          Try(rmClient.close()).recover{
+            case t:Throwable => log.error(t, "Could not close the AMRMClient.")
+          }
       }
 
       rmClientOption = None
 
       nmClientOption foreach {
-        _.close()
+        nmClient =>
+        Try(nmClient.close()).recover{
+          case t: Throwable => log.error(t, "Could not close the NMClient.")
+        }
       }
 
       nmClientOption = None
       messageListener foreach {
-        _ ! JobManagerStopped
+          _ ! JobManagerStopped
       }
+
       context.system.shutdown()
 
-    case RegisterClient =>
-      messageListener = Some(sender())
+    case RegisterClient(client) =>
+      log.info("Register {} as client.", client.path)
+      messageListener = Some(client)
+      sender ! Acknowledge
 
     case PollYarnClusterStatus =>
       sender() ! new FlinkYarnClusterStatus(instanceManager.getNumberOfRegisteredTaskManagers,
         instanceManager.getTotalNumberOfSlots)
 
-    case StartYarnSession(conf, actorSystemPort: Int) =>
-      log.info("Start yarn session.")
-      val memoryPerTaskManager = env.get(FlinkYarnClient.ENV_TM_MEMORY).toInt
-      val heapLimit = Utils.calculateHeapSize(memoryPerTaskManager)
-
-      val applicationMasterHost = env.get(Environment.NM_HOST.key)
-      require(applicationMasterHost != null, s"Application master (${Environment.NM_HOST} not set.")
-
-      numTaskManager = env.get(FlinkYarnClient.ENV_TM_COUNT).toInt
-      log.info(s"Requesting $numTaskManager task managers.")
-
-      val remoteFlinkJarPath = env.get(FlinkYarnClient.FLINK_JAR_PATH)
-      val fs = FileSystem.get(conf)
-      val appId = env.get(FlinkYarnClient.ENV_APP_ID)
-      val currDir = env.get(Environment.PWD.key())
-      val clientHomeDir = env.get(FlinkYarnClient.ENV_CLIENT_HOME_DIR)
-      val shipListString = env.get(FlinkYarnClient.ENV_CLIENT_SHIP_FILES)
-      val yarnClientUsername = env.get(FlinkYarnClient.ENV_CLIENT_USERNAME)
-
-      val jobManagerWebPort = that.webServer.getServer.getConnectors()(0).getLocalPort
-
-      val rm = AMRMClient.createAMRMClient[ContainerRequest]()
-      rm.init(conf)
-      rm.start()
-
-      rmClientOption = Some(rm)
-
-      val nm = NMClient.createNMClient()
-      nm.init(conf)
-      nm.start()
-      nm.cleanupRunningContainersOnStop(true)
-
-      nmClientOption = Some(nm)
-
-      // Register with ResourceManager
-      val url = s"http://$applicationMasterHost:$jobManagerWebPort"
-      log.info(s"Registering ApplicationMaster with tracking url $url.")
-      rm.registerApplicationMaster(applicationMasterHost, actorSystemPort, url)
-
-
-      // Priority for worker containers - priorities are intra-application
-      val priority = Records.newRecord(classOf[Priority])
-      priority.setPriority(0)
-
-      // Resource requirements for worker containers
-      val capability = Records.newRecord(classOf[Resource])
-      capability.setMemory(memoryPerTaskManager)
-      capability.setVirtualCores(1) // hard-code that number (YARN is not accunting for CPUs)
-
-      // Make container requests to ResourceManager
-      for (i <- 0 until numTaskManager) {
-        val containerRequest = new ContainerRequest(capability, null, null, priority)
-        log.info(s"Requesting TaskManager container $i.")
-        rm.addContainerRequest(containerRequest)
-      }
-
-      val flinkJar = Records.newRecord(classOf[LocalResource])
-      val flinkConf = Records.newRecord(classOf[LocalResource])
-
-      // register Flink Jar with remote HDFS
-      val remoteJarPath = new Path(remoteFlinkJarPath)
-      Utils.registerLocalResource(fs, remoteJarPath, flinkJar)
-
-      // register conf with local fs
-      Utils.setupLocalResource(conf, fs, appId, new Path(s"file://$currDir/flink-conf-modified" +
-        s".yaml"), flinkConf, new Path(clientHomeDir))
-      log.info(s"Prepared local resource for modified yaml: $flinkConf")
-
-      val hasLogback = new File(s"$currDir/logback.xml").exists()
-      val hasLog4j = new File(s"$currDir/log4j.properties").exists()
-
-      // prepare files to be shipped
-      val resources = shipListString.split(",") flatMap {
-        pathStr =>
-          if (pathStr.isEmpty) {
-            None
-          } else {
-            val resource = Records.newRecord(classOf[LocalResource])
-            val path = new Path(pathStr)
-            Utils.registerLocalResource(fs, path, resource)
-            Some((path.getName, resource))
-          }
-      } toList
-
-      val taskManagerLocalResources = ("flink.jar", flinkJar) ::("flink-conf.yaml",
-        flinkConf) :: resources toMap
-
-      allocatedContainers = 0
-      completedContainers = 0
-
-      containerLaunchContext = Some(createContainerLaunchContext(heapLimit, hasLogback, hasLog4j,
-        yarnClientUsername, conf, taskManagerLocalResources))
-
-      context.system.scheduler.scheduleOnce(ALLOCATION_DELAY, self, PollContainerCompletion)
+    case StartYarnSession(conf, actorSystemPort) => startYarnSession(conf, actorSystemPort)
 
     case PollContainerCompletion =>
       rmClientOption match {
@@ -248,7 +168,109 @@ trait YarnJobManager extends ActorLogMessages {
       }
   }
 
-  def createContainerLaunchContext(heapLimit: Int, hasLogback: Boolean, hasLog4j: Boolean,
+  private def startYarnSession(conf: Configuration, actorSystemPort: Int): Unit = {
+    Try {
+      log.info("Start yarn session.")
+      val memoryPerTaskManager = env.get(FlinkYarnClient.ENV_TM_MEMORY).toInt
+      val heapLimit = Utils.calculateHeapSize(memoryPerTaskManager)
+
+      val applicationMasterHost = env.get(Environment.NM_HOST.key)
+      require(applicationMasterHost != null, s"Application master (${Environment.NM_HOST} not set.")
+
+      numTaskManager = env.get(FlinkYarnClient.ENV_TM_COUNT).toInt
+      log.info(s"Requesting $numTaskManager task managers.")
+
+      val remoteFlinkJarPath = env.get(FlinkYarnClient.FLINK_JAR_PATH)
+      val fs = FileSystem.get(conf)
+      val appId = env.get(FlinkYarnClient.ENV_APP_ID)
+      val currDir = env.get(Environment.PWD.key())
+      val clientHomeDir = env.get(FlinkYarnClient.ENV_CLIENT_HOME_DIR)
+      val shipListString = env.get(FlinkYarnClient.ENV_CLIENT_SHIP_FILES)
+      val yarnClientUsername = env.get(FlinkYarnClient.ENV_CLIENT_USERNAME)
+
+      val jobManagerWebPort = that.webServer.getServer.getConnectors()(0).getLocalPort
+
+      val rm = AMRMClient.createAMRMClient[ContainerRequest]()
+      rm.init(conf)
+      rm.start()
+
+      rmClientOption = Some(rm)
+
+      val nm = NMClient.createNMClient()
+      nm.init(conf)
+      nm.start()
+      nm.cleanupRunningContainersOnStop(true)
+
+      nmClientOption = Some(nm)
+
+      // Register with ResourceManager
+      val url = s"http://$applicationMasterHost:$jobManagerWebPort"
+      log.info(s"Registering ApplicationMaster with tracking url $url.")
+      rm.registerApplicationMaster(applicationMasterHost, actorSystemPort, url)
+
+
+      // Priority for worker containers - priorities are intra-application
+      val priority = Records.newRecord(classOf[Priority])
+      priority.setPriority(0)
+
+      // Resource requirements for worker containers
+      val capability = Records.newRecord(classOf[Resource])
+      capability.setMemory(memoryPerTaskManager)
+      capability.setVirtualCores(1) // hard-code that number (YARN is not accounting for CPUs)
+
+      // Make container requests to ResourceManager
+      for (i <- 0 until numTaskManager) {
+        val containerRequest = new ContainerRequest(capability, null, null, priority)
+        log.info(s"Requesting TaskManager container $i.")
+        rm.addContainerRequest(containerRequest)
+      }
+
+      val flinkJar = Records.newRecord(classOf[LocalResource])
+      val flinkConf = Records.newRecord(classOf[LocalResource])
+
+      // register Flink Jar with remote HDFS
+      val remoteJarPath = new Path(remoteFlinkJarPath)
+      Utils.registerLocalResource(fs, remoteJarPath, flinkJar)
+
+      // register conf with local fs
+      Utils.setupLocalResource(conf, fs, appId, new Path(s"file://$currDir/flink-conf-modified" +
+        s".yaml"), flinkConf, new Path(clientHomeDir))
+      log.info(s"Prepared local resource for modified yaml: $flinkConf")
+
+      val hasLogback = new File(s"$currDir/logback.xml").exists()
+      val hasLog4j = new File(s"$currDir/log4j.properties").exists()
+
+      // prepare files to be shipped
+      val resources = shipListString.split(",") flatMap {
+        pathStr =>
+          if (pathStr.isEmpty) {
+            None
+          } else {
+            val resource = Records.newRecord(classOf[LocalResource])
+            val path = new Path(pathStr)
+            Utils.registerLocalResource(fs, path, resource)
+            Some((path.getName, resource))
+          }
+      } toList
+
+      val taskManagerLocalResources = ("flink.jar", flinkJar) ::("flink-conf.yaml",
+        flinkConf) :: resources toMap
+
+      allocatedContainers = 0
+      completedContainers = 0
+
+      containerLaunchContext = Some(createContainerLaunchContext(heapLimit, hasLogback, hasLog4j,
+        yarnClientUsername, conf, taskManagerLocalResources))
+
+      context.system.scheduler.scheduleOnce(ALLOCATION_DELAY, self, PollContainerCompletion)
+    } recover {
+      case t: Throwable =>
+        log.error(t, "Could not start yarn session.")
+        self ! StopYarnSession(FinalApplicationStatus.FAILED)
+    }
+  }
+
+  private def createContainerLaunchContext(heapLimit: Int, hasLogback: Boolean, hasLog4j: Boolean,
                                    yarnClientUsername: String, yarnConf: Configuration,
                                    taskManagerLocalResources: Map[String, LocalResource]):
   ContainerLaunchContext = {
@@ -296,12 +318,12 @@ trait YarnJobManager extends ActorLogMessages {
       val securityTokens = ByteBuffer.wrap(dob.getData, 0, dob.getLength)
       ctx.setTokens(securityTokens)
     } catch {
-      case e: IOException =>
-        log.warning("Getting current user info failed when trying to launch the container", e)
+      case t: Throwable =>
+        log.error(t, "Getting current user info failed when trying to launch the container")
     }
 
     ctx
   }
 
-  def env = System.getenv()
+  private def env = System.getenv()
 }


### PR DESCRIPTION
Adds proper exception handling to ```YarnJobManager``` by catching the thrown exceptions and sending a ```StopYarnSession(FinalApplicationStatus.FAILED)``` message to itself. This message will shutdown the JobManager and the corresponding ```ActorSystem```.

@rmetzger could you take a look at the changes?