### PR TITLE
[FLINK-1545] Fixes AsynchronousFileIOChannelsTest.testExceptionForwardsToClose

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousFileIOChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousFileIOChannel.java
@@ -48,7 +48,7 @@ public abstract class AsynchronousFileIOChannel<T, R extends IORequest> extends 
 	/** An atomic integer that counts the number of requests that we still wait for to return. */
 	protected final AtomicInteger requestsNotReturned = new AtomicInteger(0);
 	
-	/** Hander for completed requests */
+	/** Handler for completed requests */
 	protected final RequestDoneCallback<T> resultHandler;
 	
 	/** An exception that was encountered by the asynchronous request handling thread.*/
@@ -117,6 +117,9 @@ public abstract class AsynchronousFileIOChannel<T, R extends IORequest> extends 
 						throw new IOException("Closing of asynchronous file channel was interrupted.");
 					}
 				}
+
+				// Additional check because we might have skipped the while loop
+				checkErroneous();
 			}
 			finally {
 				// close the file

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousFileIOChannelsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousFileIOChannelsTest.java
@@ -92,8 +92,7 @@ public class AsynchronousFileIOChannelsTest {
 			testExceptionForwardsToClose(ioMan, 100, 1);
 			testExceptionForwardsToClose(ioMan, 100, 50);
 			testExceptionForwardsToClose(ioMan, 100, 100);
-		}
-		finally {
+		} finally {
 			ioMan.shutdown();
 		}
 	}


### PR DESCRIPTION
Fixes ```AsynchronousFileIOChannelsTest.testExceptionForwardsToClose``` by introducing an additional error check after the while loop in ```AsynchronousFileIOChannel.close``` method.