### PR TITLE
[FLINK-1554] Allows the LocalFlinkMiniCluster to start multiple TaskManager in the same ActorSystem

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -650,7 +650,7 @@ object JobManager {
       if(executionMode.equals(LOCAL)){
         LOG.info("Starting embedded TaskManager for JobManager's LOCAL mode execution")
 
-        TaskManager.startActorWithConfiguration("", configuration,
+        TaskManager.startActorWithConfiguration("", TaskManager.TASK_MANAGER_NAME, configuration,
           localAkkaCommunication = false, localTaskManagerCommunication = true)(jobManagerSystem)
       }
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.minicluster
 
+import akka.pattern.Patterns.gracefulStop
 import akka.pattern.ask
 import akka.actor.{ActorRef, ActorSystem}
 import com.typesafe.config.Config
@@ -126,6 +127,16 @@ abstract class FlinkMiniCluster(userConfiguration: Configuration,
   }
 
   def shutdown(): Unit = {
+    val futures = taskManagerActors map {
+        gracefulStop(_, timeout)
+    }
+
+    val future = gracefulStop(jobManagerActor, timeout)
+
+    implicit val executionContext = AkkaUtils.globalExecutionContext
+
+    Await.ready(Future.sequence(future +: futures), timeout)
+
     if(!singleActorSystem){
       taskManagerActorSystems foreach {
         _.shutdown()

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -92,7 +92,14 @@ class LocalFlinkMiniCluster(userConfiguration: Configuration, singleActorSystem:
       false
     }
 
+    val taskManagerName = if(singleActorSystem) {
+      TaskManager.TASK_MANAGER_NAME + "_" + (index + 1)
+    } else {
+      TaskManager.TASK_MANAGER_NAME
+    }
+
     TaskManager.startActorWithConfiguration(HOSTNAME,
+      taskManagerName,
       config,
       singleActorSystem,
       localExecution)(system)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -711,18 +711,19 @@ object TaskManager {
       LOG.info("Security is enabled. Starting secure TaskManager.")
       SecurityUtils.runSecured(new FlinkSecuredRunner[Unit] {
         override def run(): Unit = {
-          startActor(hostname, port, configuration)
+          startActor(hostname, port, configuration, TaskManager.TASK_MANAGER_NAME)
         }
       })
     } else {
-      startActor(hostname, port, configuration)
+      startActor(hostname, port, configuration, TaskManager.TASK_MANAGER_NAME)
     }
   }
 
-  def startActor(hostname: String, port: Int, configuration: Configuration) : Unit = {
+  def startActor(hostname: String, port: Int, configuration: Configuration,
+                 taskManagerName: String) : Unit = {
 
     val (taskManagerSystem, _) = startActorSystemAndActor(hostname, port, configuration,
-      localAkkaCommunication = false, localTaskManagerCommunication = false)
+      taskManagerName, localAkkaCommunication = false, localTaskManagerCommunication = false)
 
     taskManagerSystem.awaitTermination()
   }
@@ -780,6 +781,7 @@ object TaskManager {
   }
 
   def startActorSystemAndActor(hostname: String, port: Int, configuration: Configuration,
+                               taskManagerName: String,
                                localAkkaCommunication: Boolean,
                                localTaskManagerCommunication: Boolean): (ActorSystem, ActorRef) = {
     implicit val actorSystem = AkkaUtils.createActorSystem(configuration, Some((hostname, port)))
@@ -788,7 +790,7 @@ object TaskManager {
       parseConfiguration(hostname, configuration, localAkkaCommunication,
         localTaskManagerCommunication)
 
-    (actorSystem, startActor(connectionInfo, jobManagerURL, taskManagerConfig,
+    (actorSystem, startActor(taskManagerName, connectionInfo, jobManagerURL, taskManagerConfig,
       networkConfig))
   }
 
@@ -911,19 +913,23 @@ object TaskManager {
     (connectionInfo, jobManagerURL, taskManagerConfig, networkConfig)
   }
 
-  def startActor(connectionInfo: InstanceConnectionInfo, jobManagerURL: String,
+  def startActor(taskManagerName: String,
+                 connectionInfo: InstanceConnectionInfo,
+                 jobManagerURL: String,
                  taskManagerConfig: TaskManagerConfiguration,
                  networkConfig: NetworkEnvironmentConfiguration)
                 (implicit actorSystem: ActorSystem): ActorRef = {
-    startActor(Props(new TaskManager(connectionInfo, jobManagerURL, taskManagerConfig,
-      networkConfig)))
+    startActor(taskManagerName,
+      Props(new TaskManager(connectionInfo, jobManagerURL, taskManagerConfig, networkConfig)))
   }
 
-  def startActor(props: Props)(implicit actorSystem: ActorSystem): ActorRef = {
-    actorSystem.actorOf(props, TASK_MANAGER_NAME)
+  def startActor(taskManagerName: String, props: Props)
+                (implicit actorSystem: ActorSystem): ActorRef = {
+    actorSystem.actorOf(props, taskManagerName)
   }
 
-  def startActorWithConfiguration(hostname: String, configuration: Configuration,
+  def startActorWithConfiguration(hostname: String, taskManagerName: String,
+                                  configuration: Configuration,
                                   localAkkaCommunication: Boolean,
                                   localTaskManagerCommunication: Boolean)
                                  (implicit system: ActorSystem) = {
@@ -931,7 +937,8 @@ object TaskManager {
       parseConfiguration(hostname, configuration, localAkkaCommunication,
         localTaskManagerCommunication)
 
-    startActor(connectionInfo, jobManagerURL, taskManagerConfig, networkConnectionConfiguration)
+    startActor(taskManagerName, connectionInfo, jobManagerURL, taskManagerConfig,
+      networkConnectionConfiguration)
   }
 
   def startProfiler(instancePath: String, reportInterval: Long)(implicit system: ActorSystem):

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -68,7 +68,8 @@ FlinkMiniCluster(userConfiguration, singleActorSystem) {
         localAkkaCommunication = singleActorSystem, localTaskManagerCommunication = true)
 
     system.actorOf(Props(new TaskManager(connectionInfo, jobManagerURL, taskManagerConfig,
-      networkConnectionConfig) with TestingTaskManager), TaskManager.TASK_MANAGER_NAME + index)
+      networkConnectionConfig) with TestingTaskManager), TaskManager.TASK_MANAGER_NAME + "_" +
+      (index + 1))
   }
 
   def restartJobManager(): Unit = {

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -135,6 +135,11 @@ under the License.
 			<artifactId>scalatest_2.10</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.typesafe.akka</groupId>
+			<artifactId>akka-testkit_2.10</artifactId>
+		</dependency>
 		
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime.minicluster;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.JavaTestKit;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class LocalFlinkMiniClusterITCase {
+
+	static ActorSystem system;
+
+	@BeforeClass
+	public static void setup() {
+		system = ActorSystem.create("Testkit", AkkaUtils.getDefaultAkkaConfig());
+	}
+
+	@AfterClass
+	public static void teardown() {
+		JavaTestKit.shutdownActorSystem(system);
+		system = null;
+	}
+
+	@Test
+	public void testLocalFlinkMiniClusterWithMultipleTaskManagers() {
+		LocalFlinkMiniCluster miniCluster = null;
+
+		final int numTMs = 3;
+		final int numSlots = 14;
+
+		try{
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, numTMs);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots);
+			miniCluster = new LocalFlinkMiniCluster(config, true);
+
+			final ActorRef jm = miniCluster.getJobManager();
+
+			new JavaTestKit(system) {{
+				new Within(TestingUtils.TESTING_DURATION()) {
+
+					@Override
+					protected void run() {
+						jm.tell(JobManagerMessages.getRequestNumberRegisteredTaskManager(),
+								getRef());
+
+						expectMsgEquals(TestingUtils.TESTING_DURATION(), numTMs);
+
+						jm.tell(JobManagerMessages.getRequestTotalNumberOfSlots(), getRef());
+
+						expectMsgEquals(TestingUtils.TESTING_DURATION(), numTMs*numSlots);
+					}
+				};
+			}};
+
+
+		} finally {
+			if (miniCluster != null) {
+				miniCluster.stop();
+			}
+		}
+	}
+}

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnUtils.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnUtils.scala
@@ -38,7 +38,8 @@ object YarnUtils {
       TaskManager.parseConfiguration(hostname, config, localAkkaCommunication = false,
         localTaskManagerCommunication = false)
 
-    (actorSystem, TaskManager.startActor(Props(new TaskManager(connectionInfo, jobManagerURL,
-      taskManagerConfig, networkConnectionConfiguration) with YarnTaskManager))(actorSystem))
+    (actorSystem, TaskManager.startActor(TaskManager.TASK_MANAGER_NAME,
+      Props(new TaskManager(connectionInfo, jobManagerURL, taskManagerConfig,
+        networkConnectionConfiguration) with YarnTaskManager))(actorSystem))
   }
 }


### PR DESCRIPTION
Allows the ```LocalFlinkMiniCluster``` to start multiple ```TaskManager``` in the same ```ActorSystem``` by assigning them unique actor names.