### PR TITLE
[FLINK-1556] Corrects faulty JobClient behaviour in case of a submission failure

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
@@ -50,6 +50,12 @@ public class JobExecutionException extends Exception {
 		this.canceledByUser = canceledByUser;
 	}
 
+	public JobExecutionException(final Throwable cause, final boolean canceledByUser) {
+		super(cause);
+
+		this.canceledByUser = canceledByUser;
+	}
+
 	/**
 	 * Returns <code>true</code> if the job has been aborted as a result of a user request, <code>false</code>
 	 * otherwise.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/CancelTaskException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/CancelTaskException.java
@@ -23,4 +23,12 @@ package org.apache.flink.runtime.execution;
  */
 public class CancelTaskException extends RuntimeException {
 	private static final long serialVersionUID = 1L;
+
+	public CancelTaskException(final String msg) {
+		super(msg);
+	}
+
+	public CancelTaskException() {
+		super("");
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/RuntimeEnvironment.java
@@ -205,7 +205,7 @@ public class RuntimeEnvironment implements Environment, Runnable {
 
 			// Make sure, we enter the catch block when the task has been canceled
 			if (owner.isCanceledOrFailed()) {
-				throw new CancelTaskException();
+				throw new CancelTaskException("Task has been canceled or failed");
 			}
 
 			// Finish the produced partitions

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManagerProfiler.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManagerProfiler.scala
@@ -41,4 +41,12 @@ class JobManagerProfiler extends Actor with ActorLogMessages with ActorLogging w
           log.error(s"Received unknown profiling data: ${x.getClass.getName}" )
       }
   }
+
+  /**
+   * Handle unmatched messages with an exception.
+   */
+  override def unhandled(message: Any): Unit = {
+    // let the actor crash
+    throw new RuntimeException("Received unknown message " + message)
+  }
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/MemoryArchivist.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/MemoryArchivist.scala
@@ -82,6 +82,14 @@ ActorLogging {
   }
 
   /**
+   * Handle unmatched messages with an exception.
+   */
+  override def unhandled(message: Any): Unit = {
+    // let the actor crash
+    throw new RuntimeException("Received unknown message " + message)
+  }
+
+  /**
    * Gets all graphs that have not been garbage collected.
    * @return An iterable with all valid ExecutionGraphs
    */

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ExecutionGraphMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ExecutionGraphMessages.scala
@@ -66,10 +66,10 @@ object ExecutionGraphMessages {
    * @param jobID identifying the correspong job
    * @param newJobStatus
    * @param timestamp
-   * @param optionalMessage
+   * @param error
    */
   case class JobStatusChanged(jobID: JobID, newJobStatus: JobStatus, timestamp: Long,
-                              optionalMessage: String){
+                              error: Throwable){
     override def toString: String = {
       s"${timestampToString(timestamp)}\tJob execution switched to status $newJobStatus."
     }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
@@ -196,16 +196,16 @@ object JobManagerMessages {
   /**
    * Denotes a cancellation of the job.
    * @param jobID
-   * @param msg
+   * @param t
    */
-  case class JobResultCanceled(jobID: JobID, msg: String) extends JobResult
+  case class JobResultCanceled(jobID: JobID, t: Throwable) extends JobResult
 
   /**
    * Denotes a failed job execution.
    * @param jobID
-   * @param msg
+   * @param t
    */
-  case class JobResultFailed(jobID: JobID, msg:String) extends JobResult
+  case class JobResultFailed(jobID: JobID, t: Throwable) extends JobResult
 
   sealed trait SubmissionResponse{
     def jobID: JobID

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -354,6 +354,20 @@ import scala.collection.JavaConverters._
       cleanupTaskManager()
 
       tryJobManagerRegistration()
+
+    case FailIntermediateResultPartitions(executionID) =>
+      log.info("Fail intermediate result partitions associated with execution {}.", executionID)
+      networkEnvironment foreach {
+        _.getPartitionManager.failIntermediateResultPartitions(executionID)
+      }
+  }
+
+  /**
+   * Handle unmatched messages with an exception.
+   */
+  override def unhandled(message: Any): Unit = {
+    // let the actor crash
+    throw new RuntimeException("Received unknown message " + message)
   }
 
   /**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManagerProfiler.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManagerProfiler.scala
@@ -137,6 +137,14 @@ ActorLogMessages with ActorLogging {
       }
   }
 
+  /**
+   * Handle unmatched messages with an exception.
+   */
+  override def unhandled(message: Any): Unit = {
+    // let the actor crash
+    throw new RuntimeException("Received unknown message " + message)
+  }
+
   def startMonitoring(): Unit = {
     val interval = new FiniteDuration(reportInterval, TimeUnit.MILLISECONDS)
     val delay = new FiniteDuration((reportInterval * Math.random()).toLong, TimeUnit.MILLISECONDS)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -72,7 +72,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
 
           expectMsg(SubmissionFailure(jobGraph.getJobID, new NoResourceAvailableException(1,1,0)))
 
-          expectNoMsg()
+          expectMsg(JobResultFailed(jobGraph.getJobID, new NoResourceAvailableException(1,1,0)))
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationClient.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationClient.scala
@@ -126,4 +126,11 @@ class ApplicationClient extends Actor with ActorLogMessages with ActorLogging {
       sender() ! messagesQueue.headOption
   }
 
+  /**
+   * Handle unmatched messages with an exception.
+   */
+  override def unhandled(message: Any): Unit = {
+    // let the actor crash
+    throw new RuntimeException("Received unknown message " + message)
+  }
 }


### PR DESCRIPTION
If an error occurred during job submission, a ```SubmissionFailure``` is sent to the ```JobClient```. As a reaction, the ```JobClient``` terminated itself and sent the failure to the ```Client```. However, this does not necessarily mean that the job has reached a terminal state, because the failing procedure is executed asynchronously.

The ```JobClient``` now waits until it receives a ```JobResult``` message indicating that the job has completed and all resources are properly returned.