### PR TITLE
[builds] Allow to upload build artifacts to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,11 @@ before_script:
 
 # we have to manually set the forkCount because maven thinks that the travis
 # machine has 32 cores
-script: "mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
+#script: "mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
+
+# We run mvn and monitor its output. If there is no output for the specified number of seconds, we
+# print the stack traces of all running Java processes.
+script: "./tools/travis_mvn_watchdog.sh 300"
 
 # deploy if the first job is successful; should be replaced by an after_all_success if travis finally supports it
 after_success: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ env:
         # javadocs deploy
         - secure: "f4wACodae0NCaIZtmg/JvP40G/3dE7O6+ONDMbq8P/9dnT5peRB1q7+KZxggRmFSWTMPdPIDI7YxI/rM5wZ3pUN2eX0BpjfANT58OJdgCNXN3Hr9YOa8UykD2h6b+AHpy4G89MG65m73RvNXngHTCQ8SBIfewzeMAhHdD3Fk0u8="
         # If set to "true" and the build produces artifacts like log files, they will be uploaded to the specified S3 bucket
-        - UPLOAD_ARTIFACTS=true
         - secure: "MQDMeFQwC6BdrbynkdAr1P4lzaTH7ZCDDS1jHlb9pZxImDtWSEaEn/sYqELACw/l0flwraYioqDdGmdUfNFuCNG1nnFYX8Gpjmay2GlQOegr5cm/6aBy8HfeW1vYS2tdRBLvGeqvHDA7Ufw6hpQpFu3CqJH2ihnmu6v/MW0QVXw="
         - secure: "cfTKGKLYAdyc7nyCp64uhVgf66nzY4dqPrjfFUGpw7/lCVDDurZoZGJPNkBv5gLdjAEwFUkSyaJoWmL/ixc+YKP1LH9m7BEqku4KbAYCw7kWwCOKPFbGeolmSOCLhvmysFR2+EPBFmnvWQGeVKAvG2xMxmhE/WN92OL0TiW8Kpc="
         - secure: "KKV6pQP1csR3seQrt8y75cDKpPWzet1J8ZnrrxnX3kz3oKA1pMiflP8PcywAgVMjNK963pmEaMVDFGJFHe2M4EwaaK1lt+0153SZfktN0tg/aotAQy7XHLY7HMCvPYLfKVK1nGYtmt7LGEssFIXb4oynrszuOF59QmsbvRvf2Zc="

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ env:
         - secure: "f4wACodae0NCaIZtmg/JvP40G/3dE7O6+ONDMbq8P/9dnT5peRB1q7+KZxggRmFSWTMPdPIDI7YxI/rM5wZ3pUN2eX0BpjfANT58OJdgCNXN3Hr9YOa8UykD2h6b+AHpy4G89MG65m73RvNXngHTCQ8SBIfewzeMAhHdD3Fk0u8="
         # If set to "true" and the build produces artifacts like log files, they will be uploaded to the specified S3 bucket
         - UPLOAD_ARTIFACTS=true
-        - secure: "fIqsDR+q962Mq8sqCAggCADd6hnv6NVowbLVi6kyg7KDvnH6PSP4glXh34dNmalxzYqw5+iYQT9siGqHbg2no1Hx1WQctdlZV1eGz3XuRV/B8zT4UKoRt6YTViyFF8zf+BZEI0tfHsNDcKgOEo0eAG/7nC6pOEKQATDnLy2AQSc="
-        - secure: "f2SuLwiX6CXezNj/XEoDzqZ9YEkIIwThl8k3KgY42WX1GUXlXh1vWylZFLJFYM0rM4ngar60QfVXpZlgQU3f2HR+6wr8lU35Clf6IQSfuo7NW4AQVf6Ir/jFatYk0UxHkcSbYzZyugEc7bw/qYCisn1Jnwyfv+KueRSntLtiWvM="
-        - secure: "CNVbMuY8u5oTbtDw2mk11Wbv/HbROqW4xtqlEvRU22hjgSNmNGtRyDDVoojv2pp2XMu4uEYzz8O+MHjxV7b1vZML24IrkagjGfC3nbqxE3k5hqyE2IMAH635HpBAkOEEaBxAoOhRjYapXE3s03fTk7ZbggsHq1kIFRaaAHUAavU="
+        - secure: "MQDMeFQwC6BdrbynkdAr1P4lzaTH7ZCDDS1jHlb9pZxImDtWSEaEn/sYqELACw/l0flwraYioqDdGmdUfNFuCNG1nnFYX8Gpjmay2GlQOegr5cm/6aBy8HfeW1vYS2tdRBLvGeqvHDA7Ufw6hpQpFu3CqJH2ihnmu6v/MW0QVXw="
+        - secure: "cfTKGKLYAdyc7nyCp64uhVgf66nzY4dqPrjfFUGpw7/lCVDDurZoZGJPNkBv5gLdjAEwFUkSyaJoWmL/ixc+YKP1LH9m7BEqku4KbAYCw7kWwCOKPFbGeolmSOCLhvmysFR2+EPBFmnvWQGeVKAvG2xMxmhE/WN92OL0TiW8Kpc="
+        - secure: "KKV6pQP1csR3seQrt8y75cDKpPWzet1J8ZnrrxnX3kz3oKA1pMiflP8PcywAgVMjNK963pmEaMVDFGJFHe2M4EwaaK1lt+0153SZfktN0tg/aotAQy7XHLY7HMCvPYLfKVK1nGYtmt7LGEssFIXb4oynrszuOF59QmsbvRvf2Zc="
 
 before_script:
    - "gem install --no-document --version 0.8.9 faraday "

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,19 +47,20 @@ env:
         - secure: "SNZkMm++fvPbjdreibc4j/XTKy7rOvGvjbvJJLQ01fVDR8ur1FGB5L/CE9tm2Aye75G8br+tJ+gf5cMX8CHL+0VrvuTk5U6flbuM08Pd0pmP64ZncmGfRFKC5qTvt24YR0u3cqxWze8RTkdduz0t8xrEdyCtb94CHs1+RNS+0HA="
         # javadocs deploy
         - secure: "f4wACodae0NCaIZtmg/JvP40G/3dE7O6+ONDMbq8P/9dnT5peRB1q7+KZxggRmFSWTMPdPIDI7YxI/rM5wZ3pUN2eX0BpjfANT58OJdgCNXN3Hr9YOa8UykD2h6b+AHpy4G89MG65m73RvNXngHTCQ8SBIfewzeMAhHdD3Fk0u8="
+        # If set to "true" and the build produces artifacts like log files, they will be uploaded to the specified S3 bucket
+        - UPLOAD_ARTIFACTS=true
+        - secure: "fIqsDR+q962Mq8sqCAggCADd6hnv6NVowbLVi6kyg7KDvnH6PSP4glXh34dNmalxzYqw5+iYQT9siGqHbg2no1Hx1WQctdlZV1eGz3XuRV/B8zT4UKoRt6YTViyFF8zf+BZEI0tfHsNDcKgOEo0eAG/7nC6pOEKQATDnLy2AQSc="
+        - secure: "f2SuLwiX6CXezNj/XEoDzqZ9YEkIIwThl8k3KgY42WX1GUXlXh1vWylZFLJFYM0rM4ngar60QfVXpZlgQU3f2HR+6wr8lU35Clf6IQSfuo7NW4AQVf6Ir/jFatYk0UxHkcSbYzZyugEc7bw/qYCisn1Jnwyfv+KueRSntLtiWvM="
+        - secure: "CNVbMuY8u5oTbtDw2mk11Wbv/HbROqW4xtqlEvRU22hjgSNmNGtRyDDVoojv2pp2XMu4uEYzz8O+MHjxV7b1vZML24IrkagjGfC3nbqxE3k5hqyE2IMAH635HpBAkOEEaBxAoOhRjYapXE3s03fTk7ZbggsHq1kIFRaaAHUAavU="
 
 before_script:
    - "gem install --no-document --version 0.8.9 faraday "
    - "gem install --no-document travis-artifacts & "
-
-# we have to manually set the forkCount because maven thinks that the travis
-# machine has 32 cores
-#script: "mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
 
 # We run mvn and monitor its output. If there is no output for the specified number of seconds, we
 # print the stack traces of all running Java processes.
 script: "./tools/travis_mvn_watchdog.sh 300"
 
 # deploy if the first job is successful; should be replaced by an after_all_success if travis finally supports it
-after_success: 
-- "./tools/deploy_to_maven.sh"
+after_success:
+  - "./tools/deploy_to_maven.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,22 @@ env:
         - secure: "SNZkMm++fvPbjdreibc4j/XTKy7rOvGvjbvJJLQ01fVDR8ur1FGB5L/CE9tm2Aye75G8br+tJ+gf5cMX8CHL+0VrvuTk5U6flbuM08Pd0pmP64ZncmGfRFKC5qTvt24YR0u3cqxWze8RTkdduz0t8xrEdyCtb94CHs1+RNS+0HA="
         # javadocs deploy
         - secure: "f4wACodae0NCaIZtmg/JvP40G/3dE7O6+ONDMbq8P/9dnT5peRB1q7+KZxggRmFSWTMPdPIDI7YxI/rM5wZ3pUN2eX0BpjfANT58OJdgCNXN3Hr9YOa8UykD2h6b+AHpy4G89MG65m73RvNXngHTCQ8SBIfewzeMAhHdD3Fk0u8="
-        # If set to "true" and the build produces artifacts like log files, they will be uploaded to the specified S3 bucket
-        - secure: "MQDMeFQwC6BdrbynkdAr1P4lzaTH7ZCDDS1jHlb9pZxImDtWSEaEn/sYqELACw/l0flwraYioqDdGmdUfNFuCNG1nnFYX8Gpjmay2GlQOegr5cm/6aBy8HfeW1vYS2tdRBLvGeqvHDA7Ufw6hpQpFu3CqJH2ihnmu6v/MW0QVXw="
-        - secure: "cfTKGKLYAdyc7nyCp64uhVgf66nzY4dqPrjfFUGpw7/lCVDDurZoZGJPNkBv5gLdjAEwFUkSyaJoWmL/ixc+YKP1LH9m7BEqku4KbAYCw7kWwCOKPFbGeolmSOCLhvmysFR2+EPBFmnvWQGeVKAvG2xMxmhE/WN92OL0TiW8Kpc="
-        - secure: "KKV6pQP1csR3seQrt8y75cDKpPWzet1J8ZnrrxnX3kz3oKA1pMiflP8PcywAgVMjNK963pmEaMVDFGJFHe2M4EwaaK1lt+0153SZfktN0tg/aotAQy7XHLY7HMCvPYLfKVK1nGYtmt7LGEssFIXb4oynrszuOF59QmsbvRvf2Zc="
+        # Build artifacts like logs (variables for apache/flink repo and various commiters)
+        - secure: jJQtUL8w2bDqTF5LExDPaWmA6kizCbXhzrutiAGP9ecs79DfklDrD4yr9hSImD3i/vwupRMgI6EW0FKnBBaQU+98U2c71OX6Yk1D8r6EIhYrMOi7FVM7Nt8OIqpoYTQGg+42ol2CTHkCY7qi9ZwCpB5+VeHmsco6XrpJAF2eD4Q=
+        - secure: Mjhhzxus0WS/WDopXBmxkKY9TLGQ8lO1DQvU8fMJjExHz6MHnZW2OxPQikGCteFlp2aMgz5Y4xgzF5HHiJQ+88r5st7KSlmCNrSVSxHc1n7dQAh100viPnFf0ozoYVPsdJDvnYPHYgtUS38XqY9ba//9OZTPi/Hm3/0GKgV4g1w=
+        - secure: dQ4ttzfqjkKBNJDX07rxx0V+BDB0xBVB1R2oNwIcR3/BUEEEFRuoTdVUcEWNJ1GgXxcD4zBbNvCpgePUBFgNokKj7eWf2DYqmQTlwqeBQ9eCp4gybMRuhz4QbuUZ8Zbv+H0bPlfQI0Ne35eXrKylDc/OZspba6NxMmVzPx75cgw=
+        - secure: dfpLCkfmlGXun3riIWoNgoAfyMa8OWKBGj1HlKmyuB8Ub1q42tChK9oQiakERO+b9ucGUcscX5vwmFF2qwE2bQkxupvGND6gypZvwB6yCQ2LE8KaXRZp/CNbgl8kRIdsSc1nw8/D1bdBba5hdZZFWP84kPSdzOv+7tPdUcuYom0=
+        - secure: l7fK14ckh2yjeCYNjKkpezLWHF5jel6YFNWe/d25b8XgVIh1lbbOgWwxrZfLenQRHS1Web+mngGFWXc/e05rA2juUwd2P2YvTICJXQT5fBUrd0jqifXan6J8ntEBeMFdD0HOOwKkEJhyWqlbJXmq9DntdyaXpN7ExZEzlXb8Hu8=
+        - secure: AN8NAUhdrFvwk9j3TxFoTEHCMC7tmqXwVKF6SPJwzmSdVLiSTScQTrN7LVRthgTlr3AD23FRnLHQYiWr2xUXIC7ngaQ7o5UKQamHtIsPjJvceTFVRHcIfZs6qQCgOs47KoBDsnDP+nn4ZbgDNt+N4sMtZo/d/P2Oq3T36L0SkIw=
+        - secure: qXapBSPf9g2ids1ay890EbLvZ80CCl5KxBQK1ZnPV9PW/yyT9Hch+C8XH6z00bhvaysqHNQZ2aGbrMIu632X+YCrs6Rea53BJXnY0yqzWsXlxugx6VLI2UM/G3+PZz4djSdmYpA+5CZMkj/kPRh6f5LjQo8l2oBJq7UEjWoawoc=
+        - secure: ATJu0ZsaGNoV5EsMllmknOziwIvCi5t4v5No+F2qFD3tuKfmsGNyqOLj08EUtFmJ1d9Fn4wNXkDC7UfnLdjGUytU/fNZN3L0ffljJqrIcFX4qaxfMFpEElfbD6xe9w+D1ABqvKg2BuNw8rjXvf5imEXGnzZrBjzfarzUW3DZYx4=
+        - secure: v3adJMRxX2zYh9PYViwdsBocu2dRzCLoM4kAa4OIxwKS/LvoOQmhYytcX4VN4pzjXzRn2IebZ8go/nrzlxOVPL740RhZKHczXDMiBpiieh9l84SoTBmsmbj6u5rg3ZODmQzY3vLJ4SyU4qTzyTYZi1CkzBqm4IXyRMkixhE1/m8=
+        - secure: FmTf7OnCqD4krVZSLYMBz9yOSMUIsssGF7YGOvjTADPBywKrk4uDYT3YGRbEh11owamSFD5Xup2/dOPZP/J2DtbNWdEi5oRRjieVtPO+1uuRCI4xO1d0ht0TKMcSYFhsKmET/ol0kXwdno4lAzapo+9IRgJTMEsKZbhX0/cQ4C4=
+        - secure: XFm7b0lqDi7Opd2MlqJSrqZlwLe4MtOSlEmBMCGooUeMGjpyDTePp8KTVAejgqVmtXOFvzLykWB0mtSFQDWjJ2u9+bJgiktUJCMfqLklTDc+Gk7EWb7EI1E2f7ZBlTHRBdKCsHljuatEfMtXzitrAhOVmBGZe95xN61F8io7ktA=
+        - secure: VNoMS37cCaTivHQg1fFFBX+zn8QWqQd30/FbnZjjWJk1JgB3coJR4/mpu8vSU/NaDtsbu0yEcCHWWU1MvTAy+Ebc3GethTVkl8PyS1Z61DyfJjDl5MOuG3nvAqvITZtAbcmb1hqwOj96Jw6CdKivwYqw8OLHeKSWsMFCF0k/vO4=
+        - secure: xTnuCnUOBWyAvyqbIawvfQ8uETKaSHdIGaZR63KMTkCNk/pnY6Q3ioVy4qaM/ahJZgjrEd/31JjrfSpQdnlkY5TG4EFHq/nY5yRN8w55AzujvW9FjRKGAF5lzvzLCWFueS7kBgE6gkqaQHTMQ7W4b+q66aHs46F9kvy92AgE7Eo=
+        - secure: W3ZTeHd0WwFaBn4mjHde+iW7bgTSLL5ArQEkJUNwjxNXflbl0/1aL46qCw5aRU6JtlaWUjbuHZ5/hJKymgFtDTJafiy2IBVvWi+0kD0HBzhiHOiPx1zst27u8riFqWPoZIBZRkYG+/G0TWcfE/D4idJCtkx17lThgbZ605woZR0=
+        - secure: C1Kkwv2gqBNb9302s8tg8j+5h+V1tJGpiA5Wpj5Fz/OA8IWdgj1vNQO0+rdc+TJlSdc7aH0ggb+kayu/OgKt7JEy1bjBEZ+je7ncfN0ebp/xVlcSELIGv31yjs5hddtidi1IUW00igwN4VyyPGyPRC9s5ikrow9WUWacHDsP0Is=
 
 before_script:
    - "gem install --no-document --version 0.8.9 faraday "

--- a/flink-core/src/main/java/org/apache/flink/util/MavenForkNumberPrefixLayout.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MavenForkNumberPrefixLayout.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * The logging layout used to prefix each log event with the Maven fork number.
+ * <p>
+ * Use this layout when running tests via Maven in parallel and logging to the Console. When logging
+ * to a file, you can use a separate file for each fork.
+ */
+public class MavenForkNumberPrefixLayout extends PatternLayout {
+
+	/** Property name used to set fork number of the forked JVM. */
+	private static final String PROPERTY = "mvn.forkNumber";
+
+	private final int prefixLength;
+
+	private final StringBuilder stringBuilder;
+
+	public MavenForkNumberPrefixLayout() {
+		super();
+
+		String prefix = System.getProperty(PROPERTY);
+
+		if (prefix != null) {
+			prefix += " > ";
+
+			prefixLength = prefix.length();
+
+			stringBuilder = new StringBuilder(512);
+			stringBuilder.append(prefix);
+		}
+		else {
+			prefixLength = 0;
+			stringBuilder = null;
+		}
+	}
+
+	@Override
+	public String format(LoggingEvent event) {
+		if (prefixLength == 0) {
+			return super.format(event);
+		}
+
+		stringBuilder.setLength(prefixLength);
+
+		stringBuilder.append(super.format(event));
+
+		return stringBuilder.toString();
+	}
+}

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -16,12 +16,20 @@
 # limitations under the License.
 ################################################################################
 
-# Set root logger level to OFF and its only appender to A1.
-log4j.rootLogger=OFF, A1
+log4j.rootLogger=OFF
 
-# A1 is set to be a ConsoleAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
+# -----------------------------------------------------------------------------
+# Console (use 'console')
+# -----------------------------------------------------------------------------
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.flink.util.MavenForkNumberPrefixLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 
-# A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+# -----------------------------------------------------------------------------
+# File (use 'file')
+# -----------------------------------------------------------------------------
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.file=${log.file}
+log4j.appender.file.append=false
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -1050,6 +1050,8 @@ under the License.
 						<exclude>docs/_site/**</exclude>
 						<exclude>**/scalastyle-output.xml</exclude>
 						<exclude>build-target/**</exclude>
+						<!-- Tools: watchdog -->
+						<exclude>tools/watchdog*</exclude>
 					</excludes>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1051,8 +1051,7 @@ under the License.
 						<exclude>**/scalastyle-output.xml</exclude>
 						<exclude>build-target/**</exclude>
 						<!-- Tools: watchdog -->
-						<exclude>tools/watchdog*</exclude>
-						<exclude>tools/artifacts*</exclude>
+						<exclude>tools/artifacts/**</exclude>
 					</excludes>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1052,6 +1052,7 @@ under the License.
 						<exclude>build-target/**</exclude>
 						<!-- Tools: watchdog -->
 						<exclude>tools/watchdog*</exclude>
+						<exclude>tools/artifacts*</exclude>
 					</excludes>
 				</configuration>
 			</plugin>
@@ -1107,7 +1108,7 @@ under the License.
 						  the property is null when we have just the variable-->
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=log4j-test.properties -XX:-UseGCOverheadLimit</argLine>
+					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=log4j-test.properties -Dlog.file=${log.dir}/${surefire.forkNumber}.log -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -1120,7 +1121,7 @@ under the License.
 					<systemPropertyVariables>
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=log4j-test.properties -XX:-UseGCOverheadLimit</argLine>
+					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=log4j-test.properties -Dlog.file=${log.dir}/${surefire.forkNumber}.log -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@ under the License.
 			 it on the "mvn" commandline in travis. -->
 		<flink.forkCount>1.5C</flink.forkCount>
 		<flink.reuseForks>true</flink.reuseForks>
+		<log4j.configuration>log4j-test.properties</log4j.configuration>
 		<slf4j.version>1.7.7</slf4j.version>
 		<guava.version>17.0</guava.version>
 		<scala.version>2.10.4</scala.version>
@@ -1107,7 +1108,7 @@ under the License.
 						  the property is null when we have just the variable-->
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=log4j-test.properties -Dlog.file=${log.dir}/${surefire.forkNumber}.log -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
+					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=${log4j.configuration} -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -1120,7 +1121,7 @@ under the License.
 					<systemPropertyVariables>
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=log4j-test.properties -Dlog.file=${log.dir}/${surefire.forkNumber}.log -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
+					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=${log4j.configuration} -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,4 +1,3 @@
 _qa_workdir
 merge_pull_request.sh
-watchdog*
 artifacts/*

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,2 +1,4 @@
 _qa_workdir
 merge_pull_request.sh
+watchdog*
+artifacts/*

--- a/tools/log4j-travis.properties
+++ b/tools/log4j-travis.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=OFF
+log4j.rootLogger=INFO, file
 
 # -----------------------------------------------------------------------------
 # Console (use 'console')
@@ -29,7 +29,7 @@ log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x -
 # File (use 'file')
 # -----------------------------------------------------------------------------
 log4j.appender.file=org.apache.log4j.FileAppender
-log4j.appender.file.file=${log.dir}/{$mvn.forkNumber}.log
-log4j.appender.file.append=false
+log4j.appender.file.file=${log.dir}/${mvn.forkNumber}.log
+log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+HERE="`dirname \"$0\"`"				# relative
+HERE="`( cd \"$HERE\" && pwd )`" 	# absolutized and normalized
+if [ -z "$HERE" ] ; then
+	# error; for some reason, the path is not accessible
+	# to the script (e.g. permissions re-evaled after suid)
+	exit 1  # fail
+fi
+
+# =============================================================================
+# CONFIG
+# =============================================================================
+
+# Number of seconds w/o output before printing a stack trace and killing $MVN
+MAX_NO_OUTPUT=${1:-300}
+
+# Number of seconds to sleep before checking the output again
+SLEEP_TIME=20
+
+# Maven command to run
+MVN="mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
+
+MVN_PID="${HERE}/watchdog.mvn.pid"
+MVN_EXIT="${HERE}/watchdog.mvn.exit"
+MVN_OUT="${HERE}/watchdog.mvn.out"
+TRACE_OUT="${HERE}/watchdog.trace.out"
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+print_stacktraces () {
+	echo "=============================================================================="
+	echo "The following Java processes are running (JPS)"
+	echo "=============================================================================="
+
+	jps
+
+	local pids=( $(jps | awk '{print $1}') )
+
+	for pid in "${pids[@]}"; do
+		echo "=============================================================================="
+		echo "Printing stack trace of Java process ${pid}"
+		echo "=============================================================================="
+
+		jstack $pid
+	done
+}
+
+mod_time () {
+	if [[ `uname` == 'Darwin' ]]; then
+		eval $(stat -s $MVN_OUT)
+		echo $st_mtime
+	else
+		echo `stat -c "%Y" $MVN_OUT`
+	fi
+}
+
+the_time() {
+	echo `date +%s`
+}
+
+watchdog () {
+	touch $MVN_OUT
+
+	while true; do
+		sleep $SLEEP_TIME
+
+		time_diff=$((`the_time` - `mod_time`))
+
+		if [ $time_diff -ge $MAX_NO_OUTPUT ]; then
+			echo "=============================================================================="
+			echo "Maven produced no output for ${MAX_NO_OUTPUT} seconds."
+			echo "=============================================================================="
+
+			print_stacktraces | tee $TRACE_OUT
+
+			kill $(<$MVN_PID)
+
+			exit 1
+		fi
+	done
+}
+
+# =============================================================================
+# WATCHDOG
+# =============================================================================
+
+# Start watching $MVN_OUT
+watchdog &
+
+WD_PID=$!
+
+echo "STARTED watchdog (${WD_PID})."
+
+# Make sure to be in project root
+cd $HERE/../
+
+echo "RUNNING ${MVN} command."
+
+# Run $MVN and pipe output to $MVN_OUT for the watchdog. The PID is written to $MVN_PID to
+# allow the watchdog to kill $MVN if it is not producing any output anymore. $MVN_EXIT contains
+# the exit code. This is important for Travis' build life-cycle (success/failure).
+( $MVN & PID=$! ; echo $PID >&3 ; wait $PID ; echo $? >&4 ) 3>$MVN_PID 4>$MVN_EXIT | tee $MVN_OUT
+
+echo "Trying to KILL watchdog (${WD_PID})."
+
+# Make sure to kill the watchdog in any case after $MVN has completed
+( kill $WD_PID 2>&1 ) > /dev/null
+
+EXIT_CODE=$(<$MVN_EXIT)
+
+echo "MVN exited with EXIT CODE: ${EXIT_CODE}."
+
+rm $MVN_PID
+rm $MVN_EXIT
+
+exit $EXIT_CODE

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -66,23 +66,21 @@ UPLOAD_SECRET_KEY=$ARTIFACTS_AWS_SECRET_KEY
 # =============================================================================
 
 upload_artifacts_s3() {
-	if [ $UPLOAD_ARTIFACTS = "true" ]; then
-		echo "PRODUCED build artifacts."
+	echo "PRODUCED build artifacts."
 
-		ls $ARTIFACTS_DIR
+	ls $ARTIFACTS_DIR
 
-		if [ -n "$UPLOAD_BUCKET" ] && [ -n "$UPLOAD_ACCESS_KEY" ] && [ -n "$UPLOAD_SECRET_KEY" ]; then
-			echo "UPLOADING build artifacts."
+	if [ -n "$UPLOAD_BUCKET" ] && [ -n "$UPLOAD_ACCESS_KEY" ] && [ -n "$UPLOAD_SECRET_KEY" ]; then
+		echo "UPLOADING build artifacts."
 
-			# Install artifacts tool
-			curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+		# Install artifacts tool
+		curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 
-			PATH=$HOME/bin:$PATH
+		PATH=$HOME/bin:$PATH
 
-			# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
-			# re-creates the whole directory structure from root.
-			artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH tools/artifacts/
-		fi
+		# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
+		# re-creates the whole directory structure from root.
+		artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH tools/artifacts/
 	fi
 }
 

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -25,6 +25,12 @@ if [ -z "$HERE" ] ; then
 	exit 1  # fail
 fi
 
+ARTIFACTS_DIR="${HERE}/artifacts"
+
+mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
+
+echo "Build for commit ${TRAVIS_COMMIT} of ${TRAVIS_REPO_SLUG} [build ID: ${TRAVIS_BUILD_ID}, job number: $TRAVIS_JOB_NUMBER]." | tee "${ARTIFACTS_DIR}/build_info"
+
 # =============================================================================
 # CONFIG
 # =============================================================================
@@ -35,17 +41,50 @@ MAX_NO_OUTPUT=${1:-300}
 # Number of seconds to sleep before checking the output again
 SLEEP_TIME=20
 
-# Maven command to run
-MVN="mvn -Dflink.forkCount=2 -B $PROFILE clean install verify"
+# Maven command to run. We set the forkCount manually, because otherwise Maven assumes that the
+# Travis machine has way more cores. File loggers should use the specified log.dir property.
+MVN="mvn -Dflink.forkCount=2 -B $PROFILE -Dlog.dir=${ARTIFACTS_DIR} clean install test"
 
-MVN_PID="${HERE}/watchdog.mvn.pid"
-MVN_EXIT="${HERE}/watchdog.mvn.exit"
-MVN_OUT="${HERE}/watchdog.mvn.out"
-TRACE_OUT="${HERE}/watchdog.trace.out"
+MVN_PID="${ARTIFACTS_DIR}/watchdog.mvn.pid"
+MVN_EXIT="${ARTIFACTS_DIR}/watchdog.mvn.exit"
+MVN_OUT="${ARTIFACTS_DIR}/watchdog.mvn.out"
+
+TRACE_OUT="${ARTIFACTS_DIR}/jps-traces.out"
+
+# E.g. travis-artifacts/apache/flink/1595/1595.1
+UPLOAD_TARGET_PATH="travis-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}"
+# These variables are stored as secure variables in '.travis.yml', which are generated per repo via
+# the travis command line tool.
+UPLOAD_BUCKET=$ARTIFACTS_AWS_BUCKET
+UPLOAD_ACCESS_KEY=$ARTIFACTS_AWS_ACCESS_KEY
+UPLOAD_SECRET_KEY=$ARTIFACTS_AWS_SECRET_KEY
 
 # =============================================================================
 # FUNCTIONS
 # =============================================================================
+
+upload_artifacts_s3() {
+	if [ $UPLOAD_ARTIFACTS = "true" ]; then
+		# Only upload artifacts != watchdog files
+		num_artifacts=`find $ARTIFACTS_DIR -maxdepth 1 -type f | grep -v "watchdog*" | wc -l`
+
+		echo "UPLOADING produced build artifacts."
+
+		ls $ARTIFACTS_DIR
+
+		# Check > 1, because we also produce a build_info file per build
+		if [ "$num_artifacts" -gt 1 ]; then
+			# Install artifacts tool
+			curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+
+			PATH=$HOME/bin:$PATH
+
+			# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
+			# re-creates the whole directory structure from root.
+			artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH tools/artifacts/
+		fi
+	fi
+}
 
 print_stacktraces () {
 	echo "=============================================================================="
@@ -114,7 +153,7 @@ echo "STARTED watchdog (${WD_PID})."
 # Make sure to be in project root
 cd $HERE/../
 
-echo "RUNNING ${MVN} command."
+echo "RUNNING '${MVN}'."
 
 # Run $MVN and pipe output to $MVN_OUT for the watchdog. The PID is written to $MVN_PID to
 # allow the watchdog to kill $MVN if it is not producing any output anymore. $MVN_EXIT contains
@@ -132,5 +171,7 @@ echo "MVN exited with EXIT CODE: ${EXIT_CODE}."
 
 rm $MVN_PID
 rm $MVN_EXIT
+
+upload_artifacts_s3
 
 exit $EXIT_CODE

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -43,7 +43,7 @@ SLEEP_TIME=20
 
 # Maven command to run. We set the forkCount manually, because otherwise Maven assumes that the
 # Travis machine has way more cores. File loggers should use the specified log.dir property.
-MVN="mvn -Dflink.forkCount=2 -B $PROFILE -Dlog.dir=${ARTIFACTS_DIR} clean install test"
+MVN="mvn -Dflink.forkCount=2 -B $PROFILE -Dlog.dir=${ARTIFACTS_DIR} clean install verify"
 
 MVN_PID="${ARTIFACTS_DIR}/watchdog.mvn.pid"
 MVN_EXIT="${ARTIFACTS_DIR}/watchdog.mvn.exit"

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -54,12 +54,14 @@ MVN_OUT="${ARTIFACTS_DIR}/mvn.out"
 TRACE_OUT="${ARTIFACTS_DIR}/jps-traces.out"
 
 # E.g. travis-artifacts/apache/flink/1595/1595.1
-UPLOAD_TARGET_PATH="travis-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}"
+UPLOAD_TARGET_PATH="travis-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/"
 # These variables are stored as secure variables in '.travis.yml', which are generated per repo via
 # the travis command line tool.
 UPLOAD_BUCKET=$ARTIFACTS_AWS_BUCKET
 UPLOAD_ACCESS_KEY=$ARTIFACTS_AWS_ACCESS_KEY
 UPLOAD_SECRET_KEY=$ARTIFACTS_AWS_SECRET_KEY
+
+ARTIFACTS_FILE=${TRAVIS_JOB_NUMBER}.tar.gz
 
 # =============================================================================
 # FUNCTIONS
@@ -71,16 +73,21 @@ upload_artifacts_s3() {
 	ls $ARTIFACTS_DIR
 
 	if [ -n "$UPLOAD_BUCKET" ] && [ -n "$UPLOAD_ACCESS_KEY" ] && [ -n "$UPLOAD_SECRET_KEY" ]; then
-		echo "UPLOADING build artifacts."
+		echo "COMPRESSING build artifacts."
+
+		cd $ARTIFACTS_DIR
+		tar -zcvf $ARTIFACTS_FILE *
 
 		# Install artifacts tool
 		curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 
 		PATH=$HOME/bin:$PATH
 
+		echo "UPLOADING build artifacts."
+
 		# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
 		# re-creates the whole directory structure from root.
-		artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH tools/artifacts/
+		artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH $ARTIFACTS_FILE
 	fi
 }
 

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -67,18 +67,22 @@ UPLOAD_SECRET_KEY=$ARTIFACTS_AWS_SECRET_KEY
 
 upload_artifacts_s3() {
 	if [ $UPLOAD_ARTIFACTS = "true" ]; then
-		echo "UPLOADING produced build artifacts."
+		echo "PRODUCED build artifacts."
 
 		ls $ARTIFACTS_DIR
 
-		# Install artifacts tool
-		curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+		if [ -n "$UPLOAD_BUCKET" ] && [ -n "$UPLOAD_ACCESS_KEY" ] && [ -n "$UPLOAD_SECRET_KEY" ]; then
+			echo "UPLOADING build artifacts."
 
-		PATH=$HOME/bin:$PATH
+			# Install artifacts tool
+			curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 
-		# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
-		# re-creates the whole directory structure from root.
-		artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH tools/artifacts/
+			PATH=$HOME/bin:$PATH
+
+			# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
+			# re-creates the whole directory structure from root.
+			artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH tools/artifacts/
+		fi
 	fi
 }
 


### PR DESCRIPTION
This PR includes #389.

Currently, logging of Travis builds is disabled as the log files are discarded after a build and stdout logging is limited in size. With this PR, we can log to a file and have them uploaded automatically.

1. **Console logging**: For console logging, we can use `MavenForkNumberPrefixLayout` to prefix the log output with the fork number, which makes it easier to group log output together.

  We might consider moving that layout to a different package, though.

```
7 > 17:12:23,220 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying test vertex (5/7) (attempt #0) to host3
7 > 17:12:23,220 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Scheduling task {task=test vertex (6/7) - execution #0, sharingUnit=null, locationConstraint=null}
7 > 17:12:23,220 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Unconstrained assignment: test vertex (6/7) --> dbc442af2610e30d3309d96e14fa9d8a @ akka://TestingActorSystem/user/$$a - 5 slots - 1067599825
7 > 17:12:23,221 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying test vertex (6/7) (attempt #0) to host1
7 > 17:12:23,221 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Scheduling task {task=test vertex (7/7) - execution #0, sharingUnit=null, locationConstraint=null}
7 > 17:12:23,222 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Unconstrained assignment: test vertex (7/7) --> 8ce93c214951df5a8ad32c912ba0e456 @ akka://TestingActorSystem/user/$$a - 5 slots - 749927456
7 > 17:12:23,222 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying test vertex (7/7) (attempt #0) to host2
7 > 17:12:23,223 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Attaching 1 topologically sorted vertices to existing job graph with 0 vertices and 0 intermediate results.
7 > 17:12:23,223 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Connecting ExecutionJobVertex 126e16c348d4e5aa129104702700bf9e (test vertex) to 0 predecessors.
10 > 17:12:23,225 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying v1 (2/2) (attempt #0) to host3
6 > 17:12:23,236 DEBUG akka.event.EventStream                                        - shutting down: StandardOutLogger started
1 > 17:12:23,239 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Sending out cancel request, to remove task execution from TaskManager.
1 > 17:12:23,244 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Concurrent canceling/failing of TestVertex (1/1) - execution #0 while deployment was in progress.
10 > 17:12:23,266 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Attaching 1 topologically sorted vertices to existing job graph with 0 vertices and 0 intermediate results.
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.61 sec - in org.apache.flink.runtime.executiongraph.ExecutionVertexCancelTest
Running org.apache.flink.runtime.io.network.api.reader.UnionBufferReaderTest
10 > 17:12:23,269 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Connecting ExecutionJobVertex e8869426e7765e498ad219e3af731729 (test vertex) to 0 predecessors.
10 > 17:12:23,269 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Scheduling task {task=test vertex (1/2) - execution #0, sharingUnit=null, locationConstraint=null}
10 > 17:12:23,270 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Local assignment: test vertex (1/2) --> ee9357ffc16d51c4f7522bc479a757ac @ akka://TestingActorSystem/user/$$a - 1 slots - 2073640037
10 > 17:12:23,270 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying test vertex (1/2) (attempt #0) to host1
10 > 17:12:23,270 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Scheduling task {task=test vertex (2/2) - execution #0, sharingUnit=null, locationConstraint=null}
10 > 17:12:23,271 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Local assignment: test vertex (2/2) --> 6620d9f45b7567e2b147f5761d8060e8 @ akka://TestingActorSystem/user/$$a - 1 slots - 1864116663
10 > 17:12:23,271 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying test vertex (2/2) (attempt #0) to host3
1 > 17:12:23,277 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying TestVertex (1/1) (attempt #0) to localhost
10 > 17:12:23,277 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Attaching 1 topologically sorted vertices to existing job graph with 0 vertices and 0 intermediate results.
10 > 17:12:23,278 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Connecting ExecutionJobVertex 533fcd1e05bcce9ec185ccea7085a5aa (test vertex) to 0 predecessors.
10 > 17:12:23,278 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Scheduling task {task=test vertex (1/2) - execution #0, sharingUnit=null, locationConstraint=null}
1 > 17:12:23,280 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Sending out cancel request, to remove task execution from TaskManager.
1 > 17:12:23,280 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Cancel task call did not find task. Probably akka message call race.
1 > 17:12:23,281 DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph        - Concurrent canceling/failing of TestVertex (1/1) - execution #0 while deployment was in progress.
10 > 17:12:23,281 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Local assignment: test vertex (1/2) --> b923679116189038c5dbd280d43cfe48 @ akka://TestingActorSystem/user/$$a - 1 slots - 44559647
10 > 17:12:23,282 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph        - Deploying test vertex (1/2) (attempt #0) to host3
10 > 17:12:23,282 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Scheduling task {task=test vertex (2/2) - execution #0, sharingUnit=null, locationConstraint=null}
10 > 17:12:23,283 DEBUG org.apache.flink.runtime.jobmanager.scheduler.Scheduler       - Local assignment: test vertex (2/2) --> 1fb78d024e2664602ee31c47dd987f6c @ akka://TestingActorSystem/user/$$a - 1 slots - 1081769770
```
  I've added an example log4j properties file to `flink-runtime/tests`.

2. **File logging**: Each forked build sets its own log file (e.g. `1.log` and `2.log`) if it is enabled (example in `flink-runtime/tests` log4j properties file). If the `UPLOAD_ARTIFACTS` variable is set in Travis and the S3 credentials have been set for the respective repository, the files are uploaded.

  As an example, see [this build](https://travis-ci.org/uce/incubator-flink/builds/50960309), which I've stalled on purpose. It upload the jps traces: https://s3.amazonaws.com/flink.a.o.uce.east/travis-artifacts/uce/incubator-flink/210/210.5/jps-traces.out

---

The used S3 bucket is my private bucket and the upload currently only works for my forked repository. It is very easy to add more committers for their own repositories/own buckets.

We can finalize the setup for interested committers after review. I still want to add a minor change to compress the output.