### PR TITLE
Remove extra space after open parenthesis in InstanceConnectionInfo#toString

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceConnectionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceConnectionInfo.java
@@ -194,7 +194,7 @@ public class InstanceConnectionInfo implements IOReadableWritable, Comparable<In
 
 	@Override
 	public String toString() {
-		return getFQDNHostname() + " ( dataPort=" + dataPort + ")";
+		return getFQDNHostname() + " (dataPort=" + dataPort + ")";
 	}
 
 	@Override


### PR DESCRIPTION
Small update to remove extra space after open parenthesis in InstanceConnectionInfo#toString to be consistent with other messages and toString calls.