### PR TITLE
[FLINK-1584] Fixes TaskManagerFailsITCase

### DIFF
--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -48,9 +48,9 @@ FlinkMiniCluster(userConfiguration, singleActorSystem) {
 
   override def startJobManager(actorSystem: ActorSystem): ActorRef = {
 
-    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager, _ ,
-        executionRetries, delayBetweenRetries,
-        timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
+    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager, _,
+    executionRetries, delayBetweenRetries,
+    timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
 
     val testArchiveProps = Props(new MemoryArchivist(archiveCount) with TestingMemoryArchivist)
     val archive = actorSystem.actorOf(testArchiveProps, JobManager.ARCHIVE_NAME)
@@ -70,10 +70,5 @@ FlinkMiniCluster(userConfiguration, singleActorSystem) {
     system.actorOf(Props(new TaskManager(connectionInfo, jobManagerURL, taskManagerConfig,
       networkConnectionConfig) with TestingTaskManager), TaskManager.TASK_MANAGER_NAME + "_" +
       (index + 1))
-  }
-
-  def restartJobManager(): Unit = {
-    jobManagerActorSystem.stop(jobManagerActor)
-    jobManagerActor = startJobManager(jobManagerActorSystem)
   }
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -106,20 +106,6 @@ object TestingUtils {
     new TestingCluster(config)
   }
 
-  def startTestingClusterDeathWatch(numSlots: Int, numTMs: Int,
-                                            timeout: String = DEFAULT_AKKA_ASK_TIMEOUT):
-  TestingCluster = {
-    val config = new Configuration()
-    config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots)
-    config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, numTMs)
-    config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, timeout)
-    config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL, "200 ms")
-    config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_PAUSE, "50 ms")
-    config.setDouble(ConfigConstants.AKKA_WATCH_THRESHOLD, 1)
-
-    new TestingCluster(config, singleActorSystem = false)
-  }
-
   def setGlobalExecutionContext(): Unit = {
     AkkaUtils.globalExecutionContext = ExecutionContext.global
   }

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobmanager
+package org.apache.flink.api.scala.runtime.jobmanager
 
-import akka.actor.{PoisonPill, ActorSystem}
+import akka.actor.{ActorSystem, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.messages.JobManagerMessages.RequestNumberRegisteredTaskManager
-import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.{JobManagerTerminated,
-NotifyWhenJobManagerTerminated}
-import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.{JobManagerTerminated, NotifyWhenJobManagerTerminated}
+import org.apache.flink.test.util.ForkableFlinkMiniCluster
 import org.junit.runner.RunWith
-import org.scalatest.{WordSpecLike, Matchers, BeforeAndAfterAll}
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 @RunWith(classOf[JUnitRunner])
 class JobManagerFailsITCase(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
 with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
+  def this() = this(ActorSystem("TestingActorSystem", AkkaUtils.getDefaultAkkaConfig))
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -42,7 +42,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
     "detect a lost connection to the JobManager and try to reconnect to it" in {
       val num_slots = 11
 
-      val cluster = TestingUtils.startTestingClusterDeathWatch(num_slots, 1)
+      val cluster = ForkableFlinkMiniCluster.startClusterDeathWatch(num_slots, 1)
 
       val tm = cluster.getTaskManagers(0)
       val jm = cluster.getJobManager

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
@@ -16,16 +16,17 @@
 * limitations under the License.
 */
 
-package org.apache.flink.runtime.jobmanager
+package org.apache.flink.api.scala.runtime.taskmanager
 
-import akka.actor.{Kill, ActorSystem, PoisonPill}
+import akka.actor.{ActorSystem, Kill, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.jobgraph.{AbstractJobVertex, DistributionPattern, JobGraph}
 import org.apache.flink.runtime.jobmanager.Tasks.{BlockingReceiver, Sender}
-import org.apache.flink.runtime.messages.JobManagerMessages.{RequestNumberRegisteredTaskManager,
-JobResultFailed, SubmissionSuccess, SubmitJob}
+import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultFailed, RequestNumberRegisteredTaskManager, SubmissionSuccess, SubmitJob}
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.test.util.ForkableFlinkMiniCluster
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -34,7 +35,7 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 class TaskManagerFailsITCase(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
 with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
+  def this() = this(ActorSystem("TestingActorSystem", AkkaUtils.getDefaultAkkaConfig))
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -45,7 +46,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
     "detect a failing task manager" in {
       val num_slots = 11
 
-      val cluster = TestingUtils.startTestingClusterDeathWatch(num_slots, 2)
+      val cluster = ForkableFlinkMiniCluster.startClusterDeathWatch(num_slots, 2)
 
       val taskManagers = cluster.getTaskManagers
       val jm = cluster.getJobManager
@@ -83,7 +84,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
       val jobID = jobGraph.getJobID
 
-      val cluster = TestingUtils.startTestingCluster(num_tasks, 2)
+      val cluster = ForkableFlinkMiniCluster.startCluster(num_tasks, 2)
 
       val jm = cluster.getJobManager
 
@@ -121,7 +122,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
       val jobID = jobGraph.getJobID
 
-      val cluster = TestingUtils.startTestingCluster(num_tasks, 2)
+      val cluster = ForkableFlinkMiniCluster.startCluster(num_tasks, 2)
 
       val taskManagers = cluster.getTaskManagers
       val jm = cluster.getJobManager


### PR DESCRIPTION
Fixes ```TaskManagerFailsITCase``` by replacing the TestingCluster with a ForkableFlinkMiniCluster.