### PR TITLE
[FLINK-1556] Corrects faulty JobClient behaviour in case of a submission failure

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.program;
 
 import akka.actor.ActorSystem;
 import akka.actor.Props;
+import akka.actor.Status;
 import akka.actor.UntypedActor;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -36,7 +37,6 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobID;
 import org.apache.flink.runtime.jobmanager.JobManager;
-import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.net.NetUtils;
 import org.junit.After;
 
@@ -174,7 +174,7 @@ public class ClientTest {
 				// bam!
 			}
 			catch (Exception e) {
-				fail("wrong exception");
+				fail("wrong exception " + e);
 			}
 
 			verify(this.compilerMock, times(1)).compile(any(Plan.class));
@@ -225,7 +225,7 @@ public class ClientTest {
 
 		@Override
 		public void onReceive(Object message) throws Exception {
-			getSender().tell(new JobManagerMessages.SubmissionSuccess(new JobID()), getSelf());
+			getSender().tell(new Status.Success(new JobID()), getSelf());
 		}
 	}
 
@@ -233,7 +233,7 @@ public class ClientTest {
 
 		@Override
 		public void onReceive(Object message) throws Exception {
-			getSender().tell(new JobManagerMessages.SubmissionFailure(new JobID(), new Exception("test")), getSelf());
+			getSender().tell(new Status.Failure(new Exception("test")), getSelf());
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobCancellationException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobCancellationException.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.runtime.client;
 
+import org.apache.flink.runtime.jobgraph.JobID;
+
 /**
  * An exception which is thrown by the JobClient if a job is aborted as a result of a user
  * cancellation.
  */
-public class JobCancellationException extends Exception {
+public class JobCancellationException extends JobExecutionException {
 
-	public JobCancellationException(final String msg, final Throwable cause){
-		super(msg, cause);
+	private static final long serialVersionUID = 2818087325120827526L;
+
+	public JobCancellationException(final JobID jobID, final String msg, final Throwable cause){
+		super(jobID, msg, cause);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.client;
 
+import org.apache.flink.runtime.jobgraph.JobID;
+
 /**
  * This exception is thrown by the {@link JobClient} if a job has been aborted as a result of an
  * error which occurred during the execution.
@@ -26,13 +28,33 @@ public class JobExecutionException extends Exception {
 
 	private static final long serialVersionUID = 2818087325120827525L;
 
+	private JobID jobID;
+
 	/**
 	 * Constructs a new job execution exception.
 	 * 
 	 * @param msg The cause for the execution exception.
 	 * @param cause The cause of the exception
 	 */
-	public JobExecutionException(String msg, Throwable cause) {
+	public JobExecutionException(final JobID jobID, final String msg, final Throwable cause) {
 		super(msg, cause);
+
+		this.jobID = jobID;
+	}
+
+	public JobExecutionException(final JobID jobID, final String msg) {
+		super(msg);
+
+		this.jobID = jobID;
+	}
+
+	public JobExecutionException(final JobID jobID, final Throwable cause) {
+		super(cause);
+
+		this.jobID = jobID;
+	}
+
+	public JobID getJobID() {
+		return jobID;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobSubmissionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobSubmissionException.java
@@ -21,13 +21,17 @@ package org.apache.flink.runtime.client;
 import org.apache.flink.runtime.jobgraph.JobID;
 
 /**
- * An exception which is thrown by the JobClient if the job manager is no longer reachable.
+ * This exception denotes an error while submitting a job to the JobManager
  */
-public class JobTimeoutException extends JobExecutionException {
+public class JobSubmissionException extends JobExecutionException {
 
-	private static final long serialVersionUID = 2818087325120827529L;
+	private static final long serialVersionUID = 2818087325120827526L;
 
-	public JobTimeoutException(final JobID jobID, final String msg, final Throwable cause) {
+	public JobSubmissionException(final JobID jobID, final String msg, final Throwable cause) {
 		super(jobID, msg, cause);
+	}
+
+	public JobSubmissionException(final JobID jobID, final String msg) {
+		super(jobID, msg);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -406,7 +406,7 @@ public class ExecutionGraph implements Serializable {
 					}
 				} else {
 					// set the state of the job to failed
-					transitionState(current, JobStatus.FAILED, t);
+					transitionState(JobStatus.FAILING, JobStatus.FAILED, t);
 				}
 				
 				return;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobmanagerMessages.scala
@@ -179,10 +179,6 @@ object JobManagerMessages {
    */
   case class RequestFinalJobStatus(jobID: JobID)
 
-  sealed trait JobResult{
-    def jobID: JobID
-  }
-
   /**
    * Denotes a successful job execution.
    *
@@ -191,39 +187,7 @@ object JobManagerMessages {
    * @param accumulatorResults
    */
   case class JobResultSuccess(jobID: JobID, runtime: Long, accumulatorResults: java.util.Map[String,
-    AnyRef]) extends JobResult {}
-
-  /**
-   * Denotes a cancellation of the job.
-   * @param jobID
-   * @param t
-   */
-  case class JobResultCanceled(jobID: JobID, t: Throwable) extends JobResult
-
-  /**
-   * Denotes a failed job execution.
-   * @param jobID
-   * @param t
-   */
-  case class JobResultFailed(jobID: JobID, t: Throwable) extends JobResult
-
-  sealed trait SubmissionResponse{
-    def jobID: JobID
-  }
-
-  /**
-   * Denotes a successful job submission.
-   * @param jobID
-   */
-  case class SubmissionSuccess(jobID: JobID) extends SubmissionResponse
-
-  /**
-   * Denotes a failed job submission. The cause of the failure is denoted by [[cause]].
-   *
-   * @param jobID
-   * @param cause of the submission failure
-   */
-  case class SubmissionFailure(jobID: JobID, cause: Throwable) extends SubmissionResponse
+    AnyRef]) {}
 
   sealed trait CancellationResponse{
     def jobID: JobID

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -55,8 +55,6 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scala.None;
-import scala.None$;
 import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
@@ -19,13 +19,13 @@
 package org.apache.flink.runtime.jobmanager
 
 import akka.actor.ActorSystem
+import akka.actor.Status.Success
 import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.flink.runtime.jobgraph.{JobGraph, DistributionPattern,
 AbstractJobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks.{Receiver, Sender}
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
-import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmissionSuccess,
-SubmitJob}
+import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmitJob}
 import org.apache.flink.runtime.testingUtils.TestingUtils
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -70,7 +70,7 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with WrapA
       try {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           expectMsgType[JobResultSuccess]
         }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -20,9 +20,11 @@ package org.apache.flink.runtime.jobmanager
 
 import Tasks._
 import akka.actor.ActorSystem
+import akka.actor.Status.{Success, Failure}
 import akka.pattern.ask
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
+import org.apache.flink.runtime.client.JobExecutionException
 import org.apache.flink.runtime.jobgraph.{AbstractJobVertex, DistributionPattern, JobGraph, ScheduleMode}
 import org.apache.flink.runtime.messages.JobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobRemoved
@@ -70,9 +72,14 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(1 second) {
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionFailure(jobGraph.getJobID, new NoResourceAvailableException(1,1,0)))
+          val failure = expectMsgType[Failure]
 
-          expectMsg(JobResultFailed(jobGraph.getJobID, new NoResourceAvailableException(1,1,0)))
+          failure.cause match {
+            case e: JobExecutionException =>
+              jobGraph.getJobID should equal(e.getJobID)
+              new NoResourceAvailableException(1,1,0) should equal(e.getCause)
+            case e => fail(s"Received wrong exception of type $e.")
+          }
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)
@@ -103,7 +110,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
           val result = expectMsgType[JobResultSuccess]
 
           result.jobID should equal(jobGraph.getJobID)
@@ -133,7 +140,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           val result = expectMsgType[JobResultSuccess]
 
@@ -168,7 +175,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           val result = expectMsgType[JobResultSuccess]
 
@@ -203,7 +210,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           expectMsgType[JobResultSuccess]
         }
@@ -240,8 +247,15 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
-          expectMsgType[JobResultFailed]
+          expectMsg(Success(jobGraph.getJobID))
+          val failure = expectMsgType[Failure]
+
+          failure.cause match {
+            case e: JobExecutionException =>
+              jobGraph.getJobID should equal(e.getJobID)
+
+            case e => fail(s"Received wrong exception $e.")
+          }
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)
@@ -276,7 +290,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
       try {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           expectMsgType[JobResultSuccess]
         }
@@ -321,7 +335,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           expectMsgType[JobResultSuccess]
 
@@ -359,8 +373,16 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
 
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
-          expectMsgType[JobResultFailed]
+          expectMsg(Success(jobGraph.getJobID))
+
+          val failure = expectMsgType[Failure]
+
+          failure.cause match {
+            case e: JobExecutionException =>
+              jobGraph.getJobID should equal(e.getJobID)
+
+            case e => fail(s"Received wrong exception $e.")
+          }
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)
@@ -399,8 +421,15 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
 
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
-          expectMsgType[JobResultFailed]
+          expectMsg(Success(jobGraph.getJobID))
+          val failure = expectMsgType[Failure]
+
+          failure.cause match {
+            case e: JobExecutionException =>
+              jobGraph.getJobID should equal(e.getJobID)
+
+            case e => fail(s"Received wrong exception $e.")
+          }
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)
@@ -431,8 +460,15 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
       try {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
-          expectMsgType[JobResultFailed]
+          expectMsg(Success(jobGraph.getJobID))
+          val failure = expectMsgType[Failure]
+
+          failure.cause match {
+            case e: JobExecutionException =>
+              jobGraph.getJobID should equal(e.getJobID)
+
+            case e => fail(s"Received wrong exception $e.")
+          }
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)
@@ -466,8 +502,15 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
           expectMsg(num_tasks)
 
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
-          expectMsgType[JobResultFailed]
+          expectMsg(Success(jobGraph.getJobID))
+          val failure = expectMsgType[Failure]
+
+          failure.cause match {
+            case e: JobExecutionException =>
+              jobGraph.getJobID should equal(e.getJobID)
+
+            case e => fail(s"Received wrong exception $e.")
+          }
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)
@@ -506,8 +549,15 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
           expectMsg(num_tasks)
 
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
-          expectMsgType[JobResultFailed]
+          expectMsg(Success(jobGraph.getJobID))
+          val failure = expectMsgType[Failure]
+
+          failure.cause match {
+            case e: JobExecutionException =>
+              jobGraph.getJobID should equal(e.getJobID)
+
+            case e => fail(s"Received wrong exception $e.")
+          }
         }
 
         jm ! NotifyWhenJobRemoved(jobGraph.getJobID)
@@ -539,7 +589,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION){
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
           expectMsgType[JobResultSuccess]
         }
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
@@ -18,14 +18,14 @@
 
 package org.apache.flink.runtime.jobmanager
 
+import akka.actor.Status.Success
 import akka.actor.{ActorRef, PoisonPill, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.flink.runtime.jobgraph.{JobStatus, JobGraph, DistributionPattern,
 AbstractJobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks.{BlockingOnceReceiver, FailingOnceReceiver}
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
-import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmissionSuccess,
-SubmitJob}
+import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmitJob}
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingUtils
 import org.junit.runner.RunWith
@@ -68,7 +68,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION){
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           val result = expectMsgType[JobResultSuccess]
 
@@ -111,7 +111,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION){
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           val result = expectMsgType[JobResultSuccess]
 
@@ -155,7 +155,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
         within(TestingUtils.TESTING_DURATION){
           jm ! SubmitJob(jobGraph)
 
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
 
           jm ! WaitForAllVerticesToBeRunningOrFinished(jobGraph.getJobID)
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
@@ -19,11 +19,12 @@
 package org.apache.flink.runtime.jobmanager
 
 import akka.actor.ActorSystem
+import akka.actor.Status.Success
 import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.flink.runtime.jobgraph.{AbstractJobVertex, DistributionPattern, JobGraph}
 import org.apache.flink.runtime.jobmanager.Tasks.{Sender, AgnosticBinaryReceiver, Receiver}
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
-import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmissionSuccess, SubmitJob}
+import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmitJob}
 import org.apache.flink.runtime.testingUtils.TestingUtils
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -65,7 +66,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
       try {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
           expectMsgType[JobResultSuccess]
 
         }
@@ -108,7 +109,7 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
       try {
         within(TestingUtils.TESTING_DURATION) {
           jm ! SubmitJob(jobGraph)
-          expectMsg(SubmissionSuccess(jobGraph.getJobID))
+          expectMsg(Success(jobGraph.getJobID))
           expectMsgType[JobResultSuccess]
         }
       } finally {

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -48,9 +48,9 @@ FlinkMiniCluster(userConfiguration, singleActorSystem) {
 
   override def startJobManager(actorSystem: ActorSystem): ActorRef = {
 
-    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager, _ ,
-        executionRetries, delayBetweenRetries,
-        timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
+    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager, _,
+    executionRetries, delayBetweenRetries,
+    timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
 
     val testArchiveProps = Props(new MemoryArchivist(archiveCount) with TestingMemoryArchivist)
     val archive = actorSystem.actorOf(testArchiveProps, JobManager.ARCHIVE_NAME)
@@ -70,10 +70,5 @@ FlinkMiniCluster(userConfiguration, singleActorSystem) {
     system.actorOf(Props(new TaskManager(connectionInfo, jobManagerURL, taskManagerConfig,
       networkConnectionConfig) with TestingTaskManager), TaskManager.TASK_MANAGER_NAME + "_" +
       (index + 1))
-  }
-
-  def restartJobManager(): Unit = {
-    jobManagerActorSystem.stop(jobManagerActor)
-    jobManagerActor = startJobManager(jobManagerActorSystem)
   }
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -114,6 +114,7 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
     case NotifyWhenTaskManagerTerminated(taskManager) =>
       val waiting = waitForTaskManagerToBeTerminated.getOrElse(taskManager.path.name, Set())
       waitForTaskManagerToBeTerminated += taskManager.path.name -> (waiting + sender)
+
     case msg@Terminated(taskManager) =>
       super.receiveWithLogMessages(msg)
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -106,20 +106,6 @@ object TestingUtils {
     new TestingCluster(config)
   }
 
-  def startTestingClusterDeathWatch(numSlots: Int, numTMs: Int,
-                                            timeout: String = DEFAULT_AKKA_ASK_TIMEOUT):
-  TestingCluster = {
-    val config = new Configuration()
-    config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots)
-    config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, numTMs)
-    config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, timeout)
-    config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL, "200 ms")
-    config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_PAUSE, "50 ms")
-    config.setDouble(ConfigConstants.AKKA_WATCH_THRESHOLD, 1)
-
-    new TestingCluster(config, singleActorSystem = false)
-  }
-
   def setGlobalExecutionContext(): Unit = {
     AkkaUtils.globalExecutionContext = ExecutionContext.global
   }

--- a/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
+++ b/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
@@ -18,11 +18,13 @@
 
 package org.apache.flink.test.util
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{Props, ActorRef, ActorSystem}
 import org.apache.flink.configuration.{ConfigConstants, Configuration}
+import org.apache.flink.runtime.jobmanager.{MemoryArchivist, JobManager}
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster
 import org.apache.flink.runtime.taskmanager.TaskManager
-import org.apache.flink.runtime.testingUtils.TestingTaskManager
+import org.apache.flink.runtime.testingUtils.{TestingJobManager, TestingMemoryArchivist,
+TestingTaskManager}
 
 class ForkableFlinkMiniCluster(userConfiguration: Configuration, singleActorSystem: Boolean)
   extends LocalFlinkMiniCluster(userConfiguration, singleActorSystem) {
@@ -53,6 +55,22 @@ class ForkableFlinkMiniCluster(userConfiguration: Configuration, singleActorSyst
     super.generateConfiguration(config)
   }
 
+  override def startJobManager(actorSystem: ActorSystem): ActorRef = {
+
+    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager, _,
+    executionRetries, delayBetweenRetries,
+    timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
+
+    val testArchiveProps = Props(new MemoryArchivist(archiveCount) with TestingMemoryArchivist)
+    val archive = actorSystem.actorOf(testArchiveProps, JobManager.ARCHIVE_NAME)
+
+    val jobManagerProps = Props(new JobManager(configuration, instanceManager, scheduler,
+      libraryCacheManager, archive, accumulatorManager, None, executionRetries,
+      delayBetweenRetries, timeout) with TestingJobManager)
+
+    actorSystem.actorOf(jobManagerProps, JobManager.JOB_MANAGER_NAME)
+  }
+
   override def startTaskManager(index: Int)(implicit system: ActorSystem): ActorRef = {
     val config = configuration.clone()
 
@@ -76,5 +94,39 @@ class ForkableFlinkMiniCluster(userConfiguration: Configuration, singleActorSyst
 
     system.actorOf(Props(new TaskManager(connectionInfo, jobManagerAkkaURL, taskManagerConfig,
       networkConnectionConfig) with TestingTaskManager), TaskManager.TASK_MANAGER_NAME + index)
+  }
+
+  def restartJobManager(): Unit = {
+    jobManagerActorSystem.stop(jobManagerActor)
+    jobManagerActor = startJobManager(jobManagerActorSystem)
+  }
+}
+
+object ForkableFlinkMiniCluster {
+
+  import org.apache.flink.runtime.testingUtils.TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT
+
+  def startClusterDeathWatch(numSlots: Int, numTaskManagers: Int,
+                                    timeout: String = DEFAULT_AKKA_ASK_TIMEOUT):
+  ForkableFlinkMiniCluster = {
+    val config = new Configuration()
+    config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots)
+    config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, numTaskManagers)
+    config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, timeout)
+    config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL, "1000 ms")
+    config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_PAUSE, "4000 ms")
+    config.setDouble(ConfigConstants.AKKA_WATCH_THRESHOLD, 5)
+
+    new ForkableFlinkMiniCluster(config, singleActorSystem = false)
+  }
+
+  def startCluster(numSlots: Int, numTaskManagers: Int, timeout: String = DEFAULT_AKKA_ASK_TIMEOUT):
+  ForkableFlinkMiniCluster = {
+    val config = new Configuration()
+    config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots)
+    config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, numTaskManagers)
+    config.setInteger(ConfigConstants.JOB_MANAGER_DEAD_TASKMANAGER_TIMEOUT_KEY, 1000)
+    config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, timeout)
+    new ForkableFlinkMiniCluster(config)
   }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/failingPrograms/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/failingPrograms/JobSubmissionFailsITCase.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.failingPrograms;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.Tasks;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.test.util.ForkableFlinkMiniCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class JobSubmissionFailsITCase {
+
+	private static ActorSystem system;
+
+	private static JobGraph workingJobGraph;
+
+	@BeforeClass
+	public static void setup() {
+		system = ActorSystem.create("TestingActorSystem", AkkaUtils.getDefaultAkkaConfig());
+
+		final AbstractJobVertex jobVertex = new AbstractJobVertex("Working job vertex.");
+		jobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+
+		workingJobGraph = new JobGraph("Working testing job", jobVertex);
+	}
+
+	@AfterClass
+	public static void teardown() {
+		JavaTestKit.shutdownActorSystem(system);
+		system = null;
+	}
+
+	private boolean detached;
+
+	public JobSubmissionFailsITCase(boolean detached) {
+		this.detached = detached;
+	}
+
+	@Parameterized.Parameters(name = "Detached mode = {0}")
+	public static Collection<Boolean[]> executionModes(){
+		return Arrays.asList(new Boolean[]{false},
+				new Boolean[]{true});
+	}
+
+	private JobExecutionResult submitJob(JobGraph jobGraph, ActorRef jobClient) throws Exception {
+		if(detached) {
+			JobClient.submitJobDetached(jobGraph, jobClient, TestingUtils.TESTING_DURATION());
+			return null;
+		} else {
+			return JobClient.submitJobAndWait(jobGraph, false, jobClient, TestingUtils.TESTING_DURATION());
+		}
+	}
+
+	@Test
+	public void testExceptionInInitializeOnMaster() {
+		new JavaTestKit(system) {{
+			final int numSlots = 20;
+
+			final ForkableFlinkMiniCluster cluster =
+					ForkableFlinkMiniCluster.startCluster(numSlots/2, 2,
+							TestingUtils.TESTING_DURATION().toString());
+
+			final ActorRef jobClient = cluster.getJobClient();
+
+			final AbstractJobVertex failingJobVertex = new FailingJobVertex("Failing job vertex");
+			failingJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+
+			final JobGraph failingJobGraph = new JobGraph("Failing testing job", failingJobVertex);
+
+			try {
+				new Within(TestingUtils.TESTING_DURATION()) {
+
+					@Override
+					protected void run() {
+						try {
+							submitJob(failingJobGraph, jobClient);
+							fail("Expected JobExecutionException.");
+						} catch (JobExecutionException e) {
+							assertEquals("Test exception.", e.getCause().getMessage());
+						} catch (Throwable t) {
+							fail("Caught wrong exception of type " + t.getClass() + ".");
+							t.printStackTrace();
+						}
+
+						try {
+							JobClient.submitJobAndWait(workingJobGraph, false, jobClient,
+									TestingUtils.TESTING_DURATION());
+						} catch (Throwable t) {
+							fail("Caught unexpected exception " + t.getMessage() + ".");
+						}
+					}
+				};
+			} finally {
+				cluster.stop();
+			}
+		}};
+	}
+
+	@Test
+	public void testSubmitEmptyJobGraph() {
+		new JavaTestKit(system) {{
+			final int numSlots = 20;
+
+			final ForkableFlinkMiniCluster cluster =
+					ForkableFlinkMiniCluster.startCluster(numSlots/2, 2,
+							TestingUtils.TESTING_DURATION().toString());
+
+			final ActorRef jobClient = cluster.getJobClient();
+
+			final JobGraph jobGraph = new JobGraph("Testing job");
+
+			try {
+				new Within(TestingUtils.TESTING_DURATION()) {
+
+					@Override
+					protected void run() {
+						try {
+							submitJob(jobGraph, jobClient);
+							fail("Expected JobSubmissionException.");
+						} catch (JobSubmissionException e) {
+							assertEquals("Job is empty.", e.getMessage());
+						} catch (Throwable t) {
+							fail("Caught wrong exception of type " + t.getClass() + ".");
+							t.printStackTrace();
+						}
+
+						try {
+							JobClient.submitJobAndWait(workingJobGraph, false, jobClient,
+									TestingUtils.TESTING_DURATION());
+						} catch (Throwable t) {
+							fail("Caught unexpected exception " + t.getMessage() + ".");
+						}
+					}
+				};
+			} finally {
+				cluster.stop();
+			}
+		}};
+	}
+
+	@Test
+	public void testSubmitNullJobGraph() {
+		new JavaTestKit(system) {{
+			final int numSlots = 20;
+
+			final ForkableFlinkMiniCluster cluster =
+					ForkableFlinkMiniCluster.startCluster(numSlots/2, 2,
+							TestingUtils.TESTING_DURATION().toString());
+
+			final ActorRef jobClient = cluster.getJobClient();
+
+			try {
+				new Within(TestingUtils.TESTING_DURATION()) {
+
+					@Override
+					protected void run() {
+						try {
+							submitJob(null, jobClient);
+							fail("Expected JobSubmissionException.");
+						} catch (JobSubmissionException e) {
+							assertEquals("JobGraph must not be null.", e.getMessage());
+						} catch (Throwable t) {
+							fail("Caught wrong exception of type " + t.getClass() + ".");
+							t.printStackTrace();
+						}
+
+						try {
+							JobClient.submitJobAndWait(workingJobGraph, false, jobClient,
+									TestingUtils.TESTING_DURATION());
+						} catch (Throwable t) {
+							fail("Caught unexpected exception " + t.getMessage() + ".");
+						}
+					}
+				};
+			} finally {
+				cluster.stop();
+			}
+		}};
+	}
+
+	public static class FailingJobVertex extends AbstractJobVertex {
+		public FailingJobVertex(final String msg) {
+			super(msg);
+		}
+
+		@Override
+		public void initializeOnMaster(ClassLoader loader) throws Exception {
+			throw new Exception("Test exception.");
+		}
+	}
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobmanager
+package org.apache.flink.api.scala.runtime.jobmanager
 
-import akka.actor.{PoisonPill, ActorSystem}
+import akka.actor.{ActorSystem, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.messages.JobManagerMessages.RequestNumberRegisteredTaskManager
-import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.{JobManagerTerminated,
-NotifyWhenJobManagerTerminated}
-import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.{JobManagerTerminated, NotifyWhenJobManagerTerminated}
+import org.apache.flink.test.util.ForkableFlinkMiniCluster
 import org.junit.runner.RunWith
-import org.scalatest.{WordSpecLike, Matchers, BeforeAndAfterAll}
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 @RunWith(classOf[JUnitRunner])
 class JobManagerFailsITCase(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
 with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
+  def this() = this(ActorSystem("TestingActorSystem", AkkaUtils.getDefaultAkkaConfig))
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -42,7 +42,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
     "detect a lost connection to the JobManager and try to reconnect to it" in {
       val num_slots = 11
 
-      val cluster = TestingUtils.startTestingClusterDeathWatch(num_slots, 1)
+      val cluster = ForkableFlinkMiniCluster.startClusterDeathWatch(num_slots, 1)
 
       val tm = cluster.getTaskManagers(0)
       val jm = cluster.getJobManager

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
@@ -16,16 +16,17 @@
 * limitations under the License.
 */
 
-package org.apache.flink.runtime.jobmanager
+package org.apache.flink.api.scala.runtime.taskmanager
 
-import akka.actor.{Kill, ActorSystem, PoisonPill}
+import akka.actor.{ActorSystem, Kill, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.jobgraph.{AbstractJobVertex, DistributionPattern, JobGraph}
 import org.apache.flink.runtime.jobmanager.Tasks.{BlockingReceiver, Sender}
-import org.apache.flink.runtime.messages.JobManagerMessages.{RequestNumberRegisteredTaskManager,
-JobResultFailed, SubmissionSuccess, SubmitJob}
+import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultFailed, RequestNumberRegisteredTaskManager, SubmissionSuccess, SubmitJob}
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.test.util.ForkableFlinkMiniCluster
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -34,7 +35,7 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 class TaskManagerFailsITCase(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
 with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
+  def this() = this(ActorSystem("TestingActorSystem", AkkaUtils.getDefaultAkkaConfig))
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -45,7 +46,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
     "detect a failing task manager" in {
       val num_slots = 11
 
-      val cluster = TestingUtils.startTestingClusterDeathWatch(num_slots, 2)
+      val cluster = ForkableFlinkMiniCluster.startClusterDeathWatch(num_slots, 2)
 
       val taskManagers = cluster.getTaskManagers
       val jm = cluster.getJobManager
@@ -83,7 +84,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
       val jobID = jobGraph.getJobID
 
-      val cluster = TestingUtils.startTestingCluster(num_tasks, 2)
+      val cluster = ForkableFlinkMiniCluster.startCluster(num_tasks, 2)
 
       val jm = cluster.getJobManager
 
@@ -121,7 +122,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
       val jobID = jobGraph.getJobID
 
-      val cluster = TestingUtils.startTestingCluster(num_tasks, 2)
+      val cluster = ForkableFlinkMiniCluster.startCluster(num_tasks, 2)
 
       val taskManagers = cluster.getTaskManagers
       val jm = cluster.getJobManager


### PR DESCRIPTION
Corrects the behaviour of the ```JobClient``` in case of a submission failure. The PR also contains test cases for the job submission.

Additionally, reworked how exceptions are transmitted from the ```JobManager``` to the ```JobClient```. They are directly wrapped into a ```akka.actor.Status.Failure``` and send to the ```JobClient```.

This PR is based on #419.