### PR TITLE
Small UI css class fix

### DIFF
--- a/flink-runtime/src/main/resources/web-docs-infoserver/index.html
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/index.html
@@ -126,10 +126,10 @@ under the License.
             <div class="panel panel-info">
               <div class="panel-heading">
                 <div class="row">
-                  <div class="col-xs-6">
+                  <div class="col-xs-4">
                     <i class="fa fa-info fa-5x"></i>
                   </div>
-                  <div class="col-xs-6 text-right">
+                  <div class="col-xs-8 text-right">
                     <p class="announcement-heading"><span id="stat-taskmanagers" class="stats"></span></p>
                     <p class="announcement-text">Task Manager</p>
                   </div>
@@ -141,10 +141,10 @@ under the License.
             <div class="panel panel-primary">
               <div class="panel-heading">
                 <div class="row">
-                  <div class="col-xs-6">
+                  <div class="col-xs-4">
                     <i class="fa fa-list-ol fa-5x"></i>
                   </div>
-                  <div class="col-xs-6 text-right">
+                  <div class="col-xs-8 text-right">
                     <p class="announcement-heading"><span id="stat-slots" class="stats"></span></p>
                     <p class="announcement-text">Processing Slots</p>
                   </div>
@@ -156,10 +156,10 @@ under the License.
             <div class="panel panel-success">
               <div class="panel-heading">
                 <div class="row">
-                  <div class="col-xs-6">
+                  <div class="col-xs-4">
                     <i class="fa fa-check fa-5x"></i>
                   </div>
-                  <div class="col-xs-6 text-right">
+                  <div class="col-xs-8 text-right">
                     <p class="announcement-heading"><span id="jobs-finished" class="stats"></span></p>
                     <p class="announcement-text">Jobs Finished</p>
                   </div>
@@ -171,10 +171,10 @@ under the License.
             <div class="panel panel-warning">
               <div class="panel-heading">
                 <div class="row">
-                  <div class="col-xs-6">
+                  <div class="col-xs-4">
                     <i class="fa fa-eraser fa-5x"></i>
                   </div>
-                  <div class="col-xs-6 text-right">
+                  <div class="col-xs-8 text-right">
                     <p class="announcement-heading"><span id="jobs-canceled" class="stats"></span></p>
                     <p class="announcement-text">Jobs Canceled</p>
                   </div>
@@ -186,10 +186,10 @@ under the License.
             <div class="panel panel-danger">
               <div class="panel-heading">
                 <div class="row">
-                  <div class="col-xs-6">
+                  <div class="col-xs-4">
                     <i class="fa fa-flash fa-5x"></i>
                   </div>
-                  <div class="col-xs-6 text-right">
+                  <div class="col-xs-8 text-right">
                     <p class="announcement-heading"><span id="jobs-failed" class="stats"></span></p>
                     <p class="announcement-text">Jobs Failed</p>
                   </div>


### PR DESCRIPTION
Height of information bullets was not equal due to text break.

before:

![bildschirmfoto vom 2015-02-19 17 54 30](https://cloud.githubusercontent.com/assets/189796/6271687/a688e094-b862-11e4-9296-700dd8022c37.png)

after:

![bildschirmfoto vom 2015-02-19 17 54 56](https://cloud.githubusercontent.com/assets/189796/6271689/ab87e1c6-b862-11e4-96d9-3dd95db981d0.png)
