### PR TITLE
[FLINK-1596] remove space in filename

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/FileIOChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/FileIOChannel.java
@@ -164,7 +164,7 @@ public interface FileIOChannel {
 
 		public ID next() {
 			int threadNum = counter % paths.length;
-			String filename = String.format(" %s.%06d.channel", namePrefix, (counter++));
+			String filename = String.format("%s.%06d.channel", namePrefix, (counter++));
 			return new ID(new File(paths[threadNum], filename), threadNum);
 		}
 	}


### PR DESCRIPTION
Simple fix seems to cause issues on Windows