### PR TITLE
[FLINK-1591] Removed unnecessary merge before flatten as optimisation

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
@@ -523,7 +523,7 @@ public class StreamGraph extends StreamingPlan {
 
 		this.jobName = jobGraphName;
 
-		WindowingOptimzier.optimizeGraph(this);
+		WindowingOptimizer.optimizeGraph(this);
 
 		StreamingJobGraphGenerator jobgraphGenerator = new StreamingJobGraphGenerator(this);
 
@@ -613,7 +613,7 @@ public class StreamGraph extends StreamingPlan {
 	@Override
 	public String getStreamingPlanAsJSON() {
 
-		WindowingOptimzier.optimizeGraph(this);
+		WindowingOptimizer.optimizeGraph(this);
 
 		try {
 			return new JSONGenerator().getJSON();


### PR DESCRIPTION
This PR adds an optimisation to the WindowingOptimizer which will remove the unnecessary merge operation on the streamwindows before the flatten calls. 

This adds major performance improvement since the flatten call now can be easily chained to the windowing transformations and also eliminates the need of an expensive merge transformation