### PR TITLE
[FLINK-999] Configurability of LocalExecutor

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.api.common.Program;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -97,6 +98,7 @@ public class LocalExecutor extends PlanExecutor {
 				
 				// create the embedded runtime
 				Configuration configuration = new Configuration();
+				configuration.addAll(GlobalConfiguration.getConfiguration());
 				configuration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, getTaskManagerNumSlots());
 				configuration.setBoolean(ConfigConstants.FILESYSTEM_DEFAULT_OVERWRITE_KEY, isDefaultOverwriteFiles());
 				// start it up


### PR DESCRIPTION
Add also the global configuration to the minicluster.

This is an attempt to bring in the ability to pass configuration parameters to the embedded mini-cluster - this happened as with more slots, the machine ran out of network buffers.

The config could then be initialized using for example

`GlobalConfiguration.loadConfiguration("conf");`
