### PR TITLE
Streaming cancellation + exception handling rework

### DIFF
--- a/docs/streaming_guide.md
+++ b/docs/streaming_guide.md
@@ -168,7 +168,11 @@ Usage: `dataStream.broadcast()`
  * *Global*: All data points end up at the same operator instance. To achieve this use the parallelism setting of the corresponding operator.
 Usage: `operator.setParallelism(1)`
 
-### Sources
+### Connecting to the outside world
+
+The user is expected to connect to the outside world through the source and the sink interfaces. We provide a `cancel()` method where allocated resources can be freed up in case some other parts of the topology failed. The `cancel()` method is called upon termination.
+
+#### Sources
 
 The user can connect to data streams by the different implementations of `SourceFunction` using `StreamExecutionEnvironment.addSource(SourceFunction)`. In contrast with other operators, DataStreamSources have a default operator parallelism of 1.
 
@@ -186,7 +190,7 @@ There are several predefined ones similar to the ones of the batch API and some 
 These can be used to easily test and debug streaming programs.
 There are pre-implemented connectors for a number of the most popular message queue services, please refer to the section on [connectors](#stream-connectors) for more detail.
 
-### Sinks
+#### Sinks
 
 `DataStreamSink` represents the different outputs of a Flink Streaming program. There are several pre-defined implementations available right away:
 
@@ -495,13 +499,13 @@ Most data stream operators support directed outputs (output splitting), meaning 
 
 ~~~java
 SplitDataStream<Integer> split = someDataStream.split(outputSelector);
-DataStream<Integer> even = split.select("even”);
+DataStream<Integer> even = split.select("even");
 DataStream<Integer> odd = split.select("odd");
 ~~~
 
 In the above example the data stream named ‘even’ will only contain elements that are directed to the output named “even”. The user can of course further transform these new stream by for example squaring only the even elements.
 
-Data streams only receive the elements directed to selected output names. The user can also select multiple output names by `splitStream.select(“output1”, “output2”…)`. It is common that a stream listens to all the outputs, so `split.selectAll()` provides this functionality without having to select all names.
+Data streams only receive the elements directed to selected output names. The user can also select multiple output names by `splitStream.select(“output1”, “output2”, …)`. It is common that a stream listens to all the outputs, so `split.selectAll()` provides this functionality without having to select all names.
 
 The outputs of an operator are directed by implementing a selector function (implementing the `OutputSelector` interface):
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSink.java
@@ -134,6 +134,13 @@ public class FlumeSink<IN> extends RichSinkFunction<IN> {
 	}
 
 	@Override
+	public void cancel() {
+		if (client != null) {
+			client.client.close();
+		}
+	}
+
+	@Override
 	public void open(Configuration config) {
 		client = new FlinkRpcClientFacade();
 		client.init(host, port);

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSource.java
@@ -130,12 +130,16 @@ public class FlumeSource<OUT> extends ConnectorSource<OUT> {
 	 *            The Collector for sending data to the datastream
 	 */
 	@Override
-	public void invoke(Collector<OUT> collector) throws Exception {
+	public void run(Collector<OUT> collector) throws Exception {
 		configureAvroSource(collector);
 		avroSource.start();
 		while (!finished) {
 			this.wait();
 		}
+	}
+
+	@Override
+	public void cancel() {
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExample.java
@@ -41,7 +41,7 @@ public class KafkaProducerExample {
 		@SuppressWarnings({ "unused", "serial" })
 		DataStream<String> stream1 = env.addSource(new SourceFunction<String>() {
 			@Override
-			public void invoke(Collector<String> collector) throws Exception {
+			public void run(Collector<String> collector) throws Exception {
 				for (int i = 0; i < 100; i++) {
 					collector.collect("message #" + i);
 					Thread.sleep(100L);
@@ -49,6 +49,12 @@ public class KafkaProducerExample {
 
 				collector.collect(new String("q"));
 			}
+
+			@Override
+			public void cancel() {				
+			}
+			
+			
 		}).addSink(
 				new KafkaSink<String>(topic, host + ":" + port, new JavaDefaultStringSchema())
 		)

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSink.java
@@ -33,9 +33,9 @@ import org.apache.flink.streaming.connectors.util.SerializationSchema;
 
 /**
  * Sink that emits its inputs to a Kafka topic.
- *
+ * 
  * @param <IN>
- * 		Type of the sink input
+ *            Type of the sink input
  */
 public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	private static final long serialVersionUID = 1L;
@@ -49,14 +49,15 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	private KafkaPartitioner<IN> partitioner;
 
 	/**
-	 * Creates a KafkaSink for a given topic. The partitioner distributes the messages between the partitions of the topics.
-	 *
+	 * Creates a KafkaSink for a given topic. The partitioner distributes the
+	 * messages between the partitions of the topics.
+	 * 
 	 * @param topicId
-	 * 		ID of the Kafka topic.
+	 *            ID of the Kafka topic.
 	 * @param brokerAddr
-	 * 		Address of the Kafka broker (with port number).
+	 *            Address of the Kafka broker (with port number).
 	 * @param serializationSchema
-	 * 		User defined serialization schema.
+	 *            User defined serialization schema.
 	 */
 	public KafkaSink(String topicId, String brokerAddr,
 			SerializationSchema<IN, byte[]> serializationSchema) {
@@ -64,16 +65,17 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	}
 
 	/**
-	 * Creates a KafkaSink for a given topic. The sink produces its input into the topic.
-	 *
+	 * Creates a KafkaSink for a given topic. The sink produces its input into
+	 * the topic.
+	 * 
 	 * @param topicId
-	 * 		ID of the Kafka topic.
+	 *            ID of the Kafka topic.
 	 * @param brokerAddr
-	 * 		Address of the Kafka broker (with port number).
+	 *            Address of the Kafka broker (with port number).
 	 * @param serializationSchema
-	 * 		User defined serialization schema.
+	 *            User defined serialization schema.
 	 * @param partitioner
-	 * 		User defined partitioner.
+	 *            User defined partitioner.
 	 */
 	public KafkaSink(String topicId, String brokerAddr,
 			SerializationSchema<IN, byte[]> serializationSchema, KafkaPartitioner<IN> partitioner) {
@@ -111,9 +113,9 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 
 	/**
 	 * Called when new data arrives to the sink, and forwards it to Kafka.
-	 *
+	 * 
 	 * @param next
-	 * 		The incoming data
+	 *            The incoming data
 	 */
 	@Override
 	public void invoke(IN next) {
@@ -130,6 +132,11 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 		if (producer != null) {
 			producer.close();
 		}
+	}
+
+	@Override
+	public void cancel() {
+		close();
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -108,4 +108,9 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 		closeChannel();
 	}
 
+	@Override
+	public void cancel() {
+		close();
+	}
+
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterStreaming.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterStreaming.java
@@ -47,6 +47,10 @@ public class TwitterStreaming {
 			System.out.println("");
 		}
 
+		@Override
+		public void cancel() {
+		}
+
 	}
 
 	public static class SelectDataFlatMap extends

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/StreamOutput.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/StreamOutput.java
@@ -83,4 +83,8 @@ public class StreamOutput<OUT> implements Collector<OUT> {
 		}
 	}
 
+	public void clearBuffers() {
+		output.clearBuffers();
+	}
+
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/FileSinkFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/FileSinkFunction.java
@@ -115,4 +115,13 @@ public abstract class FileSinkFunction<IN> extends RichSinkFunction<IN> {
 	 */
 	protected abstract void resetParameters();
 
+	@Override
+	public void cancel() {
+		try {
+			close();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/PrintSinkFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/PrintSinkFunction.java
@@ -84,15 +84,19 @@ public class PrintSinkFunction<IN> extends RichSinkFunction<IN> {
 	}
 	
 	@Override
-	public void close() throws Exception {
+	public void close() {
 		this.stream = null;
 		this.prefix = null;
-		super.close();
 	}
 	
 	@Override
 	public String toString() {
 		return "Print to " + (target == STD_OUT ? "System.out" : "System.err");
+	}
+
+	@Override
+	public void cancel() {
+		close();
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/SinkFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/SinkFunction.java
@@ -21,10 +21,25 @@ import java.io.Serializable;
 
 import org.apache.flink.api.common.functions.Function;
 
+/**
+ * Interface for implementing user defined sink functionality.
+ *
+ * @param <IN> INput type parameter.
+ */
 public interface SinkFunction<IN> extends Function, Serializable {
 
+	/**
+	 * Function for standard sink behaviour. This function is called for every record.
+	 *
+	 * @param value The input record.
+	 * @throws Exception
+	 */
 	public void invoke(IN value) throws Exception;
 
+	/**
+	 * In case another vertex in topology fails this method is called before terminating
+	 * the sink. Make sure to free up any allocated resources here.
+	 */
 	public void cancel();
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/SinkFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/SinkFunction.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.functions.Function;
 
 public interface SinkFunction<IN> extends Function, Serializable {
 
-	public abstract void invoke(IN value) throws Exception;
+	public void invoke(IN value) throws Exception;
+
+	public void cancel();
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/WriteSinkFunctionByMillis.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/sink/WriteSinkFunctionByMillis.java
@@ -47,4 +47,9 @@ public class WriteSinkFunctionByMillis<IN> extends WriteSinkFunction<IN> {
 		lastTime = System.currentTimeMillis();
 	}
 
+	@Override
+	public void cancel() {
+		// No cleanup needed
+	}
+
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/FileMonitoringFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/FileMonitoringFunction.java
@@ -39,8 +39,10 @@ public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Lon
 
 	public enum WatchType {
 		ONLY_NEW_FILES, // Only new files will be processed.
-		REPROCESS_WITH_APPENDED, // When some files are appended, all contents of the files will be processed.
-		PROCESS_ONLY_APPENDED // When some files are appended, only appended contents will be processed.
+		REPROCESS_WITH_APPENDED, // When some files are appended, all contents
+									// of the files will be processed.
+		PROCESS_ONLY_APPENDED // When some files are appended, only appended
+								// contents will be processed.
 	}
 
 	private String path;
@@ -51,6 +53,8 @@ public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Lon
 	private Map<String, Long> offsetOfFiles;
 	private Map<String, Long> modificationTimes;
 
+	private volatile boolean isRunning = false;
+
 	public FileMonitoringFunction(String path, long interval, WatchType watchType) {
 		this.path = path;
 		this.interval = interval;
@@ -60,10 +64,11 @@ public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Lon
 	}
 
 	@Override
-	public void invoke(Collector<Tuple3<String, Long, Long>> collector) throws Exception {
+	public void run(Collector<Tuple3<String, Long, Long>> collector) throws Exception {
+		isRunning = true;
 		fileSystem = FileSystem.get(new URI(path));
 
-		while (true) {
+		while (isRunning) {
 			List<String> files = listNewFiles();
 			for (String filePath : files) {
 				if (watchType == WatchType.ONLY_NEW_FILES
@@ -119,5 +124,10 @@ public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Lon
 				return lastModification >= modificationTime;
 			}
 		}
+	}
+
+	@Override
+	public void cancel() {
+		isRunning = false;
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/FromElementsFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/FromElementsFunction.java
@@ -40,10 +40,14 @@ public class FromElementsFunction<T> implements SourceFunction<T> {
 	}
 
 	@Override
-	public void invoke(Collector<T> collector) throws Exception {
+	public void run(Collector<T> collector) throws Exception {
 		for (T element : iterable) {
 			collector.collect(element);
 		}
+	}
+
+	@Override
+	public void cancel() {
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/GenSequenceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/GenSequenceFunction.java
@@ -37,7 +37,7 @@ public class GenSequenceFunction extends RichParallelSourceFunction<Long> {
 	}
 
 	@Override
-	public void invoke(Collector<Long> collector) throws Exception {
+	public void run(Collector<Long> collector) throws Exception {
 		while (splitIterator.hasNext()) {
 			collector.collect(splitIterator.next());
 		}
@@ -48,6 +48,10 @@ public class GenSequenceFunction extends RichParallelSourceFunction<Long> {
 		int splitNumber = getRuntimeContext().getIndexOfThisSubtask();
 		int numOfSubTasks = getRuntimeContext().getNumberOfParallelSubtasks();
 		splitIterator = fullIterator.split(numOfSubTasks)[splitNumber];
+	}
+
+	@Override
+	public void cancel() {
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/ParallelSourceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/ParallelSourceFunction.java
@@ -17,6 +17,10 @@
 
 package org.apache.flink.streaming.api.function.source;
 
+/**
+ * {@link SourceFunction} that may be executed in parallel.
+ *
+ * @param <OUT>
+ */
 public interface ParallelSourceFunction<OUT> extends SourceFunction<OUT> {
-
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/SourceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/SourceFunction.java
@@ -24,6 +24,8 @@ import org.apache.flink.util.Collector;
 
 public interface SourceFunction<OUT> extends Function, Serializable {
 
-	public void invoke(Collector<OUT> collector) throws Exception;
+	public void run(Collector<OUT> collector) throws Exception;
+	
+	public void cancel();
 		
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/SourceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/SourceFunction.java
@@ -22,10 +22,30 @@ import java.io.Serializable;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.util.Collector;
 
+/**
+ * Interface for implementing user defined source functionality.
+ *
+ * <p>Sources implementing this specific interface are executed with
+ * degree of parallelism 1. To execute your sources in parallel
+ * see {@link ParallelSourceFunction}.</p>
+ *
+ * @param <OUT> Output type parameter.
+ */
 public interface SourceFunction<OUT> extends Function, Serializable {
 
+	/**
+	 * Function for standard source behaviour. This function is called only once
+	 * thus to produce multiple outputs make sure to produce multiple records.
+	 *
+	 * @param collector Collector for passing output records
+	 * @throws Exception
+	 */
 	public void run(Collector<OUT> collector) throws Exception;
-	
+
+	/**
+	 * In case another vertex in topology fails this method is called before terminating
+	 * the source. Make sure to free up any allocated resources here.
+	 */
 	public void cancel();
 		
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/SinkInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/SinkInvokable.java
@@ -31,7 +31,7 @@ public class SinkInvokable<IN> extends ChainableInvokable<IN, IN> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -45,6 +45,12 @@ public class SinkInvokable<IN> extends ChainableInvokable<IN, IN> {
 	public void collect(IN record) {
 		nextObject = copy(record);
 		callUserFunctionAndLogException();
+	}
+
+	@Override
+	public void cancel() {
+		super.cancel();
+		sinkFunction.cancel();
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/SourceInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/SourceInvokable.java
@@ -39,6 +39,12 @@ public class SourceInvokable<OUT> extends StreamInvokable<OUT, OUT> implements S
 
 	@Override
 	protected void callUserFunction() throws Exception {
-		sourceFunction.invoke(collector);
+		sourceFunction.run(collector);
+	}
+
+	@Override
+	public void cancel() {
+		super.cancel();
+		sourceFunction.cancel();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/StreamInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/StreamInvokable.java
@@ -114,6 +114,14 @@ public abstract class StreamInvokable<IN, OUT> implements Serializable {
 				// Task already cancelled do nothing
 				return null;
 			}
+		}  catch (IllegalStateException e) {
+			if (isRunning) {
+				throw new RuntimeException("Could not read next record due to: "
+						+ StringUtils.stringifyException(e));
+			} else {
+				// Task already cancelled do nothing
+				return null;
+			}
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/StreamInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/StreamInvokable.java
@@ -107,7 +107,13 @@ public abstract class StreamInvokable<IN, OUT> implements Serializable {
 			}
 			return nextRecord;
 		} catch (IOException e) {
-			throw new RuntimeException("Could not read next record.");
+			if (isRunning) {
+				throw new RuntimeException("Could not read next record due to: "
+						+ StringUtils.stringifyException(e));
+			} else {
+				// Task already cancelled do nothing
+				return null;
+			}
 		}
 	}
 
@@ -157,6 +163,10 @@ public abstract class StreamInvokable<IN, OUT> implements Serializable {
 		} catch (Exception e) {
 			throw new RuntimeException("Error when closing the function: " + e.getMessage());
 		}
+	}
+
+	public void cancel() {
+		isRunning = false;
 	}
 
 	public void setRuntimeContext(RuntimeContext t) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/CounterInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/CounterInvokable.java
@@ -30,14 +30,16 @@ public class CounterInvokable<IN> extends ChainableInvokable<IN, Long> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			collector.collect(++count);
 		}
 	}
 
 	@Override
 	public void collect(IN record) {
-		collector.collect(++count);
+		if (isRunning) {
+			collector.collect(++count);
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/FilterInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/FilterInvokable.java
@@ -34,7 +34,7 @@ public class FilterInvokable<IN> extends ChainableInvokable<IN, IN> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -49,7 +49,9 @@ public class FilterInvokable<IN> extends ChainableInvokable<IN, IN> {
 
 	@Override
 	public void collect(IN record) {
-		nextObject = copy(record);
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = copy(record);
+			callUserFunctionAndLogException();
+		}
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/FlatMapInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/FlatMapInvokable.java
@@ -32,7 +32,7 @@ public class FlatMapInvokable<IN, OUT> extends ChainableInvokable<IN, OUT> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -44,8 +44,10 @@ public class FlatMapInvokable<IN, OUT> extends ChainableInvokable<IN, OUT> {
 
 	@Override
 	public void collect(IN record) {
-		nextObject = copy(record);
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = copy(record);
+			callUserFunctionAndLogException();
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/MapInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/MapInvokable.java
@@ -32,7 +32,7 @@ public class MapInvokable<IN, OUT> extends ChainableInvokable<IN, OUT> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -44,7 +44,9 @@ public class MapInvokable<IN, OUT> extends ChainableInvokable<IN, OUT> {
 
 	@Override
 	public void collect(IN record) {
-		nextObject = copy(record);
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = copy(record);
+			callUserFunctionAndLogException();
+		}
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/ProjectInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/ProjectInvokable.java
@@ -41,7 +41,7 @@ public class ProjectInvokable<IN, OUT extends Tuple> extends StreamInvokable<IN,
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/StreamReduceInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/StreamReduceInvokable.java
@@ -35,7 +35,7 @@ public class StreamReduceInvokable<IN> extends ChainableInvokable<IN, IN> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			reduce();
 		}
 	}
@@ -62,8 +62,10 @@ public class StreamReduceInvokable<IN> extends ChainableInvokable<IN, IN> {
 
 	@Override
 	public void collect(IN record) {
-		nextObject = copy(record);
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = copy(record);
+			callUserFunctionAndLogException();
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/GroupedStreamDiscretizer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/GroupedStreamDiscretizer.java
@@ -60,11 +60,8 @@ public class GroupedStreamDiscretizer<IN> extends StreamDiscretizer<IN> {
 
 	@Override
 	public void invoke() throws Exception {
-		if (readNext() == null) {
-			throw new RuntimeException("DataStream must not be empty");
-		}
 
-		while (nextRecord != null) {
+		while (isRunning && readNext() != null) {
 
 			Object key = keySelector.getKey(nextObject);
 
@@ -76,8 +73,6 @@ public class GroupedStreamDiscretizer<IN> extends StreamDiscretizer<IN> {
 			}
 
 			groupDiscretizer.processRealElement(nextObject);
-
-			readNext();
 		}
 
 		for (StreamDiscretizer<IN> group : groupedDiscretizers.values()) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/GroupedWindowBufferInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/GroupedWindowBufferInvokable.java
@@ -42,7 +42,7 @@ public class GroupedWindowBufferInvokable<T> extends WindowBufferInvokable<T> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -64,8 +64,10 @@ public class GroupedWindowBufferInvokable<T> extends WindowBufferInvokable<T> {
 
 	@Override
 	public void collect(WindowEvent<T> record) {
-		nextObject = record;
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = record;
+			callUserFunctionAndLogException();
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/StreamDiscretizer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/StreamDiscretizer.java
@@ -71,7 +71,7 @@ public class StreamDiscretizer<IN> extends StreamInvokable<IN, WindowEvent<IN>> 
 	public void invoke() throws Exception {
 
 		// Continuously run
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			processRealElement(nextObject);
 		}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowBufferInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowBufferInvokable.java
@@ -26,8 +26,7 @@ import org.apache.flink.streaming.api.windowing.windowbuffer.WindowBuffer;
  * This invokable flattens the results of the window transformations by
  * outputing the elements of the {@link StreamWindow} one-by-one
  */
-public class WindowBufferInvokable<T> extends
-		ChainableInvokable<WindowEvent<T>, StreamWindow<T>> {
+public class WindowBufferInvokable<T> extends ChainableInvokable<WindowEvent<T>, StreamWindow<T>> {
 
 	protected WindowBuffer<T> buffer;
 
@@ -40,7 +39,7 @@ public class WindowBufferInvokable<T> extends
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -67,8 +66,10 @@ public class WindowBufferInvokable<T> extends
 
 	@Override
 	public void collect(WindowEvent<T> record) {
-		nextObject = record;
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = record;
+			callUserFunctionAndLogException();
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowFlattener.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowFlattener.java
@@ -34,7 +34,7 @@ public class WindowFlattener<T> extends ChainableInvokable<StreamWindow<T>, T> {
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -48,8 +48,10 @@ public class WindowFlattener<T> extends ChainableInvokable<StreamWindow<T>, T> {
 
 	@Override
 	public void collect(StreamWindow<T> record) {
-		nextObject = record;
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = record;
+			callUserFunctionAndLogException();
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowMerger.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowMerger.java
@@ -41,7 +41,7 @@ public class WindowMerger<T> extends ChainableInvokable<StreamWindow<T>, StreamW
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -69,7 +69,9 @@ public class WindowMerger<T> extends ChainableInvokable<StreamWindow<T>, StreamW
 
 	@Override
 	public void collect(StreamWindow<T> record) {
-		nextObject = record;
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = record;
+			callUserFunctionAndLogException();
+		}
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowPartitioner.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowPartitioner.java
@@ -44,7 +44,7 @@ public class WindowPartitioner<T> extends ChainableInvokable<StreamWindow<T>, St
 
 	@Override
 	public void invoke() throws Exception {
-		while (readNext() != null) {
+		while (isRunning && readNext() != null) {
 			callUserFunctionAndLogException();
 		}
 	}
@@ -71,8 +71,10 @@ public class WindowPartitioner<T> extends ChainableInvokable<StreamWindow<T>, St
 
 	@Override
 	public void collect(StreamWindow<T> record) {
-		nextObject = record;
-		callUserFunctionAndLogException();
+		if (isRunning) {
+			nextObject = record;
+			callUserFunctionAndLogException();
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
@@ -90,4 +90,10 @@ public class InputHandler<IN> {
 	public IndexedReaderIterator<StreamRecord<IN>> getInputIter() {
 		return inputIter;
 	}
+
+	public void clearReaders() {
+		if (inputs != null) {
+			inputs.clearBuffers();
+		}
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/OutputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/OutputHandler.java
@@ -32,7 +32,6 @@ import org.apache.flink.streaming.api.collector.CollectorWrapper;
 import org.apache.flink.streaming.api.collector.DirectedCollectorWrapper;
 import org.apache.flink.streaming.api.collector.StreamOutput;
 import org.apache.flink.streaming.api.invokable.ChainableInvokable;
-import org.apache.flink.streaming.api.invokable.StreamInvokable;
 import org.apache.flink.streaming.api.streamrecord.StreamRecord;
 import org.apache.flink.streaming.api.streamrecord.StreamRecordSerializer;
 import org.apache.flink.streaming.io.StreamRecordWriter;
@@ -166,8 +165,8 @@ public class OutputHandler<OUT> {
 	 *            The config of upStream task
 	 * @return
 	 */
-	private <T> StreamOutput<T> createStreamOutput(Integer outputVertex, StreamConfig configuration,
-			int outputIndex) {
+	private <T> StreamOutput<T> createStreamOutput(Integer outputVertex,
+			StreamConfig configuration, int outputIndex) {
 
 		StreamRecordSerializer<T> outSerializer = configuration
 				.getTypeSerializerOut1(vertex.userClassLoader);
@@ -218,25 +217,9 @@ public class OutputHandler<OUT> {
 		}
 	}
 
-	public void invokeUserFunction(String componentTypeName, StreamInvokable<?, OUT> userInvokable)
-			throws IOException, InterruptedException {
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("{} {} invoked with instance id {}", componentTypeName, vertex.getName(),
-					vertex.getInstanceID());
+	public void clearWriters() {
+		for (StreamOutput<?> output : outputMap.values()) {
+			output.clearBuffers();
 		}
-
-		try {
-			vertex.invokeUserFunction(userInvokable);
-		} catch (Exception e) {
-			flushOutputs();
-			throw new RuntimeException(e);
-		}
-
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("{} {} invoke finished instance id {}", componentTypeName, vertex.getName(),
-					vertex.getInstanceID());
-		}
-
-		flushOutputs();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamIterationTail.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamIterationTail.java
@@ -59,13 +59,23 @@ public class StreamIterationTail<IN> extends StreamVertex<IN, IN> {
 	@Override
 	public void invoke() throws Exception {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("SINK {} invoked", getName());
+			LOG.debug("Iteration sink {} invoked", getName());
 		}
 
-		forwardRecords();
+		try {
+			forwardRecords();
 
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("SINK {} invoke finished", getName());
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Iteration sink {} invoke finished", getName());
+			}
+		} catch (Exception e) {
+			if (LOG.isErrorEnabled()) {
+				LOG.error("Iteration sink failed due to: {}", StringUtils.stringifyException(e));
+			}
+			throw e;
+		} finally {
+			// Cleanup
+			clearBuffers();
 		}
 	}
 
@@ -75,12 +85,11 @@ public class StreamIterationTail<IN> extends StreamVertex<IN, IN> {
 			if (!pushToQueue(reuse)) {
 				break;
 			}
-			// TODO: Fix object reuse for iteration
 			reuse = inputHandler.getInputSerializer().createInstance();
 		}
 	}
 
-	private boolean pushToQueue(StreamRecord<IN> record) {
+	private boolean pushToQueue(StreamRecord<IN> record) throws InterruptedException {
 		try {
 			if (shouldWait) {
 				return dataChannel.offer(record, iterationWaitTime, TimeUnit.MILLISECONDS);
@@ -92,6 +101,7 @@ public class StreamIterationTail<IN> extends StreamVertex<IN, IN> {
 			if (LOG.isErrorEnabled()) {
 				LOG.error("Pushing back record at iteration %s failed due to: {}", iterationId,
 						StringUtils.stringifyException(e));
+				throw e;
 			}
 			return false;
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamVertex.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamVertex.java
@@ -154,6 +154,13 @@ public class StreamVertex<IN, OUT> extends AbstractInvokable implements StreamTa
 	}
 
 	@Override
+	public void cancel() {
+		if (userInvokable != null) {
+			userInvokable.cancel();
+		}
+	}
+
+	@Override
 	public StreamConfig getConfig() {
 		return configuration;
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
@@ -69,6 +69,10 @@ public class IterateTest {
 		public void invoke(Boolean tuple) {
 		}
 
+		@Override
+		public void cancel() {
+		}
+
 	}
 
 	@Test

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/OutputSplitterTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/OutputSplitterTest.java
@@ -76,6 +76,10 @@ public class OutputSplitterTest {
 			public void invoke(Integer value) {
 				splitterResult1.add(value);
 			}
+			
+			@Override
+			public void cancel() {
+			}
 		});
 
 		d1.split(new OutputSelector<Integer>() {
@@ -97,6 +101,10 @@ public class OutputSplitterTest {
 			@Override
 			public void invoke(Integer value) {
 				splitterResult2.add(value);
+			}
+			
+			@Override
+			public void cancel() {
 			}
 		});
 		env.execute();
@@ -144,6 +152,10 @@ public class OutputSplitterTest {
 			public void invoke(Integer value) {
 				splitterResult1.add(value);
 			}
+			
+			@Override
+			public void cancel() {
+			}
 		});
 
 		ds.split(new OutputSelector<Integer>() {
@@ -167,6 +179,10 @@ public class OutputSplitterTest {
 			@Override
 			public void invoke(Integer value) {
 				splitterResult2.add(value);
+			}
+			
+			@Override
+			public void cancel() {
 			}
 		});
 		env.execute();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/WindowCrossJoinTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/WindowCrossJoinTest.java
@@ -143,6 +143,10 @@ public class WindowCrossJoinTest implements Serializable {
 		public void invoke(Tuple2<Tuple2<Integer, String>, Tuple1<Integer>> value) {
 			joinResults.add(new Tuple2<Tuple2<Integer, String>, Integer>(value.f0, value.f1.f0));
 		}
+		
+		@Override
+		public void cancel() {
+		}
 	}
 
 	private static class CrossResultSink implements
@@ -152,6 +156,10 @@ public class WindowCrossJoinTest implements Serializable {
 		@Override
 		public void invoke(Tuple2<Tuple2<Integer, String>, Tuple1<Integer>> value) {
 			crossResults.add(new Tuple2<Tuple2<Integer, String>, Integer>(value.f0, value.f1.f0));
+		}
+		
+		@Override
+		public void cancel() {
 		}
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/collector/DirectedOutputTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/collector/DirectedOutputTest.java
@@ -88,6 +88,10 @@ public class DirectedOutputTest {
 			outputs.put(name, new ArrayList<Long>());
 			this.list = outputs.get(name);
 		}
+
+		@Override
+		public void cancel() {
+		}
 	}
 
 	private static Map<String, List<Long>> outputs = new HashMap<String, List<Long>>();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowIntegrationTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowIntegrationTest.java
@@ -208,6 +208,10 @@ public class WindowIntegrationTest implements Serializable {
 			windows.add(value);
 		}
 
+		@Override
+		public void cancel() {
+		}
+
 	}
 
 	@SuppressWarnings("serial")
@@ -219,6 +223,10 @@ public class WindowIntegrationTest implements Serializable {
 		@Override
 		public void invoke(StreamWindow<Integer> value) throws Exception {
 			windows.add(value);
+		}
+
+		@Override
+		public void cancel() {
 		}
 
 	}
@@ -234,6 +242,10 @@ public class WindowIntegrationTest implements Serializable {
 			windows.add(value);
 		}
 
+		@Override
+		public void cancel() {
+		}
+
 	}
 
 	@SuppressWarnings("serial")
@@ -245,6 +257,10 @@ public class WindowIntegrationTest implements Serializable {
 		@Override
 		public void invoke(StreamWindow<Integer> value) throws Exception {
 			windows.add(value);
+		}
+
+		@Override
+		public void cancel() {
 		}
 
 	}
@@ -260,6 +276,10 @@ public class WindowIntegrationTest implements Serializable {
 			windows.add(value);
 		}
 
+		@Override
+		public void cancel() {
+		}
+
 	}
 
 	@SuppressWarnings("serial")
@@ -273,6 +293,10 @@ public class WindowIntegrationTest implements Serializable {
 			windows.add(value);
 		}
 
+		@Override
+		public void cancel() {
+		}
+
 	}
 
 	@SuppressWarnings("serial")
@@ -284,6 +308,10 @@ public class WindowIntegrationTest implements Serializable {
 		@Override
 		public void invoke(StreamWindow<Integer> value) throws Exception {
 			windows.add(value);
+		}
+
+		@Override
+		public void cancel() {
 		}
 
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamvertex/StreamVertexTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamvertex/StreamVertexTest.java
@@ -50,11 +50,16 @@ public class StreamVertexTest {
 		private Tuple1<Integer> tuple = new Tuple1<Integer>(0);
 
 		@Override
-		public void invoke(Collector<Tuple1<Integer>> collector) throws Exception {
+		public void run(Collector<Tuple1<Integer>> collector) throws Exception {
 			for (int i = 0; i < 10; i++) {
 				tuple.f0 = i;
 				collector.collect(tuple);
 			}
+		}
+
+		@Override
+		public void cancel() {
+			// No cleanup needed
 		}
 	}
 
@@ -76,6 +81,10 @@ public class StreamVertexTest {
 			Integer k = tuple.getField(0);
 			Integer v = tuple.getField(1);
 			data.put(k, v);
+		}
+
+		@Override
+		public void cancel() {
 		}
 	}
 
@@ -141,6 +150,10 @@ public class StreamVertexTest {
 		@Override
 		public void invoke(String value) {
 			result.add(value);
+		}
+
+		@Override
+		public void cancel() {
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/MockSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/MockSource.java
@@ -27,7 +27,7 @@ public class MockSource<T> {
 	public static <T> List<T> createAndExecute(SourceFunction<T> source) {
 		List<T> outputs = new ArrayList<T>();
 		try {
-			source.invoke(new MockCollector<T>(outputs));
+			source.run(new MockCollector<T>(outputs));
 		} catch (Exception e) {
 			throw new RuntimeException("Cannot invoke source.", e);
 		}

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/join/WindowJoin.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/join/WindowJoin.java
@@ -108,13 +108,18 @@ public class WindowJoin {
 		}
 
 		@Override
-		public void invoke(Collector<Tuple2<String, Integer>> out) throws Exception {
+		public void run(Collector<Tuple2<String, Integer>> out) throws Exception {
 			while (true) {
 				outTuple.f0 = names[rand.nextInt(names.length)];
 				outTuple.f1 = rand.nextInt(GRADE_COUNT) + 1;
 				out.collect(outTuple);
 				Thread.sleep(rand.nextInt(SLEEP_TIME) + 1);
 			}
+		}
+		
+		@Override
+		public void cancel() {
+			// No cleanup needed
 		}
 	}
 
@@ -134,13 +139,18 @@ public class WindowJoin {
 		}
 
 		@Override
-		public void invoke(Collector<Tuple2<String, Integer>> out) throws Exception {
+		public void run(Collector<Tuple2<String, Integer>> out) throws Exception {
 			while (true) {
 				outTuple.f0 = names[rand.nextInt(names.length)];
 				outTuple.f1 = rand.nextInt(SALARY_MAX) + 1;
 				out.collect(outTuple);
 				Thread.sleep(rand.nextInt(SLEEP_TIME) + 1);
 			}
+		}
+		
+		@Override
+		public void cancel() {
+			// No cleanup needed
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/ml/IncrementalLearningSkeleton.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/ml/IncrementalLearningSkeleton.java
@@ -93,7 +93,7 @@ public class IncrementalLearningSkeleton {
 		private static final int NEW_DATA_SLEEP_TIME = 1000;
 
 		@Override
-		public void invoke(Collector<Integer> collector) throws Exception {
+		public void run(Collector<Integer> collector) throws Exception {
 			while (true) {
 				collector.collect(getNewData());
 			}
@@ -102,6 +102,11 @@ public class IncrementalLearningSkeleton {
 		private Integer getNewData() throws InterruptedException {
 			Thread.sleep(NEW_DATA_SLEEP_TIME);
 			return 1;
+		}
+		
+		@Override
+		public void cancel() {
+			// No cleanup needed
 		}
 	}
 
@@ -114,7 +119,7 @@ public class IncrementalLearningSkeleton {
 		private static final int TRAINING_DATA_SLEEP_TIME = 10;
 
 		@Override
-		public void invoke(Collector<Integer> collector) throws Exception {
+		public void run(Collector<Integer> collector) throws Exception {
 			while (true) {
 				collector.collect(getTrainingData());
 			}
@@ -125,6 +130,11 @@ public class IncrementalLearningSkeleton {
 			Thread.sleep(TRAINING_DATA_SLEEP_TIME);
 			return 1;
 
+		}
+		
+		@Override
+		public void cancel() {
+			// No cleanup needed
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/StockPrices.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/StockPrices.java
@@ -267,7 +267,7 @@ public class StockPrices {
 		}
 
 		@Override
-		public void invoke(Collector<StockPrice> collector) throws Exception {
+		public void run(Collector<StockPrice> collector) throws Exception {
 			price = DEFAULT_PRICE;
 			Random random = new Random();
 
@@ -276,6 +276,11 @@ public class StockPrices {
 				collector.collect(new StockPrice(symbol, price));
 				Thread.sleep(random.nextInt(200));
 			}
+		}
+		
+		@Override
+		public void cancel() {
+			// No cleanup needed
 		}
 	}
 
@@ -307,7 +312,7 @@ public class StockPrices {
 		StringBuilder stringBuilder;
 
 		@Override
-		public void invoke(Collector<String> collector) throws Exception {
+		public void run(Collector<String> collector) throws Exception {
 			random = new Random();
 			stringBuilder = new StringBuilder();
 
@@ -321,6 +326,11 @@ public class StockPrices {
 				Thread.sleep(500);
 			}
 
+		}
+		
+		@Override
+		public void cancel() {
+			// No cleanup needed
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowingExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowingExample.java
@@ -87,7 +87,7 @@ public class TopSpeedWindowingExample {
 		}
 
 		@Override
-		public void invoke(Collector<Tuple4<Integer, Integer, Double, Long>> collector)
+		public void run(Collector<Tuple4<Integer, Integer, Double, Long>> collector)
 				throws Exception {
 
 			while (true) {
@@ -103,6 +103,10 @@ public class TopSpeedWindowingExample {
 							speeds[carId], distances[carId], System.currentTimeMillis()));
 				}
 			}
+		}
+
+		@Override
+		public void cancel() {
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -568,6 +568,7 @@ class DataStream[T](javaStream: JavaStream[T]) {
     val sinkFunction = new SinkFunction[T] {
       val cleanFun = clean(fun)
       def invoke(in: T) = cleanFun(in)
+      def cancel() = {}
     }
     this.addSink(sinkFunction)
   }

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -224,9 +224,10 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     Validate.notNull(function, "Function must not be null.")
     val sourceFunction = new SourceFunction[T] {
       val cleanFun = StreamExecutionEnvironment.clean(function)
-      override def invoke(out: Collector[T]) {
+      override def run(out: Collector[T]) {
         cleanFun(out)
       }
+      override def cancel() = {}
     }
     addSource(sourceFunction)
   }

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
@@ -18,16 +18,14 @@
 
 package org.apache.flink.test.classloading.jar;
 
+import java.util.StringTokenizer;
+
 import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.function.sink.SinkFunction;
-import org.apache.flink.test.recordJobs.wordcount.WordCount;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.util.Collector;
-
-import java.util.StringTokenizer;
 
 @SuppressWarnings("serial")
 public class StreamingProgram {
@@ -99,6 +97,10 @@ public class StreamingProgram {
 	public static class NoOpSink implements SinkFunction<Word>{
 		@Override
 		public void invoke(Word value) throws Exception {
+		}
+
+		@Override
+		public void cancel() {
 		}
 	}
 }


### PR DESCRIPTION
This PR reworks the way runtime exceptions are handled in the streaming runtime.

User code and other types of exceptions thrown during the invocation are now properly propagated. 
This PR also introduces proper cancellation for streaminvokables with extending the Source and SinkFunction interfaces with a cancel method.

Some sources which maintain connections are also reworked to close the connections in any case.