### PR TITLE
[FLINK-1637] Reduce number of files in uberjar for java 6

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -115,12 +115,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-connectors</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-examples</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -233,23 +227,6 @@ under the License.
 					</plugin>
 				</plugins>
 			</build>
-		</profile>
-
-		<profile>
-			<id>hadoop-2</id>
-			<activation>
-				<property>
-					<!-- Please do not remove the 'hadoop2' comment. See ./tools/generate_specific_pom.sh -->
-					<!--hadoop2--><name>!hadoop.profile</name>
-				</property>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-hbase</artifactId>
-					<version>${project.version}</version>
-				</dependency>
-			</dependencies>
 		</profile>
 
 		<profile>

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
@@ -53,7 +53,8 @@ public class WordCount {
 	// *************************************************************************
 	
 	public static void main(String[] args) throws Exception {
-		
+
+
 		if(!parseParameters(args)) {
 			return;
 		}

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -179,5 +179,25 @@ rm $MVN_EXIT
 
 upload_artifacts_s3
 
+# Check the number of files in the uber jar and fail the build if there are too many files (see: FLINK-1637)
+
+# since we are in flink/tools/artifacts
+# we are going back to
+cd ../../
+
+
+UBERJAR=`find . | grep uberjar | head -n 1`
+if [ -z "$UBERJAR" ] ; then
+	echo "Uberjar not found. Assuming failed build";
+else 
+	jar tf $UBERJAR | wc -l > num_files_in_uberjar
+	NUM_FILES_IN_UBERJAR=`cat num_files_in_uberjar`
+	echo "Files in uberjar: $NUM_FILES_IN_UBERJAR. Uberjar: $UBERJAR"
+	if [ "$NUM_FILES_IN_UBERJAR" -ge "65536" ] ; then
+		echo "The number of files in the uberjar ($NUM_FILES_IN_UBERJAR) exceeds the maximum number of possible files for Java 6 (65536)"
+		exit 1
+	fi
+fi
+
 # Exit code for Travis build success/failure
 exit $EXIT_CODE


### PR DESCRIPTION
It seems that we've recently surpassed the magic number of 65536 files in our YARN uberjar.
Java 6 is not able to read jar files with so "many" files.
Therefore, I added a check to our travis tests which verify that the number of files in the jar is lower than 65k.

To to solve the problem for now, I've removed the `flink-streaming-connectors` from the distribution.
If users want to use them, they can just add them as a dependency and they should be fine (assuming our classloading is working properly).
I've also removed `flink-hbase` which is also a module users can easily get through mvn central.