### PR TITLE
Fix checking null for ternary operator check on Exception#getMessage calls

### DIFF
--- a/flink-compiler/src/main/java/org/apache/flink/compiler/dag/OptimizerNode.java
+++ b/flink-compiler/src/main/java/org/apache/flink/compiler/dag/OptimizerNode.java
@@ -1151,7 +1151,8 @@ public abstract class OptimizerNode implements Visitable<OptimizerNode>, Estimat
 
 		int i = 1; 
 		for (PactConnection conn : getIncomingConnections()) {
-			bld.append('(').append(i++).append(":").append(conn.getShipStrategy() == null ? "null" : conn.getShipStrategy().name()).append(')');
+			String shipStrategyName = conn.getShipStrategy() == null ? "null" : conn.getShipStrategy().name();
+			bld.append('(').append(i++).append(":").append(shipStrategyName).append(')');
 		}
 
 		return bld.toString();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -92,7 +92,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 			initInputReaders();
 		} catch (Exception e) {
 			throw new RuntimeException("Initializing the input streams failed" +
-				e.getMessage() == null ? "." : ": " + e.getMessage(), e);
+					(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 		}
 
 		if (LOG.isDebugEnabled()) {
@@ -156,7 +156,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 					input1 = sorter.getIterator();
 				} catch (Exception e) {
 					throw new RuntimeException("Initializing the input processing failed" +
-						e.getMessage() == null ? "." : ": " + e.getMessage(), e);
+							(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 				}
 				break;
 			default:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/RegularPactTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/RegularPactTask.java
@@ -254,7 +254,7 @@ public class RegularPactTask<S extends Function, OT> extends AbstractInvokable i
 			initOutputs();
 		} catch (Exception e) {
 			throw new RuntimeException("Initializing the output handlers failed" +
-				e.getMessage() == null ? "." : ": " + e.getMessage(), e);
+					(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 		}
 
 		if (LOG.isDebugEnabled()) {
@@ -339,7 +339,7 @@ public class RegularPactTask<S extends Function, OT> extends AbstractInvokable i
 			}
 			catch (Exception e) {
 				throw new RuntimeException("Initializing the input processing failed" +
-					e.getMessage() == null ? "." : ": " + e.getMessage(), e);
+						(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 			}
 
 			if (!this.running) {
@@ -420,7 +420,7 @@ public class RegularPactTask<S extends Function, OT> extends AbstractInvokable i
 			}
 		} catch (Exception e) {
 			throw new RuntimeException("Initializing the UDF" +
-				e.getMessage() == null ? "." : ": " + e.getMessage(), e);
+					(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 		}
 	}
 	
@@ -1002,7 +1002,7 @@ public class RegularPactTask<S extends Function, OT> extends AbstractInvokable i
 					localStub = initStub(userCodeFunctionType);
 				} catch (Exception e) {
 					throw new RuntimeException("Initializing the user code and the configuration failed" +
-						e.getMessage() == null ? "." : ": " + e.getMessage(), e);
+							(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 				}
 				
 				if (!(localStub instanceof FlatCombineFunction)) {


### PR DESCRIPTION
Add parentheses on Exception#getMessage calls from pattern of:
 
"Initializing the input processing failed" + e.getMessage() == null ? "." : ": " + e.getMessage()

to:

"Initializing the input processing failed" + (e.getMessage() == null ? "." : ": " + e.getMessage())

Extra parentheses needed to make sure ternary operator check on e.getMessage scope call.