### PR TITLE
Windowing features / fixes

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -35,6 +35,9 @@ public class DataStreamSource<OUT> extends SingleOutputStreamOperator<OUT, DataS
 			TypeInformation<OUT> outTypeInfo, StreamInvokable<?, ?> invokable, boolean isParallel) {
 		super(environment, operatorType, outTypeInfo, invokable);
 		this.isParallel = isParallel;
+		if (!isParallel) {
+			setParallelism(1);
+		}
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DiscretizedStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DiscretizedStream.java
@@ -35,6 +35,8 @@ import org.apache.flink.streaming.api.invokable.operator.windowing.WindowPartiti
 import org.apache.flink.streaming.api.invokable.operator.windowing.WindowReducer;
 import org.apache.flink.streaming.api.windowing.StreamWindow;
 import org.apache.flink.streaming.api.windowing.StreamWindowTypeInfo;
+import org.apache.flink.streaming.api.windowing.WindowUtils.WindowKey;
+import org.apache.flink.streaming.api.windowing.WindowUtils.WindowTransformation;
 
 /**
  * A {@link DiscretizedStream} represents a data stream that has been divided

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/WindowedDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/WindowedDataStream.java
@@ -46,15 +46,21 @@ import org.apache.flink.streaming.api.windowing.WindowEvent;
 import org.apache.flink.streaming.api.windowing.WindowUtils;
 import org.apache.flink.streaming.api.windowing.WindowUtils.WindowTransformation;
 import org.apache.flink.streaming.api.windowing.helper.Time;
+import org.apache.flink.streaming.api.windowing.helper.TimestampWrapper;
 import org.apache.flink.streaming.api.windowing.helper.WindowingHelper;
 import org.apache.flink.streaming.api.windowing.policy.CloneableEvictionPolicy;
 import org.apache.flink.streaming.api.windowing.policy.CloneableTriggerPolicy;
+import org.apache.flink.streaming.api.windowing.policy.CountEvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.CountTriggerPolicy;
 import org.apache.flink.streaming.api.windowing.policy.EvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.TimeEvictionPolicy;
 import org.apache.flink.streaming.api.windowing.policy.TimeTriggerPolicy;
 import org.apache.flink.streaming.api.windowing.policy.TriggerPolicy;
 import org.apache.flink.streaming.api.windowing.policy.TumblingEvictionPolicy;
 import org.apache.flink.streaming.api.windowing.windowbuffer.BasicWindowBuffer;
 import org.apache.flink.streaming.api.windowing.windowbuffer.CompletePreAggregator;
+import org.apache.flink.streaming.api.windowing.windowbuffer.SlidingCountPreReducer;
+import org.apache.flink.streaming.api.windowing.windowbuffer.SlidingTimePreReducer;
 import org.apache.flink.streaming.api.windowing.windowbuffer.TumblingGroupedPreReducer;
 import org.apache.flink.streaming.api.windowing.windowbuffer.TumblingPreReducer;
 import org.apache.flink.streaming.api.windowing.windowbuffer.WindowBuffer;
@@ -365,16 +371,41 @@ public class WindowedDataStream<OUT> {
 	@SuppressWarnings("unchecked")
 	private WindowBuffer<OUT> getWindowBuffer(WindowTransformation transformation) {
 
-		if (transformation == WindowTransformation.REDUCEWINDOW
-				&& getEviction() instanceof TumblingEvictionPolicy) {
-			if (groupByKey == null) {
-				return new TumblingPreReducer<OUT>(
-						clean((ReduceFunction<OUT>) transformation.getUDF()), getType()
-								.createSerializer(getExecutionConfig()));
-			} else {
-				return new TumblingGroupedPreReducer<OUT>(
-						clean((ReduceFunction<OUT>) transformation.getUDF()), groupByKey, getType()
-								.createSerializer(getExecutionConfig()));
+		if (transformation == WindowTransformation.REDUCEWINDOW) {
+			if (getTrigger() instanceof TumblingEvictionPolicy) {
+				if (groupByKey == null) {
+					return new TumblingPreReducer<OUT>(
+							clean((ReduceFunction<OUT>) transformation.getUDF()), getType()
+									.createSerializer(getExecutionConfig()));
+				} else {
+					return new TumblingGroupedPreReducer<OUT>(
+							clean((ReduceFunction<OUT>) transformation.getUDF()), groupByKey,
+							getType().createSerializer(getExecutionConfig()));
+				}
+			} else if (getTrigger() instanceof CountTriggerPolicy
+					&& getEviction() instanceof CountEvictionPolicy && groupByKey == null) {
+
+				int slide = ((CountTriggerPolicy<OUT>) getTrigger()).getSlideSize();
+				int window = ((CountEvictionPolicy<OUT>) getEviction()).getWindowSize();
+				int start = ((CountEvictionPolicy<OUT>) getEviction()).getStart();
+				if (slide < window) {
+					return new SlidingCountPreReducer<OUT>(
+							clean((ReduceFunction<OUT>) transformation.getUDF()), dataStream
+									.getType().createSerializer(getExecutionConfig()), window,
+							slide, start);
+				}
+			} else if (getTrigger() instanceof TimeTriggerPolicy
+					&& getEviction() instanceof TimeEvictionPolicy && groupByKey == null) {
+				int slide = (int) ((TimeTriggerPolicy<OUT>) getTrigger()).getSlideSize();
+				int window = (int) ((TimeEvictionPolicy<OUT>) getEviction()).getWindowSize();
+				TimestampWrapper<OUT> wrapper = ((TimeEvictionPolicy<OUT>) getEviction())
+						.getTimeStampWrapper();
+				if (slide < window) {
+					return new SlidingTimePreReducer<OUT>(
+							clean((ReduceFunction<OUT>) transformation.getUDF()), dataStream
+									.getType().createSerializer(getExecutionConfig()), window,
+							slide, wrapper);
+				}
 			}
 		}
 		return new BasicWindowBuffer<OUT>();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowBufferInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowBufferInvokable.java
@@ -52,10 +52,13 @@ public class WindowBufferInvokable<T> extends ChainableInvokable<WindowEvent<T>,
 	protected void handleWindowEvent(WindowEvent<T> windowEvent, WindowBuffer<T> buffer)
 			throws Exception {
 		if (windowEvent.isElement()) {
+			System.out.println("element: " + windowEvent.getElement());
 			buffer.store(windowEvent.getElement());
 		} else if (windowEvent.isEviction()) {
+			System.out.println("eviction: " + windowEvent.getEviction());
 			buffer.evict(windowEvent.getEviction());
 		} else if (windowEvent.isTrigger()) {
+			System.out.println("trigger");
 			buffer.emitWindow(collector);
 		}
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindow.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindow.java
@@ -172,6 +172,10 @@ public class StreamWindow<T> extends ArrayList<T> implements Collector<T> {
 		return this;
 	}
 
+	public void setID(int id) {
+		this.windowID = id;
+	}
+
 	/**
 	 * Checks whether this window can be merged with the given one.
 	 * 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.windowing.policy.CountEvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.CountTriggerPolicy;
+import org.apache.flink.streaming.api.windowing.policy.EvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.TimeEvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.TimeTriggerPolicy;
+import org.apache.flink.streaming.api.windowing.policy.TriggerPolicy;
+import org.apache.flink.streaming.api.windowing.policy.TumblingEvictionPolicy;
+
+public class WindowUtils {
+
+	public enum WindowTransformation {
+		REDUCEWINDOW, MAPWINDOW, NONE;
+		private Function UDF;
+
+		public WindowTransformation with(Function UDF) {
+			this.UDF = UDF;
+			return this;
+		}
+
+		public Function getUDF() {
+			return UDF;
+		}
+	}
+
+	public static boolean isParallelPolicy(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction) {
+		return (eviction instanceof CountEvictionPolicy && (trigger instanceof CountTriggerPolicy || trigger instanceof TimeTriggerPolicy))
+				|| (eviction instanceof TumblingEvictionPolicy && trigger instanceof CountTriggerPolicy);
+	}
+
+	public static boolean isTimeOnly(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction) {
+		return trigger instanceof TimeTriggerPolicy && eviction instanceof TimeEvictionPolicy;
+	}
+
+	public static boolean isSystemTimeTrigger(TriggerPolicy<?> trigger) {
+		return trigger instanceof TimeTriggerPolicy
+				&& ((TimeTriggerPolicy<?>) trigger).timestampWrapper.isDefaultTimestamp();
+	}
+
+	public static class WindowKey<R> implements KeySelector<StreamWindow<R>, Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer getKey(StreamWindow<R> value) throws Exception {
+			return value.windowID;
+		}
+
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
@@ -44,9 +44,10 @@ public class WindowUtils {
 		}
 	}
 
-	public static boolean isParallelPolicy(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction) {
-		return (eviction instanceof CountEvictionPolicy && (trigger instanceof CountTriggerPolicy || trigger instanceof TimeTriggerPolicy))
-				|| (eviction instanceof TumblingEvictionPolicy && trigger instanceof CountTriggerPolicy);
+	public static boolean isParallelPolicy(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction,
+			int inputParallelism) {
+		return inputParallelism != 1
+				&& ((eviction instanceof CountEvictionPolicy && (trigger instanceof CountTriggerPolicy || trigger instanceof TimeTriggerPolicy)) || (eviction instanceof TumblingEvictionPolicy && trigger instanceof CountTriggerPolicy));
 	}
 
 	public static boolean isSlidingTimePolicy(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/helper/Time.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/helper/Time.java
@@ -80,7 +80,6 @@ public class Time<DATA> implements WindowingHelper<DATA> {
 		this.length = length;
 		this.granularity = timeUnit;
 		this.timestampWrapper = timestampWrapper;
-		this.delay = 0;
 	}
 
 	@Override
@@ -90,7 +89,7 @@ public class Time<DATA> implements WindowingHelper<DATA> {
 
 	@Override
 	public TriggerPolicy<DATA> toTrigger() {
-		return new TimeTriggerPolicy<DATA>(granularityInMillis(), timestampWrapper, delay);
+		return new TimeTriggerPolicy<DATA>(granularityInMillis(), timestampWrapper);
 	}
 
 	/**
@@ -147,19 +146,7 @@ public class Time<DATA> implements WindowingHelper<DATA> {
 	public static <DATA> Time<DATA> of(long length, Timestamp<DATA> timestamp) {
 		return of(length, timestamp, 0);
 	}
-
-	/**
-	 * Sets the delay for the first processed window.
-	 * 
-	 * @param delay
-	 *            The number of time units before the first processed window.
-	 * @return Helper representing the time based trigger and eviction policy
-	 */
-	public Time<DATA> withDelay(long delay) {
-		this.delay = delay;
-		return this;
-	}
-
+	
 	protected long granularityInMillis() {
 		return granularity == null ? length : granularity.toMillis(length);
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountEvictionPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountEvictionPolicy.java
@@ -136,6 +136,14 @@ public class CountEvictionPolicy<IN> implements CloneableEvictionPolicy<IN> {
 		}
 	}
 
+	public int getWindowSize() {
+		return maxElements;
+	}
+
+	public int getStart() {
+		return startValue;
+	}
+
 	@Override
 	public String toString() {
 		return "CountPolicy(" + maxElements + ")";

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountEvictionPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountEvictionPolicy.java
@@ -143,6 +143,10 @@ public class CountEvictionPolicy<IN> implements CloneableEvictionPolicy<IN> {
 	public int getStart() {
 		return startValue;
 	}
+	
+	public int getDeleteOnEviction(){
+		return deleteOnEviction;
+	}
 
 	@Override
 	public String toString() {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountTriggerPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountTriggerPolicy.java
@@ -102,6 +102,10 @@ public class CountTriggerPolicy<IN> implements CloneableTriggerPolicy<IN> {
 		}
 	}
 
+	public int getSlideSize() {
+		return max;
+	}
+
 	@Override
 	public String toString() {
 		return "CountPolicy(" + max + ")";

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountTriggerPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/CountTriggerPolicy.java
@@ -105,6 +105,10 @@ public class CountTriggerPolicy<IN> implements CloneableTriggerPolicy<IN> {
 	public int getSlideSize() {
 		return max;
 	}
+	
+	public int getStart() {
+		return startValue;
+	}
 
 	@Override
 	public String toString() {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/TimeEvictionPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/TimeEvictionPolicy.java
@@ -150,10 +150,18 @@ public class TimeEvictionPolicy<DATA> implements ActiveEvictionPolicy<DATA>,
 		}
 	}
 
+	public long getWindowSize() {
+		return granularity;
+	}
+
 	@Override
 	public String toString() {
 		return "TimePolicy(" + granularity + ", " + timestampWrapper.getClass().getSimpleName()
 				+ ")";
+	}
+
+	public TimestampWrapper<DATA> getTimeStampWrapper() {
+		return timestampWrapper;
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/TimeTriggerPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/TimeTriggerPolicy.java
@@ -43,30 +43,6 @@ public class TimeTriggerPolicy<DATA> implements ActiveTriggerPolicy<DATA>,
 	protected long startTime;
 	public long granularity;
 	public TimestampWrapper<DATA> timestampWrapper;
-	protected long delay;
-
-	/**
-	 * This trigger policy triggers with regard to the time. The is measured
-	 * using a given {@link Timestamp} implementation. A point in time is always
-	 * represented as long. Therefore, parameters such as granularity can be set
-	 * as long value as well. If this value for the granularity is set to 2 for
-	 * example, the policy will trigger at every second point in time.
-	 * 
-	 * @param granularity
-	 *            The granularity of the trigger. If this value is set to x the
-	 *            policy will trigger at every x-th time point
-	 * @param timestampWrapper
-	 *            The {@link TimestampWrapper} to measure the time with. This
-	 *            can be either user defined of provided by the API.
-	 * @param timeWrapper
-	 *            This policy creates fake elements to not miss windows in case
-	 *            no element arrived within the duration of the window. This
-	 *            extractor should wrap a long into such an element of type
-	 *            DATA.
-	 */
-	public TimeTriggerPolicy(long granularity, TimestampWrapper<DATA> timestampWrapper) {
-		this(granularity, timestampWrapper, 0);
-	}
 
 	/**
 	 * This is mostly the same as
@@ -81,21 +57,16 @@ public class TimeTriggerPolicy<DATA> implements ActiveTriggerPolicy<DATA>,
 	 * @param timestampWrapper
 	 *            The {@link TimestampWrapper} to measure the time with. This
 	 *            can be either user defined of provided by the API.
-	 * @param delay
-	 *            A delay for the first trigger. If the start time given by the
-	 *            timestamp is x, the delay is y, and the granularity is z, the
-	 *            first trigger will happen at x+y+z.
 	 * @param timeWrapper
 	 *            This policy creates fake elements to not miss windows in case
 	 *            no element arrived within the duration of the window. This
 	 *            extractor should wrap a long into such an element of type
 	 *            DATA.
 	 */
-	public TimeTriggerPolicy(long granularity, TimestampWrapper<DATA> timestampWrapper, long delay) {
-		this.startTime = timestampWrapper.getStartTime() + delay;
+	public TimeTriggerPolicy(long granularity, TimestampWrapper<DATA> timestampWrapper) {
+		this.startTime = timestampWrapper.getStartTime();
 		this.timestampWrapper = timestampWrapper;
 		this.granularity = granularity;
-		this.delay = delay;
 	}
 
 	/**
@@ -194,7 +165,7 @@ public class TimeTriggerPolicy<DATA> implements ActiveTriggerPolicy<DATA>,
 
 	@Override
 	public TimeTriggerPolicy<DATA> clone() {
-		return new TimeTriggerPolicy<DATA>(granularity, timestampWrapper, delay);
+		return new TimeTriggerPolicy<DATA>(granularity, timestampWrapper);
 	}
 
 	@Override
@@ -221,6 +192,10 @@ public class TimeTriggerPolicy<DATA> implements ActiveTriggerPolicy<DATA>,
 	public String toString() {
 		return "TimePolicy(" + granularity + ", " + timestampWrapper.getClass().getSimpleName()
 				+ ")";
+	}
+	
+	public TimestampWrapper<DATA> getTimeStampWrapper() {
+		return timestampWrapper;
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/TimeTriggerPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/TimeTriggerPolicy.java
@@ -213,6 +213,10 @@ public class TimeTriggerPolicy<DATA> implements ActiveTriggerPolicy<DATA>,
 		}
 	}
 
+	public long getSlideSize() {
+		return granularity;
+	}
+
 	@Override
 	public String toString() {
 		return "TimePolicy(" + granularity + ", " + timestampWrapper.getClass().getSimpleName()

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/BasicWindowBuffer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/BasicWindowBuffer.java
@@ -63,10 +63,6 @@ public class BasicWindowBuffer<T> implements WindowBuffer<T> {
 		}
 	}
 
-	public int size() {
-		return buffer.size();
-	}
-
 	@Override
 	public BasicWindowBuffer<T> clone() {
 		return new BasicWindowBuffer<T>();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountGroupedPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountGroupedPreReducer.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+
+/**
+ * Non-grouped pre-reducer for tumbling eviction policy.
+ */
+public class SlidingCountGroupedPreReducer<T> extends SlidingGroupedPreReducer<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private long windowSize;
+	private long slideSize;
+	private int start;
+
+	protected long index = 0;
+
+	public SlidingCountGroupedPreReducer(ReduceFunction<T> reducer, TypeSerializer<T> serializer,
+			KeySelector<T, ?> key, long windowSize, long slideSize, int start) {
+		super(reducer, serializer, key);
+		if (windowSize > slideSize) {
+			this.windowSize = windowSize;
+			this.slideSize = slideSize;
+			this.start = start;
+		} else {
+			throw new RuntimeException(
+					"Window size needs to be larger than slide size for the sliding pre-reducer");
+		}
+		index = index - start;
+	}
+
+	@Override
+	protected void afterStore() {
+		index++;
+	}
+
+	@Override
+	public void store(T element) throws Exception {
+		if (index >= 0) {
+			super.store(element);
+		} else {
+			index++;
+		}
+	}
+
+	@Override
+	protected boolean currentEligible(T next) {
+		if (index <= slideSize) {
+			return true;
+		} else {
+			return index == windowSize;
+		}
+	}
+
+	@Override
+	protected void afterEmit() {
+		if (index >= slideSize) {
+			index = index - slideSize;
+		}
+	}
+
+	@Override
+	public SlidingCountGroupedPreReducer<T> clone() {
+		return new SlidingCountGroupedPreReducer<T>(reducer, serializer, key, windowSize,
+				slideSize, start);
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountPreReducer.java
@@ -27,12 +27,14 @@ public class SlidingCountPreReducer<T> extends SlidingPreReducer<T> {
 
 	private static final long serialVersionUID = 1L;
 
-	private int windowSize;
-	private int slideSize;
+	private long windowSize;
+	private long slideSize;
 	private int start;
 
+	protected long index = 0;
+
 	public SlidingCountPreReducer(ReduceFunction<T> reducer, TypeSerializer<T> serializer,
-			int windowSize, int slideSize, int start) {
+			long windowSize, long slideSize, int start) {
 		super(reducer, serializer);
 		if (windowSize > slideSize) {
 			this.windowSize = windowSize;
@@ -46,8 +48,8 @@ public class SlidingCountPreReducer<T> extends SlidingPreReducer<T> {
 	}
 
 	@Override
-	public SlidingCountPreReducer<T> clone() {
-		return new SlidingCountPreReducer<T>(reducer, serializer, windowSize, slideSize, start);
+	protected void afterStore() {
+		index++;
 	}
 
 	@Override
@@ -60,12 +62,7 @@ public class SlidingCountPreReducer<T> extends SlidingPreReducer<T> {
 	}
 
 	@Override
-	public String toString() {
-		return currentReduced.toString();
-	}
-
-	@Override
-	protected boolean addCurrentToReduce(T next) {
+	protected boolean currentEligible(T next) {
 		if (index <= slideSize) {
 			return true;
 		} else {
@@ -74,10 +71,14 @@ public class SlidingCountPreReducer<T> extends SlidingPreReducer<T> {
 	}
 
 	@Override
-	protected void updateIndexAtEmit() {
+	protected void afterEmit() {
 		if (index >= slideSize) {
 			index = index - slideSize;
 		}
 	}
 
+	@Override
+	public SlidingCountPreReducer<T> clone() {
+		return new SlidingCountPreReducer<T>(reducer, serializer, windowSize, slideSize, start);
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingGroupedPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingGroupedPreReducer.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+
+public abstract class SlidingGroupedPreReducer<T> extends SlidingPreReducer<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	protected Map<Object, T> currentReducedMap = new HashMap<Object, T>();
+	protected LinkedList<Map<Object, T>> reducedMap = new LinkedList<Map<Object, T>>();
+
+	protected KeySelector<T, ?> key;
+
+	public SlidingGroupedPreReducer(ReduceFunction<T> reducer, TypeSerializer<T> serializer,
+			KeySelector<T, ?> key) {
+		super(reducer, serializer);
+		this.key = key;
+	}
+
+	public boolean addFinalAggregate(StreamWindow<T> currentWindow) throws Exception {
+		Map<Object, T> finalReduce = null;
+
+		if (!reducedMap.isEmpty()) {
+			finalReduce = reducedMap.get(0);
+			for (int i = 1; i < reducedMap.size(); i++) {
+				finalReduce = reduceMaps(finalReduce, reducedMap.get(i));
+
+			}
+			if (currentReducedMap != null) {
+				finalReduce = reduceMaps(finalReduce, currentReducedMap);
+			}
+
+		} else {
+			finalReduce = currentReducedMap;
+		}
+
+		if (finalReduce != null) {
+			currentWindow.addAll(finalReduce.values());
+			return true;
+		} else {
+			return false;
+		}
+
+	}
+
+	private Map<Object, T> reduceMaps(Map<Object, T> first, Map<Object, T> second) throws Exception {
+
+		Map<Object, T> reduced = new HashMap<Object, T>();
+
+		// Get the common keys in the maps
+		Set<Object> interSection = new HashSet<Object>();
+		Set<Object> diffFirst = new HashSet<Object>();
+		Set<Object> diffSecond = new HashSet<Object>();
+
+		for (Object key : first.keySet()) {
+			if (second.containsKey(key)) {
+				interSection.add(key);
+			} else {
+				diffFirst.add(key);
+			}
+		}
+
+		for (Object key : second.keySet()) {
+			if (!interSection.contains(key)) {
+				diffSecond.add(key);
+			}
+		}
+
+		// Reduce the common keys
+		for (Object key : interSection) {
+			reduced.put(
+					key,
+					reducer.reduce(serializer.copy(first.get(key)),
+							serializer.copy(second.get(key))));
+		}
+
+		for (Object key : diffFirst) {
+			reduced.put(key, first.get(key));
+		}
+
+		for (Object key : diffSecond) {
+			reduced.put(key, second.get(key));
+		}
+
+		return reduced;
+	}
+
+	protected void updateCurrent(T element) throws Exception {
+		if (currentReducedMap == null) {
+			currentReducedMap = new HashMap<Object, T>();
+			currentReducedMap.put(key.getKey(element), element);
+		} else {
+			Object nextKey = key.getKey(element);
+			T last = currentReducedMap.get(nextKey);
+			if (last == null) {
+				currentReducedMap.put(nextKey, element);
+			} else {
+				currentReducedMap.put(nextKey, reducer.reduce(serializer.copy(last), element));
+			}
+		}
+	}
+
+	@Override
+	protected void removeLastReduced() {
+		reducedMap.removeFirst();
+	}
+
+	@Override
+	protected void addCurrentToBuffer(T element) throws Exception {
+		reducedMap.add(currentReducedMap);
+	}
+
+	@Override
+	protected void resetCurrent() {
+		currentReducedMap = null;
+	}
+
+	@Override
+	protected boolean currentNotEmpty() {
+		return currentReducedMap != null;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingPreReducer.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import java.util.LinkedList;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.apache.flink.util.Collector;
+
+public abstract class SlidingPreReducer<T> implements WindowBuffer<T>, CompletePreAggregator {
+
+	private static final long serialVersionUID = 1L;
+
+	protected ReduceFunction<T> reducer;
+
+	protected T currentReduced;
+	protected LinkedList<T> reduced = new LinkedList<T>();
+	protected LinkedList<Integer> elementsPerPreAggregate = new LinkedList<Integer>();
+
+	protected TypeSerializer<T> serializer;
+
+	protected int index = 0;
+	protected int toRemove = 0;
+
+	protected int elementsSinceLastPreAggregate = 0;
+
+	public SlidingPreReducer(ReduceFunction<T> reducer, TypeSerializer<T> serializer) {
+		this.reducer = reducer;
+		this.serializer = serializer;
+	}
+
+	public boolean emitWindow(Collector<StreamWindow<T>> collector) {
+		StreamWindow<T> currentWindow = new StreamWindow<T>();
+		T finalAggregate = getFinalAggregate();
+		if (finalAggregate != null) {
+			currentWindow.add(finalAggregate);
+			collector.collect(currentWindow);
+			updateIndexAtEmit();
+			return true;
+		} else {
+			updateIndexAtEmit();
+			return false;
+		}
+
+	}
+
+	protected abstract void updateIndexAtEmit();
+
+	public T getFinalAggregate() {
+		try {
+			if (!reduced.isEmpty()) {
+				T finalReduce = reduced.get(0);
+				for (int i = 1; i < reduced.size(); i++) {
+					finalReduce = reducer.reduce(finalReduce, serializer.copy(reduced.get(i)));
+
+				}
+				if (currentReduced != null) {
+					finalReduce = reducer.reduce(finalReduce, serializer.copy(currentReduced));
+				}
+				return finalReduce;
+			} else {
+				return currentReduced;
+			}
+
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public void store(T element) throws Exception {
+		addToBufferIfEligible(element);
+		index++;
+	}
+
+	protected void addToBufferIfEligible(T element) throws Exception {
+		if (addCurrentToReduce(element) && currentReduced != null) {
+			reduced.add(currentReduced);
+			elementsPerPreAggregate.add(elementsSinceLastPreAggregate);
+			currentReduced = element;
+			elementsSinceLastPreAggregate = 1;
+		} else {
+			if (currentReduced == null) {
+				currentReduced = element;
+			} else {
+				currentReduced = reducer.reduce(serializer.copy(currentReduced), element);
+			}
+			elementsSinceLastPreAggregate++;
+		}
+	}
+
+	protected abstract boolean addCurrentToReduce(T next);
+
+	public void evict(int n) {
+		toRemove += n;
+
+		Integer lastPreAggregateSize = elementsPerPreAggregate.peek();
+		while (lastPreAggregateSize != null && lastPreAggregateSize <= toRemove) {
+			toRemove = max(toRemove - elementsPerPreAggregate.removeFirst(), 0);
+			reduced.removeFirst();
+			lastPreAggregateSize = elementsPerPreAggregate.peek();
+		}
+
+		if (lastPreAggregateSize == null) {
+			toRemove = 0;
+		}
+	}
+
+	public int max(int a, int b) {
+		if (a > b) {
+			return a;
+		} else {
+			return b;
+		}
+	}
+
+	@Override
+	public abstract SlidingPreReducer<T> clone();
+
+	@Override
+	public String toString() {
+		return currentReduced.toString();
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimeGroupedPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimeGroupedPreReducer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.windowing.helper.TimestampWrapper;
+
+/**
+ * Non-grouped pre-reducer for tumbling eviction policy.
+ */
+public class SlidingTimeGroupedPreReducer<T> extends SlidingGroupedPreReducer<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private long windowSize;
+	private long slideSize;
+	private TimestampWrapper<T> timestampWrapper;
+	private T lastStored;
+	protected long windowStartTime;
+
+	public SlidingTimeGroupedPreReducer(ReduceFunction<T> reducer, TypeSerializer<T> serializer,
+			KeySelector<T, ?> key, long windowSize, long slideSize,
+			TimestampWrapper<T> timestampWrapper) {
+		super(reducer, serializer, key);
+		if (windowSize > slideSize) {
+			this.windowSize = windowSize;
+			this.slideSize = slideSize;
+		} else {
+			throw new RuntimeException(
+					"Window size needs to be larger than slide size for the sliding pre-reducer");
+		}
+		this.timestampWrapper = timestampWrapper;
+		this.windowStartTime = timestampWrapper.getStartTime();
+	}
+
+	@Override
+	public void store(T element) throws Exception {
+		super.store(element);
+		lastStored = element;
+	}
+
+	@Override
+	public SlidingTimeGroupedPreReducer<T> clone() {
+		return new SlidingTimeGroupedPreReducer<T>(reducer, serializer, key, windowSize, slideSize,
+				timestampWrapper);
+	}
+
+	@Override
+	public String toString() {
+		return currentReducedMap.toString();
+	}
+
+	@Override
+	protected void afterEmit() {
+		long lastTime = timestampWrapper.getTimestamp(lastStored);
+		if (lastTime - windowStartTime >= slideSize) {
+			windowStartTime = windowStartTime + slideSize;
+		}
+	}
+
+	@Override
+	public void evict(int n) {
+		toRemove += n;
+		Integer lastPreAggregateSize = elementsPerPreAggregate.peek();
+
+		while (lastPreAggregateSize != null && lastPreAggregateSize <= toRemove) {
+			toRemove = max(toRemove - elementsPerPreAggregate.removeFirst(), 0);
+			removeLastReduced();
+			lastPreAggregateSize = elementsPerPreAggregate.peek();
+		}
+
+		if (toRemove > 0 && lastPreAggregateSize == null) {
+			resetCurrent();
+			toRemove = 0;
+		}
+	}
+
+	@Override
+	protected boolean currentEligible(T next) {
+		return windowStartTime == timestampWrapper.getStartTime()
+				|| timestampWrapper.getTimestamp(next) - windowStartTime >= slideSize;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducer.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.windowing.helper.TimestampWrapper;
+
+/**
+ * Non-grouped pre-reducer for tumbling eviction policy.
+ */
+public class SlidingTimePreReducer<T> extends SlidingPreReducer<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private int windowSize;
+	private int slideSize;
+	private TimestampWrapper<T> timestampWrapper;
+	private T lastStored;
+	protected long windowStartTime;
+
+	public SlidingTimePreReducer(ReduceFunction<T> reducer, TypeSerializer<T> serializer,
+			int windowSize, int slideSize, TimestampWrapper<T> timestampWrapper) {
+		super(reducer, serializer);
+		if (windowSize > slideSize) {
+			this.windowSize = windowSize;
+			this.slideSize = slideSize;
+		} else {
+			throw new RuntimeException(
+					"Window size needs to be larger than slide size for the sliding pre-reducer");
+		}
+		this.timestampWrapper = timestampWrapper;
+		this.windowStartTime = timestampWrapper.getStartTime();
+	}
+
+	@Override
+	public void store(T element) throws Exception {
+		super.store(element);
+		lastStored = element;
+	}
+
+	@Override
+	public SlidingTimePreReducer<T> clone() {
+		return new SlidingTimePreReducer<T>(reducer, serializer, windowSize, slideSize,
+				timestampWrapper);
+	}
+
+	@Override
+	public String toString() {
+		return currentReduced.toString();
+	}
+
+	@Override
+	protected void updateIndexAtEmit() {
+		index = 0;
+		long lastTime = timestampWrapper.getTimestamp(lastStored);
+		if (lastTime - windowStartTime >= slideSize) {
+			windowStartTime = windowStartTime + slideSize;
+		}
+	}
+
+	@Override
+	public void evict(int n) {
+		toRemove += n;
+		Integer lastPreAggregateSize = elementsPerPreAggregate.peek();
+
+		while (lastPreAggregateSize != null && lastPreAggregateSize <= toRemove) {
+			toRemove = max(toRemove - elementsPerPreAggregate.removeFirst(), 0);
+			reduced.removeFirst();
+			lastPreAggregateSize = elementsPerPreAggregate.peek();
+		}
+
+		if (toRemove > 0 && lastPreAggregateSize == null) {
+			currentReduced = null;
+			toRemove = 0;
+		}
+	}
+
+	@Override
+	protected boolean addCurrentToReduce(T next) {
+		return windowStartTime == timestampWrapper.getStartTime()
+				|| timestampWrapper.getTimestamp(next) - windowStartTime >= slideSize;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducer.java
@@ -28,14 +28,14 @@ public class SlidingTimePreReducer<T> extends SlidingPreReducer<T> {
 
 	private static final long serialVersionUID = 1L;
 
-	private int windowSize;
-	private int slideSize;
+	private long windowSize;
+	private long slideSize;
 	private TimestampWrapper<T> timestampWrapper;
 	private T lastStored;
 	protected long windowStartTime;
 
 	public SlidingTimePreReducer(ReduceFunction<T> reducer, TypeSerializer<T> serializer,
-			int windowSize, int slideSize, TimestampWrapper<T> timestampWrapper) {
+			long windowSize, long slideSize, TimestampWrapper<T> timestampWrapper) {
 		super(reducer, serializer);
 		if (windowSize > slideSize) {
 			this.windowSize = windowSize;
@@ -66,8 +66,7 @@ public class SlidingTimePreReducer<T> extends SlidingPreReducer<T> {
 	}
 
 	@Override
-	protected void updateIndexAtEmit() {
-		index = 0;
+	protected void afterEmit() {
 		long lastTime = timestampWrapper.getTimestamp(lastStored);
 		if (lastTime - windowStartTime >= slideSize) {
 			windowStartTime = windowStartTime + slideSize;
@@ -92,7 +91,7 @@ public class SlidingTimePreReducer<T> extends SlidingPreReducer<T> {
 	}
 
 	@Override
-	protected boolean addCurrentToReduce(T next) {
+	protected boolean currentEligible(T next) {
 		return windowStartTime == timestampWrapper.getStartTime()
 				|| timestampWrapper.getTimestamp(next) - windowStartTime >= slideSize;
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducer.java
@@ -38,7 +38,6 @@ public class TumblingGroupedPreReducer<T> implements WindowBuffer<T>, CompletePr
 
 	private Map<Object, T> reducedValues;
 
-	private int numOfElements = 0;
 	private TypeSerializer<T> serializer;
 
 	public TumblingGroupedPreReducer(ReduceFunction<T> reducer, KeySelector<T, ?> keySelector,
@@ -56,7 +55,6 @@ public class TumblingGroupedPreReducer<T> implements WindowBuffer<T>, CompletePr
 			currentWindow.addAll(reducedValues.values());
 			collector.collect(currentWindow);
 			reducedValues.clear();
-			numOfElements = 0;
 			return true;
 		} else {
 			return false;
@@ -76,14 +74,9 @@ public class TumblingGroupedPreReducer<T> implements WindowBuffer<T>, CompletePr
 		}
 
 		reducedValues.put(key, reduced);
-		numOfElements++;
 	}
 
 	public void evict(int n) {
-	}
-
-	public int size() {
-		return numOfElements;
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/WindowBuffer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/WindowBuffer.java
@@ -34,8 +34,6 @@ public interface WindowBuffer<T> extends Serializable, Cloneable {
 
 	public boolean emitWindow(Collector<StreamWindow<T>> collector);
 
-	public int size();
-
 	public WindowBuffer<T> clone();
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/StreamDiscretizerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/StreamDiscretizerTest.java
@@ -72,7 +72,7 @@ public class StreamDiscretizerTest {
 		};
 
 		TriggerPolicy<Integer> trigger = new TimeTriggerPolicy<Integer>(2L,
-				new TimestampWrapper<Integer>(myTimeStamp, 1), 2L);
+				new TimestampWrapper<Integer>(myTimeStamp, 3));
 
 		EvictionPolicy<Integer> eviction = new TimeEvictionPolicy<Integer>(4L,
 				new TimestampWrapper<Integer>(myTimeStamp, 1));

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowIntegrationTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowIntegrationTest.java
@@ -89,17 +89,6 @@ public class WindowIntegrationTest implements Serializable {
 		inputs.add(11);
 		inputs.add(11);
 
-		StreamExecutionEnvironment env = new TestStreamEnvironment(2, MEMORYSIZE);
-
-		DataStream<Integer> source = env.fromCollection(inputs);
-
-		source.window(Count.of(2)).every(Count.of(3)).sum(0).getDiscretizedStream()
-				.addSink(new CentralSink1());
-
-		source.window(Count.of(4)).groupBy(new ModKey(2)).mapWindow(new IdentityWindowMap())
-				.flatten().addSink(new CentralSink2());
-
-		KeySelector<Integer, ?> key = new ModKey(2);
 		Timestamp<Integer> ts = new Timestamp<Integer>() {
 
 			private static final long serialVersionUID = 1L;
@@ -110,38 +99,50 @@ public class WindowIntegrationTest implements Serializable {
 			}
 		};
 
+		StreamExecutionEnvironment env = new TestStreamEnvironment(2, MEMORYSIZE);
+
+		DataStream<Integer> source = env.fromCollection(inputs);
+
+		source.window(Time.of(2, ts)).every(Time.of(3, ts)).sum(0).getDiscretizedStream()
+				.addSink(new CentralSink1());
+
+		source.window(Time.of(4, ts, 1)).groupBy(new ModKey(2)).mapWindow(new IdentityWindowMap())
+				.flatten().addSink(new CentralSink2());
+
+		KeySelector<Integer, ?> key = new ModKey(2);
+
 		source.groupBy(key).window(Time.of(4, ts, 1)).sum(0).getDiscretizedStream()
 				.addSink(new DistributedSink1());
 
 		source.groupBy(new ModKey(3)).window(Count.of(2)).groupBy(new ModKey(2))
 				.mapWindow(new IdentityWindowMap()).flatten().addSink(new DistributedSink2());
 
-		source.window(Count.of(2)).every(Count.of(3)).min(0).getDiscretizedStream()
+		source.window(Time.of(2, ts)).every(Time.of(3, ts)).min(0).getDiscretizedStream()
 				.addSink(new CentralSink3());
 
 		source.groupBy(key).window(Time.of(4, ts, 1)).max(0).getDiscretizedStream()
 				.addSink(new DistributedSink3());
 
-		source.window(Count.of(5)).mapWindow(new IdentityWindowMap()).flatten()
+		source.window(Time.of(5, ts, 1)).mapWindow(new IdentityWindowMap()).flatten()
 				.addSink(new DistributedSink4());
 
 		env.execute();
 
-		// sum ( Count of 2 slide 3 )
+		// sum ( Time of 2 slide 3 )
 		List<StreamWindow<Integer>> expected1 = new ArrayList<StreamWindow<Integer>>();
-		expected1.add(StreamWindow.fromElements(4));
+		expected1.add(StreamWindow.fromElements(5));
 		expected1.add(StreamWindow.fromElements(9));
-		expected1.add(StreamWindow.fromElements(22));
+		expected1.add(StreamWindow.fromElements(32));
 
 		validateOutput(expected1, CentralSink1.windows);
 
-		// Tumbling Count of 4 grouped by mod 2
+		// Tumbling Time of 4 grouped by mod 2
 		List<StreamWindow<Integer>> expected2 = new ArrayList<StreamWindow<Integer>>();
-		expected2.add(StreamWindow.fromElements(2, 2));
+		expected2.add(StreamWindow.fromElements(2, 2, 4));
 		expected2.add(StreamWindow.fromElements(1, 3));
-		expected2.add(StreamWindow.fromElements(4, 10));
-		expected2.add(StreamWindow.fromElements(5, 11));
-		expected2.add(StreamWindow.fromElements(11));
+		expected2.add(StreamWindow.fromElements(5));
+		expected2.add(StreamWindow.fromElements(10));
+		expected2.add(StreamWindow.fromElements(11, 11));
 
 		validateOutput(expected2, CentralSink2.windows);
 
@@ -167,11 +168,11 @@ public class WindowIntegrationTest implements Serializable {
 
 		validateOutput(expected4, DistributedSink2.windows);
 
-		// min ( Count of 2 slide 3 )
+		// min ( Time of 2 slide 3 )
 		List<StreamWindow<Integer>> expected5 = new ArrayList<StreamWindow<Integer>>();
-		expected5.add(StreamWindow.fromElements(2));
+		expected5.add(StreamWindow.fromElements(1));
 		expected5.add(StreamWindow.fromElements(4));
-		expected5.add(StreamWindow.fromElements(11));
+		expected5.add(StreamWindow.fromElements(10));
 
 		validateOutput(expected5, CentralSink3.windows);
 
@@ -186,8 +187,9 @@ public class WindowIntegrationTest implements Serializable {
 		validateOutput(expected6, DistributedSink3.windows);
 
 		List<StreamWindow<Integer>> expected7 = new ArrayList<StreamWindow<Integer>>();
-		expected7.add(StreamWindow.fromElements(1, 2, 2, 3, 4));
-		expected7.add(StreamWindow.fromElements(5, 10, 11, 11));
+		expected7.add(StreamWindow.fromElements(1, 2, 2, 3, 4, 5));
+		expected7.add(StreamWindow.fromElements(10));
+		expected7.add(StreamWindow.fromElements(10, 11, 11));
 
 		validateOutput(expected7, DistributedSink4.windows);
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowIntegrationTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/windowing/WindowIntegrationTest.java
@@ -44,7 +44,7 @@ public class WindowIntegrationTest implements Serializable {
 	private static final Integer MEMORYSIZE = 32;
 
 	@SuppressWarnings("serial")
-	private static class ModKey implements KeySelector<Integer, Integer> {
+	public static class ModKey implements KeySelector<Integer, Integer> {
 		private int m;
 
 		public ModKey(int m) {
@@ -126,82 +126,93 @@ public class WindowIntegrationTest implements Serializable {
 		source.window(Time.of(5, ts, 1)).mapWindow(new IdentityWindowMap()).flatten()
 				.addSink(new DistributedSink4());
 
-		source.window(Time.of(5, ts, 1)).every(Time.of(4, ts, 1)).sum(0).getDiscretizedStream()
-				.addSink(new DistributedSink5());
+		source.window(Time.of(5, ts, 1)).every(Time.of(4, ts, 1)).groupBy(new ModKey(2)).sum(0)
+				.getDiscretizedStream().addSink(new DistributedSink5());
 
 		env.execute();
 
-		// sum ( Time of 3 slide 2 )
-		List<StreamWindow<Integer>> expected1 = new ArrayList<StreamWindow<Integer>>();
-		expected1.add(StreamWindow.fromElements(5));
-		expected1.add(StreamWindow.fromElements(11));
-		expected1.add(StreamWindow.fromElements(9));
-		expected1.add(StreamWindow.fromElements(10));
-		expected1.add(StreamWindow.fromElements(32));
-
-		validateOutput(expected1, CentralSink1.windows);
-
-		// Tumbling Time of 4 grouped by mod 2
-		List<StreamWindow<Integer>> expected2 = new ArrayList<StreamWindow<Integer>>();
-		expected2.add(StreamWindow.fromElements(2, 2, 4));
-		expected2.add(StreamWindow.fromElements(1, 3));
-		expected2.add(StreamWindow.fromElements(5));
-		expected2.add(StreamWindow.fromElements(10));
-		expected2.add(StreamWindow.fromElements(11, 11));
-
-		validateOutput(expected2, CentralSink2.windows);
-
-		// groupby mod 2 sum ( Tumbling Time of 4)
-		List<StreamWindow<Integer>> expected3 = new ArrayList<StreamWindow<Integer>>();
-		expected3.add(StreamWindow.fromElements(4));
-		expected3.add(StreamWindow.fromElements(5));
-		expected3.add(StreamWindow.fromElements(22));
-		expected3.add(StreamWindow.fromElements(8));
-		expected3.add(StreamWindow.fromElements(10));
-
-		validateOutput(expected3, DistributedSink1.windows);
-
-		// groupby mod3 Tumbling Count of 2 grouped by mod 2
-		List<StreamWindow<Integer>> expected4 = new ArrayList<StreamWindow<Integer>>();
-		expected4.add(StreamWindow.fromElements(2, 2));
-		expected4.add(StreamWindow.fromElements(1));
-		expected4.add(StreamWindow.fromElements(4));
-		expected4.add(StreamWindow.fromElements(5, 11));
-		expected4.add(StreamWindow.fromElements(10));
-		expected4.add(StreamWindow.fromElements(11));
-		expected4.add(StreamWindow.fromElements(3));
-
-		validateOutput(expected4, DistributedSink2.windows);
-
-		// min ( Time of 2 slide 3 )
-		List<StreamWindow<Integer>> expected5 = new ArrayList<StreamWindow<Integer>>();
-		expected5.add(StreamWindow.fromElements(1));
-		expected5.add(StreamWindow.fromElements(4));
-		expected5.add(StreamWindow.fromElements(10));
-
-		validateOutput(expected5, CentralSink3.windows);
-
-		// groupby mod 2 max ( Tumbling Time of 4)
-		List<StreamWindow<Integer>> expected6 = new ArrayList<StreamWindow<Integer>>();
-		expected6.add(StreamWindow.fromElements(3));
-		expected6.add(StreamWindow.fromElements(5));
-		expected6.add(StreamWindow.fromElements(11));
-		expected6.add(StreamWindow.fromElements(4));
-		expected6.add(StreamWindow.fromElements(10));
-
-		validateOutput(expected6, DistributedSink3.windows);
-
-		List<StreamWindow<Integer>> expected7 = new ArrayList<StreamWindow<Integer>>();
-		expected7.add(StreamWindow.fromElements(1, 2, 2, 3, 4, 5));
-		expected7.add(StreamWindow.fromElements(10));
-		expected7.add(StreamWindow.fromElements(10, 11, 11));
-
-		validateOutput(expected7, DistributedSink4.windows);
+		 // sum ( Time of 3 slide 2 )
+		 List<StreamWindow<Integer>> expected1 = new
+		 ArrayList<StreamWindow<Integer>>();
+		 expected1.add(StreamWindow.fromElements(5));
+		 expected1.add(StreamWindow.fromElements(11));
+		 expected1.add(StreamWindow.fromElements(9));
+		 expected1.add(StreamWindow.fromElements(10));
+		 expected1.add(StreamWindow.fromElements(32));
+		
+		 validateOutput(expected1, CentralSink1.windows);
+		
+		 // Tumbling Time of 4 grouped by mod 2
+		 List<StreamWindow<Integer>> expected2 = new
+		 ArrayList<StreamWindow<Integer>>();
+		 expected2.add(StreamWindow.fromElements(2, 2, 4));
+		 expected2.add(StreamWindow.fromElements(1, 3));
+		 expected2.add(StreamWindow.fromElements(5));
+		 expected2.add(StreamWindow.fromElements(10));
+		 expected2.add(StreamWindow.fromElements(11, 11));
+		
+		 validateOutput(expected2, CentralSink2.windows);
+		
+		 // groupby mod 2 sum ( Tumbling Time of 4)
+		 List<StreamWindow<Integer>> expected3 = new
+		 ArrayList<StreamWindow<Integer>>();
+		 expected3.add(StreamWindow.fromElements(4));
+		 expected3.add(StreamWindow.fromElements(5));
+		 expected3.add(StreamWindow.fromElements(22));
+		 expected3.add(StreamWindow.fromElements(8));
+		 expected3.add(StreamWindow.fromElements(10));
+		
+		 validateOutput(expected3, DistributedSink1.windows);
+		
+		 // groupby mod3 Tumbling Count of 2 grouped by mod 2
+		 List<StreamWindow<Integer>> expected4 = new
+		 ArrayList<StreamWindow<Integer>>();
+		 expected4.add(StreamWindow.fromElements(2, 2));
+		 expected4.add(StreamWindow.fromElements(1));
+		 expected4.add(StreamWindow.fromElements(4));
+		 expected4.add(StreamWindow.fromElements(5, 11));
+		 expected4.add(StreamWindow.fromElements(10));
+		 expected4.add(StreamWindow.fromElements(11));
+		 expected4.add(StreamWindow.fromElements(3));
+		
+		 validateOutput(expected4, DistributedSink2.windows);
+		
+		 // min ( Time of 2 slide 3 )
+		 List<StreamWindow<Integer>> expected5 = new
+		 ArrayList<StreamWindow<Integer>>();
+		 expected5.add(StreamWindow.fromElements(1));
+		 expected5.add(StreamWindow.fromElements(4));
+		 expected5.add(StreamWindow.fromElements(10));
+		
+		 validateOutput(expected5, CentralSink3.windows);
+		
+		 // groupby mod 2 max ( Tumbling Time of 4)
+		 List<StreamWindow<Integer>> expected6 = new
+		 ArrayList<StreamWindow<Integer>>();
+		 expected6.add(StreamWindow.fromElements(3));
+		 expected6.add(StreamWindow.fromElements(5));
+		 expected6.add(StreamWindow.fromElements(11));
+		 expected6.add(StreamWindow.fromElements(4));
+		 expected6.add(StreamWindow.fromElements(10));
+		
+		 validateOutput(expected6, DistributedSink3.windows);
+		
+		 List<StreamWindow<Integer>> expected7 = new
+		 ArrayList<StreamWindow<Integer>>();
+		 expected7.add(StreamWindow.fromElements(1, 2, 2, 3, 4, 5));
+		 expected7.add(StreamWindow.fromElements(10));
+		 expected7.add(StreamWindow.fromElements(10, 11, 11));
+		
+		 validateOutput(expected7, DistributedSink4.windows);
 
 		List<StreamWindow<Integer>> expected8 = new ArrayList<StreamWindow<Integer>>();
-		expected8.add(StreamWindow.fromElements(12));
-		expected8.add(StreamWindow.fromElements(9));
-		expected8.add(StreamWindow.fromElements(32));
+		expected8.add(StreamWindow.fromElements(4, 8));
+		expected8.add(StreamWindow.fromElements(4, 5));
+		expected8.add(StreamWindow.fromElements(10, 22));
+
+		for (List<Integer> sw : DistributedSink5.windows) {
+			Collections.sort(sw);
+		}
 
 		validateOutput(expected8, DistributedSink5.windows);
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/policy/MultiTriggerPolicyTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/policy/MultiTriggerPolicyTest.java
@@ -31,6 +31,15 @@ import org.junit.Test;
 public class MultiTriggerPolicyTest {
 
 	/**
+	 * This constant defines the timeout for the test of the start ups of the
+	 * active trigger policy Threads.
+	 */
+	private static final int TIMEOUT = 120000;
+
+	// Use this to increase the timeout to be as long as possible.
+	// private static final int TIMEOUT=Integer.MAX_VALUE;
+
+	/**
 	 * This test covers all regular notify call. It takes no fake elements into
 	 * account.
 	 */
@@ -138,8 +147,8 @@ public class MultiTriggerPolicyTest {
 		Runnable runnable = multiTrigger.createActiveTriggerRunnable(cb);
 		new Thread(runnable).start();
 
-		assertTrue("Even after 10000ms not all active policy runnables were started.",
-				cb.check(10000, 1, 2, 3));
+		assertTrue("Even after " + TIMEOUT + "ms not all active policy runnables were started.",
+				cb.check(TIMEOUT, 1, 2, 3));
 	}
 
 	private void arrayEqualityCheck(Object[] array1, Object[] array2) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/BasicWindowBufferTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/BasicWindowBufferTest.java
@@ -41,8 +41,6 @@ public class BasicWindowBufferTest {
 		wb.store(2);
 		wb.store(10);
 
-		assertEquals(2, wb.size());
-
 		wb.emitWindow(collector);
 
 		assertEquals(1, collected.size());
@@ -50,8 +48,6 @@ public class BasicWindowBufferTest {
 
 		wb.store(4);
 		wb.evict(2);
-
-		assertEquals(1, wb.size());
 
 		wb.emitWindow(collector);
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountGroupedPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountGroupedPreReducerTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import static org.apache.flink.streaming.api.windowing.windowbuffer.SlidingTimeGroupedPreReducerTest.checkResults;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.invokable.operator.windowing.WindowIntegrationTest;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.apache.flink.streaming.api.windowing.windowbuffer.BasicWindowBufferTest.TestCollector;
+import org.junit.Test;
+
+public class SlidingCountGroupedPreReducerTest {
+
+	TypeSerializer<Integer> serializer = TypeExtractor.getForObject(1).createSerializer(null);
+
+	ReduceFunction<Integer> reducer = new SumReducer();
+
+	KeySelector<Integer, ?> key = new WindowIntegrationTest.ModKey(2);
+
+	@Test
+	public void testPreReduce1() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountGroupedPreReducer<Integer> preReducer = new SlidingCountGroupedPreReducer<Integer>(
+				reducer, serializer, key, 3, 2, 0);
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(1, 2));
+		expected.add(StreamWindow.fromElements(3, 6));
+		expected.add(StreamWindow.fromElements(5, 10));
+		expected.add(StreamWindow.fromElements(7, 14));
+		expected.add(StreamWindow.fromElements(9, 18));
+		expected.add(StreamWindow.fromElements(11, 22));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce2() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountGroupedPreReducer<Integer> preReducer = new SlidingCountGroupedPreReducer<Integer>(
+				reducer, serializer, key, 5, 2, 0);
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.emitWindow(collector);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(1, 2));
+		expected.add(StreamWindow.fromElements(4, 6));
+		expected.add(StreamWindow.fromElements(12, 8));
+		expected.add(StreamWindow.fromElements(18, 12));
+		expected.add(StreamWindow.fromElements(24, 16));
+		expected.add(StreamWindow.fromElements(30, 20));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce3() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountGroupedPreReducer<Integer> preReducer = new SlidingCountGroupedPreReducer<Integer>(
+				reducer, serializer, key, 6, 3, 0);
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.store(3);
+		preReducer.emitWindow(collector);
+		preReducer.store(4);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.store(9);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(10);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(2, 4));
+		expected.add(StreamWindow.fromElements(9, 12));
+		expected.add(StreamWindow.fromElements(21, 18));
+		expected.add(StreamWindow.fromElements(30, 27));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce4() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountGroupedPreReducer<Integer> preReducer = new SlidingCountGroupedPreReducer<Integer>(
+				reducer, serializer, key, 5, 1, 2);
+
+		preReducer.store(1);
+		preReducer.evict(1);
+		preReducer.store(1);
+		preReducer.evict(1);
+		preReducer.store(1);
+		preReducer.emitWindow(collector);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.emitWindow(collector);
+		preReducer.store(4);
+		preReducer.emitWindow(collector);
+		preReducer.store(5);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.store(7);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(1));
+		expected.add(StreamWindow.fromElements(1, 2));
+		expected.add(StreamWindow.fromElements(4, 2));
+		expected.add(StreamWindow.fromElements(4, 6));
+		expected.add(StreamWindow.fromElements(9, 6));
+		expected.add(StreamWindow.fromElements(8, 12));
+		expected.add(StreamWindow.fromElements(15, 10));
+		expected.add(StreamWindow.fromElements(12, 18));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	private static class SumReducer implements ReduceFunction<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer reduce(Integer value1, Integer value2) throws Exception {
+			return value1 + value2;
+		}
+
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingCountPreReducerTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.apache.flink.streaming.api.windowing.windowbuffer.BasicWindowBufferTest.TestCollector;
+import org.junit.Test;
+
+public class SlidingCountPreReducerTest {
+
+	TypeSerializer<Integer> serializer = TypeExtractor.getForObject(1).createSerializer(null);
+
+	ReduceFunction<Integer> reducer = new SumReducer();
+
+	@Test
+	public void testPreReduce1() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountPreReducer<Integer> preReducer = new SlidingCountPreReducer<Integer>(reducer,
+				serializer, 3, 2, 0);
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(3));
+		expected.add(StreamWindow.fromElements(9));
+		expected.add(StreamWindow.fromElements(15));
+		expected.add(StreamWindow.fromElements(21));
+		expected.add(StreamWindow.fromElements(27));
+		expected.add(StreamWindow.fromElements(33));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce2() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountPreReducer<Integer> preReducer = new SlidingCountPreReducer<Integer>(reducer,
+				serializer, 5, 2, 0);
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.emitWindow(collector);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(3));
+		expected.add(StreamWindow.fromElements(10));
+		expected.add(StreamWindow.fromElements(20));
+		expected.add(StreamWindow.fromElements(30));
+		expected.add(StreamWindow.fromElements(40));
+		expected.add(StreamWindow.fromElements(50));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce3() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountPreReducer<Integer> preReducer = new SlidingCountPreReducer<Integer>(reducer,
+				serializer, 6, 3, 0);
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.store(3);
+		preReducer.emitWindow(collector);
+		preReducer.store(4);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.store(9);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(10);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(6));
+		expected.add(StreamWindow.fromElements(21));
+		expected.add(StreamWindow.fromElements(39));
+		expected.add(StreamWindow.fromElements(57));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce4() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingCountPreReducer<Integer> preReducer = new SlidingCountPreReducer<Integer>(reducer,
+				serializer, 5, 1, 2);
+
+		preReducer.store(1);
+		preReducer.evict(1);
+		preReducer.store(1);
+		preReducer.evict(1);
+		preReducer.store(1);
+		preReducer.emitWindow(collector);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.emitWindow(collector);
+		preReducer.store(4);
+		preReducer.emitWindow(collector);
+		preReducer.store(5);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.store(7);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(1));
+		expected.add(StreamWindow.fromElements(3));
+		expected.add(StreamWindow.fromElements(6));
+		expected.add(StreamWindow.fromElements(10));
+		expected.add(StreamWindow.fromElements(15));
+		expected.add(StreamWindow.fromElements(20));
+		expected.add(StreamWindow.fromElements(25));
+		expected.add(StreamWindow.fromElements(30));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	private static class SumReducer implements ReduceFunction<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer reduce(Integer value1, Integer value2) throws Exception {
+			return value1 + value2;
+		}
+
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimeGroupedPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimeGroupedPreReducerTest.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.invokable.operator.windowing.WindowIntegrationTest;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.apache.flink.streaming.api.windowing.helper.Timestamp;
+import org.apache.flink.streaming.api.windowing.helper.TimestampWrapper;
+import org.apache.flink.streaming.api.windowing.windowbuffer.BasicWindowBufferTest.TestCollector;
+import org.junit.Test;
+
+public class SlidingTimeGroupedPreReducerTest {
+
+	TypeSerializer<Integer> serializer = TypeExtractor.getForObject(1).createSerializer(null);
+
+	ReduceFunction<Integer> reducer = new SumReducer();
+
+	KeySelector<Integer, ?> key = new WindowIntegrationTest.ModKey(2);
+
+	@Test
+	public void testPreReduce1() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimeGroupedPreReducer<Integer> preReducer = new SlidingTimeGroupedPreReducer<Integer>(
+				reducer, serializer, key, 3, 2, new TimestampWrapper<Integer>(
+						new Timestamp<Integer>() {
+
+							private static final long serialVersionUID = 1L;
+
+							@Override
+							public long getTimestamp(Integer value) {
+								return value;
+							}
+						}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(1, 2));
+		expected.add(StreamWindow.fromElements(3, 6));
+		expected.add(StreamWindow.fromElements(5, 10));
+		expected.add(StreamWindow.fromElements(7, 14));
+		expected.add(StreamWindow.fromElements(9, 18));
+		expected.add(StreamWindow.fromElements(11, 22));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	protected static void checkResults(List<StreamWindow<Integer>> expected,
+			List<StreamWindow<Integer>> actual) {
+
+		for (StreamWindow<Integer> sw : expected) {
+			Collections.sort(sw);
+		}
+
+		for (StreamWindow<Integer> sw : actual) {
+			Collections.sort(sw);
+		}
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testPreReduce2() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimeGroupedPreReducer<Integer> preReducer = new SlidingTimeGroupedPreReducer<Integer>(
+				reducer, serializer, key, 5, 2, new TimestampWrapper<Integer>(
+						new Timestamp<Integer>() {
+
+							private static final long serialVersionUID = 1L;
+
+							@Override
+							public long getTimestamp(Integer value) {
+								return value;
+							}
+						}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.emitWindow(collector);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(1, 2));
+		expected.add(StreamWindow.fromElements(4, 6));
+		expected.add(StreamWindow.fromElements(12, 8));
+		expected.add(StreamWindow.fromElements(18, 12));
+		expected.add(StreamWindow.fromElements(24, 16));
+		expected.add(StreamWindow.fromElements(30, 20));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce3() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimeGroupedPreReducer<Integer> preReducer = new SlidingTimeGroupedPreReducer<Integer>(
+				reducer, serializer, key, 6, 3, new TimestampWrapper<Integer>(
+						new Timestamp<Integer>() {
+
+							private static final long serialVersionUID = 1L;
+
+							@Override
+							public long getTimestamp(Integer value) {
+								return value;
+							}
+						}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.store(3);
+		preReducer.emitWindow(collector);
+		preReducer.store(4);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.store(9);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(10);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(2, 4));
+		expected.add(StreamWindow.fromElements(9, 12));
+		expected.add(StreamWindow.fromElements(21, 18));
+		expected.add(StreamWindow.fromElements(30, 27));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce4() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimeGroupedPreReducer<Integer> preReducer = new SlidingTimeGroupedPreReducer<Integer>(
+				reducer, serializer, key, 3, 2, new TimestampWrapper<Integer>(
+						new Timestamp<Integer>() {
+
+							private static final long serialVersionUID = 1L;
+
+							@Override
+							public long getTimestamp(Integer value) {
+								return value;
+							}
+						}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.emitWindow(collector);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(14);
+		preReducer.emitWindow(collector);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.emitWindow(collector);
+		preReducer.store(21);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+
+		preReducer.store(9);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(1, 2));
+		expected.add(StreamWindow.fromElements(3, 6));
+		expected.add(StreamWindow.fromElements(5, 10));
+		expected.add(StreamWindow.fromElements(7, 14));
+		expected.add(StreamWindow.fromElements(8));
+		expected.add(StreamWindow.fromElements(8));
+		expected.add(StreamWindow.fromElements(14));
+		expected.add(StreamWindow.fromElements(14));
+		expected.add(StreamWindow.fromElements(21));
+
+		checkResults(expected, collector.getCollected());
+	}
+
+	private static class SumReducer implements ReduceFunction<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer reduce(Integer value1, Integer value2) throws Exception {
+			return value1 + value2;
+		}
+
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducerTest.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windowbuffer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.apache.flink.streaming.api.windowing.helper.Timestamp;
+import org.apache.flink.streaming.api.windowing.helper.TimestampWrapper;
+import org.apache.flink.streaming.api.windowing.windowbuffer.BasicWindowBufferTest.TestCollector;
+import org.junit.Test;
+
+public class SlidingTimePreReducerTest {
+
+	TypeSerializer<Integer> serializer = TypeExtractor.getForObject(1).createSerializer(null);
+
+	ReduceFunction<Integer> reducer = new SumReducer();
+
+	@Test
+	public void testPreReduce1() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimePreReducer<Integer> preReducer = new SlidingTimePreReducer<Integer>(reducer,
+				serializer, 3, 2, new TimestampWrapper<Integer>(new Timestamp<Integer>() {
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public long getTimestamp(Integer value) {
+						return value;
+					}
+				}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(3));
+		expected.add(StreamWindow.fromElements(9));
+		expected.add(StreamWindow.fromElements(15));
+		expected.add(StreamWindow.fromElements(21));
+		expected.add(StreamWindow.fromElements(27));
+		expected.add(StreamWindow.fromElements(33));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce2() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimePreReducer<Integer> preReducer = new SlidingTimePreReducer<Integer>(reducer,
+				serializer, 5, 2, new TimestampWrapper<Integer>(new Timestamp<Integer>() {
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public long getTimestamp(Integer value) {
+						return value;
+					}
+				}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.emitWindow(collector);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(9);
+		preReducer.store(10);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(3));
+		expected.add(StreamWindow.fromElements(10));
+		expected.add(StreamWindow.fromElements(20));
+		expected.add(StreamWindow.fromElements(30));
+		expected.add(StreamWindow.fromElements(40));
+		expected.add(StreamWindow.fromElements(50));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce3() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimePreReducer<Integer> preReducer = new SlidingTimePreReducer<Integer>(reducer,
+				serializer, 6, 3, new TimestampWrapper<Integer>(new Timestamp<Integer>() {
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public long getTimestamp(Integer value) {
+						return value;
+					}
+				}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.store(3);
+		preReducer.emitWindow(collector);
+		preReducer.store(4);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.store(9);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(10);
+		preReducer.store(11);
+		preReducer.store(12);
+		preReducer.emitWindow(collector);
+		preReducer.evict(3);
+		preReducer.store(13);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(6));
+		expected.add(StreamWindow.fromElements(21));
+		expected.add(StreamWindow.fromElements(39));
+		expected.add(StreamWindow.fromElements(57));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	@Test
+	public void testPreReduce4() throws Exception {
+		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+
+		SlidingTimePreReducer<Integer> preReducer = new SlidingTimePreReducer<Integer>(reducer,
+				serializer, 3, 2, new TimestampWrapper<Integer>(new Timestamp<Integer>() {
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public long getTimestamp(Integer value) {
+						return value;
+					}
+				}, 1));
+
+		preReducer.store(1);
+		preReducer.store(2);
+		preReducer.emitWindow(collector);
+		preReducer.store(3);
+		preReducer.store(4);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(5);
+		preReducer.store(6);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(7);
+		preReducer.store(8);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.emitWindow(collector);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(14);
+		preReducer.emitWindow(collector);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.emitWindow(collector);
+		preReducer.store(21);
+		preReducer.emitWindow(collector);
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+
+		preReducer.store(9);
+
+		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
+		expected.add(StreamWindow.fromElements(3));
+		expected.add(StreamWindow.fromElements(9));
+		expected.add(StreamWindow.fromElements(15));
+		expected.add(StreamWindow.fromElements(21));
+		expected.add(StreamWindow.fromElements(8));
+		expected.add(StreamWindow.fromElements(8));
+		expected.add(StreamWindow.fromElements(14));
+		expected.add(StreamWindow.fromElements(14));
+		expected.add(StreamWindow.fromElements(21));
+
+		assertEquals(expected, collector.getCollected());
+	}
+
+	private static class SumReducer implements ReduceFunction<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer reduce(Integer value1, Integer value2) throws Exception {
+			return value1 + value2;
+		}
+
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducerTest.java
@@ -67,18 +67,12 @@ public class TumblingGroupedPreReducerTest {
 
 		wb.store(serializer.copy(inputs.get(0)));
 		wb.store(serializer.copy(inputs.get(1)));
-
-		assertEquals(2, wb.size());
-
 		wb.emitWindow(collector);
 
 		assertEquals(1, collected.size());
 
 		assertSetEquals(StreamWindow.fromElements(new Tuple2<Integer, Integer>(1, 1),
 				new Tuple2<Integer, Integer>(0, 0)), collected.get(0));
-
-		// Test automatic eviction
-		assertEquals(0, wb.size());
 
 		wb.store(serializer.copy(inputs.get(0)));
 		wb.store(serializer.copy(inputs.get(1)));
@@ -89,7 +83,6 @@ public class TumblingGroupedPreReducerTest {
 
 		wb.store(serializer.copy(inputs.get(3)));
 
-		assertEquals(4, wb.size());
 		wb.emitWindow(collector);
 
 		assertEquals(2, collected.size());

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingPreReducerTest.java
@@ -58,16 +58,11 @@ public class TumblingPreReducerTest {
 		wb.store(serializer.copy(inputs.get(0)));
 		wb.store(serializer.copy(inputs.get(1)));
 
-		assertEquals(2, wb.size());
-
 		wb.emitWindow(collector);
 
 		assertEquals(1, collected.size());
 		assertEquals(StreamWindow.fromElements(new Tuple2<Integer, Integer>(3, 1)),
 				collected.get(0));
-
-		// Test automatic eviction
-		assertEquals(0, wb.size());
 
 		wb.store(serializer.copy(inputs.get(0)));
 		wb.store(serializer.copy(inputs.get(1)));
@@ -78,7 +73,6 @@ public class TumblingPreReducerTest {
 
 		wb.store(serializer.copy(inputs.get(3)));
 
-		assertEquals(4, wb.size());
 		wb.emitWindow(collector);
 
 		assertEquals(2, collected.size());


### PR DESCRIPTION
This PR introduces several key optimization features and some fixes for different windowing JIRA-s

- Parallel count window discretization in case of parallel inputs
- PreReducers for sliding count and time based policies
- Detection of tumbling policies (for example count of 5 every 5 etc.)
- New tests and refactoring of the windowed datastream with an added utility class for windowing checks