### PR TITLE
[FLINK-1567] [gelly] improvements to the gelly examples.

### DIFF
--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GraphMetrics.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GraphMetrics.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.aggregation.Aggregations;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.example.utils.ExampleUtils;
 import org.apache.flink.types.NullValue;
@@ -42,25 +43,24 @@ import org.apache.flink.types.NullValue;
  * - average node degree
  * - the vertex ids with the max/min in- and out-degrees
  *
+ * The input file is expected to contain one edge per line,
+ * with long IDs and no values, in the following format:
+ * "<sourceVertexID>\t<targetVertexID>".
+ * If no arguments are provided, the example runs with a random graph of 100 vertices.
+ *
  */
 public class GraphMetrics implements ProgramDescription {
 
-	static final int NUM_VERTICES = 100;
-	static final long SEED = 9876;
-	
-
-	@Override
-	public String getDescription() {
-		return "Graph Metrics Example";
-	}
-
 	public static void main(String[] args) throws Exception {
+
+		if (!parseParameters(args)) {
+			return;
+		}
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-		/** create a random graph **/
-		Graph<Long, NullValue, NullValue> graph = Graph.fromDataSet(ExampleUtils
-				.getRandomEdges(env, NUM_VERTICES), env);
+		/** create the graph **/
+		Graph<Long, NullValue, NullValue> graph = Graph.fromDataSet(getEdgesDataSet(env), env);
 		
 		/** get the number of vertices **/
 		DataSet<Integer> numVertices = graph.numberOfVertices();
@@ -98,7 +98,7 @@ public class GraphMetrics implements ProgramDescription {
 
 		env.execute();
 	}
-	
+
 	@SuppressWarnings("serial")
 	private static final class AvgNodeDegreeMapper extends RichMapFunction<Tuple2<Long, Long>, Double> {
 
@@ -119,5 +119,59 @@ public class GraphMetrics implements ProgramDescription {
 	@SuppressWarnings("serial")
 	private static final class ProjectVertexId implements MapFunction<Tuple2<Long,Long>, Long> {
 		public Long map(Tuple2<Long, Long> value) { return value.f0; }
+	}
+
+	@Override
+	public String getDescription() {
+		return "Graph Metrics Example";
+	}
+
+	// ******************************************************************************************************************
+	// UTIL METHODS
+	// ******************************************************************************************************************
+
+	private static boolean fileOutput = false;
+
+	private static String edgesInputPath = null;
+
+	static final int NUM_VERTICES = 100;
+
+	static final long SEED = 9876;
+
+	private static boolean parseParameters(String[] args) {
+
+		if(args.length > 0) {
+			if(args.length != 1) {
+				System.err.println("Usage: LabelPropagation <vertex path> <edge path> <output path> <num iterations>");
+				return false;
+			}
+
+			fileOutput = true;
+			edgesInputPath = args[0];
+		} else {
+			System.out.println("Executing Graph Metrics example with default parameters and built-in default data.");
+			System.out.println("  Provide parameters to read input data from files.");
+			System.out.println("  See the documentation for the correct format of input files.");
+			System.out.println("Usage: GraphMetrics <input edges>");
+		}
+		return true;
+	}
+
+	@SuppressWarnings("serial")
+	private static DataSet<Edge<Long, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+		if (fileOutput) {
+			return env.readCsvFile(edgesInputPath)
+					.lineDelimiter("\n").fieldDelimiter("\t")
+					.types(Long.class, Long.class).map(
+							new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
+
+								public Edge<Long, NullValue> map(Tuple2<Long, Long> value) {
+									return new Edge<Long, NullValue>(value.f0, value.f1, 
+											NullValue.getInstance());
+								}
+					});
+		} else {
+			return ExampleUtils.getRandomEdges(env, NUM_VERTICES);
+		}
 	}
 }

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/utils/SingleSourceShortestPathsData.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/utils/SingleSourceShortestPathsData.java
@@ -21,33 +21,16 @@ package org.apache.flink.graph.example.utils;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Edge;
-import org.apache.flink.graph.Vertex;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class SingleSourceShortestPathsData {
 
-	public static final int NUM_VERTICES = 5;
-
 	public static final Long SRC_VERTEX_ID = 1L;
 
-	public static final String VERTICES = "1,1.0\n" + "2,2.0\n" + "3,3.0\n" + "4,4.0\n" + "5,5.0";
-
-	public static DataSet<Vertex<Long, Double>> getDefaultVertexDataSet(ExecutionEnvironment env) {
-
-		List<Vertex<Long, Double>> vertices = new ArrayList<Vertex<Long, Double>>();
-		vertices.add(new Vertex<Long, Double>(1L, 1.0));
-		vertices.add(new Vertex<Long, Double>(2L, 2.0));
-		vertices.add(new Vertex<Long, Double>(3L, 3.0));
-		vertices.add(new Vertex<Long, Double>(4L, 4.0));
-		vertices.add(new Vertex<Long, Double>(5L, 5.0));
-
-		return env.fromCollection(vertices);
-	}
-
-	public static final String EDGES = "1,2,12.0\n" + "1,3,13.0\n" + "2,3,23.0\n" + "3,4,34.0\n" + "3,5,35.0\n" + 
-					"4,5,45.0\n" + "5,1,51.0";
+	public static final String EDGES = "1\t2\t12.0\n" + "1\t3\t13.0\n" + "2\t3\t23.0\n" + "3\t4\t34.0\n" + "3\t5\t35.0\n" +
+					"4\t5\t45.0\n" + "5\t1\t51.0";
 
 	public static final DataSet<Edge<Long, Double>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 

--- a/flink-staging/flink-gelly/src/test/java/org/apache/flink/graph/test/example/LabelPropagationExampleITCase.java
+++ b/flink-staging/flink-gelly/src/test/java/org/apache/flink/graph/test/example/LabelPropagationExampleITCase.java
@@ -61,20 +61,20 @@ public class LabelPropagationExampleITCase extends MultipleProgramsTestBase {
 		 * Test one iteration of label propagation example with a simple graph
 		 */
 
-		final String vertices = "1 10\n" +
-				"2 10\n" +
-				"3 30\n" +
-				"4 40\n" +
-				"5 40\n" +
-				"6 40\n" +
-				"7 70\n";
+		final String vertices = "1	10\n" +
+				"2	10\n" +
+				"3	30\n" +
+				"4	40\n" +
+				"5	40\n" +
+				"6	40\n" +
+				"7	70\n";
 
-		final String edges = "1 3\n" +
-				"2 3\n" +
-				"4 7\n" +
-				"5 7\n" +
-				"6 7\n" +
-				"7 3\n";
+		final String edges = "1	3\n" +
+				"2	3\n" +
+				"4	7\n" +
+				"5	7\n" +
+				"6	7\n" +
+				"7	3\n";
 
 		String verticesPath = createTempFile(vertices);
 		String edgesPath = createTempFile(edges);
@@ -96,24 +96,24 @@ public class LabelPropagationExampleITCase extends MultipleProgramsTestBase {
 		 * Test the label propagation example where a tie must be broken
 		 */
 
-		final String vertices = "1 10\n" +
-				"2 10\n" +
-				"3 10\n" +
-				"4 10\n" +
-				"5 0\n" +
-				"6 20\n" +
-				"7 20\n" +
-				"8 20\n" +
-				"9 20\n";
+		final String vertices = "1	10\n" +
+				"2	10\n" +
+				"3	10\n" +
+				"4	10\n" +
+				"5	0\n" +
+				"6	20\n" +
+				"7	20\n" +
+				"8	20\n" +
+				"9	20\n";
 
-		final String edges = "1 5\n" +
-				"2 5\n" +
-				"3 5\n" +
-				"4 5\n" +
-				"6 5\n" +
-				"7 5\n" +
-				"8 5\n" +
-				"9 5\n";
+		final String edges = "1	5\n" +
+				"2	5\n" +
+				"3	5\n" +
+				"4	5\n" +
+				"6	5\n" +
+				"7	5\n" +
+				"8	5\n" +
+				"9	5\n";
 
 		String verticesPath = createTempFile(vertices);
 		String edgesPath = createTempFile(edges);

--- a/flink-staging/flink-gelly/src/test/java/org/apache/flink/graph/test/example/SingleSourceShortestPathsITCase.java
+++ b/flink-staging/flink-gelly/src/test/java/org/apache/flink/graph/test/example/SingleSourceShortestPathsITCase.java
@@ -36,8 +36,6 @@ import java.io.File;
 @RunWith(Parameterized.class)
 public class SingleSourceShortestPathsITCase extends MultipleProgramsTestBase {
 
-    private String verticesPath;
-
     private String edgesPath;
 
     private String resultPath;
@@ -54,20 +52,16 @@ public class SingleSourceShortestPathsITCase extends MultipleProgramsTestBase {
     @Before
     public void before() throws Exception {
         resultPath = tempFolder.newFile().toURI().toString();
-        File verticesFile = tempFolder.newFile();
-        Files.write(SingleSourceShortestPathsData.VERTICES, verticesFile, Charsets.UTF_8);
 
         File edgesFile = tempFolder.newFile();
         Files.write(SingleSourceShortestPathsData.EDGES, edgesFile, Charsets.UTF_8);
-
-        verticesPath = verticesFile.toURI().toString();
         edgesPath = edgesFile.toURI().toString();
     }
 
     @Test
     public void testSSSPExample() throws Exception {
         SingleSourceShortestPathsExample.main(new String[]{SingleSourceShortestPathsData.SRC_VERTEX_ID + "",
-                verticesPath, edgesPath, resultPath, SingleSourceShortestPathsData.NUM_VERTICES + ""});
+                edgesPath, resultPath, 10 + ""});
         expected = SingleSourceShortestPathsData.RESULTED_SINGLE_SOURCE_SHORTEST_PATHS;
     }
 


### PR DESCRIPTION
Updated GraphMetrics, MusicProfiles and PageRank to run with and without parameters.
Added input descriptions to LabelPropagation and SSSP.
Fixed some minor issues in the SSSP example.
Fixed a bug in MusicProfiles that wasn't generating the user-user graph properly.
Changed the PageRank library method to initialize the vertex ranks.