### PR TITLE
[FLINK-1594] [streaming] [wip] DataStream supports self-connection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -89,6 +89,10 @@ public class Buffer {
 			return memorySegment.wrap(0, currentSize).duplicate();
 		}
 	}
+	
+	public BufferRecycler getRecycler(){
+		return recycler;
+	}
 
 	public int getSize() {
 		synchronized (recycleLock) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferTest.java
@@ -50,4 +50,5 @@ public class BufferTest {
 			// OK => expected exception
 		}
 	}
+
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamConfig.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamConfig.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.SerializationException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.collector.OutputSelector;
+import org.apache.flink.streaming.api.collector.selector.OutputSelectorWrapper;
 import org.apache.flink.streaming.api.invokable.StreamInvokable;
 import org.apache.flink.streaming.api.streamrecord.StreamRecordSerializer;
 import org.apache.flink.streaming.api.streamvertex.StreamVertexException;
@@ -49,7 +49,8 @@ public class StreamConfig implements Serializable {
 	private static final String VERTEX_NAME = "vertexID";
 	private static final String OPERATOR_NAME = "operatorName";
 	private static final String ITERATION_ID = "iteration-id";
-	private static final String OUTPUT_SELECTOR = "outputSelector";
+//	private static final String OUTPUT_SELECTOR = "outputSelector";
+	private static final String OUTPUT_SELECTOR_WRAPPER = "outputSelectorWrapper";
 	private static final String DIRECTED_EMIT = "directedEmit";
 	private static final String SERIALIZEDUDF = "serializedudf";
 	private static final String USER_FUNCTION = "userfunction";
@@ -67,7 +68,6 @@ public class StreamConfig implements Serializable {
 	private static final String IN_STREAM_EDGES = "out stream edges";
 
 	// DEFAULT VALUES
-
 	private static final long DEFAULT_TIMEOUT = 100;
 	public static final String STATE_MONITORING = "STATE_MONITORING";
 
@@ -189,33 +189,21 @@ public class StreamConfig implements Serializable {
 		}
 	}
 
-	public void setDirectedEmit(boolean directedEmit) {
-		config.setBoolean(DIRECTED_EMIT, directedEmit);
-	}
-
-	public boolean isDirectedEmit() {
-		return config.getBoolean(DIRECTED_EMIT, false);
-	}
-
-	public void setOutputSelectors(List<OutputSelector<?>> outputSelector) {
+	public void setOutputSelectorWrapper(OutputSelectorWrapper<?> outputSelectorWrapper) {
 		try {
-			if (outputSelector != null && !outputSelector.isEmpty()) {
-				setDirectedEmit(true);
-				config.setBytes(OUTPUT_SELECTOR,
-						SerializationUtils.serialize((Serializable) outputSelector));
-			}
+			config.setBytes(OUTPUT_SELECTOR_WRAPPER, SerializationUtils.serialize(outputSelectorWrapper));
 		} catch (SerializationException e) {
-			throw new RuntimeException("Cannot serialize OutputSelector");
+			throw new RuntimeException("Cannot serialize OutputSelectorWrapper");
 		}
 	}
 
 	@SuppressWarnings("unchecked")
-	public <T> List<OutputSelector<T>> getOutputSelectors(ClassLoader cl) {
+	public <T> OutputSelectorWrapper<T> getOutputSelectorWrapper(ClassLoader cl) {
 		try {
-			return (List<OutputSelector<T>>) InstantiationUtil.readObjectFromConfig(this.config,
-					OUTPUT_SELECTOR, cl);
+			return (OutputSelectorWrapper<T>) InstantiationUtil.readObjectFromConfig(this.config,
+					OUTPUT_SELECTOR_WRAPPER, cl);
 		} catch (Exception e) {
-			throw new StreamVertexException("Cannot deserialize and instantiate OutputSelector", e);
+			throw new StreamVertexException("Cannot deserialize and instantiate OutputSelectorWrapper", e);
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamConfig.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamConfig.java
@@ -49,9 +49,7 @@ public class StreamConfig implements Serializable {
 	private static final String VERTEX_NAME = "vertexID";
 	private static final String OPERATOR_NAME = "operatorName";
 	private static final String ITERATION_ID = "iteration-id";
-//	private static final String OUTPUT_SELECTOR = "outputSelector";
 	private static final String OUTPUT_SELECTOR_WRAPPER = "outputSelectorWrapper";
-	private static final String DIRECTED_EMIT = "directedEmit";
 	private static final String SERIALIZEDUDF = "serializedudf";
 	private static final String USER_FUNCTION = "userfunction";
 	private static final String BUFFER_TIMEOUT = "bufferTimeout";
@@ -60,9 +58,7 @@ public class StreamConfig implements Serializable {
 	private static final String TYPE_SERIALIZER_OUT_1 = "typeSerializer_out_1";
 	private static final String TYPE_SERIALIZER_OUT_2 = "typeSerializer_out_2";
 	private static final String ITERATON_WAIT = "iterationWait";
-	private static final String OUTPUTS = "outvertexIDs";
 	private static final String NONCHAINED_OUTPUTS = "NONCHAINED_OUTPUTS";
-	private static final String CHAINED_OUTPUT_EDGES = "CHAINED_OUTPUTS";
 	private static final String EDGES_IN_ORDER = "rwOrder";
 	private static final String OUT_STREAM_EDGES = "out stream edges";
 	private static final String IN_STREAM_EDGES = "out stream edges";
@@ -247,7 +243,7 @@ public class StreamConfig implements Serializable {
 					SerializationUtils.serialize((Serializable) selected));
 		} else {
 			config.setBytes(OUTPUT_NAME + output,
-					SerializationUtils.serialize((Serializable) new ArrayList<String>()));
+					SerializationUtils.serialize(new ArrayList<String>()));
 		}
 	}
 
@@ -305,6 +301,7 @@ public class StreamConfig implements Serializable {
 		config.setBytes(OUT_STREAM_EDGES, SerializationUtils.serialize((Serializable) outEdges));
 	}
 
+	@SuppressWarnings("unchecked")
 	public List<StreamEdge> getOutEdges(ClassLoader cl) {
 		try {
 			return (List<StreamEdge>) InstantiationUtil.readObjectFromConfig(
@@ -318,6 +315,7 @@ public class StreamConfig implements Serializable {
 		config.setBytes(IN_STREAM_EDGES, SerializationUtils.serialize((Serializable) inEdges));
 	}
 
+	@SuppressWarnings("unchecked")
 	public List<StreamEdge> getInEdges(ClassLoader cl) {
 		try {
 			return (List<StreamEdge>) InstantiationUtil.readObjectFromConfig(

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamConfig.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamConfig.java
@@ -60,7 +60,11 @@ public class StreamConfig implements Serializable {
 	private static final String TYPE_SERIALIZER_OUT_2 = "typeSerializer_out_2";
 	private static final String ITERATON_WAIT = "iterationWait";
 	private static final String OUTPUTS = "outvertexIDs";
+	private static final String NONCHAINED_OUTPUTS = "NONCHAINED_OUTPUTS";
+	private static final String CHAINED_OUTPUT_EDGES = "CHAINED_OUTPUTS";
 	private static final String EDGES_IN_ORDER = "rwOrder";
+	private static final String OUT_STREAM_EDGES = "out stream edges";
+	private static final String IN_STREAM_EDGES = "out stream edges";
 
 	// DEFAULT VALUES
 
@@ -281,16 +285,57 @@ public class StreamConfig implements Serializable {
 		return config.getInteger(NUMBER_OF_OUTPUTS, 0);
 	}
 
-	public void setOutputs(List<Integer> outputvertexIDs) {
-		config.setBytes(OUTPUTS, SerializationUtils.serialize((Serializable) outputvertexIDs));
+	public void setNonChainedOutputs(List<StreamEdge> outputvertexIDs) {
+		config.setBytes(NONCHAINED_OUTPUTS, SerializationUtils.serialize((Serializable) outputvertexIDs));
 	}
 
 	@SuppressWarnings("unchecked")
-	public List<Integer> getOutputs(ClassLoader cl) {
+	public List<StreamEdge> getNonChainedOutputs(ClassLoader cl) {
 		try {
-			return (List<Integer>) InstantiationUtil.readObjectFromConfig(this.config, OUTPUTS, cl);
+			return (List<StreamEdge>) InstantiationUtil.readObjectFromConfig(this.config, NONCHAINED_OUTPUTS, cl);
 		} catch (Exception e) {
 			throw new RuntimeException("Could not instantiate outputs.");
+		}
+	}
+
+	public void setChainedOutputs(List<StreamEdge> chainedOutputs) {
+		config.setBytes(CHAINED_OUTPUTS,
+				SerializationUtils.serialize((Serializable) chainedOutputs));
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<StreamEdge> getChainedOutputs(ClassLoader cl) {
+		try {
+			return (List<StreamEdge>) InstantiationUtil.readObjectFromConfig(this.config,
+					CHAINED_OUTPUTS, cl);
+		} catch (Exception e) {
+			throw new RuntimeException("Could not instantiate chained outputs.");
+		}
+	}
+
+	public void setOutEdges(List<StreamEdge> outEdges) {
+		config.setBytes(OUT_STREAM_EDGES, SerializationUtils.serialize((Serializable) outEdges));
+	}
+
+	public List<StreamEdge> getOutEdges(ClassLoader cl) {
+		try {
+			return (List<StreamEdge>) InstantiationUtil.readObjectFromConfig(
+					this.config, OUT_STREAM_EDGES, cl);
+		} catch (Exception e) {
+			throw new RuntimeException("Could not instantiate outputs.");
+		}
+	}
+
+	public void setInEdges(List<StreamEdge> inEdges) {
+		config.setBytes(IN_STREAM_EDGES, SerializationUtils.serialize((Serializable) inEdges));
+	}
+
+	public List<StreamEdge> getInEdges(ClassLoader cl) {
+		try {
+			return (List<StreamEdge>) InstantiationUtil.readObjectFromConfig(
+					this.config, IN_STREAM_EDGES, cl);
+		} catch (Exception e) {
+			throw new RuntimeException("Could not instantiate inputs.");
 		}
 	}
 
@@ -327,21 +372,6 @@ public class StreamConfig implements Serializable {
 
 	public int getInputIndex(int inputNumber) {
 		return config.getInteger(INPUT_TYPE + inputNumber, 0);
-	}
-
-	public void setChainedOutputs(List<Integer> chainedOutputs) {
-		config.setBytes(CHAINED_OUTPUTS,
-				SerializationUtils.serialize((Serializable) chainedOutputs));
-	}
-
-	@SuppressWarnings("unchecked")
-	public List<Integer> getChainedOutputs(ClassLoader cl) {
-		try {
-			return (List<Integer>) InstantiationUtil.readObjectFromConfig(this.config,
-					CHAINED_OUTPUTS, cl);
-		} catch (Exception e) {
-			throw new RuntimeException("Could not instantiate chained outputs.");
-		}
 	}
 
 	public void setTransitiveChainedTaskConfigs(Map<Integer, StreamConfig> chainedTaskConfigs) {
@@ -382,9 +412,10 @@ public class StreamConfig implements Serializable {
 		builder.append("\nTask name: " + getVertexID());
 		builder.append("\nNumber of non-chained inputs: " + getNumberOfInputs());
 		builder.append("\nNumber of non-chained outputs: " + getNumberOfOutputs());
-		builder.append("\nOutput names: " + getOutputs(cl));
+		builder.append("\nOutput names: " + getNonChainedOutputs(cl));
 		builder.append("\nPartitioning:");
-		for (Integer outputname : getOutputs(cl)) {
+		for (StreamEdge output : getNonChainedOutputs(cl)) {
+			int outputname = output.getTargetVertex();
 			builder.append("\n\t" + outputname + ": " + getPartitioner(cl, outputname));
 		}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
@@ -55,7 +55,7 @@ public class StreamEdge {
 		return selectedNames;
 	}
 
-	public StreamPartitioner<?> getOutputPartitioner() {
+	public StreamPartitioner<?> getPartitioner() {
 		return outputPartitioner;
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api;
+
+import java.util.List;
+
+import org.apache.flink.streaming.partitioner.StreamPartitioner;
+
+public class StreamEdge {
+
+	final private int sourceVertex;
+	final private int targetVertex;
+	final private int typeNumber;
+	final private List<String> selectedNames;
+//	private OutputSelector<?> outputSelector;
+	final private StreamPartitioner<?> outputPartitioner;
+
+	public StreamEdge(int sourceVertex, int targetVertex, int typeNumber, List<String> selectedNames, StreamPartitioner<?> outputPartitioner) {
+		this.sourceVertex = sourceVertex;
+		this.targetVertex = targetVertex;
+		this.typeNumber = typeNumber;
+		this.selectedNames = selectedNames;
+//		this.outputSelector = outputSelector;
+		this.outputPartitioner = outputPartitioner;
+	}
+
+	public int getSourceVertex() {
+		return sourceVertex;
+	}
+
+	public int getTargetVertex() {
+		return targetVertex;
+	}
+
+	public int getTypeNumber() {
+		return typeNumber;
+	}
+
+	public List<String> getSelectedNames() {
+		return selectedNames;
+	}
+
+	public StreamPartitioner<?> getOutputPartitioner() {
+		return outputPartitioner;
+	}
+
+	@Override
+	public String toString() {
+		return "StreamGraphEdge{" +
+				"sourceVertex=" + sourceVertex +
+				", targetVertex=" + targetVertex +
+				", typeNumber=" + typeNumber +
+				", selectedNames=" + selectedNames +
+				", outputPartitioner=" + outputPartitioner +
+				'}';
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
@@ -22,13 +22,24 @@ import java.util.List;
 
 import org.apache.flink.streaming.partitioner.StreamPartitioner;
 
+/**
+ * An edge in the streaming topology. One edge like this does not necessarily
+ * gets converted to a connection between two job vertices (due to chaining/optimization).
+ */
 public class StreamEdge implements Serializable {
 
 	final private int sourceVertex;
 	final private int targetVertex;
+
+	/**
+	 * The type number of the input for co-tasks.
+	 */
 	final private int typeNumber;
+
+	/**
+	 * A list of output names that the target vertex listens to (if there is output selection).
+	 */
 	final private List<String> selectedNames;
-//	private OutputSelector<?> outputSelector;
 	final private StreamPartitioner<?> outputPartitioner;
 
 	public StreamEdge(int sourceVertex, int targetVertex, int typeNumber, List<String> selectedNames, StreamPartitioner<?> outputPartitioner) {
@@ -36,7 +47,6 @@ public class StreamEdge implements Serializable {
 		this.targetVertex = targetVertex;
 		this.typeNumber = typeNumber;
 		this.selectedNames = selectedNames;
-//		this.outputSelector = outputSelector;
 		this.outputPartitioner = outputPartitioner;
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
@@ -17,11 +17,12 @@
 
 package org.apache.flink.streaming.api;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.apache.flink.streaming.partitioner.StreamPartitioner;
 
-public class StreamEdge {
+public class StreamEdge implements Serializable {
 
 	final private int sourceVertex;
 	final private int targetVertex;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdge.java
@@ -28,6 +28,10 @@ import org.apache.flink.streaming.partitioner.StreamPartitioner;
  */
 public class StreamEdge implements Serializable {
 
+	private static final long serialVersionUID = 1L;
+
+	final private String edgeId;
+
 	final private int sourceVertex;
 	final private int targetVertex;
 
@@ -48,6 +52,12 @@ public class StreamEdge implements Serializable {
 		this.typeNumber = typeNumber;
 		this.selectedNames = selectedNames;
 		this.outputPartitioner = outputPartitioner;
+
+		this.edgeId = sourceVertex + "_"
+				+ targetVertex + "_"
+				+ typeNumber + "_"
+				+ selectedNames + "_"
+				+ outputPartitioner;
 	}
 
 	public int getSourceVertex() {
@@ -71,13 +81,36 @@ public class StreamEdge implements Serializable {
 	}
 
 	@Override
+	public int hashCode() {
+		return edgeId.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		StreamEdge that = (StreamEdge) o;
+
+		if (!edgeId.equals(that.edgeId)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
 	public String toString() {
-		return "StreamGraphEdge{" +
-				"sourceVertex=" + sourceVertex +
-				", targetVertex=" + targetVertex +
+		return "(" +
+				sourceVertex +
+				" -> " + targetVertex +
 				", typeNumber=" + typeNumber +
 				", selectedNames=" + selectedNames +
 				", outputPartitioner=" + outputPartitioner +
-				'}';
+				')';
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdgeList.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdgeList.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class StreamEdgeList {
+
+	private Map<Integer, List<StreamEdge>> outEdgeLists;
+	private Map<Integer, List<StreamEdge>> inEdgeLists;
+
+	public StreamEdgeList() {
+		outEdgeLists = new HashMap<Integer, List<StreamEdge>>();
+		inEdgeLists = new HashMap<Integer, List<StreamEdge>>();
+	}
+
+	public void addVertex(int vertexId) {
+		outEdgeLists.put(vertexId, new ArrayList<StreamEdge>());
+		inEdgeLists.put(vertexId, new ArrayList<StreamEdge>());
+	}
+
+	public void removeVertex(int vertexId) {
+		ArrayList<StreamEdge> toRemove = new ArrayList<StreamEdge>();
+
+		for (StreamEdge edge : outEdgeLists.get(vertexId)) {
+			toRemove.add(edge);
+		}
+
+		for (StreamEdge edge : inEdgeLists.get(vertexId)) {
+			toRemove.add(edge);
+		}
+
+		for (StreamEdge edge : toRemove) {
+			removeEdge(edge);
+		}
+
+		outEdgeLists.remove(vertexId);
+		inEdgeLists.remove(vertexId);
+	}
+
+	public void addEdge(StreamEdge edge) {
+		int sourceId = edge.getSourceVertex();
+		int targetId = edge.getTargetVertex();
+		outEdgeLists.get(sourceId).add(edge);
+		inEdgeLists.get(targetId).add(edge);
+	}
+
+	public void removeEdge(StreamEdge edge) {
+		int sourceId = edge.getSourceVertex();
+		int targetId = edge.getTargetVertex();
+		removeEdge(sourceId, targetId);
+	}
+
+	public void removeEdge(int sourceId, int targetId) {
+		Iterator<StreamEdge> outIterator = outEdgeLists.get(sourceId).iterator();
+		while (outIterator.hasNext()) {
+			StreamEdge edge = outIterator.next();
+
+			if (edge.getTargetVertex() == targetId) {
+				outIterator.remove();
+			}
+		}
+
+		Iterator<StreamEdge> inIterator = inEdgeLists.get(targetId).iterator();
+		while (inIterator.hasNext()) {
+			StreamEdge edge = inIterator.next();
+
+			if (edge.getSourceVertex() == sourceId) {
+				inIterator.remove();
+			}
+		}
+	}
+
+	public List<StreamEdge> getOutEdges(int i) {
+		List<StreamEdge> outEdges = outEdgeLists.get(i);
+
+		if (outEdges == null) {
+			throw new RuntimeException("No such vertex in stream graph: " + i);
+		}
+
+		return outEdges;
+	}
+
+	public List<StreamEdge> getInEdges(int i) {
+		List<StreamEdge> inEdges = inEdgeLists.get(i);
+
+		if (inEdges == null) {
+			throw new RuntimeException("No such vertex in stream graph: " + i);
+		}
+
+		return inEdges;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdgeList.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdgeList.java
@@ -90,23 +90,59 @@ public class StreamEdgeList {
 		}
 	}
 
-	public List<StreamEdge> getOutEdges(int i) {
-		List<StreamEdge> outEdges = outEdgeLists.get(i);
+	public StreamEdge getEdge(int sourceId, int targetId) {
+		Iterator<StreamEdge> outIterator = outEdgeLists.get(sourceId).iterator();
+		while (outIterator.hasNext()) {
+			StreamEdge edge = outIterator.next();
+
+			if (edge.getTargetVertex() == targetId) {
+				return edge;
+			}
+		}
+
+		throw new RuntimeException("No such edge in stream graph: " + sourceId + " -> " + targetId);
+	}
+
+	public List<StreamEdge> getOutEdges(int vertexId) {
+		List<StreamEdge> outEdges = outEdgeLists.get(vertexId);
 
 		if (outEdges == null) {
-			throw new RuntimeException("No such vertex in stream graph: " + i);
+			throw new RuntimeException("No such vertex in stream graph: " + vertexId);
 		}
 
 		return outEdges;
 	}
 
-	public List<StreamEdge> getInEdges(int i) {
-		List<StreamEdge> inEdges = inEdgeLists.get(i);
+	public List<StreamEdge> getInEdges(int vertexId) {
+		List<StreamEdge> inEdges = inEdgeLists.get(vertexId);
 
 		if (inEdges == null) {
-			throw new RuntimeException("No such vertex in stream graph: " + i);
+			throw new RuntimeException("No such vertex in stream graph: " + vertexId);
 		}
 
 		return inEdges;
+	}
+
+	public List<Integer> getOutEdgeIndices(int vertexId) {
+		List<StreamEdge> outEdges = getOutEdges(vertexId);
+		List<Integer> outEdgeIndices = new ArrayList<Integer>();
+
+		for (StreamEdge edge : outEdges) {
+			outEdgeIndices.add(edge.getTargetVertex());
+		}
+
+		return outEdgeIndices;
+	}
+
+	public List<Integer> getInEdgeIndices(int vertexId) {
+		List<StreamEdge> inEdges = getInEdges(vertexId);
+
+		List<Integer> inEdgeIndices = new ArrayList<Integer>();
+
+		for (StreamEdge edge : inEdges) {
+			inEdgeIndices.add(edge.getSourceVertex());
+		}
+
+		return inEdgeIndices;
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdgeList.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamEdgeList.java
@@ -23,6 +23,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Stores the stream topology with adjacency list graph representation.
+ * Edges are represented with {@link org.apache.flink.streaming.api.StreamEdge}s
+ */
 public class StreamEdgeList {
 
 	private Map<Integer, List<StreamEdge>> outEdgeLists;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
@@ -37,7 +37,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.compiler.plan.StreamingPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.streaming.api.collector.OutputSelector;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
+import org.apache.flink.streaming.api.collector.selector.OutputSelectorWrapperFactory;
+import org.apache.flink.streaming.api.collector.selector.OutputSelectorWrapper;
 import org.apache.flink.streaming.api.invokable.StreamInvokable;
 import org.apache.flink.streaming.api.invokable.operator.co.CoInvokable;
 import org.apache.flink.streaming.api.streamrecord.StreamRecordSerializer;
@@ -537,8 +539,8 @@ public class StreamGraph extends StreamingPlan {
 		return inputFormatLists.get(vertexID);
 	}
 
-	public List<OutputSelector<?>> getOutputSelector(Integer vertexID) {
-		return outputSelectors.get(vertexID);
+	public OutputSelectorWrapper<?> getOutputSelectorWrapper(Integer vertexID) {
+		return OutputSelectorWrapperFactory.create(outputSelectors.get(vertexID));
 	}
 
 	public Integer getIterationID(Integer vertexID) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -53,7 +52,10 @@ public class StreamingJobGraphGenerator {
 	private JobGraph jobGraph;
 	private Collection<Integer> builtVertices;
 
+	private List<StreamEdge> physicalEdgesInOrder;
+
 	private Map<Integer, Map<Integer, StreamConfig>> chainedConfigs;
+
 	private Map<Integer, StreamConfig> vertexConfigs;
 	private Map<Integer, String> chainedNames;
 
@@ -67,6 +69,7 @@ public class StreamingJobGraphGenerator {
 		this.chainedConfigs = new HashMap<Integer, Map<Integer, StreamConfig>>();
 		this.vertexConfigs = new HashMap<Integer, StreamConfig>();
 		this.chainedNames = new HashMap<Integer, String>();
+		this.physicalEdgesInOrder = new ArrayList<StreamEdge>();
 	}
 
 	public JobGraph createJobGraph(String jobName) {
@@ -77,17 +80,43 @@ public class StreamingJobGraphGenerator {
 		jobGraph.setJobType(JobGraph.JobType.STREAMING);
 		jobGraph.setMonitoringEnabled(streamGraph.isMonitoringEnabled());
 		jobGraph.setMonitorInterval(streamGraph.getMonitoringInterval());
-		if(jobGraph.isMonitoringEnabled())
-		{
+		if (jobGraph.isMonitoringEnabled()) {
 			jobGraph.setNumberOfExecutionRetries(Integer.MAX_VALUE);
 		}
 		init();
 
 		setChaining();
 
+		setPhysicalEdges();
+
 		setSlotSharing();
 
 		return jobGraph;
+	}
+
+	private void setPhysicalEdges() {
+		Map<Integer, List<StreamEdge>> physicalInEdgesInOrder = new HashMap<Integer, List<StreamEdge>>();
+
+		for (StreamEdge edge : physicalEdgesInOrder) {
+			int target = edge.getTargetVertex();
+
+			List<StreamEdge> inEdges = physicalInEdgesInOrder.get(target);
+
+			// create if not set
+			if (inEdges == null) {
+				inEdges = new ArrayList<StreamEdge>();
+				physicalInEdgesInOrder.put(target, inEdges);
+			}
+
+			inEdges.add(edge);
+		}
+
+		for (Map.Entry<Integer, List<StreamEdge>> inEdges : physicalInEdgesInOrder.entrySet()) {
+			int vertex = inEdges.getKey();
+			List<StreamEdge> edgeList = inEdges.getValue();
+
+			vertexConfigs.get(vertex).setInPhysicalEdges(edgeList);
+		}
 	}
 
 	private void setChaining() {
@@ -96,11 +125,12 @@ public class StreamingJobGraphGenerator {
 		}
 	}
 
-	private List<Tuple2<Integer, Integer>> createChain(Integer startNode, Integer current) {
+	private List<StreamEdge> createChain(Integer startNode, Integer current) {
 
 		if (!builtVertices.contains(startNode)) {
 
-			List<Tuple2<Integer, Integer>> transitiveOutEdges = new ArrayList<Tuple2<Integer, Integer>>();
+			List<StreamEdge> transitiveOutEdges = new ArrayList<StreamEdge>();
+
 			List<StreamEdge> chainableOutputs = new ArrayList<StreamEdge>();
 			List<StreamEdge> nonChainableOutputs = new ArrayList<StreamEdge>();
 
@@ -117,7 +147,7 @@ public class StreamingJobGraphGenerator {
 			}
 
 			for (StreamEdge nonChainable : nonChainableOutputs) {
-				transitiveOutEdges.add(new Tuple2<Integer, Integer>(current, nonChainable.getTargetVertex()));
+				transitiveOutEdges.add(nonChainable);
 				createChain(nonChainable.getTargetVertex(), nonChainable.getTargetVertex());
 			}
 
@@ -133,9 +163,8 @@ public class StreamingJobGraphGenerator {
 				config.setChainStart();
 				config.setOutEdgesInOrder(transitiveOutEdges);
 				config.setOutEdges(streamGraph.getOutEdges(current));
-				config.setInEdges(streamGraph.getInEdges(current));
 
-				for (Tuple2<Integer, Integer> edge : transitiveOutEdges) {
+				for (StreamEdge edge : transitiveOutEdges) {
 					connect(startNode, edge);
 				}
 
@@ -154,7 +183,7 @@ public class StreamingJobGraphGenerator {
 			return transitiveOutEdges;
 
 		} else {
-			return new ArrayList<Tuple2<Integer, Integer>>();
+			return new ArrayList<StreamEdge>();
 		}
 	}
 
@@ -165,9 +194,11 @@ public class StreamingJobGraphGenerator {
 			for (StreamEdge chainable : chainedOutputs) {
 				outputChainedNames.add(chainedNames.get(chainable.getTargetVertex()));
 			}
-			return operatorName + " -> (" + StringUtils.join(outputChainedNames, ", ") + ")";
+			String returnOperatorName = operatorName + " -> (" + StringUtils.join(outputChainedNames, ", ") + ")";
+			return returnOperatorName;
 		} else if (chainedOutputs.size() == 1) {
-			return operatorName + " -> " + chainedNames.get(chainedOutputs.get(0));
+			String returnOperatorName = operatorName + " -> " + chainedNames.get(chainedOutputs.get(0).getTargetVertex());
+			return returnOperatorName;
 		} else {
 			return operatorName;
 		}
@@ -238,30 +269,20 @@ public class StreamingJobGraphGenerator {
 		vertexConfigs.put(vertexID, config);
 	}
 
-	private <T> void connect(Integer headOfChain, Tuple2<Integer, Integer> edge) {
+	private void connect(Integer headOfChain, StreamEdge edge) {
 
-		Integer upStreamvertexID = edge.f0;
-		Integer downStreamvertexID = edge.f1;
+		physicalEdgesInOrder.add(edge);
 
-		int outputIndex = streamGraph.getOutEdges(upStreamvertexID).indexOf(downStreamvertexID);
+		Integer downStreamvertexID = edge.getTargetVertex();
 
 		AbstractJobVertex headVertex = streamVertices.get(headOfChain);
 		AbstractJobVertex downStreamVertex = streamVertices.get(downStreamvertexID);
 
 		StreamConfig downStreamConfig = new StreamConfig(downStreamVertex.getConfiguration());
-		StreamConfig upStreamConfig = headOfChain.equals(upStreamvertexID) ? new StreamConfig(
-				headVertex.getConfiguration()) : chainedConfigs.get(headOfChain).get(
-				upStreamvertexID);
 
-		int numOfInputs = downStreamConfig.getNumberOfInputs();
+		downStreamConfig.setNumberOfInputs(downStreamConfig.getNumberOfInputs() + 1);
 
-		downStreamConfig.setInputIndex(numOfInputs++, streamGraph.getEdge(upStreamvertexID, downStreamvertexID).getTypeNumber());
-		downStreamConfig.setNumberOfInputs(numOfInputs);
-
-		StreamPartitioner<?> partitioner = streamGraph.getEdge(upStreamvertexID, downStreamvertexID).getPartitioner();
-
-		upStreamConfig.setPartitioner(downStreamvertexID, partitioner);
-
+		StreamPartitioner<?> partitioner = edge.getPartitioner();
 		if (partitioner.getStrategy() == PartitioningStrategy.FORWARD) {
 			downStreamVertex.connectNewDataSetAsInput(headVertex, DistributionPattern.POINTWISE);
 		} else {
@@ -281,14 +302,15 @@ public class StreamingJobGraphGenerator {
 		StreamInvokable<?, ?> headInvokable = streamGraph.getInvokable(vertexID);
 		StreamInvokable<?, ?> outInvokable = streamGraph.getInvokable(outName);
 
-		return streamGraph.getInEdges(outName).size() == 1
-				&& outInvokable != null
-				&& outInvokable.getChainingStrategy() == ChainingStrategy.ALWAYS
-				&& (headInvokable.getChainingStrategy() == ChainingStrategy.HEAD || headInvokable
+		return
+				streamGraph.getInEdges(outName).size() == 1
+						&& outInvokable != null
+						&& outInvokable.getChainingStrategy() == ChainingStrategy.ALWAYS
+						&& (headInvokable.getChainingStrategy() == ChainingStrategy.HEAD || headInvokable
 						.getChainingStrategy() == ChainingStrategy.ALWAYS)
-				&& streamGraph.getEdge(vertexID, outName).getPartitioner().getStrategy() == PartitioningStrategy.FORWARD
-				&& streamGraph.getParallelism(vertexID) == streamGraph.getParallelism(outName)
-				&& streamGraph.chaining;
+						&& edge.getPartitioner().getStrategy() == PartitioningStrategy.FORWARD
+						&& streamGraph.getParallelism(vertexID) == streamGraph.getParallelism(outName)
+						&& streamGraph.chaining;
 	}
 
 	private void setSlotSharing() {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
@@ -213,7 +213,7 @@ public class StreamingJobGraphGenerator {
 		config.setTypeSerializerOut2(streamGraph.getOutSerializer2(vertexID));
 
 		config.setUserInvokable(streamGraph.getInvokable(vertexID));
-		config.setOutputSelectors(streamGraph.getOutputSelector(vertexID));
+		config.setOutputSelectorWrapper(streamGraph.getOutputSelectorWrapper(vertexID));
 
 		config.setNumberOfOutputs(nonChainableOutputs.size());
 		config.setNonChainedOutputs(nonChainableOutputs);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
@@ -253,7 +253,6 @@ public class StreamingJobGraphGenerator {
 				headVertex.getConfiguration()) : chainedConfigs.get(headOfChain).get(
 				upStreamvertexID);
 
-//		List<Integer> outEdgeIndexList = streamGraph.getOutEdgeTypes(upStreamvertexID);
 		int numOfInputs = downStreamConfig.getNumberOfInputs();
 
 		downStreamConfig.setInputIndex(numOfInputs++, streamGraph.getEdge(upStreamvertexID, downStreamvertexID).getTypeNumber());

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/WindowingOptimizer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/WindowingOptimizer.java
@@ -54,13 +54,13 @@ public class WindowingOptimizer {
 
 		for (Integer flattener : flatteners) {
 			// Flatteners should have exactly one input
-			Integer input = streamGraph.getInEdges(flattener).get(0);
+			Integer input = streamGraph.getInEdges(flattener).get(0).getSourceVertex();
 
 			// Check whether the flatten is applied after a merge
 			if (streamGraph.getInvokable(input) instanceof WindowMerger) {
 
 				// Mergers should have exactly one input
-				Integer mergeInput = streamGraph.getInEdges(input).get(0);
+				Integer mergeInput = streamGraph.getInEdges(input).get(0).getSourceVertex();
 				streamGraph.setEdge(mergeInput, flattener, new DistributePartitioner(true), 0,
 						new ArrayList<String>());
 
@@ -97,9 +97,9 @@ public class WindowingOptimizer {
 			boolean inMatching = false;
 			for (Tuple2<StreamDiscretizer<?>, List<Integer>> matching : matchingDiscretizers) {
 				Set<Integer> discretizerInEdges = new HashSet<Integer>(
-						streamGraph.getInEdges(discretizer.f0));
+						streamGraph.getInEdgeIndices(discretizer.f0));
 				Set<Integer> matchingInEdges = new HashSet<Integer>(
-						streamGraph.getInEdges(matching.f1.get(0)));
+						streamGraph.getInEdgeIndices(matching.f1.get(0)));
 
 				if (discretizer.f1.equals(matching.f0)
 						&& discretizerInEdges.equals(matchingInEdges)) {
@@ -130,7 +130,7 @@ public class WindowingOptimizer {
 	private static void replaceDiscretizer(StreamGraph streamGraph, Integer toReplace,
 			Integer replaceWith) {
 		// Convert to array to create a copy
-		List<Integer> outEdges = new ArrayList<Integer>(streamGraph.getOutEdges(toReplace));
+		List<Integer> outEdges = new ArrayList<Integer>(streamGraph.getOutEdgeIndices(toReplace));
 
 		int numOutputs = outEdges.size();
 
@@ -139,11 +139,11 @@ public class WindowingOptimizer {
 			Integer output = outEdges.get(i);
 
 			streamGraph.setEdge(replaceWith, output,
-					streamGraph.getOutPartitioner(toReplace, output), 0, new ArrayList<String>());
+					streamGraph.getEdge(toReplace, output).getPartitioner(), 0, new ArrayList<String>());
 			streamGraph.removeEdge(toReplace, output);
 		}
 
-		List<Integer> inEdges = new ArrayList<Integer>(streamGraph.getInEdges(toReplace));
+		List<Integer> inEdges = new ArrayList<Integer>(streamGraph.getInEdgeIndices(toReplace));
 		// Remove inputs
 		for (Integer input : inEdges) {
 			streamGraph.removeEdge(input, toReplace);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/CollectorWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/CollectorWrapper.java
@@ -29,7 +29,6 @@ public class CollectorWrapper<OUT> implements Collector<OUT> {
 		this.outputSelectorWrapper = outputSelectorWrapper;
 	}
 
-	@SuppressWarnings("unchecked")
 	public void addCollector(Collector<?> output, StreamEdge edge) {
 		outputSelectorWrapper.addCollector(output, edge);
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/BroadcastOutputSelectorWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/BroadcastOutputSelectorWrapper.java
@@ -25,12 +25,14 @@ import org.apache.flink.util.Collector;
 
 public class BroadcastOutputSelectorWrapper<OUT> implements OutputSelectorWrapper<OUT> {
 
+	private static final long serialVersionUID = 1L;
 	private List<Collector<OUT>> outputs;
 
 	public BroadcastOutputSelectorWrapper() {
 		outputs = new ArrayList<Collector<OUT>>();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void addCollector(Collector<?> output, StreamEdge edge) {
 		outputs.add((Collector<OUT>) output);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/BroadcastOutputSelectorWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/BroadcastOutputSelectorWrapper.java
@@ -15,34 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.collector;
+package org.apache.flink.streaming.api.collector.selector;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.flink.streaming.api.StreamEdge;
-import org.apache.flink.streaming.api.collector.selector.OutputSelectorWrapper;
 import org.apache.flink.util.Collector;
 
-public class CollectorWrapper<OUT> implements Collector<OUT> {
+public class BroadcastOutputSelectorWrapper<OUT> implements OutputSelectorWrapper<OUT> {
 
-	private OutputSelectorWrapper<OUT> outputSelectorWrapper;
+	private List<Collector<OUT>> outputs;
 
-	public CollectorWrapper(OutputSelectorWrapper<OUT> outputSelectorWrapper) {
-		this.outputSelectorWrapper = outputSelectorWrapper;
+	public BroadcastOutputSelectorWrapper() {
+		outputs = new ArrayList<Collector<OUT>>();
 	}
 
-	@SuppressWarnings("unchecked")
+	@Override
 	public void addCollector(Collector<?> output, StreamEdge edge) {
-		outputSelectorWrapper.addCollector(output, edge);
+		outputs.add((Collector<OUT>) output);
 	}
 
 	@Override
-	public void collect(OUT record) {
-		for (Collector<OUT> output : outputSelectorWrapper.getSelectedOutputs(record)) {
-			output.collect(record);
-		}
+	public Iterable<Collector<OUT>> getSelectedOutputs(OUT record) {
+		return outputs;
 	}
-
-	@Override
-	public void close() {
-	}
-
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutputSelectorWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutputSelectorWrapper.java
@@ -37,11 +37,9 @@ public class DirectedOutputSelectorWrapper<OUT> implements OutputSelectorWrapper
 
 	private Map<String, List<Collector<OUT>>> outputMap;
 	private Set<Collector<OUT>> selectAllOutputs;
-//	private Set<Collector<OUT>> emitted;
 
 	public DirectedOutputSelectorWrapper(List<OutputSelector<OUT>> outputSelectors) {
 		this.outputSelectors = outputSelectors;
-//		this.emitted = new HashSet<Collector<OUT>>();
 		this.selectAllOutputs = new HashSet<Collector<OUT>>(); //new LinkedList<Collector<OUT>>();
 		this.outputMap = new HashMap<String, List<Collector<OUT>>>();
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutputSelectorWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutputSelectorWrapper.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 public class DirectedOutputSelectorWrapper<OUT> implements OutputSelectorWrapper<OUT> {
 
+	private static final long serialVersionUID = 1L;
+
 	private static final Logger LOG = LoggerFactory.getLogger(DirectedOutputSelectorWrapper.class);
 
 	private List<OutputSelector<OUT>> outputSelectors;
@@ -44,6 +46,7 @@ public class DirectedOutputSelectorWrapper<OUT> implements OutputSelectorWrapper
 		this.outputMap = new HashMap<String, List<Collector<OUT>>>();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void addCollector(Collector<?> output, StreamEdge edge) {
 		List<String> selectedNames = edge.getSelectedNames();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelector.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelector.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.collector;
+package org.apache.flink.streaming.api.collector.selector;
 
 import java.io.Serializable;
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelectorWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelectorWrapper.java
@@ -15,34 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.collector;
+package org.apache.flink.streaming.api.collector.selector;
+
+import java.io.Serializable;
 
 import org.apache.flink.streaming.api.StreamEdge;
-import org.apache.flink.streaming.api.collector.selector.OutputSelectorWrapper;
 import org.apache.flink.util.Collector;
 
-public class CollectorWrapper<OUT> implements Collector<OUT> {
+public interface OutputSelectorWrapper<OUT> extends Serializable {
 
-	private OutputSelectorWrapper<OUT> outputSelectorWrapper;
+	public void addCollector(Collector<?> output, StreamEdge edge);
 
-	public CollectorWrapper(OutputSelectorWrapper<OUT> outputSelectorWrapper) {
-		this.outputSelectorWrapper = outputSelectorWrapper;
-	}
-
-	@SuppressWarnings("unchecked")
-	public void addCollector(Collector<?> output, StreamEdge edge) {
-		outputSelectorWrapper.addCollector(output, edge);
-	}
-
-	@Override
-	public void collect(OUT record) {
-		for (Collector<OUT> output : outputSelectorWrapper.getSelectedOutputs(record)) {
-			output.collect(record);
-		}
-	}
-
-	@Override
-	public void close() {
-	}
+	public Iterable<Collector<OUT>> getSelectedOutputs(OUT record);
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelectorWrapperFactory.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelectorWrapperFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.collector.selector;
+
+import java.util.List;
+
+public class OutputSelectorWrapperFactory {
+
+	public static OutputSelectorWrapper<?> create(List<OutputSelector<?>> outputSelectors) {
+		if (outputSelectors.size() == 0) {
+			return new BroadcastOutputSelectorWrapper();
+		} else {
+			return new DirectedOutputSelectorWrapper(outputSelectors);
+		}
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelectorWrapperFactory.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/collector/selector/OutputSelectorWrapperFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 public class OutputSelectorWrapperFactory {
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public static OutputSelectorWrapper<?> create(List<OutputSelector<?>> outputSelectors) {
 		if (outputSelectors.size() == 0) {
 			return new BroadcastOutputSelectorWrapper();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -47,7 +47,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.StreamGraph;
-import org.apache.flink.streaming.api.collector.OutputSelector;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.datastream.temporaloperator.StreamCrossOperator;
 import org.apache.flink.streaming.api.datastream.temporaloperator.StreamJoinOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -238,12 +238,12 @@ public class DataStream<OUT> {
 
 	/**
 	 * Operator used for directing tuples to specific named outputs using an
-	 * {@link org.apache.flink.streaming.api.collector.OutputSelector}. Calling
+	 * {@link org.apache.flink.streaming.api.collector.selector.OutputSelector}. Calling
 	 * this method on an operator creates a new {@link SplitDataStream}.
 	 * 
 	 * @param outputSelector
 	 *            The user defined
-	 *            {@link org.apache.flink.streaming.api.collector.OutputSelector}
+	 *            {@link org.apache.flink.streaming.api.collector.selector.OutputSelector}
 	 *            for directing the tuples.
 	 * @return The {@link SplitDataStream}
 	 */

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SplitDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SplitDataStream.java
@@ -19,7 +19,7 @@ package org.apache.flink.streaming.api.datastream;
 
 import java.util.Arrays;
 
-import org.apache.flink.streaming.api.collector.OutputSelector;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 
 /**
  * The SplitDataStream represents an operator that has been split using an

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/CoStreamVertex.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/CoStreamVertex.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.io.CoRecordReader;
 import org.apache.flink.streaming.io.IndexedReaderIterator;
 import org.apache.flink.util.MutableObjectIterator;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 public class CoStreamVertex<IN1, IN2, OUT> extends StreamVertex<IN1, OUT> {
@@ -63,9 +64,10 @@ public class CoStreamVertex<IN1, IN2, OUT> extends StreamVertex<IN1, OUT> {
 	}
 
 	@Override
-	public void clearBuffers() {
+	public void clearBuffers() throws IOException {
 		outputHandler.clearWriters();
 		coReader.clearBuffers();
+		coReader.cleanup();
 	}
 
 	protected void setConfigInputs() throws StreamVertexException {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/CoStreamVertex.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/CoStreamVertex.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.api.streamvertex;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
+import org.apache.flink.streaming.api.StreamEdge;
+import org.apache.flink.streaming.api.invokable.operator.co.CoInvokable;
 import org.apache.flink.streaming.api.streamrecord.StreamRecord;
 import org.apache.flink.streaming.api.streamrecord.StreamRecordSerializer;
 import org.apache.flink.streaming.io.CoReaderIterator;
@@ -29,6 +31,7 @@ import org.apache.flink.util.MutableObjectIterator;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class CoStreamVertex<IN1, IN2, OUT> extends StreamVertex<IN1, OUT> {
 
@@ -78,8 +81,10 @@ public class CoStreamVertex<IN1, IN2, OUT> extends StreamVertex<IN1, OUT> {
 		ArrayList<InputGate> inputList1 = new ArrayList<InputGate>();
 		ArrayList<InputGate> inputList2 = new ArrayList<InputGate>();
 
+		List<StreamEdge> inEdges = configuration.getInEdges(userClassLoader);
+
 		for (int i = 0; i < numberOfInputs; i++) {
-			int inputType = configuration.getInputIndex(i);
+			int inputType = inEdges.get(i).getTypeNumber();
 			InputGate reader = getEnvironment().getInputGate(i);
 			switch (inputType) {
 			case 1:

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/CoStreamVertex.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/CoStreamVertex.java
@@ -80,7 +80,7 @@ public class CoStreamVertex<IN1, IN2, OUT> extends StreamVertex<IN1, OUT> {
 		ArrayList<InputGate> inputList1 = new ArrayList<InputGate>();
 		ArrayList<InputGate> inputList2 = new ArrayList<InputGate>();
 
-		List<StreamEdge> inEdges = configuration.getInEdges(userClassLoader);
+		List<StreamEdge> inEdges = configuration.getInPhysicalEdges(userClassLoader);
 
 		for (int i = 0; i < numberOfInputs; i++) {
 			int inputType = inEdges.get(i).getTypeNumber();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.api.streamvertex;
 
+import java.io.IOException;
+
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.io.network.api.reader.MutableReader;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -86,9 +88,10 @@ public class InputHandler<IN> {
 		return inputIter;
 	}
 
-	public void clearReaders() {
+	public void clearReaders() throws IOException {
 		if (inputs != null) {
 			inputs.clearBuffers();
 		}
+		inputs.cleanup();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
@@ -66,12 +66,6 @@ public class InputHandler<IN> {
 		}
 	}
 
-	private IndexedReaderIterator<StreamRecord<IN>> createInputIterator() {
-		final IndexedReaderIterator<StreamRecord<IN>> iter = new IndexedReaderIterator<StreamRecord<IN>>(
-				inputs, inputSerializer);
-		return iter;
-	}
-
 	protected static <T> IndexedReaderIterator<StreamRecord<T>> staticCreateInputIterator(
 			MutableReader<?> inputReader, TypeSerializer<StreamRecord<T>> serializer) {
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
@@ -91,7 +91,7 @@ public class InputHandler<IN> {
 	public void clearReaders() throws IOException {
 		if (inputs != null) {
 			inputs.clearBuffers();
+			inputs.cleanup();
 		}
-		inputs.cleanup();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/InputHandler.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.io.network.api.reader.MutableReader;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
-import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.streaming.api.StreamConfig;
 import org.apache.flink.streaming.api.streamrecord.StreamRecord;
 import org.apache.flink.streaming.api.streamrecord.StreamRecordSerializer;
 import org.apache.flink.streaming.io.IndexedMutableReader;
 import org.apache.flink.streaming.io.IndexedReaderIterator;
+import org.apache.flink.streaming.io.InputGateFactory;
 
 public class InputHandler<IN> {
 	private StreamRecordSerializer<IN> inputSerializer = null;
@@ -56,17 +56,20 @@ public class InputHandler<IN> {
 		int numberOfInputs = configuration.getNumberOfInputs();
 
 		if (numberOfInputs > 0) {
-			InputGate inputGate = numberOfInputs < 2 ? streamVertex.getEnvironment()
-					.getInputGate(0) : new UnionInputGate(streamVertex.getEnvironment()
-					.getAllInputGates());
-
+			InputGate inputGate = InputGateFactory.createInputGate(streamVertex.getEnvironment().getAllInputGates());
 			inputs = new IndexedMutableReader<DeserializationDelegate<StreamRecord<IN>>>(inputGate);
+
 			inputs.registerTaskEventListener(streamVertex.getSuperstepListener(),
 					StreamingSuperstep.class);
 
 			inputIter = new IndexedReaderIterator<StreamRecord<IN>>(inputs, inputSerializer);
 		}
+	}
 
+	private IndexedReaderIterator<StreamRecord<IN>> createInputIterator() {
+		final IndexedReaderIterator<StreamRecord<IN>> iter = new IndexedReaderIterator<StreamRecord<IN>>(
+				inputs, inputSerializer);
+		return iter;
 	}
 
 	protected static <T> IndexedReaderIterator<StreamRecord<T>> staticCreateInputIterator(

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/OutputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/OutputHandler.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.api.StreamConfig;
+import org.apache.flink.streaming.api.StreamEdge;
 import org.apache.flink.streaming.api.collector.CollectorWrapper;
 import org.apache.flink.streaming.api.collector.DirectedCollectorWrapper;
 import org.apache.flink.streaming.api.collector.StreamOutput;
@@ -117,7 +118,8 @@ public class OutputHandler<OUT> {
 				chainedTaskConfig.getOutputSelectors(cl)) : new CollectorWrapper<OUT>();
 
 		// Create collectors for the network outputs
-		for (Integer output : chainedTaskConfig.getOutputs(cl)) {
+		for (StreamEdge outputEdge : chainedTaskConfig.getNonChainedOutputs(cl)) {
+			Integer output = outputEdge.getTargetVertex();
 
 			Collector<?> outCollector = outputMap.get(output);
 
@@ -130,7 +132,9 @@ public class OutputHandler<OUT> {
 		}
 
 		// Create collectors for the chained outputs
-		for (Integer output : chainedTaskConfig.getChainedOutputs(cl)) {
+		for (StreamEdge outputEdge : chainedTaskConfig.getChainedOutputs(cl)) {
+			Integer output = outputEdge.getTargetVertex();
+
 			Collector<?> outCollector = createChainedCollector(chainedConfigs.get(output));
 			if (isDirectEmit) {
 				((DirectedCollectorWrapper<OUT>) wrapper).addCollector(outCollector,

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamVertex.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamVertex.java
@@ -191,7 +191,7 @@ public class StreamVertex<IN, OUT> extends AbstractInvokable implements StreamTa
 
 	}
 
-	protected void clearBuffers() {
+	protected void clearBuffers() throws IOException {
 		if (outputHandler != null) {
 			outputHandler.clearWriters();
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamVertex.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamVertex.java
@@ -114,9 +114,8 @@ public class StreamVertex<IN, OUT> extends AbstractInvokable implements StreamTa
 		if (configuration.getStateMonitoring() && !states.isEmpty()) {
 			getEnvironment().getJobManager().tell(
 					new StateBarrierAck(getEnvironment().getJobID(), getEnvironment()
-							.getJobVertexId(), context.getIndexOfThisSubtask(), barrierID, 
-							new LocalStateHandle(states)),
-					ActorRef.noSender());
+							.getJobVertexId(), context.getIndexOfThisSubtask(), barrierID,
+							new LocalStateHandle(states)), ActorRef.noSender());
 		} else {
 			getEnvironment().getJobManager().tell(
 					new BarrierAck(getEnvironment().getJobID(), getEnvironment().getJobVertexId(),

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamingSuperstep.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/streamvertex/StreamingSuperstep.java
@@ -49,4 +49,12 @@ public class StreamingSuperstep extends TaskEvent {
 	public long getId() {
 		return id;
 	}
+
+	public boolean equals(Object other) {
+		if (other == null || !(other instanceof StreamingSuperstep)) {
+			return false;
+		} else {
+			return ((StreamingSuperstep) other).id == this.id;
+		}
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/BarrierBuffer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/BarrierBuffer.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.io;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -223,6 +224,20 @@ public class BarrierBuffer {
 			startSuperstep(superstep);
 		}
 		blockChannel(bufferOrEvent.getChannelIndex());
+	}
+
+	public void cleanup() throws IOException {
+		bufferSpiller.close();
+		File spillfile1 = bufferSpiller.getSpillFile();
+		if (spillfile1 != null) {
+			spillfile1.delete();
+		}
+
+		spillReader.close();
+		File spillfile2 = spillReader.getSpillFile();
+		if (spillfile2 != null) {
+			spillfile2.delete();
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/BufferSpiller.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/BufferSpiller.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.util.Random;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.util.StringUtils;
+
+public class BufferSpiller {
+
+	protected static Random rnd = new Random();
+
+	private File spillFile;
+	protected FileChannel spillingChannel;
+	private String tempDir;
+
+	public BufferSpiller() throws IOException {
+		String tempDirString = GlobalConfiguration.getString(
+				ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
+				ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH);
+		String[] tempDirs = tempDirString.split(",|" + File.pathSeparator);
+
+		tempDir = tempDirs[rnd.nextInt(tempDirs.length)];
+
+		createSpillingChannel();
+	}
+
+	/**
+	 * Dumps the contents of the buffer to disk and recycles the buffer.
+	 */
+	public void spill(Buffer buffer) throws IOException {
+		spillingChannel.write(buffer.getNioBuffer());
+		buffer.recycle();
+	}
+
+	@SuppressWarnings("resource")
+	private void createSpillingChannel() throws IOException {
+		this.spillFile = new File(tempDir, randomString(rnd) + ".buffer");
+		this.spillingChannel = new RandomAccessFile(spillFile, "rw").getChannel();
+	}
+
+	private static String randomString(Random random) {
+		final byte[] bytes = new byte[20];
+		random.nextBytes(bytes);
+		return StringUtils.byteToHexString(bytes);
+	}
+
+	public void close() throws IOException {
+		if (spillingChannel != null && spillingChannel.isOpen()) {
+			spillingChannel.close();
+		}
+	}
+
+	public void resetSpillFile() throws IOException {
+		close();
+		createSpillingChannel();
+	}
+
+	public File getSpillFile() {
+		return spillFile;
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/BufferSpiller.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/BufferSpiller.java
@@ -51,8 +51,14 @@ public class BufferSpiller {
 	 * Dumps the contents of the buffer to disk and recycles the buffer.
 	 */
 	public void spill(Buffer buffer) throws IOException {
-		spillingChannel.write(buffer.getNioBuffer());
-		buffer.recycle();
+		try {
+			spillingChannel.write(buffer.getNioBuffer());
+			buffer.recycle();
+		} catch (IOException e) {
+			close();
+			throw new IOException(e);
+		}
+
 	}
 
 	@SuppressWarnings("resource")

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/CoRecordReader.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/CoRecordReader.java
@@ -39,7 +39,7 @@ import org.apache.flink.streaming.api.streamvertex.StreamingSuperstep;
  */
 @SuppressWarnings("rawtypes")
 public class CoRecordReader<T1 extends IOReadableWritable, T2 extends IOReadableWritable> extends
-		AbstractReader implements EventListener<InputGate> {
+		AbstractReader implements EventListener<InputGate>, StreamingReader {
 
 	private final InputGate bufferReader1;
 
@@ -232,8 +232,8 @@ public class CoRecordReader<T1 extends IOReadableWritable, T2 extends IOReadable
 	public void onEvent(InputGate bufferReader) {
 		addToAvailable(bufferReader);
 	}
-	
-	protected void addToAvailable(InputGate bufferReader){
+
+	protected void addToAvailable(InputGate bufferReader) {
 		if (bufferReader == bufferReader1) {
 			availableRecordReaders.add(1);
 		} else if (bufferReader == bufferReader2) {
@@ -278,4 +278,12 @@ public class CoRecordReader<T1 extends IOReadableWritable, T2 extends IOReadable
 
 	}
 
+	public void cleanup() throws IOException {
+		try {
+			barrierBuffer1.cleanup();
+		} finally {
+			barrierBuffer2.cleanup();
+		}
+
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/InputGateFactory.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/InputGateFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import java.util.Collection;
+
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
+
+public class InputGateFactory {
+
+	public static InputGate createInputGate(Collection<InputGate> inputGates) {
+		return createInputGate(inputGates.toArray(new InputGate[inputGates.size()]));
+	}
+
+	public static InputGate createInputGate(InputGate[] inputGates) {
+		if (inputGates.length <= 0) {
+			throw new RuntimeException("No such input gate.");
+		}
+
+		if (inputGates.length < 2) {
+			return inputGates[0];
+		} else {
+			return new UnionInputGate(inputGates);
+		}
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/RecordWriterFactory.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/RecordWriterFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecordWriterFactory {
+	private static final Logger LOG = LoggerFactory.getLogger(RecordWriterFactory.class);
+
+	public static <OUT extends IOReadableWritable> RecordWriter<OUT> createRecordWriter(ResultPartitionWriter bufferWriter, ChannelSelector<OUT> channelSelector, long bufferTimeout) {
+
+		RecordWriter<OUT> output;
+
+		if (bufferTimeout >= 0) {
+			output = new StreamRecordWriter<OUT>(bufferWriter, channelSelector, bufferTimeout);
+
+			if (LOG.isTraceEnabled()) {
+				LOG.trace("StreamRecordWriter initiated with {} bufferTimeout.", bufferTimeout);
+			}
+		} else {
+			output = new RecordWriter<OUT>(bufferWriter, channelSelector);
+
+			if (LOG.isTraceEnabled()) {
+				LOG.trace("RecordWriter initiated.");
+			}
+		}
+
+		return output;
+
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/SpillReader.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/SpillReader.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+
+public class SpillReader {
+
+	private FileChannel spillingChannel;
+	private File spillFile;
+
+	/**
+	 * Reads the next buffer from the spilled file. If a buffer pool was given,
+	 * uses the buffer pool to request a new buffer to read into.
+	 * 
+	 */
+	public Buffer readNextBuffer(int bufferSize, BufferPool bufferPool) throws IOException {
+
+		Buffer buffer = null;
+
+		// If available tries to request a new buffer from the pool
+		if (bufferPool != null) {
+			buffer = bufferPool.requestBuffer();
+		}
+
+		// If no bufferpool provided or the pool was empty create a new buffer
+		if (buffer == null) {
+			buffer = new Buffer(new MemorySegment(new byte[bufferSize]), new BufferRecycler() {
+
+				@Override
+				public void recycle(MemorySegment memorySegment) {
+					memorySegment.free();
+				}
+			});
+		}
+
+		spillingChannel.read(buffer.getMemorySegment().wrap(0, bufferSize));
+
+		return buffer;
+	}
+
+	@SuppressWarnings("resource")
+	public void setSpillFile(File nextSpillFile) throws IOException {
+		// We can close and delete the file now
+		close();
+		if (spillFile != null) {
+			spillFile.delete();
+		}
+		this.spillFile = nextSpillFile;
+		this.spillingChannel = new RandomAccessFile(spillFile, "rw").getChannel();
+	}
+
+	public void close() throws IOException {
+		if (this.spillingChannel != null && this.spillingChannel.isOpen()) {
+			this.spillingChannel.close();
+		}
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/SpillingBufferOrEvent.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/SpillingBufferOrEvent.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import java.io.IOException;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+
+public class SpillingBufferOrEvent {
+
+	private BufferOrEvent boe;
+	private boolean isSpilled = false;
+
+	private SpillReader spillReader;
+
+	private BufferPool bufferPool;
+
+	private int channelIndex;
+	private int bufferSize;
+
+	public SpillingBufferOrEvent(BufferOrEvent boe, BufferSpiller spiller, SpillReader reader)
+			throws IOException {
+
+		this.boe = boe;
+		this.spillReader = reader;
+
+		if (shouldSpill()) {
+			spiller.spill(boe.getBuffer());
+			isSpilled = true;
+			boe = null;
+		}
+	}
+
+	/**
+	 * If the buffer wasn't spilled simply returns the instance from the field,
+	 * otherwise reads it from the spill reader
+	 */
+	public BufferOrEvent getBufferOrEvent() throws IOException {
+		if (isSpilled) {
+			return new BufferOrEvent(spillReader.readNextBuffer(bufferSize, bufferPool),
+					channelIndex);
+		} else {
+			return boe;
+		}
+	}
+
+	/**
+	 * Checks whether a given buffer should be spilled to disk. Currently it
+	 * checks whether the buffer pool from which the buffer was supplied is
+	 * empty and only spills if it is. This avoids out of memory exceptions and
+	 * also blocks at the input gate.
+	 */
+	private boolean shouldSpill() throws IOException {
+		if (boe.isBuffer()) {
+			Buffer buffer = boe.getBuffer();
+			this.bufferSize = buffer.getSize();
+			BufferRecycler recycler = buffer.getRecycler();
+
+			if (recycler instanceof BufferPool) {
+				bufferPool = (BufferPool) recycler;
+				Buffer nextBuffer = bufferPool.requestBuffer();
+				if (nextBuffer == null) {
+					return true;
+				} else {
+					nextBuffer.recycle();
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public boolean isSpilled() {
+		return isSpilled;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/StreamingAbstractRecordReader.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/StreamingAbstractRecordReader.java
@@ -43,8 +43,8 @@ import org.slf4j.LoggerFactory;
  * @param <T>
  *            The type of the record that can be read with this record reader.
  */
-public abstract class StreamingAbstractRecordReader<T extends IOReadableWritable> extends AbstractReader implements
-		ReaderBase {
+public abstract class StreamingAbstractRecordReader<T extends IOReadableWritable> extends
+		AbstractReader implements ReaderBase, StreamingReader {
 
 	@SuppressWarnings("unused")
 	private static final Logger LOG = LoggerFactory.getLogger(StreamingAbstractRecordReader.class);
@@ -121,5 +121,9 @@ public abstract class StreamingAbstractRecordReader<T extends IOReadableWritable
 				buffer.recycle();
 			}
 		}
+	}
+
+	public void cleanup() throws IOException {
+		barrierBuffer.cleanup();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/StreamingReader.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/StreamingReader.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import java.io.IOException;
+
+public interface StreamingReader {
+
+	public void cleanup() throws IOException;
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/CoStreamTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/CoStreamTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.function.co.CoMapFunction;
+import org.apache.flink.streaming.util.TestListResultSink;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+
+public class CoStreamTest {
+
+	private static final long MEMORY_SIZE = 32;
+
+	private static ArrayList<String> expected;
+
+	public static void main(String[] args) throws InterruptedException {
+		for (int i = 0; i < 200; i++) {
+			test();
+		}
+	}
+
+	//	@Test
+	public static void test() {
+		expected = new ArrayList<String>();
+
+		StreamExecutionEnvironment env = new TestStreamEnvironment(3, MEMORY_SIZE);
+
+		TestListResultSink<String> resultSink = new TestListResultSink<String>();
+
+		DataStream<Integer> src = env.fromElements(1, 3, 5);
+		DataStream<Integer> src2 = env.fromElements(1, 3, 5);
+
+		DataStream<Integer> grouped = src.groupBy(new KeySelector<Integer, Integer>() {
+			@Override
+			public Integer getKey(Integer value) throws Exception {
+				return value;
+			}
+		});
+
+		DataStream<Integer> grouped2 = src2.groupBy(new KeySelector<Integer, Integer>() {
+			@Override
+			public Integer getKey(Integer value) throws Exception {
+				return value;
+			}
+		});
+
+		DataStream<String> connected = grouped.connect(grouped2).map(new CoMapFunction<Integer, Integer, String>() {
+			@Override
+			public String map1(Integer value) {
+				return value.toString();
+			}
+
+			@Override
+			public String map2(Integer value) {
+				return value.toString();
+			}
+		});
+
+		connected.addSink(resultSink);
+
+		connected.print();
+
+		try {
+			env.execute();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		expected = new ArrayList<String>();
+		expected.addAll(Arrays.asList("1", "1", "3", "3", "5", "5"));
+
+		System.out.println(resultSink.getResult());
+		assertEquals(expected, expected);
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/CoStreamTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/CoStreamTest.java
@@ -21,66 +21,100 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.function.co.CoMapFunction;
+import org.apache.flink.streaming.api.function.co.CoFlatMapFunction;
+import org.apache.flink.streaming.api.invokable.StreamInvokable;
 import org.apache.flink.streaming.util.TestListResultSink;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.Collector;
+import org.junit.Test;
 
 public class CoStreamTest {
 
 	private static final long MEMORY_SIZE = 32;
 
-	private static ArrayList<String> expected;
+	private static ArrayList<String> expected = new ArrayList<String>();
 
-	public static void main(String[] args) throws InterruptedException {
-		for (int i = 0; i < 200; i++) {
-			test();
-		}
-	}
+	@Test
+	public void test() {
 
-	//	@Test
-	public static void test() {
-		expected = new ArrayList<String>();
-
-		StreamExecutionEnvironment env = new TestStreamEnvironment(3, MEMORY_SIZE);
+		StreamExecutionEnvironment env = new TestStreamEnvironment(1, MEMORY_SIZE);
 
 		TestListResultSink<String> resultSink = new TestListResultSink<String>();
 
 		DataStream<Integer> src = env.fromElements(1, 3, 5);
-		DataStream<Integer> src2 = env.fromElements(1, 3, 5);
 
-		DataStream<Integer> grouped = src.groupBy(new KeySelector<Integer, Integer>() {
+		DataStream<Integer> filter1 = src.filter(new FilterFunction<Integer>() {
+	
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(Integer value) throws Exception {
+				return true;
+			}
+		}).groupBy(new KeySelector<Integer, Integer>() {
+
+			private static final long serialVersionUID = 1L;
+
 			@Override
 			public Integer getKey(Integer value) throws Exception {
 				return value;
 			}
 		});
 
-		DataStream<Integer> grouped2 = src2.groupBy(new KeySelector<Integer, Integer>() {
-			@Override
-			public Integer getKey(Integer value) throws Exception {
-				return value;
-			}
-		});
+		DataStream<Tuple2<Integer, Integer>> filter2 = src
+				.map(new MapFunction<Integer, Tuple2<Integer, Integer>>() {
 
-		DataStream<String> connected = grouped.connect(grouped2).map(new CoMapFunction<Integer, Integer, String>() {
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public Tuple2<Integer, Integer> map(Integer value) throws Exception {
+						return new Tuple2<Integer, Integer>(value, value + 1);
+					}
+				})
+				.distribute()
+				.filter(new FilterFunction<Tuple2<Integer, Integer>>() {
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public boolean filter(Tuple2<Integer, Integer> value) throws Exception {
+						return true;
+					}
+				}).setChainingStrategy(StreamInvokable.ChainingStrategy.NEVER).groupBy(new KeySelector<Tuple2<Integer, Integer>, Integer>() {
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public Integer getKey(Tuple2<Integer, Integer> value) throws Exception {
+						return value.f0;
+					}
+				});
+
+		DataStream<String> connected = filter1.connect(filter2).flatMap(new CoFlatMapFunction<Integer, Tuple2<Integer, Integer>, String>() {
+
+			private static final long serialVersionUID = 1L;
+
 			@Override
-			public String map1(Integer value) {
-				return value.toString();
+			public void flatMap1(Integer value, Collector<String> out) throws Exception {
+				out.collect(value.toString());
 			}
 
 			@Override
-			public String map2(Integer value) {
-				return value.toString();
+			public void flatMap2(Tuple2<Integer, Integer> value, Collector<String> out) throws Exception {
+				out.collect(value.toString());
 			}
 		});
 
 		connected.addSink(resultSink);
-
-		connected.print();
 
 		try {
 			env.execute();
@@ -89,9 +123,11 @@ public class CoStreamTest {
 		}
 
 		expected = new ArrayList<String>();
-		expected.addAll(Arrays.asList("1", "1", "3", "3", "5", "5"));
+		expected.addAll(Arrays.asList("(1,2)", "(3,4)", "(5,6)", "1", "3", "5"));
 
-		System.out.println(resultSink.getResult());
-		assertEquals(expected, expected);
+		List<String> result = resultSink.getResult();
+		Collections.sort(result);
+
+		assertEquals(expected, result);
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/OutputSplitterTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/OutputSplitterTest.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.flink.streaming.api.collector.OutputSelector;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.TestListResultSink;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/StreamEdgeListTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/StreamEdgeListTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class StreamEdgeListTest {
+
+	private StreamEdgeList edgeList;
+
+	@Before
+	public void init() {
+		edgeList = new StreamEdgeList();
+	}
+
+	@Test
+	public void test() {
+		edgeList.addVertex(1);
+		edgeList.addVertex(2);
+		edgeList.addVertex(3);
+
+
+		// add edges
+		StreamEdge edge1 = new StreamEdge(1, 2, -1, null, null);
+		StreamEdge edge2 = new StreamEdge(2, 3, -1, null, null);
+		StreamEdge edge3 = new StreamEdge(1, 3, -1, null, null);
+
+		edgeList.addEdge(edge1);
+		edgeList.addEdge(edge2);
+		edgeList.addEdge(edge3);
+
+		// check adding
+		checkIfSameElements(edgeList.getOutEdges(1), Arrays.asList(edge1, edge3));
+		checkIfSameElements(edgeList.getOutEdges(2), Arrays.asList(edge2));
+		checkIfSameElements(edgeList.getOutEdges(3), new ArrayList<StreamEdge>());
+
+		checkIfSameElements(edgeList.getInEdges(1), new ArrayList<StreamEdge>());
+		checkIfSameElements(edgeList.getInEdges(2), Arrays.asList(edge1));
+		checkIfSameElements(edgeList.getInEdges(3), Arrays.asList(edge2, edge3));
+
+		// add duplicate edges
+		StreamEdge edge1new = new StreamEdge(1, 2, -2, null, null);
+		StreamEdge edge2new = new StreamEdge(2, 3, -2, null, null);
+
+		edgeList.addEdge(edge1new);
+		edgeList.addEdge(edge2new);
+
+		// check adding
+		checkIfSameElements(edgeList.getOutEdges(1), Arrays.asList(edge1, edge1new, edge3));
+		checkIfSameElements(edgeList.getOutEdges(2), Arrays.asList(edge2, edge2new));
+		checkIfSameElements(edgeList.getOutEdges(3), new ArrayList<StreamEdge>());
+
+		checkIfSameElements(edgeList.getInEdges(1), new ArrayList<StreamEdge>());
+		checkIfSameElements(edgeList.getInEdges(2), Arrays.asList(edge1, edge1new));
+		checkIfSameElements(edgeList.getInEdges(3), Arrays.asList(edge2, edge2new, edge3));
+
+		// remove a duplicate edge
+		edgeList.removeEdge(1, 2);
+
+		// check removing
+		checkIfSameElements(edgeList.getOutEdges(1), Arrays.asList(edge3));
+		checkIfSameElements(edgeList.getOutEdges(2), Arrays.asList(edge2, edge2new));
+
+		checkIfSameElements(edgeList.getInEdges(1), new ArrayList<StreamEdge>());
+		checkIfSameElements(edgeList.getInEdges(2), new ArrayList<StreamEdge>());
+
+		// add back an edge and delete a vertex
+		edgeList.addEdge(edge1);
+		edgeList.removeVertex(2);
+
+		// check removing
+		checkIfSameElements(edgeList.getOutEdges(1), Arrays.asList(edge3));
+		try {
+			checkIfSameElements(edgeList.getOutEdges(2), null);
+			fail();
+		} catch (RuntimeException e) {
+		}
+		checkIfSameElements(edgeList.getOutEdges(3), new ArrayList<StreamEdge>());
+
+		checkIfSameElements(edgeList.getInEdges(1), new ArrayList<StreamEdge>());
+		try {
+			checkIfSameElements(edgeList.getInEdges(2), null);
+			fail();
+		} catch (RuntimeException e) {
+		}
+		checkIfSameElements(edgeList.getInEdges(3), Arrays.asList(edge3));
+	}
+
+	private <T> void checkIfSameElements(List<T> expected, List<T> result) {
+		assertEquals(new HashSet<T>(expected), new HashSet<T>(result));
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/collector/DirectedOutputTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/collector/DirectedOutputTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.datastream.SplitDataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.function.sink.SinkFunction;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/collector/OutputSelectorTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/collector/OutputSelectorTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.junit.Test;
 
 public class OutputSelectorTest {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/co/SelfConnectionTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/invokable/operator/co/SelfConnectionTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.invokable.operator.co;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.function.co.CoMapFunction;
+import org.apache.flink.streaming.api.invokable.StreamInvokable;
+import org.apache.flink.streaming.api.windowing.helper.Timestamp;
+import org.apache.flink.streaming.util.TestListResultSink;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.Collector;
+import org.junit.Test;
+
+public class SelfConnectionTest implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int MEMORY_SIZE = 32;
+
+	private static List<String> expected;
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void sameDataStreamTest() {
+
+		StreamExecutionEnvironment env = new TestStreamEnvironment(3, MEMORY_SIZE);
+
+		TestListResultSink<String> resultSink = new TestListResultSink<String>();
+
+		Timestamp<Integer> timeStamp = new Timestamp<Integer>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public long getTimestamp(Integer value) {
+				return value;
+			}
+
+		};
+
+		KeySelector keySelector = new KeySelector<Integer, Integer>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Integer getKey(Integer value) throws Exception {
+				return value;
+			}
+		};
+
+		DataStream<Integer> src = env.fromElements(1, 3, 5);
+
+		@SuppressWarnings("unused")
+		DataStream<Tuple2<Integer, Integer>> dataStream =
+				src.join(src).onWindow(50L, timeStamp, timeStamp).where(keySelector).equalTo(keySelector)
+						.map(new MapFunction<Tuple2<Integer, Integer>, String>() {
+
+							private static final long serialVersionUID = 1L;
+
+							@Override
+							public String map(Tuple2<Integer, Integer> value) throws Exception {
+								return value.toString();
+							}
+						})
+						.addSink(resultSink);
+
+
+		try {
+			env.execute();
+
+			expected = new ArrayList<String>();
+
+			expected.addAll(Arrays.asList("(1,1)", "(3,3)", "(5,5)"));
+
+			List<String> result = resultSink.getResult();
+
+			Collections.sort(expected);
+			Collections.sort(result);
+
+			assertEquals(expected, result);
+		} catch (Exception e) {
+			fail();
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * We connect two different data streams in a chain to a CoMap.
+	 */
+	@Test
+	public void differentDataStreamSameChain() {
+
+		TestListResultSink<String> resultSink = new TestListResultSink<String>();
+
+		StreamExecutionEnvironment env = new TestStreamEnvironment(1, MEMORY_SIZE);
+
+		DataStream<Integer> src = env.fromElements(1, 3, 5);
+
+		DataStream<String> stringMap = src.map(new MapFunction<Integer, String>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String map(Integer value) throws Exception {
+				return "x " + value;
+			}
+		}).setChainingStrategy(StreamInvokable.ChainingStrategy.ALWAYS);
+
+		stringMap.connect(src).map(new CoMapFunction<String, Integer, String>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String map1(String value) {
+				return value;
+			}
+
+			@Override
+			public String map2(Integer value) {
+				return String.valueOf(value + 1);
+			}
+		}).addSink(resultSink);
+
+		try {
+			env.execute();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		expected = new ArrayList<String>();
+
+		expected.addAll(Arrays.asList("x 1", "x 3", "x 5", "2", "4", "6"));
+
+		List<String> result = resultSink.getResult();
+
+		Collections.sort(expected);
+		Collections.sort(result);
+
+		assertEquals(expected, result);
+	}
+
+	/**
+	 * We connect two different data streams in different chains to a CoMap.
+	 * (This is not actually self-connect.)
+	 */
+	@Test
+	public void differentDataStreamDifferentChain() {
+
+		TestListResultSink<String> resultSink = new TestListResultSink<String>();
+
+		StreamExecutionEnvironment env = new TestStreamEnvironment(3, MEMORY_SIZE);
+
+		DataStream<Integer> src = env.fromElements(1, 3, 5).setChainingStrategy(StreamInvokable.ChainingStrategy.NEVER);
+
+		DataStream<String> stringMap = src.flatMap(new FlatMapFunction<Integer, String>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void flatMap(Integer value, Collector<String> out) throws Exception {
+				out.collect("x " + value);
+			}
+		}).groupBy(new KeySelector<String, Integer>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Integer getKey(String value) throws Exception {
+				return value.length();
+			}
+		});
+
+		DataStream<Long> longMap = src.map(new MapFunction<Integer, Long>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Long map(Integer value) throws Exception {
+				return Long.valueOf(value + 1);
+			}
+		}).groupBy(new KeySelector<Long, Long>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Long getKey(Long value) throws Exception {
+				return value;
+			}
+		});
+
+
+		stringMap.connect(longMap).map(new CoMapFunction<String, Long, String>() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String map1(String value) {
+				return value;
+			}
+
+			@Override
+			public String map2(Long value) {
+				return value.toString();
+			}
+		}).addSink(resultSink);
+
+		try {
+			env.execute();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		expected = new ArrayList<String>();
+
+		expected.addAll(Arrays.asList("x 1", "x 3", "x 5", "2", "4", "6"));
+
+		List<String> result = resultSink.getResult();
+
+		Collections.sort(expected);
+		Collections.sort(result);
+
+		assertEquals(expected, result);
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamvertex/StreamVertexTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamvertex/StreamVertexTest.java
@@ -134,11 +134,13 @@ public class StreamVertexTest {
 
 		@Override
 		public String map1(String value) {
+//			System.out.println(value);
 			return value;
 		}
 
 		@Override
 		public String map2(Long value) {
+//			System.out.println(value);
 			return value.toString();
 		}
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/BarrierBufferIOTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/BarrierBufferIOTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Random;
+
+import org.apache.flink.runtime.event.task.TaskEvent;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.util.event.EventListener;
+import org.junit.Test;
+
+public class BarrierBufferIOTest {
+
+	@Test
+	public void IOTest() throws IOException, InterruptedException {
+
+		BufferPool pool1 = new NetworkBufferPool(100, 1024).createBufferPool(100, true);
+		BufferPool pool2 = new NetworkBufferPool(100, 1024).createBufferPool(100, true);
+
+		MockInputGate myIG = new MockInputGate(new BufferPool[] { pool1, pool2 },
+				new BarrierGenerator[] { new CountBarrier(100000), new RandomBarrier(100000) });
+		// new BarrierSimulator[] { new CountBarrier(1000), new
+		// CountBarrier(1000) });
+
+		BarrierBuffer barrierBuffer = new BarrierBuffer(myIG,
+				new BarrierBufferTest.MockReader(myIG));
+
+		try {
+			// long time = System.currentTimeMillis();
+			for (int i = 0; i < 2000000; i++) {
+				BufferOrEvent boe = barrierBuffer.getNextNonBlocked();
+				if (boe.isBuffer()) {
+					boe.getBuffer().recycle();
+				} else {
+					barrierBuffer.processSuperstep(boe);
+				}
+			}
+			// System.out.println("Ran for " + (System.currentTimeMillis() -
+			// time));
+		} catch (Exception e) {
+			fail();
+		} finally {
+			barrierBuffer.cleanup();
+		}
+	}
+
+	private static class RandomBarrier implements BarrierGenerator {
+		private static Random rnd = new Random();
+
+		double threshold;
+
+		public RandomBarrier(double expectedEvery) {
+			threshold = 1 / expectedEvery;
+		}
+
+		@Override
+		public boolean isNextBarrier() {
+			return rnd.nextDouble() < threshold;
+		}
+	}
+
+	private static class CountBarrier implements BarrierGenerator {
+
+		long every;
+		long c = 0;
+
+		public CountBarrier(long every) {
+			this.every = every;
+		}
+
+		@Override
+		public boolean isNextBarrier() {
+			return c++ % every == 0;
+		}
+	}
+
+	protected static class MockInputGate implements InputGate {
+
+		private int numChannels;
+		private BufferPool[] bufferPools;
+		private int[] currentSupersteps;
+		BarrierGenerator[] barrierGens;
+		int currentChannel = 0;
+		long c = 0;
+
+		public MockInputGate(BufferPool[] bufferPools, BarrierGenerator[] barrierGens) {
+			this.numChannels = bufferPools.length;
+			this.currentSupersteps = new int[numChannels];
+			this.bufferPools = bufferPools;
+			this.barrierGens = barrierGens;
+		}
+
+		@Override
+		public int getNumberOfInputChannels() {
+			return numChannels;
+		}
+
+		@Override
+		public boolean isFinished() {
+			return false;
+		}
+
+		@Override
+		public void requestPartitions() throws IOException, InterruptedException {
+		}
+
+		@Override
+		public BufferOrEvent getNextBufferOrEvent() throws IOException, InterruptedException {
+			currentChannel = (currentChannel + 1) % numChannels;
+
+			if (barrierGens[currentChannel].isNextBarrier()) {
+				return BarrierBufferTest.createSuperstep(++currentSupersteps[currentChannel],
+						currentChannel);
+			} else {
+				Buffer buffer = bufferPools[currentChannel].requestBuffer();
+				buffer.getMemorySegment().putLong(0, c++);
+
+				return new BufferOrEvent(buffer, currentChannel);
+			}
+
+		}
+
+		@Override
+		public void sendTaskEvent(TaskEvent event) throws IOException {
+		}
+
+		@Override
+		public void registerListener(EventListener<InputGate> listener) {
+		}
+
+	}
+
+	protected interface BarrierGenerator {
+		public boolean isNextBarrier();
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/BarrierBufferTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/BarrierBufferTest.java
@@ -110,26 +110,34 @@ public class BarrierBufferTest {
 		BarrierBuffer bb = new BarrierBuffer(mockIG1, mockAR1);
 		BufferOrEvent nextBoe;
 
-		assertEquals(input.get(0), nextBoe = bb.getNextNonBlocked());
-		assertEquals(input.get(1), nextBoe = bb.getNextNonBlocked());
-		assertEquals(input.get(2), nextBoe = bb.getNextNonBlocked());
+		check(input.get(0), nextBoe = bb.getNextNonBlocked());
+		check(input.get(1), nextBoe = bb.getNextNonBlocked());
+		check(input.get(2), nextBoe = bb.getNextNonBlocked());
 		bb.processSuperstep(nextBoe);
-		assertEquals(input.get(7), nextBoe = bb.getNextNonBlocked());
-		assertEquals(input.get(8), nextBoe = bb.getNextNonBlocked());
+		check(input.get(7), nextBoe = bb.getNextNonBlocked());
+		check(input.get(8), nextBoe = bb.getNextNonBlocked());
 		bb.processSuperstep(nextBoe);
-		assertEquals(input.get(3), nextBoe = bb.getNextNonBlocked());
+		check(input.get(3), nextBoe = bb.getNextNonBlocked());
 		bb.processSuperstep(nextBoe);
-		assertEquals(input.get(10), nextBoe = bb.getNextNonBlocked());
-		assertEquals(input.get(11), nextBoe = bb.getNextNonBlocked());
+		check(input.get(10), nextBoe = bb.getNextNonBlocked());
+		check(input.get(11), nextBoe = bb.getNextNonBlocked());
 		bb.processSuperstep(nextBoe);
-		assertEquals(input.get(4), nextBoe = bb.getNextNonBlocked());
-		assertEquals(input.get(5), nextBoe = bb.getNextNonBlocked());
+		check(input.get(4), nextBoe = bb.getNextNonBlocked());
+		check(input.get(5), nextBoe = bb.getNextNonBlocked());
 		bb.processSuperstep(nextBoe);
-		assertEquals(input.get(12), nextBoe = bb.getNextNonBlocked());
+		check(input.get(12), nextBoe = bb.getNextNonBlocked());
 		bb.processSuperstep(nextBoe);
-		assertEquals(input.get(6), nextBoe = bb.getNextNonBlocked());
-		assertEquals(input.get(9), nextBoe = bb.getNextNonBlocked());
+		check(input.get(6), nextBoe = bb.getNextNonBlocked());
+		check(input.get(9), nextBoe = bb.getNextNonBlocked());
 
+	}
+
+	private static void check(BufferOrEvent expected, BufferOrEvent actual) {
+		assertEquals(expected.isBuffer(), actual.isBuffer());
+		assertEquals(expected.getChannelIndex(), actual.getChannelIndex());
+		if (expected.isEvent()) {
+			assertEquals(expected.getEvent(), actual.getEvent());
+		}
 	}
 
 	protected static class MockInputGate implements InputGate {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/BarrierBufferTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/BarrierBufferTest.java
@@ -54,6 +54,7 @@ public class BarrierBufferTest {
 		assertEquals(input.get(1), bb.getNextNonBlocked());
 		assertEquals(input.get(2), bb.getNextNonBlocked());
 
+		bb.cleanup();
 	}
 
 	@Test
@@ -84,6 +85,7 @@ public class BarrierBufferTest {
 		bb.processSuperstep(nextBoe);
 		assertEquals(input.get(6), nextBoe = bb.getNextNonBlocked());
 
+		bb.cleanup();
 	}
 
 	@Test
@@ -130,6 +132,7 @@ public class BarrierBufferTest {
 		check(input.get(6), nextBoe = bb.getNextNonBlocked());
 		check(input.get(9), nextBoe = bb.getNextNonBlocked());
 
+		bb.cleanup();
 	}
 
 	private static void check(BufferOrEvent expected, BufferOrEvent actual) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/SpillingBufferOrEventTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/io/SpillingBufferOrEventTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.junit.Test;
+
+public class SpillingBufferOrEventTest {
+
+	@Test
+	public void testSpilling() throws IOException, InterruptedException {
+		BufferSpiller bsp = new BufferSpiller();
+		SpillReader spr = new SpillReader();
+
+		BufferPool pool1 = new NetworkBufferPool(10, 256).createBufferPool(2, true);
+		BufferPool pool2 = new NetworkBufferPool(10, 256).createBufferPool(2, true);
+
+		Buffer b1 = pool1.requestBuffer();
+		b1.getMemorySegment().putInt(0, 10000);
+		BufferOrEvent boe1 = new BufferOrEvent(b1, 0);
+		SpillingBufferOrEvent sboe1 = new SpillingBufferOrEvent(boe1, bsp, spr);
+
+		assertFalse(sboe1.isSpilled());
+
+		Buffer b2 = pool2.requestBuffer();
+		b2.getMemorySegment().putInt(0, 10000);
+		BufferOrEvent boe2 = new BufferOrEvent(b2, 0);
+		SpillingBufferOrEvent sboe2 = new SpillingBufferOrEvent(boe2, bsp, spr);
+
+		assertFalse(sboe2.isSpilled());
+
+		Buffer b3 = pool1.requestBuffer();
+		b3.getMemorySegment().putInt(0, 50000);
+		BufferOrEvent boe3 = new BufferOrEvent(b3, 0);
+		SpillingBufferOrEvent sboe3 = new SpillingBufferOrEvent(boe3, bsp, spr);
+
+		assertTrue(sboe3.isSpilled());
+
+		Buffer b4 = pool2.requestBuffer();
+		b4.getMemorySegment().putInt(0, 60000);
+		BufferOrEvent boe4 = new BufferOrEvent(b4, 0);
+		SpillingBufferOrEvent sboe4 = new SpillingBufferOrEvent(boe4, bsp, spr);
+
+		assertTrue(sboe4.isSpilled());
+
+		bsp.close();
+
+		spr.setSpillFile(bsp.getSpillFile());
+
+		Buffer b1ret = sboe1.getBufferOrEvent().getBuffer();
+		assertEquals(10000, b1ret.getMemorySegment().getInt(0));
+		b1ret.recycle();
+
+		Buffer b2ret = sboe2.getBufferOrEvent().getBuffer();
+		assertEquals(10000, b2ret.getMemorySegment().getInt(0));
+		b2ret.recycle();
+
+		Buffer b3ret = sboe3.getBufferOrEvent().getBuffer();
+		assertEquals(50000, b3ret.getMemorySegment().getInt(0));
+		b3ret.recycle();
+
+		Buffer b4ret = sboe4.getBufferOrEvent().getBuffer();
+		assertEquals(60000, b4ret.getMemorySegment().getInt(0));
+		b4ret.recycle();
+
+		spr.close();
+		bsp.getSpillFile().delete();
+
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListResultSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListResultSink.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.function.sink.RichSinkFunction;
 
 public class TestListResultSink<T> extends RichSinkFunction<T> {
 
+	private static final long serialVersionUID = 1L;
 	private int resultListId;
 
 	public TestListResultSink() {
@@ -50,6 +51,7 @@ public class TestListResultSink<T> extends RichSinkFunction<T> {
 		super.close();
 	}
 
+	@SuppressWarnings("unchecked")
 	private List<T> resultList() {
 		synchronized (TestListWrapper.getInstance()) {
 			return (List<T>) TestListWrapper.getInstance().getList(resultListId);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListResultSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListResultSink.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.function.sink.RichSinkFunction;
+
+public class TestListResultSink<T> extends RichSinkFunction<T> {
+
+	private int resultListId;
+
+	public TestListResultSink() {
+		this.resultListId = TestListWrapper.getInstance().createList();
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+	}
+
+	@Override
+	public void invoke(T value) throws Exception {
+		synchronized (resultList()) {
+			resultList().add(value);
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+	}
+
+	private List<T> resultList() {
+		synchronized (TestListWrapper.getInstance()) {
+			return (List<T>) TestListWrapper.getInstance().getList(resultListId);
+		}
+	}
+
+	public List<T> getResult() {
+		synchronized (resultList()) {
+			ArrayList<T> copiedList = new ArrayList<T>(resultList());
+			return copiedList;
+		}
+	}
+
+	public List<T> getSortedResult() {
+		synchronized (resultList()) {
+			TreeSet<T> treeSet = new TreeSet<T>(resultList());
+			ArrayList<T> sortedList = new ArrayList<T>(treeSet);
+			return sortedList;
+		}
+	}
+
+	@Override
+	public void cancel() {
+
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListWrapper.java
@@ -25,8 +25,10 @@ public class TestListWrapper {
 
 	private static TestListWrapper instance;
 
+	@SuppressWarnings("rawtypes")
 	private List<List<? extends Comparable>> lists;
 
+	@SuppressWarnings("rawtypes")
 	private TestListWrapper() {
 		lists = Collections.synchronizedList(new ArrayList<List<? extends Comparable>>());
 	}
@@ -43,12 +45,14 @@ public class TestListWrapper {
 	 *
 	 * @return The ID of the list.
 	 */
+	@SuppressWarnings("rawtypes")
 	public int createList() {
 		lists.add(new ArrayList<Comparable>());
 		return lists.size() - 1;
 	}
 
 	public List<?> getList(int listId) {
+		@SuppressWarnings("rawtypes")
 		List<? extends Comparable> list = lists.get(listId);
 		if (list == null) {
 			throw new RuntimeException("No such list.");

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/TestListWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TestListWrapper {
+
+	private static TestListWrapper instance;
+
+	private List<List<? extends Comparable>> lists;
+
+	private TestListWrapper() {
+		lists = Collections.synchronizedList(new ArrayList<List<? extends Comparable>>());
+	}
+
+	public static TestListWrapper getInstance() {
+		if (instance == null) {
+			instance = new TestListWrapper();
+		}
+		return instance;
+	}
+
+	/**
+	 * Creates and stores a list, returns with the id.
+	 *
+	 * @return The ID of the list.
+	 */
+	public int createList() {
+		lists.add(new ArrayList<Comparable>());
+		return lists.size() - 1;
+	}
+
+	public List<?> getList(int listId) {
+		List<? extends Comparable> list = lists.get(listId);
+		if (list == null) {
+			throw new RuntimeException("No such list.");
+		}
+
+		return list;
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/iteration/IterateExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/iteration/IterateExample.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.collector.OutputSelector;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeDataStream;
 import org.apache.flink.streaming.api.datastream.SplitDataStream;

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.scala
 
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
+import org.apache.flink.streaming.api.collector.selector.OutputSelector
 import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream,
   SingleOutputStreamOperator, GroupedDataStream}
 import scala.collection.JavaConverters._
@@ -38,7 +39,6 @@ import org.apache.flink.streaming.api.function.sink.SinkFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment.clean
 import org.apache.flink.streaming.api.windowing.helper.WindowingHelper
 import org.apache.flink.streaming.api.windowing.policy.{ EvictionPolicy, TriggerPolicy }
-import org.apache.flink.streaming.api.collector.OutputSelector
 import scala.collection.JavaConversions._
 import java.util.HashMap
 import org.apache.flink.streaming.api.function.aggregation.SumFunction


### PR DESCRIPTION
* Added StreamEdge abstraction, so more than one edge can be defined between stream operators.
* Added OutputSelectorWrapper to avoid directed emission spreading over all the code.
* Added factories for reader and writer creation

Travis fails on StreamVertexTest.coTest() (it gets stuck). Locally it passes.