### PR TITLE
Cleanup of low level Kafka consumer (PersistentKafkaSource)

### DIFF
--- a/docs/streaming_guide.md
+++ b/docs/streaming_guide.md
@@ -1166,12 +1166,9 @@ A class providing an interface for receiving data from Kafka.
 
 The followings have to be provided for the `KafkaSource(…)` constructor in order:
 
-1. The hostname
-2. The group name
-3. The topic name
-4. The parallelism
-5. Deserialisation schema
-
+1. Zookeeper hostname
+2. The topic name
+3. Deserialisation schema
 
 Example:
 
@@ -1179,15 +1176,41 @@ Example:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 DataStream<String> stream = env
-	.addSource(new KafkaSource<String>("localhost:2181", "group", "test", new SimpleStringSchema()))
+	.addSource(new KafkaSource<String>("localhost:2181", "test", new SimpleStringSchema()))
 	.print();
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 stream = env
-    .addSource(new KafkaSource[String]("localhost:2181", "group", "test", new SimpleStringSchema)
+    .addSource(new KafkaSource[String]("localhost:2181", "test", new SimpleStringSchema)
     .print
+{% endhighlight %}
+</div>
+</div>
+
+#### Persistent Kafka Source
+As Kafka persists all their data, a fault tolerant Kafka source can be provided.
+
+The PersistentKafkaSource can read a topic, and if the job fails for some reason, when restarting the source will continue on reading from where it left off. For example if there are 3 partitions in the topic with offsets 31, 122, 110 read at the time of job failure, then at the time of restart it will continue on reading from those offsets, no matter whether these partitions have new messages.
+
+The followings have to be provided for the `PersistentKafkaSource(…)` constructor in order:
+
+1. The topic name
+2. The hostname of a Kafka broker
+3. Deserialisation schema
+
+Example:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+stream.addSink(new PersistentKafkaSource<String>("test", "localhost:9092", new SimpleStringSchema()));
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+stream.addSink(new PersistentKafkaSource[String]("test", "localhost:9092", new SimpleStringSchema))
 {% endhighlight %}
 </div>
 </div>
@@ -1195,10 +1218,10 @@ stream = env
 #### Kafka Sink
 A class providing an interface for sending data to Kafka. 
 
-The followings have to be provided for the `KafkaSink()` constructor in order:
+The followings have to be provided for the `KafkaSink(…)` constructor in order:
 
 1. The topic name
-2. The hostname
+2. The hostname of a Kafka broker
 3. Serialisation schema
 
 Example: 
@@ -1206,12 +1229,12 @@ Example:
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-stream.addSink(new KafkaSink<String, String>("test", "localhost:9092", new SimpleStringSchema()));
+stream.addSink(new KafkaSink<String>("test", "localhost:9092", new SimpleStringSchema()));
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-stream.addSink(new KafkaSink[String, String]("test", "localhost:9092", new SimpleStringSchema))
+stream.addSink(new KafkaSink[String]("test", "localhost:9092", new SimpleStringSchema))
 {% endhighlight %}
 </div>
 </div>

--- a/flink-staging/flink-streaming/flink-streaming-connectors/pom.xml
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/pom.xml
@@ -46,7 +46,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka_2.10</artifactId>
-			<version>0.8.2.0</version>
+			<version>0.8.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.sun.jmx</groupId>

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExample.java
@@ -56,7 +56,7 @@ public class KafkaProducerExample {
 			
 			
 		}).addSink(
-				new KafkaSink<String>(topic, host + ":" + port, new JavaDefaultStringSchema())
+				new KafkaSink<String>(host + ":" + port, topic, new JavaDefaultStringSchema())
 		)
 		.setParallelism(3);
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSimpleConsumerExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSimpleConsumerExample.java
@@ -37,7 +37,7 @@ public class KafkaSimpleConsumerExample {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment().setDegreeOfParallelism(4);
 
 		DataStream<String> kafkaStream = env
-				.addSource(new PersistentKafkaSource<String>(topic, host, port, new JavaDefaultStringSchema()));
+				.addSource(new PersistentKafkaSource<String>(topic, host + ":" + port, new JavaDefaultStringSchema()));
 
 		kafkaStream.print();
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSimpleConsumerExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSimpleConsumerExample.java
@@ -27,8 +27,6 @@ public class KafkaSimpleConsumerExample {
 	private static String host;
 	private static int port;
 	private static String topic;
-	private static int partition;
-	private static long offset;
 
 	public static void main(String[] args) throws Exception {
 
@@ -39,7 +37,7 @@ public class KafkaSimpleConsumerExample {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment().setDegreeOfParallelism(4);
 
 		DataStream<String> kafkaStream = env
-				.addSource(new PersistentKafkaSource<String>(topic, host, port, partition, offset, new JavaDefaultStringSchema()));
+				.addSource(new PersistentKafkaSource<String>(topic, host, port, new JavaDefaultStringSchema()));
 
 		kafkaStream.print();
 
@@ -47,15 +45,13 @@ public class KafkaSimpleConsumerExample {
 	}
 
 	private static boolean parseParameters(String[] args) {
-		if (args.length == 4) {
+		if (args.length == 3) {
 			host = args[0];
 			port = Integer.parseInt(args[1]);
 			topic = args[2];
-			partition = Integer.parseInt(args[3]);
-			offset = Long.parseLong(args[4]);
 			return true;
 		} else {
-			System.err.println("Usage: KafkaConsumerExample <host> <port> <topic> <partition> <offset>");
+			System.err.println("Usage: KafkaConsumerExample <host> <port> <topic>");
 			return false;
 		}
 	}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSimpleConsumerExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSimpleConsumerExample.java
@@ -35,9 +35,8 @@ public class KafkaSimpleConsumerExample {
 		}
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment().setDegreeOfParallelism(4);
-
 		DataStream<String> kafkaStream = env
-				.addSource(new PersistentKafkaSource<String>(topic, host + ":" + port, new JavaDefaultStringSchema()));
+				.addSource(new PersistentKafkaSource<String>(host + ":" + port, topic, new JavaDefaultStringSchema()));
 
 		kafkaStream.print();
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSource.java
@@ -106,6 +106,8 @@ public class KafkaSource<OUT> extends ConnectorSource<OUT> {
 		List<KafkaStream<byte[], byte[]>> streams = consumerMap.get(topicId);
 		KafkaStream<byte[], byte[]> stream = streams.get(0);
 
+		consumer.commitOffsets();
+
 		consumerIterator = stream.iterator();
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/KafkaTopicUtils.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/KafkaTopicUtils.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kafka.api.simple;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Collection;
 import java.util.Properties;
 
 import org.I0Itec.zkclient.ZkClient;
@@ -27,6 +28,7 @@ import org.I0Itec.zkclient.serialize.ZkSerializer;
 import kafka.admin.AdminUtils;
 import kafka.api.PartitionMetadata;
 import kafka.api.TopicMetadata;
+import kafka.cluster.Broker;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
@@ -35,6 +37,14 @@ import scala.collection.Seq;
  * or creating a topic.
  */
 public class KafkaTopicUtils {
+
+	public static void main(String[] args) {
+		KafkaTopicUtils kafkaTopicUtils = new KafkaTopicUtils("localhost:2181", 5000, 5000);
+//		TopicMetadata para4 = kafkaTopicUtils.getTopicInfo("para4");
+//		PartitionMetadata next = JavaConversions.asJavaCollection(para4.partitionsMetadata()).iterator().next();
+//		next.
+		System.out.println(kafkaTopicUtils.getLeaderBrokerAddressForTopic("para4"));
+	}
 
 	private final ZkClient zkClient;
 
@@ -59,6 +69,19 @@ public class KafkaTopicUtils {
 	public int getNumberOfPartitions(String topicName) {
 		Seq<PartitionMetadata> partitionMetadataSeq = getTopicInfo(topicName).partitionsMetadata();
 		return JavaConversions.asJavaCollection(partitionMetadataSeq).size();
+	}
+
+	public String getLeaderBrokerAddressForTopic(String topicName) {
+		TopicMetadata topicInfo = getTopicInfo(topicName);
+
+		Collection<PartitionMetadata> partitions = JavaConversions.asJavaCollection(topicInfo.partitionsMetadata());
+		PartitionMetadata partitionMetadata = partitions.iterator().next();
+
+		Broker leader = JavaConversions.asJavaCollection(partitionMetadata.isr()).iterator().next();
+
+		// TODO for Kafka version 8.2.0
+		//		return leader.connectionString();
+		return leader.getConnectionString();
 	}
 
 	public TopicMetadata getTopicInfo(String topicName) {

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/MessageWithMetadata.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/MessageWithMetadata.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.api.simple;
+
+/**
+ * POJO encapsulating records received from Kafka with their offset and partition.
+ */
+public class MessageWithMetadata {
+
+	private int partition;
+	private long offset;
+	private byte[] message;
+
+	public MessageWithMetadata(long offset, byte[] message, int partition) {
+		this.partition = partition;
+		this.offset = offset;
+		this.message = message;
+	}
+
+	public long getOffset() {
+		return offset;
+	}
+
+	public byte[] getMessage() {
+		return message;
+	}
+
+	public int getPartition() {
+		return partition;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/PersistentKafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/PersistentKafkaSource.java
@@ -52,9 +52,9 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 
 	private int partition;
 	
-	public PersistentKafkaSource(String topicId, String host, int port,
+	public PersistentKafkaSource(String topicId, String host,
 			DeserializationSchema<OUT> deserializationSchema) {
-		super(topicId, host, port, deserializationSchema);
+		super(topicId, host, deserializationSchema);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -63,7 +63,7 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 		StreamingRuntimeContext context = (StreamingRuntimeContext) getRuntimeContext();
 		int indexOfSubtask = context.getIndexOfThisSubtask();
 		int numberOfSubtasks = context.getNumberOfParallelSubtasks();
-		int numberOfPartitions = new KafkaTopicUtils(hostName + ":2181", 5000, 5000).getNumberOfPartitions(topicId);
+		int numberOfPartitions = new KafkaTopicUtils(hostName, 5000, 5000).getNumberOfPartitions(topicId);
 
 		if (indexOfSubtask >= numberOfPartitions) {
 			iterator = new KafkaIdleConsumerIterator();
@@ -73,7 +73,7 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 
 				partitions = kafkaOffSet.getState();
 
-				iterator = new KafkaMultiplePartitionsIterator(hostName, port, topicId, partitions, 500);
+				iterator = new KafkaMultiplePartitionsIterator(hostName, topicId, partitions, 500);
 			} else {
 				partitions = new HashMap<Integer, KafkaOffset>();
 
@@ -89,7 +89,7 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 
 				context.registerState("kafka", kafkaOffSet);
 
-				iterator = new KafkaMultiplePartitionsIterator(hostName, port, topicId, partitions, 500);
+				iterator = new KafkaMultiplePartitionsIterator(hostName, topicId, partitions, 500);
 			}
 
 			if (LOG.isInfoEnabled()) {

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/PersistentKafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/PersistentKafkaSource.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.OperatorState;
 import org.apache.flink.streaming.api.streamvertex.StreamingRuntimeContext;
+import org.apache.flink.streaming.connectors.kafka.api.simple.iterator.KafkaConsumerIterator;
 import org.apache.flink.streaming.connectors.kafka.api.simple.iterator.KafkaIdleConsumerIterator;
 import org.apache.flink.streaming.connectors.kafka.api.simple.iterator.KafkaMultiplePartitionsIterator;
 import org.apache.flink.streaming.connectors.kafka.api.simple.offset.CurrentOffset;
@@ -39,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * by the whole execution graph.
  *
  * @param <OUT>
- *            Type of the messages on the topic.
+ * 		Type of the messages on the topic.
  */
 public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 
@@ -47,14 +48,48 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PersistentKafkaSource.class);
 
-	private transient OperatorState<Map<Integer, KafkaOffset>> kafkaOffSet;
-	private transient Map<Integer, KafkaOffset> partitions;
+	protected transient OperatorState<Map<Integer, KafkaOffset>> kafkaOffSet;
+	protected transient Map<Integer, KafkaOffset> partitions;
 
 	private int partition;
-	
-	public PersistentKafkaSource(String topicId, String host,
+
+	private int zookeeperSyncTimeMillis;
+	private int waitOnEmptyFetchMillis;
+
+	/**
+	 * Creates a persistent Kafka source that consumes a topic.
+	 *
+	 * @param zookeeperHost
+	 * 		Address of the Zookeeper host (with port number).
+	 * @param topicId
+	 * 		ID of the Kafka topic.
+	 * @param deserializationSchema
+	 * 		User defined deserialization schema.
+	 */
+	public PersistentKafkaSource(String zookeeperHost, String topicId,
 			DeserializationSchema<OUT> deserializationSchema) {
-		super(topicId, host, deserializationSchema);
+		this(zookeeperHost, topicId, deserializationSchema, 5000, 500);
+	}
+
+	/**
+	 * Creates a persistent Kafka source that consumes a topic.
+	 *
+	 * @param zookeeperHost
+	 * 		Address of the Zookeeper host (with port number).
+	 * @param topicId
+	 * 		ID of the Kafka topic.
+	 * @param deserializationSchema
+	 * 		User defined deserialization schema.
+	 * @param zookeeperSyncTimeMillis
+	 * 		Synchronization time with zookeeper.
+	 * @param waitOnEmptyFetchMillis
+	 * 		Time to wait before fetching for new message.
+	 */
+	public PersistentKafkaSource(String zookeeperHost, String topicId,
+			DeserializationSchema<OUT> deserializationSchema, int zookeeperSyncTimeMillis, int waitOnEmptyFetchMillis) {
+		super(topicId, zookeeperHost, deserializationSchema);
+		this.zookeeperSyncTimeMillis = zookeeperSyncTimeMillis;
+		this.waitOnEmptyFetchMillis = waitOnEmptyFetchMillis;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -63,7 +98,13 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 		StreamingRuntimeContext context = (StreamingRuntimeContext) getRuntimeContext();
 		int indexOfSubtask = context.getIndexOfThisSubtask();
 		int numberOfSubtasks = context.getNumberOfParallelSubtasks();
-		int numberOfPartitions = new KafkaTopicUtils(hostName, 5000, 5000).getNumberOfPartitions(topicId);
+
+		KafkaTopicUtils kafkaTopicUtils =
+				new KafkaTopicUtils(zookeeperServerAddress, zookeeperSyncTimeMillis, zookeeperSyncTimeMillis);
+
+		int numberOfPartitions = kafkaTopicUtils.getNumberOfPartitions(topicId);
+
+		String brokerAddress = kafkaTopicUtils.getLeaderBrokerAddressForTopic(topicId);
 
 		if (indexOfSubtask >= numberOfPartitions) {
 			iterator = new KafkaIdleConsumerIterator();
@@ -72,25 +113,21 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 				kafkaOffSet = (OperatorState<Map<Integer, KafkaOffset>>) context.getState("kafka");
 
 				partitions = kafkaOffSet.getState();
-
-				iterator = new KafkaMultiplePartitionsIterator(hostName, topicId, partitions, 500);
 			} else {
 				partitions = new HashMap<Integer, KafkaOffset>();
 
 				partition = indexOfSubtask;
 
-				for (int partitionIndex = indexOfSubtask;
-					 partitionIndex < numberOfPartitions;
-					 partitionIndex += numberOfSubtasks) {
+				for (int partitionIndex = indexOfSubtask; partitionIndex < numberOfPartitions; partitionIndex += numberOfSubtasks) {
 					partitions.put(partitionIndex, new CurrentOffset());
 				}
 
 				kafkaOffSet = new OperatorState<Map<Integer, KafkaOffset>>(partitions);
 
 				context.registerState("kafka", kafkaOffSet);
-
-				iterator = new KafkaMultiplePartitionsIterator(hostName, topicId, partitions, 500);
 			}
+
+			iterator = getMultiKafkaIterator(brokerAddress, topicId, partitions, waitOnEmptyFetchMillis);
 
 			if (LOG.isInfoEnabled()) {
 				LOG.info("KafkaSource ({}/{}) listening to partitions {} of topic {}.",
@@ -101,12 +138,21 @@ public class PersistentKafkaSource<OUT> extends SimpleKafkaSource<OUT> {
 		iterator.initialize();
 	}
 
+	protected KafkaConsumerIterator getMultiKafkaIterator(String hostName, String topic, Map<Integer, KafkaOffset> partitionsWithOffset, int waitOnEmptyFetch) {
+		return new KafkaMultiplePartitionsIterator(hostName, topic, partitionsWithOffset, waitOnEmptyFetch);
+	}
+
 	@Override
 	public void run(Collector<OUT> collector) throws Exception {
 		MessageWithMetadata msg;
 		while (iterator.hasNext()) {
 			msg = iterator.nextWithOffset();
 			OUT out = schema.deserialize(msg.getMessage());
+
+			if (schema.isEndOfStream(out)) {
+				break;
+			}
+
 			collector.collect(out);
 
 			// TODO avoid object creation

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/SimpleKafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/SimpleKafkaSource.java
@@ -35,20 +35,16 @@ public class SimpleKafkaSource<OUT> extends ConnectorSource<OUT> {
 
 	protected String topicId;
 	protected final String hostName;
-	protected final int port;
+//	protected final int port;
 	protected KafkaConsumerIterator iterator;
 
-	public SimpleKafkaSource(String topic, String hostName, int port,
+	public SimpleKafkaSource(String topic, String hostName,
 			DeserializationSchema<OUT> deserializationSchema) {
 		super(deserializationSchema);
 		this.topicId = topic;
 		this.hostName = hostName;
-		this.port = port;
+//		this.port = port;
 	}
-
-//	protected final void initializeConnection() {
-//		iterator = new KafkaMorePartitionsIterator(hostName, port, topicId, List.of(new PartitionWithOffset(partition, new CurrentOffset())), 500);
-//	}
 
 	protected void setInitialOffset(Configuration config) throws InterruptedException {
 		iterator.initialize();

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/SimpleKafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/SimpleKafkaSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka.api.simple;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.ConnectorSource;
+import org.apache.flink.streaming.connectors.kafka.api.simple.iterator.KafkaConsumerIterator;
 import org.apache.flink.streaming.connectors.util.DeserializationSchema;
 import org.apache.flink.util.Collector;
 
@@ -32,33 +33,31 @@ import org.apache.flink.util.Collector;
 public class SimpleKafkaSource<OUT> extends ConnectorSource<OUT> {
 	private static final long serialVersionUID = 1L;
 
-	private String topicId;
-	private final String hostName;
-	private final int port;
-	private final int partition;
+	protected String topicId;
+	protected final String hostName;
+	protected final int port;
 	protected KafkaConsumerIterator iterator;
 
-	public SimpleKafkaSource(String topic, String hostName, int port, int partition,
-								DeserializationSchema<OUT> deserializationSchema) {
+	public SimpleKafkaSource(String topic, String hostName, int port,
+			DeserializationSchema<OUT> deserializationSchema) {
 		super(deserializationSchema);
 		this.topicId = topic;
 		this.hostName = hostName;
 		this.port = port;
-		this.partition = partition;
 	}
 
-	private void initializeConnection() {
-		iterator = new KafkaConsumerIterator(hostName, port, topicId, partition);
-	}
+//	protected final void initializeConnection() {
+//		iterator = new KafkaMorePartitionsIterator(hostName, port, topicId, List.of(new PartitionWithOffset(partition, new CurrentOffset())), 500);
+//	}
 
 	protected void setInitialOffset(Configuration config) throws InterruptedException {
-		iterator.initializeFromCurrent();
+		iterator.initialize();
 	}
 
 	@Override
 	public void run(Collector<OUT> collector) throws Exception {
 		while (iterator.hasNext()) {
-			MessageWithOffset msg = iterator.nextWithOffset();
+			MessageWithMetadata msg = iterator.nextWithOffset();
 			OUT out = schema.deserialize(msg.getMessage());
 			collector.collect(out);
 		}
@@ -71,7 +70,7 @@ public class SimpleKafkaSource<OUT> extends ConnectorSource<OUT> {
 
 	@Override
 	public void open(Configuration config) throws InterruptedException {
-		initializeConnection();
+//		initializeConnection();
 		setInitialOffset(config);
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/SimpleKafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/SimpleKafkaSource.java
@@ -34,16 +34,14 @@ public class SimpleKafkaSource<OUT> extends ConnectorSource<OUT> {
 	private static final long serialVersionUID = 1L;
 
 	protected String topicId;
-	protected final String hostName;
-//	protected final int port;
+	protected final String zookeeperServerAddress;
 	protected KafkaConsumerIterator iterator;
 
-	public SimpleKafkaSource(String topic, String hostName,
+	public SimpleKafkaSource(String topic, String zookeeperServerAddress,
 			DeserializationSchema<OUT> deserializationSchema) {
 		super(deserializationSchema);
 		this.topicId = topic;
-		this.hostName = hostName;
-//		this.port = port;
+		this.zookeeperServerAddress = zookeeperServerAddress;
 	}
 
 	protected void setInitialOffset(Configuration config) throws InterruptedException {

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaConsumerIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaConsumerIterator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.api.simple.iterator;
+
+import org.apache.flink.streaming.connectors.kafka.api.simple.MessageWithMetadata;
+
+/**
+ * Iterator interface for different types of Kafka consumers.
+ */
+public interface KafkaConsumerIterator {
+
+	public void initialize() throws InterruptedException;
+
+	public boolean hasNext();
+
+	/**
+	 * Returns the next message received from Kafka as a
+	 * byte array.
+	 *
+	 * @return next message as a byte array.
+	 */
+	public byte[] next() throws InterruptedException;
+
+	/**
+	 * Returns the next message and its offset received from
+	 * Kafka encapsulated in a POJO.
+	 *
+	 * @return next message and its offset.
+	 */
+	public MessageWithMetadata nextWithOffset() throws InterruptedException;
+}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaIdleConsumerIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaIdleConsumerIterator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.api.simple.iterator;
+
+import org.apache.flink.streaming.connectors.kafka.api.simple.MessageWithMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaIdleConsumerIterator implements KafkaConsumerIterator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaIdleConsumerIterator.class);
+
+	public KafkaIdleConsumerIterator() {
+		if (LOG.isWarnEnabled()) {
+			LOG.warn("Idle Kafka consumer created. The subtask does nothing.");
+		}
+	}
+
+
+	@Override
+	public void initialize() throws InterruptedException {
+
+	}
+
+	@Override
+	public boolean hasNext() {
+		return false;
+	}
+
+	@Override
+	public byte[] next() {
+		throw new RuntimeException("Idle consumer has no input.");
+	}
+
+	@Override
+	public MessageWithMetadata nextWithOffset() {
+		throw new RuntimeException("Idle consumer has no input.");
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
@@ -33,8 +33,13 @@ public class KafkaMultiplePartitionsIterator implements KafkaConsumerIterator {
 	private List<KafkaOnePartitionIterator> partitions;
 	private final int waitOnEmptyFetch;
 
-	public KafkaMultiplePartitionsIterator(String hostName, int port, String topic, Map<Integer, KafkaOffset> partitionsWithOffset, int waitOnEmptyFetch) {
+	public KafkaMultiplePartitionsIterator(String hostName, String topic, Map<Integer, KafkaOffset> partitionsWithOffset, int waitOnEmptyFetch) {
 		partitions = new ArrayList<KafkaOnePartitionIterator>(partitionsWithOffset.size());
+
+		String[] hostAndPort = hostName.split(":");
+
+		String host = hostAndPort[0];
+		int port = Integer.parseInt(hostAndPort[1]);
 
 		this.waitOnEmptyFetch = waitOnEmptyFetch;
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
@@ -30,8 +30,8 @@ public class KafkaMultiplePartitionsIterator implements KafkaConsumerIterator {
 
 	private static final Logger LOG = LoggerFactory.getLogger(KafkaMultiplePartitionsIterator.class);
 
-	private List<KafkaOnePartitionIterator> partitions;
-	private final int waitOnEmptyFetch;
+	protected List<KafkaOnePartitionIterator> partitions;
+	protected final int waitOnEmptyFetch;
 
 	public KafkaMultiplePartitionsIterator(String hostName, String topic, Map<Integer, KafkaOffset> partitionsWithOffset, int waitOnEmptyFetch) {
 		partitions = new ArrayList<KafkaOnePartitionIterator>(partitionsWithOffset.size());
@@ -45,7 +45,7 @@ public class KafkaMultiplePartitionsIterator implements KafkaConsumerIterator {
 
 		for (Map.Entry<Integer, KafkaOffset> partitionWithOffset : partitionsWithOffset.entrySet()) {
 			partitions.add(new KafkaOnePartitionIterator(
-					hostName,
+					host,
 					port,
 					topic,
 					partitionWithOffset.getKey(),
@@ -70,7 +70,7 @@ public class KafkaMultiplePartitionsIterator implements KafkaConsumerIterator {
 		return nextWithOffset().getMessage();
 	}
 
-	private int lastCheckedPartitionIndex = -1;
+	protected int lastCheckedPartitionIndex = -1;
 
 	@Override
 	public MessageWithMetadata nextWithOffset() throws InterruptedException {
@@ -94,7 +94,7 @@ public class KafkaMultiplePartitionsIterator implements KafkaConsumerIterator {
 		}
 	}
 
-	private int nextPartition(int currentPartition) {
+	protected int nextPartition(int currentPartition) {
 		return (currentPartition + 1) % partitions.size();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.api.simple.iterator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.flink.streaming.connectors.kafka.api.simple.MessageWithMetadata;
+import org.apache.flink.streaming.connectors.kafka.api.simple.offset.KafkaOffset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaMultiplePartitionsIterator implements KafkaConsumerIterator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaMultiplePartitionsIterator.class);
+
+	private List<KafkaOnePartitionIterator> partitions;
+	private final int waitOnEmptyFetch;
+
+	public KafkaMultiplePartitionsIterator(String hostName, int port, String topic, Map<Integer, KafkaOffset> partitionsWithOffset, int waitOnEmptyFetch) {
+		partitions = new ArrayList<KafkaOnePartitionIterator>(partitionsWithOffset.size());
+
+		this.waitOnEmptyFetch = waitOnEmptyFetch;
+
+		for (Map.Entry<Integer, KafkaOffset> partitionWithOffset : partitionsWithOffset.entrySet()) {
+			partitions.add(new KafkaOnePartitionIterator(
+					hostName,
+					port,
+					topic,
+					partitionWithOffset.getKey(),
+					partitionWithOffset.getValue()));
+		}
+	}
+
+	@Override
+	public void initialize() throws InterruptedException {
+		for (KafkaOnePartitionIterator partition : partitions) {
+			partition.initialize();
+		}
+	}
+
+	@Override
+	public boolean hasNext() {
+		return true;
+	}
+
+	@Override
+	public byte[] next() throws InterruptedException {
+		return nextWithOffset().getMessage();
+	}
+
+	private int lastCheckedPartitionIndex = -1;
+
+	@Override
+	public MessageWithMetadata nextWithOffset() throws InterruptedException {
+		KafkaOnePartitionIterator partition;
+
+		while (true) {
+			for (int i = nextPartition(lastCheckedPartitionIndex); i < partitions.size(); i = nextPartition(i)) {
+				partition = partitions.get(i);
+
+				if (partition.fetchHasNext()) {
+					lastCheckedPartitionIndex = i;
+					return partition.nextWithOffset();
+				}
+			}
+
+			try {
+				Thread.sleep(waitOnEmptyFetch);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	private int nextPartition(int currentPartition) {
+		return (currentPartition + 1) % partitions.size();
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaOnePartitionIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaOnePartitionIterator.java
@@ -252,8 +252,7 @@ public class KafkaOnePartitionIterator implements KafkaConsumerIterator, Seriali
 				}
 			} catch (Exception e) {
 				throw new RuntimeException("Error communicating with Broker [" + seed
-						+ "] to find Leader for [" + a_topic + ", " + a_partition + "] Reason: "
-						+ e);
+						+ "] to find Leader for [" + a_topic + ", " + a_partition + "]", e);
 			} finally {
 				if (consumer != null) {
 					consumer.close();

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaOnePartitionIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaOnePartitionIterator.java
@@ -15,23 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.api.simple;
+package org.apache.flink.streaming.connectors.kafka.api.simple.iterator;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+
+import org.apache.flink.streaming.connectors.kafka.api.simple.MessageWithMetadata;
+import org.apache.flink.streaming.connectors.kafka.api.simple.offset.KafkaOffset;
 
 import kafka.api.FetchRequest;
 import kafka.api.FetchRequestBuilder;
-import kafka.api.PartitionOffsetRequestInfo;
-import kafka.common.TopicAndPartition;
 import kafka.javaapi.FetchResponse;
-import kafka.javaapi.OffsetResponse;
 import kafka.javaapi.PartitionMetadata;
 import kafka.javaapi.TopicMetadata;
 import kafka.javaapi.TopicMetadataRequest;
@@ -41,7 +39,7 @@ import kafka.message.MessageAndOffset;
 /**
  * Iterates the records received from a partition of a Kafka topic as byte arrays.
  */
-public class KafkaConsumerIterator implements Serializable {
+public class KafkaOnePartitionIterator implements KafkaConsumerIterator, Serializable {
 
 	private static final long serialVersionUID = 1L;
 
@@ -52,10 +50,11 @@ public class KafkaConsumerIterator implements Serializable {
 	private int port;
 	private int partition;
 	private long readOffset;
-	private long waitOnEmptyFetch;
 	private transient SimpleConsumer consumer;
 	private List<String> replicaBrokers;
 	private String clientName;
+
+	private KafkaOffset initialOffset;
 
 	private transient Iterator<MessageAndOffset> iter;
 	private transient FetchResponse fetchResponse;
@@ -68,33 +67,18 @@ public class KafkaConsumerIterator implements Serializable {
 	 * @param port Port of the known Kafka broker
 	 * @param topic Name of the topic to listen to
 	 * @param partition Partition in the chosen topic
-	 * @param waitOnEmptyFetch wait time on empty fetch in millis
 	 */
-	public KafkaConsumerIterator(String hostName, int port, String topic, int partition,
-			long waitOnEmptyFetch) {
-
+	public KafkaOnePartitionIterator(String hostName, int port, String topic, int partition, KafkaOffset initialOffset) {
 		this.hosts = new ArrayList<String>();
 		hosts.add(hostName);
 		this.port = port;
 
 		this.topic = topic;
 		this.partition = partition;
-		this.waitOnEmptyFetch = waitOnEmptyFetch;
+
+		this.initialOffset = initialOffset;
 
 		replicaBrokers = new ArrayList<String>();
-	}
-
-	/**
-	 * Constructor without configurable wait time on empty fetch. For connecting to the Kafka service
-	 * we use the so called simple or low level Kafka API thus directly connecting to one of the brokers.
-	 *
-	 * @param hostName Hostname of a known Kafka broker
-	 * @param port Port of the known Kafka broker
-	 * @param topic Name of the topic to listen to
-	 * @param partition Partition in the chosen topic
-	 */
-	public KafkaConsumerIterator(String hostName, int port, String topic, int partition){
-		this(hostName, port, topic, partition, DEFAULT_WAIT_ON_EMPTY_FETCH);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -105,16 +89,14 @@ public class KafkaConsumerIterator implements Serializable {
 	 * Initializes the connection by detecting the leading broker of
 	 * the topic and establishing a connection to it.
 	 */
-	private void initialize() throws InterruptedException {
+	public void initialize() throws InterruptedException {
 		PartitionMetadata metadata;
 		do {
 			metadata = findLeader(hosts, port, topic, partition);
-			if (metadata == null) {
-				try {
-					Thread.sleep(waitOnEmptyFetch);
-				} catch (InterruptedException e) {
-					throw new InterruptedException("Establishing connection to Kafka failed");
-				}
+			try {
+				Thread.sleep(DEFAULT_WAIT_ON_EMPTY_FETCH);
+			} catch (InterruptedException e) {
+				throw new InterruptedException("Establishing connection to Kafka failed");
 			}
 		} while (metadata == null);
 
@@ -127,41 +109,21 @@ public class KafkaConsumerIterator implements Serializable {
 		clientName = "Client_" + topic + "_" + partition;
 
 		consumer = new SimpleConsumer(leadBroker, port, 100000, 64 * 1024, clientName);
-	}
 
-	/**
-	 * Initializes a connection from the earliest available offset.
-	 */
-	public void initializeFromBeginning() throws InterruptedException {
-		initialize();
-		readOffset = getLastOffset(consumer, topic, partition,
-				kafka.api.OffsetRequest.EarliestTime(), clientName);
+		readOffset = initialOffset.getOffset(consumer, topic, partition, clientName);
 
 		resetFetchResponse(readOffset);
 	}
 
 	/**
-	 * Initializes a connection from the latest available offset.
-	 */
-	public void initializeFromCurrent() throws InterruptedException {
-		initialize();
-		readOffset = getLastOffset(consumer, topic, partition,
-				kafka.api.OffsetRequest.LatestTime(), clientName);
-
-		resetFetchResponse(readOffset);
-	}
-
-	/**
-	 * Initializes a connection from the specified offset.
+	 * Sets the partition to read from.
 	 *
-	 * @param offset Desired Kafka offset
+	 * @param partition
+	 * 		partition number
 	 */
-	public void initializeFromOffset(long offset) throws InterruptedException {
-		initialize();
-		readOffset = offset;
-		resetFetchResponse(readOffset);
+	public void setPartition(int partition) {
+		this.partition = partition;
 	}
-
 
 	// --------------------------------------------------------------------------------------------
 	//  Iterator methods
@@ -186,22 +148,29 @@ public class KafkaConsumerIterator implements Serializable {
 		return nextWithOffset().getMessage();
 	}
 
+	public boolean fetchHasNext() {
+		synchronized (fetchResponse) {
+			if (!iter.hasNext()) {
+				resetFetchResponse(readOffset);
+				return iter.hasNext();
+			} else {
+				return true;
+			}
+		}
+	}
+
 	/**
 	 * Returns the next message and its offset received from
 	 * Kafka encapsulated in a POJO.
 	 *
 	 * @return next message and its offset.
 	 */
-	public MessageWithOffset nextWithOffset() throws InterruptedException {
+	public MessageWithMetadata nextWithOffset() throws InterruptedException {
 
 		synchronized (fetchResponse) {
-			while (!iter.hasNext()) {
-				resetFetchResponse(readOffset);
-				try {
-					Thread.sleep(waitOnEmptyFetch);
-				} catch (InterruptedException e) {
-					throw new InterruptedException("Fetching from Kafka was interrupted");
-				}
+			if (!iter.hasNext()) {
+				throw new RuntimeException(
+						"Trying to read when response is not fetched. Call fetchHasNext() first.");
 			}
 
 			MessageAndOffset messageAndOffset = iter.next();
@@ -218,7 +187,7 @@ public class KafkaConsumerIterator implements Serializable {
 			byte[] bytes = new byte[payload.limit()];
 			payload.get(bytes);
 
-			return new MessageWithOffset(messageAndOffset.offset(), bytes);
+			return new MessageWithMetadata(messageAndOffset.offset(), bytes, partition);
 		}
 	}
 
@@ -241,6 +210,7 @@ public class KafkaConsumerIterator implements Serializable {
 	private void resetFetchResponse(long offset) {
 		FetchRequest req = new FetchRequestBuilder().clientId(clientName)
 				.addFetch(topic, partition, offset, 100000).build();
+
 		fetchResponse = consumer.fetch(req);
 
 		//TODO deal with broker failures
@@ -251,7 +221,8 @@ public class KafkaConsumerIterator implements Serializable {
 	private PartitionMetadata findLeader(List<String> a_hosts, int a_port, String a_topic,
 			int a_partition) {
 		PartitionMetadata returnMetaData = null;
-		loop: for (String seed : a_hosts) {
+		loop:
+		for (String seed : a_hosts) {
 			SimpleConsumer consumer = null;
 			try {
 				consumer = new SimpleConsumer(seed, a_port, 100000, 64 * 1024, "leaderLookup");
@@ -287,20 +258,4 @@ public class KafkaConsumerIterator implements Serializable {
 		return returnMetaData;
 	}
 
-	private static long getLastOffset(SimpleConsumer consumer, String topic, int partition,
-			long whichTime, String clientName) {
-		TopicAndPartition topicAndPartition = new TopicAndPartition(topic, partition);
-		Map<TopicAndPartition, PartitionOffsetRequestInfo> requestInfo = new HashMap<TopicAndPartition, PartitionOffsetRequestInfo>();
-		requestInfo.put(topicAndPartition, new PartitionOffsetRequestInfo(whichTime, 1));
-		kafka.javaapi.OffsetRequest request = new kafka.javaapi.OffsetRequest(requestInfo,
-				kafka.api.OffsetRequest.CurrentVersion(), clientName);
-		OffsetResponse response = consumer.getOffsetsBefore(request);
-
-		if (response.hasError()) {
-			throw new RuntimeException("Error fetching data from Kafka broker. Reason: "
-					+ response.errorCode(topic, partition));
-		}
-		long[] offsets = response.offsets(topic, partition);
-		return offsets[0];
-	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/BeginningOffset.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/BeginningOffset.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.api.simple.offset;
+
+import kafka.api.OffsetRequest;
+import kafka.javaapi.consumer.SimpleConsumer;
+
+public class BeginningOffset extends KafkaOffset {
+
+	@Override
+	public long getOffset(SimpleConsumer consumer, String topic, int partition, String clientName) {
+		return getLastOffset(consumer, topic, partition, OffsetRequest.EarliestTime(), clientName);
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/CurrentOffset.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/CurrentOffset.java
@@ -15,23 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.api.simple;
+package org.apache.flink.streaming.connectors.kafka.api.simple.offset;
 
-import org.apache.flink.streaming.connectors.util.DeserializationSchema;
+import kafka.api.OffsetRequest;
+import kafka.javaapi.consumer.SimpleConsumer;
 
-public class KafkaDeserializingConsumerIterator<IN> extends KafkaConsumerIterator {
+public class CurrentOffset extends KafkaOffset {
 
-	private static final long serialVersionUID = 1L;
-	private DeserializationSchema<IN> deserializationSchema;
-
-	public KafkaDeserializingConsumerIterator(String host, int port, String topic, int partition, long waitOnEmptyFetch,
-												DeserializationSchema<IN> deserializationSchema) {
-		super(host, port, topic, partition, waitOnEmptyFetch);
-		this.deserializationSchema = deserializationSchema;
-	}
-
-	public IN nextRecord() throws InterruptedException {
-		return deserializationSchema.deserialize(next());
+	@Override
+	public long getOffset(SimpleConsumer consumer, String topic, int partition, String clientName) {
+		return getLastOffset(consumer, topic, partition, OffsetRequest.LatestTime(), clientName);
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/GivenOffset.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/GivenOffset.java
@@ -15,33 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.api.simple;
+package org.apache.flink.streaming.connectors.kafka.api.simple.offset;
 
-/**
- * POJO encapsulating records received from Kafka with their offset.
- */
-public class MessageWithOffset {
-	private long offset;
-	private byte[] message;
+import kafka.javaapi.consumer.SimpleConsumer;
 
-	public MessageWithOffset(long offset, byte[] message) {
+public class GivenOffset extends KafkaOffset {
+
+	private final long offset;
+
+	public GivenOffset(long offset) {
 		this.offset = offset;
-		this.message = message;
 	}
 
-	public long getOffset() {
+	@Override
+	public long getOffset(SimpleConsumer consumer, String topic, int partition, String clientName) {
 		return offset;
 	}
 
-	public void setOffset(long offset) {
-		this.offset = offset;
-	}
-
-	public byte[] getMessage() {
-		return message;
-	}
-
-	public void setMessage(byte[] message) {
-		this.message = message;
-	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/KafkaOffset.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/KafkaOffset.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.api.simple.offset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import kafka.api.PartitionOffsetRequestInfo;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.OffsetResponse;
+import kafka.javaapi.consumer.SimpleConsumer;
+
+public abstract class KafkaOffset {
+
+	public abstract long getOffset(SimpleConsumer consumer, String topic, int partition,
+			String clientName);
+
+	protected long getLastOffset(SimpleConsumer consumer, String topic, int partition,
+			long whichTime, String clientName) {
+		TopicAndPartition topicAndPartition = new TopicAndPartition(topic, partition);
+		Map<TopicAndPartition, PartitionOffsetRequestInfo> requestInfo = new HashMap<TopicAndPartition, PartitionOffsetRequestInfo>();
+		requestInfo.put(topicAndPartition, new PartitionOffsetRequestInfo(whichTime, 1));
+		kafka.javaapi.OffsetRequest request = new kafka.javaapi.OffsetRequest(requestInfo,
+				kafka.api.OffsetRequest.CurrentVersion(), clientName);
+		OffsetResponse response = consumer.getOffsetsBefore(request);
+
+		if (response.hasError()) {
+			throw new RuntimeException("Error fetching data from Kafka broker. Reason: "
+					+ response.errorCode(topic, partition));
+		}
+		long[] offsets = response.offsets(topic, partition);
+		return offsets[0];
+	}
+
+}


### PR DESCRIPTION
* When there are more partitions of topic than parallel subtasks listening partitions get distributed between subtask in order to read one message in the topic exactly once. 

These are only tested locally yet, not on a cluster with multiple brokers!