### PR TITLE
[FLINK-1654] Wrong scala example of POJO type in documentation

### DIFF
--- a/docs/programming_guide.md
+++ b/docs/programming_guide.md
@@ -1431,7 +1431,7 @@ public class WordWithCount {
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-class WordWithCount(val word: String, val count: Int) {
+class WordWithCount(var word: String, var count: Int) {
     def this() {
       this(null, -1)
     }


### PR DESCRIPTION
More detail description and discussion in [JIRA](https://issues.apache.org/jira/browse/FLINK-1654).