### PR TITLE
[FLINK-1641] Make projection operator chainable.

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/ProjectInvokable.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/invokable/operator/ProjectInvokable.java
@@ -21,9 +21,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.invokable.StreamInvokable;
+import org.apache.flink.streaming.api.invokable.ChainableInvokable;
 
-public class ProjectInvokable<IN, OUT extends Tuple> extends StreamInvokable<IN, OUT> {
+public class ProjectInvokable<IN, OUT extends Tuple> extends ChainableInvokable<IN, OUT> {
 	private static final long serialVersionUID = 1L;
 
 	transient OUT outTuple;
@@ -49,7 +49,7 @@ public class ProjectInvokable<IN, OUT extends Tuple> extends StreamInvokable<IN,
 	@Override
 	protected void callUserFunction() throws Exception {
 		for (int i = 0; i < this.numFields; i++) {
-			outTuple.setField(nextRecord.getField(fields[i]), i);
+			outTuple.setField(((Tuple)nextObject).getField(fields[i]), i);
 		}
 		collector.collect(outTuple);
 	}
@@ -59,5 +59,13 @@ public class ProjectInvokable<IN, OUT extends Tuple> extends StreamInvokable<IN,
 		super.open(config);
 		this.outTypeSerializer = outTypeInformation.createSerializer(executionConfig);
 		outTuple = outTypeSerializer.createInstance();
+	}
+
+	@Override
+	public void collect(IN record) {
+		if (isRunning) {
+			nextObject = copy(record);
+			callUserFunctionAndLogException();
+		}
 	}
 }


### PR DESCRIPTION
I tested this by adding a dummy project to the WordCount example, by adding
.project(0, 1).types(String.class, Integer.class)
to line 70.
Without the chaining modification, the log looks like this:
Deploying Grouped Aggregation (4/4) (attempt #0) to localhost
Deploying Projection -> Stream Sink (4/4) (attempt #0) to localhost
And with the modification, it looks like this:
Deploying Grouped Aggregation -> Projection -> Stream Sink (4/4) (attempt #0) to localhost
If I read this correctly, then it means that it was chained as expected. Should I also create an automated test for this?