### PR TITLE
[FLINK-1714]Fix the bug of logger class loader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.flink.runtime.security;
 
-import org.apache.flink.runtime.operators.MapPartitionDriver;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
@@ -27,7 +26,7 @@ import java.security.PrivilegedExceptionAction;
 
 public class SecurityUtils {
 
-	private static final Logger LOG = LoggerFactory.getLogger(MapPartitionDriver.class);
+	private static final Logger LOG = LoggerFactory.getLogger(SecurityUtils.class);
 
 	// load Hadoop configuration when loading the security utils.
 	private static Configuration hdConf = new Configuration();


### PR DESCRIPTION
For log in class SecurityUtils, the  LoggerFactory.getLogger() function should be for "SecurityUtils" not "MapPartitionDriver". It is a bug I think