### PR TITLE
Fix issue where Windows paths were not recognized as absolute

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
@@ -31,7 +31,6 @@ import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.io.StringRecord;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -279,9 +278,6 @@ public class Path implements IOReadableWritable, Serializable {
 	 * @return <code>true</code> if the path string contains a windows drive letter, <code>false</code> otherwise
 	 */
 	private boolean hasWindowsDrive(String path, boolean slashed) {
-		if (!OperatingSystem.isWindows()) {
-			return false;
-		}
 		final int start = slashed ? 1 : 0;
 		return path.length() >= start + 2
 			&& (!slashed || path.charAt(0) == '/')
@@ -317,7 +313,10 @@ public class Path implements IOReadableWritable, Serializable {
 	 */
 	public boolean isAbsolute() {
 		final int start = hasWindowsDrive(uri.getPath(), true) ? 3 : 0;
-		return uri.getPath().startsWith(SEPARATOR, start);
+		if (uri.getPath().length() > start) {
+			return uri.getPath().startsWith(SEPARATOR, start);
+		}
+		return true;
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/core/fs/PathTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/PathTest.java
@@ -63,6 +63,15 @@ public class PathTest {
 		assertEquals("/my/path", p.toUri().getPath());
 		assertEquals("file", p.toUri().getScheme());
 
+		p = new Path("C:/my/windows/path");
+		assertEquals("/C:/my/windows/path", p.toUri().getPath());
+
+		p = new Path("file:/C:/my/windows/path");
+		assertEquals("/C:/my/windows/path", p.toUri().getPath());
+
+		p = new Path("C:");
+		assertEquals("/C:", p.toUri().getPath());
+
 		try {
 			new Path((String)null);
 			fail();
@@ -95,6 +104,15 @@ public class PathTest {
 		p = new Path("./my/rel/path");
 		assertFalse(p.isAbsolute());
 
+		p = new Path("C:/my/abs/windows/path");
+		assertTrue(p.isAbsolute());
+
+		p = new Path("file:/C:");
+		assertTrue(p.isAbsolute());
+
+		p = new Path("C:");
+		assertTrue(p.isAbsolute());
+
 	}
 
 	@Test
@@ -115,6 +133,12 @@ public class PathTest {
 		p = new Path("/");
 		assertEquals("", p.getName());
 
+		p = new Path("C:/my/windows/path");
+		assertEquals("path", p.getName());
+
+		p = new Path("file:/C:/my/windows/path");
+		assertEquals("path", p.getName());
+
 	}
 
 	@Test
@@ -134,6 +158,9 @@ public class PathTest {
 
 		p = new Path("/");
 		assertNull(p.getParent());
+
+		p = new Path("C:/my/windows/path");
+		assertEquals("/C:/my/windows", p.getParent().toUri().getPath());
 	}
 
 	@Test
@@ -146,6 +173,10 @@ public class PathTest {
 		p = new Path("/my/path/");
 		p = p.suffix("/abc");
 		assertEquals("/my/path/abc", p.toUri().getPath());
+
+		p = new Path("C:/my/windows/path");
+		p = p.suffix("/abc");
+		assertEquals("/C:/my/windows/path/abc", p.toUri().getPath());
 
 	}
 
@@ -163,6 +194,9 @@ public class PathTest {
 
 		p = new Path("/");
 		assertEquals(0, p.depth());
+
+		p = new Path("C:/my/windows/path");
+		assertEquals(4, p.depth());
 	}
 
 	@Test


### PR DESCRIPTION
Hello!

An issue caused all tests to fail on Windows, because the path `file:/C:` was not recognized as absolute.
This pull-request fixes that issue.