### PR TITLE
[FLINK-1720] Integrate ScalaDoc into JavaDoc

### DIFF
--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -134,7 +134,7 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins>
+					<compilerPlugins combine.children="append">
 					   <compilerPlugin>
 						   <groupId>org.scalamacros</groupId>
 						   <artifactId>paradise_${scala.version}</artifactId>

--- a/flink-staging/flink-expressions/pom.xml
+++ b/flink-staging/flink-expressions/pom.xml
@@ -129,7 +129,7 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins>
+					<compilerPlugins combine.children="append">
 						<compilerPlugin>
 							<groupId>org.scalamacros</groupId>
 							<artifactId>paradise_${scala.version}</artifactId>

--- a/flink-staging/flink-hcatalog/pom.xml
+++ b/flink-staging/flink-hcatalog/pom.xml
@@ -82,13 +82,6 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins>
-						<compilerPlugin>
-							<groupId>org.scalamacros</groupId>
-							<artifactId>paradise_${scala.version}</artifactId>
-							<version>${scala.macros.version}</version>
-						</compilerPlugin>
-					</compilerPlugins>
 				</configuration>
 			</plugin>
 

--- a/flink-staging/flink-streaming/flink-streaming-examples/pom.xml
+++ b/flink-staging/flink-streaming/flink-streaming-examples/pom.xml
@@ -369,13 +369,6 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins>
-					   <compilerPlugin>
-						   <groupId>org.scalamacros</groupId>
-						   <artifactId>paradise_${scala.version}</artifactId>
-						   <version>${scala.macros.version}</version>
-					   </compilerPlugin>
-				   </compilerPlugins>
 				</configuration>
 			</plugin>
 			

--- a/flink-staging/flink-streaming/flink-streaming-scala/pom.xml
+++ b/flink-staging/flink-streaming/flink-streaming-scala/pom.xml
@@ -113,7 +113,7 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins>
+					<compilerPlugins combine.children="append">
 					   <compilerPlugin>
 						   <groupId>org.scalamacros</groupId>
 						   <artifactId>paradise_${scala.version}</artifactId>

--- a/flink-test-utils/pom.xml
+++ b/flink-test-utils/pom.xml
@@ -112,13 +112,6 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins>
-						<compilerPlugin>
-							<groupId>org.scalamacros</groupId>
-							<artifactId>paradise_${scala.version}</artifactId>
-							<version>${scala.macros.version}</version>
-						</compilerPlugin>
-					</compilerPlugins>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,65 @@ under the License.
 			<id>docs-and-source</id>
 			<build>
 				<plugins>
+
+					<!-- We need to clean compiled classes to make sure that genjavadoc
+					is called to generate our fake Java source from Scala source. -->
+					<plugin>
+						<artifactId>maven-clean-plugin</artifactId>
+						<version>2.5</version><!--$NO-MVN-MAN-VER$-->
+						<executions>
+							<execution>
+								<id>clean-target</id>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>clean</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>doc</id>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<args>
+								<arg>-P:genjavadoc:out=${project.build.directory}/genjavadoc</arg>
+							</args>
+							<compilerPlugins>
+								<compilerPlugin>
+									<groupId>com.typesafe.genjavadoc</groupId>
+									<artifactId>genjavadoc-plugin_${scala.version}</artifactId>
+									<version>0.8</version>
+								</compilerPlugin>
+							</compilerPlugins>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>build-helper-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>add-source</goal>
+								</goals>
+								<configuration>
+									<sources>
+										<source>${project.build.directory}/genjavadoc</source>
+									</sources>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
This uses genjavadoc to generate Fake Java Source that only serves as a proxy for the Scala code. ScalaDoc syntax in the original will be converted to JavaDoc syntax in the Fake Code.

This is only executed in the docs-and-source profile, so normal build behaviour is not affected.