### PR TITLE
[FLINK-1740] Pass config param for numberOfExecutionRetries to the JobGraph for streaming jobs

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamGraph.java
@@ -555,6 +555,10 @@ public class StreamGraph extends StreamingPlan {
 		return operatorNames.get(vertexID);
 	}
 
+	public ExecutionConfig getExecutionConfig() {
+		return executionConfig;
+	}
+
 	public void setMonitoringEnabled(boolean monitoringEnabled) {
 		this.monitoringEnabled = monitoringEnabled;
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
@@ -80,8 +80,14 @@ public class StreamingJobGraphGenerator {
 		jobGraph.setJobType(JobGraph.JobType.STREAMING);
 		jobGraph.setMonitoringEnabled(streamGraph.isMonitoringEnabled());
 		jobGraph.setMonitorInterval(streamGraph.getMonitoringInterval());
-		if (jobGraph.isMonitoringEnabled()) {
-			jobGraph.setNumberOfExecutionRetries(Integer.MAX_VALUE);
+		if(jobGraph.isMonitoringEnabled()) {
+			int executionRetries = streamGraph.getExecutionConfig().getNumberOfExecutionRetries();
+			if(executionRetries != -1) {
+				jobGraph.setNumberOfExecutionRetries(executionRetries);
+			}
+			else {
+				jobGraph.setNumberOfExecutionRetries(Integer.MAX_VALUE);	
+			}
 		}
 		init();
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -152,18 +152,57 @@ public abstract class StreamExecutionEnvironment {
 		this.bufferTimeout = timeoutMillis;
 		return this;
 	}
-	
-	public StreamExecutionEnvironment enableMonitoring(long interval)
-	{
+
+	/**
+	 * Method for enabling fault-tolerance. Activates monitoring and backup of streaming operator states.
+	 *
+	 * <p>
+	 * Setting this option assumes that the job is used in production and thus if not stated explicitly
+	 * otherwise with calling with the {@link #setNumberOfExecutionRetries(int numberOfExecutionRetries)}
+	 * method in case of failure the job will be resubmitted to the cluster indefinitely.
+	 *
+	 * @param interval Time interval between state checkpoints in millis
+	 */
+	public StreamExecutionEnvironment enableMonitoring(long interval) {
 		streamGraph.setMonitoringEnabled(true);
 		streamGraph.setMonitoringInterval(interval);
 		return this;
 	}
-	
-	public StreamExecutionEnvironment enableMonitoring()
-	{
+
+
+	/**
+	 * Method for enabling fault-tolerance. Activates monitoring and backup of streaming operator states.
+	 *
+	 * <p>
+	 * Setting this option assumes that the job is used in production and thus if not stated explicitly
+	 * otherwise with calling with the {@link #setNumberOfExecutionRetries(int numberOfExecutionRetries)}
+	 * method in case of failure the job will be resubmitted to the cluster indefinitely.
+	 */
+	public StreamExecutionEnvironment enableMonitoring() {
 		streamGraph.setMonitoringEnabled(true);
 		return this;
+	}
+
+	/**
+	 * Sets the number of times that failed tasks are re-executed. A value of zero
+	 * effectively disables fault tolerance. A value of {@code -1} indicates that the system
+	 * default value (as defined in the configuration) should be used.
+	 *
+	 * @param numberOfExecutionRetries The number of times the system will try to re-execute failed tasks.
+	 */
+	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
+		config.setNumberOfExecutionRetries(numberOfExecutionRetries);
+	}
+
+	/**
+	 * Gets the number of times the system will try to re-execute failed tasks. A value
+	 * of {@code -1} indicates that the system default value (as defined in the configuration)
+	 * should be used.
+	 *
+	 * @return The number of times the system will try to re-execute failed tasks.
+	 */
+	public int getNumberOfExecutionRetries() {
+		return config.getNumberOfExecutionRetries();
 	}
 
 	/**

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -76,6 +76,48 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def getBufferTimout: Long = javaEnv.getBufferTimeout()
 
   /**
+   * Method for enabling fault-tolerance. Activates monitoring and backup of streaming operator states.
+   * Time interval between state checkpoints is specified in in millis.
+   *
+   * Setting this option assumes that the job is used in production and thus if not stated explicitly
+   * otherwise with calling with the {@link #setNumberOfExecutionRetries(int numberOfExecutionRetries)}
+   * method in case of failure the job will be resubmitted to the cluster indefinitely.
+   */
+  def enableMonitoring(interval : Long) : StreamExecutionEnvironment = {
+    javaEnv.enableMonitoring(interval)
+    this
+  }
+
+  /**
+   * Method for enabling fault-tolerance. Activates monitoring and backup of streaming operator states.
+   *
+   * Setting this option assumes that the job is used in production and thus if not stated explicitly
+   * otherwise with calling with the {@link #setNumberOfExecutionRetries(int numberOfExecutionRetries)}
+   * method in case of failure the job will be resubmitted to the cluster indefinitely.
+   */
+  def enableMonitoring() : StreamExecutionEnvironment = {
+    javaEnv.enableMonitoring()
+    this
+  }
+
+  /**
+   * Sets the number of times that failed tasks are re-executed. A value of zero
+   * effectively disables fault tolerance. A value of "-1" indicates that the system
+   * default value (as defined in the configuration) should be used.
+   */
+  def setNumberOfExecutionRetries(numRetries: Int): Unit = {
+    javaEnv.setNumberOfExecutionRetries(numRetries)
+  }
+
+  /**
+   * Gets the number of times the system will try to re-execute failed tasks. A value
+   * of "-1" indicates that the system default value (as defined in the configuration)
+   * should be used.
+   */
+  def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
+
+
+  /**
    * Registers the given type with the serializer at the [[KryoSerializer]].
    *
    * Note that the serializer instance must be serializable (as defined by java.io.Serializable),


### PR DESCRIPTION
We now use the config parameter for numberofExecutionRetries on the generated job graph. 
Also piggypacked a minor fix for a compilation error that currently occurs in flink-tests