### PR TITLE
[FLINK-1766]Fix the bug of equals function of FSKey

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -106,7 +106,6 @@ public abstract class FileSystem {
 		 */
 		@Override
 		public boolean equals(final Object obj) {
-
 			if (obj == this) {
 				return true;
 			}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -107,10 +107,10 @@ public abstract class FileSystem {
 		@Override
 		public boolean equals(final Object obj) {
 
-            if(obj == this)
-            {
-                return  true;
-            }
+			if (obj == this) {
+				return true;
+			}
+
 			if (obj instanceof FSKey) {
 				final FSKey key = (FSKey) obj;
 
@@ -131,7 +131,6 @@ public abstract class FileSystem {
 		 */
 		@Override
 		public int hashCode() {
-
 			if (this.scheme != null) {
 				return this.scheme.hashCode();
 			}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -107,6 +107,10 @@ public abstract class FileSystem {
 		@Override
 		public boolean equals(final Object obj) {
 
+            if(obj == this)
+            {
+                return  true;
+            }
 			if (obj instanceof FSKey) {
 				final FSKey key = (FSKey) obj;
 


### PR DESCRIPTION
The equals function in org.apache.flink.core.fs.FileSystem.FSKey should first confirm whether obj == this, if obj is the same object.It should return true