### PR TITLE
[FLINK-1768]Fix the bug of BlobServerConnection's LOG.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -56,7 +56,7 @@ import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_ERROR;
 class BlobServerConnection extends Thread {
 
 	/** The log object used for debugging. */
-	private static final Logger LOG = LoggerFactory.getLogger(BlobServer.class);
+	private static final Logger LOG = LoggerFactory.getLogger(BlobServerConnection.class);
 
 	/** The socket to communicate with the client. */
 	private final Socket clientSocket;


### PR DESCRIPTION
The LOG in class of BlobServerConnection should be created by classloader of BlobServerConnection.class
