### PR TITLE
[FLINK-1774]Remove the redundant code in try{} block.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -308,9 +308,6 @@ class BlobServerConnection extends Thread {
 				}
 			}
 
-			fos.close();
-			fos = null;
-
 			if (contentAdressable == NAME_ADDRESSABLE) {
 				File storageFile = this.blobServer.getStorageLocation(jobID, key);
 				if (!incomingFile.renameTo(storageFile)) {


### PR DESCRIPTION
Remove the redundant code of "fos.close(); fos = null;" in try block because the fos,close() code will always executes in finally block.