### PR TITLE
[FLINK-1779]Rename the function  getCurrentyActiveConnections in ' org.apache.flink.runtime.blob'.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -336,7 +336,12 @@ public class BlobServer extends Thread implements BlobService {
 		}
 	}
 
-	List<BlobServerConnection> getCurrentyActiveConnections() {
+	/**
+	 * Returns all the current active connections in the BlobServer.
+	 *
+	 * @return the list of all the active in current BlobServer
+	 */
+	List<BlobServerConnection> getCurrentActiveConnections() {
 		synchronized (activeConnections) {
 			return new ArrayList<BlobServerConnection>(activeConnections);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -116,7 +116,7 @@ public class BlobServerGetTest {
 			BlobUtils.readFully(is, receiveBuffer, 0, receiveBuffer.length, null);
 
 			// shut down the server
-			for (BlobServerConnection conn : server.getCurrentyActiveConnections()) {
+			for (BlobServerConnection conn : server.getCurrentActiveConnections()) {
 				conn.close();
 			}
 


### PR DESCRIPTION
I think the function name "getCurrentyActiveConnections" in ' org.apache.flink.runtime.blob' is a wrong spelling, it should be "getCurrentActiveConnections" is more better, and also I add some comments about the function and the update Tests.