### PR TITLE
[FLINK-1756] [streaming] Rename Stream Monitoring to Streaming Checkpointing in JobGraph

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -79,9 +79,9 @@ public class JobGraph implements Serializable {
 	
 	private JobType jobType = JobType.BATCH;
 	
-	private boolean monitoringEnabled = false;
+	private boolean checkpointingEnabled = false;
 	
-	private long monitorInterval = 10000;
+	private long checkpointingInterval = 10000;
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -270,20 +270,20 @@ public class JobGraph implements Serializable {
 		return jobType;
 	}
 
-	public void setMonitoringEnabled(boolean monitoringEnabled) {
-		this.monitoringEnabled = monitoringEnabled;
+	public void setCheckpointingEnabled(boolean checkpointingEnabled) {
+		this.checkpointingEnabled = checkpointingEnabled;
 	}
 
-	public boolean isMonitoringEnabled() {
-		return monitoringEnabled;
+	public boolean isCheckpointingEnabled() {
+		return checkpointingEnabled;
 	}
 
-	public void setMonitorInterval(long monitorInterval) {
-		this.monitorInterval = monitorInterval;
+	public void setCheckpointingInterval(long checkpointingInterval) {
+		this.checkpointingInterval = checkpointingInterval;
 	}
 
-	public long getMonitorInterval() {
-		return monitorInterval;
+	public long getCheckpointingInterval() {
+		return checkpointingInterval;
 	}
 
 	/**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -487,8 +487,8 @@ class JobManager(val configuration: Configuration,
         executionGraph.setScheduleMode(jobGraph.getScheduleMode)
         executionGraph.setQueuedSchedulingAllowed(jobGraph.getAllowQueuedScheduling)
         
-        executionGraph.setCheckpointingEnabled(jobGraph.isMonitoringEnabled)
-        executionGraph.setCheckpointingInterval(jobGraph.getMonitorInterval)
+        executionGraph.setCheckpointingEnabled(jobGraph.isCheckpointingEnabled)
+        executionGraph.setCheckpointingInterval(jobGraph.getCheckpointingInterval)
 
         // initialize the vertices that have a master initialization hook
         // file output formats create directories here, input formats create splits

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/StreamingJobGraphGenerator.java
@@ -78,10 +78,10 @@ public class StreamingJobGraphGenerator {
 		// Turn lazy scheduling off
 		jobGraph.setScheduleMode(ScheduleMode.ALL);
 		jobGraph.setJobType(JobGraph.JobType.STREAMING);
-		jobGraph.setMonitoringEnabled(streamGraph.isCheckpointingEnabled());
-		jobGraph.setMonitorInterval(streamGraph.getCheckpointingInterval());
+		jobGraph.setCheckpointingEnabled(streamGraph.isCheckpointingEnabled());
+		jobGraph.setCheckpointingInterval(streamGraph.getCheckpointingInterval());
 
-		if(jobGraph.isMonitoringEnabled()) {
+		if(jobGraph.isCheckpointingEnabled()) {
 			int executionRetries = streamGraph.getExecutionConfig().getNumberOfExecutionRetries();
 			if(executionRetries != -1) {
 				jobGraph.setNumberOfExecutionRetries(executionRetries);


### PR DESCRIPTION
This is improves #506 and renames Monitoring to Checkpointing in JobGraph too.