### PR TITLE
[FLINK-1785] [test] Master tests in flink-tachyon fail with java.lang.NoSuchFieldError: IBM_JAVA.

### DIFF
--- a/flink-staging/flink-tachyon/pom.xml
+++ b/flink-staging/flink-tachyon/pom.xml
@@ -40,6 +40,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>${shading-artifact.name}</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -60,6 +61,20 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-hdfs</artifactId>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<version>${hadoop.version}</version><!--$NO-MVN-MAN-VER$-->
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<version>${hadoop.version}</version><!--$NO-MVN-MAN-VER$-->
+		</dependency>
+		<dependency>
 			<groupId>org.tachyonproject</groupId>
 			<artifactId>tachyon</artifactId>
 			<version>0.5.0</version>
@@ -77,21 +92,6 @@ under the License.
 			<artifactId>jetty-util</artifactId>
 			<version>7.6.8.v20121106</version><!--$NO-MVN-MAN-VER$-->
 			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-hdfs</artifactId>
-			<scope>test</scope>
-			<type>test-jar</type>
-			<version>${hadoop.version}</version><!--$NO-MVN-MAN-VER$-->
-		</dependency>
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-common</artifactId>
-			<scope>test</scope>
-			<type>test-jar</type>
-			<version>${hadoop.version}</version><!--$NO-MVN-MAN-VER$-->
 		</dependency>
 	</dependencies>
 	<dependencyManagement>


### PR DESCRIPTION
Move the hadoop-hdfs and hadoop-common test jars dependency before Tachyon.

Looks like Maven respect the ordering of dependencies and first declarations win.
Seemed like Tachyon brings transitive dependencies of older hadoop versions.