### PR TITLE
[FLINK-1664] Adds checks if selected sort key is sortable

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -132,7 +132,15 @@ public abstract class TypeInformation<T> implements Serializable {
 	 * @return True, if the type can be used as a key, false otherwise.
 	 */
 	public abstract boolean isKeyType();
-	
+
+	/**
+	 * Checks whether this type can be used as a key for sorting.
+	 * The order produced by sorting this type must be meaningful.
+	 */
+	public boolean isSortKeyType() {
+		return isKeyType();
+	}
+
 	/**
 	 * Creates a serializer for the type. The serializer may use the ExecutionConfig
 	 * for parameterization.

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeType.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeType.java
@@ -169,6 +169,26 @@ public abstract class CompositeType<T> extends TypeInformation<T> {
 		return getFieldIndex(fieldName) >= 0;
 	}
 
+	@Override
+	public boolean isKeyType() {
+		for(int i=0;i<this.getArity();i++) {
+			if (!this.getTypeAt(i).isKeyType()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean isSortKeyType() {
+		for(int i=0;i<this.getArity();i++) {
+			if (!this.getTypeAt(i).isSortKeyType()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	/**
 	 * Returns the names of the composite fields of this type. The order of the returned array must
 	 * be consistent with the internal field index ordering.

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/Keys.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/Keys.java
@@ -82,18 +82,18 @@ public abstract class Keys<T> {
 
 			this.keyExtractor = keyExtractor;
 			this.keyType = keyType;
-			
+
+			if(!keyType.isKeyType()) {
+				throw new InvalidProgramException("Return type "+keyType+" of KeySelector "+keyExtractor.getClass()+" is not a valid key type");
+			}
+
 			// we have to handle a special case here:
-			// if the keyType is a tuple type, we need to select the full tuple with all its fields.
-			if(keyType.isTupleType()) {
+			// if the keyType is a composite type, we need to select the full type with all its fields.
+			if(keyType instanceof CompositeType) {
 				ExpressionKeys<K> ek = new ExpressionKeys<K>(new String[] {ExpressionKeys.SELECT_ALL_CHAR}, keyType);
 				logicalKeyFields = ek.computeLogicalKeyPositions();
 			} else {
 				logicalKeyFields = new int[] {0};
-			}
-
-			if (!this.keyType.isKeyType()) {
-				throw new IllegalArgumentException("Invalid type of KeySelector keys");
 			}
 		}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
@@ -118,8 +118,11 @@ public class PojoTypeInfo<T> extends CompositeType<T> {
 	}
 
 	@Override
-	public boolean isKeyType() {
-		return Comparable.class.isAssignableFrom(typeClass);
+	public boolean isSortKeyType() {
+		// Support for sorting POJOs that implement Comparable is not implemented yet.
+		// Since the order of fields in a POJO type is not well defined, sorting on fields
+		//   gives only some undefined order.
+		return false;
 	}
 	
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -223,11 +223,6 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	}
 	
 	@Override
-	public boolean isKeyType() {
-		return isValidKeyType(this);
-	}
-
-	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof TupleTypeInfoBase) {
 			@SuppressWarnings("unchecked")
@@ -243,20 +238,6 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	@Override
 	public int hashCode() {
 		return this.types.hashCode() ^ Arrays.deepHashCode(this.types);
-	}
-
-	private boolean isValidKeyType(TypeInformation<?> typeInfo) {
-		if(typeInfo instanceof TupleTypeInfoBase) {
-			TupleTypeInfoBase<?> tupleType = ((TupleTypeInfoBase<?>)typeInfo);
-			for(int i=0;i<tupleType.getArity();i++) {
-				if (!isValidKeyType(tupleType.getTypeAt(i))) {
-					return false;
-				}
-			}
-			return true;
-		} else  {
-			return typeInfo.isKeyType();
-		}
 	}
 
 	@Override

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/DataSinkTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/DataSinkTest.java
@@ -256,23 +256,6 @@ public class DataSinkTest {
 	}
 
 	@Test
-	public void testPojoSingleOrderFull() {
-
-		final ExecutionEnvironment env = ExecutionEnvironment
-				.getExecutionEnvironment();
-		DataSet<CustomType> pojoDs = env
-				.fromCollection(pojoData);
-
-		// should work
-		try {
-			pojoDs.writeAsText("/tmp/willNotHappen")
-					.sortLocalOutput("*", Order.ASCENDING);
-		} catch (Exception e) {
-			Assert.fail();
-		}
-	}
-
-	@Test
 	public void testPojoTwoOrder() {
 
 		final ExecutionEnvironment env = ExecutionEnvironment
@@ -315,6 +298,35 @@ public class DataSinkTest {
 		pojoDs.writeAsText("/tmp/willNotHappen")
 				.sortLocalOutput("myInt", Order.ASCENDING)
 				.sortLocalOutput("notThere", Order.DESCENDING);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testPojoSingleOrderFull() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment
+				.getExecutionEnvironment();
+		DataSet<CustomType> pojoDs = env
+				.fromCollection(pojoData);
+
+		// must not work
+		pojoDs.writeAsText("/tmp/willNotHappen")
+				.sortLocalOutput("*", Order.ASCENDING);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testArrayOrderFull() {
+
+		List<Object[]> arrayData = new ArrayList<Object[]>();
+		arrayData.add(new Object[0]);
+
+		final ExecutionEnvironment env = ExecutionEnvironment
+				.getExecutionEnvironment();
+		DataSet<Object[]> pojoDs = env
+				.fromCollection(arrayData);
+
+		// must not work
+		pojoDs.writeAsText("/tmp/willNotHappen")
+				.sortLocalOutput("*", Order.ASCENDING);
 	}
 
 	/**

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
@@ -24,13 +24,16 @@ import java.util.List;
 
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,11 +51,23 @@ public class GroupingTest {
 					BasicTypeInfo.LONG_TYPE_INFO,
 					BasicTypeInfo.INT_TYPE_INFO
 			);
-	
+
+	private final TupleTypeInfo<Tuple4<Integer, Long, CustomType, Long[]>> tupleWithCustomInfo = new
+			TupleTypeInfo<Tuple4<Integer, Long, CustomType, Long[]>>(
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				TypeExtractor.createTypeInfo(CustomType.class),
+				BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO
+			);
+
 	// LONG DATA
 	private final List<Long> emptyLongData = new ArrayList<Long>();
 	
 	private final List<CustomType> customTypeData = new ArrayList<CustomType>();
+
+	private final List<Tuple4<Integer, Long, CustomType, Long[]>> tupleWithCustomData =
+			new ArrayList<Tuple4<Integer, Long, CustomType, Long[]>>();
+
 	
 	@Test  
 	public void testGroupByKeyFields1() {
@@ -187,7 +202,6 @@ public class GroupingTest {
 		// should not work, key out of tuple bounds
 		ds.groupBy("nested.myNonExistent");
 	}
-
 	
 	@Test
 	@SuppressWarnings("serial")
@@ -233,41 +247,67 @@ public class GroupingTest {
 			Assert.fail();
 		}
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test
 	@SuppressWarnings("serial")
 	public void testGroupByKeySelector3() {
 		
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		this.customTypeData.add(new CustomType());
-		
-		DataSet<CustomType> customDs = env.fromCollection(customTypeData);
-		// should not work
-		customDs.groupBy(
-				new KeySelector<GroupingTest.CustomType, CustomType>() {
-					@Override
-					public CustomType getKey(CustomType value) {
-						return value;
-				}
-		});
+
+		try {
+			DataSet<CustomType> customDs = env.fromCollection(customTypeData);
+			// should not work
+			customDs.groupBy(
+					new KeySelector<GroupingTest.CustomType, CustomType>() {
+						@Override
+						public CustomType getKey(CustomType value) {
+							return value;
+						}
+					});
+		} catch(Exception e) {
+			Assert.fail();
+		}
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test
 	@SuppressWarnings("serial")
 	public void testGroupByKeySelector4() {
-		
+
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		this.customTypeData.add(new CustomType());
-		
+
+		try {
+			DataSet<CustomType> customDs = env.fromCollection(customTypeData);
+			// should not work
+			customDs.groupBy(
+					new KeySelector<GroupingTest.CustomType, Tuple2<Integer, GroupingTest.CustomType>>() {
+						@Override
+						public Tuple2<Integer, CustomType> getKey(CustomType value) {
+							return new Tuple2<Integer, CustomType>(value.myInt, value);
+						}
+					});
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	@SuppressWarnings("serial")
+	public void testGroupByKeySelector5() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		this.customTypeData.add(new CustomType());
+
 		DataSet<CustomType> customDs = env.fromCollection(customTypeData);
 		// should not work
 		customDs.groupBy(
-				new KeySelector<GroupingTest.CustomType, Tuple2<Integer, GroupingTest.CustomType>>() {
+				new KeySelector<GroupingTest.CustomType, CustomType2>() {
 					@Override
-					public Tuple2<Integer, CustomType> getKey(CustomType value) {
-						return new Tuple2<Integer, CustomType>(value.myInt, value);
-				}
-		});
+					public CustomType2 getKey(CustomType value) {
+						return new CustomType2();
+					}
+				});
 	}
 	
 	@Test
@@ -313,6 +353,30 @@ public class GroupingTest {
 		}).sortGroup(0, Order.ASCENDING);
 		
 	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testGroupSortKeyFields4() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy(0)
+				.sortGroup(2, Order.ASCENDING);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testGroupSortKeyFields5() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy(0)
+				.sortGroup(3, Order.ASCENDING);
+	}
 	
 	@Test
 	public void testChainedGroupSortKeyFields() {
@@ -327,7 +391,166 @@ public class GroupingTest {
 			Assert.fail();
 		}
 	}
-	
+
+	@Test
+	public void testGroupSortByKeyExpression1() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should work
+		try {
+			tupleDs.groupBy("f0").sortGroup("f1", Order.ASCENDING);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test
+	public void testGroupSortByKeyExpression2() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should work
+		try {
+			tupleDs.groupBy("f0").sortGroup("f2.myString", Order.ASCENDING);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test
+	public void testGroupSortByKeyExpression3() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should work
+		try {
+			tupleDs.groupBy("f0")
+					.sortGroup("f2.myString", Order.ASCENDING)
+					.sortGroup("f1", Order.DESCENDING);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testGroupSortByKeyExpression4() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy("f0")
+				.sortGroup("f2", Order.ASCENDING);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testGroupSortByKeyExpression5() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy("f0")
+				.sortGroup("f1", Order.ASCENDING)
+				.sortGroup("f2", Order.ASCENDING);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testGroupSortByKeyExpression6() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy("f0")
+				.sortGroup("f3", Order.ASCENDING);
+	}
+
+	@SuppressWarnings("serial")
+	@Test
+	public void testGroupSortByKeySelector1() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy(
+				new KeySelector<Tuple4<Integer,Long,CustomType,Long[]>, Long>() {
+					@Override
+					public Long getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+						return value.f1;
+					}
+				})
+				.sortGroup(
+						new KeySelector<Tuple4<Integer, Long, CustomType, Long[]>, Integer>() {
+							@Override
+							public Integer getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+								return value.f0;
+							}
+						}, Order.ASCENDING);
+	}
+
+	@SuppressWarnings("serial")
+	@Test(expected = InvalidProgramException.class)
+	public void testGroupSortByKeySelector2() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy(
+				new KeySelector<Tuple4<Integer,Long,CustomType,Long[]>, Long>() {
+					@Override
+					public Long getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+						return value.f1;
+					}
+				})
+				.sortGroup(
+						new KeySelector<Tuple4<Integer, Long, CustomType, Long[]>, CustomType>() {
+							@Override
+							public CustomType getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+								return value.f2;
+							}
+						}, Order.ASCENDING);
+	}
+
+	@SuppressWarnings("serial")
+	@Test(expected = InvalidProgramException.class)
+	public void testGroupSortByKeySelector3() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs =
+				env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should not work
+		tupleDs.groupBy(
+				new KeySelector<Tuple4<Integer,Long,CustomType,Long[]>, Long>() {
+					@Override
+					public Long getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+						return value.f1;
+					}
+				})
+				.sortGroup(
+						new KeySelector<Tuple4<Integer, Long, CustomType, Long[]>, Long[]>() {
+							@Override
+							public Long[] getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+								return value.f3;
+							}
+						}, Order.ASCENDING);
+	}
+
 
 	public static class CustomType implements Serializable {
 		
@@ -353,5 +576,12 @@ public class GroupingTest {
 		public String toString() {
 			return myInt+","+myLong+","+myString;
 		}
+	}
+
+	public static class CustomType2 implements Serializable {
+
+		public int myInt;
+		public int[] myIntArray;
+
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.operator;
+
+import org.apache.flink.api.common.InvalidProgramException;
+import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SortPartitionTest {
+
+	// TUPLE DATA
+	private final List<Tuple5<Integer, Long, String, Long, Integer>> emptyTupleData =
+			new ArrayList<Tuple5<Integer, Long, String, Long, Integer>>();
+
+	private final TupleTypeInfo<Tuple5<Integer, Long, String, Long, Integer>> tupleTypeInfo = new
+			TupleTypeInfo<Tuple5<Integer, Long, String, Long, Integer>>(
+					BasicTypeInfo.INT_TYPE_INFO,
+					BasicTypeInfo.LONG_TYPE_INFO,
+					BasicTypeInfo.STRING_TYPE_INFO,
+					BasicTypeInfo.LONG_TYPE_INFO,
+					BasicTypeInfo.INT_TYPE_INFO
+			);
+
+	private final TupleTypeInfo<Tuple4<Integer, Long, CustomType, Long[]>> tupleWithCustomInfo = new
+			TupleTypeInfo<Tuple4<Integer, Long, CustomType, Long[]>>(
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				TypeExtractor.createTypeInfo(CustomType.class),
+				BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO
+			);
+
+	// LONG DATA
+	private final List<Long> emptyLongData = new ArrayList<Long>();
+
+	private final List<CustomType> customTypeData = new ArrayList<CustomType>();
+
+	private final List<Tuple4<Integer, Long, CustomType, Long[]>> tupleWithCustomData =
+			new ArrayList<Tuple4<Integer, Long, CustomType, Long[]>>();
+
+
+	@Test
+	public void testSortPartitionPositionKeys1() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			tupleDs.sortPartition(0, Order.ASCENDING);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test
+	public void testSortPartitionPositionKeys2() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			tupleDs
+					.sortPartition(0, Order.ASCENDING)
+					.sortPartition(3, Order.DESCENDING);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testSortPartitionWithPositionKeys3() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// must not work
+		tupleDs.sortPartition(2, Order.ASCENDING);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testSortPartitionWithPositionKeys4() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// must not work
+		tupleDs.sortPartition(3, Order.ASCENDING);
+	}
+
+	@Test
+	public void testSortPartitionExpressionKeys1() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			tupleDs.sortPartition("f1", Order.ASCENDING);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test
+	public void testSortPartitionExpressionKeys2() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should work
+		try {
+			tupleDs
+					.sortPartition("f0", Order.ASCENDING)
+					.sortPartition("f2.nested.myInt", Order.DESCENDING);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testSortPartitionWithExpressionKeys3() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// must not work
+		tupleDs.sortPartition("f2.nested", Order.ASCENDING);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testSortPartitionWithExpressionKeys4() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// must not work
+		tupleDs.sortPartition("f3", Order.ASCENDING);
+	}
+
+	public static class CustomType implements Serializable {
+		
+		public static class Nest {
+			public int myInt;
+		}
+		private static final long serialVersionUID = 1L;
+		
+		public int myInt;
+		public long myLong;
+		public String myString;
+		public Nest nested;
+		
+		public CustomType() {};
+		
+		public CustomType(int i, long l, String s) {
+			myInt = i;
+			myLong = l;
+			myString = s;
+		}
+		
+		@Override
+		public String toString() {
+			return myInt+","+myLong+","+myString;
+		}
+	}
+
+	public static class CustomType2 implements Serializable {
+
+		public int myInt;
+		public int[] myIntArray;
+
+	}
+}


### PR DESCRIPTION
- Adds checks if a sort key can be actually sorted. 
  - The POJO type is defined as non-sortable, because an order would depend on the undefined order of POJO fields. 
- Adds a few more tests for API sort functions