### PR TITLE
[FLINK-1805]The class IOManagerAsync should use its own Log instance

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
@@ -47,7 +47,7 @@ public class IOManagerAsync extends IOManager implements UncaughtExceptionHandle
 	private final AtomicBoolean isShutdown = new AtomicBoolean();
 
 	/** Logging */
-	protected static final Logger LOG = LoggerFactory.getLogger(IOManagerAsync.class);
+	private static final Logger LOG = LoggerFactory.getLogger(IOManagerAsync.class);
 
 	// -------------------------------------------------------------------------
 	//               Constructors / Destructors

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.io.disk.iomanager;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -43,7 +45,10 @@ public class IOManagerAsync extends IOManager implements UncaughtExceptionHandle
 
 	/** Flag to signify that the IOManager has been shut down already */
 	private final AtomicBoolean isShutdown = new AtomicBoolean();
-	
+
+	/** Logging */
+	protected static final Logger LOG = LoggerFactory.getLogger(IOManagerAsync.class);
+
 	// -------------------------------------------------------------------------
 	//               Constructors / Destructors
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Although class 'IOManagerAsync' is extended from 'IOManager' in package 'org.apache.flink.runtime.io.disk.iomanager', but I think it should has its own Log instance.