### PR TITLE
[tools] Add --abbrev-ref to get the right branch name of HEAD

### DIFF
--- a/tools/merge_flink_pr.py
+++ b/tools/merge_flink_pr.py
@@ -92,7 +92,7 @@ def continue_maybe(prompt):
         fail("Okay, exiting")
 
 
-original_head = run_cmd("git rev-parse HEAD")[:8]
+original_head = run_cmd("git rev-parse --abbrev-ref HEAD").rstrip("/\n")
 
 
 def clean_up():


### PR DESCRIPTION
Add --abbrev-ref to get the right branch name of HEAD rather than checksum to return back to original branch.

Without it will make merge tool to go to unnamed branch.

Somehow old PR #548 could not be reopen so submit new one. Sorry