### PR TITLE
[FLINK-1792] TM Monitoring: CPU utilization, hide graphs by default and show summary only

### DIFF
--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -292,7 +292,12 @@ function processTMdata(json) {
         // cpu load
         var cpuLoadValue = Number((metricsJSON.gauges["cpuLoad"].value*100).toFixed(2));
         taskManagerMemory[tm.instanceID]["cpuLoad"].push({x:time, y:cpuLoadValue });
-        $("#"+tmRowIdCssName+"-cpuLoad").html(cpuLoadValue);
+        if(cpuLoadValue != -100){
+          $("#"+tmRowIdCssName+"-cpuLoad").html(cpuLoadValue);
+        } else {
+          $("#"+tmRowIdCssName+"-cpuLoad").html("NA"+getTooltipHTML("CPU Load is unavailable as the java version is not 1.7 or above"));
+        }
+
 
         // generate summary for the last summaryTime minutes
         var summaryStats = generateSummaryFor(taskManagerMemory[tm.instanceID],summaryTime);
@@ -425,6 +430,10 @@ function generateSummaryFor(stats,time){
     var summary = {};
     var numElements = time*12;
     for(var key in stats){
+        if(key=="cpuLoad" && stats[key][0] && stats[key][0]['y']==-100){
+            summary[key]="NA";
+            continue;
+        }
         var prevValues = stats[key].slice(numElements*-1);
         var sum = (prevValues.reduce(function(p,q){return {x:p.x+q.x,y:p.y+q.y}})).y;
         var avg = Number((sum/(prevValues.length)).toFixed(2));

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -60,6 +60,9 @@ var memoryValues = ["memory.non-heap.used" , "memory.flink.used", "memory.heap.u
 
 var metricsLimit = 3;
 
+// number of minutes for which the summary will be provided
+var summaryTime = 10;
+
 /**
 Create rickshaw graph for the specified taskManager id (tmid).
 **/
@@ -69,6 +72,7 @@ function createGraph(tmId, maxload, maxmem) {
     var scales = [];
     scales.push(d3.scale.linear().domain([0, maxmem]));
     scales.push(d3.scale.linear().domain([0, maxload]).nice());
+    scales.push(d3.scale.linear().domain([0,100]));
     for(i in memoryValues) {
         var value = memoryValues[i];
         taskManagerMemory[tmId][value] = [];
@@ -88,6 +92,16 @@ function createGraph(tmId, maxload, maxmem) {
         scale: scales[1],
         data: taskManagerMemory[tmId]["load"],
         name: "OS Load",
+        renderer: 'line',
+        stroke: 'rgba(0,0,0,0.5)'
+    });
+    taskManagerMemory[tmId]["cpuLoad"] = [];
+    // add cpu load series
+    series.push({
+        color: palette.color(),
+        scale: scales[2],
+        data: taskManagerMemory[tmId]["cpuLoad"],
+        name: "CPU Load",
         renderer: 'line',
         stroke: 'rgba(0,0,0,0.5)'
     });
@@ -121,7 +135,7 @@ function createGraph(tmId, maxload, maxmem) {
     var y_axis_load = new Rickshaw.Graph.Axis.Y.Scaled( {
         graph: graph,
         orientation: 'right',
-        scale: scales[1],
+        scale: scales[2],
         grid: false,
         element: document.getElementById("y_axis-load-"+tmId)
     } );
@@ -199,10 +213,12 @@ function processTMdata(json) {
 		// check if taskManager has a row
 		tmRow = $("#"+tmRowIdCssName);
 		if(tmRow.length == 0) {
-		    var tmMemoryBox = "<div class=\"chart_container\" id=\"chart_container-"+tm.instanceID+"\">"+
+		    // *-memory_stats div contains only the statistics where as chart_container-* div contains the graph
+		    var tmMemoryBox =  "<div id=\""+tmRowIdCssName+"-memory_stats"+"\">"+"</div>"+
+		                       "<div class=\"chart_container\" id=\"chart_container-"+tm.instanceID+"\">"+
                                   "<div class=\"y_axis\" id=\"y_axis-"+tm.instanceID+"\"><p class=\"axis_label\">Memory</p></div>"+
                                   "<div class=\"chart\" id=\"chart-"+tm.instanceID+"\"><i>Waiting for first Heartbeat to arrive</i></div>"+
-                                  "<div class=\"y_axis-load\" id=\"y_axis-load-"+tm.instanceID+"\"><p class=\"axis_label\">Load</p></div>"+
+                                  "<div class=\"y_axis-load\" id=\"y_axis-load-"+tm.instanceID+"\"><p class=\"axis_label\">CPU Load</p></div>"+
                                "<div class=\"legend\" id=\"legend-"+tm.instanceID+"\"></div>"+
                                "</div>";
 
@@ -224,6 +240,25 @@ function processTMdata(json) {
 		    taskManagerGraph[tm.instanceID].render();
         //    taskManagerGraph[tm.instanceID].resize();
 		}
+
+        // html dump for memory statistics of task manager
+        var tmMemStats = $("#"+tmRowIdCssName+"-memory_stats");
+        tmMemStats.html("<b>CPU Load</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-cpuLoad\"></span>% "+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_cpuLoad\"></span>%"+"<br>"+
+                        "<b>OS Load</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-osLoad\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_load\"></span>"+"<br>"+
+                        "<b>Memory.heap.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memHeapUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_heap_used\"></span>"+"<br>"+
+                        "<b>Memory.flink.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memFlinkUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_flink_used\"></span>"+"<br>"+
+                        "<b>Memory.non-heap.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memNonHeapUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_non-heap_used\"></span>"+"<br><br>"+
+                        "<button id=\"graph_button-"+tm.instanceID+"\" onclick=\"hideShowGraph('"+tm.instanceID+"')\"></button>"+"<br>");
+
+        // preserve the show/hide state of graph after update interval
+        var graphElement =  $("#chart_container-"+tm.instanceID);
+        if(graphElement.is(':visible')){
+            $("#graph_button-"+tm.instanceID).text("Hide Detailed Graph");
+        } else {
+            $("#graph_button-"+tm.instanceID).text("Show Detailed Graph");
+        }
+
+
         // fill (update) row with contents
         // memory statistics
         var time = getUnixTime();
@@ -234,26 +269,46 @@ function processTMdata(json) {
             switch(valueKey) {
                 case "memory.heap.used":
                     var value = metricsJSON.gauges[valueKey].value - flinkMemory;
+                    $("#"+tmRowIdCssName+"-memHeapUsed").html(formatBase1024KMGTP(value));
                     break;
                 case "memory.non-heap.used":
                     var value = metricsJSON.gauges[valueKey].value;
+                    $("#"+tmRowIdCssName+"-memNonHeapUsed").html(formatBase1024KMGTP(value));
                     break;
                 case "memory.flink.used":
                     var value = flinkMemory;
+                    $("#"+tmRowIdCssName+"-memFlinkUsed").html(formatBase1024KMGTP(value));
                     break;
             }
             taskManagerMemory[tm.instanceID][valueKey].push({x: time, y: value})
         }
-        // load
-        taskManagerMemory[tm.instanceID]["load"].push({x:time, y:metricsJSON.gauges["load"].value });
+        // os load
+        var osLoadValue = Number(metricsJSON.gauges["load"].value.toFixed(2));
+        taskManagerMemory[tm.instanceID]["load"].push({x:time, y:osLoadValue });
+        $("#"+tmRowIdCssName+"-osLoad").html(osLoadValue);
+
+        // cpu load
+        var cpuLoadValue = Number((metricsJSON.gauges["cpuLoad"].value*100).toFixed(2));
+        taskManagerMemory[tm.instanceID]["cpuLoad"].push({x:time, y:cpuLoadValue });
+        $("#"+tmRowIdCssName+"-cpuLoad").html(cpuLoadValue);
+
+        // generate summary for the last summaryTime minutes
+        var summaryStats = generateSummaryFor(taskManagerMemory[tm.instanceID],summaryTime);
+        // fill the averages
+        for(var statKey in summaryStats){
+            $("#"+tmRowIdCssName+"-avg_"+statKey.replace(/\./g,'_')).html(summaryStats[statKey]);
+        }
 
         if(metricsLimit == -1 || i < metricsLimit) {
             taskManagerGraph[tm.instanceID].update();
         } else {
-            $("#chart_container-"+tm.instanceID).hide();
+            tmMemStats.hide();
         }
 
-
+        // tooltip to show the time used for summary
+        var avgTimeInfo = "";
+        avgTimeInfo = getTooltipHTML("The average values are for the previous "+summaryTime+" minutes");
+        $("#tmTableHeaderMemStat").html("Memory Statistics "+avgTimeInfo);
 
         // info box
         tmInfoBox = $("#"+tmRowIdCssName+"-info");
@@ -314,34 +369,65 @@ function updateLimit(element) {
             $("#metrics-limit-all,#metrics-limit-none").removeClass("active");
             $(element).addClass("active");
             metricsLimit = 3;
-            hideShowGraphs();
+            hideShowMemStats();
             break;
         case 'metrics-limit-all':
             $("#metrics-limit-3,#metrics-limit-none").removeClass("active");
             $(element).addClass("active");
             metricsLimit = -1;
-            hideShowGraphs();
+            hideShowMemStats();
             break;
         case 'metrics-limit-none':
             $("#metrics-limit-all,#metrics-limit-3").removeClass("active");
             $(element).addClass("active");
             metricsLimit = 0;
-            hideShowGraphs();
+            hideShowMemStats();
             break;
     }
 }
+// toggle function for showing/hiding graphs
+function hideShowGraph(tmid){
+    var element = $("#chart_container-"+tmid);
+    if(element.is(":visible")){
+        $("#graph_button-"+tmid).text("Show Detailed Graph");
+        element.hide();
+    } else {
+         $("#graph_button-"+tmid).text("Hide Detailed Graph");
+         element.show();
+    }
+}
 
-function hideShowGraphs() {
+// hide/show memory statistics for task managers according to metric limits
+function hideShowMemStats() {
     var i = 0;
     for(tmid in taskManagerMemory) {
        if(metricsLimit == -1 || i++ < metricsLimit) {
-            $("#chart_container-"+tmid).show();
+            $("#tm-row-"+tmid+"-memory_stats").show();
        } else {
+            $("#tm-row-"+tmid+"-memory_stats").hide();
+       }
+       if(metricsLimit == 0 && $("#chart_container-"+tmid).is(":visible")){
+            $("#graph_button-"+tmid).text("Show Detailed Graph");
             $("#chart_container-"+tmid).hide();
        }
     }
 }
 
+// generate summary for the last *time* minutes
+function generateSummaryFor(stats,time){
+    var summary = {};
+    var numElements = time*12;
+    for(var key in stats){
+        var prevValues = stats[key].slice(numElements*-1);
+        var sum = (prevValues.reduce(function(p,q){return {x:p.x+q.x,y:p.y+q.y}})).y;
+        var avg = Number((sum/(prevValues.length)).toFixed(2));
+        if (avg > 1024){
+            avg = formatBase1024KMGTP(avg);
+            }
+        summary[key]=avg;
+        }
+    return summary;
+}
 
 function updateTaskManagers() {
 	$.ajax({ url : "setupInfo?get=taskmanagers", type : "GET", cache: false, success : function(json) {

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -215,6 +215,7 @@ function processTMdata(json) {
 		if(tmRow.length == 0) {
 		    // *-memory_stats div contains only the statistics where as chart_container-* div contains the graph
 		    var tmMemoryBox =  "<div id=\""+tmRowIdCssName+"-memory_stats"+"\">"+"</div>"+
+                               "<button type=\"button\" class=\"btn btn-default\" id=\"graph_button-"+tm.instanceID+"\" onclick=\"hideShowGraph('"+tm.instanceID+"')\"></button>"+"<br>"+
 		                       "<div class=\"chart_container\" id=\"chart_container-"+tm.instanceID+"\">"+
                                   "<div class=\"y_axis\" id=\"y_axis-"+tm.instanceID+"\"><p class=\"axis_label\">Memory</p></div>"+
                                   "<div class=\"chart\" id=\"chart-"+tm.instanceID+"\"><i>Waiting for first Heartbeat to arrive</i></div>"+
@@ -247,15 +248,16 @@ function processTMdata(json) {
                         "<b>OS Load</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-osLoad\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_load\"></span>"+"<br>"+
                         "<b>Memory.heap.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memHeapUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_heap_used\"></span>"+"<br>"+
                         "<b>Memory.flink.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memFlinkUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_flink_used\"></span>"+"<br>"+
-                        "<b>Memory.non-heap.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memNonHeapUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_non-heap_used\"></span>"+"<br><br>"+
-                        "<button id=\"graph_button-"+tm.instanceID+"\" onclick=\"hideShowGraph('"+tm.instanceID+"')\"></button>"+"<br>");
+                        "<b>Memory.non-heap.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memNonHeapUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_non-heap_used\"></span>"+"<br><br>");
 
         // preserve the show/hide state of graph after update interval
         var graphElement =  $("#chart_container-"+tm.instanceID);
         if(graphElement.is(':visible')){
             $("#graph_button-"+tm.instanceID).text("Hide Detailed Graph");
+            $("#tm-row-"+tm.instanceID+"-memory_stats").hide();
         } else {
             $("#graph_button-"+tm.instanceID).text("Show Detailed Graph");
+            $("#tm-row-"+tm.instanceID+"-memory_stats").show();
         }
 
 
@@ -391,9 +393,11 @@ function hideShowGraph(tmid){
     if(element.is(":visible")){
         $("#graph_button-"+tmid).text("Show Detailed Graph");
         element.hide();
+        $("#tm-row-"+tmid+"-memory_stats").show();
     } else {
          $("#graph_button-"+tmid).text("Hide Detailed Graph");
          element.show();
+         $("#tm-row-"+tmid+"-memory_stats").hide();
     }
 }
 
@@ -401,14 +405,17 @@ function hideShowGraph(tmid){
 function hideShowMemStats() {
     var i = 0;
     for(tmid in taskManagerMemory) {
-       if(metricsLimit == -1 || i++ < metricsLimit) {
-            $("#tm-row-"+tmid+"-memory_stats").show();
-       } else {
-            $("#tm-row-"+tmid+"-memory_stats").hide();
-       }
-       if(metricsLimit == 0 && $("#chart_container-"+tmid).is(":visible")){
+       // by default hide the graphs when Show/Disable Metrics is clicked
+       if($("#chart_container-"+tmid).is(":visible")){
             $("#graph_button-"+tmid).text("Show Detailed Graph");
             $("#chart_container-"+tmid).hide();
+       }
+       if(metricsLimit == -1 || i++ < metricsLimit) {
+            $("#tm-row-"+tmid+"-memory_stats").show();
+            $("#graph_button-"+tmid).show();
+       } else {
+            $("#tm-row-"+tmid+"-memory_stats").hide();
+            $("#graph_button-"+tmid).hide();
        }
     }
 }

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -215,12 +215,12 @@ function processTMdata(json) {
 		if(tmRow.length == 0) {
 		    // *-memory_stats div contains only the statistics where as chart_container-* div contains the graph
 		    var tmMemoryBox =  "<div id=\""+tmRowIdCssName+"-memory_stats"+"\">"+"</div>"+
-                               "<button type=\"button\" class=\"btn btn-default\" id=\"graph_button-"+tm.instanceID+"\" onclick=\"hideShowGraph('"+tm.instanceID+"')\"></button>"+"<br>"+
+		                       "<button type=\"button\" class=\"btn btn-default\" id=\"graph_button-"+tm.instanceID+"\" onclick=\"hideShowGraph('"+tm.instanceID+"')\"></button>"+"<br>"+
 		                       "<div class=\"chart_container\" id=\"chart_container-"+tm.instanceID+"\">"+
                                   "<div class=\"y_axis\" id=\"y_axis-"+tm.instanceID+"\"><p class=\"axis_label\">Memory</p></div>"+
                                   "<div class=\"chart\" id=\"chart-"+tm.instanceID+"\"><i>Waiting for first Heartbeat to arrive</i></div>"+
                                   "<div class=\"y_axis-load\" id=\"y_axis-load-"+tm.instanceID+"\"><p class=\"axis_label\">CPU Load</p></div>"+
-                               "<div class=\"legend\" id=\"legend-"+tm.instanceID+"\"></div>"+
+                                  "<div class=\"legend\" id=\"legend-"+tm.instanceID+"\"></div>"+
                                "</div>";
 
             var content = "<tr id=\""+tmRowIdCssName+"\">" +
@@ -293,9 +293,9 @@ function processTMdata(json) {
         var cpuLoadValue = Number((metricsJSON.gauges["cpuLoad"].value*100).toFixed(2));
         taskManagerMemory[tm.instanceID]["cpuLoad"].push({x:time, y:cpuLoadValue });
         if(cpuLoadValue != -100){
-          $("#"+tmRowIdCssName+"-cpuLoad").html(cpuLoadValue);
+            $("#"+tmRowIdCssName+"-cpuLoad").html(cpuLoadValue);
         } else {
-          $("#"+tmRowIdCssName+"-cpuLoad").html("NA"+getTooltipHTML("CPU Load is unavailable as the java version is not 1.7 or above"));
+            $("#"+tmRowIdCssName+"-cpuLoad").html("NA"+getTooltipHTML("CPU Load is unavailable as the java version is not 1.7 or above"));
         }
 
 
@@ -400,9 +400,9 @@ function hideShowGraph(tmid){
         element.hide();
         $("#tm-row-"+tmid+"-memory_stats").show();
     } else {
-         $("#graph_button-"+tmid).text("Hide Detailed Graph");
-         element.show();
-         $("#tm-row-"+tmid+"-memory_stats").hide();
+        $("#graph_button-"+tmid).text("Hide Detailed Graph");
+        element.show();
+        $("#tm-row-"+tmid+"-memory_stats").hide();
     }
 }
 
@@ -410,18 +410,18 @@ function hideShowGraph(tmid){
 function hideShowMemStats() {
     var i = 0;
     for(tmid in taskManagerMemory) {
-       // by default hide the graphs when Show/Disable Metrics is clicked
-       if($("#chart_container-"+tmid).is(":visible")){
+        // by default hide the graphs when Show/Disable Metrics is clicked
+        if($("#chart_container-"+tmid).is(":visible")){
             $("#graph_button-"+tmid).text("Show Detailed Graph");
             $("#chart_container-"+tmid).hide();
-       }
-       if(metricsLimit == -1 || i++ < metricsLimit) {
+        }
+        if(metricsLimit == -1 || i++ < metricsLimit) {
             $("#tm-row-"+tmid+"-memory_stats").show();
             $("#graph_button-"+tmid).show();
-       } else {
+        } else {
             $("#tm-row-"+tmid+"-memory_stats").hide();
             $("#graph_button-"+tmid).hide();
-       }
+        }
     }
 }
 
@@ -439,9 +439,9 @@ function generateSummaryFor(stats,time){
         var avg = Number((sum/(prevValues.length)).toFixed(2));
         if (avg > 1024){
             avg = formatBase1024KMGTP(avg);
-            }
-        summary[key]=avg;
         }
+        summary[key]=avg;
+    }
     return summary;
 }
 

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -214,8 +214,8 @@ function processTMdata(json) {
 		tmRow = $("#"+tmRowIdCssName);
 		if(tmRow.length == 0) {
 		    // *-memory_stats div contains only the statistics where as chart_container-* div contains the graph
-		    var tmMemoryBox =  "<div id=\""+tmRowIdCssName+"-memory_stats"+"\">"+"</div>"+
-		                       "<button type=\"button\" class=\"btn btn-default\" id=\"graph_button-"+tm.instanceID+"\" onclick=\"hideShowGraph('"+tm.instanceID+"')\"></button>"+"<br>"+
+		    var tmMemoryBox =  "<button type=\"button\" class=\"btn btn-default\" id=\"graph_button-"+tm.instanceID+"\" onclick=\"hideShowGraph('"+tm.instanceID+"')\"></button>"+"<br>"+"<br>"+
+		                       "<div id=\""+tmRowIdCssName+"-memory_stats"+"\">"+"</div>"+
 		                       "<div class=\"chart_container\" id=\"chart_container-"+tm.instanceID+"\">"+
                                   "<div class=\"y_axis\" id=\"y_axis-"+tm.instanceID+"\"><p class=\"axis_label\">Memory</p></div>"+
                                   "<div class=\"chart\" id=\"chart-"+tm.instanceID+"\"><i>Waiting for first Heartbeat to arrive</i></div>"+
@@ -244,11 +244,16 @@ function processTMdata(json) {
 
         // html dump for memory statistics of task manager
         var tmMemStats = $("#"+tmRowIdCssName+"-memory_stats");
-        tmMemStats.html("<b>CPU Load</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-cpuLoad\"></span>% "+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_cpuLoad\"></span>%"+"<br>"+
-                        "<b>OS Load</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-osLoad\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_load\"></span>"+"<br>"+
-                        "<b>Memory.heap.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memHeapUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_heap_used\"></span>"+"<br>"+
-                        "<b>Memory.flink.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memFlinkUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_flink_used\"></span>"+"<br>"+
-                        "<b>Memory.non-heap.used</b> "+"<br>"+"Current: <span id=\""+tmRowIdCssName+"-memNonHeapUsed\"></span>"+"&emsp; &emsp; &emsp;"+"Avg: <span id=\""+tmRowIdCssName+"-avg_memory_non-heap_used\"></span>"+"<br><br>");
+        tmMemStats.html("<table><tr><td><b>CPU Load</b></td><td></td></tr>"+
+                        "<tr><td>Current: <span id=\""+tmRowIdCssName+"-cpuLoad\"></span>%</td>"+"<td>Avg: <span id=\""+tmRowIdCssName+"-avg_cpuLoad\"></span>%</td></tr>"+
+                        "<tr><td><b>OS Load</b></td><td></td></tr>"+
+                        "<tr><td>Current: <span id=\""+tmRowIdCssName+"-osLoad\"></span></td>"+"<td>Avg: <span id=\""+tmRowIdCssName+"-avg_load\"></span></td></tr>"+
+                        "<tr><td><b>Memory.heap.used</b></td><td></td></tr>"+
+                        "<tr><td>Current: <span id=\""+tmRowIdCssName+"-memHeapUsed\"></span></td>"+"<td>Avg: <span id=\""+tmRowIdCssName+"-avg_memory_heap_used\"></span></td></tr>"+
+                        "<tr><td><b>Memory.flink.used</b></td><td></td></tr>"+
+                        "<tr><td>Current: <span id=\""+tmRowIdCssName+"-memFlinkUsed\"></span></td>"+"<td>Avg: <span id=\""+tmRowIdCssName+"-avg_memory_flink_used\"></span></td></tr>"+
+                        "<tr><td><b>Memory.non-heap.used</b></td><td></td></tr>"+
+                        "<tr><td>Current: <span id=\""+tmRowIdCssName+"-memNonHeapUsed\"></span></td>"+"<td>Avg: <span id=\""+tmRowIdCssName+"-avg_memory_non-heap_used\"></span></td></tr></table>");
 
         // preserve the show/hide state of graph after update interval
         var graphElement =  $("#chart_container-"+tm.instanceID);

--- a/flink-runtime/src/main/resources/web-docs-infoserver/taskmanagers.html
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/taskmanagers.html
@@ -50,6 +50,7 @@ under the License.
     .chart_container {
         position: relative;
         font-family: Arial, Helvetica, sans-serif;
+        display: none;
     }
     .chart {
         position: relative;
@@ -157,7 +158,7 @@ under the License.
 	          <div class="table-responsive" id="taskmanagerTable">
                   <table class="table table-bordered table-hover table-striped">
                       <tr id="taskmanagerTable-header"><th>TaskManager</th>
-                          <th>Memory Statistics</th>
+                          <th id="tmTableHeaderMemStat">Memory Statistics</th>
                           <th>Information</th>
                       </tr>
                   </table>

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1894,6 +1894,10 @@ object TaskManager {
       override def getValue: Double =
         ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage()
     })
+    metricRegistry.register("cpuLoad", new Gauge[Double] {
+      override def getValue: Double =
+        ManagementFactory.getOperatingSystemMXBean().asInstanceOf[com.sun.management.OperatingSystemMXBean].getProcessCpuLoad()
+    })
     metricRegistry
   }
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1895,24 +1895,22 @@ object TaskManager {
         ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage()
     })
     metricRegistry.register("cpuLoad", new Gauge[Double] {
-      override def getValue: Double =
-        ManagementFactory.getOperatingSystemMXBean().asInstanceOf[com.sun.management.OperatingSystemMXBean].getProcessCpuLoad()
-    })
-    try{
-      metricRegistry.register("cpuLoad", new Gauge[Double] {
-        override def getValue: Double =
-          ManagementFactory.getOperatingSystemMXBean().
+      override def getValue: Double = {
+        try{
+          return ManagementFactory.getOperatingSystemMXBean().
             asInstanceOf[com.sun.management.OperatingSystemMXBean].getProcessCpuLoad()
-      })
-    } catch {
-      case t:Throwable => {
-        if (t.isInstanceOf[java.lang.ClassCastException]){
-          LOG.warn("Error casting to OperatingSystemMXBean",t)
-        } else {
-          LOG.warn("Error retrieving process CPU Load",t)
+        } catch {
+          case t:Throwable => {
+            if (t.isInstanceOf[java.lang.ClassCastException]){
+              LOG.warn("Error casting to OperatingSystemMXBean",t)
+            } else {
+              LOG.warn("Error retrieving process CPU Load",t)
+            }
+            return -1
+          }
         }
       }
-    }
+    })
     metricRegistry
   }
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1895,21 +1895,21 @@ object TaskManager {
       override def getValue: Double =
         ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage()
     })
+    
     // Preprocessing steps for registering cpuLoad
     // fetch the method to get process CPU load
     val getCPULoadMethod: Method = getMethodToFetchCPULoad()
 
-    // Log getProcessCpuLoad method not available for Java 6
-    if(getCPULoadMethod == null){
-      LOG.warn("getProcessCpuLoad method not available in the Operating System Bean" +
-      "implementation for this Java runtime environment\n" + Thread.currentThread().getStackTrace)
-    }
-
     // define the fetchCPULoad method as per the fetched getCPULoadMethod
-    val fetchCPULoad: (Any) => Double = if (getCPULoadMethod != null) {
-      (obj: Any) => getCPULoadMethod.invoke(obj).asInstanceOf[Double]
+    // dummy initialisation
+    var fetchCPULoad:(Any) => Double = (obj:Any) => -1
+
+    if(getCPULoadMethod != null){
+      fetchCPULoad = (obj:Any) => getCPULoadMethod.invoke(obj).asInstanceOf[Double]
     } else {
-      (obj: Any) => -1
+      // Log getProcessCpuLoad method not available for Java 6
+      LOG.warn("getProcessCpuLoad method not available in the Operating System Bean" +
+        "implementation for this Java runtime environment\n" + Thread.currentThread().getStackTrace)
     }
 
     metricRegistry.register("cpuLoad", new Gauge[Double] {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1899,11 +1899,7 @@ object TaskManager {
         try{
           val osMXBean = ManagementFactory.getOperatingSystemMXBean().
             asInstanceOf[com.sun.management.OperatingSystemMXBean]
-          if(containsMethodInImpl(osMXBean,"getProcessCpuLoad")) {
-            return osMXBean.getProcessCpuLoad()
-          } else {
-            return -1
-          }
+          return fetchCPULoad(osMXBean).asInstanceOf[Double]
         } catch {
           case t:Throwable => {
             if (t.isInstanceOf[java.lang.ClassCastException]){
@@ -1920,20 +1916,20 @@ object TaskManager {
   }
 
   /**
-   * Checks whether a method exists in an object's class implementation
-   *  without raising any exc eptions
+   * Returns CPU Load if getProcessCpuLoad method is present
+   * in the implementation of OperatingSystemMXBean
+   * else returns -1
    *
    * @param obj
-   * @param methodName
    * @return
    */
-  private def containsMethodInImpl(obj: Any,methodName: String): Boolean = {
-    val methodsList = obj.getClass().getMethods()
+  private def fetchCPULoad(obj: Any): Any = {
+    val methodsList = classOf[com.sun.management.OperatingSystemMXBean].getMethods()
     for(method <- methodsList){
-      if(method.getName() == methodName) {
-        return true
+      if(method.getName() == "getProcessCpuLoad") {
+        return method.invoke(obj)
       }
     }
-    return false
+    return -1
   }
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1900,8 +1900,7 @@ object TaskManager {
           val osMXBean = ManagementFactory.getOperatingSystemMXBean().
             asInstanceOf[com.sun.management.OperatingSystemMXBean]
           if(containsMethodInImpl(osMXBean,"getProcessCpuLoad")) {
-            return ManagementFactory.getOperatingSystemMXBean().
-              asInstanceOf[com.sun.management.OperatingSystemMXBean].getProcessCpuLoad()
+            return osMXBean.getProcessCpuLoad()
           } else {
             return -1
           }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1902,7 +1902,7 @@ object TaskManager {
     // Log getProcessCpuLoad method not available for Java 6
     if(getCPULoadMethod == null){
       LOG.warn("getProcessCpuLoad method not available in the Operating System Bean" +
-      "implementation for this Java runtime environment\n"+Thread.currentThread().getStackTrace)
+      "implementation for this Java runtime environment\n" + Thread.currentThread().getStackTrace)
     }
 
     // define the fetchCPULoad method as per the fetched getCPULoadMethod

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1898,6 +1898,21 @@ object TaskManager {
       override def getValue: Double =
         ManagementFactory.getOperatingSystemMXBean().asInstanceOf[com.sun.management.OperatingSystemMXBean].getProcessCpuLoad()
     })
+    try{
+      metricRegistry.register("cpuLoad", new Gauge[Double] {
+        override def getValue: Double =
+          ManagementFactory.getOperatingSystemMXBean().
+            asInstanceOf[com.sun.management.OperatingSystemMXBean].getProcessCpuLoad()
+      })
+    } catch {
+      case t:Throwable => {
+        if (t.isInstanceOf[java.lang.ClassCastException]){
+          LOG.warn("Error casting to OperatingSystemMXBean",t)
+        } else {
+          LOG.warn("Error retrieving process CPU Load",t)
+        }
+      }
+    }
     metricRegistry
   }
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1902,15 +1902,16 @@ object TaskManager {
     // Log getProcessCpuLoad unavailable for Java 6
     if(fetchCPULoad.isEmpty){
       LOG.warn("getProcessCpuLoad method not available in the Operating System Bean" +
-        "implementation for this Java runtime environment\n" + Thread.currentThread().getStackTrace)
+        "implementation for this Java runtime environment\n" +
+        Thread.currentThread().getStackTrace)
     }
 
     metricRegistry.register("cpuLoad", new Gauge[Double] {
       override def getValue: Double = {
         try{
-          val osMXBean = ManagementFactory.getOperatingSystemMXBean().
-            asInstanceOf[com.sun.management.OperatingSystemMXBean]
-          fetchCPULoad.map(_.invoke(osMXBean).asInstanceOf[Double]).getOrElse(-1)
+          fetchCPULoad.map(_.invoke(ManagementFactory.getOperatingSystemMXBean().
+            asInstanceOf[com.sun.management.OperatingSystemMXBean]).
+            asInstanceOf[Double]).getOrElse(-1)
         } catch {
           case t: Throwable => {
             LOG.warn("Error retrieving CPU Load through OperatingSystemMXBean", t)


### PR DESCRIPTION
Added CPU Load % using another implementation of the OperatingSystemMXBean (https://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/OperatingSystemMXBean.html) and its method getProcessCpuLoad(). 
Added show/hide button for detailed graph and summary for the metrics. Currently, the summary is being generated for the previous 10 minutes by default.  