### PR TITLE
Added type hints for streaming operators

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -195,13 +195,6 @@ public class DataStream<OUT> {
 		return this.typeInfo;
 	}
 
-	@SuppressWarnings("unchecked")
-	public <R> DataStream<R> setType(TypeInformation<R> outType) {
-		streamGraph.setOutType(id, outType);
-		typeInfo = outType;
-		return (DataStream<R>) this;
-	}
-
 	public <F> F clean(F f) {
 		if (getExecutionEnvironment().getConfig().isClosureCleanerEnabled()) {
 			ClosureCleaner.clean(f, true);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -17,7 +17,10 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.invokable.StreamInvokable;
 import org.apache.flink.streaming.api.invokable.StreamInvokable.ChainingStrategy;
@@ -54,16 +57,8 @@ public class SingleOutputStreamOperator<OUT, O extends SingleOutputStreamOperato
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	public <R> SingleOutputStreamOperator<R, ?> setType(TypeInformation<R> outType) {
-		streamGraph.setOutType(id, outType);
-		typeInfo = outType;
-		return (SingleOutputStreamOperator<R, ?>) this;
-	}
-
 	/**
-	 * Sets the parallelism for this operator. The degree must be 1 or
-	 * more.
+	 * Sets the parallelism for this operator. The degree must be 1 or more.
 	 * 
 	 * @param parallelism
 	 *            The parallelism for this operator.
@@ -126,6 +121,131 @@ public class SingleOutputStreamOperator<OUT, O extends SingleOutputStreamOperato
 	public SingleOutputStreamOperator<OUT, O> setChainingStrategy(ChainingStrategy strategy) {
 		this.invokable.setChainingStrategy(strategy);
 		return this;
+	}
+
+	/**
+	 * Adds a type information hint about the return type of this operator.
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler throws away
+	 * generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes a type information string that will be parsed. A type
+	 * information string can contain the following types:
+	 * 
+	 * <ul>
+	 * <li>Basic types such as <code>Integer</code>, <code>String</code>, etc.
+	 * <li>Basic type arrays such as <code>Integer[]</code>,
+	 * <code>String[]</code>, etc.
+	 * <li>Tuple types such as <code>Tuple1&lt;TYPE0&gt;</code>,
+	 * <code>Tuple2&lt;TYPE0, TYPE1&gt;</code>, etc.</li>
+	 * <li>Pojo types such as
+	 * <code>org.my.MyPojo&lt;myFieldName=TYPE0,myFieldName2=TYPE1&gt;</code>,
+	 * etc.</li>
+	 * <li>Generic types such as <code>java.lang.Class</code>, etc.
+	 * <li>Custom type arrays such as <code>org.my.CustomClass[]</code>,
+	 * <code>org.my.CustomClass$StaticInnerClass[]</code>, etc.
+	 * <li>Value types such as <code>DoubleValue</code>,
+	 * <code>StringValue</code>, <code>IntegerValue</code>, etc.</li>
+	 * <li>Tuple array types such as
+	 * <code>Tuple2&lt;TYPE0,TYPE1&gt;[], etc.</code></li>
+	 * <li>Writable types such as
+	 * <code>Writable&lt;org.my.CustomWritable&gt;</code></li>
+	 * <li>Enum types such as <code>Enum&lt;org.my.CustomEnum&gt;</code></li>
+	 * </ul>
+	 * 
+	 * Example:
+	 * <code>"Tuple2&lt;String,Tuple2&lt;Integer,org.my.MyJob$Pojo&lt;word=String&gt;&gt;&gt;"</code>
+	 * 
+	 * @param typeInfoString
+	 *            type information string to be parsed
+	 * @return This operator with a given return type hint.
+	 */
+	public <R> SingleOutputStreamOperator<R, ?> returns(String typeInfoString) {
+		if (typeInfoString == null) {
+			throw new IllegalArgumentException("Type information string must not be null.");
+		}
+		return returns(TypeInfoParser.<R> parse(typeInfoString));
+	}
+
+	/**
+	 * Adds a type information hint about the return type of this operator.
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler throws away
+	 * generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes an instance of
+	 * {@link org.apache.flink.api.common.typeinfo.TypeInformation} such as:
+	 * 
+	 * <ul>
+	 * <li>{@link org.apache.flink.api.common.typeinfo.BasicTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.TupleTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.PojoTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.WritableTypeInfo}</li>
+	 * <li>{@link org.apache.flink.api.java.typeutils.ValueTypeInfo}</li>
+	 * <li>etc.</li>
+	 * </ul>
+	 * 
+	 * @param typeInfo
+	 *            type information as a return type hint
+	 * @return This operator with a given return type hint.
+	 */
+	public <R> SingleOutputStreamOperator<R, ?> returns(TypeInformation<R> typeInfo) {
+		if (typeInfo == null) {
+			throw new IllegalArgumentException("Type information must not be null.");
+		}
+		streamGraph.setOutType(id, typeInfo);
+		this.typeInfo = typeInfo;
+		@SuppressWarnings("unchecked")
+		SingleOutputStreamOperator<R, ?> returnStream = (SingleOutputStreamOperator<R, ?>) this;
+		return returnStream;
+	}
+
+	/**
+	 * Adds a type information hint about the return type of this operator.
+	 * 
+	 * <p>
+	 * Type hints are important in cases where the Java compiler throws away
+	 * generic type information necessary for efficient execution.
+	 * 
+	 * <p>
+	 * This method takes a class that will be analyzed by Flink's type
+	 * extraction capabilities.
+	 * 
+	 * <p>
+	 * Examples for classes are:
+	 * <ul>
+	 * <li>Basic types such as <code>Integer.class</code>,
+	 * <code>String.class</code>, etc.</li>
+	 * <li>POJOs such as <code>MyPojo.class</code></li>
+	 * <li>Classes that <b>extend</b> tuples. Classes like
+	 * <code>Tuple1.class</code>,<code>Tuple2.class</code>, etc. are <b>not</b>
+	 * sufficient.</li>
+	 * <li>Arrays such as <code>String[].class</code>, etc.</li>
+	 * </ul>
+	 * 
+	 * @param typeClass
+	 *            class as a return type hint
+	 * @return This operator with a given return type hint.
+	 */
+	@SuppressWarnings("unchecked")
+	public <R> SingleOutputStreamOperator<R, ?> returns(Class<R> typeClass) {
+		if (typeClass == null) {
+			throw new IllegalArgumentException("Type class must not be null.");
+		}
+
+		try {
+			TypeInformation<R> ti = (TypeInformation<R>) TypeExtractor
+					.createTypeInfo(typeClass);
+			return returns(ti);
+		} catch (InvalidTypesException e) {
+			throw new InvalidTypesException(
+					"The given class is not suited for providing necessary type information.", e);
+		}
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/temporaloperator/StreamCrossOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/temporaloperator/StreamCrossOperator.java
@@ -101,7 +101,7 @@ public class StreamCrossOperator<I1, I2> extends
 
 			streamGraph.setInvokable(id, invokable);
 
-			return setType(outTypeInfo);
+			return this.returns(outTypeInfo);
 
 		}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/temporaloperator/StreamJoinOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/temporaloperator/StreamJoinOperator.java
@@ -247,7 +247,7 @@ public class StreamJoinOperator<I1, I2> extends
 
 			streamGraph.setInvokable(id, invokable);
 
-			return setType(outType);
+			return this.returns(outType);
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/FromElementsFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/FromElementsFunction.java
@@ -27,6 +27,8 @@ public class FromElementsFunction<T> implements SourceFunction<T> {
 
 	Iterable<T> iterable;
 
+	private volatile boolean isRunning;
+
 	public FromElementsFunction(T... elements) {
 		this.iterable = Arrays.asList(elements);
 	}
@@ -41,13 +43,19 @@ public class FromElementsFunction<T> implements SourceFunction<T> {
 
 	@Override
 	public void run(Collector<T> collector) throws Exception {
+		isRunning = true;
 		for (T element : iterable) {
-			collector.collect(element);
+			if (isRunning) {
+				collector.collect(element);
+			} else {
+				break;
+			}
 		}
 	}
 
 	@Override
 	public void cancel() {
+		isRunning = false;
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/GenSequenceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/function/source/GenSequenceFunction.java
@@ -32,13 +32,16 @@ public class GenSequenceFunction extends RichParallelSourceFunction<Long> {
 	private NumberSequenceIterator fullIterator;
 	private NumberSequenceIterator splitIterator;
 
+	private volatile boolean isRunning;
+
 	public GenSequenceFunction(long from, long to) {
 		fullIterator = new NumberSequenceIterator(from, to);
 	}
 
 	@Override
 	public void run(Collector<Long> collector) throws Exception {
-		while (splitIterator.hasNext()) {
+		isRunning = true;
+		while (splitIterator.hasNext() && isRunning) {
 			collector.collect(splitIterator.next());
 		}
 	}
@@ -52,6 +55,7 @@ public class GenSequenceFunction extends RichParallelSourceFunction<Long> {
 
 	@Override
 	public void cancel() {
+		isRunning = false;
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/StreamRecordWriter.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/io/StreamRecordWriter.java
@@ -39,7 +39,8 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 		this(writer, channelSelector, 1000);
 	}
 
-	public StreamRecordWriter(ResultPartitionWriter writer, ChannelSelector<T> channelSelector, long timeout) {
+	public StreamRecordWriter(ResultPartitionWriter writer, ChannelSelector<T> channelSelector,
+			long timeout) {
 		super(writer, channelSelector);
 
 		this.timeout = timeout;
@@ -57,26 +58,28 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 
 			flush();
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new RuntimeException(e);
 		} catch (InterruptedException e) {
-			e.printStackTrace();
+			// Do nothing here
 		}
 	}
 
 	private class OutputFlusher extends Thread {
 		private volatile boolean running = true;
-		
+
 		public void terminate() {
 			running = false;
 		}
-		
+
 		@Override
 		public void run() {
 			while (running) {
 				try {
 					flush();
 					Thread.sleep(timeout);
-				} catch (Exception e) {
+				} catch (InterruptedException e) {
+					// Do nothing here
+				} catch (IOException e) {
 					throw new RuntimeException(e);
 				}
 			}

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamCrossOperator.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamCrossOperator.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.api.scala
 
 import org.apache.flink.api.common.ExecutionConfig
-
 import scala.reflect.ClassTag
 import org.apache.commons.lang.Validate
 import org.apache.flink.api.common.functions.CrossFunction
@@ -33,6 +32,7 @@ import org.apache.flink.streaming.api.invokable.operator.co.CoWindowInvokable
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment.clean
 import org.apache.flink.streaming.api.datastream.temporaloperator.TemporalWindow
 import java.util.concurrent.TimeUnit
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator
 
 class StreamCrossOperator[I1, I2](i1: JavaStream[I1], i2: JavaStream[I2]) extends
   TemporalOperator[I1, I2, StreamCrossOperator.CrossWindow[I1, I2]](i1, i2) {
@@ -90,7 +90,8 @@ object StreamCrossOperator {
       javaStream.getExecutionEnvironment().getStreamGraph().setInvokable(javaStream.getId(),
         invokable)
 
-      javaStream.setType(implicitly[TypeInformation[R]])
+      javaStream.asInstanceOf[SingleOutputStreamOperator[_,_]].returns(
+          implicitly[TypeInformation[R]])
     }
     
     override def every(length: Long, timeUnit: TimeUnit): CrossWindow[I1, I2] = {

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamJoinOperator.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamJoinOperator.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.api.scala
 
 import org.apache.flink.api.common.ExecutionConfig
-
 import scala.Array.canBuildFrom
 import scala.reflect.ClassTag
 import org.apache.commons.lang.Validate
@@ -37,6 +36,7 @@ import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment.clean
 import org.apache.flink.streaming.util.keys.KeySelectorUtil
 import org.apache.flink.streaming.api.datastream.temporaloperator.TemporalWindow
 import java.util.concurrent.TimeUnit
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator
 
 class StreamJoinOperator[I1, I2](i1: JavaStream[I1], i2: JavaStream[I2]) extends 
 TemporalOperator[I1, I2, StreamJoinOperator.JoinWindow[I1, I2]](i1, i2) {
@@ -202,7 +202,8 @@ object StreamJoinOperator {
       javaStream.getExecutionEnvironment().getStreamGraph().setInvokable(javaStream.getId(),
         invokable)
 
-      javaStream.setType(implicitly[TypeInformation[R]])
+      javaStream.asInstanceOf[SingleOutputStreamOperator[_,_]].returns(
+          implicitly[TypeInformation[R]])
     }
   }
 


### PR DESCRIPTION
The only difference between this and the batch approach is that we allow the change of type as well. I don't think this could break functionality but we use this feature internally.