### PR TITLE
[FLINK-1753] [streaming] Added test for Kafka connector with tuple type

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSink.java
@@ -34,7 +34,6 @@ import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 import kafka.producer.ProducerConfig;
 import kafka.serializer.DefaultEncoder;
-import kafka.serializer.StringEncoder;
 
 /**
  * Sink that emits its inputs to a Kafka topic.
@@ -123,7 +122,9 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 		props.put("request.required.acks", "1");
 
 		props.put("serializer.class", DefaultEncoder.class.getCanonicalName());
-		props.put("key.serializer.class", StringEncoder.class.getCanonicalName());
+
+		// this will not be used as the key will not be serialized
+		props.put("key.serializer.class", DefaultEncoder.class.getCanonicalName());
 
 		if (partitioner != null) {
 			props.put("partitioner.class", PartitionerWrapper.class.getCanonicalName());
@@ -152,7 +153,9 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	@Override
 	public void invoke(IN next) {
 		byte[] serialized = schema.serialize(next);
-		producer.send(new KeyedMessage<IN, byte[]>(topicId, next, serialized));
+
+		// Sending message without serializable key.
+		producer.send(new KeyedMessage<IN, byte[]>(topicId, null, next, serialized));
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/config/PartitionerWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/config/PartitionerWrapper.java
@@ -32,7 +32,7 @@ import kafka.utils.VerifiableProperties;
  *
  * This PartitionerWrapper is called with the Properties. From there, we extract the wrapped Partitioner instance.
  *
- * The serialziable PartitionerWrapper is serialized into the Properties Hashmap and also deserialized from there.
+ * The serializable PartitionerWrapper is serialized into the Properties Hashmap and also deserialized from there.
  */
 public class PartitionerWrapper implements Partitioner {
 	public final static String SERIALIZED_WRAPPER_NAME = "flink.kafka.wrapper.serialized";

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -24,7 +26,9 @@ import java.net.UnknownHostException;
 import java.util.BitSet;
 import java.util.Properties;
 
+import org.apache.commons.lang.SerializationUtils;
 import org.apache.curator.test.TestingServer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.net.NetUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -36,11 +40,14 @@ import org.apache.flink.streaming.connectors.kafka.api.KafkaSink;
 import org.apache.flink.streaming.connectors.kafka.api.simple.KafkaTopicUtils;
 import org.apache.flink.streaming.connectors.kafka.api.simple.PersistentKafkaSource;
 import org.apache.flink.streaming.connectors.kafka.api.simple.offset.Offset;
+import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JavaDefaultStringSchema;
+import org.apache.flink.streaming.util.serialization.SerializationSchema;
 import org.apache.flink.util.Collector;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
@@ -61,74 +68,178 @@ public class KafkaITCase {
 
 	private static final Logger LOG = LoggerFactory.getLogger(KafkaITCase.class);
 
-	private final String TOPIC = "myTopic";
+	private static int zkPort;
+	private static int kafkaPort;
+	private static String kafkaHost;
 
-	private int zkPort;
-	private int kafkaPort;
-	private String kafkaHost;
+	private static String zookeeperConnectionString;
 
-	private String zookeeperConnectionString;
+	@ClassRule
+	public static TemporaryFolder tempFolder = new TemporaryFolder();
+	public static File tmpZkDir;
+	public static File tmpKafkaDir;
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
-	public File tmpZkDir;
-	public File tmpKafkaDir;
+	private static TestingServer zookeeper;
+	private static KafkaServer broker1;
 
-	@Before
-	public void prepare() throws IOException {
+
+	@BeforeClass
+	public static void prepare() throws IOException {
+		LOG.info("Starting KafkaITCase.prepare()");
 		tmpZkDir = tempFolder.newFolder();
 		tmpKafkaDir = tempFolder.newFolder();
 		kafkaHost = InetAddress.getLocalHost().getHostName();
 		zkPort = NetUtils.getAvailablePort();
 		kafkaPort = NetUtils.getAvailablePort();
 		zookeeperConnectionString = "localhost:" + zkPort;
-	}
 
-	@Test
-	public void test() {
-		LOG.info("Starting KafkaITCase.test()");
-		TestingServer zookeeper = null;
-		KafkaServer broker1 = null;
+		zookeeper = null;
+		broker1 = null;
+
 		try {
+			LOG.info("Starting Zookeeper");
 			zookeeper = getZookeeper();
+			LOG.info("Starting KafkaServer");
 			broker1 = getKafkaServer(0);
-			LOG.info("ZK and KafkaServer started. Creating test topic:");
-			createTestTopic();
-
-			LOG.info("Starting Kafka Topology in Flink:");
-			startKafkaTopology();
-
-			LOG.info("Test succeeded.");
+			LOG.info("ZK and KafkaServer started.");
 		} catch (Throwable t) {
 			LOG.warn("Test failed with exception", t);
 			Assert.fail("Test failed with: " + t.getMessage());
-		} finally {
-			LOG.info("Shutting down all services");
-			if (broker1 != null) {
-				broker1.shutdown();
+		}
+	}
+
+	@AfterClass
+	public static void shutDownServices() {
+		LOG.info("Shutting down all services");
+		if (broker1 != null) {
+			broker1.shutdown();
+		}
+		if (zookeeper != null) {
+			try {
+				zookeeper.stop();
+			} catch (IOException e) {
+				LOG.warn("ZK.stop() failed", e);
 			}
-			if (zookeeper != null) {
-				try {
-					zookeeper.stop();
-				} catch (IOException e) {
-					LOG.warn("ZK.stop() failed", e);
+		}
+	}
+
+	@Test
+	public void tupleTestTopology() throws Exception {
+		LOG.info("Starting KafkaITCase.tupleTestTopology()");
+
+		String topic = "tupleTestTopic";
+		createTestTopic(topic, 1);
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+
+		// add consuming topology:
+		DataStreamSource<Tuple2<Long, String>> consuming = env.addSource(
+				new PersistentKafkaSource<Tuple2<Long, String>>(zookeeperConnectionString, topic, new TupleSerializationSchema(), 5000, 100, Offset.FROM_BEGINNING));
+		consuming.addSink(new SinkFunction<Tuple2<Long, String>>() {
+			int elCnt = 0;
+			int start = -1;
+			BitSet validator = new BitSet(101);
+
+			@Override
+			public void invoke(Tuple2<Long, String> value) throws Exception {
+				LOG.info("Got " + value);
+				String[] sp = value.f1.split("-");
+				int v = Integer.parseInt(sp[1]);
+
+				assertEquals(value.f0 - 1000, (long) v);
+
+				if (start == -1) {
+					start = v;
+				}
+				Assert.assertFalse("Received tuple twice", validator.get(v - start));
+				validator.set(v - start);
+				elCnt++;
+				if (elCnt == 100) {
+					// check if everything in the bitset is set to true
+					int nc;
+					if ((nc = validator.nextClearBit(0)) != 100) {
+						throw new RuntimeException("The bitset was not set to 1 on all elements. Next clear:" + nc + " Set: " + validator);
+					}
+					throw new SuccessException();
 				}
 			}
+		});
+
+		// add producing topology
+		DataStream<Tuple2<Long, String>> stream = env.addSource(new SourceFunction<Tuple2<Long, String>>() {
+			private static final long serialVersionUID = 1L;
+			boolean running = true;
+
+			@Override
+			public void run(Collector<Tuple2<Long, String>> collector) throws Exception {
+				LOG.info("Starting source.");
+				int cnt = 0;
+				while (running) {
+					collector.collect(new Tuple2<Long, String>(1000L + cnt, "kafka-" + cnt++));
+					try {
+						Thread.sleep(100);
+					} catch (InterruptedException ignored) {
+					}
+				}
+			}
+
+			@Override
+			public void cancel() {
+				LOG.info("Source got cancel()");
+				running = false;
+			}
+		});
+		stream.addSink(new KafkaSink<Tuple2<Long, String>>(zookeeperConnectionString, topic, new TupleSerializationSchema()));
+
+		try {
+			env.setParallelism(1);
+			env.execute();
+		} catch (JobExecutionException good) {
+			Throwable t = good.getCause();
+			int limit = 0;
+			while (!(t instanceof SuccessException)) {
+				t = t.getCause();
+				if (limit++ == 20) {
+					LOG.warn("Test failed with exception", good);
+					Assert.fail("Test failed with: " + good.getMessage());
+				}
+			}
+		}
+		LOG.info("Finished KafkaITCase.tupleTestTopology()");
+	}
+
+	private static class TupleSerializationSchema implements DeserializationSchema<Tuple2<Long, String>>, SerializationSchema<Tuple2<Long, String>, byte[]> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public Tuple2<Long, String> deserialize(byte[] message) {
+			Object deserializedObject = SerializationUtils.deserialize(message);
+			return (Tuple2<Long, String>) deserializedObject;
+		}
+
+		@Override
+		public byte[] serialize(Tuple2<Long, String> element) {
+			return SerializationUtils.serialize(element);
+		}
+
+		@Override
+		public boolean isEndOfStream(Tuple2<Long, String> nextElement) {
+			return false;
 		}
 
 	}
 
-	private void createTestTopic() {
-		KafkaTopicUtils kafkaTopicUtils = new KafkaTopicUtils(zookeeperConnectionString);
-		kafkaTopicUtils.createTopic(TOPIC, 1, 1);
-	}
+	@Test
+	public void simpleTestTopology() throws Exception {
+		String topic = "simpleTestTopic";
 
-	private void startKafkaTopology() throws Exception {
+		createTestTopic(topic, 1);
+
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
 
 		// add consuming topology:
 		DataStreamSource<String> consuming = env.addSource(
-				new PersistentKafkaSource<String>(zookeeperConnectionString, TOPIC, new JavaDefaultStringSchema(), 5000, 100, Offset.FROM_BEGINNING));
+				new PersistentKafkaSource<String>(zookeeperConnectionString, topic, new JavaDefaultStringSchema(), 5000, 100, Offset.FROM_BEGINNING));
 		consuming.addSink(new SinkFunction<String>() {
 			int elCnt = 0;
 			int start = -1;
@@ -176,11 +287,11 @@ public class KafkaITCase {
 
 			@Override
 			public void cancel() {
-				LOG.info("Source got chancel()");
+				LOG.info("Source got cancel()");
 				running = false;
 			}
 		});
-		stream.addSink(new KafkaSink<String>(zookeeperConnectionString, TOPIC, new JavaDefaultStringSchema()));
+		stream.addSink(new KafkaSink<String>(zookeeperConnectionString, topic, new JavaDefaultStringSchema()));
 
 		try {
 			env.setParallelism(1);
@@ -191,21 +302,28 @@ public class KafkaITCase {
 			while (!(t instanceof SuccessException)) {
 				t = t.getCause();
 				if (limit++ == 20) {
-					throw good;
+					LOG.warn("Test failed with exception", good);
+					Assert.fail("Test failed with: " + good.getMessage());
 				}
 			}
 		}
 	}
 
 
-	private TestingServer getZookeeper() throws Exception {
+	private void createTestTopic(String topic, int numberOfPartitions) {
+		KafkaTopicUtils kafkaTopicUtils = new KafkaTopicUtils(zookeeperConnectionString);
+		kafkaTopicUtils.createTopic(topic, numberOfPartitions, 1);
+	}
+
+
+	private static TestingServer getZookeeper() throws Exception {
 		return new TestingServer(zkPort, tmpZkDir);
 	}
 
 	/**
 	 * Copied from com.github.sakserv.minicluster.KafkaLocalBrokerIntegrationTest (ASL licensed)
 	 */
-	private KafkaServer getKafkaServer(int brokerId) throws UnknownHostException {
+	private static KafkaServer getKafkaServer(int brokerId) throws UnknownHostException {
 		Properties kafkaProperties = new Properties();
 		// properties have to be Strings
 		kafkaProperties.put("advertised.host.name", kafkaHost);
@@ -220,13 +338,12 @@ public class KafkaITCase {
 		return server;
 	}
 
-	public class LocalSystemTime implements Time {
+	public static class LocalSystemTime implements Time {
 
 		@Override
 		public long milliseconds() {
 			return System.currentTimeMillis();
 		}
-
 		public long nanoseconds() {
 			return System.nanoTime();
 		}
@@ -243,9 +360,7 @@ public class KafkaITCase {
 	}
 
 	public static class SuccessException extends Exception {
-
 		private static final long serialVersionUID = 1L;
-
 	}
 
 }


### PR DESCRIPTION
Fixed a small bug with Kafka key serializer and extended the KafkaITCase with multiple tests:
* topology that sends Kafka non-String type (Tuple) objects
* topology that uses custom partitioning at Kafka producer.
* topology that uses the regular KafkaSource