### PR TITLE
Fixup ReusingKeyGroupedIterator value iterators in NonReusingSortMergeCoGroupIterator.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIterator.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.operators.util.CoGroupTaskIterator;
-import org.apache.flink.runtime.util.ReusingKeyGroupedIterator;
+import org.apache.flink.runtime.util.NonReusingKeyGroupedIterator;
 import org.apache.flink.util.MutableObjectIterator;
 
 import java.io.IOException;
@@ -45,9 +45,9 @@ public class NonReusingSortMergeCoGroupIterator<T1, T2> implements CoGroupTaskIt
 
 	private TypePairComparator<T1, T2> comp;
 
-	private ReusingKeyGroupedIterator<T1> iterator1;
+	private NonReusingKeyGroupedIterator<T1> iterator1;
 
-	private ReusingKeyGroupedIterator<T2> iterator2;
+	private NonReusingKeyGroupedIterator<T2> iterator2;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -61,8 +61,8 @@ public class NonReusingSortMergeCoGroupIterator<T1, T2> implements CoGroupTaskIt
 
 		this.comp = pairComparator;
 
-		this.iterator1 = new ReusingKeyGroupedIterator<T1>(input1, serializer1, groupingComparator1);
-		this.iterator2 = new ReusingKeyGroupedIterator<T2>(input2, serializer2, groupingComparator2);
+		this.iterator1 = new NonReusingKeyGroupedIterator<T1>(input1, groupingComparator1);
+		this.iterator2 = new NonReusingKeyGroupedIterator<T2>(input2, groupingComparator2);
 	}
 
 	@Override


### PR DESCRIPTION
Correct me if I'm wrong, but I think that the NonReusingSortMergeCoGroupIterator should construct value iterators which are non-reusing as well, otherwise you have unexpected behavior like this:

```java

public static void main(String[] args) throws Exception{
    ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
    env.getConfig().disableObjectReuse();

    in1.coGroup(in2).where("name").equalTo("name").with(new SampleCoGroup());

    env.execute()
}

public static class SampleCoGroup implements CoGroupFunction<Person,StudentInfo,Tuple3<String,String,String>>{
    @Override
    public void coGroup(Iterable<Person> iterable, Iterable<StudentInfo> iterable1, Collector<Tuple3<String, String, String>> collector) throws Exception {
        for(StudentInfo info : iterable1) {
            infos.add(info); // faulty behavior
        }
        // ...
    }
}

```