### PR TITLE
[docs] Add custom search

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -54,13 +54,21 @@ under the License.
           {% include sidenav.html %}
         </div>  
         <div class="col-md-9">
-          <h1>{{ page.title }}</h1>
-	  
-          {{ content }}
-	  
-        <!-- Disqus Area -->
-          <div style="padding-top:30px" id="disqus_thread"></div>
-      
+          <div class="row" style="padding-bottom:5px">
+            <form class="form-horizontal" action="search.html">
+              <div class="col-sm-10"><input name="q" type="text" class="form-control" placeholder="Search all pages"></div>
+              <div class="col-sm-2"><button type="submit" class="btn btn-default">Search</button></div>
+            </form>
+          </div>
+
+          <div class="row">
+            <h1>{{ page.title }}</h1>
+  	  
+            {{ content }}
+  	  
+            <!-- Disqus Area -->
+            <div style="padding-top:30px" id="disqus_thread"></div>
+        
             <script type="text/javascript">
                 /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
                 var disqus_shortname = 'stratosphere-eu'; // required: replace example with your forum shortname
@@ -75,15 +83,12 @@ under the License.
             <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
           </div>
         </div>
-
         <div class="footer">
           {% capture footer %}{% include footer.md %}{% endcapture %}
           {{ footer | markdownify }}
         </div>
       </div>
     </div>
-
-    
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -93,8 +98,6 @@ under the License.
 
       ga('create', 'UA-52545728-1', 'auto');
       ga('send', 'pageview');
-
     </script>
-
   </body>
 </html>

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,36 @@
+---
+title:  "Search"
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<script>
+  (function() {
+    var cx = '000888944958067045520:z90hn2izm0k';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+        '//www.google.com/cse/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+
+<gcse:searchresults-only></gcse:searchresults-only>


### PR DESCRIPTION
As per discussion on dev@f.a.o, this commit adds a custom search to our documentation.

The custom search is currently linked under my Google account. We can figure out how to add other committers if needed.

Adds http://ci.apache.org/projects/flink/flink-docs-master/ to the search (excluding */api for the code docs).