### PR TITLE
[FLINK-1826]Remove the redundant codes never be executed in function getNumPages

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/DefaultMemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/DefaultMemoryManager.java
@@ -395,10 +395,6 @@ public class DefaultMemoryManager implements MemoryManager {
 	// ------------------------------------------------------------------------
 	
 	private int getNumPages(long numBytes) {
-		if (numBytes < 0) {
-			throw new IllegalArgumentException("The number of bytes to allocate must not be negative.");
-		}
-		
 		final long numPages = numBytes >>> this.pageSizeBits;
 		if (numPages <= Integer.MAX_VALUE) {
 			return (int) numPages;


### PR DESCRIPTION
Remove the code never be executed in function getNumPages, because the input of numBytes has be validataion by its caller of DefaultMemoryManager(long memorySize, int numberOfSlots, int pageSize).