### PR TITLE
[FLINK-1832] Fix start scripts for Cygwin and paths with spaces

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -25,7 +25,7 @@
 manglePath() {
     UNAME=$(uname -s)
     if [ "${UNAME:0:6}" == "CYGWIN" ]; then
-        echo `cygpath -w $1`
+        echo `cygpath -w "$1"`
     else
         echo $1
     fi
@@ -35,7 +35,7 @@ manglePathList() {
     UNAME=$(uname -s)
     # a path list, for example a java classpath
     if [ "${UNAME:0:6}" == "CYGWIN" ]; then
-        echo `cygpath -wp $1`
+        echo `cygpath -wp "$1"`
     else
         echo $1
     fi

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -17,6 +17,18 @@
 # limitations under the License.
 ################################################################################
 
+constructFlinkClassPath() {
+
+    for jarfile in "$FLINK_LIB_DIR"/*.jar ; do
+        if [[ $FLINK_CLASSPATH = "" ]]; then
+            FLINK_CLASSPATH=$jarfile;
+        else
+            FLINK_CLASSPATH=$FLINK_CLASSPATH:$jarfile
+        fi
+    done
+
+    echo $FLINK_CLASSPATH
+}
 
 # These are used to mangle paths that are passed to java when using 
 # cygwin. Cygwin paths are like linux paths, i.e. /path/to/somewhere
@@ -188,9 +200,6 @@ fi
 # DO NOT USE FOR MEMORY SETTINGS! Use conf/flink-conf.yaml with keys
 # KEY_JOBM_HEAP_MB and KEY_TASKM_HEAP_MB for that!
 JVM_ARGS=""
-
-# Default classpath 
-CLASSPATH=`manglePathList $( echo $FLINK_LIB_DIR/*.jar . | sed 's/ /:/g' )`
 
 # Check if deprecated HADOOP_HOME is set.
 if [ -n "$HADOOP_HOME" ]; then

--- a/flink-dist/src/main/flink-bin/bin/flink
+++ b/flink-dist/src/main/flink-bin/bin/flink
@@ -27,23 +27,7 @@ if [ "$FLINK_IDENT_STRING" = "" ]; then
         FLINK_IDENT_STRING="$USER"
 fi
 
-
-# auxiliary function to construct a lightweight classpath for the
-# Flink CLI client
-constructCLIClientClassPath() {
-
-	for jarfile in $FLINK_LIB_DIR/*.jar ; do
-		if [[ $CC_CLASSPATH = "" ]]; then
-			CC_CLASSPATH=$jarfile;
-		else
-			CC_CLASSPATH=$CC_CLASSPATH:$jarfile
-		fi
-	done
-
-	echo $CC_CLASSPATH
-}
-
-CC_CLASSPATH=`manglePathList $(constructCLIClientClassPath)`
+CC_CLASSPATH=`constructFlinkClassPath`
 
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-flink-client-$HOSTNAME.log
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-cli.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
@@ -51,4 +35,4 @@ log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4
 export FLINK_CONF_DIR
 
 # Add HADOOP_CLASSPATH to allow the usage of Hadoop file systems
-$JAVA_RUN $JVM_ARGS $log_setting -classpath $CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS org.apache.flink.client.CliFrontend $*
+$JAVA_RUN $JVM_ARGS "$log_setting" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.client.CliFrontend $*

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -32,26 +32,11 @@ if [ "$JAVA_VERSION" -lt 18 ]; then
     JVM_ARGS="$JVM_ARGS -XX:MaxPermSize=256m"
 fi
 
-
-
 if [ "$FLINK_IDENT_STRING" = "" ]; then
     FLINK_IDENT_STRING="$USER"
 fi
 
-# auxilliary function to construct a the classpath for the jobManager
-constructJobManagerClassPath() {
-    for jarfile in "$FLINK_LIB_DIR"/*.jar ; do
-        if [[ $FLINK_JM_CLASSPATH = "" ]]; then
-            FLINK_JM_CLASSPATH=$jarfile;
-        else
-            FLINK_JM_CLASSPATH=$FLINK_JM_CLASSPATH:$jarfile
-        fi
-    done
-
-    echo $FLINK_JM_CLASSPATH
-}
-
-FLINK_JM_CLASSPATH=`manglePathList "$(constructJobManagerClassPath)"`
+FLINK_JM_CLASSPATH=`constructFlinkClassPath`
 
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-jobmanager-$HOSTNAME.log
 out=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-jobmanager-$HOSTNAME.out
@@ -95,7 +80,7 @@ case $STARTSTOP in
         rotateLogFile $out
 
         echo Starting job manager
-        $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "$FLINK_JM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS" org.apache.flink.runtime.jobmanager.JobManager --executionMode $EXECUTIONMODE --configDir "$FLINK_CONF_DIR"  > "$out" 2>&1 < /dev/null &
+        $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_JM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.runtime.jobmanager.JobManager --executionMode $EXECUTIONMODE --configDir "$FLINK_CONF_DIR"  > "$out" 2>&1 < /dev/null &
         echo $! > $pid
 
     ;;

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -29,22 +29,7 @@ if [ "$FLINK_IDENT_STRING" = "" ]; then
     FLINK_IDENT_STRING="$USER"
 fi
 
-# auxilliary function to construct a lightweight classpath for the
-# Flink TaskManager
-constructTaskManagerClassPath() {
-
-    for jarfile in "$FLINK_LIB_DIR"/*.jar ; do
-        if [[ $FLINK_TM_CLASSPATH = "" ]]; then
-            FLINK_TM_CLASSPATH=$jarfile;
-        else
-            FLINK_TM_CLASSPATH=$FLINK_TM_CLASSPATH:$jarfile
-        fi
-    done
-
-    echo $FLINK_TM_CLASSPATH
-}
-
-FLINK_TM_CLASSPATH=`manglePathList "$(constructTaskManagerClassPath)"`
+FLINK_TM_CLASSPATH=`constructFlinkClassPath`
 
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-taskmanager-$HOSTNAME.log
 out=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-taskmanager-$HOSTNAME.out
@@ -83,7 +68,7 @@ case $STARTSTOP in
         rotateLogFile $out
 
         echo Starting task manager on host $HOSTNAME
-        $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS" org.apache.flink.runtime.taskmanager.TaskManager --configDir "$FLINK_CONF_DIR" > "$out" 2>&1 < /dev/null &
+        $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.runtime.taskmanager.TaskManager --configDir "$FLINK_CONF_DIR" > "$out" 2>&1 < /dev/null &
         echo $! > $pid
 
     ;;

--- a/flink-dist/src/main/flink-bin/bin/webclient.sh
+++ b/flink-dist/src/main/flink-bin/bin/webclient.sh
@@ -32,21 +32,7 @@ fi
 
 JVM_ARGS="$JVM_ARGS -Xmx512m"
 
-# auxilliary function to construct the classpath for the webclient
-constructWebclientClassPath() {
-
-	for jarfile in "$FLINK_LIB_DIR"/*.jar ; do
-		if [[ $FLINK_WEBCLIENT_CLASSPATH = "" ]]; then
-			FLINK_WEBCLIENT_CLASSPATH=$jarfile;
-		else
-			FLINK_WEBCLIENT_CLASSPATH=$FLINK_WEBCLIENT_CLASSPATH:$jarfile
-		fi
-	done
-
-	echo $FLINK_WEBCLIENT_CLASSPATH
-}
-
-FLINK_WEBCLIENT_CLASSPATH=`manglePathList "$(constructWebclientClassPath)"`
+FLINK_WEBCLIENT_CLASSPATH=`constructFlinkClassPath`
 
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-webclient-$HOSTNAME.log
 out=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-webclient-$HOSTNAME.out
@@ -64,7 +50,7 @@ case $STARTSTOP in
                         fi
                 fi
                 echo Starting Flink webclient
-		$JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "$FLINK_WEBCLIENT_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS" org.apache.flink.client.WebFrontend --configDir "$FLINK_CONF_DIR" > "$out" 2>&1 < /dev/null &
+		$JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$FLINK_WEBCLIENT_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.client.WebFrontend --configDir "$FLINK_CONF_DIR" > "$out" 2>&1 < /dev/null &
 		echo $! > $pid
 	;;
 


### PR DESCRIPTION
A few fixes for the start and submission scripts. 
Right now they fail for:
- all scripts fail on Cygwin
- `./bin/flink` fails on Unix for Flink root paths that contain spaces

Also, some duplicated code is removed.

Fixes should be backported to 0.8 as well.