### PR TITLE
[runtime] Avoid IllegalStateException when TaskManager is killed during startup

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
@@ -103,7 +103,14 @@ public abstract class IOManager {
 				shutdown();
 			}
 		};
-		Runtime.getRuntime().addShutdownHook(this.shutdownHook);
+		try {
+			Runtime.getRuntime().addShutdownHook(this.shutdownHook);
+		} catch (IllegalStateException e) {
+			// race, JVM is in shutdown already, we can safely ignore this
+			LOG.debug("Unable to add shutdown hook, shutdown already in progress", e);
+		} catch (Throwable t) {
+			LOG.warn("Error while adding shutdown hook for IOManager", t);
+		}
 	}
 
 	/**
@@ -132,6 +139,7 @@ public abstract class IOManager {
 			}
 			catch (IllegalStateException e) {
 				// race, JVM is in shutdown already, we can safely ignore this
+				LOG.debug("Unable to remove shutdown hook, shutdown already in progress", e);
 			}
 			catch (Throwable t) {
 				LOG.warn("Exception while unregistering IOManager's shutdown hook.", t);

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -123,7 +123,13 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		checkForLogString("The Flink YARN client has been started in detached mode");
 
 		Assert.assertFalse("The runner should detach.", runner.isAlive());
-		sleep(5000); // wait for 5 seconds to make sure the the app has been started completely before we kill it
+
+		LOG.info("Waiting until two containers are running");
+		// wait until two containers are running
+		while(getRunningContainers() < 2) {
+			sleep(500);
+		}
+		LOG.info("Two containers are running. Killing the application");
 
 		// kill application "externally".
 		try {


### PR DESCRIPTION
A YARN test was failing because a TaskManager had the following exception in its logs
```
15:17:14,651 INFO  org.apache.flink.runtime.taskmanager.TaskManager              - Temporary file directory '/home/travis/build/rmetzger/flink/flink-yarn-tests/target/flink-yarn-tests-fifo/flink-yarn-tests-fifo-localDir-nm-0_0/usercache/travis/appcache/application_1428678925260_0006': total 18 GB, usable 10 GB (55.56% usable)
15:17:14,859 INFO  org.apache.flink.runtime.io.network.buffer.NetworkBufferPool  - Allocated 64 MB for network buffer pool (number of memory segments: 2048, bytes per segment: 32768).
15:17:15,150 INFO  org.apache.flink.runtime.taskmanager.TaskManager              - Using 0.7 of the currently free heap space for Flink managed memory (492 MB).
15:17:16,114 ERROR org.apache.flink.yarn.appMaster.YarnTaskManagerRunner         - RECEIVED SIGNAL 15: SIGTERM
15:17:16,115 INFO  org.apache.flink.runtime.io.disk.iomanager.IOManager          - I/O manager uses directory /home/travis/build/rmetzger/flink/flink-yarn-tests/target/flink-yarn-tests-fifo/flink-yarn-tests-fifo-localDir-nm-0_0/usercache/travis/appcache/application_1428678925260_0006/flink-io-65c2a428-64a1-4a60-bf65-2a5f49dd965c for spill files.
15:17:16,116 ERROR org.apache.flink.runtime.taskmanager.TaskManager              - Error while starting up taskManager
java.lang.IllegalStateException: Shutdown in progress
	at java.lang.ApplicationShutdownHooks.add(ApplicationShutdownHooks.java:66)
	at java.lang.Runtime.addShutdownHook(Runtime.java:211)
	at org.apache.flink.runtime.io.disk.iomanager.IOManager.<init>(IOManager.java:106)
	at org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync.<init>(IOManagerAsync.java:78)
	at org.apache.flink.runtime.taskmanager.TaskManager$.startTaskManagerComponentsAndActor(TaskManager.scala:1555)
	at org.apache.flink.runtime.taskmanager.TaskManager$.runTaskManager(TaskManager.scala:1392)
	at org.apache.flink.runtime.taskmanager.TaskManager$.selectNetworkInterfaceAndRunTaskManager(TaskManager.scala:1265)
	at org.apache.flink.runtime.taskmanager.TaskManager.selectNetworkInterfaceAndRunTaskManager(TaskManager.scala)
	at org.apache.flink.yarn.appMaster.YarnTaskManagerRunner$1.run(YarnTaskManagerRunner.java:90)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1608)
	at org.apache.flink.yarn.appMaster.YarnTaskManagerRunner.main(YarnTaskManagerRunner.java:86)
```

This change should avoid such errors in the future.