### PR TITLE
[docs] Remove skeleton page from navigation, add links to ML pages

### DIFF
--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -54,13 +54,18 @@ under the License.
   <li><div class="sidenav-item"><a href="{{ site.baseurl }}/cli.html">Command-Line Interface</a></div></li>
   <li><div class="sidenav-item-bottom"><a href="{{ site.baseurl }}/web_client.html">Web Interface</a></div></li>
 
+  <li><div class="sidenav-category">Machine Learning Library <small style="font-size:75%">Beta</small></div></li>
+  <li><div class="sidenav-item"><a href="{{ site.baseurl }}/ml/alternating_least_squares.html">Alternating Least Squares</a> <small>Beta</small></div></li>
+  <li><div class="sidenav-item"><a href="{{ site.baseurl }}/ml/multiple_linear_regression.html">Multiple linear regression</a> <small>Beta</small></div></li>
+  <li><div class="sidenav-item"><a href="{{ site.baseurl }}/ml/polynomial_base_feature_mapper.html">Polynomial Base Feature Mapper</a> <small>Beta</small></div></li>
+  <li><div class="sidenav-item-bottom"><a href="{{ site.baseurl }}/ml/cocoa.html">CoCoA</a> <small>Beta</small></div></li>
+
   <li><div class="sidenav-category">Advanced</div></li>
   <li><div class="sidenav-item"><a href="{{ site.baseurl }}/internal_general_arch.html">Architecture and Process Model</a></div></li>
   <!-- <li><a href="internal_program_life_cycle.html">From Program to Execution</a></li> -->
   <li><div class="sidenav-item"><a href="{{ site.baseurl }}/internal_types_serialization.html">Type extraction and Serialization</a></div></li>
-  <li><div class="sidenav-item"><a href="{{ site.baseurl }}/internal_distributed_akka.html">Distributed Communication via Akka</a></div></li>
+  <!-- <li><div class="sidenav-item"><a href="{{ site.baseurl }}/internal_distributed_akka.html">Distributed Communication via Akka</a></div></li> -->
   <li><div class="sidenav-item"><a href="{{ site.baseurl }}/internal_job_scheduling.html">Jobs and Scheduling</a></div></li>
-  <!-- <li><a href="#">Types & Serialization</a></li> -->
   <!-- <li><a href="#">Distributed Runtime & Data Exchange</a></li> -->
   <!-- <li><a href="#">Runtime Algorithms and Memory Management</a></li> -->
   <!-- <li><a href=#">Program Optimizer</a></li> -->


### PR DESCRIPTION
Do you agree?

Its ugly to have pages like this in the documentation: http://ci.apache.org/projects/flink/flink-docs-master/internal_distributed_akka.html