### PR TITLE
[FLINK-1753] Added Kafka connectors test and configuration options

### DIFF
--- a/docs/streaming_guide.md
+++ b/docs/streaming_guide.md
@@ -1257,12 +1257,12 @@ Example:
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-stream.addSink(new PersistentKafkaSource<String>("localhost:2181", "test", new SimpleStringSchema()));
+stream.addSource(new PersistentKafkaSource<String>("localhost:2181", "test", new SimpleStringSchema()));
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-stream.addSink(new PersistentKafkaSource[String]("localhost:2181", "test", new SimpleStringSchema))
+stream.addSource(new PersistentKafkaSource[String]("localhost:2181", "test", new SimpleStringSchema))
 {% endhighlight %}
 </div>
 </div>
@@ -1290,6 +1290,25 @@ stream.addSink(new KafkaSink[String]("localhost:2181", "test", new SimpleStringS
 {% endhighlight %}
 </div>
 </div>
+
+The user can also define custom Kafka producer configuration for the KafkaSink with the constructor:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+public KafkaSink(String zookeeperAddress, String topicId, Properties producerConfig,
+      SerializationSchema<IN, byte[]> serializationSchema)
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+public KafkaSink(String zookeeperAddress, String topicId, Properties producerConfig,
+      SerializationSchema serializationSchema)
+{% endhighlight %}
+</div>
+</div>
+
+If this constructor is used, the user needs to make sure to set the broker with the "metadata.broker.list" property. Also the serializer configuration should be left default, the serialization should be set via SerializationSchema.
 
 More about Kafka can be found [here](https://kafka.apache.org/documentation.html).
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/KafkaSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka.api;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.flink.api.java.ClosureCleaner;
@@ -50,7 +51,7 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	private static final Logger LOG = LoggerFactory.getLogger(KafkaSink.class);
 
 	private Producer<IN, byte[]> producer;
-	private Properties props;
+	private Properties userDefinedProperties;
 	private String topicId;
 	private String zookeeperAddress;
 	private SerializationSchema<IN, byte[]> schema;
@@ -58,8 +59,8 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	private Class<? extends SerializableKafkaPartitioner> partitionerClass = null;
 
 	/**
-	 * Creates a KafkaSink for a given topic. The partitioner distributes the
-	 * messages between the partitions of the topics.
+	 * Creates a KafkaSink for a given topic. The sink produces its input to
+	 * the topic.
 	 *
 	 * @param zookeeperAddress
 	 * 		Address of the Zookeeper host (with port number).
@@ -68,14 +69,40 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	 * @param serializationSchema
 	 * 		User defined serialization schema.
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	public KafkaSink(String zookeeperAddress, String topicId,
 			SerializationSchema<IN, byte[]> serializationSchema) {
-		this(zookeeperAddress, topicId, serializationSchema, (Class) null);
+		this(zookeeperAddress, topicId, new Properties(), serializationSchema);
 	}
 
 	/**
-	 * Creates a KafkaSink for a given topic. The sink produces its input into
+	 * Creates a KafkaSink for a given topic with custom Producer configuration.
+	 * If you use this constructor, the broker should be set with the "metadata.broker.list"
+	 * configuration.
+	 *
+	 * @param zookeeperAddress
+	 * 		Address of the Zookeeper host (with port number).
+	 * @param topicId
+	 * 		ID of the Kafka topic.
+	 * @param producerConfig
+	 * 		Configurations of the Kafka producer
+	 * @param serializationSchema
+	 * 		User defined serialization schema.
+	 */
+	public KafkaSink(String zookeeperAddress, String topicId, Properties producerConfig,
+			SerializationSchema<IN, byte[]> serializationSchema) {
+		NetUtils.ensureCorrectHostnamePort(zookeeperAddress);
+		Preconditions.checkNotNull(topicId, "TopicID not set");
+		ClosureCleaner.ensureSerializable(partitioner);
+
+		this.zookeeperAddress = zookeeperAddress;
+		this.topicId = topicId;
+		this.schema = serializationSchema;
+		this.partitionerClass = null;
+		this.userDefinedProperties = producerConfig;
+	}
+
+	/**
+	 * Creates a KafkaSink for a given topic. The sink produces its input to
 	 * the topic.
 	 *
 	 * @param zookeeperAddress
@@ -89,25 +116,13 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 	 */
 	public KafkaSink(String zookeeperAddress, String topicId,
 			SerializationSchema<IN, byte[]> serializationSchema, SerializableKafkaPartitioner partitioner) {
-		NetUtils.ensureCorrectHostnamePort(zookeeperAddress);
-		Preconditions.checkNotNull(topicId, "TopicID not set");
-		ClosureCleaner.ensureSerializable(partitioner);
-
-		this.zookeeperAddress = zookeeperAddress;
-		this.topicId = topicId;
-		this.schema = serializationSchema;
+		this(zookeeperAddress, topicId, serializationSchema);
 		this.partitioner = partitioner;
 	}
 
 	public KafkaSink(String zookeeperAddress, String topicId,
 			SerializationSchema<IN, byte[]> serializationSchema, Class<? extends SerializableKafkaPartitioner> partitioner) {
-		NetUtils.ensureCorrectHostnamePort(zookeeperAddress);
-		Preconditions.checkNotNull(topicId, "TopicID not set");
-		ClosureCleaner.ensureSerializable(partitioner);
-
-		this.zookeeperAddress = zookeeperAddress;
-		this.topicId = topicId;
-		this.schema = serializationSchema;
+		this(zookeeperAddress, topicId, serializationSchema);
 		this.partitionerClass = partitioner;
 	}
 
@@ -124,27 +139,31 @@ public class KafkaSink<IN> extends RichSinkFunction<IN> {
 			LOG.info("Broker list: {}", listOfBrokers);
 		}
 
-		props = new Properties();
+		Properties properties = new Properties();
 
-		props.put("metadata.broker.list", listOfBrokers);
-		props.put("request.required.acks", "-1");
-		props.put("message.send.max.retries", "10");
+		properties.put("metadata.broker.list", listOfBrokers);
+		properties.put("request.required.acks", "-1");
+		properties.put("message.send.max.retries", "10");
 
-		props.put("serializer.class", DefaultEncoder.class.getCanonicalName());
+		properties.put("serializer.class", DefaultEncoder.class.getCanonicalName());
 
 		// this will not be used as the key will not be serialized
-		props.put("key.serializer.class", DefaultEncoder.class.getCanonicalName());
+		properties.put("key.serializer.class", DefaultEncoder.class.getCanonicalName());
+
+		for (Map.Entry<Object, Object> propertiesEntry : userDefinedProperties.entrySet()) {
+			properties.put(propertiesEntry.getKey(), propertiesEntry.getValue());
+		}
 
 		if (partitioner != null) {
-			props.put("partitioner.class", PartitionerWrapper.class.getCanonicalName());
+			properties.put("partitioner.class", PartitionerWrapper.class.getCanonicalName());
 			// java serialization will do the rest.
-			props.put(PartitionerWrapper.SERIALIZED_WRAPPER_NAME, partitioner);
+			properties.put(PartitionerWrapper.SERIALIZED_WRAPPER_NAME, partitioner);
 		}
 		if (partitionerClass != null) {
-			props.put("partitioner.class", partitionerClass);
+			properties.put("partitioner.class", partitionerClass);
 		}
 
-		ProducerConfig config = new ProducerConfig(props);
+		ProducerConfig config = new ProducerConfig(properties);
 
 		try {
 			producer = new Producer<IN, byte[]>(config);

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/KafkaTopicUtils.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/KafkaTopicUtils.java
@@ -19,7 +19,10 @@ package org.apache.flink.streaming.connectors.kafka.api.simple;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Properties;
+import java.util.Set;
 
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkMarshallingError;
@@ -31,6 +34,8 @@ import kafka.admin.AdminUtils;
 import kafka.api.PartitionMetadata;
 import kafka.api.TopicMetadata;
 import kafka.cluster.Broker;
+import kafka.common.LeaderNotAvailableException;
+import kafka.common.UnknownTopicOrPartitionException;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
@@ -42,22 +47,29 @@ public class KafkaTopicUtils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicUtils.class);
 
-	private final ZkClient zkClient;
+	private ZkClient zkClient;
 
 	public static final int DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS = 10000;
 	public static final int DEFAULT_ZOOKEEPER_CONNECTION_TIMEOUT_MS = 10000;
+
+	private final String zookeeperAddress;
+	private final int sessionTimeoutMs;
+	private final int connectionTimeoutMs;
+
+	private volatile boolean isRunning = false;
 
 	public KafkaTopicUtils(String zookeeperServer) {
 		this(zookeeperServer, DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS, DEFAULT_ZOOKEEPER_CONNECTION_TIMEOUT_MS);
 	}
 
 	public KafkaTopicUtils(String zookeeperAddress, int sessionTimeoutMs, int connectionTimeoutMs) {
-		zkClient = new ZkClient(zookeeperAddress, sessionTimeoutMs, connectionTimeoutMs,
-				new KafkaZKStringSerializer());
-		zkClient.waitUntilConnected();
+		this.zookeeperAddress = zookeeperAddress;
+		this.sessionTimeoutMs = sessionTimeoutMs;
+		this.connectionTimeoutMs = connectionTimeoutMs;
 	}
 
 	public void createTopic(String topicName, int numOfPartitions, int replicationFactor) {
+
 		LOG.info("Creating Kafka topic '{}'", topicName);
 		Properties topicConfig = new Properties();
 		if (topicExists(topicName)) {
@@ -65,36 +77,150 @@ public class KafkaTopicUtils {
 				LOG.warn("Kafka topic \"{}\" already exists. Returning without action.", topicName);
 			}
 		} else {
+			LOG.info("Connecting zookeeper");
+
+			initZkClient();
 			AdminUtils.createTopic(zkClient, topicName, numOfPartitions, replicationFactor, topicConfig);
+			closeZkClient();
 		}
 	}
 
+	public String getBrokerList(String topicName) {
+		return getBrokerAddressList(getBrokerAddresses(topicName));
+	}
+
+	public String getBrokerList(String topicName, int partitionId) {
+		return getBrokerAddressList(getBrokerAddresses(topicName, partitionId));
+	}
+
+	public Set<String> getBrokerAddresses(String topicName) {
+		int numOfPartitions = getNumberOfPartitions(topicName);
+
+		HashSet<String> brokers = new HashSet<String>();
+		for (int i = 0; i < numOfPartitions; i++) {
+			brokers.addAll(getBrokerAddresses(topicName, i));
+		}
+		return brokers;
+	}
+
+	public Set<String> getBrokerAddresses(String topicName, int partitionId) {
+		PartitionMetadata partitionMetadata = waitAndGetPartitionMetadata(topicName, partitionId);
+		Collection<Broker> inSyncReplicas = JavaConversions.asJavaCollection(partitionMetadata.isr());
+
+		HashSet<String> addresses = new HashSet<String>();
+		for (Broker broker : inSyncReplicas) {
+			addresses.add(broker.connectionString());
+		}
+		return addresses;
+	}
+
+	private static String getBrokerAddressList(Set<String> brokerAddresses) {
+		StringBuilder brokerAddressList = new StringBuilder("");
+		for (String broker : brokerAddresses) {
+			brokerAddressList.append(broker);
+			brokerAddressList.append(',');
+		}
+		brokerAddressList.deleteCharAt(brokerAddressList.length() - 1);
+
+		return brokerAddressList.toString();
+	}
+
 	public int getNumberOfPartitions(String topicName) {
-		Seq<PartitionMetadata> partitionMetadataSeq = getTopicInfo(topicName).partitionsMetadata();
+		Seq<PartitionMetadata> partitionMetadataSeq = getTopicMetadata(topicName).partitionsMetadata();
 		return JavaConversions.asJavaCollection(partitionMetadataSeq).size();
 	}
 
-	public String getLeaderBrokerAddressForTopic(String topicName) {
-		TopicMetadata topicInfo = getTopicInfo(topicName);
-
-		Collection<PartitionMetadata> partitions = JavaConversions.asJavaCollection(topicInfo.partitionsMetadata());
-		PartitionMetadata partitionMetadata = partitions.iterator().next();
-
-		Broker leader = JavaConversions.asJavaCollection(partitionMetadata.isr()).iterator().next();
-
-		return leader.connectionString();
+	public PartitionMetadata waitAndGetPartitionMetadata(String topicName, int partitionId) {
+		isRunning = true;
+		PartitionMetadata partitionMetadata = null;
+		while (isRunning) {
+			try {
+				partitionMetadata = getPartitionMetadata(topicName, partitionId);
+				return partitionMetadata;
+			} catch (LeaderNotAvailableException e) {
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("Got {} trying to fetch metadata again", e.getMessage());
+				}
+			}
+		}
+		isRunning = false;
+		return partitionMetadata;
 	}
 
-	public TopicMetadata getTopicInfo(String topicName) {
+	public PartitionMetadata getPartitionMetadata(String topicName, int partitionId) {
+		PartitionMetadata partitionMetadata = getPartitionMetadataWithErrorCode(topicName, partitionId);
+		switch (partitionMetadata.errorCode()) {
+			case 0:
+				return partitionMetadata;
+			case 3:
+				throw new UnknownTopicOrPartitionException("While fetching metadata for " + topicName + " / " + partitionId);
+			case 5:
+				throw new LeaderNotAvailableException("While fetching metadata for " + topicName + " / " + partitionId);
+				default:
+					throw new RuntimeException("Unknown error occurred while fetching metadata for "
+							+ topicName + " / " + partitionId + ", with error code: " + partitionMetadata.errorCode());
+		}
+	}
+
+	private PartitionMetadata getPartitionMetadataWithErrorCode(String topicName, int partitionId) {
+		TopicMetadata topicInfo = getTopicMetadata(topicName);
+
+		Collection<PartitionMetadata> partitions = JavaConversions.asJavaCollection(topicInfo.partitionsMetadata());
+
+		Iterator<PartitionMetadata> iterator = partitions.iterator();
+		for (PartitionMetadata partition : partitions) {
+			if (partition.partitionId() == partitionId) {
+				return partition;
+			}
+		}
+
+		throw new RuntimeException("No such partition: " + topicName + " / " + partitionId);
+	}
+
+	public TopicMetadata getTopicMetadata(String topicName) {
+		TopicMetadata topicMetadata = getTopicMetadataWithErrorCode(topicName);
+		switch (topicMetadata.errorCode()) {
+			case 0:
+				return topicMetadata;
+			case 3:
+				throw new UnknownTopicOrPartitionException("While fetching metadata for topic " + topicName);
+			case 5:
+				throw new LeaderNotAvailableException("While fetching metadata for topic " + topicName);
+			default:
+				throw new RuntimeException("Unknown error occurred while fetching metadata for topic "
+						+ topicName + ", with error code: " + topicMetadata.errorCode());
+		}
+	}
+
+	private TopicMetadata getTopicMetadataWithErrorCode(String topicName) {
 		if (topicExists(topicName)) {
-			return AdminUtils.fetchTopicMetadataFromZk(topicName, zkClient);
+			initZkClient();
+			TopicMetadata topicMetadata = AdminUtils.fetchTopicMetadataFromZk(topicName, zkClient);
+			closeZkClient();
+
+			return topicMetadata;
 		} else {
 			throw new RuntimeException("Topic does not exist: " + topicName);
 		}
 	}
 
 	public boolean topicExists(String topicName) {
-		return AdminUtils.topicExists(zkClient, topicName);
+		initZkClient();
+		boolean topicExists = AdminUtils.topicExists(zkClient, topicName);
+		closeZkClient();
+
+		return topicExists;
+	}
+
+	private void initZkClient() {
+		zkClient = new ZkClient(zookeeperAddress, sessionTimeoutMs, connectionTimeoutMs,
+				new KafkaZKStringSerializer());
+		zkClient.waitUntilConnected();
+	}
+
+	private void closeZkClient() {
+		zkClient.close();
+		zkClient = null;
 	}
 
 	private static class KafkaZKStringSerializer implements ZkSerializer {

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/PersistentKafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/PersistentKafkaSource.java
@@ -167,8 +167,6 @@ public class PersistentKafkaSource<OUT> extends ConnectorSource<OUT> {
 
 		int numberOfPartitions = kafkaTopicUtils.getNumberOfPartitions(topicId);
 
-		String brokerAddress = kafkaTopicUtils.getLeaderBrokerAddressForTopic(topicId);
-
 		if (indexOfSubtask >= numberOfPartitions) {
 			iterator = new KafkaIdleConsumerIterator();
 		} else {
@@ -188,7 +186,7 @@ public class PersistentKafkaSource<OUT> extends ConnectorSource<OUT> {
 				context.registerState("kafka", kafkaOffSet);
 			}
 
-			iterator = getMultiKafkaIterator(brokerAddress, topicId, partitions, waitOnEmptyFetchMillis);
+			iterator = new KafkaMultiplePartitionsIterator(topicId, partitions, kafkaTopicUtils, waitOnEmptyFetchMillis, connectTimeoutMs, bufferSize);
 
 			if (LOG.isInfoEnabled()) {
 				LOG.info("KafkaSource ({}/{}) listening to partitions {} of topic {}.",
@@ -197,10 +195,6 @@ public class PersistentKafkaSource<OUT> extends ConnectorSource<OUT> {
 		}
 
 		iterator.initialize();
-	}
-
-	protected KafkaConsumerIterator getMultiKafkaIterator(String hostName, String topic, Map<Integer, KafkaOffset> partitionsWithOffset, int waitOnEmptyFetch) {
-		return new KafkaMultiplePartitionsIterator(hostName, topic, partitionsWithOffset, waitOnEmptyFetch, this.connectTimeoutMs, this.bufferSize);
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaMultiplePartitionsIterator.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.flink.streaming.connectors.kafka.api.simple.KafkaTopicUtils;
 import org.apache.flink.streaming.connectors.kafka.api.simple.MessageWithMetadata;
 import org.apache.flink.streaming.connectors.kafka.api.simple.offset.KafkaOffset;
 import org.slf4j.Logger;
@@ -33,25 +34,22 @@ public class KafkaMultiplePartitionsIterator implements KafkaConsumerIterator {
 	protected List<KafkaSinglePartitionIterator> partitions;
 	protected final int waitOnEmptyFetch;
 
-	public KafkaMultiplePartitionsIterator(String hostName, String topic,
+	public KafkaMultiplePartitionsIterator(String topic,
 										Map<Integer, KafkaOffset> partitionsWithOffset,
+										KafkaTopicUtils kafkaTopicUtils,
 										int waitOnEmptyFetch, int connectTimeoutMs, int bufferSize) {
 		partitions = new ArrayList<KafkaSinglePartitionIterator>(partitionsWithOffset.size());
-
-		String[] hostAndPort = hostName.split(":");
-
-		String host = hostAndPort[0];
-		int port = Integer.parseInt(hostAndPort[1]);
 
 		this.waitOnEmptyFetch = waitOnEmptyFetch;
 
 		for (Map.Entry<Integer, KafkaOffset> partitionWithOffset : partitionsWithOffset.entrySet()) {
 			partitions.add(new KafkaSinglePartitionIterator(
-					host,
-					port,
 					topic,
 					partitionWithOffset.getKey(),
-					partitionWithOffset.getValue(), connectTimeoutMs, bufferSize));
+					partitionWithOffset.getValue(),
+					kafkaTopicUtils,
+					connectTimeoutMs,
+					bufferSize));
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTopicUtilsTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTopicUtilsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.curator.test.TestingServer;
+import org.apache.flink.runtime.net.NetUtils;
+import org.apache.flink.streaming.connectors.kafka.api.simple.KafkaTopicUtils;
+import org.apache.flink.streaming.connectors.kafka.util.KafkaLocalSystemTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import kafka.api.PartitionMetadata;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+
+public class KafkaTopicUtilsTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicUtilsTest.class);
+	private static final int NUMBER_OF_BROKERS = 2;
+	private static final String TOPIC = "myTopic";
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Test
+	public void test() {
+		int zkPort;
+		String kafkaHost;
+		String zookeeperConnectionString;
+
+		File tmpZkDir;
+		List<File> tmpKafkaDirs;
+		Map<String, KafkaServer> kafkaServers = null;
+		TestingServer zookeeper = null;
+
+		try {
+			tmpZkDir = tempFolder.newFolder();
+
+			tmpKafkaDirs = new ArrayList<File>(NUMBER_OF_BROKERS);
+			for (int i = 0; i < NUMBER_OF_BROKERS; i++) {
+				tmpKafkaDirs.add(tempFolder.newFolder());
+			}
+
+			zkPort = NetUtils.getAvailablePort();
+			kafkaHost = InetAddress.getLocalHost().getHostName();
+			zookeeperConnectionString = "localhost:" + zkPort;
+
+			// init zookeeper
+			zookeeper = new TestingServer(zkPort, tmpZkDir);
+
+			// init kafka kafkaServers
+			kafkaServers = new HashMap<String, KafkaServer>();
+
+			for (int i = 0; i < NUMBER_OF_BROKERS; i++) {
+				KafkaServer kafkaServer = getKafkaServer(kafkaHost, zookeeperConnectionString, i, tmpKafkaDirs.get(i));
+				kafkaServers.put(kafkaServer.config().advertisedHostName() + ":" + kafkaServer.config().advertisedPort(), kafkaServer);
+			}
+
+			// create Kafka topic
+			final KafkaTopicUtils kafkaTopicUtils = new KafkaTopicUtils(zookeeperConnectionString);
+			kafkaTopicUtils.createTopic(TOPIC, 1, 2);
+
+			// check whether topic exists
+			assertTrue(kafkaTopicUtils.topicExists(TOPIC));
+
+			// check number of partitions
+			assertEquals(1, kafkaTopicUtils.getNumberOfPartitions(TOPIC));
+
+			// get partition metadata without error
+			PartitionMetadata partitionMetadata = kafkaTopicUtils.waitAndGetPartitionMetadata(TOPIC, 0);
+			assertEquals(0, partitionMetadata.errorCode());
+
+			// get broker list
+			assertEquals(new HashSet<String>(kafkaServers.keySet()), kafkaTopicUtils.getBrokerAddresses(TOPIC));
+		} catch (IOException e) {
+			fail(e.toString());
+		} catch (Exception e) {
+			fail(e.toString());
+		} finally {
+			LOG.info("Shutting down all services");
+			for (KafkaServer broker : kafkaServers.values()) {
+				if (broker != null) {
+					broker.shutdown();
+				}
+			}
+
+			if (zookeeper != null) {
+				try {
+					zookeeper.stop();
+				} catch (IOException e) {
+					LOG.warn("ZK.stop() failed", e);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Copied from com.github.sakserv.minicluster.KafkaLocalBrokerIntegrationTest (ASL licensed)
+	 */
+	private static KafkaServer getKafkaServer(String kafkaHost, String zookeeperConnectionString, int brokerId, File tmpFolder) throws UnknownHostException {
+		Properties kafkaProperties = new Properties();
+
+		int kafkaPort = NetUtils.getAvailablePort();
+
+		// properties have to be Strings
+		kafkaProperties.put("advertised.host.name", kafkaHost);
+		kafkaProperties.put("port", Integer.toString(kafkaPort));
+		kafkaProperties.put("broker.id", Integer.toString(brokerId));
+		kafkaProperties.put("log.dir", tmpFolder.toString());
+		kafkaProperties.put("zookeeper.connect", zookeeperConnectionString);
+		KafkaConfig kafkaConfig = new KafkaConfig(kafkaProperties);
+
+		KafkaServer server = new KafkaServer(kafkaConfig, new KafkaLocalSystemTime());
+		server.startup();
+		return server;
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/util/KafkaLocalSystemTime.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/util/KafkaLocalSystemTime.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import kafka.utils.Time;
+
+public class KafkaLocalSystemTime implements Time {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaLocalSystemTime.class);
+
+	@Override
+	public long milliseconds() {
+		return System.currentTimeMillis();
+	}
+
+	public long nanoseconds() {
+		return System.nanoTime();
+	}
+
+	@Override
+	public void sleep(long ms) {
+		try {
+			Thread.sleep(ms);
+		} catch (InterruptedException e) {
+			LOG.warn("Interruption", e);
+		}
+	}
+
+}
+


### PR DESCRIPTION
* Added broker failure test to KafkaITCase, PersistentKafkaSource and KafkaSink can now recover on broker failure.
* Added Properties parameter to KafkaSink constructor, thus custom Kafka Producer configuration can be used
* Updated documentation