### PR TITLE
[scheduling] implement backtracking with intermediate result checking

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -120,6 +120,11 @@ public class Execution implements Serializable {
 	private ConcurrentLinkedQueue<PartialInputChannelDeploymentDescriptor> partialInputChannelDeploymentDescriptors;
 
 	private volatile ExecutionState state = CREATED;
+
+	/**
+	 * Flag indicating whether this Execution has been marked to be scheduled
+	 */
+	private volatile boolean scheduled;
 	
 	private volatile SimpleSlot assignedResource;     // once assigned, never changes until the execution is archived
 	
@@ -163,6 +168,14 @@ public class Execution implements Serializable {
 
 	public ExecutionState getState() {
 		return state;
+	}
+
+	public boolean isScheduled() {
+		return scheduled;
+	}
+
+	public void setScheduled() {
+		this.scheduled = true;
 	}
 
 	public SimpleSlot getAssignedResource() {
@@ -470,8 +483,6 @@ public class Execution implements Serializable {
 					@Override
 					public Boolean call() throws Exception {
 						try {
-							final ExecutionGraph consumerGraph = consumerVertex.getExecutionGraph();
-
 							consumerVertex.scheduleForExecution(
 									consumerVertex.getExecutionGraph().getScheduler(),
 									consumerVertex.getExecutionGraph().isQueuedSchedulingAllowed());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -257,7 +257,7 @@ public class ExecutionJobVertex implements Serializable {
 	//---------------------------------------------------------------------------------------------
 	//  Actions
 	//---------------------------------------------------------------------------------------------
-	
+
 	public void scheduleAll(Scheduler scheduler, boolean queued) throws NoResourceAvailableException {
 		
 		ExecutionVertex[] vertices = this.taskVertices;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -219,7 +219,7 @@ public class ExecutionVertex implements Serializable {
 	public StateHandle getOperatorState() {
 		return operatorState;
 	}
-	
+
 	public ExecutionGraph getExecutionGraph() {
 		return this.jobVertex.getGraph();
 	}
@@ -464,6 +464,13 @@ public class ExecutionVertex implements Serializable {
 
 		if (partition == null) {
 			throw new IllegalStateException("Unknown partition " + partitionId + ".");
+		} else {
+			// store the location of the ResultPartition
+			SimpleSlot slot = currentExecution.getAssignedResource();
+			if (slot != null) {
+				Instance taskManager = slot.getInstance();
+				partition.setLocation(taskManager);
+			}
 		}
 
 		if (partition.getIntermediateResult().getResultType().isPipelined()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -121,6 +121,10 @@ public class IntermediateResult {
 
 	void resetForNewExecution() {
 		this.numberOfRunningProducers.set(numParallelProducers);
+		// reset previously stored locations
+		for (IntermediateResultPartition partition : partitions) {
+			partition.setLocation(null);
+		}
 	}
 
 	int decrementNumberOfRunningProducersAndGetRemaining() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
@@ -35,6 +36,12 @@ public class IntermediateResultPartition {
 	private final IntermediateResultPartitionID partitionId;
 
 	private List<List<ExecutionEdge>> consumers;
+
+	/**
+	 * If set, the Instance where the partition was last available
+	 * It's availability has to be checked before it can be requested/pinned
+	 */
+	private Instance location = null;
 
 	public IntermediateResultPartition(IntermediateResult totalResult, ExecutionVertex producer, int partitionNumber) {
 		this.totalResult = totalResult;
@@ -58,6 +65,22 @@ public class IntermediateResultPartition {
 
 	public IntermediateResultPartitionID getPartitionId() {
 		return partitionId;
+	}
+
+	public boolean isLocationAvailable() {
+		return location != null && location.isAlive();
+	}
+
+	/**
+	 * Last reported location of a ResultPartition for this IntermediateResultPartition
+	 * @return Instance which contains the task manager location
+	 */
+	public Instance getLocation() {
+		return location;
+	}
+
+	public void setLocation(Instance location) {
+		this.location = location;
 	}
 
 	ResultPartitionType getResultType() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobEdge.java
@@ -34,7 +34,10 @@ public class JobEdge implements java.io.Serializable {
 	/** The distribution pattern that should be used for this job edge. */
 	private final DistributionPattern distributionPattern;
 	
-	/** The data set at the source of the edge, may be null if the edge is not yet connected*/
+	/**
+	 *  The data set at the source of the edge, may be null if the edge is not yet connected
+	 *  or this edge belong to a Source
+	 */
 	private IntermediateDataSet source;
 	
 	/** The id of the source intermediate data set */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
@@ -25,6 +25,9 @@ public enum ScheduleMode {
 	 */
 	FROM_SOURCES,
 
+	/**
+	 * Schedule tasks with backtracking from the sinks towards the sources.
+	 */
 	BACKTRACKING,
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -112,7 +112,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 			return (SimpleSlot) ret;
 		}
 		else {
-			throw new RuntimeException();
+			throw new RuntimeException("Failed to schedule task immediately.");
 		}
 	}
 	
@@ -125,7 +125,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 			return (SlotAllocationFuture) ret;
 		}
 		else {
-			throw new RuntimeException();
+			throw new RuntimeException("Failed to schedule task queued.");
 		}
 	}
 	

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -577,6 +577,8 @@ class JobManager(val flinkConfiguration: Configuration,
           return
       }
 
+      executionGraph.setDispatcher(AkkaUtils.globalExecutionContext)
+
       // NOTE: Scheduling the job for execution is a separate action from the job submission.
       // The success of submitting the job must be independent from the success of scheduling
       // the job.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.messages
 
 import org.apache.flink.runtime.instance.InstanceID
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID
 
 /**
  * Miscellaneous actor messages exchanged with the TaskManager.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.messages
 
 import org.apache.flink.runtime.deployment.{TaskDeploymentDescriptor, InputChannelDeploymentDescriptor}
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID
+import org.apache.flink.runtime.jobgraph.{IntermediateResultPartitionID, IntermediateDataSetID}
 import org.apache.flink.runtime.taskmanager.TaskExecutionState
 
 /**
@@ -117,6 +117,21 @@ object TaskMessages {
   case class FailIntermediateResultPartitions(executionID: ExecutionAttemptID)
     extends TaskMessage
 
+  /**
+   * Check availability of an intermediate result partition
+   * @param partitionID
+   * @see ExecutionVertex.scheduleOrUpdateConsumers
+   */
+  case class LockResultPartition(partitionID: IntermediateResultPartitionID)
+    extends TaskMessage
+
+  /**
+   * Pin/lock an ResultPartition for resuming
+   * @param partitionID
+   * @param locked
+   */
+  case class LockResultPartitionReply(partitionID: IntermediateResultPartitionID, locked: Boolean)
+    extends TaskMessage
 
   // --------------------------------------------------------------------------
   //  Report Messages

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -51,7 +51,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
 import org.apache.flink.runtime.io.disk.iomanager.{IOManager, IOManagerAsync}
 import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.io.network.netty.NettyConfig
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID
+import org.apache.flink.runtime.jobgraph.{IntermediateResultPartitionID, IntermediateDataSetID}
 import org.apache.flink.runtime.jobgraph.tasks.{OperatorStateCarrier,BarrierTransceiver}
 import org.apache.flink.runtime.jobmanager.JobManager
 import org.apache.flink.runtime.memorymanager.{MemoryManager, DefaultMemoryManager}
@@ -338,6 +338,12 @@ extends Actor with ActorLogMessages with ActorLogging {
                 "Fatal leak: Unable to release intermediate result partition data", t)
           }
         }
+
+      /**
+       * Always deny locking of ResultPartitions.
+       */
+      case LockResultPartition(partitionID: IntermediateResultPartitionID) =>
+        sender ! LockResultPartitionReply(partitionID, false)
 
       // notifies the TaskManager that the state of a task has changed.
       // the TaskManager informs the JobManager and cleans up in case the transition

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/BacktrackingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/BacktrackingTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.scheduler;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.UntypedActor;
+import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.instance.Instance;
+import org.apache.flink.runtime.instance.InstanceDiedException;
+import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.InputFormatVertex;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OutputFormatVertex;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobmanager.Tasks;
+import org.apache.flink.runtime.messages.TaskMessages;
+import org.apache.flink.runtime.messages.TaskMessages.*;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BacktrackingTest {
+
+	public static ActorSystem system;
+
+	/**
+	 * TaskManager stub which acknowledges/denies the availability of IntermediateResults
+	 */
+	public static class TestTaskManager extends UntypedActor {
+
+		ActorRef testEnvironment;
+		private Set<IntermediateResultPartitionID> availableResults = new HashSet<IntermediateResultPartitionID>();
+
+		public TestTaskManager(ActorRef testEnvironment) {
+			this.testEnvironment = testEnvironment;
+		}
+
+		@Override
+		public void onReceive(Object msg) throws Exception {
+
+			if (msg instanceof TaskMessages.SubmitTask) {
+				System.out.println("task submitted: " + msg);
+				testEnvironment.forward(msg, getContext());
+
+			} else if (msg instanceof IntermediateResultPartitionID) {
+				// collect all intermediate results ids sent by the testing system
+				availableResults.add((IntermediateResultPartitionID) msg);
+
+			} else if (msg instanceof LockResultPartition) {
+
+				IntermediateResultPartitionID partitionID = ((LockResultPartition) msg).partitionID();
+				System.out.println("intermediate partition requested: " + partitionID);
+				if (availableResults.contains(partitionID)) {
+					System.out.println("acknowledging result: " + partitionID);
+					getSender().tell(new LockResultPartitionReply(partitionID, true), getSelf());
+				} else {
+					System.out.println("denying result: " + partitionID);
+					getSender().tell(new LockResultPartitionReply(partitionID, false), getSelf());
+				}
+				testEnvironment.forward(msg, getContext());
+
+			} else {
+				System.out.println("Unknown msg " + msg);
+			}
+		}
+
+	}
+
+	@Before
+	public void setup(){
+		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
+		TestingUtils.setCallingThreadDispatcher(system);
+	}
+
+	@After
+	public void teardown(){
+		TestingUtils.setGlobalExecutionContext();
+		JavaTestKit.shutdownActorSystem(system);
+	}
+
+	private AbstractJobVertex createNode(String name) {
+		AbstractJobVertex abstractJobVertex = new AbstractJobVertex(name);
+		abstractJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		return abstractJobVertex;
+	}
+
+	private AbstractJobVertex createOutputNode(String name) {
+		AbstractJobVertex abstractJobVertex = new OutputFormatVertex(name);
+		abstractJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		return abstractJobVertex;
+	}
+
+	private AbstractJobVertex createInputNode(String name) {
+		AbstractJobVertex abstractJobVertex = new InputFormatVertex(name);
+		abstractJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		return abstractJobVertex;
+	}
+
+	@Test
+	public void testBacktrackingIntermediateResults() throws InstanceDiedException, NoResourceAvailableException {
+		final JobID jobId = new JobID();
+		final String jobName = "Test Job Sample Name";
+		final Configuration cfg = new Configuration();
+
+		// JobVertex to resume execution from
+		final AbstractJobVertex resumePoint;
+
+        /*
+               sink1         sink2
+                 O             O
+                 ^             ^
+                ´ `           ´ `
+               ´   `         ´   `
+             _´     `_     _´     `_
+             O       O     O       O
+             ^       ^     ^       ^
+              `     ´       `     ´
+               `   ´         `   ´
+                `_´           `_´
+                 O             O    <----- resume from here
+                 ^             ^
+                  `           ´
+                   `         ´
+                    `       ´
+                     `     ´
+                      `   ´
+                       `_´
+                        O
+                     source
+        */
+
+		// topologically sorted list
+		final List<AbstractJobVertex> list = new ArrayList<AbstractJobVertex>();
+
+		final AbstractJobVertex source = createInputNode("source1");
+		list.add(source);
+
+		AbstractJobVertex node1 = createOutputNode("sink1");
+		{
+			AbstractJobVertex child1 = createNode("sink1-child1");
+			AbstractJobVertex child2 = createNode("sink1-child2");
+			node1.connectNewDataSetAsInput(child1, DistributionPattern.ALL_TO_ALL);
+			node1.connectNewDataSetAsInput(child2, DistributionPattern.ALL_TO_ALL);
+
+			AbstractJobVertex child1child2child = createNode("sink1-child1-child2-child");
+			child1.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+			child2.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+
+			child1child2child.connectNewDataSetAsInput(source, DistributionPattern.ALL_TO_ALL);
+
+			list.add(child1child2child);
+			list.add(child1);
+			list.add(child2);
+		}
+
+		AbstractJobVertex node2 = createOutputNode("sink2");
+		{
+			AbstractJobVertex child1 = createNode("sink2-child1");
+			AbstractJobVertex child2 = createNode("sink2-child2");
+			node2.connectNewDataSetAsInput(child1, DistributionPattern.ALL_TO_ALL);
+			node2.connectNewDataSetAsInput(child2, DistributionPattern.ALL_TO_ALL);
+
+			// resume from this node
+			AbstractJobVertex child1child2child = createNode("sink1-child1-child2-child");
+			resumePoint = child1child2child;
+
+			child1.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+			child2.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+
+			child1child2child.connectNewDataSetAsInput(source, DistributionPattern.ALL_TO_ALL);
+
+			list.add(child1child2child);
+			list.add(child1);
+			list.add(child2);
+		}
+
+		list.add(node1);
+		list.add(node2);
+
+		final ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+
+		new JavaTestKit(system) {
+			{
+
+				final Props props = Props.create(TestTaskManager.class, getRef());
+				final ActorRef taskManagerActor = system.actorOf(props);
+
+				// set a dispatcher for testing purposes
+				eg.setDispatcher(system.dispatcher());
+
+				eg.setScheduleMode(ScheduleMode.BACKTRACKING);
+
+				try {
+					eg.attachJobGraph(list);
+				} catch (JobException e) {
+					e.printStackTrace();
+					fail("Job failed with exception: " + e.getMessage());
+				}
+
+				// list if of partition that should be acknowleged
+				List<IntermediateResultPartitionID> acknowledgePartitions = new ArrayList<IntermediateResultPartitionID>();
+
+				ExecutionJobVertex executionJobVertex = eg.getAllVertices().get(resumePoint.getID());
+				for (IntermediateResult result : executionJobVertex.getInputs()) {
+						for (IntermediateResultPartition partition : result.getPartitions()) {
+							// mock an instance
+							Instance mockInstance = Mockito.mock(Instance.class);
+							Mockito.when(mockInstance.isAlive()).thenReturn(true);
+							Mockito.when(mockInstance.getTaskManager()).thenReturn(taskManagerActor);
+							// set the mock as a location
+							partition.setLocation(mockInstance);
+							// send the tests actor ref to the TestTaskManager to receive messages
+							taskManagerActor.tell(partition.getPartitionId(), getRef());
+							// let the TestTaskManager acknowledge this partition
+							acknowledgePartitions.add(partition.getPartitionId());
+						}
+				}
+
+				// list of execution vertices to be scheduled
+				List<JobVertexID> schedulePoints = new ArrayList<JobVertexID>();
+				schedulePoints.add(resumePoint.getID());
+				schedulePoints.add(source.getID());
+
+				final Scheduler scheduler = new Scheduler();
+
+				Instance i1 = null;
+				try {
+					i1 = ExecutionGraphTestUtils.getInstance(taskManagerActor, 3);
+				} catch (Exception e) {
+					e.printStackTrace();
+					fail("Couldn't get instance: " + e.getMessage());
+				}
+
+				scheduler.newInstanceAvailable(i1);
+
+				try {
+					eg.scheduleForExecution(scheduler);
+				} catch (JobException e) {
+					e.printStackTrace();
+				}
+
+				Object[] messages = receiveN(schedulePoints.size() + acknowledgePartitions.size());
+				for (Object msg : messages) {
+					if (msg instanceof LockResultPartition) {
+						LockResultPartition msg1 = (LockResultPartition) msg;
+						assertTrue("Available partition should have been requested.",
+								acknowledgePartitions.contains(msg1.partitionID()));
+					} else if (msg instanceof SubmitTask) {
+						SubmitTask msg1 = (SubmitTask) msg;
+						assertTrue("These nodes should have been scheduled",
+								schedulePoints.contains(msg1.tasks().getVertexID()));
+					} else {
+						fail("Unexpected message");
+					}
+				}
+
+			}
+		};
+	}
+
+	@Test
+	public void testMassiveExecutionGraphExecutionVertexScheduling() {
+
+		final JobID jobId = new JobID();
+		final String jobName = "Test Job Sample Name";
+		final Configuration cfg = new Configuration();
+
+		final int numSinks = 10;
+		final int depth = 10000;
+		final int maxParallelism = 50;
+
+		Random rand = new Random(System.currentTimeMillis());
+
+		LinkedList<AbstractJobVertex> allNodes = new LinkedList<AbstractJobVertex>();
+
+		for (int s = 0; s < numSinks; s++) {
+			AbstractJobVertex node = new OutputFormatVertex("sink" + s);
+			node.setInvokableClass(Tasks.NoOpInvokable.class);
+
+			node.setParallelism(rand.nextInt(maxParallelism) + 1);
+			allNodes.addLast(node);
+
+			for (int i = 0; i < depth; i++) {
+				AbstractJobVertex other = new AbstractJobVertex("vertex" + i + " sink" + s);
+				other.setInvokableClass(Tasks.NoOpInvokable.class);
+				node.connectNewDataSetAsInput(other, DistributionPattern.ALL_TO_ALL);
+				allNodes.addFirst(other);
+				node = other;
+			}
+
+		}
+
+		final ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+
+		eg.setScheduleMode(ScheduleMode.BACKTRACKING);
+
+		try {
+			eg.attachJobGraph(allNodes);
+		} catch (JobException e) {
+			e.printStackTrace();
+			fail("Job failed with exception: " + e.getMessage());
+		}
+
+		new JavaTestKit(system) {
+			{
+
+				final Props props = Props.create(TestTaskManager.class, getRef());
+				final ActorRef taskManagerActor = system.actorOf(props);
+
+
+				Scheduler scheduler = new Scheduler();
+
+				Instance i1 = null;
+				try {
+					i1 = ExecutionGraphTestUtils.getInstance(taskManagerActor, numSinks);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+
+				scheduler.newInstanceAvailable(i1);
+
+				try {
+					eg.scheduleForExecution(scheduler);
+				} catch (JobException e) {
+					e.printStackTrace();
+					fail("Failed to schedule ExecutionGraph");
+				}
+
+				for (int i=0; i < numSinks; i++) {
+					expectMsgClass(TaskMessages.SubmitTask.class);
+				}
+
+			}
+		};
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -67,7 +67,6 @@ public class SchedulerTestUtils {
 		return new Instance(ActorRef.noSender(), ci, new InstanceID(), resources, numSlots);
 	}
 	
-	
 	public static Execution getDummyTask() {
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
 		when(vertex.getJobId()).thenReturn(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -255,7 +255,27 @@ public class TaskManagerTest {
 			}
 		}};
 	}
-	
+
+	@Test
+	public void testPartitionReject() {
+		new JavaTestKit(system){{
+
+			ActorRef jobManager = null;
+			ActorRef taskManager = null;
+				jobManager = system.actorOf(Props.create(SimpleJobManager.class));
+				taskManager = createTaskManager(jobManager);
+
+			// send a non-existing partition id to the task manager
+			IntermediateResultPartitionID partitionID = new IntermediateResultPartitionID();
+			taskManager.tell(
+					new TaskMessages.LockResultPartition(partitionID),
+					getRef());
+
+			expectMsgEquals(new TaskMessages.LockResultPartitionReply(partitionID, false));
+		}};
+	}
+
+
 	@Test
 	public void testGateChannelEdgeMismatch() {
 		new JavaTestKit(system){{


### PR DESCRIPTION
- backtracks from the sinks of an ExecutionGraph
- checks the availability of IntermediatePartitionResults
- marks ExecutionVertex to be scheduled

This first version of backtracking does not support resume/recovery from
intermediate results yet. It lays the foundation for integrating the
remaining changes.