### PR TITLE
[FLINK-1885] [gelly] Added bulk execution mode to gellys vertex centric iterations

### DIFF
--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/spargel/IterationConfiguration.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/spargel/IterationConfiguration.java
@@ -60,6 +60,9 @@ public class IterationConfiguration {
 	/** flag that defines whether the solution set is kept in managed memory **/
 	private boolean unmanagedSolutionSet = false;
 	
+	/** flag that defines whether to use a bulk iteration instead of a delta iteration **/
+	private boolean useBulkIteration = false;
+	
 	public IterationConfiguration() {}
 
 
@@ -188,5 +191,23 @@ public class IterationConfiguration {
 	 */
 	public List<Tuple2<String, DataSet<?>>> getMessagingBcastVars() {
 		return this.bcVarsMessaging;
+	}
+	
+	/**
+	 * Defines whether to use a bulk iteration or a delta iteration
+	 * as internal runtime representation of the vertex-centric iteration.
+	 */
+	public void useBulkIteration(boolean useBulkIteration) {
+		this.useBulkIteration = useBulkIteration;
+	}
+	
+	/**
+	 * Get the flag useBulkIteration
+	 * 
+	 * @return a boolean indicating whether to use a bulk iteration or a delta iteration
+	 * as internal runtime representation of the vertex-centric iteration.
+	 */
+	public boolean getUseBulkIteration() {
+		return this.useBulkIteration;
 	}
 }

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/spargel/VertexCentricIteration.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/spargel/VertexCentricIteration.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.functions.RichCoGroupFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.operators.CoGroupOperator;
 import org.apache.flink.api.java.operators.CustomUnaryOperation;
+import org.apache.flink.api.java.operators.IterativeDataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
@@ -139,6 +140,11 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey> & Se
 			throw new IllegalStateException("The input data set has not been set.");
 		}
 		
+		// check if a bulk iteration should be used
+		if (this.configuration != null && this.configuration.getUseBulkIteration()) {
+			return this.createBulkResult();
+		}
+		
 		// prepare some type information
 		TypeInformation<Vertex<VertexKey, VertexValue>> vertexTypes = initialVertices.getType();
 		TypeInformation<VertexKey> keyType = ((TupleTypeInfo<?>) initialVertices.getType()).getTypeAt(0);
@@ -202,6 +208,79 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey> & Se
 		return iteration.closeWith(updates, updates);
 		
 	}
+	
+	/**
+	 * Creates the operator that represents this vertex-centric graph computation.
+	 * This is different from createResult because it uses a bulk iteration instead of 
+	 * a delta iteration to represent the computation.
+	 * 
+	 * @return The operator that represents this vertex-centric graph computation.
+	 */
+	private DataSet<Vertex<VertexKey, VertexValue>> createBulkResult() {
+		if (this.initialVertices == null) {
+			throw new IllegalStateException("The input data set has not been set.");
+		}
+
+		// prepare some type information
+		TypeInformation<Vertex<VertexKey, VertexValue>> vertexTypes = initialVertices.getType();
+		TypeInformation<VertexKey> keyType = ((TupleTypeInfo<?>) initialVertices.getType()).getTypeAt(0);
+		TypeInformation<Tuple2<VertexKey, Message>> messageTypeInfo = new TupleTypeInfo<Tuple2<VertexKey,Message>>(keyType, messageType);
+	
+		final IterativeDataSet<Vertex<VertexKey, VertexValue>> iteration =
+			this.initialVertices.iterate(this.maximumNumberOfIterations);
+
+		// set up the iteration operator
+		if (this.configuration != null) {
+
+			iteration.name(this.configuration.getName(
+					"Vertex-centric iteration (" + updateFunction + " | " + messagingFunction + ")"));
+			iteration.setParallelism(this.configuration.getParallelism());
+
+			// register all aggregators
+			for (Map.Entry<String, Aggregator<?>> entry : this.configuration.getAggregators().entrySet()) {
+				iteration.registerAggregator(entry.getKey(), entry.getValue());
+			}
+		}
+		else {
+			// no configuration provided; set default name
+			iteration.name("Vertex-centric iteration (" + updateFunction + " | " + messagingFunction + ")");
+		}
+		
+		// build the messaging function (co group)
+		CoGroupOperator<?, ?, Tuple2<VertexKey, Message>> messages;
+		MessagingUdfWithEdgeValues<VertexKey, VertexValue, Message, EdgeValue> messenger = new MessagingUdfWithEdgeValues<VertexKey, VertexValue, Message, EdgeValue>(messagingFunction, messageTypeInfo);
+		messages = this.edgesWithValue.coGroup(iteration).where(0).equalTo(0).with(messenger);
+		
+		// configure coGroup message function with name and broadcast variables
+		messages = messages.name("Messaging");
+
+		if (this.configuration != null) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getMessagingBcastVars()) {
+				messages = messages.withBroadcastSet(e.f1, e.f0);
+			}			
+		}
+		
+		VertexUpdateUdf<VertexKey, VertexValue, Message> updateUdf = new VertexUpdateUdf<VertexKey, VertexValue, Message>(updateFunction, vertexTypes, true);
+		
+		// build the update function (co group)
+		CoGroupOperator<?, ?, Vertex<VertexKey, VertexValue>> updates =
+				messages.coGroup(iteration).where(0).equalTo(0).with(updateUdf);
+		
+		// configure coGroup update function with name and broadcast variables
+		updates = updates.name("Vertex State Updates");
+
+		if (this.configuration != null) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getUpdateBcastVars()) {
+				updates = updates.withBroadcastSet(e.f1, e.f0);
+			}			
+		}
+
+		// let the operator know that we preserve the key field
+		updates.withForwardedFieldsFirst("0").withForwardedFieldsSecond("0");
+		
+		return iteration.closeWith(updates, updates);
+		
+	}
 
 	/**
 	 * Creates a new vertex-centric iteration operator for graphs where the edges are associated with a value (such as
@@ -246,12 +325,21 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey> & Se
 		
 		private transient TypeInformation<Vertex<VertexKey, VertexValue>> resultType;
 		
+		private boolean inBulkIteration = false;
+		
 		
 		private VertexUpdateUdf(VertexUpdateFunction<VertexKey, VertexValue, Message> vertexUpdateFunction,
 				TypeInformation<Vertex<VertexKey, VertexValue>> resultType)
 		{
 			this.vertexUpdateFunction = vertexUpdateFunction;
 			this.resultType = resultType;
+		}
+		
+		private VertexUpdateUdf(VertexUpdateFunction<VertexKey, VertexValue, Message> vertexUpdateFunction,
+				TypeInformation<Vertex<VertexKey, VertexValue>> resultType, boolean inBulkIteration)
+		{
+			this(vertexUpdateFunction, resultType);
+			this.inBulkIteration = inBulkIteration;
 		}
 
 		@Override
@@ -270,6 +358,10 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey> & Se
 				
 				vertexUpdateFunction.setOutput(vertexState, out);
 				vertexUpdateFunction.updateVertex(vertexState.f0, vertexState.f1, messageIter);
+				
+				if(inBulkIteration && !vertexUpdateFunction.lastVertexCollected()) {
+					out.collect(vertexState);
+				}
 			}
 			else {
 				final Iterator<Tuple2<VertexKey, Message>> messageIter = messages.iterator();

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/spargel/VertexUpdateFunction.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/spargel/VertexUpdateFunction.java
@@ -41,6 +41,8 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 
 	private static final long serialVersionUID = 1L;
 	
+	private boolean lastVertexCollected = false;
+	
 	// --------------------------------------------------------------------------------------------
 	//  Public API Methods
 	// --------------------------------------------------------------------------------------------
@@ -80,6 +82,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	public void setNewVertexValue(VertexValue newValue) {
 		outVal.f1 = newValue;
 		out.collect(outVal);
+		this.lastVertexCollected = true;
 	}
 	
 	/**
@@ -124,6 +127,10 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 		return this.runtimeContext.<T>getBroadcastVariable(name);
 	}
 	
+	public boolean lastVertexCollected() {
+		return lastVertexCollected;
+	}
+	
 	// --------------------------------------------------------------------------------------------
 	//  internal methods
 	// --------------------------------------------------------------------------------------------
@@ -142,5 +149,6 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	void setOutput(Vertex<VertexKey, VertexValue> val, Collector<Vertex<VertexKey, VertexValue>> out) {
 		this.out = out;
 		this.outVal = val;
+		this.lastVertexCollected = false;
 	}
 }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/FLINK-1885

I essentially exchanged the delta iteration with a bulk iteration and made the coGroup of the VertexUpdateUdf kind of an outer join so that the vertices that are not changed in one superstep are kept around in the next one.