### PR TITLE
[FLINK-1891]Add the input storageDirectory empty check

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -64,15 +64,19 @@ public class BlobUtils {
 	 * @return the storage directory used by a BLOB service
 	 */
 	static File initStorageDirectory(String storageDirectory) {
-		File baseDir = storageDirectory != null ?
-				new File(storageDirectory) :
-				new File(System.getProperty("java.io.tmpdir"));
+		File baseDir;
+		if (storageDirectory == null || storageDirectory.isEmpty()) {
+			baseDir = new File(System.getProperty("java.io.tmpdir"));
+		}
+		else {
+			baseDir = new File(storageDirectory);
+		}
 
 		File storageDir;
 		final int MAX_ATTEMPTS = 10;
 		int attempt;
 
-		for(attempt = 0; attempt < MAX_ATTEMPTS; attempt++){
+		for(attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
 			storageDir = new File(baseDir, String.format(
 					"blobStore-%s", UUID.randomUUID().toString()));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -65,7 +65,7 @@ public class BlobUtils {
 	 */
 	static File initStorageDirectory(String storageDirectory) {
 		File baseDir;
-		if (storageDirectory == null || storageDirectory.isEmpty()) {
+		if (storageDirectory == null || storageDirectory.trim().isEmpty()) {
 			baseDir = new File(System.getProperty("java.io.tmpdir"));
 		}
 		else {


### PR DESCRIPTION
Add the input storageDirectory empty check, if input of storageDirectory is empty, we should use tmp as the base dir
And also fix the code style proble of blank space between every ) and {