### PR TITLE
Make PersistentKafkaSource more configurable

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaConsumerIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaConsumerIterator.java
@@ -24,9 +24,9 @@ import org.apache.flink.streaming.connectors.kafka.api.simple.MessageWithMetadat
  */
 public interface KafkaConsumerIterator {
 
-	public void initialize() throws InterruptedException;
+	void initialize() throws InterruptedException;
 
-	public boolean hasNext();
+	boolean hasNext();
 
 	/**
 	 * Returns the next message received from Kafka as a
@@ -34,7 +34,7 @@ public interface KafkaConsumerIterator {
 	 *
 	 * @return next message as a byte array.
 	 */
-	public byte[] next() throws InterruptedException;
+	byte[] next() throws InterruptedException;
 
 	/**
 	 * Returns the next message and its offset received from
@@ -42,5 +42,5 @@ public interface KafkaConsumerIterator {
 	 *
 	 * @return next message and its offset.
 	 */
-	public MessageWithMetadata nextWithOffset() throws InterruptedException;
+	MessageWithMetadata nextWithOffset() throws InterruptedException;
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaIdleConsumerIterator.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/iterator/KafkaIdleConsumerIterator.java
@@ -21,6 +21,9 @@ import org.apache.flink.streaming.connectors.kafka.api.simple.MessageWithMetadat
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * No-op iterator. Used when more source tasks are available than Kafka partitions
+ */
 public class KafkaIdleConsumerIterator implements KafkaConsumerIterator {
 
 	private static final Logger LOG = LoggerFactory.getLogger(KafkaIdleConsumerIterator.class);

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/GivenOffset.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/kafka/api/simple/offset/GivenOffset.java
@@ -19,6 +19,9 @@ package org.apache.flink.streaming.connectors.kafka.api.simple.offset;
 
 import kafka.javaapi.consumer.SimpleConsumer;
 
+/**
+ * Offset given by a message read from Kafka.
+ */
 public class GivenOffset extends KafkaOffset {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/test/resources/log4j-test.properties
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=OFF, testlogger
+log4j.rootLogger=INFO, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target = System.err


### PR DESCRIPTION
The `PersistentKafkaSource` contained some hardcoded configuration values.
With this change I'm using more config values from the `ConsumerConfig`