### PR TITLE
[FLINK-1908] JobManager startup delay isn't considered when using start-cluster.sh script

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -82,12 +82,16 @@ DEFAULT_ENV_PID_DIR="/tmp"                          # Directory to store *.pid f
 DEFAULT_ENV_LOG_MAX=5                               # Maximum number of old log files to keep
 DEFAULT_ENV_JAVA_OPTS=""                            # Optional JVM args
 DEFAULT_ENV_SSH_OPTS=""                             # Optional SSH parameters running in cluster mode
+DEFAULT_JOBM_RPC_ADDR="localhost"                   # JobManager RPC address for connection test
+DEFAULT_JOBM_RPC_PORT="6123"                        # JobManager RPC port for connection test
 
 ########################################################################################################################
 # CONFIG KEYS: The default values can be overwritten by the following keys in conf/flink-conf.yaml
 ########################################################################################################################
 
 KEY_JOBM_HEAP_MB="jobmanager.heap.mb"
+KEY_JOBM_RPC_ADDR="jobmanager.rpc.address"
+KEY_JOBM_RPC_PORT="jobmanager.rpc.port"
 KEY_TASKM_HEAP_MB="taskmanager.heap.mb"
 KEY_ENV_PID_DIR="env.pid.dir"
 KEY_ENV_LOG_MAX="env.log.max"

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -37,6 +37,26 @@ fi
 # cluster mode, bring up job manager locally and a task manager on every slave host
 "$FLINK_BIN_DIR"/jobmanager.sh start cluster
 
+# wait until jobmanager starts
+JOBMANAGER_ADDR=$(readFromConfig ${KEY_JOBM_RPC_ADDR} "${DEFAULT_JOBM_RPC_ADDR}" "${YAML_CONF}")
+JOBMANAGER_PORT=$(readFromConfig ${KEY_JOBM_RPC_PORT} "${DEFAULT_JOBM_RPC_PORT}" "${YAML_CONF}")
+
+echo "Waiting for job manager"
+for i in {1..30}; do
+  nc -z "${JOBMANAGER_ADDR}" $JOBMANAGER_PORT
+  if [ "$?" -eq "0" ]; then
+    echo ""
+    break
+  fi
+
+  if [ "$i" -eq "30" ]; then
+     echo -e "\nCannot connect to job manager, canceling task manager startup"
+     exit 1
+  fi
+  echo -n "."
+  sleep 1
+done
+
 GOON=true
 while $GOON
 do


### PR DESCRIPTION
Creates dependency on netcat package (nc)