### PR TITLE
[FLINK-1909] [streaming] Type handling refactor for sources + scala api

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
@@ -123,7 +123,7 @@ public class ConnectedDataStream<IN1, IN2> {
 	 * 
 	 * @return The type of the first input
 	 */
-	public TypeInformation<IN1> getInputType1() {
+	public TypeInformation<IN1> getType1() {
 		return dataStream1.getType();
 	}
 
@@ -132,7 +132,7 @@ public class ConnectedDataStream<IN1, IN2> {
 	 * 
 	 * @return The type of the second input
 	 */
-	public TypeInformation<IN2> getInputType2() {
+	public TypeInformation<IN2> getType2() {
 		return dataStream2.getType();
 	}
 
@@ -244,10 +244,10 @@ public class ConnectedDataStream<IN1, IN2> {
 	public <OUT> SingleOutputStreamOperator<OUT, ?> map(CoMapFunction<IN1, IN2, OUT> coMapper) {
 
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.getBinaryOperatorReturnType(coMapper,
-				CoMapFunction.class, false, true, getInputType1(), getInputType2(),
+				CoMapFunction.class, false, true, getType1(), getType2(),
 				Utils.getCallLocationName(), true);
 
-		return addCoFunction("Co-Map", outTypeInfo, new CoStreamMap<IN1, IN2, OUT>(
+		return transform("Co-Map", outTypeInfo, new CoStreamMap<IN1, IN2, OUT>(
 				clean(coMapper)));
 
 	}
@@ -271,10 +271,10 @@ public class ConnectedDataStream<IN1, IN2> {
 			CoFlatMapFunction<IN1, IN2, OUT> coFlatMapper) {
 
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.getBinaryOperatorReturnType(coFlatMapper,
-				CoFlatMapFunction.class, false, true, getInputType1(), getInputType2(),
+				CoFlatMapFunction.class, false, true, getType1(), getType2(),
 				Utils.getCallLocationName(), true);
 
-		return addCoFunction("Co-Flat Map", outTypeInfo, new CoStreamFlatMap<IN1, IN2, OUT>(
+		return transform("Co-Flat Map", outTypeInfo, new CoStreamFlatMap<IN1, IN2, OUT>(
 				clean(coFlatMapper)));
 	}
 
@@ -297,10 +297,10 @@ public class ConnectedDataStream<IN1, IN2> {
 	public <OUT> SingleOutputStreamOperator<OUT, ?> reduce(CoReduceFunction<IN1, IN2, OUT> coReducer) {
 
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.getBinaryOperatorReturnType(coReducer,
-				CoReduceFunction.class, false, true, getInputType1(), getInputType2(),
+				CoReduceFunction.class, false, true, getType1(), getType2(),
 				Utils.getCallLocationName(), true);
 
-		return addCoFunction("Co-Reduce", outTypeInfo, getReduceOperator(clean(coReducer)));
+		return transform("Co-Reduce", outTypeInfo, getReduceOperator(clean(coReducer)));
 
 	}
 
@@ -365,10 +365,10 @@ public class ConnectedDataStream<IN1, IN2> {
 		}
 		
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.getBinaryOperatorReturnType(coWindowFunction,
-				CoWindowFunction.class, false, true, getInputType1(), getInputType2(),
+				CoWindowFunction.class, false, true, getType1(), getType2(),
 				Utils.getCallLocationName(), true);
 
-		return addCoFunction("Co-Window", outTypeInfo, new CoStreamWindow<IN1, IN2, OUT>(
+		return transform("Co-Window", outTypeInfo, new CoStreamWindow<IN1, IN2, OUT>(
 				clean(coWindowFunction), windowSize, slideInterval, timestamp1, timestamp2));
 
 	}
@@ -397,20 +397,20 @@ public class ConnectedDataStream<IN1, IN2> {
 			throw new IllegalArgumentException("Slide interval must be positive");
 		}
 
-		return addCoFunction("Co-Window", outTypeInfo, new CoStreamWindow<IN1, IN2, OUT>(
+		return transform("Co-Window", outTypeInfo, new CoStreamWindow<IN1, IN2, OUT>(
 				clean(coWindowFunction), windowSize, slideInterval, timestamp1, timestamp2));
 
 	}
 
-	public <OUT> SingleOutputStreamOperator<OUT, ?> addCoFunction(String functionName,
+	public <OUT> SingleOutputStreamOperator<OUT, ?> transform(String functionName,
 			TypeInformation<OUT> outTypeInfo, CoStreamOperator<IN1, IN2, OUT> operator) {
 
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		SingleOutputStreamOperator<OUT, ?> returnStream = new SingleOutputStreamOperator(
 				environment, functionName, outTypeInfo, operator);
 
-		dataStream1.streamGraph.addCoOperator(returnStream.getId(), operator, getInputType1(),
-				getInputType2(), outTypeInfo, functionName);
+		dataStream1.streamGraph.addCoOperator(returnStream.getId(), operator, getType1(),
+				getType2(), outTypeInfo, functionName);
 
 		dataStream1.connectGraph(dataStream1, returnStream.getId(), 1);
 		dataStream1.connectGraph(dataStream2, returnStream.getId(), 2);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -93,7 +93,7 @@ import org.apache.flink.streaming.util.serialization.SerializationSchema;
  * <ul>
  * <li>{@link DataStream#map},</li>
  * <li>{@link DataStream#filter}, or</li>
- * <li>{@link DataStream#aggregate}.</li>
+ * <li>{@link DataStream#sum}.</li>
  * </ul>
  * 
  * @param <OUT>

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DiscretizedStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DiscretizedStream.java
@@ -133,7 +133,7 @@ public class DiscretizedStream<OUT> extends WindowedDataStream<OUT> {
 		return reduced.discretizedStream
 				.groupBy(new WindowKey<OUT>())
 				.connect(numOfParts.groupBy(0))
-				.addCoFunction(
+				.transform(
 						"CoFlatMap",
 						reduced.discretizedStream.getType(),
 						new CoStreamFlatMap<StreamWindow<OUT>, Tuple2<Integer, Integer>, StreamWindow<OUT>>(

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/TypeFillTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/TypeFillTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.functions.co.CoFlatMapFunction;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.co.CoReduceFunction;
 import org.apache.flink.streaming.api.functions.co.CoWindowFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.Collector;
 import org.junit.Test;
 
@@ -41,6 +42,12 @@ public class TypeFillTest {
 	@Test
 	public void test() {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		try {
+			env.addSource(new TestSource<Integer>()).print();
+			fail();
+		} catch (Exception e) {
+		}
 
 		DataStream<Long> source = env.generateSequence(1, 10);
 
@@ -76,6 +83,7 @@ public class TypeFillTest {
 		} catch (Exception e) {
 		}
 
+		env.addSource(new TestSource<Integer>()).returns("Integer");
 		source.map(new TestMap<Long, Long>()).returns(Long.class).print();
 		source.flatMap(new TestFlatMap<Long, Long>()).returns("Long").print();
 		source.connect(source).map(new TestCoMap<Long, Long, Integer>()).returns("Integer").print();
@@ -102,6 +110,19 @@ public class TypeFillTest {
 			map.returns("String");
 			fail();
 		} catch (Exception e) {
+		}
+
+	}
+
+	private class TestSource<T> implements SourceFunction<T> {
+
+		@Override
+		public void run(Collector<T> collector) throws Exception {
+
+		}
+
+		@Override
+		public void cancel() {
 		}
 
 	}

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedDataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedDataStream.scala
@@ -21,7 +21,7 @@ package org.apache.flink.streaming.api.scala
 import java.util
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
-import org.apache.flink.streaming.api.datastream.{ConnectedDataStream => JavaCStream}
+import org.apache.flink.streaming.api.datastream.{ConnectedDataStream => JavaCStream, DataStream => JavaStream}
 import org.apache.flink.streaming.api.functions.co.{CoFlatMapFunction, CoMapFunction, CoReduceFunction, CoWindowFunction}
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment.clean
 import org.apache.flink.util.Collector
@@ -54,8 +54,7 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
       def map2(in2: IN2): R = clean(fun2)(in2)
     }
 
-    new DataStream(javaStream.addCoFunction("map", implicitly[TypeInformation[R]],
-      new CoStreamMap[IN1, IN2, R](comapper)))
+    map(comapper)
   }
 
   /**
@@ -78,8 +77,8 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
       throw new NullPointerException("Map function must not be null.")
     }
 
-    new DataStream(javaStream.addCoFunction("map", implicitly[TypeInformation[R]],
-      new CoStreamMap[IN1, IN2, R](coMapper)))
+    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]    
+    javaStream.map(coMapper).returns(outType).asInstanceOf[JavaStream[R]]
   }
 
   /**
@@ -102,8 +101,9 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     if (coFlatMapper == null) {
       throw new NullPointerException("FlatMap function must not be null.")
     }
-    new DataStream[R](javaStream.addCoFunction("flatMap", implicitly[TypeInformation[R]],
-      new CoStreamFlatMap[IN1, IN2, R](coFlatMapper)))
+    
+    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]    
+    javaStream.flatMap(coFlatMapper).returns(outType).asInstanceOf[JavaStream[R]]
   }
 
   /**
@@ -235,13 +235,13 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
    * The function used for grouping the second input
    * @return @return The transformed { @link ConnectedDataStream}
    */
-  def groupBy[K: TypeInformation](fun1: IN1 => _, fun2: IN2 => _):
+  def groupBy[K: TypeInformation, L: TypeInformation](fun1: IN1 => K, fun2: IN2 => L):
   ConnectedDataStream[IN1, IN2] = {
 
-    val keyExtractor1 = new KeySelector[IN1, Any] {
+    val keyExtractor1 = new KeySelector[IN1, K] {
       def getKey(in: IN1) = clean(fun1)(in)
     }
-    val keyExtractor2 = new KeySelector[IN2, Any] {
+    val keyExtractor2 = new KeySelector[IN2, L] {
       def getKey(in: IN2) = clean(fun2)(in)
     }
 
@@ -267,9 +267,9 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     if (coReducer == null) {
       throw new NullPointerException("Reduce function must not be null.")
     }
-
-    new DataStream[R](javaStream.addCoFunction("coReduce", implicitly[TypeInformation[R]],
-      new CoStreamReduce[IN1, IN2, R](coReducer)))
+    
+    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]    
+    javaStream.reduce(coReducer).returns(outType).asInstanceOf[JavaStream[R]]
   }
 
   /**
@@ -325,12 +325,16 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
    * @return The transformed { @link DataStream}.
    */
   def windowReduce[R: TypeInformation: ClassTag](coWindowFunction: 
-      CoWindowFunction[IN1, IN2, R], windowSize: Long, slideInterval: Long) = {
+      CoWindowFunction[IN1, IN2, R], windowSize: Long, slideInterval: Long):
+      DataStream[R] = {
     if (coWindowFunction == null) {
       throw new NullPointerException("CoWindow function must no be null")
     }
-
-    javaStream.windowReduce(coWindowFunction, windowSize, slideInterval)
+    
+    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]    
+    
+    javaStream.windowReduce(coWindowFunction, windowSize, slideInterval).
+    returns(outType).asInstanceOf[JavaStream[R]]
   }
 
   /**
@@ -351,7 +355,8 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
    * @return The transformed { @link DataStream}.
    */
   def windowReduce[R: TypeInformation: ClassTag](coWindower: (Seq[IN1], Seq[IN2], 
-      Collector[R]) => Unit, windowSize: Long, slideInterval: Long) = {
+      Collector[R]) => Unit, windowSize: Long, slideInterval: Long):
+      DataStream[R] = {
     if (coWindower == null) {
       throw new NullPointerException("CoWindow function must no be null")
     }
@@ -361,7 +366,7 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
           out: Collector[R]): Unit = clean(coWindower)(first, second, out)
     }
 
-    javaStream.windowReduce(coWindowFun, windowSize, slideInterval)
+    windowReduce(coWindowFun, windowSize, slideInterval)
   }
 
   /**
@@ -388,7 +393,7 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
    * @return The type of the first input
    */
   def getInputType1(): TypeInformation[IN1] = {
-    javaStream.getInputType1
+    javaStream.getType1
   }
 
   /**
@@ -397,7 +402,7 @@ class ConnectedDataStream[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
    * @return The type of the second input
    */
   def getInputType2(): TypeInformation[IN2] = {
-    javaStream.getInputType2
+    javaStream.getType2
   }
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -261,7 +261,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     val sourceFunction = new FromElementsFunction[T](scala.collection.JavaConversions
         .asJavaCollection(data))
         
-    javaEnv.addSource(sourceFunction, typeInfo)
+    javaEnv.addSource(sourceFunction).returns(typeInfo)
   }
 
   /**
@@ -277,7 +277,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     Validate.notNull(function, "Function must not be null.")
     val cleanFun = StreamExecutionEnvironment.clean(function)
     val typeInfo = implicitly[TypeInformation[T]]
-    javaEnv.addSource(cleanFun, typeInfo)
+    javaEnv.addSource(cleanFun).returns(typeInfo)
   }
   
    /**


### PR DESCRIPTION
This PR reworks the way sources handle type extraction, allowing for missing types (with returns) and also fixes some issues around type handling for the streaming Scala api.