### PR TITLE
[FLINK-1906] [docs] Add tip to work around plain Tuple return type of project operator

### DIFF
--- a/docs/dataset_transformations.md
+++ b/docs/dataset_transformations.md
@@ -193,6 +193,21 @@ DataSet<Tuple3<Integer, Double, String>> in = // [...]
 DataSet<Tuple2<String, Integer>> out = in.project(2,0);
 ~~~
 
+#### Projection with Type Hint
+
+Note that the Java compiler cannot infer the return type of `project` operator. This can cause a problem if you call another operator on a result of `project` operator such as:
+
+~~~java
+DataSet<Tuple5<String,String,String,String,String>> ds = ....
+DataSet<Tuple1<String>> ds2 = ds.project(0).distinct(0);
+~~~
+
+This problem can be overcome by hinting the return type of `project` operator like this:
+
+~~~java
+DataSet<Tuple1<String>> ds2 = ds.<Tuple1<String>>project(0).distinct(0);
+~~~
+
 ### Transformations on Grouped DataSet
 
 The reduce operations can operate on grouped data sets. Specifying the key to


### PR DESCRIPTION
Add a tip about project transformation with type hinting in documentation. Related JIRA is [here](https://issues.apache.org/jira/browse/FLINK-1906).