### PR TITLE
Periodic full stream aggregates added + partitioner bugfix

### DIFF
--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -634,6 +634,7 @@ Several predefined policies are provided in the API, including delta-based, coun
  * `Time.of(…)`
  * `Count.of(…)`
  * `Delta.of(…)`
+ * `FullStream.window()`
 
 For detailed description of these policies please refer to the [Javadocs](http://flink.apache.org/docs/latest/api/java/).
 
@@ -773,6 +774,9 @@ dataStream.window(Count.of(1000)).groupBy(firstKey).mapWindow(…)
 The above call would create global windows of 1000 elements group it by the first key and then apply a mapWindow transformation. The resulting windowed stream will then be grouped by the second key and further reduced. The results of the reduce transformation are then flattened.
 
 Notice that here we only defined the window size once at the beginning of the transformation. This means that anything that happens afterwards (`groupBy(firstKey).mapWindow(…).groupBy(secondKey).reduceWindow(…)`) happens inside the 1000 element windows. Of course the mapWindow might reduce the number of elements but the key idea is that each transformation still corresponds to the same 1000 elements in the original stream.
+
+#### Periodic aggregations on the full stream history
+Sometimes it is necessary to aggregate over all the previously seen data in the stream. For this purpose either use the `dataStream.window(FullStream.window()).every(trigger)` or equivalently `dataStream.every(trigger)`. 
 
 #### Global vs local discretisation
 By default all window discretisation calls (`dataStream.window(…)`) define global windows meaning that a global window of count 100 will contain the last 100 elements arrived at the discretisation operator in order. In most cases (except for Time) this means that the operator doing the actual discretisation needs to have a parallelism of 1 to be able to correctly execute the discretisation logic.

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowPartExtractor.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowPartExtractor.java
@@ -40,7 +40,7 @@ public class WindowPartExtractor<OUT> implements FlatMapFunction<StreamWindow<OU
 		// We dont emit new values for the same index, this avoids sending the
 		// same information for the same partitioned window multiple times
 		if (value.windowID != lastIndex) {
-
+			
 			// For empty windows we send 0 since these windows will be filtered
 			// out
 			if (value.isEmpty()) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.windowing.helper.TimestampWrapper;
 import org.apache.flink.streaming.api.windowing.policy.CountEvictionPolicy;
 import org.apache.flink.streaming.api.windowing.policy.CountTriggerPolicy;
 import org.apache.flink.streaming.api.windowing.policy.EvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.KeepAllEvictionPolicy;
 import org.apache.flink.streaming.api.windowing.policy.TimeEvictionPolicy;
 import org.apache.flink.streaming.api.windowing.policy.TimeTriggerPolicy;
 import org.apache.flink.streaming.api.windowing.policy.TriggerPolicy;
@@ -118,7 +119,7 @@ public class WindowUtils {
 	}
 
 	public static boolean isTumblingPolicy(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction) {
-		if (eviction instanceof TumblingEvictionPolicy) {
+		if (eviction instanceof TumblingEvictionPolicy || eviction instanceof KeepAllEvictionPolicy) {
 			return true;
 		} else if (isTimeOnly(trigger, eviction)) {
 			long slide = getSlideSize(trigger);
@@ -140,7 +141,8 @@ public class WindowUtils {
 	}
 
 	public static boolean isTimeOnly(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction) {
-		return trigger instanceof TimeTriggerPolicy && eviction instanceof TimeEvictionPolicy;
+		return trigger instanceof TimeTriggerPolicy
+				&& (eviction instanceof TimeEvictionPolicy || eviction instanceof KeepAllEvictionPolicy);
 	}
 
 	public static boolean isCountOnly(TriggerPolicy<?> trigger, EvictionPolicy<?> eviction) {
@@ -170,7 +172,7 @@ public class WindowUtils {
 
 			return slide > window
 					&& ((CountTriggerPolicy<?>) trigger).getStart() == ((CountEvictionPolicy<?>) eviction)
-					.getStart()
+							.getStart()
 					&& ((CountEvictionPolicy<?>) eviction).getDeleteOnEviction() == 1;
 		} else {
 			return false;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/helper/FullStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/helper/FullStream.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.helper;
+
+import java.io.Serializable;
+
+import org.apache.flink.streaming.api.windowing.policy.EvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.KeepAllEvictionPolicy;
+import org.apache.flink.streaming.api.windowing.policy.TriggerPolicy;
+
+/**
+ * Window that represents the full stream history. Can be used only as eviction
+ * policy and only with operations that support pre-aggregator such as reduce or
+ * aggregations.
+ */
+public class FullStream<DATA> implements WindowingHelper<DATA>, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private FullStream() {
+	}
+
+	@Override
+	public EvictionPolicy<DATA> toEvict() {
+		return new KeepAllEvictionPolicy<DATA>();
+	}
+
+	@Override
+	public TriggerPolicy<DATA> toTrigger() {
+		throw new RuntimeException(
+				"Full stream policy can be only used as eviction. Use .every(..) after the window call.");
+	}
+
+	/**
+	 * Returns a helper representing an eviction that keeps all previous record
+	 * history.
+	 */
+	public static <R> FullStream<R> window() {
+		return new FullStream<R>();
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/KeepAllEvictionPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/KeepAllEvictionPolicy.java
@@ -14,35 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.streaming.runtime.partitioner;
 
-import java.io.Serializable;
+package org.apache.flink.streaming.api.windowing.policy;
 
-import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
-import org.apache.flink.runtime.plugable.SerializationDelegate;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-
-public abstract class StreamPartitioner<T> implements
-		ChannelSelector<SerializationDelegate<StreamRecord<T>>>, Serializable {
-
-	public enum PartitioningStrategy {
-
-		FORWARD, DISTRIBUTE, SHUFFLE, BROADCAST, GLOBAL, GROUPBY;
-
-	}
+public class KeepAllEvictionPolicy<T> implements EvictionPolicy<T> {
 
 	private static final long serialVersionUID = 1L;
-	private PartitioningStrategy strategy;
 
-	public StreamPartitioner(PartitioningStrategy strategy) {
-		this.strategy = strategy;
+	@Override
+	public int notifyEviction(T datapoint, boolean triggered, int bufferSize) {
+		return 0;
 	}
 
-	public PartitioningStrategy getStrategy() {
-		return strategy;
-	}
-
-	public StreamPartitioner<T> copy() {
-		return this;
-	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducer.java
@@ -37,16 +37,23 @@ public class TumblingGroupedPreReducer<T> extends WindowBuffer<T> implements Pre
 	private KeySelector<T, ?> keySelector;
 
 	private Map<Object, T> reducedValues;
-	private Map<Object, T> keyInstancePerKey = new HashMap<Object, T>();
 
 	private TypeSerializer<T> serializer;
 
+	private boolean evict = true;
+
 	public TumblingGroupedPreReducer(ReduceFunction<T> reducer, KeySelector<T, ?> keySelector,
 			TypeSerializer<T> serializer) {
+		this(reducer, keySelector, serializer, true);
+	}
+
+	public TumblingGroupedPreReducer(ReduceFunction<T> reducer, KeySelector<T, ?> keySelector,
+			TypeSerializer<T> serializer, boolean evict) {
 		this.reducer = reducer;
 		this.serializer = serializer;
 		this.keySelector = keySelector;
 		this.reducedValues = new HashMap<Object, T>();
+		this.evict = evict;
 	}
 
 	public void emitWindow(Collector<StreamWindow<T>> collector) {
@@ -55,11 +62,12 @@ public class TumblingGroupedPreReducer<T> extends WindowBuffer<T> implements Pre
 			StreamWindow<T> currentWindow = createEmptyWindow();
 			currentWindow.addAll(reducedValues.values());
 			collector.collect(currentWindow);
-			reducedValues.clear();
 		} else if (emitEmpty) {
 			collector.collect(createEmptyWindow());
 		}
-
+		if (evict) {
+			reducedValues.clear();
+		}
 	}
 
 	public void store(T element) throws Exception {
@@ -74,23 +82,25 @@ public class TumblingGroupedPreReducer<T> extends WindowBuffer<T> implements Pre
 		}
 
 		reducedValues.put(key, reduced);
-
-		if (emitPerGroup && !keyInstancePerKey.containsKey(key)) {
-			keyInstancePerKey.put(key, element);
-		}
 	}
 
+	@Override
 	public void evict(int n) {
 	}
 
 	@Override
 	public TumblingGroupedPreReducer<T> clone() {
-		return new TumblingGroupedPreReducer<T>(reducer, keySelector, serializer);
+		return new TumblingGroupedPreReducer<T>(reducer, keySelector, serializer, evict);
 	}
 
 	@Override
 	public String toString() {
 		return reducedValues.toString();
+	}
+
+	public TumblingGroupedPreReducer<T> noEvict() {
+		this.evict = false;
+		return this;
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/DistributePartitioner.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/DistributePartitioner.java
@@ -31,9 +31,11 @@ public class DistributePartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
 	private int[] returnArray = new int[] {-1};
+	private boolean forward;
 
 	public DistributePartitioner(boolean forward) {
 		super(forward ? PartitioningStrategy.FORWARD : PartitioningStrategy.DISTRIBUTE);
+		this.forward = forward;
 	}
 
 	@Override
@@ -42,5 +44,9 @@ public class DistributePartitioner<T> extends StreamPartitioner<T> {
 		this.returnArray[0] = (this.returnArray[0] + 1) % numberOfOutputChannels;
 
 		return this.returnArray;
+	}
+	
+	public StreamPartitioner<T> copy() {
+		return new DistributePartitioner<T>(forward);
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingGroupedPreReducerTest.java
@@ -66,6 +66,7 @@ public class TumblingGroupedPreReducerTest {
 		wb.store(serializer.copy(inputs.get(0)));
 		wb.store(serializer.copy(inputs.get(1)));
 		wb.emitWindow(collector);
+		wb.evict(2);
 
 		assertEquals(1, collected.size());
 
@@ -76,12 +77,10 @@ public class TumblingGroupedPreReducerTest {
 		wb.store(serializer.copy(inputs.get(1)));
 		wb.store(serializer.copy(inputs.get(2)));
 
-		// Nothing should happen here
-		wb.evict(3);
-
 		wb.store(serializer.copy(inputs.get(3)));
 
 		wb.emitWindow(collector);
+		wb.evict(4);
 
 		assertEquals(2, collected.size());
 
@@ -114,13 +113,15 @@ public class TumblingGroupedPreReducerTest {
 		wb.store(serializer.copy(inputs.get(0)));
 		wb.store(serializer.copy(inputs.get(1)));
 		wb.emitWindow(collector);
-
+		wb.evict(2);
+		
 		assertSetEquals(StreamWindow.fromElements(inputs.get(0), inputs.get(1)), collected.get(0));
 		
 		wb.store(serializer.copy(inputs.get(0)));
 		wb.store(serializer.copy(inputs.get(1)));
 		wb.store(serializer.copy(inputs.get(2)));
 		wb.emitWindow(collector);
+		wb.evict(3);
 		
 		assertSetEquals(StreamWindow.fromElements(new Tuple2<Integer, Integer>(2, 0), inputs.get(1)), collected.get(1));
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/TumblingPreReducerTest.java
@@ -59,6 +59,7 @@ public class TumblingPreReducerTest {
 		wb.store(serializer.copy(inputs.get(1)));
 
 		wb.emitWindow(collector);
+		wb.evict(2);
 
 		assertEquals(1, collected.size());
 		assertEquals(StreamWindow.fromElements(new Tuple2<Integer, Integer>(3, 1)),
@@ -68,12 +69,10 @@ public class TumblingPreReducerTest {
 		wb.store(serializer.copy(inputs.get(1)));
 		wb.store(serializer.copy(inputs.get(2)));
 
-		// Nothing should happen here
-		wb.evict(3);
-
 		wb.store(serializer.copy(inputs.get(3)));
 
 		wb.emitWindow(collector);
+		wb.evict(4);
 
 		assertEquals(2, collected.size());
 		assertEquals(StreamWindow.fromElements(new Tuple2<Integer, Integer>(10, -2)),

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -530,6 +530,13 @@ class DataStream[T](javaStream: JavaStream[T]) {
    */
   def window(trigger: TriggerPolicy[T], eviction: EvictionPolicy[T]):
     WindowedDataStream[T] = javaStream.window(trigger, eviction)
+    
+  /**
+   * Create a WindowedDataStream based on the full stream history to perform periodic
+   * aggregations.
+   */  
+  def every(windowingHelper: WindowingHelper[_]): WindowedDataStream[T] = 
+    javaStream.every(windowingHelper)
 
   /**
    *


### PR DESCRIPTION
This PR introduces periodic full stream aggregates on data streams as a special case of windowing.

Usage:

dataStream.every(trigger).reduce(..)
dataStream.every(trigger).sum/max/min/...

or

dataStream.window(FullStream.window()).every()

It only allows aggregations  so we dont need to keep the full history in a buffer.
It also works together with parallel time discretization.