### PR TITLE
FLINK-1693 Add DEPRECATED annotations in Spargel APIs and update the doc to refer to Gelly for Flink graph processing.

### DIFF
--- a/docs/libs/spargel_guide.md
+++ b/docs/libs/spargel_guide.md
@@ -1,5 +1,5 @@
 ---
-title: "Spargel Graph Processing API"
+title: "Spargel Graph Processing API - DEPRECATED"
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -32,7 +32,7 @@ This vertex-centric view makes it easy to express a large class of graph problem
 * This will be replaced by the TOC
 {:toc}
 
-Spargel API
+Spargel API - DEPRECATED (Please check out new [Gelly API](gelly_guide.html) for graph processing with Apache Flink)
 -----------
 
 The Spargel API is part of the *addons* Maven project. All relevant classes are located in the *org.apache.flink.spargel.java* package.

--- a/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/MessagingFunction.java
+++ b/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/MessagingFunction.java
@@ -39,6 +39,7 @@ import org.apache.flink.util.Collector;
  * @param <Message> The type of the message sent between vertices along the edges.
  * @param <EdgeValue> The type of the values that are associated with the edges.
  */
+@Deprecated
 public abstract class MessagingFunction<VertexKey extends Comparable<VertexKey>, VertexValue, Message, EdgeValue> implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -56,6 +57,7 @@ public abstract class MessagingFunction<VertexKey extends Comparable<VertexKey>,
 	 * 
 	 * @throws Exception The computation may throw exceptions, which causes the superstep to fail.
 	 */
+	@Deprecated
 	public abstract void sendMessages(VertexKey vertexKey, VertexValue vertexValue) throws Exception;
 	
 	/**
@@ -63,6 +65,7 @@ public abstract class MessagingFunction<VertexKey extends Comparable<VertexKey>,
 	 * 
 	 * @throws Exception Exceptions in the pre-superstep phase cause the superstep to fail.
 	 */
+	@Deprecated
 	public void preSuperstep() throws Exception {}
 	
 	/**
@@ -70,6 +73,7 @@ public abstract class MessagingFunction<VertexKey extends Comparable<VertexKey>,
 	 * 
 	 * @throws Exception Exceptions in the post-superstep phase cause the superstep to fail.
 	 */
+	@Deprecated
 	public void postSuperstep() throws Exception {}
 	
 	

--- a/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/OutgoingEdge.java
+++ b/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/OutgoingEdge.java
@@ -29,6 +29,7 @@ package org.apache.flink.spargel.java;
  * @param <EdgeValue> The type of the value associated with the edge. For scenarios where the edges do not hold
  *                    value, this type may be arbitrary.
  */
+@Deprecated
 public final class OutgoingEdge<VertexKey extends Comparable<VertexKey>, EdgeValue> implements java.io.Serializable {
 	
 	private static final long serialVersionUID = 1L;
@@ -47,6 +48,7 @@ public final class OutgoingEdge<VertexKey extends Comparable<VertexKey>, EdgeVal
 	 * 
 	 * @return The target vertex id.
 	 */
+	@Deprecated
 	public VertexKey target() {
 		return target;
 	}
@@ -58,6 +60,7 @@ public final class OutgoingEdge<VertexKey extends Comparable<VertexKey>, EdgeVal
 	 *  
 	 * @return The value associated with the edge.
 	 */
+	@Deprecated
 	public EdgeValue edgeValue() {
 		return edgeValue;
 	}

--- a/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/VertexCentricIteration.java
+++ b/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/VertexCentricIteration.java
@@ -70,6 +70,7 @@ import org.apache.flink.util.Collector;
  * @param <Message> The type of the message sent between vertices along the edges.
  * @param <EdgeValue> The type of the values that are associated with the edges.
  */
+@Deprecated
 public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, VertexValue, Message, EdgeValue> 
 	implements CustomUnaryOperation<Tuple2<VertexKey, VertexValue>, Tuple2<VertexKey, VertexValue>>
 {
@@ -174,6 +175,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * @param name The name of the aggregator, used to retrieve it and its aggregates during execution. 
 	 * @param aggregator The aggregator.
 	 */
+	@Deprecated
 	public void registerAggregator(String name, Aggregator<?> aggregator) {
 		this.aggregators.put(name, aggregator);
 	}
@@ -184,6 +186,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * @param name The name under which the broadcast data is available in the messaging function.
 	 * @param data The data set to be broadcasted.
 	 */
+	@Deprecated
 	public void addBroadcastSetForMessagingFunction(String name, DataSet<?> data) {
 		this.bcVarsMessaging.add(new Tuple2<String, DataSet<?>>(name, data));
 	}
@@ -194,6 +197,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * @param name The name under which the broadcast data is available in the vertex update function.
 	 * @param data The data set to be broadcasted.
 	 */
+	@Deprecated
 	public void addBroadcastSetForUpdateFunction(String name, DataSet<?> data) {
 		this.bcVarsUpdate.add(new Tuple2<String, DataSet<?>>(name, data));
 	}
@@ -203,6 +207,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @param name The name for the iteration.
 	 */
+	@Deprecated
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -212,6 +217,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @return The name of the iteration.
 	 */
+	@Deprecated
 	public String getName() {
 		return name;
 	}
@@ -221,6 +227,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @param parallelism The parallelism.
 	 */
+	@Deprecated
 	public void setParallelism(int parallelism) {
 		Validate.isTrue(parallelism > 0 || parallelism == -1, "The parallelism must be positive, or -1 (use default).");
 		this.parallelism = parallelism;
@@ -231,6 +238,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @return The iterations parallelism, or -1, if not set.
 	 */
+	@Deprecated
 	public int getParallelism() {
 		return parallelism;
 	}
@@ -242,6 +250,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @param unmanaged True, to keep the solution set in unmanaged memory, false otherwise.
 	 */
+	@Deprecated
 	public void setSolutionSetUnmanagedMemory(boolean unmanaged) {
 		this.unmanagedSolutionSet = unmanaged;
 	}
@@ -253,6 +262,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @return True, if the solution set is in unmanaged memory, false otherwise.
 	 */
+	@Deprecated
 	public boolean isSolutionSetUnmanagedMemory() {
 		return this.unmanagedSolutionSet;
 	}
@@ -373,6 +383,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @return An in stance of the vertex-centric graph computation operator.
 	 */
+	@Deprecated
 	public static final <VertexKey extends Comparable<VertexKey>, VertexValue, Message>
 			VertexCentricIteration<VertexKey, VertexValue, Message, ?> withPlainEdges(
 					DataSet<Tuple2<VertexKey, VertexKey>> edgesWithoutValue,
@@ -402,6 +413,7 @@ public class VertexCentricIteration<VertexKey extends Comparable<VertexKey>, Ver
 	 * 
 	 * @return An in stance of the vertex-centric graph computation operator.
 	 */
+	@Deprecated
 	public static final <VertexKey extends Comparable<VertexKey>, VertexValue, Message, EdgeValue>
 			VertexCentricIteration<VertexKey, VertexValue, Message, EdgeValue> withValuedEdges(
 					DataSet<Tuple3<VertexKey, VertexKey, EdgeValue>> edgesWithValue,

--- a/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/VertexUpdateFunction.java
+++ b/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/VertexUpdateFunction.java
@@ -36,6 +36,7 @@ import org.apache.flink.util.Collector;
  * <VertexValue> The vertex value type.
  * <Message> The message type.
  */
+@Deprecated
 public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKey>, VertexValue, Message> implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -55,6 +56,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * 
 	 * @throws Exception The computation may throw exceptions, which causes the superstep to fail.
 	 */
+	@Deprecated
 	public abstract void updateVertex(VertexKey vertexKey, VertexValue vertexValue, MessageIterator<Message> inMessages) throws Exception;
 	
 	/**
@@ -62,6 +64,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * 
 	 * @throws Exception Exceptions in the pre-superstep phase cause the superstep to fail.
 	 */
+	@Deprecated
 	public void preSuperstep() throws Exception {}
 	
 	/**
@@ -69,6 +72,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * 
 	 * @throws Exception Exceptions in the post-superstep phase cause the superstep to fail.
 	 */
+	@Deprecated
 	public void postSuperstep() throws Exception {}
 	
 	/**
@@ -76,6 +80,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * 
 	 * @param newValue The new vertex value.
 	 */
+	@Deprecated
 	public void setNewVertexValue(VertexValue newValue) {
 		outVal.f1 = newValue;
 		out.collect(outVal);
@@ -86,6 +91,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * 
 	 * @return The number of the current superstep.
 	 */
+	@Deprecated
 	public int getSuperstepNumber() {
 		return this.runtimeContext.getSuperstepNumber();
 	}
@@ -97,6 +103,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * @param name The name of the aggregator.
 	 * @return The aggregator registered under this name, or null, if no aggregator was registered.
 	 */
+	@Deprecated
 	public <T extends Aggregator<?>> T getIterationAggregator(String name) {
 		return this.runtimeContext.<T>getIterationAggregator(name);
 	}
@@ -107,6 +114,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * @param name The name of the aggregator.
 	 * @return The aggregated value of the previous iteration.
 	 */
+	@Deprecated
 	public <T extends Value> T getPreviousIterationAggregate(String name) {
 		return this.runtimeContext.<T>getPreviousIterationAggregate(name);
 	}
@@ -119,6 +127,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Comparable<VertexKe
 	 * @param name The name under which the broadcast set is registered.
 	 * @return The broadcast data set.
 	 */
+	@Deprecated
 	public <T> Collection<T> getBroadcastSet(String name) {
 		return this.runtimeContext.<T>getBroadcastVariable(name);
 	}

--- a/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/examples/SpargelConnectedComponents.java
+++ b/flink-staging/flink-spargel/src/main/java/org/apache/flink/spargel/java/examples/SpargelConnectedComponents.java
@@ -70,6 +70,7 @@ public class SpargelConnectedComponents {
 	 * A map function that takes a Long value and creates a 2-tuple out of it:
 	 * <pre>(Long value) -> (value, value)</pre>
 	 */
+	@Deprecated
 	public static final class IdAssigner implements MapFunction<Long, Tuple2<Long, Long>> {
 		@Override
 		public Tuple2<Long, Long> map(Long value) {


### PR DESCRIPTION
Mark all user-facing from the Spargel API as deprecated and add a comment in the docs and point people to Gelly.

This should help migration to Gelly in the next release.