### PR TITLE
[FLINK-1925] Fixes blocking method submitTask on the TM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotAllocationFuture;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotAllocationFutureAction;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.messages.Messages;
 import org.apache.flink.runtime.messages.TaskMessages.TaskOperationResult;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.util.ExceptionUtils;
@@ -345,26 +346,9 @@ public class Execution implements Serializable {
 						}
 					}
 					else {
-						if (success == null) {
-							markFailed(new Exception("Failed to deploy the task to slot " + slot + ": TaskOperationResult was null"));
-						}
-
-						if (success instanceof TaskOperationResult) {
-							TaskOperationResult result = (TaskOperationResult) success;
-
-							if (!result.executionID().equals(attemptId)) {
-								markFailed(new Exception("Answer execution id does not match the request execution id."));
-							} else if (result.success()) {
-								switchToRunning();
-							} else {
-								// deployment failed :(
-								markFailed(new Exception("Failed to deploy the task " +
-										getVertexWithAttempt() + " to slot " + slot + ": " + result
-										.description()));
-							}
-						} else {
+						if (!(success instanceof Messages.Acknowledge$)) {
 							markFailed(new Exception("Failed to deploy the task to slot " + slot +
-									": Response was not of type TaskOperationResult"));
+									": Response was not of type Acknowledge"));
 						}
 					}
 				}
@@ -757,7 +741,7 @@ public class Execution implements Serializable {
 		}
 	}
 
-	private boolean switchToRunning() {
+	boolean switchToRunning() {
 
 		if (transitionState(DEPLOYING, RUNNING)) {
 			sendPartitionInfos();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -346,7 +346,7 @@ public class Execution implements Serializable {
 						}
 					}
 					else {
-						if (!(success instanceof Messages.Acknowledge$)) {
+						if (!(success.equals(Messages.getAcknowledge()))) {
 							markFailed(new Exception("Failed to deploy the task to slot " + slot +
 									": Response was not of type Acknowledge"));
 						}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -601,6 +601,8 @@ public class ExecutionGraph implements Serializable {
 		Execution attempt = this.currentExecutions.get(state.getID());
 		if (attempt != null) {
 			switch (state.getExecutionState()) {
+				case RUNNING:
+					return attempt.switchToRunning();
 				case FINISHED:
 					attempt.markFinished();
 					return true;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
@@ -26,15 +26,7 @@ object Messages {
   /**
    * Message to signal the successful reception of another message
    */
-  case object Acknowledge {
-
-    /**
-     * Accessor for the case object instance, to simplify Java interoperability.
-     *
-     * @return The Acknowledge case object instance.
-     */
-    def get(): Acknowledge.type = this
-  }
+  case object Acknowledge
 
   /**
    * Signals that the receiver (JobManager/TaskManager) shall disconnect the sender.
@@ -48,5 +40,12 @@ object Messages {
    * @param reason The reason for disconnecting, to be displayed in log and error messages.
    */
   case class Disconnect(reason: String)
+
+  /**
+   * Accessor for the case object instance, to simplify Java interoperability.
+   *
+   * @return The Acknowledge case object instance.
+   */
+  def getAcknowledge(): Acknowledge.type = Acknowledge
 
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
@@ -47,5 +47,4 @@ object Messages {
    * @return The Acknowledge case object instance.
    */
   def getAcknowledge(): Acknowledge.type = Acknowledge
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -126,7 +126,7 @@ public class ExecutionGraphDeploymentTest {
 
 			vertex.deployToSlot(slot);
 
-			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 
 			TaskDeploymentDescriptor descr = tm.lastTDD;
 			assertNotNull(descr);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 import java.util.LinkedList;
 
 import akka.actor.ActorRef;
+import akka.actor.Status;
 import akka.actor.UntypedActor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
@@ -43,6 +44,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.messages.Messages;
 import org.apache.flink.runtime.messages.TaskMessages.SubmitTask;
 import org.apache.flink.runtime.messages.TaskMessages.FailIntermediateResultPartitions;
 import org.apache.flink.runtime.messages.TaskMessages.CancelTask;
@@ -119,7 +121,7 @@ public class ExecutionGraphTestUtils {
 				SubmitTask submitTask = (SubmitTask) msg;
 				lastTDD = submitTask.tasks();
 
-				getSender().tell(new TaskOperationResult(submitTask.tasks().getExecutionId(), true), getSelf());
+				getSender().tell(Messages.getAcknowledge(), getSelf());
 			} else if (msg instanceof CancelTask) {
 				CancelTask cancelTask = (CancelTask) msg;
 				getSender().tell(new TaskOperationResult(cancelTask.attemptID(), true), getSelf());
@@ -136,10 +138,7 @@ public class ExecutionGraphTestUtils {
 		@Override
 		public void onReceive(Object msg) throws Exception {
 			if (msg instanceof SubmitTask) {
-				SubmitTask submitTask = (SubmitTask) msg;
-
-				getSender().tell(new TaskOperationResult(submitTask.tasks().getExecutionId(),
-						false, ERROR_MESSAGE),	getSelf());
+				getSender().tell(new Status.Failure(new Exception(ERROR_MESSAGE)),	getSelf());
 			} else if (msg instanceof CancelTask) {
 				CancelTask cancelTask = (CancelTask) msg;
 				getSender().tell(new TaskOperationResult(cancelTask.attemptID(), true), getSelf());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -129,7 +129,7 @@ public class ExecutionVertexSchedulingTest {
 	}
 	
 	@Test
-	public void testScheduleToRunning() {
+	public void testScheduleToDeploying() {
 		try {
 			TestingUtils.setCallingThreadDispatcher(system);
 			ActorRef tm = TestActorRef.create(system, Props.create(ExecutionGraphTestUtils
@@ -149,7 +149,7 @@ public class ExecutionVertexSchedulingTest {
 
 			// try to deploy to the slot
 			vertex.scheduleForExecution(scheduler, false);
-			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -85,6 +85,8 @@ public class TaskManagerTest {
 
 	private static Timeout timeout = new Timeout(1, TimeUnit.MINUTES);
 
+	private final FiniteDuration d = new FiniteDuration(20, TimeUnit.SECONDS);
+
 	@BeforeClass
 	public static void setup() {
 		system = ActorSystem.create("TestActorSystem", TestingUtils.testConfig());
@@ -117,7 +119,7 @@ public class TaskManagerTest {
 					new ArrayList<BlobKey>(), 0);
 
 				final ActorRef tmClosure = taskManager;
-				new Within(duration("10 seconds")) {
+				new Within(d) {
 
 					@Override
 					protected void run() {
@@ -174,7 +176,6 @@ public class TaskManagerTest {
 					new ArrayList<BlobKey>(), 0);
 
 				final ActorRef tm = taskManager;
-				final FiniteDuration d = duration("10 second");
 
 				new Within(d) {
 
@@ -302,8 +303,6 @@ public class TaskManagerTest {
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 					new ArrayList<BlobKey>(), 0);
 
-				final FiniteDuration d = duration("10 second");
-
 				new Within(d){
 
 					@Override
@@ -393,8 +392,6 @@ public class TaskManagerTest {
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
 						new ArrayList<BlobKey>(), 0);
-
-				final FiniteDuration d = duration("10 second");
 
 				new Within(d) {
 
@@ -519,8 +516,6 @@ public class TaskManagerTest {
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
 						new ArrayList<BlobKey>(), 0);
-
-				final FiniteDuration d = duration("10 second");
 
 				new Within(d){
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -557,10 +557,6 @@ public class TaskManagerTest {
 							}
 
 							if (t1 != null) {
-								if (t1.getExecutionState() == ExecutionState.RUNNING) {
-									tm.tell(new CancelTask(eid1), getRef());
-									expectMsgEquals(new TaskOperationResult(eid1, true));
-								}
 								Future<Object> response = Patterns.ask(tm, new TestingTaskManagerMessages.NotifyWhenTaskRemoved(eid1),
 										timeout);
 								Await.ready(response, d);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -117,7 +117,7 @@ public class TaskManagerTest {
 					new ArrayList<BlobKey>(), 0);
 
 				final ActorRef tmClosure = taskManager;
-				new Within(duration("2 seconds")) {
+				new Within(duration("10 seconds")) {
 
 					@Override
 					protected void run() {
@@ -174,7 +174,7 @@ public class TaskManagerTest {
 					new ArrayList<BlobKey>(), 0);
 
 				final ActorRef tm = taskManager;
-				final FiniteDuration d = duration("1 second");
+				final FiniteDuration d = duration("10 second");
 
 				new Within(d) {
 
@@ -302,7 +302,7 @@ public class TaskManagerTest {
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 					new ArrayList<BlobKey>(), 0);
 
-				final FiniteDuration d = duration("2 second");
+				final FiniteDuration d = duration("10 second");
 
 				new Within(d){
 
@@ -394,7 +394,7 @@ public class TaskManagerTest {
 						Collections.singletonList(ircdd),
 						new ArrayList<BlobKey>(), 0);
 
-				final FiniteDuration d = duration("2 second");
+				final FiniteDuration d = duration("10 second");
 
 				new Within(d) {
 
@@ -520,7 +520,7 @@ public class TaskManagerTest {
 						Collections.singletonList(ircdd),
 						new ArrayList<BlobKey>(), 0);
 
-				final FiniteDuration d = duration("2 second");
+				final FiniteDuration d = duration("10 second");
 
 				new Within(d){
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -182,12 +182,6 @@ public class TaskManagerTest {
 					@Override
 					protected void run() {
 						try {
-							tm.tell(new SubmitTask(tdd1), getRef());
-							tm.tell(new SubmitTask(tdd2), getRef());
-
-							expectMsgEquals(Messages.getAcknowledge());
-							expectMsgEquals(Messages.getAcknowledge());
-
 							Future<Object> t1Running = Patterns.ask(
 									tm,
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(eid1),
@@ -196,6 +190,12 @@ public class TaskManagerTest {
 									tm,
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(eid2),
 									timeout);
+
+							tm.tell(new SubmitTask(tdd1), getRef());
+							tm.tell(new SubmitTask(tdd2), getRef());
+
+							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Messages.getAcknowledge());
 
 							Await.ready(t1Running, d);
 							Await.ready(t2Running, d);
@@ -398,11 +398,6 @@ public class TaskManagerTest {
 					@Override
 					protected void run() {
 						try {
-							tm.tell(new SubmitTask(tdd1), getRef());
-							expectMsgEquals(Messages.getAcknowledge());
-							tm.tell(new SubmitTask(tdd2), getRef());
-							expectMsgEquals(Messages.getAcknowledge());
-
 							Future<Object> t1Running = Patterns.ask(
 									tm,
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(eid1),
@@ -411,6 +406,11 @@ public class TaskManagerTest {
 									tm,
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(eid2),
 									timeout);
+
+							tm.tell(new SubmitTask(tdd1), getRef());
+							expectMsgEquals(Messages.getAcknowledge());
+							tm.tell(new SubmitTask(tdd2), getRef());
+							expectMsgEquals(Messages.getAcknowledge());
 
 							Await.ready(t1Running, d);
 							Await.ready(t2Running, d);
@@ -522,12 +522,6 @@ public class TaskManagerTest {
 					@Override
 					protected void run() {
 						try {
-							tm.tell(new SubmitTask(tdd2), getRef());
-							tm.tell(new SubmitTask(tdd1), getRef());
-
-							expectMsgEquals(Messages.getAcknowledge());
-							expectMsgEquals(Messages.getAcknowledge());
-
 							Future<Object> t1Running = Patterns.ask(
 									tm,
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(eid1),
@@ -536,6 +530,12 @@ public class TaskManagerTest {
 									tm,
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(eid2),
 									timeout);
+
+							tm.tell(new SubmitTask(tdd2), getRef());
+							tm.tell(new SubmitTask(tdd1), getRef());
+
+							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Messages.getAcknowledge());
 
 							Await.ready(t1Running, d);
 							Await.ready(t2Running, d);

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.taskmanager.Task
 object TestingTaskManagerMessages {
   
   case class NotifyWhenTaskRemoved(executionID: ExecutionAttemptID)
+
+  case class NotifyWhenTaskIsRunning(executionID: ExecutionAttemptID)
   
   case class ResponseRunningTasks(tasks: Map[ExecutionAttemptID, Task]){
     import collection.JavaConverters._


### PR DESCRIPTION
The ```submitTask``` method which processes the ```SubmitTask``` message blocks while downloading the task jars from the ```JobManager```. Depending on the number of TMs and jars, this can take a long time. 

In order to get rid of the blocking call the ```submitTask``` method is split up into two phases: TDD reception with eager acknowledgement and TDD instantiation with a subsequent state update message. The TDD instantiation is executed concurrently in a future. Upon finishing the instantiation, an ```UpdateTaskExecutionState``` message with ```ExecutionState.RUNNING``` is sent to the JM. This implies that the state of the ```Execution``` is not directly set to ```RUNNING``` by the ```SubmitTask``` future handler which is created in ```Execution.deployToSlot```.