### PR TITLE
[FLINK-1937] [ml] Fixes sparse vector/matrix creation fromCOO with a single element

### DIFF
--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseMatrix.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseMatrix.scala
@@ -250,4 +250,18 @@ object SparseMatrix{
 
     new SparseMatrix(numRows, numCols, prunedRowIndices, colPtrs, prunedData)
   }
+
+  /** Convenience method to convert a single tuple with an integer value into a SparseMatrix.
+    * The problem is that providing a single tuple to the fromCOO method, the Scala type inference
+    * cannot infer that the tuple has to be of type (Int, Int, Double) because of the overloading
+    * with the Iterable type.
+    *
+    * @param numRows
+    * @param numCols
+    * @param entry
+    * @return
+    */
+  def fromCOO(numRows: Int, numCols: Int, entry: (Int, Int, Int)): SparseMatrix = {
+    fromCOO(numRows, numCols, (entry._1, entry._2, entry._3.toDouble))
+  }
 }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -178,4 +178,16 @@ object SparseVector {
 
     new SparseVector(size, indices, data)
   }
+
+  /** Convenience method to be able to instantiate a SparseVector with a single element. The Scala
+    * type inference mechanism cannot infer that the second tuple value has to be of type Double
+    * if only a single tuple is provided.
+    *
+    * @param size
+    * @param entry
+    * @return
+    */
+  def fromCOO(size: Int, entry: (Int, Int)): SparseVector = {
+    fromCOO(size, (entry._1, entry._2.toDouble))
+  }
 }

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseMatrixSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseMatrixSuite.scala
@@ -24,6 +24,19 @@ class SparseMatrixSuite extends FlatSpec with Matchers {
 
   behavior of "Flink's SparseMatrix"
 
+  it should "contain a single element provided as a coordinate list (COO)" in {
+    val sparseMatrix = SparseMatrix.fromCOO(4, 4, (0, 0, 1))
+
+    sparseMatrix(0, 0) should equal(1)
+
+    for(i <- 1 until sparseMatrix.size) {
+      val row = i / sparseMatrix.numCols
+      val col = i % sparseMatrix.numCols
+
+      sparseMatrix(row, col) should equal(0)
+    }
+  }
+
   it should "be initialized from a coordinate list representation (COO)" in {
     val data = List[(Int, Int, Double)]((0, 0, 0), (0, 1, 0), (3, 4, 43), (2, 1, 17),
       (3, 3, 88), (4 , 2, 99), (1, 4, 91), (3, 4, -1))

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
@@ -24,6 +24,16 @@ class SparseVectorSuite extends FlatSpec with Matchers {
 
   behavior of "Flink's SparseVector"
 
+  it should "contain a single element provided as coordinate list (COO)" in {
+    val sparseVector = SparseVector.fromCOO(3, (0, 1))
+
+    sparseVector(0) should equal(1)
+
+    for(index <- 1 until 3) {
+      sparseVector(index) should equal(0)
+    }
+  }
+
   it should "contain the initialization data provided as coordinate list (COO)" in {
     val data = List[(Int, Double)]((0, 1), (2, 0), (4, 42), (0, 3))
     val size = 5


### PR DESCRIPTION
The problem seems to be that Scala apparently cannot infer the correct type of a single tuple in the presence of the overloaded method with the ```Iterable``` type parameter. If one provides more than one element, then Scala knows that only the varargs method is applicable and thus infers that the tuples have to be of type ```(Int, Double)```.

One can solve this problem by specifying explicitly that the single tuple is of type ```(Int, Double)```. However, to ensure a nice user experience I added a special case method which takes a single tuple of type ```(Int, Int)``` and converts it into a ```(Int, Double)``` type.