### PR TITLE
[FLINK-1843] remove SoftReferences on archived ExecutionGraphs

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -292,7 +292,7 @@ class JobManager(val flinkConfiguration: Configuration,
           if (newJobStatus.isTerminalState) {
             jobInfo.end = timeStamp
 
-          // is the client waiting for the job result?
+            // is the client waiting for the job result?
             newJobStatus match {
               case JobStatus.FINISHED =>
                 val accumulatorResults: java.util.Map[String, SerializedValue[AnyRef]] = try {
@@ -326,7 +326,7 @@ class JobManager(val flinkConfiguration: Configuration,
           }
         case None =>
           removeJob(jobID)
-          }
+      }
 
     case msg: BarrierAck =>
       currentJobs.get(msg.jobID) match {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ArchiveMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ArchiveMessages.scala
@@ -34,6 +34,14 @@ object ArchiveMessages {
   case object RequestArchivedJobs
 
   /**
+   * Reqeuest a specific ExecutionGraph by JobID. The response is [[RequestArchivedJob]]
+   * @param jobID
+   */
+  case class RequestArchivedJob(jobID: JobID)
+
+  case class ArchivedJob(job: Option[ExecutionGraph])
+
+  /**
    * Response to [[RequestArchivedJobs]] message. The response contains the archived jobs.
    * @param jobs
    */

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingMemoryArchivist.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingMemoryArchivist.scala
@@ -34,7 +34,7 @@ trait TestingMemoryArchivist extends ActorLogMessages {
 
   def receiveTestingMessages: Receive = {
     case RequestExecutionGraph(jobID) =>
-      val executionGraph = getGraph(jobID)
+      val executionGraph = graphs.get(jobID)
       
       executionGraph match {
         case Some(graph) => sender ! ExecutionGraphFound(jobID, graph)


### PR DESCRIPTION
The previously introduced SoftReferences to store archived execution graphs cleared old graphs in a non-transparent order. This pull requests removes the SoftReferences and reverts back to keeping a fixed-sized list of old execution graphs.