### PR TITLE
 [scheduling] implement backtracking of intermediate results

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Backtracking.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Backtracking.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import akka.actor.ActorRef;
+import akka.dispatch.OnComplete;
+import akka.pattern.Patterns;
+import akka.util.Timeout;
+import com.google.common.base.Preconditions;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.messages.TaskMessages;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.Future;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+
+/**
+ * Backtracking is a mechanism to schedule only those Execution Vertices of an Execution Graph which
+ * do not have an intermediate result available. This is in contrast to the simple way of scheduling
+ * a job, where all Execution Vertices are executed starting from the source. The Backtracking starts
+ * from the sinks and traverses the Execution Graph to the sources. It only reaches the sources if
+ * no intermediate result could be found on the way.
+ *
+ * @see ExecutionGraph
+ * @see ExecutionVertex
+ * @see Execution
+ */
+public class Backtracking {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Backtracking.class);
+
+	private final Deque<TaskRequirement> taskRequirements = new ArrayDeque<TaskRequirement>();
+
+	private final Map<IntermediateResultPartitionID, Boolean> visitedPartitions = new HashMap<IntermediateResultPartitionID, Boolean>();
+
+	private ScheduleAction scheduleAction;
+	private Runnable postBacktrackingHook;
+	
+	public Backtracking(Collection<ExecutionJobVertex> vertices) {
+		Preconditions.checkNotNull(vertices);
+
+		// add all sinks found to the stack
+		for (ExecutionJobVertex ejv : vertices) {
+			if (ejv.getJobVertex().isOutputVertex()) {
+				for (ExecutionVertex ev : ejv.getTaskVertices()) {
+					if (ev.getExecutionState() == ExecutionState.CREATED) {
+						taskRequirements.add(new TaskRequirement(ev));
+					}
+				}
+			}
+		}
+
+		this.scheduleAction = new ScheduleAction() {
+			@Override
+			public void schedule(ExecutionVertex ev) {}
+		};
+
+		this.postBacktrackingHook = new Runnable() {
+			@Override
+			public void run() {}
+		};
+	}
+
+	/**
+	 * Scheduling to be performed when an ExecutionVertex is encountered that cannot be resumed
+	 */
+	public interface ScheduleAction {
+		void schedule(ExecutionVertex ev);
+	}
+
+	/**
+	 * A TaskRequirement encapsulates an ExecutionVertex and its IntermediateResultPartitions which
+	 * are required for execution.
+	 */
+	private class TaskRequirement {
+
+		private final ExecutionVertex executionVertex;
+		private final Deque<IntermediateResultPartition> pendingInputs = new ArrayDeque<IntermediateResultPartition>();
+		private final int numInputs;
+
+		private int availableInputs = 0;
+
+		public TaskRequirement(ExecutionVertex executionVertex) {
+			this.executionVertex = executionVertex;
+			this.pendingInputs.addAll(executionVertex.getInputs());
+			this.numInputs = pendingInputs.size();
+		}
+
+		public ExecutionVertex getExecutionVertex() {
+			return executionVertex;
+		}
+
+		public boolean pendingRequirements() {
+			Iterator<IntermediateResultPartition> iter = pendingInputs.iterator();
+			while (iter.hasNext()) {
+				Boolean visitedPartition = visitedPartitions.get(iter.next().getPartitionId());
+				if (visitedPartition == null) {
+					return true;
+				} else {
+					if (visitedPartition) {
+						availableInputs++;
+					}
+					iter.remove();
+				}
+			}
+			return false;
+		}
+
+		public IntermediateResultPartition getNextRequirement() {
+			return pendingInputs.pop();
+		}
+
+		public boolean needsToBeScheduled() {
+			return numInputs == availableInputs;
+		}
+
+		public void inputFound() {
+			availableInputs++;
+		}
+
+		@Override
+		public String toString() {
+			return "TaskRequirement{" +
+					"executionVertex=" + executionVertex +
+					", pendingInputs=" + pendingInputs.size() +
+					'}';
+		}
+	}
+
+	/**
+	 * Action to be performed on an ExecutionVertex when it is determined to be scheduled.
+	 * @param scheduleAction A ScheduleAction which receives an ExecutionVertex.
+	 */
+	public void setScheduleAction(ScheduleAction scheduleAction) {
+		Preconditions.checkNotNull(scheduleAction);
+		this.scheduleAction = scheduleAction;
+	}
+
+	/**
+	 * Hook executed after backtracking finishes. Note that because of the use of futures, this may
+	 * not be when the scheduleUsingBacktracking() method returns.
+	 * @param postBacktrackingHook A Runnable that is executed after backtracking finishes.
+	 */
+	public void setPostBacktrackingHook(Runnable postBacktrackingHook) {
+		Preconditions.checkNotNull(postBacktrackingHook);
+		this.postBacktrackingHook = postBacktrackingHook;
+	}
+
+	/* Visit the ExecutionGraph from the previously determined sinks using a pre-order depth-first
+	 * iterative traversal.
+	 */
+	public void scheduleUsingBacktracking() {
+
+		while (!taskRequirements.isEmpty()) {
+
+			final TaskRequirement taskRequirement = taskRequirements.peek();
+			final ExecutionVertex task = taskRequirement.getExecutionVertex();
+			task.getCurrentExecutionAttempt().setScheduled();
+
+			if (task.getExecutionState() != ExecutionState.CREATED && task.getExecutionState() != ExecutionState.DEPLOYING) {
+				LOG.debug("Resetting ExecutionVertex {} from {} to CREATED.", task, task.getExecutionState());
+				task.resetForNewExecution();
+				task.getCurrentExecutionAttempt().setScheduled();
+			}
+
+			if (taskRequirement.pendingRequirements()) {
+
+				final IntermediateResultPartition resultRequired = taskRequirement.getNextRequirement();
+
+				if (resultRequired.isLocationAvailable()) {
+					ActorRef taskManager = resultRequired.getLocation().getTaskManager();
+
+					LOG.debug("Requesting availability of IntermediateResultPartition " + resultRequired.getPartitionId());
+					// pin ResulPartition for this intermediate result
+					Future<Object> future = Patterns.ask(
+							taskManager,
+							new TaskMessages.LockResultPartition(
+									resultRequired.getPartitionId(),
+									// We lock this result for all consumers. We have to make sure
+									// to release it once a job finishes.
+									resultRequired.getNumConsumers()
+							),
+							Timeout.durationToTimeout(AkkaUtils.getDefaultTimeout())
+					);
+
+					/** BEGIN Asynchronous callback **/
+					future.onComplete(new OnComplete<Object>() {
+						@Override
+						public void onComplete(Throwable failure, Object success) {
+							if (success instanceof TaskMessages.LockResultPartitionReply &&
+									((TaskMessages.LockResultPartitionReply) success).locked()) {
+								LOG.debug("Resuming from IntermediateResultPartition " + resultRequired.getPartitionId());
+								visitedPartitions.put(resultRequired.getPartitionId(), true);
+								taskRequirement.inputFound();
+							} else {
+								// intermediate result not available
+								visitedPartitions.put(resultRequired.getPartitionId(), false);
+								taskRequirements.push(new TaskRequirement(resultRequired.getProducer()));
+							}
+							// TODO try again in case of errors?
+							// continue with backtracking
+							scheduleUsingBacktracking();
+						}
+					}, AkkaUtils.globalExecutionContext());
+					/** END Asynchronous callback **/
+
+					// interrupt backtracking here and continue once future is complete
+					return;
+
+				} else {
+					visitedPartitions.put(resultRequired.getPartitionId(), false);
+					taskRequirements.push(new TaskRequirement(resultRequired.getProducer()));
+				}
+
+			} else {
+				taskRequirements.pop();
+
+				if (taskRequirement.needsToBeScheduled()) {
+					scheduleAction.schedule(task);
+				}
+
+			}
+
+		}
+
+		LOG.debug("Finished backtracking.");
+		postBacktrackingHook.run();
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -244,7 +244,7 @@ public class ExecutionJobVertex implements Serializable {
 			}
 			
 			this.inputs.add(ires);
-			
+
 			int consumerIndex = ires.registerConsumer();
 			
 			for (int i = 0; i < parallelism; i++) {
@@ -257,7 +257,7 @@ public class ExecutionJobVertex implements Serializable {
 	//---------------------------------------------------------------------------------------------
 	//  Actions
 	//---------------------------------------------------------------------------------------------
-	
+
 	public void scheduleAll(Scheduler scheduler, boolean queued) throws NoResourceAvailableException {
 		
 		ExecutionVertex[] vertices = this.taskVertices;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -108,7 +108,8 @@ public class IntermediateResult {
 		numConsumers++;
 
 		for (IntermediateResultPartition p : partitions) {
-			if (p.addConsumerGroup() != index) {
+			int consumerGroupIndex = p.addConsumerGroup();
+			if (consumerGroupIndex != index && !resultType.isPersistent()) {
 				throw new RuntimeException("Inconsistent consumer mapping between intermediate result partitions.");
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -167,6 +167,8 @@ public class NetworkEnvironment {
 
 				LOG.debug("Starting result partition manager and network connection manager");
 				this.partitionManager = new ResultPartitionManager();
+				// inject partition manager
+				this.networkBufferPool.setResultPartitionManager(partitionManager);
 				this.taskEventDispatcher = new TaskEventDispatcher();
 				this.partitionConsumableNotifier = new JobManagerResultPartitionConsumableNotifier(
 													jobManagerRef, taskManagerRef, new Timeout(jobManagerTimeout));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -107,6 +107,9 @@ public class ResultPartition implements BufferPoolOwner {
 
 	private boolean hasNotifiedPipelinedConsumers;
 
+	/**
+	 * ResultPartition has been completely produced.
+	 */
 	private boolean isFinished;
 
 	// - Statistics ----------------------------------------------------------
@@ -209,6 +212,11 @@ public class ResultPartition implements BufferPoolOwner {
 	public long getTotalNumberOfBytes() {
 		return totalNumberOfBytes;
 	}
+
+	public boolean isFinished() {
+		return isFinished;
+	}
+
 
 	// ------------------------------------------------------------------------
 
@@ -402,4 +410,13 @@ public class ResultPartition implements BufferPoolOwner {
 			hasNotifiedPipelinedConsumers = true;
 		}
 	}
+
+	/**
+	 * Gets the type of the ResultPartition
+	 * @return ResultPartitionType
+	 */
+	public ResultPartitionType getPartitionType() {
+		return partitionType;
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionID.java
@@ -35,7 +35,7 @@ public final class ResultPartitionID implements Serializable {
 
 	private final IntermediateResultPartitionID partitionId;
 
-	private final ExecutionAttemptID producerId;
+	private ExecutionAttemptID producerId;
 
 	public ResultPartitionID() {
 		this(new IntermediateResultPartitionID(), new ExecutionAttemptID());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -28,6 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -40,8 +44,17 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ResultPartitionManager.class);
 
+	/**
+	 * Table of running/finished ResultPartitions with corresponding IDs
+	 */
 	public final Table<ExecutionAttemptID, IntermediateResultPartitionID, ResultPartition>
 			registeredPartitions = HashBasedTable.create();
+
+	/**
+	 * Cached ResultPartitions which are used to resume/recover from
+	 */
+	private final HashMap<IntermediateResultPartitionID, ResultPartition> cachedResultPartitions =
+			new LinkedHashMap<IntermediateResultPartitionID, ResultPartition>();
 
 	private boolean isShutdown;
 
@@ -88,7 +101,8 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 					registeredPartitions.row(executionId);
 
 			for (ResultPartition partition : partitions.values()) {
-				partition.release();
+				// move to cache if cachable
+				updateIntermediateResultPartitionCache(partition);
 			}
 
 			for (IntermediateResultPartitionID partitionId : ImmutableList
@@ -98,6 +112,26 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 			}
 
 			LOG.debug("Released all partitions produced by {}.", executionId);
+		}
+	}
+
+	/**
+	 * Moves a produced ResultPartition to a the cache where it can be retrieved and put back
+	 * to the registeredPartitions later on.
+	 * @param partition
+	 */
+	public void updateIntermediateResultPartitionCache(ResultPartition partition) {
+		synchronized (cachedResultPartitions) {
+			// cache only persistent results
+			if (partition.isFinished() && partition.getPartitionType().isPersistent()) {
+				IntermediateResultPartitionID intermediateResultPartitionID = partition.getPartitionId().getPartitionId();
+				// remove if already registered
+				cachedResultPartitions.remove(intermediateResultPartitionID);
+				// add as most recently inserted element
+				cachedResultPartitions.put(intermediateResultPartitionID, partition);
+			} else {
+				partition.release();
+			}
 		}
 	}
 
@@ -119,10 +153,50 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 		}
 	}
 
+	/**
+	 * Registers and pins a cached ResultPartition that holds the data for an IntermediateResultPartition.
+	 * @param partitionID The IntermediateResultPartitionID to find a corresponding ResultPartition for.
+	 * @param numConsumers The number of consumers that want to access the ResultPartition
+	 * @return true if the registering/pinning succeeded, false otherwise.
+	 */
+	public boolean pinCachedResultPartition(IntermediateResultPartitionID partitionID, int numConsumers) {
+		synchronized (cachedResultPartitions) {
+			ResultPartition resultPartition = cachedResultPartitions.get(partitionID);
+			if (resultPartition != null) {
+				try {
+					// update its least recently used value
+					updateIntermediateResultPartitionCache(resultPartition);
+
+					synchronized (registeredPartitions) {
+						if (!registeredPartitions.containsValue(resultPartition)) {
+							LOG.debug("Registered previously cached ResultPartition {}.", resultPartition);
+							registerResultPartition(resultPartition);
+						}
+					}
+
+					for (int i = 0; i < numConsumers; i++) {
+						resultPartition.pin();
+					}
+
+					LOG.debug("Pinned the ResultPartition {} for the intermediate result {}.", resultPartition, partitionID);
+					return true;
+				} catch (IOException e) {
+					throw new IllegalStateException("Failed to pin the ResultPartition for the intermediate result partition " + partitionID);
+				}
+			}
+			return false;
+		}
+	}
+
+
 	// ------------------------------------------------------------------------
 	// Notifications
 	// ------------------------------------------------------------------------
 
+	/**
+	 * Notification from a @link{ResultPartition} when no pending references exist anymore
+	 * @param partition
+	 */
 	void onConsumedPartition(ResultPartition partition) {
 		final ResultPartition previous;
 
@@ -137,9 +211,46 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 
 		// Release the partition if it was successfully removed
 		if (partition == previous) {
-			partition.release();
+			// move to cache if cachable
+			updateIntermediateResultPartitionCache(partition);
 
-			LOG.debug("Released {}.", partition);
+			LOG.debug("Cached {}.", partition);
+		}
+	}
+
+	/**
+	 * Triggered by @link{NetworkBufferPool} when network buffers should be freed
+	 * @param requiredBuffers The number of buffers that should be cleared.
+	 */
+	public boolean releaseLeastRecentlyUsedCachedPartitions (int requiredBuffers) {
+		synchronized (cachedResultPartitions) {
+			// make a list of ResultPartitions to release
+			List<ResultPartition> toBeReleased = new ArrayList<ResultPartition>();
+			int numBuffersToBeFreed = 0;
+
+			// traverse from least recently used cached ResultPartition
+			for (Map.Entry<IntermediateResultPartitionID, ResultPartition> entry : cachedResultPartitions.entrySet()) {
+				ResultPartition cachedResult = entry.getValue();
+
+				synchronized (registeredPartitions) {
+					if (!registeredPartitions.containsValue(cachedResult)) {
+						if (numBuffersToBeFreed < requiredBuffers) {
+							toBeReleased.add(cachedResult);
+							numBuffersToBeFreed += cachedResult.getTotalNumberOfBuffers();
+						}
+					}
+				}
+
+				// check if we reached the desired number of buffers
+				if (numBuffersToBeFreed >= requiredBuffers) {
+					for (ResultPartition result : toBeReleased) {
+						result.release();
+						cachedResultPartitions.remove(entry.getKey());
+					}
+					return true;
+				}
+			}
+			return false;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -71,6 +71,11 @@ public abstract class ResultSubpartition {
 
 	abstract public void finish() throws IOException;
 
+	/**
+	 * Releases the memory of the SubPartiton.
+	 * Should only be called by the parenting ResultPartition.
+	 * @throws IOException
+	 */
 	abstract public void release() throws IOException;
 
 	abstract public ResultSubpartitionView createReadView(BufferProvider bufferProvider) throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/AbstractJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/AbstractJobVertex.java
@@ -52,6 +52,9 @@ public class AbstractJobVertex implements java.io.Serializable {
 	/** List of edges with incoming data. One per Reader. */
 	private final ArrayList<JobEdge> inputs = new ArrayList<JobEdge>();
 
+	/** Indicator whether this vertex reads directly from an intermediate result */
+	private boolean resumesFromIntermediateResult = false;
+
 	/** Number of subtasks to split this task into at runtime.*/
 	private int parallelism = -1;
 
@@ -364,7 +367,7 @@ public class AbstractJobVertex implements java.io.Serializable {
 	public boolean isOutputVertex() {
 		return this.results.isEmpty();
 	}
-	
+
 	public boolean hasNoConnectedInputs() {
 		for (JobEdge edge : inputs) {
 			if (!edge.isIdReference()) {
@@ -373,6 +376,14 @@ public class AbstractJobVertex implements java.io.Serializable {
 		}
 		
 		return true;
+	}
+
+	public void setResumeFromIntermediateResult() {
+		this.resumesFromIntermediateResult = true;
+	}
+
+	public boolean resumesFromIntermediateResult() {
+		return this.resumesFromIntermediateResult;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobEdge.java
@@ -34,7 +34,10 @@ public class JobEdge implements java.io.Serializable {
 	/** The distribution pattern that should be used for this job edge. */
 	private final DistributionPattern distributionPattern;
 	
-	/** The data set at the source of the edge, may be null if the edge is not yet connected*/
+	/**
+	 *  The data set at the source of the edge, may be null if the edge is not yet connected
+	 *  or this edge belong to a Source
+	 */
 	private IntermediateDataSet source;
 	
 	/** The id of the source intermediate data set */
@@ -111,9 +114,13 @@ public class JobEdge implements java.io.Serializable {
 	public IntermediateDataSetID getSourceId() {
 		return sourceId;
 	}
-	
+
+	/**
+	 * Returns true if this edge is simply referenced by an id and not by a produced intermediate result
+	 * @return
+	 */
 	public boolean isIdReference() {
-		return this.source == null;
+		return this.source == null && this.sourceId != null;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -303,7 +303,7 @@ public class JobGraph implements Serializable {
 			while (iter.hasNext()) {
 				AbstractJobVertex vertex = iter.next();
 				
-				if (vertex.hasNoConnectedInputs()) {
+				if (vertex.isInputVertex() || vertex.resumesFromIntermediateResult()) {
 					sorted.add(vertex);
 					iter.remove();
 				}
@@ -455,6 +455,16 @@ public class JobGraph implements Serializable {
 			if (bc != null) {
 				bc.close();
 			}
+		}
+	}
+
+	/**
+	 * Sets the default parallelism of all job vertices in this JobGraph.
+	 * @param parallelism
+	 */
+	public void setParallelism(int parallelism) {
+		for (AbstractJobVertex ejv : taskVertices.values()) {
+			ejv.setParallelism(parallelism);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
@@ -43,7 +43,7 @@ public enum JobStatus {
 
 	/** All of the job's tasks have successfully finished. */
 	FINISHED(true),
-	
+
 	/** The job is currently undergoing a reset and total restart */
 	RESTARTING(false);
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
@@ -25,6 +25,9 @@ public enum ScheduleMode {
 	 */
 	FROM_SOURCES,
 
+	/**
+	 * Schedule tasks with backtracking from the sinks towards the sources.
+	 */
 	BACKTRACKING,
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -112,7 +112,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 			return (SimpleSlot) ret;
 		}
 		else {
-			throw new RuntimeException();
+			throw new RuntimeException("Failed to schedule task immediately.");
 		}
 	}
 	
@@ -125,7 +125,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 			return (SlotAllocationFuture) ret;
 		}
 		else {
-			throw new RuntimeException();
+			throw new RuntimeException("Failed to schedule task queued.");
 		}
 	}
 	

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -100,9 +100,8 @@ class JobManager(val flinkConfiguration: Configuration,
                  val timeout: FiniteDuration)
   extends Actor with ActorLogMessages with ActorSynchronousLogging {
 
-  /** List of current jobs running jobs */
-  val currentJobs = scala.collection.mutable.HashMap[JobID, (ExecutionGraph, JobInfo)]()
-
+  /** Last job (for others see [[MemoryArchivist]] */
+  var currentJob: Option[(ExecutionGraph, JobInfo)] = None
 
   /**
    * Run when the job manager is started. Simply logs an informational message.
@@ -121,8 +120,10 @@ class JobManager(val flinkConfiguration: Configuration,
 
     archive ! PoisonPill
 
-    for((e,_) <- currentJobs.values) {
-      e.fail(new Exception("The JobManager is shutting down."))
+    currentJob match {
+      case Some((graph, f)) =>
+        graph.fail(new Exception("The JobManager is shutting down."))
+      case None =>
     }
 
     instanceManager.shutdown()
@@ -191,8 +192,8 @@ class JobManager(val flinkConfiguration: Configuration,
     case CancelJob(jobID) =>
       log.info(s"Trying to cancel job with ID $jobID.")
 
-      currentJobs.get(jobID) match {
-        case Some((executionGraph, _)) =>
+      currentJob match {
+        case Some((executionGraph, _)) if executionGraph.getJobID == jobID =>
           // execute the cancellation asynchronously
           Future {
             executionGraph.cancel()
@@ -209,12 +210,12 @@ class JobManager(val flinkConfiguration: Configuration,
       if (taskExecutionState == null) {
         sender ! false
       } else {
-        currentJobs.get(taskExecutionState.getJobID) match {
-          case Some((executionGraph, _)) =>
+        currentJob match {
+          case Some((graph, _)) if graph.getJobID == taskExecutionState.getJobID =>
             val originalSender = sender()
 
             Future {
-              val result = executionGraph.updateState(taskExecutionState)
+              val result = graph.updateState(taskExecutionState)
               originalSender ! result
             }(context.dispatcher)
 
@@ -227,8 +228,8 @@ class JobManager(val flinkConfiguration: Configuration,
       }
 
     case RequestNextInputSplit(jobID, vertexID, executionAttempt) =>
-      val serializedInputSplit = currentJobs.get(jobID) match {
-        case Some((executionGraph,_)) =>
+      val serializedInputSplit = currentJob match {
+        case Some((executionGraph,_)) if executionGraph.getJobID == jobID =>
           val execution = executionGraph.getRegisteredExecutions.get(executionAttempt)
 
           if (execution == null) {
@@ -279,8 +280,9 @@ class JobManager(val flinkConfiguration: Configuration,
       sender ! NextInputSplit(serializedInputSplit)
 
     case JobStatusChanged(jobID, newJobStatus, timeStamp, error) =>
-      currentJobs.get(jobID) match {
-        case Some((executionGraph, jobInfo)) => executionGraph.getJobName
+      currentJob match {
+        case Some((executionGraph, jobInfo)) if executionGraph.getJobID == jobID =>
+          executionGraph.getJobName
           log.info(s"Status of job $jobID (${executionGraph.getJobName}) changed to $newJobStatus" +
             s" ${if (error == null) "" else error.getMessage}.")
 
@@ -316,29 +318,27 @@ class JobManager(val flinkConfiguration: Configuration,
                 throw exception
             }
 
-            removeJob(jobID)
-
           }
         case None =>
-          removeJob(jobID)
+          removeCurrentJob()
       }
 
     case msg: BarrierAck =>
-      currentJobs.get(msg.jobID) match {
-        case Some(jobExecution) =>
-          jobExecution._1.getStateCheckpointerActor forward  msg
+      currentJob match {
+        case Some((executionGraph, jobInfo)) if executionGraph.getJobID == msg.jobID =>
+          executionGraph.getStateCheckpointerActor forward  msg
         case None =>
       }
     case msg: StateBarrierAck =>
-      currentJobs.get(msg.jobID) match {
-        case Some(jobExecution) =>
-          jobExecution._1.getStateCheckpointerActor forward  msg
+      currentJob match {
+        case Some((executionGraph, jobInfo)) if executionGraph.getJobID == msg.jobID =>
+          executionGraph.getStateCheckpointerActor forward  msg
         case None =>
       }
 
     case ScheduleOrUpdateConsumers(jobId, partitionId) =>
-      currentJobs.get(jobId) match {
-        case Some((executionGraph, _)) =>
+      currentJob match {
+        case Some((executionGraph, _)) if executionGraph.getJobID == jobId  =>
           sender ! Acknowledge
           executionGraph.scheduleOrUpdateConsumers(partitionId)
         case None =>
@@ -349,25 +349,28 @@ class JobManager(val flinkConfiguration: Configuration,
       }
 
     case RequestJobStatus(jobID) =>
-      currentJobs.get(jobID) match {
-        case Some((executionGraph,_)) => sender ! CurrentJobStatus(jobID, executionGraph.getState)
+      currentJob match {
+        case Some((executionGraph,_)) if executionGraph.getJobID == jobID =>
+          sender ! CurrentJobStatus(jobID, executionGraph.getState)
         case None =>
           // check the archive
           archive forward RequestJobStatus(jobID)
       }
 
     case RequestRunningJobs =>
-      val executionGraphs = currentJobs map {
-        case (_, (eg, jobInfo)) => eg
+      val executionGraph = currentJob match {
+        case Some((eg, jobInfo)) => Seq(eg)
+        case None => Seq()
       }
 
-      sender ! RunningJobs(executionGraphs)
+      sender ! RunningJobs(executionGraph)
 
     case RequestRunningJobsStatus =>
       try {
-        val jobs = currentJobs map {
-          case (_, (eg, _)) => new JobStatusMessage(eg.getJobID, eg.getJobName,
-                                            eg.getState, eg.getStatusTimestamp(JobStatus.CREATED))
+        val jobs = currentJob match {
+          case Some((eg, _)) => Seq(new JobStatusMessage(eg.getJobID, eg.getJobName,
+                                            eg.getState, eg.getStatusTimestamp(JobStatus.CREATED)))
+          case None => Seq()
         }
 
         sender ! RunningJobsStatus(jobs)
@@ -377,8 +380,9 @@ class JobManager(val flinkConfiguration: Configuration,
       }
 
     case RequestJob(jobID) =>
-      currentJobs.get(jobID) match {
-        case Some((eg, _)) => sender ! JobFound(jobID, eg)
+      currentJob match {
+        case Some((eg, _)) if eg.getJobID == jobID  =>
+          sender ! JobFound(jobID, eg)
         case None =>
           // check the archive
           archive forward RequestJob(jobID)
@@ -470,11 +474,20 @@ class JobManager(val flinkConfiguration: Configuration,
           throw new JobSubmissionException(jobId, "The given job is empty")
         }
 
-        // see if there already exists an ExecutionGraph for the corresponding job ID
-        executionGraph = currentJobs.getOrElseUpdate(jobGraph.getJobID,
-          (new ExecutionGraph(jobGraph.getJobID, jobGraph.getName,
-            jobGraph.getJobConfiguration, timeout, jobGraph.getUserJarBlobKeys, userCodeLoader),
-            JobInfo(sender(), System.currentTimeMillis())))._1
+        executionGraph = currentJob match {
+          case Some((graph, _)) if !graph.getState.isTerminalState =>
+              throw new Exception("Job still running")
+          case Some((graph, _)) if graph.getJobID == jobId =>
+            // resume here
+            graph
+          case _ =>
+            removeCurrentJob()
+            val newGraph = new ExecutionGraph(jobGraph.getJobID, jobGraph.getName,
+              jobGraph.getJobConfiguration, timeout, jobGraph.getUserJarBlobKeys, userCodeLoader)
+            val newJobInfo = JobInfo(sender(), System.currentTimeMillis())
+            currentJob = Option(newGraph, newJobInfo)
+            newGraph
+        }
 
         // configure the execution graph
         val jobNumberRetries = if (jobGraph.getNumberOfExecutionRetries >= 0) {
@@ -551,7 +564,7 @@ class JobManager(val flinkConfiguration: Configuration,
           log.error(s"Failed to submit job ${jobId} (${jobName})", t)
 
           libraryCacheManager.unregisterJob(jobId)
-          currentJobs.remove(jobId)
+          currentJob = None
 
           if (executionGraph != null) {
             executionGraph.fail(t)
@@ -656,15 +669,23 @@ class JobManager(val flinkConfiguration: Configuration,
 
   /**
    * Removes the job and sends it to the MemoryArchivist
-   * @param jobID ID of the job to remove and archive
    */
-  private def removeJob(jobID: JobID): Unit = {
-    currentJobs.remove(jobID) match {
-      case Some((eg, _)) =>
+  private def removeCurrentJob(): Unit = {
+    currentJob match {
+      case Some((eg, _))  =>
+        currentJob = None
         try {
           eg.prepareForArchiving()
 
-          archive ! ArchiveExecutionGraph(jobID, eg)
+          archive ! ArchiveExecutionGraph(eg.getJobID, eg)
+
+          val jobID = eg.getJobID
+          try {
+            libraryCacheManager.unregisterJob(eg.getJobID)
+          } catch {
+            case t: Throwable =>
+              log.error(s"Could not properly unregister job $jobID form the library cache.", t)
+          }
         } catch {
           case t: Throwable => log.error(s"Could not prepare the execution graph $eg for " +
             "archiving.", t)
@@ -673,12 +694,7 @@ class JobManager(val flinkConfiguration: Configuration,
       case None =>
     }
 
-    try {
-      libraryCacheManager.unregisterJob(jobID)
-    } catch {
-      case t: Throwable =>
-        log.error(s"Could not properly unregister job $jobID form the library cache.", t)
-    }
+
   }
 }
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -157,8 +157,8 @@ object JobManagerMessages {
   case object RequestRunningJobs
 
   /**
-   * This message is the response to the [[RequestRunningJobs]] message. It contains all
-   * execution graphs of the currently running jobs.
+   * This message is the response to the [[RequestRunningJobs]] message. It contains the
+   * ExecutionGraph of the running job.
    */
   case class RunningJobs(runningJobs: Iterable[ExecutionGraph]) {
     def this() = this(Seq())

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.messages
 
 import org.apache.flink.runtime.instance.InstanceID
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID
 
 /**
  * Miscellaneous actor messages exchanged with the TaskManager.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.messages
 
 import org.apache.flink.runtime.deployment.{TaskDeploymentDescriptor, InputChannelDeploymentDescriptor}
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID
+import org.apache.flink.runtime.jobgraph.{IntermediateResultPartitionID, IntermediateDataSetID}
 import org.apache.flink.runtime.taskmanager.TaskExecutionState
 
 /**
@@ -117,6 +117,21 @@ object TaskMessages {
   case class FailIntermediateResultPartitions(executionID: ExecutionAttemptID)
     extends TaskMessage
 
+  /**
+   * Check availability of an intermediate result partition
+   * @param partitionID id of intermediate result to be locked
+   * @param numConsumers the number of consumers that want to access this intermediate result
+   */
+  case class LockResultPartition(partitionID: IntermediateResultPartitionID, numConsumers: Int)
+    extends TaskMessage
+
+  /**
+   * Pin/lock an ResultPartition for resuming
+   * @param locked true if ResultPartition for the requested IntermediateResultPartition
+   *               is available
+   */
+  case class LockResultPartitionReply(locked: Boolean)
+    extends TaskMessage
 
   // --------------------------------------------------------------------------
   //  Report Messages

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -78,10 +78,12 @@ public class ExecutionVertexSchedulingTest {
 			
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
+			vertex.getCurrentExecutionAttempt().setScheduled();
 			vertex.scheduleForExecution(scheduler, false);
 			
 			// will have failed
 			assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
+			vertex.getCurrentExecutionAttempt().setScheduled();
 			assertTrue(slot.isReleased());
 		}
 		catch (Exception e) {
@@ -111,6 +113,7 @@ public class ExecutionVertexSchedulingTest {
 			
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
+			vertex.getCurrentExecutionAttempt().setScheduled();
 			vertex.scheduleForExecution(scheduler, true);
 			
 			// future has not yet a slot
@@ -148,6 +151,7 @@ public class ExecutionVertexSchedulingTest {
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 
 			// try to deploy to the slot
+			vertex.getCurrentExecutionAttempt().setScheduled();
 			vertex.scheduleForExecution(scheduler, false);
 			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
@@ -128,5 +128,4 @@ public class BufferPoolFactoryTest {
 
 		assertEquals(networkBufferPool.getTotalNumberOfMemorySegments(), second.getNumBuffers());
 	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManagerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertFalse;
+
+public class ResultPartitionManagerTest {
+
+	@Test
+	public void testFreeCachedResultPartitions() {
+		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
+
+		ResultPartition resultPartition1 = Mockito.mock(ResultPartition.class);
+		ResultPartition resultPartition2 = Mockito.mock(ResultPartition.class);
+		ResultPartition resultPartition3 = Mockito.mock(ResultPartition.class);
+
+		ResultPartitionID partitionID1 = new ResultPartitionID();
+		ResultPartitionID partitionID2 = new ResultPartitionID();
+		ResultPartitionID partitionID3 = new ResultPartitionID();
+
+		Mockito.when(resultPartition1.getPartitionId()).thenReturn(partitionID1);
+		Mockito.when(resultPartition1.isFinished()).thenReturn(true);
+		Mockito.when(resultPartition1.getPartitionType()).thenReturn(ResultPartitionType.BLOCKING);
+		Mockito.when(resultPartition1.getTotalNumberOfBuffers()).thenReturn(5);
+
+
+		Mockito.when(resultPartition2.getPartitionId()).thenReturn(partitionID2);
+		Mockito.when(resultPartition2.isFinished()).thenReturn(true);
+		Mockito.when(resultPartition2.getPartitionType()).thenReturn(ResultPartitionType.BLOCKING);
+		Mockito.when(resultPartition2.getTotalNumberOfBuffers()).thenReturn(3);
+
+
+		Mockito.when(resultPartition3.getPartitionId()).thenReturn(partitionID3);
+		Mockito.when(resultPartition3.isFinished()).thenReturn(true);
+		Mockito.when(resultPartition3.getPartitionType()).thenReturn(ResultPartitionType.BLOCKING);
+		Mockito.when(resultPartition3.getTotalNumberOfBuffers()).thenReturn(2);
+
+		try {
+			resultPartitionManager.registerResultPartition(resultPartition1);
+			resultPartitionManager.registerResultPartition(resultPartition2);
+			resultPartitionManager.registerResultPartition(resultPartition3);
+		} catch (IOException e) {
+			e.printStackTrace();
+			fail("failed to register ResultPartition");
+		}
+
+		resultPartitionManager.releasePartitionsProducedBy(partitionID1.getProducerId());
+		resultPartitionManager.releasePartitionsProducedBy(partitionID2.getProducerId());
+		resultPartitionManager.releasePartitionsProducedBy(partitionID3.getProducerId());
+
+		assertFalse(resultPartitionManager.releaseLeastRecentlyUsedCachedPartitions(10000));
+		assertFalse(resultPartitionManager.releaseLeastRecentlyUsedCachedPartitions(11));
+		assertTrue(resultPartitionManager.releaseLeastRecentlyUsedCachedPartitions(10));
+		assertFalse(resultPartitionManager.releaseLeastRecentlyUsedCachedPartitions(10));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/BacktrackingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/BacktrackingTest.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.scheduler;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.UntypedActor;
+import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.instance.Instance;
+import org.apache.flink.runtime.instance.InstanceConnectionInfo;
+import org.apache.flink.runtime.instance.InstanceDiedException;
+import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.InputFormatVertex;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OutputFormatVertex;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobmanager.Tasks;
+import org.apache.flink.runtime.messages.TaskMessages;
+import org.apache.flink.runtime.messages.TaskMessages.*;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BacktrackingTest {
+
+	public static ActorSystem system;
+
+	/**
+	 * TaskManager stub which acknowledges/denies the availability of IntermediateResults
+	 */
+	public static class TestTaskManager extends UntypedActor {
+
+		ActorRef testEnvironment;
+		private Set<IntermediateResultPartitionID> availableResults = new HashSet<IntermediateResultPartitionID>();
+
+		public TestTaskManager(ActorRef testEnvironment) {
+			this.testEnvironment = testEnvironment;
+		}
+
+		@Override
+		public void onReceive(Object msg) throws Exception {
+
+			if (msg instanceof TaskMessages.SubmitTask) {
+				//System.out.println("task submitted: " + msg);
+				testEnvironment.forward(msg, getContext());
+
+			} else if (msg instanceof IntermediateResultPartitionID) {
+				// collect all intermediate results ids sent by the testing system
+				availableResults.add((IntermediateResultPartitionID) msg);
+
+			} else if (msg instanceof LockResultPartition) {
+				LockResultPartition unpacked = ((LockResultPartition) msg);
+				IntermediateResultPartitionID partitionID = unpacked.partitionID();
+				System.out.println("intermediate partition requested: " + partitionID);
+				if (availableResults.contains(partitionID)) {
+					System.out.println("acknowledging result: " + partitionID);
+					getSender().tell(new LockResultPartitionReply(true), getSelf());
+				} else {
+					System.out.println("denying result: " + partitionID);
+					getSender().tell(new LockResultPartitionReply(false), getSelf());
+				}
+				testEnvironment.forward(msg, getContext());
+
+			} else {
+				System.out.println("Unknown msg " + msg);
+			}
+		}
+
+	}
+
+	@Before
+	public void setup(){
+		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
+		TestingUtils.setCallingThreadDispatcher(system);
+	}
+
+	@After
+	public void teardown(){
+		TestingUtils.setGlobalExecutionContext();
+		JavaTestKit.shutdownActorSystem(system);
+	}
+
+	private AbstractJobVertex createNode(String name) {
+		AbstractJobVertex abstractJobVertex = new AbstractJobVertex(name);
+		abstractJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		return abstractJobVertex;
+	}
+
+	private AbstractJobVertex createOutputNode(String name) {
+		AbstractJobVertex abstractJobVertex = new OutputFormatVertex(name);
+		abstractJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		return abstractJobVertex;
+	}
+
+	private AbstractJobVertex createInputNode(String name) {
+		AbstractJobVertex abstractJobVertex = new InputFormatVertex(name);
+		abstractJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		return abstractJobVertex;
+	}
+
+	@Test
+	public void testBacktrackingIntermediateResults() throws InstanceDiedException, NoResourceAvailableException {
+		final JobID jobId = new JobID();
+		final String jobName = "Test Job Sample Name";
+		final Configuration cfg = new Configuration();
+
+		// JobVertex which has intermediate results available
+		final AbstractJobVertex resumePoint;
+
+        /*
+               sink1         sink2
+                 O             O
+                 ^             ^
+                ´ `           ´ `
+               ´   `         ´   `
+             _´     `_     _´     `_
+             O       O     O       O    <---- resume starts here
+             ^       ^     ^       ^
+              `     ´       `     ´
+               `   ´         `   ´
+                `_´           `_´
+                 O             O    <----- result available
+                 ^             ^
+                  `           ´
+                   `         ´
+                    `       ´
+                     `     ´
+                      `   ´
+                       `_´
+                        O
+                     source
+        */
+
+		// topologically sorted list
+		final List<AbstractJobVertex> list = new ArrayList<AbstractJobVertex>();
+
+		final AbstractJobVertex source = createInputNode("source1");
+		list.add(source);
+
+		AbstractJobVertex node1 = createOutputNode("sink1");
+		{
+			AbstractJobVertex child1 = createNode("sink1-child1");
+			AbstractJobVertex child2 = createNode("sink1-child2");
+			node1.connectNewDataSetAsInput(child1, DistributionPattern.ALL_TO_ALL);
+			node1.connectNewDataSetAsInput(child2, DistributionPattern.ALL_TO_ALL);
+
+			AbstractJobVertex child1child2child = createNode("sink1-child1-child2-child");
+			child1.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+			child2.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+
+			child1child2child.connectNewDataSetAsInput(source, DistributionPattern.ALL_TO_ALL);
+
+			list.add(child1child2child);
+			list.add(child1);
+			list.add(child2);
+		}
+
+		AbstractJobVertex node2 = createOutputNode("sink2");
+		final AbstractJobVertex child1 = createNode("sink2-child1");
+		final AbstractJobVertex child2 = createNode("sink2-child2");
+		node2.connectNewDataSetAsInput(child1, DistributionPattern.ALL_TO_ALL);
+		node2.connectNewDataSetAsInput(child2, DistributionPattern.ALL_TO_ALL);
+
+		// resume from this node
+		AbstractJobVertex child1child2child = createNode("sink1-child1-child2-child");
+		resumePoint = child1child2child;
+
+		child1.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+		child2.connectNewDataSetAsInput(child1child2child, DistributionPattern.ALL_TO_ALL);
+
+		child1child2child.connectNewDataSetAsInput(source, DistributionPattern.ALL_TO_ALL);
+
+		list.add(child1child2child);
+		list.add(child1);
+		list.add(child2);
+
+		list.add(node1);
+		list.add(node2);
+
+		final ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+
+		new JavaTestKit(system) {
+			{
+
+				final Props props = Props.create(TestTaskManager.class, getRef());
+				final ActorRef taskManagerActor = system.actorOf(props);
+
+				eg.setScheduleMode(ScheduleMode.BACKTRACKING);
+
+				try {
+					eg.attachJobGraph(list);
+				} catch (JobException e) {
+					e.printStackTrace();
+					fail("Job failed with exception: " + e.getMessage());
+				}
+
+				// list if of partition that should be requested
+				final Set<IntermediateResultPartitionID> requestedPartitions = new HashSet<IntermediateResultPartitionID>();
+
+				for (ExecutionJobVertex ejv : eg.getAllVertices().values()) {
+					for (IntermediateResult result : ejv.getInputs()) {
+						for (IntermediateResultPartition partition : result.getPartitions()) {
+							if (result.getProducer().getJobVertex() == resumePoint) {
+								// mock an instance
+								Instance mockInstance = Mockito.mock(Instance.class);
+								Mockito.when(mockInstance.isAlive()).thenReturn(true);
+								Mockito.when(mockInstance.getTaskManager()).thenReturn(taskManagerActor);
+								InstanceConnectionInfo instanceConnectionInfo = new InstanceConnectionInfo();
+								Mockito.when(mockInstance.getInstanceConnectionInfo()).thenReturn(instanceConnectionInfo);
+								// set the mock as a location
+								partition.getProducer().getCurrentExecutionAttempt().setResultPartitionLocation(mockInstance);
+								// send the tests actor ref to the TestTaskManager to receive messages
+								taskManagerActor.tell(partition.getPartitionId(), getRef());
+								requestedPartitions.add(partition.getPartitionId());
+							}
+						}
+					}
+				}
+
+				final Set<JobVertexID> schedulePoints = new HashSet<JobVertexID>();
+				// list of execution vertices to be scheduled
+				schedulePoints.add(child1.getID());
+				schedulePoints.add(child2.getID());
+				schedulePoints.add(source.getID());
+
+				final Scheduler scheduler = new Scheduler();//Mockito.mock(Scheduler.class);
+
+				Instance i1 = null;
+				try {
+					i1 = ExecutionGraphTestUtils.getInstance(taskManagerActor, 10);
+				} catch (Exception e) {
+					e.printStackTrace();
+					fail("Couldn't get instance: " + e.getMessage());
+				}
+
+				scheduler.newInstanceAvailable(i1);
+
+				try {
+					eg.scheduleForExecution(scheduler);
+				} catch (JobException e) {
+					e.printStackTrace();
+					fail();
+				}
+
+				new Within(duration("5 seconds")) {
+					@Override
+					protected void run() {
+						Object[] messages = receiveN(schedulePoints.size() + requestedPartitions.size());
+						for (Object msg : messages) {
+							if (msg instanceof LockResultPartition) {
+								LockResultPartition msg1 = (LockResultPartition) msg;
+								assertTrue("Available partition should have been requested.",
+										requestedPartitions.contains(msg1.partitionID()));
+							} else if (msg instanceof SubmitTask) {
+								SubmitTask msg1 = (SubmitTask) msg;
+								assertTrue("These nodes should have been scheduled",
+										schedulePoints.contains(msg1.tasks().getVertexID()));
+							} else {
+								fail("Unexpected message");
+							}
+						}
+					}
+				};
+
+			}
+		};
+	}
+
+	@Test
+	public void testMassiveExecutionGraphExecutionVertexScheduling() {
+
+		final JobID jobId = new JobID();
+		final String jobName = "Test Job Sample Name";
+		final Configuration cfg = new Configuration();
+
+		final int numSinks = 10;
+		final int depth = 50;
+		final int parallelism = 100;
+
+		//Random rand = new Random(System.currentTimeMillis());
+
+		LinkedList<AbstractJobVertex> allNodes = new LinkedList<AbstractJobVertex>();
+
+		for (int s = 0; s < numSinks; s++) {
+			AbstractJobVertex node = new OutputFormatVertex("sink" + s);
+			node.setInvokableClass(Tasks.NoOpInvokable.class);
+
+			//node.setParallelism(rand.nextInt(maxParallelism) + 1);
+			node.setParallelism(parallelism);
+			allNodes.addLast(node);
+
+			for (int i = 0; i < depth; i++) {
+				AbstractJobVertex other = new AbstractJobVertex("vertex" + i + " sink" + s);
+				other.setParallelism(parallelism);
+				other.setInvokableClass(Tasks.NoOpInvokable.class);
+				node.connectNewDataSetAsInput(other, DistributionPattern.ALL_TO_ALL);
+				allNodes.addFirst(other);
+				node = other;
+			}
+
+		}
+
+		final ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+
+		eg.setScheduleMode(ScheduleMode.BACKTRACKING);
+
+		try {
+			eg.attachJobGraph(allNodes);
+		} catch (JobException e) {
+			e.printStackTrace();
+			fail("Job failed with exception: " + e.getMessage());
+		}
+
+		new JavaTestKit(system) {
+			{
+
+				final Props props = Props.create(TestTaskManager.class, getRef());
+				final ActorRef taskManagerActor = system.actorOf(props);
+
+
+				Scheduler scheduler = new Scheduler();
+
+				Instance i1 = null;
+				try {
+					i1 = ExecutionGraphTestUtils.getInstance(taskManagerActor, numSinks * parallelism);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+
+				scheduler.newInstanceAvailable(i1);
+
+				try {
+					eg.scheduleForExecution(scheduler);
+				} catch (JobException e) {
+					e.printStackTrace();
+					fail("Failed to schedule ExecutionGraph");
+				}
+
+				for (int i=0; i < numSinks * parallelism; i++) {
+					// all sources should be scheduled
+					expectMsgClass(duration("1 second"), TaskMessages.SubmitTask.class);
+				}
+
+			}
+		};
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -67,7 +67,6 @@ public class SchedulerTestUtils {
 		return new Instance(ActorRef.noSender(), ci, new InstanceID(), resources, numSlots);
 	}
 	
-	
 	public static Execution getDummyTask() {
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
 		when(vertex.getJobId()).thenReturn(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -337,7 +337,25 @@ public class TaskManagerTest {
 			}
 		}};
 	}
-	
+
+	@Test
+	public void testPartitionReject() {
+		new JavaTestKit(system){{
+
+			ActorRef jobManager = system.actorOf(Props.create(SimpleJobManager.class));
+			ActorRef taskManager = createTaskManager(jobManager, true);
+
+			// send a non-existing partition id to the task manager
+			IntermediateResultPartitionID partitionID = new IntermediateResultPartitionID();
+			taskManager.tell(
+					new TaskMessages.LockResultPartition(partitionID, 1),
+					getRef());
+
+			expectMsgEquals(duration("1 second"),
+					new TaskMessages.LockResultPartitionReply(false));
+		}};
+	}
+
 	@Test
 	public void testGateChannelEdgeMismatch() {
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -25,8 +25,11 @@ import org.apache.flink.runtime.ActorLogMessages
 import org.apache.flink.runtime.execution.ExecutionState
 import org.apache.flink.runtime.jobgraph.JobStatus
 import org.apache.flink.runtime.jobmanager.{JobManager, MemoryArchivist}
-import org.apache.flink.runtime.messages.ExecutionGraphMessages.JobStatusChanged
+import org.apache.flink.runtime.messages.ExecutionGraphMessages.{ExecutionStateChanged,
+JobStatusChanged}
+import org.apache.flink.runtime.messages.JobManagerMessages.ScheduleOrUpdateConsumers
 import org.apache.flink.runtime.messages.Messages.Disconnect
+import org.apache.flink.runtime.messages.TaskMessages.UpdateTaskExecutionState
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
 
@@ -54,6 +57,8 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
 
   val waitForJobStatus = scala.collection.mutable.HashMap[JobID,
     collection.mutable.HashMap[JobStatus, Set[ActorRef]]]()
+
+  val waitForTaskScheduled = scala.collection.mutable.HashMap[JobID, Set[ActorRef]]()
 
   var disconnectDisabled = false
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -63,9 +63,9 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
 
   def receiveTestingMessages: Receive = {
     case RequestExecutionGraph(jobID) =>
-      currentJobs.get(jobID) match {
-        case Some((executionGraph, jobInfo)) => sender ! ExecutionGraphFound(jobID,
-          executionGraph)
+      currentJob match {
+        case Some((executionGraph, jobInfo)) if executionGraph.getJobID == jobID =>
+          sender ! ExecutionGraphFound(jobID, executionGraph)
         case None => archive.tell(RequestExecutionGraph(jobID), sender)
       }
 
@@ -95,8 +95,10 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
       }
 
     case NotifyListeners =>
-      for(jobID <- currentJobs.keySet){
-        notifyListeners(jobID)
+      currentJob match {
+        case Some((eg, _)) =>
+          notifyListeners(eg.getJobID)
+        case None =>
       }
 
       if(waitForAllVerticesToBeRunning.isEmpty && waitForAllVerticesToBeRunningOrFinished.isEmpty) {
@@ -132,8 +134,8 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
       }
 
     case RequestWorkingTaskManager(jobID) =>
-      currentJobs.get(jobID) match {
-        case Some((eg, _)) =>
+      currentJob match {
+        case Some((eg, _)) if eg.getJobID == jobID =>
           if(eg.getAllExecutionVertices.isEmpty){
             sender ! WorkingTaskManager(ActorRef.noSender)
           } else {
@@ -196,16 +198,16 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
   }
 
   def checkIfAllVerticesRunning(jobID: JobID): Boolean = {
-    currentJobs.get(jobID) match {
-      case Some((eg, _)) =>
+    currentJob match {
+      case Some((eg, _)) if eg.getJobID == jobID =>
         eg.getAllExecutionVertices.forall( _.getExecutionState == ExecutionState.RUNNING)
       case None => false
     }
   }
 
   def checkIfAllVerticesRunningOrFinished(jobID: JobID): Boolean = {
-    currentJobs.get(jobID) match {
-      case Some((eg, _)) =>
+    currentJob match {
+      case Some((eg, _)) if eg.getJobID == jobID =>
         eg.getAllExecutionVertices.forall {
           case vertex =>
             (vertex.getExecutionState == ExecutionState.RUNNING

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
@@ -20,7 +20,8 @@ package org.apache.flink.runtime.testingUtils
 
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
+import org.apache.flink.runtime.executiongraph.{ExecutionJobVertex, ExecutionAttemptID}
+import org.apache.flink.runtime.jobgraph.{IntermediateDataSetID, IntermediateResultPartitionID}
 import org.apache.flink.runtime.taskmanager.Task
 
 /**
@@ -51,7 +52,15 @@ object TestingTaskManagerMessages {
   case class NotifyWhenJobManagerTerminated(jobManager: ActorRef)
 
   case class JobManagerTerminated(jobManager: ActorRef)
-  
+
+  /** For ResumeITCase */
+  case class NotifyWhenTaskSubmitted(jobID: JobID)
+
+  case class NotifyWhenResultPartitionChanges(partitionID: IntermediateResultPartitionID)
+
+  case class ResultPartitionCached(partitionID: IntermediateResultPartitionID)
+  case class ResultPartitionLocked(partitionID: IntermediateResultPartitionID)
+
   // --------------------------------------------------------------------------
   // Utility methods to allow simpler case object access from Java
   // --------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/resume/ResumeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/resume/ResumeITCase.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.resume;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.pattern.Patterns;
+import akka.testkit.JavaTestKit;
+import akka.util.Timeout;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.io.network.api.reader.RecordReader;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.messages.JobManagerMessages.*;
+import org.apache.flink.runtime.messages.TaskMessages;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.*;
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.test.util.ForkableFlinkMiniCluster;
+import org.apache.flink.types.IntValue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import akka.actor.Status.Success;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class ResumeITCase {
+
+	private static int PARALLELISM = 10;
+	ActorSystem system;
+
+	@Before
+	public void setup(){
+		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
+		TestingUtils.setCallingThreadDispatcher(system);
+	}
+
+	@After
+	public void teardown(){
+		TestingUtils.setGlobalExecutionContext();
+		JavaTestKit.shutdownActorSystem(system);
+	}
+
+	@Test
+	public void testResumeFromIntermediateResults() {
+
+		final JobID jobId = new JobID();
+		final String jobName = "Resume from intermediate result";
+		final Configuration cfg = new Configuration();
+
+		/* Simple test to resume from an intermediate result cached as a ResultPartition at a task manager
+
+					O receiver          receiver O  O sink
+					^                            | /
+					|                            |/
+					■ intermediate result        ■ intermediate result
+					^                            |
+					|                            |
+					O source                     O source
+
+         */
+
+		AbstractJobVertex source = new AbstractJobVertex("source");
+		source.setInvokableClass(Sender.class);
+
+		final IntermediateDataSet intermediateResult = source.createAndAddResultDataSet(ResultPartitionType.BLOCKING);
+
+		final AbstractJobVertex receiver = new AbstractJobVertex("receiver");
+		receiver.setInvokableClass(Receiver.class);
+		receiver.connectDataSetAsInput(intermediateResult, DistributionPattern.ALL_TO_ALL);
+
+		// first job graph
+		final JobGraph jobGraph1 = new JobGraph(jobId, jobName, source, receiver);
+		jobGraph1.setScheduleMode(ScheduleMode.BACKTRACKING);
+		jobGraph1.setParallelism(PARALLELISM);
+
+		final AbstractJobVertex sink = new AbstractJobVertex("sink");
+		sink.setInvokableClass(Receiver.class);
+		sink.setResumeFromIntermediateResult();
+
+		sink.connectDataSetAsInput(intermediateResult, DistributionPattern.ALL_TO_ALL);
+
+		// second job graph
+		final JobGraph jobGraph2 = new JobGraph(jobId, jobName, sink);
+		jobGraph2.setScheduleMode(ScheduleMode.BACKTRACKING);
+		jobGraph2.setParallelism(PARALLELISM);
+
+		ForkableFlinkMiniCluster cluster = ForkableFlinkMiniCluster.startCluster(2 * PARALLELISM, 1, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
+
+		final ActorRef jobManager = cluster.getJobManager();
+		final ActorRef taskManager = cluster.getTaskManagersAsJava().get(0);
+
+
+		new JavaTestKit(system) {{
+			new Within(TestingUtils.TESTING_DURATION()) {
+				@Override
+				protected void run() {
+					taskManager.tell(new TestingTaskManagerMessages.NotifyWhenTaskSubmitted(jobId), getRef());
+
+					jobManager.tell(new SubmitJob(jobGraph1, false), getRef());
+					expectMsgClass(Success.class);
+
+					// TODO check caching of intermediate result
+					//expectMsgEquals(new TestingTaskManagerMessages.ResultPartitionCached(intermediateResult.getId()));
+
+					for (int i = 0; i < PARALLELISM * 2; i++) {
+						expectMsgClass(TaskMessages.SubmitTask.class);
+					}
+
+					expectMsgClass(JobResultSuccess.class);
+
+					// request execution graph
+					FiniteDuration t = new FiniteDuration(5, TimeUnit.SECONDS);
+					Future<Object> future = Patterns.ask(jobManager, new RequestExecutionGraph(jobId), new Timeout(t));
+					ExecutionGraph executionGraph = null;
+					try {
+						executionGraph = ((ExecutionGraphFound)Await.result(future, t)).executionGraph();
+					} catch (Exception e) {
+						e.printStackTrace();
+						fail("Failed to get ExecutionGraph of first job.");
+					}
+
+					// list of intermediate result partitions that should be reused
+					Set<IntermediateResultPartitionID> resultsToBeAcknowledged = new HashSet<IntermediateResultPartitionID>();
+					for (IntermediateResult result : executionGraph.getAllIntermediateResults().values()) {
+						if(result.getId().equals(intermediateResult.getId())) {
+							for (IntermediateResultPartition partition : result.getPartitions()) {
+								IntermediateResultPartitionID partitionId = partition.getPartitionId();
+								resultsToBeAcknowledged.add(partitionId);
+								// call back for partition changes
+								taskManager.tell(new TestingTaskManagerMessages.NotifyWhenResultPartitionChanges(partitionId), getRef());
+							}
+						}
+					}
+
+					// submit second job and register for execution graph changes
+					jobManager.tell(new SubmitJob(jobGraph2, false), getRef());
+					expectMsgClass(Success.class);
+
+
+					for (Object msg : receiveN(PARALLELISM * 2)) {
+
+						if (msg instanceof TestingTaskManagerMessages.ResultPartitionLocked) {
+							assertTrue("Locked ResultPartitions should be correct.",
+									resultsToBeAcknowledged.contains(((TestingTaskManagerMessages.ResultPartitionLocked) msg).partitionID()));
+						} else if (msg instanceof TaskMessages.SubmitTask) {
+							assertTrue("Scheduled vertices should be correct.",
+									((TaskMessages.SubmitTask) msg).tasks().getVertexID().equals(sink.getID()));
+						} else {
+							fail("Unknown message " + msg);
+						}
+
+					}
+
+					expectMsgClass(JobResultSuccess.class);
+
+				}
+			};
+		}};
+
+	}
+
+	public static class Sender extends AbstractInvokable {
+
+		private RecordWriter<IntValue> writer;
+
+		@Override
+		public void registerInputOutput() {
+			writer = new RecordWriter<IntValue>(getEnvironment().getWriter(0));
+		}
+
+		@Override
+		public void invoke() throws Exception {
+
+			try {
+				for (int i=0; i < PARALLELISM; i++) {
+					writer.emit(new IntValue(23));
+				}
+				writer.flush();
+			}
+			finally {
+				writer.clearBuffers();
+			}
+		}
+	}
+
+	public static class Receiver extends AbstractInvokable {
+
+		private RecordReader<IntValue> reader;
+
+		@Override
+		public void registerInputOutput() {
+			reader = new RecordReader<IntValue>(
+					getEnvironment().getInputGate(0),
+					IntValue.class);
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			try {
+				IntValue record;
+				int numValues = 0;
+
+				while ((record = reader.next()) != null) {
+					record.getValue();
+					numValues++;
+				}
+
+				assertTrue("There should be no more values available.", numValues == PARALLELISM);
+			}
+			finally {
+				reader.clearBuffers();
+			}
+		}
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -726,7 +726,7 @@ under the License.
 						<exclude>flink-staging/flink-avro/src/test/java/org/apache/flink/api/io/avro/generated/*.java</exclude>
 						<exclude>flink-staging/flink-language-binding/flink-python/src/test/python/org/apache/flink/languagebinding/api/python/flink/test/data_csv</exclude>
 						<exclude>flink-staging/flink-language-binding/flink-python/src/test/python/org/apache/flink/languagebinding/api/python/flink/test/data_text</exclude>
-						<!-- Python -->						
+						<!-- Python -->
 						<exclude>flink-staging/flink-language-binding/flink-python/src/main/python/org/apache/flink/languagebinding/api/python/dill/**</exclude>
 						<!-- Configuration Files. -->
 						<exclude>**/flink-bin/conf/slaves</exclude>


### PR DESCRIPTION
For batch programs, we currently schedule all tasks which are sources
and let them kick off the execution of the connected tasks. This
approach bears some problems when executing large dataflows with many
branches. With backtracking, we traverse the execution graph
output-centrically (from the sinks) in a depth-first manner. This
enables us to use resources differently.

In the course of backtracking, only tasks will be executed that are
required to supply inputs to the current task. When a job is newly
submitted, this means that the backtracking will reach the
sources. When the job has been previously executed and intermediate
results are available, old ResultPartitions to resume from can be
requested while backtracking.

Backtracking is disabled by default. It can be enabled by setting the
ScheduleMode in JobGraph to BACKTRACKING.

CHANGELOG
- new scheduling mode: backtracking
- backtracks from the sinks of an ExecutionGraph
- checks the availability of IntermediatePartitionResults
- marks ExecutionVertex to be scheduled
- caches ResultPartitions and reloads them
- resumes from intermediate results
- test for general behavior of backtracking (BacktrackingTest)
- test for resuming from an intermediate result (ResumeITCase)
- test for releasing of cached ResultPartitions (ResultPartitionManagerTest)
- allow multiple consumers per blocking intermediate result (batch)