### PR TITLE
[FLINK-1855] SocketTextStreamWordCount example cannot be run from the webclient

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-examples/pom.xml
+++ b/flink-staging/flink-streaming/flink-streaming-examples/pom.xml
@@ -283,7 +283,8 @@ under the License.
 
 							<includes>
 								<include>org/apache/flink/streaming/examples/windowing/WindowWordCount.class</include>
-								<include>org/apache/flink/streaming/examples/wordcount/WordCount$Tokenizer.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/WordCount.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/WordCount$*.class</include>
 								<include>org/apache/flink/examples/java/wordcount/util/WordCountData.class</include>
 							</includes>
 						</configuration>
@@ -307,7 +308,8 @@ under the License.
 
 							<includes>
 								<include>org/apache/flink/streaming/examples/socket/SocketTextStreamWordCount.class</include>
-								<include>org/apache/flink/streaming/examples/wordcount/WordCount$Tokenizer.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/WordCount.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/WordCount$*.class</include>
 							</includes>
 						</configuration>
 					</execution>


### PR DESCRIPTION
This PR fixes [FLINK-1855](https://issues.apache.org/jira/browse/FLINK-1855). Tested in Local Cluster  with Oracle JDK7, JDK8.