### PR TITLE
[FLINK-1968] [runtime] Clean up and improve the distributed cache.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -19,9 +19,10 @@
 package org.apache.flink.api.common.functions.util;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.Future;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.accumulators.Accumulator;
@@ -51,20 +52,30 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 
 	private final HashMap<String, Accumulator<?, ?>> accumulators = new HashMap<String, Accumulator<?, ?>>();
 	
-	private final DistributedCache distributedCache = new DistributedCache();
+	private final DistributedCache distributedCache;
 	
 	
-	public AbstractRuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig) {
+	public AbstractRuntimeUDFContext(String name,
+										int numParallelSubtasks, int subtaskIndex,
+										ClassLoader userCodeClassLoader,
+										ExecutionConfig executionConfig)
+	{
+		this(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig,
+				Collections.<String, Future<Path>>emptyMap());
+	}
+	
+	public AbstractRuntimeUDFContext(String name,
+										int numParallelSubtasks, int subtaskIndex,
+										ClassLoader userCodeClassLoader,
+										ExecutionConfig executionConfig,
+										Map<String, Future<Path>> cpTasks)
+	{
 		this.name = name;
 		this.numParallelSubtasks = numParallelSubtasks;
 		this.subtaskIndex = subtaskIndex;
 		this.userCodeClassLoader = userCodeClassLoader;
 		this.executionConfig = executionConfig;
-	}
-	
-	public AbstractRuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig, Map<String, FutureTask<Path>> cpTasks) {
-		this(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig);
-		this.distributedCache.setCopyTasks(cpTasks);
+		this.distributedCache = new DistributedCache(cpTasks);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.functions.util;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.Future;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
@@ -42,7 +42,7 @@ public class RuntimeUDFContext extends AbstractRuntimeUDFContext {
 		super(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig);
 	}
 	
-	public RuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig, Map<String, FutureTask<Path>> cpTasks) {
+	public RuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig, Map<String, Future<Path>> cpTasks) {
 		super(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig, cpTasks);
 	}
 	

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -168,17 +168,15 @@ public abstract class FileSystem {
 	 * @throws IOException
 	 *         thrown if a reference to the file system instance could not be obtained
 	 */
-	public static FileSystem getLocalFileSystem() throws IOException {
-
-		URI localUri;
-
+	public static FileSystem getLocalFileSystem() {
+		// this should really never fail.
 		try {
-			localUri = OperatingSystem.isWindows() ?  new URI("file:/") : new URI("file:///");
-		} catch (URISyntaxException e) {
-			throw new IOException("Cannot create URI for local file system");
+			URI localUri = OperatingSystem.isWindows() ? new URI("file:/") : new URI("file:///");
+			return get(localUri);
 		}
-
-		return get(localUri);
+		catch (Exception e) {
+			throw new RuntimeException("Cannot create URI for local file system");
+		}
 	}
 
 	/**
@@ -193,7 +191,7 @@ public abstract class FileSystem {
 	 *         thrown if a reference to the file system instance could not be obtained
 	 */
 	public static FileSystem get(URI uri) throws IOException {
-		FileSystem fs = null;
+		FileSystem fs;
 
 		synchronized (SYNCHRONIZATION_OBJECT) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -18,58 +18,62 @@
 
 package org.apache.flink.runtime.execution;
 
-import akka.actor.ActorRef;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
-import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 
 import java.util.Map;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.Future;
 
 /**
- * The user code of every task runs inside an <code>Environment</code> object.
- * The environment provides important services to the task. It keeps track of
- * setting up the communication channels and provides access to input splits,
- * memory manager, etc.
+ * The Environment gives the code executed in a task access to the task's properties
+ * (such as name, parallelism), the configurations, the data stream readers and writers,
+ * as well as the various components that are provided by the TaskManager, such as
+ * memory manager, I/O manager, ...
  */
 public interface Environment {
 
 	/**
-	 * Returns the ID of the job from the original job graph. It is used by the library cache manager to find the
-	 * required
-	 * libraries for executing the assigned Nephele task.
+	 * Returns the ID of the job that the task belongs to.
 	 *
 	 * @return the ID of the job from the original job graph
 	 */
 	JobID getJobID();
 
 	/**
-	 * Gets the ID of the jobVertex that this task corresponds to.
+	 * Gets the ID of the JobVertex for which this task executes a parallel subtask.
 	 *
 	 * @return The JobVertexID of this task.
 	 */
 	JobVertexID getJobVertexId();
 
 	/**
-	 * Returns the task configuration object which was attached to the original JobVertex.
+	 * Gets the ID of the task execution attempt.
 	 *
-	 * @return the task configuration object which was attached to the original JobVertex.
+	 * @return The ID of the task execution attempt.
+	 */
+	ExecutionAttemptID getExecutionId();
+
+	/**
+	 * Returns the task-wide configuration object, originally attache to the job vertex.
+	 *
+	 * @return The task-wide configuration
 	 */
 	Configuration getTaskConfiguration();
 
 	/**
-	 * Returns the job configuration object which was attached to the original {@link JobGraph}.
+	 * Returns the job-wide configuration object that was attached to the JobGraph.
 	 *
-	 * @return the job configuration object which was attached to the original {@link JobGraph}
+	 * @return The job-wide configuration
 	 */
 	Configuration getJobConfiguration();
 
@@ -132,7 +136,7 @@ public interface Environment {
 	 */
 	ClassLoader getUserClassLoader();
 
-	Map<String, FutureTask<Path>> getCopyTask();
+	Map<String, Future<Path>> getDistributedCacheEntries();
 
 	BroadcastVariableManager getBroadcastVariableManager();
 
@@ -154,14 +158,5 @@ public interface Environment {
 	InputGate getInputGate(int index);
 
 	InputGate[] getAllInputGates();
-
-
-	/**
-	 * Returns the proxy object for the accumulator protocol.
-	 */
-	// THIS DOES NOT BELONG HERE, THIS TOTALLY BREAKS COMPONENTIZATION.
-	// THE EXECUTED TASKS HAVE BEEN KEPT INDEPENDENT OF ANY RPC OR ACTOR
-	// COMMUNICATION !!!
-	ActorRef getJobManager();
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -22,98 +22,218 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.util.IOUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The FileCache is used to create the local files for the registered cache files when a task is deployed. 
+ * The FileCache is used to create the local files for the registered cache files when a task is deployed.
  * The files will be removed when the task is unregistered after a 5 second delay.
  * A given file x will be placed in "<system-tmp-dir>/tmp_<jobID>/".
  */
 public class FileCache {
 
-	private static final Logger LOG = LoggerFactory.getLogger(FileCache.class);
+	static final Logger LOG = LoggerFactory.getLogger(FileCache.class);
 	
-	private static final Object lock = new Object();
-	
-	
-	private LocalFileSystem lfs = new LocalFileSystem();
+	/** cache-wide lock to ensure consistency. copies are not done under this lock */
+	private final Object lock = new Object();
 
-	private Map<JobID, Map<String, Integer>> jobCounts = new HashMap<JobID, Map<String, Integer>>();
+	private final Map<JobID, Map<String, Tuple4<Integer, File, Path, Future<Path>>>> entries;
 
-	private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(10, ExecutorThreadFactory.INSTANCE);
+	private final ScheduledExecutorService executorService;
+
+	private final File[] storageDirectories;
+
+	private final Thread shutdownHook;
+
+	private int nextDirectory;
+
+	// ------------------------------------------------------------------------
+
+	public FileCache(Configuration config) throws IOException {
+		
+		String tempDirs = config.getString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
+				ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH);
+
+		String[] directories = tempDirs.split(",|" + File.pathSeparator);
+		String cacheDirName = "flink-dist-cache-" + UUID.randomUUID().toString();
+		storageDirectories = new File[directories.length];
+
+		for (int i = 0; i < directories.length; i++) {
+			storageDirectories[i] = new File(directories[i], cacheDirName);
+			String path = storageDirectories[i].getAbsolutePath();
+
+			if (storageDirectories[i].mkdirs()) {
+				LOG.info("User file cache uses directory " + path);
+			} else {
+				LOG.error("User file cache cannot create directory " + path);
+				// delete all other directories we created so far
+				for (int k = 0; k < i; k++) {
+					if (!storageDirectories[k].delete()) {
+						LOG.warn("User file cache cannot remove prior directory " +
+								storageDirectories[k].getAbsolutePath());
+					}
+				}
+				throw new IOException("File cache cannot create temp storage directory: " + path);
+			}
+		}
+
+		this.shutdownHook = createShutdownHook(this, LOG);
+
+		this.entries = new HashMap<JobID, Map<String, Tuple4<Integer, File, Path, Future<Path>>>>();
+		this.executorService = Executors.newScheduledThreadPool(10, ExecutorThreadFactory.INSTANCE);
+	}
+
+	/**
+	 * Shuts down the file cache by cancelling all
+	 */
+	public void shutdown() {
+		synchronized (lock) {
+			// first shutdown the thread pool
+			ScheduledExecutorService es = this.executorService;
+			if (es != null) {
+				es.shutdown();
+				try {
+					es.awaitTermination(5000L, TimeUnit.MILLISECONDS);
+				}
+				catch (InterruptedException e) {
+					// may happen
+				}
+			}
+			
+			entries.clear();
+			
+			// clean up the all storage directories
+			for (File dir : storageDirectories) {
+				try {
+					FileUtils.deleteDirectory(dir);
+				}
+				catch (IOException e) {
+					LOG.error("File cache could not properly clean up storage directory.");
+				}
+			}
+
+			// Remove shutdown hook to prevent resource leaks, unless this is invoked by the
+			// shutdown hook itself
+			if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
+				try {
+					Runtime.getRuntime().removeShutdownHook(shutdownHook);
+				}
+				catch (IllegalStateException e) {
+					// race, JVM is in shutdown already, we can safely ignore this
+				}
+				catch (Throwable t) {
+					LOG.warn("Exception while unregistering file cache's cleanup shutdown hook.");
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
 
 	/**
 	 * If the file doesn't exists locally, it will copy the file to the temp directory.
-	 * @param name file identifier
-	 * @param entry entry containing all relevant information
-	 * @param jobID
-	 * @return copy task
+	 *
+	 * @param name  The name under which the file is registered.
+	 * @param entry The cache entry descriptor (path, executable flag)
+	 * @param jobID The ID of the job for which the file is copied.
+	 * @return The handle to the task that copies the file.
 	 */
-	public FutureTask<Path> createTmpFile(String name, DistributedCacheEntry entry, JobID jobID) {
+	public Future<Path> createTmpFile(String name, DistributedCacheEntry entry, JobID jobID) {
 		synchronized (lock) {
-			if (!jobCounts.containsKey(jobID)) {
-				jobCounts.put(jobID, new HashMap<String, Integer>());
+			Map<String, Tuple4<Integer, File, Path, Future<Path>>> jobEntries = entries.get(jobID);
+			if (jobEntries == null) {
+				jobEntries = new HashMap<String, Tuple4<Integer, File, Path, Future<Path>>>();
+				entries.put(jobID, jobEntries);
 			}
-			Map<String, Integer> count = jobCounts.get(jobID);
-			if (count.containsKey(name)) {
-				count.put(name, count.get(name) + 1);
-			} else {
-				count.put(name, 1);
+
+			// tuple is (ref-count, parent-temp-dir, cached-file-path, copy-process)
+			Tuple4<Integer, File, Path, Future<Path>> fileEntry = jobEntries.get(name);
+			if (fileEntry != null) {
+				// file is already in the cache. return a future that
+				// immediately returns the file
+				fileEntry.f0 = fileEntry.f0 + 1;
+				
+				// return the future. may be that the copy is still in progress
+				return fileEntry.f3;
+			}
+			else {
+				// need to copy the file
+
+				// create the target path
+				File tempDirToUse = new File(storageDirectories[nextDirectory++], jobID.toString());
+				if (nextDirectory >= storageDirectories.length) {
+					nextDirectory = 0;
+				}
+
+				String sourceFile = entry.filePath;
+				int posOfSep = sourceFile.lastIndexOf("/");
+				if (posOfSep > 0) {
+					sourceFile = sourceFile.substring(posOfSep + 1);
+				}
+
+				Path target = new Path(tempDirToUse.getAbsolutePath() + "/" + sourceFile);
+
+				// kick off the copying
+				CopyProcess cp = new CopyProcess(entry, target);
+				FutureTask<Path> copyTask = new FutureTask<Path>(cp);
+				executorService.submit(copyTask);
+				
+				// store our entry
+				jobEntries.put(name, new Tuple4<Integer, File, Path, Future<Path>>(1, tempDirToUse, target, copyTask));
+				
+				return copyTask;
 			}
 		}
-		CopyProcess cp = new CopyProcess(entry, jobID);
-		FutureTask<Path> copyTask = new FutureTask<Path>(cp);
-		executorService.submit(copyTask);
-		return copyTask;
 	}
 
 	/**
 	 * Deletes the local file after a 5 second delay.
-	 * @param name file identifier
-	 * @param entry entry containing all relevant information
-	 * @param jobID
+	 *
+	 * @param name  The name under which the file is registered.
+	 * @param jobID The ID of the job for which the file is copied.
 	 */
-	public void deleteTmpFile(String name, DistributedCacheEntry entry, JobID jobID) {
-		DeleteProcess dp = new DeleteProcess(name, entry, jobID);
+	public void deleteTmpFile(String name, JobID jobID) {
+		DeleteProcess dp = new DeleteProcess(lock, entries, name, jobID);
 		executorService.schedule(dp, 5000L, TimeUnit.MILLISECONDS);
 	}
-
-	public Path getTempDir(JobID jobID, String childPath) {
-		return new Path(GlobalConfiguration.getString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
-			ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH), DistributedCache.TMP_PREFIX + jobID.toString() + "/" + childPath);
-	}
-
-	public void shutdown() {
-		ScheduledExecutorService es = this.executorService;
-		if (es != null) {
-			es.shutdown();
-			try {
-				es.awaitTermination(5000L, TimeUnit.MILLISECONDS);
-			} catch (InterruptedException e) {
-				throw new RuntimeException("Error shutting down the file cache", e);
-			}
+	
+	
+	boolean holdsStillReference(String name, JobID jobId) {
+		Map<String, Tuple4<Integer, File, Path, Future<Path>>> jobEntries = entries.get(jobId);
+		if (jobEntries != null) {
+			Tuple4<Integer, File, Path, Future<Path>> entry = jobEntries.get(name);
+			return entry != null && entry.f0 > 0;
+		}
+		else {
+			return false;
 		}
 	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
 
 	public static void copy(Path sourcePath, Path targetPath, boolean executable) throws IOException {
 		FileSystem sFS = sourcePath.getFileSystem();
@@ -137,80 +257,144 @@ public class FileCache {
 					FSDataOutputStream lfsOutput = tFS.create(targetPath, false);
 					FSDataInputStream fsInput = sFS.open(sourcePath);
 					IOUtils.copyBytes(fsInput, lfsOutput);
+					//noinspection ResultOfMethodCallIgnored
 					new File(targetPath.toString()).setExecutable(executable);
-				} catch (IOException ioe) {
+				}
+				catch (IOException ioe) {
 					LOG.error("could not copy file to local file cache.", ioe);
 				}
 			}
 		}
 	}
 
+	private static Thread createShutdownHook(final FileCache cache, final Logger logger) {
+
+		Thread shutdownHook = new Thread(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					cache.shutdown();
+				}
+				catch (Throwable t) {
+					logger.error("Error during shutdown of file cache via JVM shutdown hook: " + t.getMessage(), t);
+				}
+			}
+		});
+
+		try {
+			// Add JVM shutdown hook to call shutdown of service
+			Runtime.getRuntime().addShutdownHook(shutdownHook);
+			return shutdownHook;
+		}
+		catch (IllegalStateException e) {
+			// JVM is already shutting down. no need to do our work
+			return null;
+		}
+		catch (Throwable t) {
+			logger.error("Cannot register shutdown hook that cleanly terminates the file cache service.");
+			return null;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  background processes
+	// ------------------------------------------------------------------------
+
 	/**
 	 * Asynchronous file copy process
 	 */
-	private class CopyProcess implements Callable<Path> {
-		
-		private JobID jobID;
-		private String filePath;
-		private Boolean executable;
+	private static class CopyProcess implements Callable<Path> {
 
-		public CopyProcess(DistributedCacheEntry e, JobID jobID) {
-			this.filePath = e.filePath;
+		private final Path filePath;
+		private final Path cachedPath;
+		private boolean executable;
+
+		public CopyProcess(DistributedCacheEntry e, Path cachedPath) {
+			this.filePath = new Path(e.filePath);
 			this.executable = e.isExecutable;
-			this.jobID = jobID;
+			this.cachedPath = cachedPath;
 		}
+
 		@Override
-		public Path call()  {
-			Path tmp = getTempDir(jobID, filePath.substring(filePath.lastIndexOf("/") + 1));
-			try {
-				synchronized (lock) {
-					copy(new Path(filePath), tmp, this.executable);
-				}
-			} catch (IOException e) {
-				LOG.error("Could not copy file to local file cache.", e);
-			}
-			return tmp;
+		public Path call() throws IOException {
+			// let exceptions propagate. we can retrieve them later from
+			// the future and report them upon access to the result
+			copy(filePath, cachedPath, this.executable);
+			return cachedPath;
 		}
 	}
 
 	/**
 	 * If no task is using this file after 5 seconds, clear it.
 	 */
-	private class DeleteProcess implements Runnable {
-		
-		private String name;
-		private JobID jobID;
-		private String filePath;
+	private static class DeleteProcess implements Runnable {
 
-		public DeleteProcess(String name, DistributedCacheEntry e, JobID jobID) {
+		private final Object lock;
+		private final Map<JobID, Map<String, Tuple4<Integer, File, Path, Future<Path>>>> entries;
+
+		private final String name;
+		private final JobID jobID;
+
+		public DeleteProcess(Object lock, Map<JobID, Map<String, Tuple4<Integer, File, Path, Future<Path>>>> entries,
+								String name, JobID jobID)
+		{
+			this.lock = lock;
+			this.entries = entries;
 			this.name = name;
 			this.jobID = jobID;
-			this.filePath = e.filePath;
 		}
+
 		@Override
 		public void run() {
-			Path tmp = getTempDir(jobID, filePath.substring(filePath.lastIndexOf("/") + 1));
 			try {
 				synchronized (lock) {
-					Map<String, Integer> count = jobCounts.get(jobID);
-					if (count.containsKey(name)) {
-						count.put(name, count.get(name) - 1);
-						if (count.get(name) == 0) {
-							if (lfs.exists(tmp)) {
-								lfs.delete(tmp, true);
+					Map<String, Tuple4<Integer, File, Path, Future<Path>>> jobEntries = entries.get(jobID);
+					
+					if (jobEntries != null) {
+						Tuple4<Integer, File, Path, Future<Path>> entry = jobEntries.get(name);
+						
+						if (entry != null) {
+							int count = entry.f0;
+							if (count > 1) {
+								// multiple references still
+								entry.f0 = count - 1;
 							}
-							count.remove(name);
-							if (count.isEmpty()) { //delete job directory
-								tmp = getTempDir(jobID, "");
-								if (lfs.exists(tmp)) {
-									lfs.delete(tmp, true);
+							else {
+								// we remove the last reference
+								jobEntries.remove(name);
+								if (jobEntries.isEmpty()) {
+									entries.remove(jobID);
 								}
-								jobCounts.remove(jobID);
+								
+								// abort the copy
+								entry.f3.cancel(true);
+
+								// remove the file
+								File file = new File(entry.f2.toString());
+								if (file.exists()) {
+									if (file.isDirectory()) {
+										FileUtils.deleteDirectory(file);
+									}
+									else if (!file.delete()) {
+										LOG.error("Could not delete locally cached file " + file.getAbsolutePath());
+									}
+								}
+								
+								// remove the job wide temp directory, if it is now empty
+								File parent = entry.f1;
+								if (parent.isDirectory()) {
+									String[] children = parent.list();
+									if (children == null || children.length == 0) {
+										//noinspection ResultOfMethodCallIgnored
+										parent.delete();
+									}
+								}
 							}
 						}
 					}
 				}
-			} catch (IOException e) {
+			}
+			catch (IOException e) {
 				LOG.error("Could not delete file from local file cache.", e);
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
@@ -62,7 +62,8 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
 		} else {
 			Environment env = parent.getEnvironment();
 			this.udfContext = new DistributedRuntimeUDFContext(taskName, env.getNumberOfSubtasks(),
-					env.getIndexInSubtaskGroup(), userCodeClassLoader, parent.getExecutionConfig(), env.getCopyTask());
+					env.getIndexInSubtaskGroup(), userCodeClassLoader, parent.getExecutionConfig(),
+					env.getDistributedCacheEntries());
 		}
 
 		this.executionConfig = executionConfig;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.operators.util;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.Future;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
@@ -45,7 +45,7 @@ public class DistributedRuntimeUDFContext extends AbstractRuntimeUDFContext {
 		super(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig);
 	}
 	
-	public DistributedRuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig, Map<String, FutureTask<Path>> cpTasks) {
+	public DistributedRuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig, Map<String, Future<Path>> cpTasks) {
 		super(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig, cpTasks);
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -16,16 +16,15 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.runtime.operators.testutils;
 
-import akka.actor.ActorRef;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.partition.consumer.IteratorWrappingTestSingleInputGate;
@@ -46,10 +45,11 @@ import org.apache.flink.util.MutableObjectIterator;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.Future;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -211,18 +211,13 @@ public class MockEnvironment implements Environment {
 	}
 
 	@Override
-	public ActorRef getJobManager() {
-		throw new UnsupportedOperationException("getAccumulatorProtocolProxy() is not supported by MockEnvironment");
-	}
-
-	@Override
 	public ClassLoader getUserClassLoader() {
 		return getClass().getClassLoader();
 	}
 
 	@Override
-	public Map<String, FutureTask<Path>> getCopyTask() {
-		return null;
+	public Map<String, Future<Path>> getDistributedCacheEntries() {
+		return Collections.emptyMap();
 	}
 
 	@Override
@@ -250,6 +245,11 @@ public class MockEnvironment implements Environment {
 	@Override
 	public JobVertexID getJobVertexId() {
 		return new JobVertexID(new byte[16]);
+	}
+
+	@Override
+	public ExecutionAttemptID getExecutionId() {
+		return new ExecutionAttemptID(0L, 0L);
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointCommitter.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointCommitter.java
@@ -16,13 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.common.functions;
+package org.apache.flink.streaming.api.checkpoint;
 
 /**
- * The base interface for all user-defined functions.
- * 
- * <p>This interface is empty in order to allow extending interfaces to
- * be SAM (single abstract method) interfaces that can be implemented via Java 8 lambdas.</p>
+ * This interface must be implemented by functions/operations that want to receive
+ * a commit notification once a checkpoint has been completely acknowledged by all
+ * participants.
  */
-public interface Function {
+public interface CheckpointCommitter {
+
+	/**
+	 * This method is called as a notification once a distributed checkpoint has been completed.
+	 * 
+	 * Note that any exception during this method will not cause the checkpoint to
+	 * fail any more.
+	 * 
+	 * @param checkpointId The ID of the checkpoint that has been completed.
+	 */
+	void commitCheckpoint(long checkpointId);
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/Checkpointed.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/Checkpointed.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.checkpoint;
+
+import org.apache.flink.runtime.state.OperatorState;
+
+/**
+ * This method must be implemented by functions that have state that needs to be
+ * checkpointed. The functions get a call whenever a checkpoint should take place
+ * and return a snapshot of their state, which will be checkpointed.
+ * 
+ * <p>This interface marks a function as <i>synchronously</i> checkpointed. While the
+ * state is written, the function is not called, so the function needs not return a
+ * copy of its state, but may return a reference to its state. Functions that can
+ * continue to work and mutate the state, even while the state snapshot is being accessed,
+ * can implement the {@link org.apache.flink.streaming.api.checkpoint.CheckpointedAsynchronously}
+ * interface.</p>
+ */
+public interface Checkpointed {
+
+	/**
+	 * Gets the current operator state as a checkpoint. The state must reflect all operations
+	 * from all prior operations if this function. 
+	 * 
+	 * @param checkpointId The ID of the checkpoint.
+	 * @param checkpointTimestamp The timestamp of the checkpoint, as derived by
+	 *                            System.currentTimeMillis() on the JobManager.
+	 *                            
+	 * @return A snapshot of the operator state.
+	 * 
+	 * @throws Exception Thrown if the creation of the state object failed. This causes the
+	 *                   checkpoint to fail. The system may decide to fail the operation (and trigger
+	 *                   recovery), or to discard this checkpoint attempt and to continue running
+	 *                   and to try again with the next checkpoint attempt.
+	 */
+	OperatorState<?> snapshotState(long checkpointId, long checkpointTimestamp) throws Exception;
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.checkpoint;
+
+/**
+ * This interface marks a function/operator as <i>asynchronously checkpointed</i>.
+ * Similar to the {@link Checkpointed} interface, the function must produce a
+ * snapshot of its state. However, the function must be able to continue working
+ * and mutating its state without mutating the returned state snapshot.
+ * 
+ * <p>Asynchronous checkpoints are desirable, because they allow the data streams at the
+ * point of the checkpointed function/operator to continue running while the checkpoint
+ * is in progress.</p>
+ * 
+ * <p>To be able to support asynchronous snapshots, the state returned by the
+ * {@link #snapshotState(long, long)} method is typically a copy or shadow copy
+ * of the actual state.</p>
+ */
+public interface CheckpointedAsynchronously extends Checkpointed {}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/StreamSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/StreamSource.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source;
+
+/**
+ * Base interface for all stream data sources in Flink. The contract of a stream source
+ * is similar to an iterator - it is consumed as in the following pseudo code:
+ * 
+ * <pre>{@code
+ * StreamSource<T> source = ...;
+ * Collector<T> out = ...;
+ * while (!source.reachedEnd()) {
+ *   out.collect(source.next());
+ * }
+ * }
+ * </pre>
+ * 
+ * <b>Note about blocking behavior</b>
+ * <p>This implementations of the methods in the stream sources must have certain guarantees about
+ * blocking behavior. One of the two characteristics must be fulfilled.</p>
+ * <ul>
+ *     <li>The methods must react to thread interrupt calls and break out of blocking calls with
+ *         an {@link InterruptedException}.</li>
+ *     <li>The method may ignore interrupt calls and/or swallow InterruptedExceptions, if it is guaranteed
+ *         that the method returns quasi immediately irrespectively of the input. This is true for example
+ *         for file streams, where the call is guaranteed to return after a very short I/O delay in
+ *         the order of milliseconds.</li>
+ * </ul>
+ * 
+ * @param <T> The type of the records produced by this source.
+ */
+public interface StreamSource<T> {
+	
+	/**
+	 * Checks whether the stream has reached its end.
+	 *
+	 * <p>This method must obey the contract about blocking behavior declared in the
+	 * description of this class.</p>
+	 * 
+	 * @return True, if the end of the stream has been reached, false if more data is available.
+	 * 
+	 * @throws InterruptedException The calling thread may be interrupted to pull the function out of this
+	 *                              method during checkpoints.
+	 * @throws Exception Any other exception that is thrown causes the source to fail and results in failure of
+	 *                   the streaming program, or triggers recovery, depending on the program setup.
+	 */
+	boolean reachedEnd() throws Exception;
+
+
+	/**
+	 * Produces the next record.
+	 * 
+	 * <p>This method must obey the contract about blocking behavior declared in the
+	 * description of this class.</p>
+	 * 
+	 * @return The next record produced by this stream source.
+	 * 
+	 * @throws InterruptedException The calling thread may be interrupted to pull the function out of this
+	 *                              method during checkpoints.
+	 * @throws Exception Any other exception that is thrown causes the source to fail and results in failure of
+	 *                   the streaming program, or triggers recovery, depending on the program setup.
+	 */
+	T next() throws Exception;
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamingRuntimeContext.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamingRuntimeContext.java
@@ -42,7 +42,7 @@ public class StreamingRuntimeContext extends RuntimeUDFContext {
 	public StreamingRuntimeContext(String name, Environment env, ClassLoader userCodeClassLoader,
 			ExecutionConfig executionConfig, Map<String, OperatorState<?>> operatorStates) {
 		super(name, env.getNumberOfSubtasks(), env.getIndexInSubtaskGroup(), userCodeClassLoader,
-				executionConfig, env.getCopyTask());
+				executionConfig, env.getDistributedCacheEntries());
 		this.env = env;
 		this.operatorStates = operatorStates;
 	}


### PR DESCRIPTION
 - Gives a proper exception when a non-cached file is accessed
 - Forwards I/O exceptions that happen during file transfer, rather than only returning null when transfer failed
 - Consistently keeps reference counts and copies only when needed
 - Properly removes all files when shutdown
 - Uses a shutdown hook to remove files when process is killed

Build on top of pull request #643 