### PR TITLE
[streaming] Added naming for streaming operators

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DiscretizedStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DiscretizedStream.java
@@ -76,6 +76,25 @@ public class DiscretizedStream<OUT> extends WindowedDataStream<OUT> {
 		this.isPartitioned = isPartitioned;
 	}
 
+	/**
+	 * Gets the name of the name of the current data stream. This name is
+	 * used by the visualization and logging during the program.
+	 *
+	 * @return Name of the stream.
+	 */
+	public String getName(){
+		return discretizedStream.getName();
+	}
+
+	/**
+	 * Sets the name of the name of the current data stream. This name is
+	 * used by the visualization and logging during the program.
+	 */
+	public DiscretizedStream<OUT> setName(String name){
+		discretizedStream.setName(name);
+		return this;
+	}
+
 	public DataStream<OUT> flatten() {
 		return discretizedStream.transform("Window Flatten", getType(), new WindowFlattener<OUT>());
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -41,6 +41,25 @@ public class SingleOutputStreamOperator<OUT, O extends SingleOutputStreamOperato
 	protected boolean isSplit;
 	protected StreamOperator<?, ?> operator;
 
+	/**
+	 * Gets the name of the name of the current data stream. This name is
+	 * used by the visualization and logging during the program.
+	 *
+	 * @return Name of the stream.
+	 */
+	public String getName(){
+		return streamGraph.getStreamNode(getId()).getOperatorName();
+	}
+
+	/**
+	 * Sets the name of the name of the current data stream. This name is
+	 * used by the visualization and logging during the program.
+	 */
+	public DataStream<OUT> setName(String name){
+		streamGraph.getStreamNode(id).setOperatorName(name);
+		return this;
+	}
+
 	protected SingleOutputStreamOperator(StreamExecutionEnvironment environment,
 			String operatorType, TypeInformation<OUT> outTypeInfo, StreamOperator<?, ?> operator) {
 		super(environment, operatorType, outTypeInfo);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.IterativeDataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.CoFlatMapFunction;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.windowing.helper.Count;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.Collector;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DataStreamTest {
+
+	private static final long MEMORYSIZE = 32;
+	private static int PARALLELISM = 1;
+
+	@Test
+	public void testNaming() throws Exception {
+		StreamExecutionEnvironment env = new TestStreamEnvironment(PARALLELISM, MEMORYSIZE);
+
+		DataStream<Long> dataStream1 = env.generateSequence(0, 0).setName("testSource1")
+				.map(new MapFunction<Long, Long>() {
+					@Override
+					public Long map(Long value) throws Exception {
+						return null;
+					}
+				}).setName("testMap");
+
+		DataStream<Long> dataStream2 = env.generateSequence(0, 0).setName("testSource2")
+				.reduce(new ReduceFunction<Long>() {
+					@Override
+					public Long reduce(Long value1, Long value2) throws Exception {
+						return null;
+					}
+				}).setName("testReduce");
+
+		DataStream<Long> connected = dataStream1.connect(dataStream2)
+				.flatMap(new CoFlatMapFunction<Long, Long, Long>() {
+					@Override
+					public void flatMap1(Long value, Collector<Long> out) throws Exception {
+					}
+
+					@Override
+					public void flatMap2(Long value, Collector<Long> out) throws Exception {
+					}
+				}).setName("testCoFlatMap")
+				.window(Count.of(10))
+				.foldWindow(0L, new FoldFunction<Long, Long>() {
+					@Override
+					public Long fold(Long accumulator, Long value) throws Exception {
+						return null;
+					}
+				}).setName("testWindowFold")
+				.flatten();
+
+		//test functionality through the operator names in the execution plan
+		String plan = env.getExecutionPlan();
+
+		assertTrue(plan.contains("testSource1"));
+		assertTrue(plan.contains("testSource2"));
+		assertTrue(plan.contains("testMap"));
+		assertTrue(plan.contains("testReduce"));
+		assertTrue(plan.contains("testCoFlatMap"));
+		assertTrue(plan.contains("testWindowFold"));
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -94,6 +94,29 @@ class DataStream[T](javaStream: JavaStream[T]) {
         " "  +
         "parallelism.")
   }
+
+  /**
+   * Gets the name of the name of the current data stream. This name is
+   * used by the visualization and logging during the program.
+   *
+   * @return Name of the stream.
+   */
+  def getName : String = javaStream match {
+    case stream : SingleOutputStreamOperator[_,_] => javaStream.getName
+    case _ => throw new
+        UnsupportedOperationException("Only supported for operators.")
+  }
+
+  /**
+   * Sets the name of the name of the current data stream. This name is
+   * used by the visualization and logging during the program.
+   */
+  def setName(name: String) : DataStream[_] = javaStream match {
+    case stream : SingleOutputStreamOperator[_,_] => javaStream.setName(name)
+    case _ => throw new
+        UnsupportedOperationException("Only supported for operators.")
+    this
+  }
   
   /**
    * Turns off chaining for this operator so thread co-location will not be

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedDataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedDataStream.scala
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
 import org.apache.flink.api.streaming.scala.ScalaStreamingAggregator
-import org.apache.flink.streaming.api.datastream.{WindowedDataStream => JavaWStream}
+import org.apache.flink.streaming.api.datastream.{WindowedDataStream => JavaWStream, DiscretizedStream}
 import org.apache.flink.streaming.api.functions.WindowMapFunction
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction.AggregationType
 import org.apache.flink.streaming.api.functions.aggregation.SumFunction
@@ -37,6 +37,30 @@ import org.apache.flink.streaming.api.windowing.helper.WindowingHelper
 import org.apache.flink.util.Collector
 
 class WindowedDataStream[T](javaStream: JavaWStream[T]) {
+
+
+  /**
+   * Gets the name of the name of the current data stream. This name is
+   * used by the visualization and logging during the program.
+   *
+   * @return Name of the stream.
+   */
+  def getName : String = javaStream match {
+    case stream : DiscretizedStream[_] => javaStream.getName
+    case _ => throw new
+        UnsupportedOperationException("Only supported for windowing operators.")
+  }
+
+  /**
+   * Sets the name of the name of the current data stream. This name is
+   * used by the visualization and logging during the program.
+   */
+  def setName(name: String) : WindowedDataStream[T] = javaStream match {
+    case stream : DiscretizedStream[_] => javaStream.setName(name)
+    case _ => throw new
+        UnsupportedOperationException("Only supported for windowing operators.")
+    this
+  }
 
   /**
    * Defines the slide size (trigger frequency) for the windowed data stream.


### PR DESCRIPTION
This improves tracking of jobs.

Added for standard and windowing operators, both Java and Scala APIs.