### PR TITLE
[FLINK-1980] allowing users to decorate input streams

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -654,25 +654,25 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 		}
 	}
 
-    /**
-     * This method allows to wrap/decorate the raw {@link FSDataInputStream} for a certain file split, e.g., for decoding.
-     * When overriding this method, also consider adapting {@link FileInputFormat#testForUnsplittable} if your
-     * stream decoration renders the input file unsplittable. Also consider calling existing superclass implementations.
-     *
-     * @param inputStream is the input stream to decorated
-     * @param fileSplit   is the file split for which the input stream shall be decorated
-     * @return the decorated input stream
-     * @throws Throwable if the decoration fails
-     * @see org.apache.flink.api.common.io.InputStreamFSInputWrapper
-     */
-    protected FSDataInputStream decorateInputStream(FSDataInputStream inputStream, FileInputSplit fileSplit) throws Throwable {
-        // Wrap stream in a extracting (decompressing) stream if file ends with .deflate.
-        if (fileSplit.getPath().getName().endsWith(DEFLATE_SUFFIX)) {
-            return new InflaterInputStreamFSInputWrapper(stream);
-        }
+	/**
+	 * This method allows to wrap/decorate the raw {@link FSDataInputStream} for a certain file split, e.g., for decoding.
+	 * When overriding this method, also consider adapting {@link FileInputFormat#testForUnsplittable} if your
+	 * stream decoration renders the input file unsplittable. Also consider calling existing superclass implementations.
+	 *
+	 * @param inputStream is the input stream to decorated
+	 * @param fileSplit   is the file split for which the input stream shall be decorated
+	 * @return the decorated input stream
+	 * @throws Throwable if the decoration fails
+	 * @see org.apache.flink.api.common.io.InputStreamFSInputWrapper
+	 */
+	protected FSDataInputStream decorateInputStream(FSDataInputStream inputStream, FileInputSplit fileSplit) throws Throwable {
+		// Wrap stream in a extracting (decompressing) stream if file ends with .deflate.
+		if (fileSplit.getPath().getName().endsWith(DEFLATE_SUFFIX)) {
+			return new InflaterInputStreamFSInputWrapper(stream);
+		}
 
-        return inputStream;
-    }
+		return inputStream;
+	}
 
 	/**
 	 * Closes the file input stream of the input format.

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -641,11 +641,7 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 		
 		try {
 			this.stream = isot.waitForCompletion();
-			// Wrap stream in a extracting (decompressing) stream if file ends with .deflate.
-			if(fileSplit.getPath().getName().endsWith(DEFLATE_SUFFIX)) {
-				this.stream = new InflaterInputStreamFSInputWrapper(stream);
-			}
-			
+			this.stream = decorateInputStream(this.stream, fileSplit);
 		}
 		catch (Throwable t) {
 			throw new IOException("Error opening the Input Split " + fileSplit.getPath() + 
@@ -657,7 +653,27 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 			this.stream.seek(this.splitStart);
 		}
 	}
-	
+
+    /**
+     * This method allows to wrap/decorate the raw {@link FSDataInputStream} for a certain file split, e.g., for decoding.
+     * When overriding this method, also consider adapting {@link FileInputFormat#testForUnsplittable} if your
+     * stream decoration renders the input file unsplittable. Also consider calling existing superclass implementations.
+     *
+     * @param inputStream is the input stream to decorated
+     * @param fileSplit   is the file split for which the input stream shall be decorated
+     * @return the decorated input stream
+     * @throws Throwable if the decoration fails
+     * @see org.apache.flink.api.common.io.InputStreamFSInputWrapper
+     */
+    protected FSDataInputStream decorateInputStream(FSDataInputStream inputStream, FileInputSplit fileSplit) throws Throwable {
+        // Wrap stream in a extracting (decompressing) stream if file ends with .deflate.
+        if (fileSplit.getPath().getName().endsWith(DEFLATE_SUFFIX)) {
+            return new InflaterInputStreamFSInputWrapper(stream);
+        }
+
+        return inputStream;
+    }
+
 	/**
 	 * Closes the file input stream of the input format.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InflaterInputStreamFSInputWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InflaterInputStreamFSInputWrapper.java
@@ -19,41 +19,14 @@
 
 package org.apache.flink.api.common.io;
 
-import java.io.IOException;
-import java.util.zip.InflaterInputStream;
-
 import org.apache.flink.core.fs.FSDataInputStream;
 
-public class InflaterInputStreamFSInputWrapper extends FSDataInputStream {
+import java.util.zip.InflaterInputStream;
 
-	private InflaterInputStream inStream;
+public class InflaterInputStreamFSInputWrapper extends InputStreamFSInputWrapper {
 
 	public InflaterInputStreamFSInputWrapper(FSDataInputStream inStream) {
-		this.inStream = new InflaterInputStream(inStream);
-	}
-	
-	@Override
-	public void seek(long desired) throws IOException {
-		throw new UnsupportedOperationException("Compressed streams do not support the seek operation");
+		super(new InflaterInputStream(inStream));
 	}
 
-	@Override
-	public long getPos() throws IOException {
-		throw new UnsupportedOperationException("Compressed streams do not support the getPos operation");
-	}
-
-	@Override
-	public int read() throws IOException {
-		return inStream.read();
-	}
-	
-	@Override
-	public int read(byte[] b, int off, int len) throws IOException {
-		return inStream.read(b, off, len);
-	}
-	
-	@Override
-	public int read(byte[] b) throws IOException {
-		return inStream.read(b);
-	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.api.common.io;
 
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -12,49 +30,49 @@ import java.io.InputStream;
  */
 public class InputStreamFSInputWrapper extends FSDataInputStream {
 
-    private final InputStream inStream;
+	private final InputStream inStream;
 
-    private long pos = 0;
+	private long pos = 0;
 
-    public InputStreamFSInputWrapper(InputStream inStream) {
-        this.inStream = inStream;
-    }
+	public InputStreamFSInputWrapper(InputStream inStream) {
+		this.inStream = inStream;
+	}
 
-    @Override
-    public void seek(long desired) throws IOException {
-        if (desired < this.pos) {
-            throw new IllegalArgumentException("Wrapped InputStream: cannot search backwards.");
-        } else if (desired == pos) {
-            return;
-        }
+	@Override
+	public void seek(long desired) throws IOException {
+		if (desired < this.pos) {
+			throw new IllegalArgumentException("Wrapped InputStream: cannot search backwards.");
+		} else if (desired == pos) {
+			return;
+		}
 
-        this.inStream.skip(desired - pos);
-        this.pos = desired;
-    }
+		this.inStream.skip(desired - pos);
+		this.pos = desired;
+	}
 
-    @Override
-    public long getPos() throws IOException {
-        return this.pos;
-    }
+	@Override
+	public long getPos() throws IOException {
+		return this.pos;
+	}
 
-    @Override
-    public int read() throws IOException {
-        int read = inStream.read();
-        if (read != -1) {
-            this.pos++;
-        }
-        return read;
-    }
+	@Override
+	public int read() throws IOException {
+		int read = inStream.read();
+		if (read != -1) {
+			this.pos++;
+		}
+		return read;
+	}
 
-    @Override
-    public int read(byte[] b, int off, int len) throws IOException {
-        int numReadBytes = inStream.read(b, off, len);
-        this.pos += numReadBytes;
-        return numReadBytes;
-    }
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		int numReadBytes = inStream.read(b, off, len);
+		this.pos += numReadBytes;
+		return numReadBytes;
+	}
 
-    @Override
-    public int read(byte[] b) throws IOException {
-        return read(b, 0, b.length);
-    }
+	@Override
+	public int read(byte[] b) throws IOException {
+		return read(b, 0, b.length);
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
@@ -67,7 +67,9 @@ public class InputStreamFSInputWrapper extends FSDataInputStream {
 	@Override
 	public int read(byte[] b, int off, int len) throws IOException {
 		int numReadBytes = inStream.read(b, off, len);
-		this.pos += numReadBytes;
+		if (numReadBytes != -1) {
+			this.pos += numReadBytes;
+		}
 		return numReadBytes;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
@@ -1,0 +1,60 @@
+package org.apache.flink.api.common.io;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class wraps an {@link java.io.InputStream} and exposes it as {@link org.apache.flink.core.fs.FSDataInputStream}.
+ * <br>
+ * <i>NB: {@link #seek(long)} and {@link #getPos()} are currently not supported.</i>
+ */
+public class InputStreamFSInputWrapper extends FSDataInputStream {
+
+    private final InputStream inStream;
+
+    private long pos = 0;
+
+    public InputStreamFSInputWrapper(InputStream inStream) {
+        this.inStream = inStream;
+    }
+
+    @Override
+    public void seek(long desired) throws IOException {
+        if (desired < this.pos) {
+            throw new IllegalArgumentException("Wrapped InputStream: cannot search backwards.");
+        } else if (desired == pos) {
+            return;
+        }
+
+        this.inStream.skip(desired - pos);
+        this.pos = desired;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return this.pos;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int read = inStream.read();
+        if (read != -1) {
+            this.pos++;
+        }
+        return read;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int numReadBytes = inStream.read(b, off, len);
+        this.pos += numReadBytes;
+        return numReadBytes;
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return read(b, 0, b.length);
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.api.common.io;
 
-import java.io.*;
-import java.net.URI;
-
 import org.apache.flink.api.common.io.FileInputFormat.FileBaseStatistics;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
@@ -30,6 +27,15 @@ import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.types.IntValue;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
 
 public class FileInputFormatTest {
 
@@ -337,38 +343,38 @@ public class FileInputFormatTest {
 	}
 
 
-    @Test
-    public void testDecorateInputStream() throws IOException {
-        // create temporary file with 3 blocks
-        final File tempFile = File.createTempFile("input-stream-decoration-test", "tmp");
-        tempFile.deleteOnExit();
-        final int blockSize = 8;
-        final int numBlocks = 3;
-        FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
-        for (int i = 0; i < blockSize * numBlocks; i++) {
-            fileOutputStream.write(new byte[]{1});
-        }
-        fileOutputStream.close();
+	@Test
+	public void testDecorateInputStream() throws IOException {
+		// create temporary file with 3 blocks
+		final File tempFile = File.createTempFile("input-stream-decoration-test", "tmp");
+		tempFile.deleteOnExit();
+		final int blockSize = 8;
+		final int numBlocks = 3;
+		FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+		for (int i = 0; i < blockSize * numBlocks; i++) {
+			fileOutputStream.write(new byte[]{1});
+		}
+		fileOutputStream.close();
 
-        final Configuration config = new Configuration();
+		final Configuration config = new Configuration();
 
-        final FileInputFormat<byte[]> inputFormat = new MyDecoratedInputFormat();
-        inputFormat.setFilePath(tempFile.toURI().toString());
+		final FileInputFormat<byte[]> inputFormat = new MyDecoratedInputFormat();
+		inputFormat.setFilePath(tempFile.toURI().toString());
 
-        inputFormat.configure(config);
+		inputFormat.configure(config);
 
-        FileInputSplit[] inputSplits = inputFormat.createInputSplits(3);
+		FileInputSplit[] inputSplits = inputFormat.createInputSplits(3);
 
-        byte[] bytes = null;
-        for (FileInputSplit inputSplit : inputSplits) {
-            inputFormat.open(inputSplit);
-            while (!inputFormat.reachedEnd()) {
-                if ((bytes = inputFormat.nextRecord(bytes)) != null) {
-                    Assert.assertArrayEquals(new byte[]{(byte) 0xFE}, bytes);
-                }
-            }
-        }
-    }
+		byte[] bytes = null;
+		for (FileInputSplit inputSplit : inputSplits) {
+			inputFormat.open(inputSplit);
+			while (!inputFormat.reachedEnd()) {
+				if ((bytes = inputFormat.nextRecord(bytes)) != null) {
+					Assert.assertArrayEquals(new byte[]{(byte) 0xFE}, bytes);
+				}
+			}
+		}
+	}
 	
 	// ------------------------------------------------------------------------
 	
@@ -387,47 +393,47 @@ public class FileInputFormatTest {
 	}
 
 
-    private static final class MyDecoratedInputFormat extends FileInputFormat<byte[]> {
+	private static final class MyDecoratedInputFormat extends FileInputFormat<byte[]> {
 
-        private static final long serialVersionUID = 1L;
+		private static final long serialVersionUID = 1L;
 
-        @Override
-        public boolean reachedEnd() throws IOException {
-            return this.splitLength <= this.stream.getPos();
-        }
+		@Override
+		public boolean reachedEnd() throws IOException {
+			return this.splitLength <= this.stream.getPos();
+		}
 
-        @Override
-        public byte[] nextRecord(byte[] reuse) throws IOException {
-            int read = this.stream.read();
-            if (read == -1) throw new IllegalStateException();
-            return new byte[] { (byte) read };
-        }
+		@Override
+		public byte[] nextRecord(byte[] reuse) throws IOException {
+			int read = this.stream.read();
+			if (read == -1) throw new IllegalStateException();
+			return new byte[]{(byte) read};
+		}
 
-        @Override
-        protected FSDataInputStream decorateInputStream(FSDataInputStream inputStream, FileInputSplit fileSplit) throws Throwable {
-            inputStream = super.decorateInputStream(inputStream, fileSplit);
-            return new InputStreamFSInputWrapper(new InvertedInputStream(inputStream));
-        }
+		@Override
+		protected FSDataInputStream decorateInputStream(FSDataInputStream inputStream, FileInputSplit fileSplit) throws Throwable {
+			inputStream = super.decorateInputStream(inputStream, fileSplit);
+			return new InputStreamFSInputWrapper(new InvertedInputStream(inputStream));
+		}
 
-    }
+	}
 
-    private static final class InvertedInputStream extends InputStream {
+	private static final class InvertedInputStream extends InputStream {
 
-        private final InputStream originalStream;
+		private final InputStream originalStream;
 
-        private InvertedInputStream(InputStream originalStream) {
-            this.originalStream = originalStream;
-        }
+		private InvertedInputStream(InputStream originalStream) {
+			this.originalStream = originalStream;
+		}
 
-        @Override
-        public int read() throws IOException {
-            int read = this.originalStream.read();
-            return read == -1 ? -1 : (~read & 0xFF);
-        }
+		@Override
+		public int read() throws IOException {
+			int read = this.originalStream.read();
+			return read == -1 ? -1 : (~read & 0xFF);
+		}
 
-        @Override
-        public int available() throws IOException {
-            return this.originalStream.available();
-        }
-    }
+		@Override
+		public int available() throws IOException {
+			return this.originalStream.available();
+		}
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -18,24 +18,20 @@
 
 package org.apache.flink.api.common.io;
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
 
 import org.apache.flink.api.common.io.FileInputFormat.FileBaseStatistics;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.types.IntValue;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class FileInputFormatTest { 
+public class FileInputFormatTest {
 
 	@Test
 	public void testGetStatisticsNonExistingFile() {
@@ -339,6 +335,40 @@ public class FileInputFormatTest {
 			Assert.fail(e.getMessage());
 		}
 	}
+
+
+    @Test
+    public void testDecorateInputStream() throws IOException {
+        // create temporary file with 3 blocks
+        final File tempFile = File.createTempFile("input-stream-decoration-test", "tmp");
+        tempFile.deleteOnExit();
+        final int blockSize = 8;
+        final int numBlocks = 3;
+        FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+        for (int i = 0; i < blockSize * numBlocks; i++) {
+            fileOutputStream.write(new byte[]{1});
+        }
+        fileOutputStream.close();
+
+        final Configuration config = new Configuration();
+
+        final FileInputFormat<byte[]> inputFormat = new MyDecoratedInputFormat();
+        inputFormat.setFilePath(tempFile.toURI().toString());
+
+        inputFormat.configure(config);
+
+        FileInputSplit[] inputSplits = inputFormat.createInputSplits(3);
+
+        byte[] bytes = null;
+        for (FileInputSplit inputSplit : inputSplits) {
+            inputFormat.open(inputSplit);
+            while (!inputFormat.reachedEnd()) {
+                if ((bytes = inputFormat.nextRecord(bytes)) != null) {
+                    Assert.assertArrayEquals(new byte[]{(byte) 0xFE}, bytes);
+                }
+            }
+        }
+    }
 	
 	// ------------------------------------------------------------------------
 	
@@ -355,4 +385,49 @@ public class FileInputFormatTest {
 			return null;
 		}
 	}
+
+
+    private static final class MyDecoratedInputFormat extends FileInputFormat<byte[]> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean reachedEnd() throws IOException {
+            return this.splitLength <= this.stream.getPos();
+        }
+
+        @Override
+        public byte[] nextRecord(byte[] reuse) throws IOException {
+            int read = this.stream.read();
+            if (read == -1) throw new IllegalStateException();
+            return new byte[] { (byte) read };
+        }
+
+        @Override
+        protected FSDataInputStream decorateInputStream(FSDataInputStream inputStream, FileInputSplit fileSplit) throws Throwable {
+            inputStream = super.decorateInputStream(inputStream, fileSplit);
+            return new InputStreamFSInputWrapper(new InvertedInputStream(inputStream));
+        }
+
+    }
+
+    private static final class InvertedInputStream extends InputStream {
+
+        private final InputStream originalStream;
+
+        private InvertedInputStream(InputStream originalStream) {
+            this.originalStream = originalStream;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int read = this.originalStream.read();
+            return read == -1 ? -1 : (~read & 0xFF);
+        }
+
+        @Override
+        public int available() throws IOException {
+            return this.originalStream.available();
+        }
+    }
 }


### PR DESCRIPTION
* add a decorateInputStream() method as hook in FileInputFormat
* provide a InputStreamFSInputWrapper to conveniently wrap InputStreams
* base existing .deflate file support on these changes
* add a test to verify the decoration