### PR TITLE
[hotfix][scala] Let type analysis work on some Java types

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
@@ -148,6 +148,7 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
         .filter { _.isTerm }
         .map { _.asTerm }
         .filter { _.isVar }
+        .filter { !_.isStatic }
         .filterNot { _.annotations.exists( _.tpe <:< typeOf[scala.transient]) }
 
       if (fields.isEmpty) {
@@ -186,7 +187,7 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
 
       val fieldDescriptors = fields map {
         f =>
-          val fieldTpe = f.getter.asMethod.returnType.asSeenFrom(tpe, tpe.typeSymbol)
+          val fieldTpe = f.typeSignatureIn(tpe)
           FieldDescriptor(f.name.toString.trim, f.getter, f.setter, fieldTpe, analyze(fieldTpe))
       }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
@@ -144,6 +144,26 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
 
   case class WritableDescriptor(id: Int, tpe: Type) extends UDTDescriptor
 
+  case class JavaTupleDescriptor(
+      id: Int,
+      tpe: Type,
+      fie Int,
+      tpe: Type,
+      fields: Seq[UDTDescriptor])
+    extends UDTDescriptor {
+
+    // Hack: ignore the ctorTpe, since two Type instances representing
+    // the same ctor function type don't appear to be considered equal.
+    // Equality of the tpe and ctor fields implies equality of ctorTpe anyway.
+    override def hashCode = (id, tpe, fields).hashCode
+
+    override def equals(that: Any) = that match {
+      case JavaTupleDescriptor(thatId, thatTpe, thatFields) =>
+        (id, tpe, fields).equals(
+          thatId, thatTpe, thatFields)
+      case _ => false
+    }
+
   }
 }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
@@ -32,97 +32,34 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
   abstract sealed class UDTDescriptor {
     val id: Int
     val tpe: Type
-    val isPrimitiveProduct: Boolean = false
-    
-    def canBeKey: Boolean
-
-    def flatten: Seq[UDTDescriptor]
-    def getters: Seq[FieldDescriptor] = Seq()
-
-    def select(member: String): Option[UDTDescriptor] =
-      getters find { _.getter.name.toString == member } map { _.desc }
-    
-    def select(path: List[String]): Seq[Option[UDTDescriptor]] = path match {
-      case Nil => Seq(Some(this))
-      case head :: tail => getters find { _.getter.name.toString == head } match {
-        case None => Seq(None)
-        case Some(d : FieldDescriptor) => d.desc.select(tail)
-      }
-    }
-
-    def findById(id: Int): Option[UDTDescriptor] = flatten.find { _.id == id }
-
-    def findByType[T <: UDTDescriptor: ClassTag]: Seq[T] = {
-      val clazz = classTag[T].runtimeClass
-      flatten filter { item => clazz.isAssignableFrom(item.getClass) } map { _.asInstanceOf[T] }
-    }
-
-    def getRecursiveRefs: Seq[UDTDescriptor] =
-      findByType[RecursiveDescriptor].flatMap { rd => findById(rd.refId) }.distinct
   }
 
-  case class GenericClassDescriptor(id: Int, tpe: Type) extends UDTDescriptor {
-    override def flatten = Seq(this)
+  case class GenericClassDescriptor(id: Int, tpe: Type) extends UDTDescriptor
 
-    def canBeKey = false
-  }
+  case class UnsupportedDescriptor(id: Int, tpe: Type, errors: Seq[String]) extends UDTDescriptor
 
-  case class UnsupportedDescriptor(id: Int, tpe: Type, errors: Seq[String]) extends UDTDescriptor {
-    override def flatten = Seq(this)
-    
-    def canBeKey = tpe <:< typeOf[Comparable[_]]
-  }
+  case class TypeParameterDescriptor(id: Int, tpe: Type) extends UDTDescriptor
 
-  case class TypeParameterDescriptor(id: Int, tpe: Type) extends UDTDescriptor {
-    override val isPrimitiveProduct = false
-    override def flatten = Seq(this)
-    override def canBeKey = false
-  }
+  case class PrimitiveDescriptor(id: Int, tpe: Type, default: Literal, wrapper: Type) extends UDTDescriptor
 
-  case class PrimitiveDescriptor(id: Int, tpe: Type, default: Literal, wrapper: Type)
-      extends UDTDescriptor {
-    override val isPrimitiveProduct = true
-    override def flatten = Seq(this)
-    override def canBeKey = wrapper <:< typeOf[org.apache.flink.types.Key[_]]
-  }
+  case class NothingDesciptor(id: Int, tpe: Type) extends UDTDescriptor
 
-  case class NothingDesciptor(id: Int, tpe: Type)
-    extends UDTDescriptor {
-    override val isPrimitiveProduct = false
-    override def flatten = Seq(this)
-    override def canBeKey = false
-  }
+  case class EitherDescriptor(id: Int, tpe: Type, left: UDTDescriptor, right: UDTDescriptor) extends UDTDescriptor
 
-  case class EitherDescriptor(id: Int, tpe: Type, left: UDTDescriptor, right: UDTDescriptor)
-    extends UDTDescriptor {
-    override val isPrimitiveProduct = false
-    override def flatten = Seq(this)
-    override def canBeKey = false
-  }
+  case class TryDescriptor(id: Int, tpe: Type, elem: UDTDescriptor) extends UDTDescriptor
 
-  case class TryDescriptor(id: Int, tpe: Type, elem: UDTDescriptor)
-    extends UDTDescriptor {
-    override val isPrimitiveProduct = false
-    override def flatten = Seq(this)
-    override def canBeKey = false
-  }
-
-  case class OptionDescriptor(id: Int, tpe: Type, elem: UDTDescriptor)
-    extends UDTDescriptor {
-    override val isPrimitiveProduct = false
-    override def flatten = Seq(this)
-    override def canBeKey = false
-  }
+  case class OptionDescriptor(id: Int, tpe: Type, elem: UDTDescriptor) extends UDTDescriptor
 
   case class BoxedPrimitiveDescriptor(
-      id: Int, tpe: Type, default: Literal, wrapper: Type, box: Tree => Tree, unbox: Tree => Tree)
-    extends UDTDescriptor {
-
-    override val isPrimitiveProduct = true
-    override def flatten = Seq(this)
-    override def canBeKey = wrapper <:< typeOf[org.apache.flink.types.Key[_]]
+      id: Int,
+      tpe: Type,
+      default: Literal,
+      wrapper: Type,
+      box: Tree => Tree,
+      unbox: Tree => Tree) extends UDTDescriptor {
 
     override def hashCode() = (id, tpe, default, wrapper, "BoxedPrimitiveDescriptor").hashCode()
+
     override def equals(that: Any) = that match {
       case BoxedPrimitiveDescriptor(thatId, thatTpe, thatDefault, thatWrapper, _, _) =>
         (id, tpe, default, wrapper).equals(thatId, thatTpe, thatDefault, thatWrapper)
@@ -130,12 +67,10 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
     }
   }
 
-  case class ArrayDescriptor(id: Int, tpe: Type, elem: UDTDescriptor)
-    extends UDTDescriptor {
-    override def canBeKey = false
-    override def flatten = this +: elem.flatten
+  case class ArrayDescriptor(id: Int, tpe: Type, elem: UDTDescriptor) extends UDTDescriptor {
 
     override def hashCode() = (id, tpe, elem).hashCode()
+
     override def equals(that: Any) = that match {
       case that @ ArrayDescriptor(thatId, thatTpe, thatElem) =>
         (id, tpe, elem).equals((thatId, thatTpe, thatElem))
@@ -143,17 +78,15 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
     }
   }
 
-  case class TraversableDescriptor(id: Int, tpe: Type, elem: UDTDescriptor)
-    extends UDTDescriptor {
-    override def canBeKey = false
-    override def flatten = this +: elem.flatten
+  case class TraversableDescriptor(id: Int, tpe: Type, elem: UDTDescriptor) extends UDTDescriptor {
 
-    def getInnermostElem: UDTDescriptor = elem match {
-      case list: TraversableDescriptor => list.getInnermostElem
-      case _                    => elem
-    }
+//    def getInnermostElem: UDTDescriptor = elem match {
+//      case list: TraversableDescriptor => list.getInnermostElem
+//      case _                    => elem
+//    }
 
     override def hashCode() = (id, tpe, elem).hashCode()
+
     override def equals(that: Any) = that match {
       case that @ TraversableDescriptor(thatId, thatTpe, thatElem) =>
         (id, tpe, elem).equals((thatId, thatTpe, thatElem))
@@ -161,19 +94,13 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
     }
   }
 
-  case class PojoDescriptor(id: Int, tpe: Type, override val getters: Seq[FieldDescriptor])
-    extends UDTDescriptor {
-
-    override val isPrimitiveProduct = getters.nonEmpty && getters.forall(_.desc.isPrimitiveProduct)
-
-    override def flatten = this +: (getters flatMap { _.desc.flatten })
-
-    override def canBeKey = flatten forall { f => f.canBeKey }
+  case class PojoDescriptor(id: Int, tpe: Type, getters: Seq[FieldDescriptor]) extends UDTDescriptor {
 
     // Hack: ignore the ctorTpe, since two Type instances representing
     // the same ctor function type don't appear to be considered equal.
     // Equality of the tpe and ctor fields implies equality of ctorTpe anyway.
     override def hashCode = (id, tpe, getters).hashCode
+
     override def equals(that: Any) = that match {
       case PojoDescriptor(thatId, thatTpe, thatGetters) =>
         (id, tpe, getters).equals(
@@ -181,13 +108,6 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
       case _ => false
     }
 
-    override def select(path: List[String]): Seq[Option[UDTDescriptor]] = path match {
-      case Nil => getters flatMap { g => g.desc.select(Nil) }
-      case head :: tail => getters find { _.getter.name.toString == head } match {
-        case None => Seq(None)
-        case Some(d : FieldDescriptor) => d.desc.select(tail)
-      }
-    }
   }
 
   case class CaseClassDescriptor(
@@ -195,33 +115,20 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
       tpe: Type,
       mutable: Boolean,
       ctor: Symbol,
-      override val getters: Seq[FieldDescriptor])
-    extends UDTDescriptor {
-
-    override val isPrimitiveProduct = getters.nonEmpty && getters.forall(_.desc.isPrimitiveProduct)
-
-    override def flatten = this +: (getters flatMap { _.desc.flatten })
-    
-    override def canBeKey = flatten forall { f => f.canBeKey }
+      getters: Seq[FieldDescriptor]) extends UDTDescriptor {
 
     // Hack: ignore the ctorTpe, since two Type instances representing
     // the same ctor function type don't appear to be considered equal. 
     // Equality of the tpe and ctor fields implies equality of ctorTpe anyway.
     override def hashCode = (id, tpe, ctor, getters).hashCode
+
     override def equals(that: Any) = that match {
       case CaseClassDescriptor(thatId, thatTpe, thatMutable, thatCtor, thatGetters) =>
         (id, tpe, mutable, ctor, getters).equals(
           thatId, thatTpe, thatMutable, thatCtor, thatGetters)
       case _ => false
     }
-    
-    override def select(path: List[String]): Seq[Option[UDTDescriptor]] = path match {
-      case Nil => getters flatMap { g => g.desc.select(Nil) }
-      case head :: tail => getters find { _.getter.name.toString == head } match {
-        case None => Seq(None)
-        case Some(d : FieldDescriptor) => d.desc.select(tail)
-      }
-    }
+
   }
 
   case class FieldDescriptor(
@@ -231,21 +138,12 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
       tpe: Type,
       desc: UDTDescriptor)
 
-  case class RecursiveDescriptor(id: Int, tpe: Type, refId: Int) extends UDTDescriptor {
-    override def flatten = Seq(this)
-    override def canBeKey = tpe <:< typeOf[org.apache.flink.types.Key[_]]
-  }
-  
-  case class ValueDescriptor(id: Int, tpe: Type) extends UDTDescriptor {
-    override val isPrimitiveProduct = true
-    override def flatten = Seq(this)
-    override def canBeKey = tpe <:< typeOf[org.apache.flink.types.Key[_]]
-  }
+  case class RecursiveDescriptor(id: Int, tpe: Type, refId: Int) extends UDTDescriptor
 
-  case class WritableDescriptor(id: Int, tpe: Type) extends UDTDescriptor {
-    override val isPrimitiveProduct = true
-    override def flatten = Seq(this)
-    override def canBeKey = tpe <:< typeOf[org.apache.hadoop.io.WritableComparable[_]]
+  case class ValueDescriptor(id: Int, tpe: Type) extends UDTDescriptor
+
+  case class WritableDescriptor(id: Int, tpe: Type) extends UDTDescriptor
+
   }
 }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
@@ -296,7 +296,7 @@ private[flink] trait TypeInformationGen[C <: Context] {
       var error = false
       while (traversalClazz != null) {
         for (field <- traversalClazz.getDeclaredFields) {
-          if (clazzFields.contains(field.getName)) {
+          if (clazzFields.contains(field.getName) && !Modifier.isStatic(field.getModifiers)) {
             println(s"The field $field is already contained in the " +
               s"hierarchy of the class $clazz. Please use unique field names throughout " +
               "your class hierarchy")

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
@@ -53,6 +53,24 @@ class MyObject[A](var a: A) {
 class TypeInformationGenTest {
 
   @Test
+  def testJavaTuple(): Unit = {
+    val ti = createTypeInformation[org.apache.flink.api.java.tuple.Tuple3[Int, String, Integer]]
+
+    Assert.assertTrue(ti.isTupleType)
+    Assert.assertEquals(3, ti.getArity)
+    Assert.assertTrue(ti.isInstanceOf[TupleTypeInfoBase[_]])
+    val tti = ti.asInstanceOf[TupleTypeInfoBase[_]]
+    Assert.assertEquals(classOf[org.apache.flink.api.java.tuple.Tuple3[_, _, _]], tti.getTypeClass)
+    for (i <- 0 until 3) {
+      Assert.assertTrue(tti.getTypeAt(i).isInstanceOf[BasicTypeInfo[_]])
+    }
+
+    Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti.getTypeAt(0))
+    Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1))
+    Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti.getTypeAt(2))
+  }
+
+  @Test
   def testBasicType(): Unit = {
     val ti = createTypeInformation[Boolean]
 
@@ -162,7 +180,7 @@ class TypeInformationGenTest {
     Assert.assertTrue(ti.isInstanceOf[TupleTypeInfoBase[_]])
     val tti = ti.asInstanceOf[TupleTypeInfoBase[_]]
     Assert.assertEquals(classOf[Tuple9[_,_,_,_,_,_,_,_,_]], tti.getTypeClass)
-    for (i <- 0 until 0) {
+    for (i <- 0 until 9) {
       Assert.assertTrue(tti.getTypeAt(i).isInstanceOf[BasicTypeInfo[_]])
     }
 


### PR DESCRIPTION
This is mostly to allow Vertex, which is a Java Tuple2<> to be used in
the Scala Gelly API.