### PR TITLE
[FLINK-1964] Rework TwitterSource to use a Properties object

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/PropertiesUtil.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/PropertiesUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.twitter;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Provides utility methods to use when working with properties files.
+ */
+public final class PropertiesUtil {
+
+	private PropertiesUtil() {}
+
+	/**
+	 * Loads properties from the given file path.
+	 *
+	 * @param path the path to the properties file.
+	 *
+	 * @return the loaded properties.
+	 */
+	public static Properties load(final String path) {
+		InputStream input = null;
+		try {
+			input = new FileInputStream(path);
+			Properties properties = new Properties();
+			properties.load(input);
+			return properties;
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot load the properties file with path [" + path + "].", e);
+		} finally {
+			if (input != null) {
+				try {
+					input.close();
+				} catch (IOException e) {}				
+			}
+		}
+	}	
+	
+}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterStreaming.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterStreaming.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.connectors.twitter;
 
+import java.util.Properties;
+
 import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -71,7 +73,7 @@ public class TwitterStreaming {
 			} 
 		}
 	}
-
+	
 	public static void main(String[] args) throws Exception {
 
 		String path = new String();
@@ -82,11 +84,13 @@ public class TwitterStreaming {
 			System.err.println("USAGE:\nTwitterStreaming <pathToPropertiesFile>");
 			return;
 		}
+		
+		Properties authenticationProperties = PropertiesUtil.load(path);
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment
 				.createLocalEnvironment(PARALLELISM);
 
-		DataStream<String> streamSource = env.addSource(new TwitterSource(path, NUMBEROFTWEETS))
+		DataStream<String> streamSource = env.addSource(new TwitterSource(authenticationProperties, NUMBEROFTWEETS))
 				.setParallelism(SOURCE_PARALLELISM);
 
 		DataStream<Tuple5<Long, Integer, String, String, String>> selectedDataStream = streamSource

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterTopology.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterTopology.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.connectors.twitter;
 
+import java.util.Properties;
+
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -55,7 +57,7 @@ public class TwitterTopology {
 		}
 
 	}
-
+	
 	public static void main(String[] args) throws Exception {
 
 		String path = new String();
@@ -66,10 +68,12 @@ public class TwitterTopology {
 			System.err.println("USAGE:\nTwitterLocal <pathToPropertiesFile>");
 			return;
 		}
+		
+		Properties authenticationProperties = PropertiesUtil.load(path);
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-		DataStream<String> streamSource = env.addSource(new TwitterSource(path, NUMBEROFTWEETS));
+		DataStream<String> streamSource = env.addSource(new TwitterSource(authenticationProperties, NUMBEROFTWEETS));
 
 
 		DataStream<Tuple2<String, Integer>> dataStream = streamSource

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/twitter/TwitterStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/twitter/TwitterStream.java
@@ -17,16 +17,18 @@
 
 package org.apache.flink.streaming.examples.twitter;
 
+import java.util.Properties;
+import java.util.StringTokenizer;
+
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.json.JSONParseFlatMap;
+import org.apache.flink.streaming.connectors.twitter.PropertiesUtil;
 import org.apache.flink.streaming.connectors.twitter.TwitterSource;
 import org.apache.flink.streaming.examples.twitter.util.TwitterStreamData;
 import org.apache.flink.util.Collector;
 import org.apache.sling.commons.json.JSONException;
-
-import java.util.StringTokenizer;
 
 /**
  * Implements the "TwitterStream" program that computes a most used word
@@ -154,11 +156,13 @@ public class TwitterStream {
 		}
 		return true;
 	}
-
+	
 	private static DataStream<String> getTextDataStream(StreamExecutionEnvironment env) {
 		if (fileInput) {
+		    // load the authentication properties from given input path
+			Properties authenticationProperties = PropertiesUtil.load(propertiesPath);
 			// read the text file from given input path
-			return env.addSource(new TwitterSource(propertiesPath));
+			return env.addSource(new TwitterSource(authenticationProperties));
 		} else {
 			// get default test text data
 			return env.fromElements(TwitterStreamData.TEXTS);


### PR DESCRIPTION
I have changed TwitterSource and its related code to use a properties object insted of a file path so we could inject properties from different sources.