### PR TITLE
Pluggable state backend support for checkpoints

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -402,6 +402,18 @@ public final class ConfigConstants {
 	 */
 	public static final String AKKA_LOOKUP_TIMEOUT = "akka.lookup.timeout";
 	
+	// ----------------------------- Streaming --------------------------------
+	
+	/**
+	 * State backend for checkpoints;
+	 */
+	public static final String STATE_BACKEND = "state.backend";
+	
+	/**
+	 * Directory for saving streaming checkpoints
+	 */
+	public static final String STATE_BACKEND_FS_DIR = "state.backend.fs.checkpointdir";
+	
 	// ----------------------------- Miscellaneous ----------------------------
 	
 	/**
@@ -624,6 +636,9 @@ public final class ConfigConstants {
 
 	public static String DEFAULT_AKKA_LOOKUP_TIMEOUT = "10 s";
 	
+	// ----------------------------- Streaming Values --------------------------
+	
+	public static String DEFAULT_STATE_BACKEND = "jobmanager";
 
 	// ----------------------------- LocalExecution ----------------------------
 

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -48,6 +48,21 @@ jobmanager.web.port: 8081
 webclient.port: 8080
 
 #==============================================================================
+# Streaming state checkpointing
+#==============================================================================
+
+# The backend that will be used to store operator state checkpoints if 
+# checkpointing is enabled. 
+#
+# Supported backends: jobmanager, filesystem
+
+state.backend: jobmanager
+
+# Directory for storing checkpoints in a flink supported filesystem
+#
+# state.backend.fs.checkpointdir: hdfs://checkpoints
+
+#==============================================================================
 # Advanced
 #==============================================================================
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -97,6 +97,8 @@ public class CheckpointCoordinator {
 	
 	private ActorRef jobStatusListener;
 	
+	private ClassLoader userClassLoader;
+	
 	private boolean shutdown;
 	
 	// --------------------------------------------------------------------------------------------
@@ -104,7 +106,8 @@ public class CheckpointCoordinator {
 	public CheckpointCoordinator(JobID job, int numSuccessfulCheckpointsToRetain, long checkpointTimeout,
 								ExecutionVertex[] tasksToTrigger,
 								ExecutionVertex[] tasksToWaitFor,
-								ExecutionVertex[] tasksToCommitTo) {
+								ExecutionVertex[] tasksToCommitTo,
+								ClassLoader userClassLoader) {
 		
 		// some sanity checks
 		if (job == null || tasksToTrigger == null ||
@@ -127,6 +130,7 @@ public class CheckpointCoordinator {
 		this.pendingCheckpoints = new LinkedHashMap<Long, PendingCheckpoint>();
 		this.completedCheckpoints = new ArrayDeque<SuccessfulCheckpoint>(numSuccessfulCheckpointsToRetain + 1);
 		this.recentPendingCheckpoints = new ArrayDeque<Long>(NUM_GHOST_CHECKPOINT_IDS);
+		this.userClassLoader = userClassLoader;
 
 		timer = new Timer("Checkpoint Timer", true);
 	}
@@ -166,13 +170,13 @@ public class CheckpointCoordinator {
 			
 			// clear and discard all pending checkpoints
 			for (PendingCheckpoint pending : pendingCheckpoints.values()) {
-				pending.discard();
+					pending.discard(userClassLoader, true);
 			}
 			pendingCheckpoints.clear();
 			
 			// clean and discard all successful checkpoints
 			for (SuccessfulCheckpoint checkpoint : completedCheckpoints) {
-				checkpoint.dispose();
+				checkpoint.dispose(userClassLoader);
 			}
 			completedCheckpoints.clear();
 		}
@@ -253,7 +257,9 @@ public class CheckpointCoordinator {
 							// note that checkpoint completion discards the pending checkpoint object
 							if (!checkpoint.isDiscarded()) {
 								LOG.info("Checkpoint " + checkpointID + " expired before completing.");
-								checkpoint.discard();
+								
+								checkpoint.discard(userClassLoader, true);
+								
 								pendingCheckpoints.remove(checkpointID);
 								rememberRecentCheckpointId(checkpointID);
 							}
@@ -288,7 +294,10 @@ public class CheckpointCoordinator {
 			LOG.warn("Failed to trigger checkpoint (" + numUnsuccessful + " consecutive failed attempts so far)", t);
 			
 			synchronized (lock) {
-				pendingCheckpoints.remove(checkpointID);
+				PendingCheckpoint checkpoint = pendingCheckpoints.remove(checkpointID);
+				if (checkpoint != null && !checkpoint.isDiscarded()) {
+					checkpoint.discard(userClassLoader, true);
+				}
 			}
 			
 			return false;
@@ -325,7 +334,7 @@ public class CheckpointCoordinator {
 						completed = checkpoint.toCompletedCheckpoint();
 						completedCheckpoints.addLast(completed);
 						if (completedCheckpoints.size() > numSuccessfulCheckpointsToRetain) {
-							completedCheckpoints.removeFirst();
+							completedCheckpoints.removeFirst().dispose(userClassLoader);;
 						}
 						pendingCheckpoints.remove(checkpointId);
 						rememberRecentCheckpointId(checkpointId);
@@ -383,7 +392,9 @@ public class CheckpointCoordinator {
 			PendingCheckpoint p = entries.next().getValue();
 			if (p.getCheckpointTimestamp() < timestamp) {
 				rememberRecentCheckpointId(p.getCheckpointId());
-				p.discard();
+
+				p.discard(userClassLoader, true);
+
 				entries.remove();
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -176,7 +176,7 @@ public class CheckpointCoordinator {
 			
 			// clean and discard all successful checkpoints
 			for (SuccessfulCheckpoint checkpoint : completedCheckpoints) {
-				checkpoint.dispose(userClassLoader);
+				checkpoint.discard(userClassLoader);
 			}
 			completedCheckpoints.clear();
 		}
@@ -334,7 +334,7 @@ public class CheckpointCoordinator {
 						completed = checkpoint.toCompletedCheckpoint();
 						completedCheckpoints.addLast(completed);
 						if (completedCheckpoints.size() > numSuccessfulCheckpointsToRetain) {
-							completedCheckpoints.removeFirst().dispose(userClassLoader);;
+							completedCheckpoints.removeFirst().discard(userClassLoader);
 						}
 						pendingCheckpoints.remove(checkpointId);
 						rememberRecentCheckpointId(checkpointId);
@@ -409,7 +409,7 @@ public class CheckpointCoordinator {
 												boolean allOrNothingState) throws Exception {
 		synchronized (lock) {
 			if (shutdown) {
-				throw new IllegalStateException("CheckpointCoordinator is hut down");
+				throw new IllegalStateException("CheckpointCoordinator is shut down");
 			}
 			
 			if (completedCheckpoints.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateForTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateForTask.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import java.io.IOException;
+
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.util.SerializedValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple bean to describe the state belonging to a parallel operator.
@@ -33,6 +37,8 @@ import org.apache.flink.runtime.util.SerializedValue;
  * the respective classloader.
  */
 public class StateForTask {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(StateForTask.class);
 
 	/** The state of the parallel operator */
 	private final SerializedValue<StateHandle<?>> state;
@@ -42,9 +48,9 @@ public class StateForTask {
 	
 	/** The index of the parallel subtask */
 	private final int subtask;
-
+	
 	public StateForTask(SerializedValue<StateHandle<?>> state, JobVertexID operatorId, int subtask) {
-		if (state == null || operatorId == null || subtask < 0) {
+	if (state == null || operatorId == null || subtask < 0) {
 			throw new IllegalArgumentException();
 		}
 		
@@ -65,6 +71,14 @@ public class StateForTask {
 
 	public int getSubtask() {
 		return subtask;
+	}
+	
+	public void discard(ClassLoader userClassLoader) {
+		try {
+			state.deserializeValue(userClassLoader).discardState();
+		} catch (Exception e) {
+			LOG.warn("Failed to discard checkpoint state: " + this, e);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateForTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateForTask.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.checkpoint;
 
-import java.io.IOException;
-
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.util.SerializedValue;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SuccessfulCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SuccessfulCheckpoint.java
@@ -66,7 +66,7 @@ public class SuccessfulCheckpoint {
 
 	// --------------------------------------------------------------------------------------------
 	
-	public void dispose(ClassLoader userClassLoader) {
+	public void discard(ClassLoader userClassLoader) {
 		for(StateForTask state: states){
 			state.discard(userClassLoader);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SuccessfulCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SuccessfulCheckpoint.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -27,6 +29,8 @@ import java.util.List;
  * and that is considered completed.
  */
 public class SuccessfulCheckpoint {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(SuccessfulCheckpoint.class);
 	
 	private final JobID job;
 	
@@ -62,7 +66,10 @@ public class SuccessfulCheckpoint {
 
 	// --------------------------------------------------------------------------------------------
 	
-	public void dispose() {
+	public void dispose(ClassLoader userClassLoader) {
+		for(StateForTask state: states){
+			state.discard(userClassLoader);
+		}
 		states.clear();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -307,7 +307,7 @@ public class ExecutionGraph implements Serializable {
 		// create the coordinator that triggers and commits checkpoints and holds the state 
 		snapshotCheckpointsEnabled = true;
 		checkpointCoordinator = new CheckpointCoordinator(jobID, NUMBER_OF_SUCCESSFUL_CHECKPOINTS_TO_RETAIN,
-				checkpointTimeout, tasksToTrigger, tasksToWaitFor, tasksToCommitTo);
+				checkpointTimeout, tasksToTrigger, tasksToWaitFor, tasksToCommitTo, userClassLoader);
 		
 		// the periodic checkpoint scheduler is activated and deactivated as a result of
 		// job status changes (running -> on, all other states -> off)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
@@ -34,7 +34,7 @@ public abstract class ByteStreamStateHandle implements StateHandle<Serializable>
 
 	private static final long serialVersionUID = -962025800339325828L;
 
-	transient Serializable state;
+	private transient Serializable state;
 
 	public ByteStreamStateHandle(Serializable state) {
 		this.state = state;
@@ -52,9 +52,11 @@ public abstract class ByteStreamStateHandle implements StateHandle<Serializable>
 
 	@Override
 	public Serializable getState() throws Exception {
-		ObjectInputStream stream = new ObjectInputStream(getInputStream());
-		state = (Serializable) stream.readObject();
-		stream.close();
+		if (!stateFetched()) {
+			ObjectInputStream stream = new ObjectInputStream(getInputStream());
+			state = (Serializable) stream.readObject();
+			stream.close();
+		}
 		return state;
 	}
 
@@ -63,5 +65,13 @@ public abstract class ByteStreamStateHandle implements StateHandle<Serializable>
 		stream.writeObject(state);
 		stream.close();
 		oos.defaultWriteObject();
+	}
+
+	/**
+	 * Checks whether the state has already been fetched from the remote
+	 * storage.
+	 */
+	public boolean stateFetched() {
+		return state != null;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.state;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -37,7 +36,7 @@ public abstract class ByteStreamStateHandle implements StateHandle<Serializable>
 
 	transient Serializable state;
 
-	public ByteStreamStateHandle(Serializable state) throws IOException {
+	public ByteStreamStateHandle(Serializable state) {
 		this.state = state;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
@@ -25,6 +25,12 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 
+/**
+ * Statehandle that writes/reads the contents of the serializable checkpointed
+ * state to the provided input and outputstreams using default java
+ * serialization.
+ * 
+ */
 public abstract class ByteStreamStateHandle implements StateHandle<Serializable> {
 
 	private static final long serialVersionUID = -962025800339325828L;
@@ -35,8 +41,14 @@ public abstract class ByteStreamStateHandle implements StateHandle<Serializable>
 		this.state = state;
 	}
 
+	/**
+	 * The state will be written to the stream returned by this method.
+	 */
 	protected abstract OutputStream getOutputStream() throws Exception;
 
+	/**
+	 * The state will be read from the stream returned by this method.
+	 */
 	protected abstract InputStream getInputStream() throws Exception;
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ByteStreamStateHandle.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+public abstract class ByteStreamStateHandle implements StateHandle<Serializable> {
+
+	private static final long serialVersionUID = -962025800339325828L;
+
+	transient Serializable state;
+
+	public ByteStreamStateHandle(Serializable state) throws IOException {
+		this.state = state;
+	}
+
+	protected abstract OutputStream getOutputStream() throws Exception;
+
+	protected abstract InputStream getInputStream() throws Exception;
+
+	@Override
+	public Serializable getState() throws Exception {
+		ObjectInputStream stream = new ObjectInputStream(getInputStream());
+		state = (Serializable) stream.readObject();
+		stream.close();
+		return state;
+	}
+
+	private void writeObject(ObjectOutputStream oos) throws Exception {
+		ObjectOutputStream stream = new ObjectOutputStream(getOutputStream());
+		stream.writeObject(state);
+		stream.close();
+		oos.defaultWriteObject();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileStateHandle.java
@@ -29,7 +29,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.StringUtils;
 
-import scala.util.Random;
+import java.util.Random;
 
 /**
  * Statehandle that writes the checkpointed state to a random file in the
@@ -44,7 +44,7 @@ public class FileStateHandle extends ByteStreamStateHandle {
 
 	private String pathString;
 
-	public FileStateHandle(Serializable state, String folder) throws IOException {
+	public FileStateHandle(Serializable state, String folder) {
 		super(state);
 		this.pathString = folder + "/" + randomString();
 	}
@@ -66,6 +66,36 @@ public class FileStateHandle extends ByteStreamStateHandle {
 	@Override
 	public void discardState() throws Exception {
 		FileSystem.get(new URI(pathString)).delete(new Path(pathString), false);
+	}
+
+	/**
+	 * Creates a {@link StateHandleProvider} for creating
+	 * {@link FileStateHandle}s for a given checkpoint directory.
+	 * 
+	 */
+	public static StateHandleProvider<Serializable> createProvider(String checkpointDir) {
+		return new FileStateHandleProvider(checkpointDir);
+	}
+
+	/**
+	 * {@link StateHandleProvider} to generate {@link FileStateHandle}s for the
+	 * given checkpoint directory.
+	 * 
+	 */
+	private static class FileStateHandleProvider implements StateHandleProvider<Serializable> {
+
+		private static final long serialVersionUID = 3496670017955260518L;
+		private String path;
+
+		public FileStateHandleProvider(String path) {
+			this.path = path;
+		}
+
+		@Override
+		public FileStateHandle createStateHandle(Serializable state) {
+			return new FileStateHandle(state, path);
+		}
+
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileStateHandle.java
@@ -31,11 +31,18 @@ import org.apache.flink.util.StringUtils;
 
 import scala.util.Random;
 
+/**
+ * Statehandle that writes the checkpointed state to a random file in the
+ * provided checkpoint directory. Any Flink supported File system can be used
+ * but it is advised to use a filesystem that is persistent in case of node
+ * failures, such as HDFS or Tachyon.
+ * 
+ */
 public class FileStateHandle extends ByteStreamStateHandle {
 
 	private static final long serialVersionUID = 1L;
 
-	String pathString;
+	private String pathString;
 
 	public FileStateHandle(Serializable state, String folder) throws IOException {
 		super(state);
@@ -55,4 +62,10 @@ public class FileStateHandle extends ByteStreamStateHandle {
 		new Random().nextBytes(bytes);
 		return StringUtils.byteToHexString(bytes);
 	}
+
+	@Override
+	public void discardState() throws Exception {
+		FileSystem.get(new URI(pathString)).delete(new Path(pathString), false);
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileStateHandle.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.StringUtils;
+
+import scala.util.Random;
+
+public class FileStateHandle extends ByteStreamStateHandle {
+
+	private static final long serialVersionUID = 1L;
+
+	String pathString;
+
+	public FileStateHandle(Serializable state, String folder) throws IOException {
+		super(state);
+		this.pathString = folder + "/" + randomString();
+	}
+
+	protected OutputStream getOutputStream() throws IOException, URISyntaxException {
+		return FileSystem.get(new URI(pathString)).create(new Path(pathString), true);
+	}
+
+	protected InputStream getInputStream() throws IOException, URISyntaxException {
+		return FileSystem.get(new URI(pathString)).open(new Path(pathString));
+	}
+
+	private String randomString() {
+		final byte[] bytes = new byte[20];
+		new Random().nextBytes(bytes);
+		return StringUtils.byteToHexString(bytes);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/LocalStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/LocalStateHandle.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.state;
 import java.io.Serializable;
 
 /**
- * A StateHandle that includes a map of operator states directly.
+ * A StateHandle that includes the operator states directly.
  */
 public class LocalStateHandle implements StateHandle<Serializable> {
 
@@ -36,5 +36,9 @@ public class LocalStateHandle implements StateHandle<Serializable> {
 	@Override
 	public Serializable getState() {
 		return state;
+	}
+
+	@Override
+	public void discardState() throws Exception {
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandle.java
@@ -34,4 +34,11 @@ public interface StateHandle<T> extends Serializable {
 	 * @throws java.lang.Exception Thrown, if the state cannot be fetched.
 	 */
 	T getState() throws Exception;
+	
+	/**
+	 * Discards the state referred to by this handle, to free up resources in
+	 * the persistent storage. This method is called when the handle will not be
+	 * used any more.
+	 */
+	void discardState() throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandleProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandleProvider.java
@@ -21,39 +21,19 @@ package org.apache.flink.runtime.state;
 import java.io.Serializable;
 
 /**
- * A StateHandle that includes the operator states directly.
+ * Stateful streaming operators use a StateHandleProvider to create new
+ * {@link StateHandle}s to store each checkpoint in a persistent storage layer.
  */
-public class LocalStateHandle implements StateHandle<Serializable> {
+public interface StateHandleProvider<T> extends Serializable {
 
-	private static final long serialVersionUID = 2093619217898039610L;
+	/**
+	 * Creates a new {@link StateHandle} instance that will be used to store the
+	 * state checkpoint. This method is called for each state checkpoint saved.
+	 * 
+	 * @param state
+	 *            State to be stored in the handle.
+	 * 
+	 */
+	public StateHandle<T> createStateHandle(T state);
 
-	private final Serializable state;
-
-	public LocalStateHandle(Serializable state) {
-		this.state = state;
-	}
-
-	@Override
-	public Serializable getState() {
-		return state;
-	}
-
-	@Override
-	public void discardState() throws Exception {
-	}
-	
-	public static LocalStateHandleProvider createProvider(){
-		return new LocalStateHandleProvider();
-	}
-
-	private static class LocalStateHandleProvider implements StateHandleProvider<Serializable> {
-
-		private static final long serialVersionUID = 4665419208932921425L;
-
-		@Override
-		public LocalStateHandle createStateHandle(Serializable state) {
-			return new LocalStateHandle(state);
-		}
-
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -53,10 +53,8 @@ import org.apache.flink.runtime.messages.TaskMessages;
 import org.apache.flink.runtime.messages.TaskMessages.TaskInFinalState;
 import org.apache.flink.runtime.messages.TaskManagerMessages.FatalError;
 import org.apache.flink.runtime.state.StateHandle;
-
 import org.apache.flink.runtime.state.StateUtils;
 import org.apache.flink.runtime.util.SerializedValue;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -522,7 +520,7 @@ public class Task implements Runnable {
 						StateUtils.setOperatorState(op, state);
 					}
 					catch (Exception e) {
-						throw new Exception("Failed to deserialize state handle and setup initial operator state");
+						throw new RuntimeException("Failed to deserialize state handle and setup initial operator state.", e);
 					}
 				}
 				else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -38,6 +38,8 @@ import java.util.List;
  */
 public class CheckpointCoordinatorTest {
 	
+	ClassLoader cl = Thread.currentThread().getContextClassLoader();
+	
 	@Test
 	public void testCheckpointAbortsIfTriggerTasksAreNotExecuted() {
 		try {
@@ -59,7 +61,7 @@ public class CheckpointCoordinatorTest {
 					jid, 1, 600000,
 					new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
 					new ExecutionVertex[] { ackVertex1, ackVertex2 },
-					new ExecutionVertex[] {} );
+					new ExecutionVertex[] {}, cl );
 
 			// nothing should be happening
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -101,7 +103,7 @@ public class CheckpointCoordinatorTest {
 					jid, 1, 600000,
 					new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
 					new ExecutionVertex[] { ackVertex1, ackVertex2 },
-					new ExecutionVertex[] {} );
+					new ExecutionVertex[] {}, cl );
 
 			// nothing should be happening
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -139,7 +141,7 @@ public class CheckpointCoordinatorTest {
 					jid, 1, 600000,
 					new ExecutionVertex[] { vertex1, vertex2 },
 					new ExecutionVertex[] { vertex1, vertex2 },
-					new ExecutionVertex[] { vertex1, vertex2 });
+					new ExecutionVertex[] { vertex1, vertex2 }, cl);
 			
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -282,7 +284,7 @@ public class CheckpointCoordinatorTest {
 					jid, 2, 600000,
 					new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
 					new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 },
-					new ExecutionVertex[] { commitVertex });
+					new ExecutionVertex[] { commitVertex }, cl);
 			
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -409,7 +411,7 @@ public class CheckpointCoordinatorTest {
 					jid, 10, 600000,
 					new ExecutionVertex[] { triggerVertex1, triggerVertex2 },
 					new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 },
-					new ExecutionVertex[] { commitVertex });
+					new ExecutionVertex[] { commitVertex }, cl);
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -523,7 +525,7 @@ public class CheckpointCoordinatorTest {
 					jid, 2, 200,
 					new ExecutionVertex[] { triggerVertex },
 					new ExecutionVertex[] { ackVertex1, ackVertex2 },
-					new ExecutionVertex[] { commitVertex });
+					new ExecutionVertex[] { commitVertex }, cl);
 			
 			// trigger a checkpoint, partially acknowledged
 			assertTrue(coord.triggerCheckpoint(timestamp));
@@ -581,7 +583,7 @@ public class CheckpointCoordinatorTest {
 					jid, 2, 200000,
 					new ExecutionVertex[] { triggerVertex },
 					new ExecutionVertex[] { ackVertex1, ackVertex2 },
-					new ExecutionVertex[] { commitVertex });
+					new ExecutionVertex[] { commitVertex }, cl);
 
 			assertTrue(coord.triggerCheckpoint(timestamp));
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -30,9 +30,7 @@ import org.apache.flink.runtime.state.LocalStateHandle;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.runtime.util.SerializedValue;
-
 import org.junit.Test;
-
 import org.mockito.Mockito;
 
 import java.util.HashMap;
@@ -46,6 +44,8 @@ import static org.mockito.Mockito.*;
  * Tests concerning the restoring of state from a checkpoint to the task executions.
  */
 public class CheckpointStateRestoreTest {
+	
+	ClassLoader cl = Thread.currentThread().getContextClassLoader();
 	
 	@Test
 	public void testSetState() {
@@ -82,7 +82,7 @@ public class CheckpointStateRestoreTest {
 			CheckpointCoordinator coord = new CheckpointCoordinator(jid, 1, 200000L, 
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
-					new ExecutionVertex[0]);
+					new ExecutionVertex[0], cl);
 			
 			// create ourselves a checkpoint with state
 			final long timestamp = 34623786L;
@@ -151,7 +151,7 @@ public class CheckpointStateRestoreTest {
 			CheckpointCoordinator coord = new CheckpointCoordinator(jid, 1, 200000L,
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
-					new ExecutionVertex[0]);
+					new ExecutionVertex[0], cl);
 
 			// create ourselves a checkpoint with state
 			final long timestamp = 34623786L;
@@ -191,7 +191,7 @@ public class CheckpointStateRestoreTest {
 			CheckpointCoordinator coord = new CheckpointCoordinator(new JobID(), 1, 200000L,
 					new ExecutionVertex[] { mock(ExecutionVertex.class) },
 					new ExecutionVertex[] { mock(ExecutionVertex.class) },
-					new ExecutionVertex[0]);
+					new ExecutionVertex[0], cl);
 
 			try {
 				coord.restoreLatestCheckpointedState(new HashMap<JobVertexID, ExecutionJobVertex>(), true, false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
@@ -96,5 +96,9 @@ public class CheckpointMessagesTest {
 		public int hashCode() {
 			return getClass().hashCode();
 		}
-	};
+
+		@Override
+		public void discardState() throws Exception {
+		}
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/IterativeDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/IterativeDataStream.java
@@ -17,9 +17,6 @@
 
 package org.apache.flink.streaming.api.datastream;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-
 /**
  * The iterative data stream represents the start of an iteration in a
  * {@link DataStream}.
@@ -31,21 +28,13 @@ public class IterativeDataStream<IN> extends
 		SingleOutputStreamOperator<IN, IterativeDataStream<IN>> {
 
 	static Integer iterationCount = 0;
-	protected Integer iterationID;
-	protected long waitTime;
-
+	
 	protected IterativeDataStream(DataStream<IN> dataStream, long maxWaitTime) {
 		super(dataStream);
 		setBufferTimeout(dataStream.environment.getBufferTimeout());
 		iterationID = iterationCount;
 		iterationCount++;
-		waitTime = maxWaitTime;
-	}
-
-	protected IterativeDataStream(DataStream<IN> dataStream, Integer iterationID, long waitTime) {
-		super(dataStream);
-		this.iterationID = iterationID;
-		this.waitTime = waitTime;
+		iterationWaitTime = maxWaitTime;
 	}
 
 	/**
@@ -70,35 +59,9 @@ public class IterativeDataStream<IN> extends
 		// We add an iteration sink to the tail which will send tuples to the
 		// iteration head
 		streamGraph.addIterationTail(iterationSink.getId(), iterationTail.getId(), iterationID,
-				waitTime);
+				iterationWaitTime);
 
 		connectGraph(iterationTail.forward(), iterationSink.getId(), 0);
 		return iterationTail;
-	}
-
-	@Override
-	public <R> SingleOutputStreamOperator<R, ?> transform(String operatorName,
-			TypeInformation<R> outTypeInfo, OneInputStreamOperator<IN, R> operator) {
-
-		// We call the superclass tranform method
-		SingleOutputStreamOperator<R, ?> returnStream = super.transform(operatorName, outTypeInfo,
-				operator);
-
-		// Then we add a source that will take care of receiving feedback tuples
-		// from the tail
-		addIterationSource(returnStream);
-
-		return returnStream;
-	}
-
-	private <X> void addIterationSource(DataStream<X> dataStream) {
-		Integer id = ++counter;
-		streamGraph.addIterationHead(id, dataStream.getId(), iterationID, waitTime);
-		streamGraph.setParallelism(id, dataStream.getParallelism());
-	}
-
-	@Override
-	public IterativeDataStream<IN> copy() {
-		return new IterativeDataStream<IN>(this, iterationID, waitTime);
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -40,6 +40,8 @@ import org.apache.flink.client.program.Client.OptimizerPlanEnvironment;
 import org.apache.flink.client.program.ContextEnvironment;
 import org.apache.flink.client.program.PackagedProgram.PreviewPlanEnvironment;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.FileStateHandle;
+import org.apache.flink.runtime.state.StateHandleProvider;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.functions.source.FileMonitoringFunction.WatchType;
@@ -233,6 +235,19 @@ public abstract class StreamExecutionEnvironment {
 	 */
 	public StreamExecutionEnvironment enableCheckpointing() {
 		streamGraph.setCheckpointingEnabled(true);
+		return this;
+	}
+
+	/**
+	 * Sets the {@link StateHandleProvider} used for storing operator state
+	 * checkpoints when checkpointing is enabled.
+	 * <p>
+	 * An example would be using a {@link FileStateHandle#createProvider(Path)}
+	 * to use any Flink supported file system as a state backend
+	 * 
+	 */
+	public StreamExecutionEnvironment setStateHandleProvider(StateHandleProvider<?> provider) {
+		streamGraph.setStateHandleProvider(provider);
 		return this;
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.StateHandleProvider;
 import org.apache.flink.streaming.api.collector.selector.OutputSelectorWrapper;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecordSerializer;
@@ -57,6 +58,7 @@ public class StreamConfig implements Serializable {
 	private static final String EDGES_IN_ORDER = "edgesInOrder";
 	private static final String OUT_STREAM_EDGES = "outStreamEdges";
 	private static final String IN_STREAM_EDGES = "inStreamEdges";
+	private static final String STATEHANDLE_PROVIDER = "stateHandleProvider";
 
 	// DEFAULT VALUES
 	private static final long DEFAULT_TIMEOUT = 100;
@@ -375,6 +377,25 @@ public class StreamConfig implements Serializable {
 			return confs == null ? new HashMap<Integer, StreamConfig>() : confs;
 		} catch (Exception e) {
 			throw new StreamTaskException("Could not instantiate configuration.", e);
+		}
+	}
+	
+	public void setStateHandleProvider(StateHandleProvider<?> provider) {
+
+		try {
+			InstantiationUtil.writeObjectToConfig(provider, this.config, STATEHANDLE_PROVIDER);
+		} catch (IOException e) {
+			throw new StreamTaskException("Could not serialize stateHandle provider.", e);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public <R> StateHandleProvider<R> getStateHandleProvider(ClassLoader cl) {
+		try {
+			return (StateHandleProvider<R>) InstantiationUtil
+					.readObjectFromConfig(this.config, STATEHANDLE_PROVIDER, cl);
+		} catch (Exception e) {
+			throw new StreamTaskException("Could not instantiate statehandle provider.", e);
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -38,7 +38,6 @@ import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.state.LocalStateHandle;
 import org.apache.flink.runtime.state.StateHandleProvider;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -78,7 +77,7 @@ public class StreamGraph extends StreamingPlan {
 
 	private Map<Integer, StreamLoop> streamLoops;
 	protected Map<Integer, StreamLoop> vertexIDtoLoop;
-	private StateHandleProvider<?> stateHandleProvider = LocalStateHandle.createProvider();
+	private StateHandleProvider<?> stateHandleProvider;
 
 	public StreamGraph(StreamExecutionEnvironment environment) {
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -38,6 +38,8 @@ import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.state.LocalStateHandle;
+import org.apache.flink.runtime.state.StateHandleProvider;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -76,6 +78,7 @@ public class StreamGraph extends StreamingPlan {
 
 	private Map<Integer, StreamLoop> streamLoops;
 	protected Map<Integer, StreamLoop> vertexIDtoLoop;
+	private StateHandleProvider<?> stateHandleProvider = LocalStateHandle.createProvider();
 
 	public StreamGraph(StreamExecutionEnvironment environment) {
 
@@ -114,6 +117,14 @@ public class StreamGraph extends StreamingPlan {
 
 	public void setCheckpointingInterval(long checkpointingInterval) {
 		this.checkpointingInterval = checkpointingInterval;
+	}
+
+	public void setStateHandleProvider(StateHandleProvider<?> provider) {
+		this.stateHandleProvider = provider;
+	}
+
+	public StateHandleProvider<?> getStateHandleProvider() {
+		return this.stateHandleProvider;
 	}
 
 	public long getCheckpointingInterval() {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -258,6 +258,7 @@ public class StreamingJobGraphGenerator {
 		config.setNonChainedOutputs(nonChainableOutputs);
 		config.setChainedOutputs(chainableOutputs);
 		config.setStateMonitoring(streamGraph.isCheckpointingEnabled());
+		config.setStateHandleProvider(streamGraph.getStateHandleProvider());
 
 		Class<? extends AbstractInvokable> vertexClass = vertex.getJobVertexClass();
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCommittingOperator;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointedOperator;
 import org.apache.flink.runtime.jobgraph.tasks.OperatorStateCarrier;
 import org.apache.flink.runtime.state.LocalStateHandle;
+import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.util.event.EventListener;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -41,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 
 public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends AbstractInvokable implements
-		OperatorStateCarrier<LocalStateHandle>, CheckpointedOperator, CheckpointCommittingOperator {
+		OperatorStateCarrier<StateHandle<Serializable>>, CheckpointedOperator, CheckpointCommittingOperator {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamTask.class);
 
@@ -136,7 +137,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 	 * Re-injects the user states into the map. Also set the state on the functions.
 	 */
 	@Override
-	public void setInitialState(LocalStateHandle stateHandle) throws Exception {
+	public void setInitialState(StateHandle<Serializable> stateHandle) throws Exception {
 		// here, we later resolve the state handle into the actual state by
 		// loading the state described by the handle from the backup store
 		Serializable state = stateHandle.getState();
@@ -184,7 +185,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 					LOG.info("Starting checkpoint {} on task {}", checkpointId, getName());
 					
 					// first draw the state that should go into checkpoint
-					LocalStateHandle state;
+					StateHandle<Serializable> state;
 					try {
 
 						Serializable userState = null;

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -19,19 +19,17 @@
 package org.apache.flink.streaming.api.scala
 
 import scala.reflect.ClassTag
-
 import com.esotericsoftware.kryo.Serializer
 import org.apache.commons.lang.Validate
 import org.joda.time.Instant
-
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
 import org.apache.flink.streaming.api.functions.source.FileMonitoringFunction.WatchType
 import org.apache.flink.streaming.api.functions.source.{FromElementsFunction, SourceFunction}
-
 import scala.reflect.ClassTag
+import org.apache.flink.runtime.state.StateHandleProvider
 
 class StreamExecutionEnvironment(javaEnv: JavaEnv) {
 
@@ -125,7 +123,16 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     javaEnv.enableCheckpointing()
     this
   }
-  
+
+  /**
+   * Sets the given StateHandleProvider to be used for storing operator state
+   * checkpoints when checkpointing is enabled.
+   */
+  def setStateHandleProvider(provider: StateHandleProvider[_]): StreamExecutionEnvironment = {
+    javaEnv.setStateHandleProvider(provider)
+    this
+  }
+ 
   /**
    * Disables operator chaining for streaming operators. Operator chaining
    * allows non-shuffle operations to be co-located in the same thread fully

--- a/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/FileStateHandleTest.java
+++ b/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/FileStateHandleTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tachyon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+
+import org.apache.flink.runtime.state.FileStateHandle;
+import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.runtime.state.StateHandleProvider;
+import org.apache.flink.runtime.util.SerializedValue;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FileStateHandleTest {
+
+	private String hdfsURI;
+	private MiniDFSCluster hdfsCluster;
+	private org.apache.hadoop.fs.Path hdPath;
+	private org.apache.hadoop.fs.FileSystem hdfs;
+
+	@Before
+	public void createHDFS() {
+		try {
+			Configuration hdConf = new Configuration();
+
+			File baseDir = new File("./target/hdfs/filestatehandletest").getAbsoluteFile();
+			FileUtil.fullyDelete(baseDir);
+			hdConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+			MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(hdConf);
+			hdfsCluster = builder.build();
+
+			hdfsURI = "hdfs://" + hdfsCluster.getURI().getHost() + ":"
+					+ hdfsCluster.getNameNodePort() + "/";
+
+			hdPath = new org.apache.hadoop.fs.Path("/StateHandleTest");
+			hdfs = hdPath.getFileSystem(hdConf);
+			hdfs.mkdirs(hdPath);
+
+		} catch (Throwable e) {
+			e.printStackTrace();
+			Assert.fail("Test failed " + e.getMessage());
+		}
+	}
+
+	@After
+	public void destroyHDFS() {
+		try {
+			hdfs.delete(hdPath, true);
+			hdfsCluster.shutdown();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+
+	@Test
+	public void testFileStateHandle() throws Exception {
+
+		Serializable state = "state";
+
+		// Create a state handle provider for the hdfs directory
+		StateHandleProvider<Serializable> handleProvider = FileStateHandle.createProvider(hdfsURI
+				+ hdPath);
+
+		FileStateHandle handle = (FileStateHandle) handleProvider.createStateHandle(state);
+
+		assertTrue(handle.stateFetched());
+
+		// Serialize the handle so it writes the value to hdfs
+		SerializedValue<StateHandle<Serializable>> serializedHandle = new SerializedValue<StateHandle<Serializable>>(
+				handle);
+
+		// Deserialize the handle and verify that the state is not fetched yet
+		FileStateHandle deserializedHandle = (FileStateHandle) serializedHandle
+				.deserializeValue(Thread.currentThread().getContextClassLoader());
+		assertFalse(deserializedHandle.stateFetched());
+
+		// Fetch the and compare with original
+		assertEquals(state, deserializedHandle.getState());
+
+		// Test whether discard removes the checkpoint file properly
+		assertTrue(hdfs.listFiles(hdPath, true).hasNext());
+		handle.discardState();
+		assertFalse(hdfs.listFiles(hdPath, true).hasNext());
+
+	}
+
+}

--- a/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/HDFSTest.java
+++ b/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/HDFSTest.java
@@ -45,10 +45,10 @@ import java.io.StringWriter;
  */
 public class HDFSTest {
 
-	private String hdfsURI;
+	protected String hdfsURI;
 	private MiniDFSCluster hdfsCluster;
 	private org.apache.hadoop.fs.Path hdPath;
-	private org.apache.hadoop.fs.FileSystem hdfs;
+	protected org.apache.hadoop.fs.FileSystem hdfs;
 
 	@Before
 	public void createHDFS() {


### PR DESCRIPTION
This PR introduces the pluggable state backends using StateHandleProviders and extends the StateHandle interface with a discard method for cleaning up the unnecessary checkpoints.

It also adds a statehandle/provider implementation for storing checkpoints in any flink supported file system such as HDFS or Tachyon.

The checkpoint coordinator has been modified to properly discard user state handles using the following logic:
 - If a pending checkpoint expires (by the timer thread) it discards the user state
 - When a successful checkpoint expires (by acquiring following successful ones) it discards user states
 - When the checkpoint coordinator is shut down it discards all pending and successful states

Travis error:
I modified the recovery IT case to use the local file system for storing the checkpoints. Afterwards it checks whether the directory is empty. The test passes if I only run that specific test locally , but it seems to fail when I run with the other IT cases for no apparent reason. Usually a couple of files (2-5) remain in the checkpoint directory, meaning that almost all of them had been deleted but those. Also the checkpointing and recovery logic runs fine without test failure.

Could it happen that the jobmanager doesnt shut down the checkpointmanager in time?

I would appreciate some help figuring this out somehow, or trying to reproduce it locally. 