### PR TITLE
implement a simple session management

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -151,9 +151,13 @@ public class LocalExecutor extends PlanExecutor {
 			// check if we start a session dedicated for this execution
 			final boolean shutDownAtEnd;
 			if (this.flink == null) {
-				// we start a session just for us now
-				shutDownAtEnd = true;
-				
+				if (getSessionTimeout() == 0) {
+					// we start a session just for us now
+					shutDownAtEnd = true;
+				} else {
+					shutDownAtEnd = false;
+				}
+
 				// configure the number of local slots equal to the parallelism of the local plan
 				if (this.taskManagerNumSlots == DEFAULT_TASK_MANAGER_NUM_SLOTS) {
 					int maxParallelism = plan.getMaximumParallelism();
@@ -174,6 +178,10 @@ public class LocalExecutor extends PlanExecutor {
 				
 				JobGraphGenerator jgg = new JobGraphGenerator();
 				JobGraph jobGraph = jgg.compileJobGraph(op);
+				if (getJobID() != null) {
+					jobGraph.setJobID(getJobID());
+					jobGraph.setSessionTimeout(getSessionTimeout());
+				}
 				
 				boolean sysoutPrint = isPrintingStatusDuringExecution();
 				SerializedJobExecutionResult result = flink.submitJobAndWait(jobGraph,sysoutPrint);

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -54,7 +54,7 @@ public class RemoteExecutor extends PlanExecutor {
 
 	private final List<String> jarFiles;
 	private final InetSocketAddress address;
-	
+
 	public RemoteExecutor(String hostname, int port) {
 		this(hostname, port, Collections.<String>emptyList());
 	}
@@ -85,7 +85,9 @@ public class RemoteExecutor extends PlanExecutor {
 	public JobExecutionResult executePlanWithJars(JobWithJars p) throws Exception {
 		Client c = new Client(this.address, new Configuration(), p.getUserCodeClassLoader(), -1);
 		c.setPrintStatusDuringExecution(isPrintingStatusDuringExecution());
-		
+		c.setJobID(getJobID());
+		c.setSessionTimeout(getSessionTimeout());
+
 		JobSubmissionResult result = c.run(p, -1, true);
 		if (result instanceof JobExecutionResult) {
 			return (JobExecutionResult) result;
@@ -101,7 +103,9 @@ public class RemoteExecutor extends PlanExecutor {
 		
 		Client c = new Client(this.address, new Configuration(), program.getUserCodeClassLoader(), -1);
 		c.setPrintStatusDuringExecution(isPrintingStatusDuringExecution());
-		
+		c.setJobID(getJobID());
+		c.setSessionTimeout(getSessionTimeout());
+
 		JobSubmissionResult result = c.run(program.getPlanWithJars(), -1, true);
 		if(result instanceof JobExecutionResult) {
 			return (JobExecutionResult) result;
@@ -120,6 +124,7 @@ public class RemoteExecutor extends PlanExecutor {
 		PlanJSONDumpGenerator jsonGen = new PlanJSONDumpGenerator();
 		return jsonGen.getOptimizerPlanAsJSON(op);
 	}
+
 	
 	// --------------------------------------------------------------------------------------------
 	//   Utilities
@@ -147,5 +152,7 @@ public class RemoteExecutor extends PlanExecutor {
 		}
 		return new InetSocketAddress(host, port);
 	}
+
+
 	
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -60,6 +61,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		Plan p = createProgramPlan(jobName);
 		JobWithJars toRun = new JobWithJars(p, this.jarFilesToAttach, this.userCodeClassLoader);
 
+		this.client.setJobID(jobID);
+		this.client.setSessionTimeout(sessionTimeout);
 		JobSubmissionResult result = this.client.run(toRun, getParallelism(), wait);
 		if(result instanceof JobExecutionResult) {
 			this.lastJobExecutionResult = (JobExecutionResult) result;
@@ -79,6 +82,12 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 		PlanJSONDumpGenerator gen = new PlanJSONDumpGenerator();
 		return gen.getOptimizerPlanAsJSON(op);
+	}
+
+	@Override
+	public void startNewSession() throws Exception {
+		client.endSession();
+		jobID = JobID.generate();
 	}
 
 	public boolean isWait() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -712,7 +712,11 @@ public class PackagedProgram {
 			// do not go on with anything now!
 			throw new Client.ProgramAbortException();
 		}
-		
+
+		@Override
+		public void startNewSession() throws Exception {
+		}
+
 		public void setAsContext() {
 			ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 				@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.junit.Assert.fail;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -33,7 +33,7 @@ import java.util.List;
  * dependencies of all runtime classes.
  */
 public abstract class PlanExecutor {
-	
+
 	private static final String LOCAL_EXECUTOR_CLASS = "org.apache.flink.client.LocalExecutor";
 	private static final String REMOTE_EXECUTOR_CLASS = "org.apache.flink.client.RemoteExecutor";
 
@@ -50,6 +50,43 @@ public abstract class PlanExecutor {
 	
 	public boolean isPrintingStatusDuringExecution() {
 		return this.printUpdatesToSysout;
+	}
+
+	/** Job identifer, may only be set for explicit resume of a job.  */
+	private JobID jobID = null;
+
+	private long sessionTimeout = 0;
+
+	/**
+	 * Sets the job identifier for execution of jobs. May be set to null to disable session management.
+	 * @param jobID
+	 */
+	public void setJobID(JobID jobID) {
+		this.jobID = jobID;
+	}
+
+	/**
+	 * Gets the job identifier of this executor.
+	 * @return
+	 */
+	public JobID getJobID() {
+		return jobID;
+	}
+
+	/**
+	 * Gets the session timeout.
+	 * @return The session timeout in seconds.
+	 */
+	public long getSessionTimeout() {
+		return sessionTimeout;
+	}
+
+	/**
+	 * Sets the session timeout.
+	 * @return The session timeout in seconds.
+	 */
+	public void setSessionTimeout(long sessionTimeout) {
+		this.sessionTimeout = sessionTimeout;
 	}
 	
 	// ------------------------------------------------------------------------
@@ -102,7 +139,7 @@ public abstract class PlanExecutor {
 	/**
 	 * Creates an executor that runs the plan on a remote environment. The remote executor is typically used
 	 * to send the program to a cluster for execution.
-	 * 
+	 *
 	 * @param hostname The address of the JobManager to send the program to.
 	 * @param port The port of the JobManager to send the program to.
 	 * @param jarFiles A list of jar files that contain the user-defined function (UDF) classes and all classes used

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -52,4 +52,8 @@ public class CollectionEnvironment extends ExecutionEnvironment {
 	public String getExecutionPlan() throws Exception {
 		throw new UnsupportedOperationException("Execution plans are not used for collection-based execution.");
 	}
+
+	@Override
+	public void startNewSession() throws Exception {
+	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -26,11 +26,11 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.io.FileInputFormat;
@@ -106,9 +106,13 @@ public abstract class ExecutionEnvironment {
 	private static boolean allowLocalExecution = true;
 	
 	// --------------------------------------------------------------------------------------------
-	
-	private final UUID executionId;
-	
+
+	/** The id of the job which can be build incrementally. */
+	protected JobID jobID;
+
+	/** The session timeout in seconds */
+	protected long sessionTimeout = 0;
+
 	private final List<DataSink<?>> sinks = new ArrayList<DataSink<?>>();
 	
 	private final List<Tuple2<String, DistributedCacheEntry>> cacheFile = new ArrayList<Tuple2<String, DistributedCacheEntry>>();
@@ -129,7 +133,7 @@ public abstract class ExecutionEnvironment {
 	 * Creates a new Execution Environment.
 	 */
 	protected ExecutionEnvironment() {
-		this.executionId = UUID.randomUUID();
+		jobID = JobID.generate();
 	}
 
 	/**
@@ -228,14 +232,14 @@ public abstract class ExecutionEnvironment {
 	}
 	
 	/**
-	 * Gets the UUID by which this environment is identified. The UUID sets the execution context
+	 * Gets the JobID by which this environment is identified. The JobID sets the execution context
 	 * in the cluster or local environment.
 	 *
-	 * @return The UUID of this environment.
+	 * @return The JobID of this environment.
 	 * @see #getIdString()
 	 */
-	public UUID getId() {
-		return this.executionId;
+	public JobID getId() {
+		return this.jobID;
 	}
 
 	/**
@@ -249,13 +253,30 @@ public abstract class ExecutionEnvironment {
 
 
 	/**
-	 * Gets the UUID by which this environment is identified, as a string.
+	 * Gets the JobID by which this environment is identified, as a string.
 	 * 
-	 * @return The UUID as a string.
+	 * @return The JobID as a string.
 	 * @see #getId()
 	 */
 	public String getIdString() {
-		return this.executionId.toString();
+		return this.jobID.toString();
+	}
+
+	/**
+	 * Starts a new job and thereby a new session, discarding all intermediate results.
+	 */
+	public abstract void startNewSession() throws Exception;
+
+	/**
+	 * Sets the session timeout to hold the intermediate results of a job. This only
+	 * applies the updated timeout in future executions.
+	 * @param timeout The timeout in seconds.
+	 */
+	public void setSessionTimeout(long timeout) {
+		if (timeout < 0) {
+			throw new IllegalArgumentException("The session timeout must not be less than zero.");
+		}
+		sessionTimeout = timeout;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -1173,4 +1194,5 @@ public abstract class ExecutionEnvironment {
 	public static boolean localExecutionIsAllowed() {
 		return allowLocalExecution;
 	}
+
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -19,8 +19,15 @@
 package org.apache.flink.api.java;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /**
  * An {@link ExecutionEnvironment} that sends programs 
@@ -31,11 +38,15 @@ import org.apache.flink.api.common.PlanExecutor;
 public class RemoteEnvironment extends ExecutionEnvironment {
 	
 	private final String host;
-	
+
 	private final int port;
-	
+
 	private final String[] jarFiles;
-	
+
+	private static String clientClassName = "org.apache.flink.client.program.Client";
+
+	private Thread shutdownHook;
+
 	/**
 	 * Creates a new RemoteEnvironment that points to the master (JobManager) described by the
 	 * given host name and port.
@@ -50,41 +61,92 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		if (host == null) {
 			throw new NullPointerException("Host must not be null.");
 		}
-		
+
 		if (port < 1 || port >= 0xffff) {
 			throw new IllegalArgumentException("Port out of range");
 		}
-		
+
 		this.host = host;
 		this.port = port;
 		this.jarFiles = jarFiles;
+
+		shutdownHook = new Thread() {
+			@Override
+			public void run() {
+				endSession();
+			}
+		};
+
+		Runtime.getRuntime().addShutdownHook(shutdownHook);
 	}
-	
-	
+
+
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
-		
+
 		PlanExecutor executor = PlanExecutor.createRemoteExecutor(host, port, jarFiles);
+		executor.setJobID(jobID);
+		executor.setSessionTimeout(sessionTimeout);
 		executor.setPrintStatusDuringExecution(p.getExecutionConfig().isSysoutLoggingEnabled());
 
 		this.lastJobExecutionResult = executor.executePlan(p);
 		return this.lastJobExecutionResult;
 	}
-	
+
 	@Override
 	public String getExecutionPlan() throws Exception {
 		Plan p = createProgramPlan("unnamed", false);
 		p.setDefaultParallelism(getParallelism());
 		registerCachedFilesWithPlan(p);
-		
+
 		PlanExecutor executor = PlanExecutor.createRemoteExecutor(host, port, jarFiles);
 		return executor.getOptimizerPlanAsJSON(p);
+	}
+
+	private void endSession() {
+		System.out.println("Hello");
+		try {
+			Class<?> clientClass = Class.forName(clientClassName);
+			Constructor<?> constructor = clientClass.getConstructor(Configuration.class, ClassLoader.class);
+			Configuration configuration = new Configuration();
+			configuration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, host);
+			configuration.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, port);
+			Method setJobID = clientClass.getDeclaredMethod("setJobID", JobID.class);
+			Method endSession = clientClass.getDeclaredMethod("endSession");
+
+			Object client = constructor.newInstance(configuration, ClassLoader.getSystemClassLoader());
+			setJobID.invoke(client, jobID);
+			endSession.invoke(client);
+		} catch (NoSuchMethodException e) {
+			throw new RuntimeException("Couldn't find constructor/method method to invoke on the Client class.");
+		} catch (InstantiationException e) {
+			throw new RuntimeException("Couldn't instantiate the Client class.");
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException("Couldn't access the Client class or its methods.");
+		} catch (InvocationTargetException e) {
+			throw new RuntimeException("Couldn't invoke the Client class method.");
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Couldn't find the Client class.");
+		}
+	}
+
+	@Override
+	public void startNewSession() {
+		endSession();
+		jobID = JobID.generate();
 	}
 
 	@Override
 	public String toString() {
 		return "Remote Environment (" + this.host + ":" + this.port + " - parallelism = " +
 				(getParallelism() == -1 ? "default" : getParallelism()) + ") : " + getIdString();
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		super.finalize();
+		Runtime.getRuntime().removeShutdownHook(shutdownHook);
+		endSession();
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/Session.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/Session.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java;
+
+import org.junit.Test;
+
+public class Session {
+
+	@Test
+	public void testSessionRestart() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.startNewSession();
+	}
+}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -196,6 +196,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		JobGraph graph = new JobGraph(program.getJobName());
 		graph.setNumberOfExecutionRetries(program.getOriginalPactPlan().getNumberOfExecutionRetries());
 		graph.setAllowQueuedScheduling(false);
+		// TODO
 		
 		// add vertices to the graph
 		for (AbstractJobVertex vertex : this.vertices.values()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -168,6 +168,9 @@ public class ExecutionGraph implements Serializable {
 
 	/** Flag that indicate whether the executed dataflow should be periodically snapshotted */
 	private boolean snapshotCheckpointsEnabled;
+
+	/** Flag to indicate whether the Graph has been archived */
+	private boolean isArchived = false;
 		
 
 	// ------ Execution status and progress. These values are volatile, and accessed under the lock -------
@@ -281,6 +284,10 @@ public class ExecutionGraph implements Serializable {
 
 	public ScheduleMode getScheduleMode() {
 		return scheduleMode;
+	}
+
+	public boolean isArchived() {
+		return isArchived;
 	}
 
 	public void enableSnaphotCheckpointing(long interval, long checkpointTimeout,
@@ -641,6 +648,8 @@ public class ExecutionGraph implements Serializable {
 		requiredJarFiles.clear();
 		jobStatusListenerActors.clear();
 		executionListenerActors.clear();
+
+		isArchived = true;
 	}
 
 	public ExecutionConfig getExecutionConfig() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
@@ -202,7 +202,7 @@ public class TaskExecutionState implements java.io.Serializable {
 	
 	@Override
 	public String toString() {
-		return String.format("TaskState jobId=%s, executionId=%s, state=%s, error=%s", 
+		return String.format("TaskState jobId=%s, jobID=%s, state=%s, error=%s",
 				jobID, executionId, executionState,
 				cachedError == null ? (serializedError == null ? "(null)" : "(serialized)")
 									: (cachedError.getClass().getName() + ": " + cachedError.getMessage()));

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobInfo.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobInfo.scala
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager
 
 import akka.actor.ActorRef
 
+
 /**
  * Utility class to store job information on the [[JobManager]]. The JobInfo stores which actor
  * submitted the job, when the start time and, if already terminated, the end time was.
@@ -29,7 +30,15 @@ import akka.actor.ActorRef
  * @param client Actor which submitted the job
  * @param start Starting time
  */
-class JobInfo(val client: ActorRef, val start: Long){
+class JobInfo(val client: ActorRef, val start: Long,
+              val sessionTimeout: Long) {
+
+  var sessionAlive = true
+
+  var lastActive = 0L
+
+  setLastActive()
+
   var end: Long = -1
 
   def duration: Long = {
@@ -39,8 +48,13 @@ class JobInfo(val client: ActorRef, val start: Long){
       -1
     }
   }
+
+  def setLastActive() =
+    lastActive = System.currentTimeMillis()
 }
 
 object JobInfo{
-  def apply(client: ActorRef, start: Long) = new JobInfo(client, start)
+  def apply(client: ActorRef, start: Long,
+            sessionTimeout: Long) =
+    new JobInfo(client, start, sessionTimeout)
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmanager
 import java.io.{IOException, File}
 import java.net.InetSocketAddress
 import java.util.Collections
+import java.util.concurrent.TimeUnit
 
 import akka.actor.Status.{Success, Failure}
 import grizzled.slf4j.Logger
@@ -61,6 +62,8 @@ import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 /**
  * The job manager is responsible for receiving Flink jobs, scheduling the tasks, gathering the
@@ -100,7 +103,7 @@ class JobManager(protected val flinkConfiguration: Configuration,
                  protected val timeout: FiniteDuration)
   extends Actor with ActorLogMessages with ActorSynchronousLogging {
 
-  /** List of current jobs running jobs */
+  /** List of current running jobs */
   protected val currentJobs = scala.collection.mutable.HashMap[JobID, (ExecutionGraph, JobInfo)]()
 
 
@@ -319,7 +322,19 @@ class JobManager(protected val flinkConfiguration: Configuration,
                 throw exception
             }
 
-            removeJob(jobID)
+
+            if (jobInfo.sessionAlive) {
+              jobInfo.setLastActive()
+              val lastActivity = jobInfo.lastActive
+              context.system.scheduler.scheduleOnce(jobInfo.sessionTimeout seconds) {
+                // remove only if no activity occurred in the meantime
+                if (lastActivity == jobInfo.lastActive) {
+                  removeJob(jobID)
+                }
+              }
+            } else {
+              removeJob(jobID)
+            }
 
           }
         case None =>
@@ -406,6 +421,18 @@ class JobManager(protected val flinkConfiguration: Configuration,
     case RequestJobManagerStatus =>
       sender() ! JobManagerStatusAlive
 
+    case RemoveCachedJob(jobID) =>
+      currentJobs.get(jobID) match {
+        case Some((graph, info)) =>
+          if (graph.getState.isTerminalState) {
+            removeJob(graph.getJobID)
+          } else {
+            // triggers removal upon completion of job
+            info.sessionAlive = false
+          }
+        case None =>
+      }
+
     case Disconnect(msg) =>
       val taskManager = sender()
 
@@ -461,10 +488,17 @@ class JobManager(protected val flinkConfiguration: Configuration,
         }
 
         // see if there already exists an ExecutionGraph for the corresponding job ID
-        executionGraph = currentJobs.getOrElseUpdate(jobGraph.getJobID,
-          (new ExecutionGraph(jobGraph.getJobID, jobGraph.getName,
-            jobGraph.getJobConfiguration, timeout, jobGraph.getUserJarBlobKeys, userCodeLoader),
-            JobInfo(sender(), System.currentTimeMillis())))._1
+        executionGraph = currentJobs.get(jobGraph.getJobID) match {
+          case Some((graph, jobInfo)) =>
+            jobInfo.setLastActive()
+            graph
+          case None =>
+            val graph = new ExecutionGraph(jobGraph.getJobID, jobGraph.getName,
+              jobGraph.getJobConfiguration, timeout, jobGraph.getUserJarBlobKeys, userCodeLoader)
+            val jobInfo = JobInfo(sender(), System.currentTimeMillis(), jobGraph.getSessionTimeout)
+            currentJobs.put(jobGraph.getJobID, (graph, jobInfo))
+            graph
+        }
 
         // configure the execution graph
         val jobNumberRetries = if (jobGraph.getNumberOfExecutionRetries >= 0) {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.messages
 
+import java.util.UUID
+
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.client.{SerializedJobExecutionResult, JobStatusMessage}
 import org.apache.flink.runtime.executiongraph.{ExecutionAttemptID, ExecutionGraph}
@@ -207,6 +209,12 @@ object JobManagerMessages {
    * @param jobID
    */
   case class JobNotFound(jobID: JobID) extends JobResponse with JobStatusResponse
+
+  /**
+   * Removes the job belonging to the job identifier from the job manager and archives it.
+   * @param jobID The job identifier
+   */
+  case class RemoveCachedJob(jobID: JobID)
 
   /**
    * Requests the instances of all registered task managers.

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -22,7 +22,7 @@ import java.util.UUID
 import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult}
+import org.apache.flink.api.common.{JobID, ExecutionConfig, JobExecutionResult}
 import org.apache.flink.api.java.io._
 import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -127,7 +127,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * Gets the UUID by which this environment is identified. The UUID sets the execution context
    * in the cluster or local environment.
    */
-  def getId: UUID = {
+  def getId: JobID = {
     javaEnv.getId
   }
   
@@ -141,6 +141,22 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def getIdString: String = {
     javaEnv.getIdString
+  }
+
+  /**
+   * Starts a new session, discarding all intermediate results.
+   */
+  def startNewSession() {
+    javaEnv.startNewSession()
+  }
+
+  /**
+   * Sets the session timeout to hold the intermediate results of a job. This only
+   * applies the updated timeout in future executions.
+   * @param timeout The timeout in seconds.
+   */
+  def setSessionTimeout(timeout: Long) {
+    javaEnv.setSessionTimeout(timeout)
   }
 
   /**

--- a/flink-staging/flink-tez/src/main/java/org/apache/flink/tez/client/LocalTezEnvironment.java
+++ b/flink-staging/flink-tez/src/main/java/org/apache/flink/tez/client/LocalTezEnvironment.java
@@ -68,4 +68,9 @@ public class LocalTezEnvironment extends ExecutionEnvironment {
 		};
 		initializeContextEnvironment(factory);
 	}
+
+	@Override
+	public void startNewSession() throws Exception {
+		throw new UnsupportedOperationException("Session management is not implemented in Flink on Tez.");
+	}
 }

--- a/flink-staging/flink-tez/src/main/java/org/apache/flink/tez/client/RemoteTezEnvironment.java
+++ b/flink-staging/flink-tez/src/main/java/org/apache/flink/tez/client/RemoteTezEnvironment.java
@@ -75,4 +75,9 @@ public class RemoteTezEnvironment extends ExecutionEnvironment {
 		compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), new org.apache.flink.configuration.Configuration());
 		executor = new TezExecutor(compiler, this.getDegreeOfParallelism());
 	}
+
+	@Override
+	public void startNewSession() throws Exception {
+		throw new UnsupportedOperationException("Session management is not implemented in Flink on Tez.");
+	}
 }

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -42,6 +42,10 @@ public class TestEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
+	public void startNewSession() throws Exception {
+	}
+
+	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		try {
 			OptimizedPlan op = compileProgram(jobName);

--- a/flink-tests/src/test/java/org/apache/flink/test/clients/examples/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/clients/examples/LocalExecutorITCase.java
@@ -55,7 +55,8 @@ public class LocalExecutorITCase {
 			executor.setTaskManagerNumSlots(parallelism);
 			executor.setPrintStatusDuringExecution(false);
 			executor.start();
-			Plan wcPlan = wc.getPlan(Integer.valueOf(parallelism).toString(), inFile.toURI().toString(),outFile.toURI().toString());
+			Plan wcPlan = wc.getPlan(Integer.valueOf(parallelism).toString(),
+					inFile.toURI().toString(), outFile.toURI().toString());
 			wcPlan.setExecutionConfig(new ExecutionConfig());
 			executor.executePlan(wcPlan);
 			executor.stop();


### PR DESCRIPTION
This pull request implements a rudimentary session management. Together with the backtracking #640, this will enable users to successively submit jobs to the cluster and access intermediate results. Session handling ensures that the results are cleared eventually.

ExecutionGraphs are kept as long as
- no timeout occurred or
- the session has not been explicitly ended