### PR TITLE
[streaming] Fast calculation of medians of windows

### DIFF
--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -878,6 +878,9 @@ Sometimes it is sufficient to create local discretisations, which allows the dis
 
 For example, `dataStream.window(Count.of(100)).maxBy(field)` would create global windows of 100 elements (Count discretises with parallelism of 1) and return the record with the max value by the selected field; alternatively the `dataStream.window(Count.of(100)).local().maxBy(field)` would create several count discretisers (as defined by the environment parallelism) and compute the max values accordingly.
 
+#### Computing statistics (median, etc.)
+A library for computing statistics of windows is available in the Maven module `flink-contrib/flink-streaming-contrib`. Calling `org.apache.flink.contrib.streaming.DataStreamUtils.statistics` on a `WindowedDataStream` returns a `WindowedDataStreamStatistics`, which is a descendant of `WindowedDataStream`, and contains additional methods for computing median, etc.
+
 
 ### Temporal database style operators
 

--- a/flink-contrib/flink-streaming-contrib/pom.xml
+++ b/flink-contrib/flink-streaming-contrib/pom.xml
@@ -47,10 +47,18 @@ under the License.
 			<artifactId>flink-clients</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/DataStreamUtils.java
+++ b/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/DataStreamUtils.java
@@ -23,8 +23,10 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Iterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.contrib.streaming.windowing.WindowedDataStreamStatistics;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.WindowedDataStream;
 import org.apache.flink.streaming.api.environment.RemoteStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.runtime.net.NetUtils;
@@ -82,5 +84,13 @@ public class DataStreamUtils {
 				throw new RuntimeException("Exception in execute()", e);
 			}
 		}
+	}
+
+
+	/**
+	 * Gets the extended statistical functionality for a {@link WindowedDataStream}.
+	 */
+	public static <OUT> WindowedDataStreamStatistics<OUT> statistics(WindowedDataStream<OUT> windowedDataStream) {
+		return new WindowedDataStreamStatistics<OUT>(windowedDataStream);
 	}
 }

--- a/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/windowing/MedianGroupedPreReducer.java
+++ b/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/windowing/MedianGroupedPreReducer.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.windowing;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.apache.flink.streaming.api.windowing.windowbuffer.PreAggregator;
+import org.apache.flink.streaming.api.windowing.windowbuffer.WindowBuffer;
+import org.apache.flink.streaming.util.FieldAccessor;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.Queue;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+
+/**
+ * Grouped pre-reducer for calculating median with any eviction policy.
+ *
+ * It stores a MedianPreReducer for every group.
+ */
+public class MedianGroupedPreReducer<T> extends WindowBuffer<T> implements PreAggregator, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	// This is for getting and setting the field specified in the parameters to the median call.
+	private FieldAccessor<T, Double> fieldAccessor;
+
+	private TypeSerializer<T> serializer;
+
+	private KeySelector<T, ?> keySelector;
+
+	// PreReducers for the individual groups
+	private Map<Object, MedianPreReducer<T>> groupPreReducers = new TreeMap<Object, MedianPreReducer<T>>();
+
+	// Holds a reference for the groupPreReducer belonging to each element currently in the window.
+	// (This is used at evict, so that we have to index into groupPreReducers only on store.)
+	private Queue<MedianPreReducer<T>> groupPreReducerPerElement = new ArrayDeque<MedianPreReducer<T>>();
+
+	public MedianGroupedPreReducer(FieldAccessor<T, Double> fieldAccessor, TypeSerializer<T> serializer,
+									KeySelector<T, ?> keySelector) {
+		this.fieldAccessor = fieldAccessor;
+		this.serializer = serializer;
+		this.keySelector = keySelector;
+	}
+
+	public MedianGroupedPreReducer(int pos, TypeInformation<T> typeInfo, ExecutionConfig config,
+									KeySelector<T, ?> keySelector) {
+		this.fieldAccessor = FieldAccessor.create(pos, typeInfo, config);
+		this.serializer = typeInfo.createSerializer(config);
+		this.keySelector = keySelector;
+	}
+
+	public MedianGroupedPreReducer(String field, TypeInformation<T> typeInfo, ExecutionConfig config,
+									KeySelector<T, ?> keySelector) {
+		this.fieldAccessor = FieldAccessor.create(field, typeInfo, config);
+		this.serializer = typeInfo.createSerializer(config);
+		this.keySelector = keySelector;
+	}
+
+	@Override
+	public void store(T elem) throws Exception {
+		Object key = keySelector.getKey(elem);
+		MedianPreReducer<T> groupPreReducer = groupPreReducers.get(key);
+		if (groupPreReducer == null) { // Group doesn't exist yet, create it.
+			groupPreReducer = new MedianPreReducer<T>(fieldAccessor, serializer);
+			groupPreReducers.put(key, groupPreReducer);
+		}
+		groupPreReducer.store(elem);
+		groupPreReducerPerElement.add(groupPreReducer);
+	}
+
+	@Override
+	public void evict(int n) {
+		for (int i = 0; i < n; i++) {
+			MedianPreReducer<T> groupPreReducer = groupPreReducerPerElement.poll();
+			if (groupPreReducer == null) {
+				break;
+			}
+			groupPreReducer.evict(1);
+		}
+	}
+
+	@Override
+	public void emitWindow(Collector<StreamWindow<T>> collector) {
+		StreamWindow<T> currentWindow = createEmptyWindow();
+		for(Iterator<MedianPreReducer<T>> it = groupPreReducers.values().iterator(); it.hasNext(); ) {
+			MedianPreReducer<T> groupPreReducer = it.next();
+			T groupMedian = groupPreReducer.getMedian();
+			if (groupMedian != null) {
+				currentWindow.add(groupMedian);
+			} else {
+				it.remove(); // Remove groups that don't contain elements, to not leak memory for long ago seen groups.
+			}
+		}
+		if (!currentWindow.isEmpty() || emitEmpty) {
+			collector.collect(currentWindow);
+		}
+	}
+
+	@Override
+	public WindowBuffer<T> clone() {
+		return new MedianGroupedPreReducer<T>(fieldAccessor, serializer, keySelector);
+	}
+
+}

--- a/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/windowing/MedianPreReducer.java
+++ b/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/windowing/MedianPreReducer.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.windowing;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.apache.flink.streaming.api.windowing.windowbuffer.PreAggregator;
+import org.apache.flink.streaming.api.windowing.windowbuffer.WindowBuffer;
+import org.apache.flink.util.Collector;
+import org.apache.flink.streaming.util.FieldAccessor;
+
+import java.util.TreeMap;
+import java.util.Map.Entry;
+import java.util.Deque;
+import java.util.ArrayDeque;
+import java.util.Comparator;
+import java.io.Serializable;
+
+/**
+ * Non-grouped pre-reducer for calculating median with any eviction policy.
+ */
+public class MedianPreReducer<T> extends WindowBuffer<T> implements PreAggregator, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	// This is for getting and setting the field specified in the parameters to the median call.
+	private FieldAccessor<T, Double> fieldAccessor;
+
+	private TypeSerializer<T> serializer;
+
+	// These contain lower-than-median and higher-than-median elements.
+	// Elements that compare equal to the median can be in either.
+	// The invariant is that low always contains the same amount or one more element than high.
+	//   (see the assert in updateMedian)
+	TreeMultiset<T>
+			low = new TreeMultiset<T>(new CompareOnField()),
+			high = new TreeMultiset<T>(new CompareOnField());
+	Deque<T> elements = new ArrayDeque<T>();
+
+	T median;
+
+	public T getMedian() {
+		return median;
+	}
+
+	public MedianPreReducer(FieldAccessor<T, Double> fieldAccessor, TypeSerializer<T> serializer) {
+		this.fieldAccessor = fieldAccessor;
+		this.serializer = serializer;
+	}
+
+	public MedianPreReducer(int pos, TypeInformation<T> typeInfo, ExecutionConfig config) {
+		this.fieldAccessor = FieldAccessor.create(pos, typeInfo, config);
+		this.serializer = typeInfo.createSerializer(config);
+	}
+
+	public MedianPreReducer(String field, TypeInformation<T> typeInfo, ExecutionConfig config) {
+		this.fieldAccessor = FieldAccessor.create(field, typeInfo, config);
+		this.serializer = typeInfo.createSerializer(config);
+	}
+
+	private void updateMedian() {
+		assert low.size() == high.size() || low.size() == high.size() + 1;
+		if (low.size() == 0) {
+			median = null;
+		} else if (low.size() == high.size()) {
+			// This is essentially  (low.last + high.first) / 2,  but we have to drill down to the double field
+			median = serializer.copy(elements.getLast());
+			median = fieldAccessor.set(median, (fieldAccessor.get(low.last()) + fieldAccessor.get(high.first())) / 2);
+		} else {
+			// low.last
+			median = serializer.copy(elements.getLast());
+			median = fieldAccessor.set(median, fieldAccessor.get(low.last()));
+		}
+	}
+
+	private void moveUpIfNeccessary() {
+		if (low.size() > high.size() + 1) {
+			high.add(low.pollLast());
+		}
+	}
+	private void moveDownIfNeccessary() {
+		if (low.size() < high.size()) {
+			low.add(high.pollFirst());
+		}
+	}
+
+	@Override
+	public void store(T elem) throws Exception {
+		if (median == null) {
+			low.add(elem);
+		} else if(fieldAccessor.get(elem) <= fieldAccessor.get(median)) {
+			low.add(elem);
+			moveUpIfNeccessary();
+		} else if (fieldAccessor.get(elem) > fieldAccessor.get(median)) {
+			high.add(elem);
+			moveDownIfNeccessary();
+		}
+		elements.addLast(elem);
+		updateMedian();
+	}
+
+	@Override
+	public void evict(int n) {
+		for (int i = 0; i < n; i++) {
+			T elem = elements.pollFirst();
+			if(elem == null) {
+				break;
+			}
+			if (low.contains(elem)) {
+				low.removeOne(elem);
+				moveDownIfNeccessary();
+			} else if (high.contains(elem)) {
+				high.removeOne(elem);
+				moveUpIfNeccessary();
+			} else {
+				throw new RuntimeException("Internal error in MedianPreReducer");
+			}
+		}
+		updateMedian();
+	}
+
+	@Override
+	public void emitWindow(Collector<StreamWindow<T>> collector) {
+		if (median != null) {
+			StreamWindow<T> currentWindow = createEmptyWindow();
+			currentWindow.add(median);
+			collector.collect(currentWindow);
+		} else if (emitEmpty) {
+			collector.collect(createEmptyWindow());
+		}
+	}
+
+	@Override
+	public WindowBuffer<T> clone() {
+		return new MedianPreReducer<T>(fieldAccessor, serializer);
+	}
+
+	private class CompareOnField implements Comparator<T>, Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public int compare(T a, T b) {
+			try {
+				return fieldAccessor.get(a).compareTo(fieldAccessor.get(b));
+			} catch (ClassCastException e) {
+				throw new RuntimeException("ClassCastException in MedianPreReducer: " + e.getMessage()
+						+ "\nWindowedDataStream.median only supports Double fields!");
+			}
+		}
+	}
+
+	// This multiset class is implemented by storing the counts of the elements in a TreeMap.
+	static class TreeMultiset<T> extends TreeMap<T, Integer> {
+
+		int size = 0;
+
+		@Override
+		public int size() {
+			return size;
+		}
+
+		TreeMultiset(Comparator<T> comparator) {
+			super(comparator);
+		}
+
+		T first() {
+			return firstKey();
+		}
+
+		T last() {
+			return lastKey();
+		}
+
+		T pollFirst() {
+			if (!isEmpty()) {
+				size--;
+			}
+			Entry<T, Integer> first = firstEntry();
+			if (first.getValue() > 1) {
+				put(first.getKey(), first.getValue() - 1);
+				return first.getKey();
+			} else {
+				return pollFirstEntry().getKey();
+			}
+		}
+
+		T pollLast() {
+			if (!isEmpty()) {
+				size--;
+			}
+			Entry<T, Integer> last = lastEntry();
+			if (last.getValue() > 1) {
+				put(last.getKey(), last.getValue() - 1);
+				return last.getKey();
+			} else {
+				return pollLastEntry().getKey();
+			}
+		}
+
+		void add(T elem) {
+			size++;
+			Integer oldCount = get(elem);
+			if (oldCount == null) {
+				oldCount = 0;
+			}
+			put(elem, oldCount + 1);
+		}
+
+		Boolean contains(T elem) {
+			return get(elem) != null;
+		}
+
+		void removeOne(T elem) {
+			assert contains(elem);
+			size--;
+			Integer oldCount = get(elem);
+			if (oldCount > 1) {
+				put(elem, oldCount - 1);
+			} else {
+				remove(elem);
+			}
+		}
+	}
+}

--- a/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/windowing/WindowedDataStreamStatistics.java
+++ b/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/windowing/WindowedDataStreamStatistics.java
@@ -1,0 +1,89 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.flink.contrib.streaming.windowing;
+
+import org.apache.flink.contrib.streaming.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.DiscretizedStream;
+import org.apache.flink.streaming.api.datastream.WindowedDataStream;
+import org.apache.flink.streaming.api.windowing.WindowUtils;
+import org.apache.flink.streaming.api.windowing.windowbuffer.WindowBuffer;
+
+/**
+ * An extension for {@link WindowedDataStream} with additional statistics
+ * functionality. Can be constructed directly through the constructor or
+ * through the convenience method {@link DataStreamUtils#statistics(WindowedDataStream)}.
+ *
+ * @param <OUT>
+ *            The output type of the {@link WindowedDataStream}
+ */
+public class WindowedDataStreamStatistics<OUT> extends WindowedDataStream<OUT> {
+
+	public WindowedDataStreamStatistics(WindowedDataStream<OUT> windowedDataStream) {
+		super(windowedDataStream);
+	}
+
+	/**
+	 * Gives the median of the current window at the specified field at every trigger.
+	 * The type of the field can only be Double (as the median of integers might be a fraction).
+	 *
+	 * The median is updated online as the window changes, and the runtime of
+	 * one update is logarithmic with the current window size.
+	 *
+	 * @param pos
+	 *            The position in the tuple/array to calculate the median of
+	 * @return The transformed DataStream.
+	 */
+	@SuppressWarnings("unchecked")
+	public DiscretizedStream<OUT> median(int pos) {
+		WindowBuffer<OUT> windowBuffer;
+		if (groupByKey == null) {
+			windowBuffer = new MedianPreReducer<OUT>(pos, getType(), getExecutionConfig());
+		} else {
+			windowBuffer = new MedianGroupedPreReducer<OUT>(pos, getType(), getExecutionConfig(), groupByKey);
+		}
+		return discretize(WindowUtils.WindowTransformation.OTHER, windowBuffer);
+	}
+
+	/**
+	 * Gives the median of the current window at the specified field at every trigger.
+	 * The type of the field can only be Double (as the median of integers might be a fraction).
+	 *
+	 * The field is given by a field expression that is either
+	 * the name of a public field or a getter method with parentheses of the
+	 * stream's underlying type. A dot can be used to drill down into objects,
+	 * as in {@code "field1.getInnerField2()" }.
+	 *
+	 * The median is updated online as the window changes, and the runtime of
+	 * one update is logarithmic with the current window size.
+	 *
+	 * @param field
+	 *            The field to calculate the median of
+	 * @return The transformed DataStream.
+	 */
+	@SuppressWarnings("unchecked")
+	public DiscretizedStream<OUT> median(String field) {
+		WindowBuffer<OUT> windowBuffer;
+		if (groupByKey == null) {
+			windowBuffer = new MedianPreReducer<OUT>(field, getType(), getExecutionConfig());
+		} else {
+			windowBuffer = new MedianGroupedPreReducer<OUT>(field, getType(), getExecutionConfig(), groupByKey);
+		}
+		return discretize(WindowUtils.WindowTransformation.OTHER, windowBuffer);
+	}
+
+}

--- a/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/windowing/MedianGroupedPreReducerTest.java
+++ b/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/windowing/MedianGroupedPreReducerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.windowing;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.windowing.windowbuffer.BasicWindowBufferTest.TestCollector;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+import org.junit.Test;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Random;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.TreeMap;
+import java.util.Map.Entry;
+
+import static org.junit.Assert.assertEquals;
+
+// As the MedianGroupedPreReducer uses the non-grouped MedianPreReducer, this also tests that class.
+public class MedianGroupedPreReducerTest {
+
+	TypeInformation<Tuple2<Integer, Double>> typeInfo = TypeExtractor.getForObject(new Tuple2<Integer, Double>(1, 1.0));
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testMedianPreReducer() throws Exception {
+		Random rnd = new Random(42);
+
+		ArrayDeque<Tuple2<Integer, Double> > inputs = new ArrayDeque<Tuple2<Integer, Double> >();
+
+		KeySelector<Tuple2<Integer,Double>, Integer> keySelector = new KeySelector<Tuple2<Integer,Double>, Integer>() {
+			@Override
+			public Integer getKey(Tuple2<Integer, Double> value) throws Exception {
+				return value.f0;
+			}
+		};
+		MedianGroupedPreReducer<Tuple2<Integer, Double>> preReducer =
+				new MedianGroupedPreReducer<Tuple2<Integer, Double>>(1, typeInfo, null, keySelector);
+
+		TestCollector<StreamWindow<Tuple2<Integer, Double>>> collector =
+				new TestCollector<StreamWindow<Tuple2<Integer, Double>>>();
+
+		List<StreamWindow<Tuple2<Integer, Double>>> collected = collector.getCollected();
+
+		// We do a bunch of random operations, and check the results by also naively calculating the median.
+		int N = 10000;
+		for(int i = 0; i < N; i++) {
+			switch (rnd.nextInt(3)) {
+				case 0: // store
+					Tuple2<Integer, Double> elem;
+					Integer group =  rnd.nextInt(5);
+					// We sometimes add doubles and sometimes add small integers.
+					// The latter is for ensuring that it happens that there are duplicate elements,
+					// so that we test TreeMultiset properly.
+					if(rnd.nextDouble() < 0.5) {
+						elem = new Tuple2<Integer, Double>(group, (double)rnd.nextInt(5));
+					} else {
+						elem = new Tuple2<Integer, Double>(group, rnd.nextDouble());
+					}
+					inputs.addLast(elem);
+					preReducer.store(elem);
+					break;
+				case 1: // evict
+					int howMany = rnd.nextInt(2) + 1;
+					int howMany2 = Math.min(howMany, inputs.size());
+					for(int j = 0; j < howMany2; j++) {
+						inputs.removeFirst();
+					}
+					preReducer.evict(howMany);
+					break;
+				case 2: // emitWindow
+					if(inputs.size() > 0) {
+						// Calculate the correct medians:
+						// The inputs are split into groups into inputDoublesPerGroup,
+						// then the medians are calculated per group into correctMedians.
+						TreeMap<Integer, ArrayList<Double>> inputDoublesPerGroup = new TreeMap<Integer, ArrayList<Double>>();
+						for (Tuple2<Integer, Double> e : inputs) {
+							Integer key = keySelector.getKey(e);
+							ArrayList<Double> a = inputDoublesPerGroup.get(key);
+							if(a == null) { // Group doesn't exist yet, create it.
+								a = new ArrayList<Double>();
+								inputDoublesPerGroup.put(key, a);
+							}
+							a.add(e.f1);
+						}
+						TreeMap<Integer, Double> correctMedians = new TreeMap<Integer, Double>();
+						for(Entry<Integer, ArrayList<Double>> e: inputDoublesPerGroup.entrySet()) {
+							ArrayList<Double> doublesInGroup = e.getValue();
+							Collections.sort(doublesInGroup);
+							int half = doublesInGroup.size() / 2;
+							correctMedians.put(
+									e.getKey(),
+									doublesInGroup.size() % 2 == 1 ?
+											doublesInGroup.get(half) :
+											(doublesInGroup.get(half) + doublesInGroup.get(half - 1)) / 2);
+						}
+
+						preReducer.emitWindow(collector);
+						for(Tuple2<Integer, Double> e: collected.get(collected.size() - 1)){
+							assertEquals(
+									correctMedians.get(keySelector.getKey(e)),
+									e.f1);
+						}
+					}
+					break;
+			}
+		}
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/WindowedDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/WindowedDataStream.java
@@ -381,7 +381,7 @@ public class WindowedDataStream<OUT> {
 				outType);
 	}
 
-	private DiscretizedStream<OUT> discretize(WindowTransformation transformation,
+	protected DiscretizedStream<OUT> discretize(WindowTransformation transformation,
 			WindowBuffer<OUT> windowBuffer) {
 
 		OneInputStreamOperator<OUT, WindowEvent<OUT>> discretizer = getDiscretizer();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/WindowUtils.java
@@ -32,7 +32,7 @@ import org.apache.flink.streaming.api.windowing.policy.TumblingEvictionPolicy;
 public class WindowUtils {
 
 	public enum WindowTransformation {
-		REDUCEWINDOW, MAPWINDOW, FOLDWINDOW, NONE;
+		REDUCEWINDOW, MAPWINDOW, FOLDWINDOW, OTHER, NONE;
 		private Function UDF;
 
 		public WindowTransformation with(Function UDF) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/FieldAccessorTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/FieldAccessorTest.java
@@ -72,4 +72,6 @@ public class FieldAccessorTest {
 			// Nothing to do here
 		}
 	}
+
+	// Note: Other parts of FieldAccessor are tested by AggregationFunctionTest and TopSpeedWindowingExampleITCase.
 }


### PR DESCRIPTION
I started working on my Google Summer of Code Project. I decided to start with the fast calculation of medians of windows. The MedianPreReducer keeps track of the median at every window change by keeping the lower and upper halves of the window in two multisets. The updates have logarithmic runtime with the current window size. (Adding an element to or removing an element from the window involves moving at most one of the other elements between the lower and upper halves.)

The parameters of WindowedDataStream.median is the same as for the sum, min, max, etc. methods. (But here, the specified field can only be of Double type.) I implemented a few helper classes for accessing the field that is specified by these parameters. I think that the other methods with similar field selection (sum, min, max, etc.) could also be refactored to use these helper classes, so that the code duplication in SumAggregator and ComparableAggregator could be eliminated (the duplication of both the field access logic, and the logic of the byAggregate comparisons). Should I do this refactoring?

Currently, the implementation only handles non-grouped data streams, but I plan to create a GroupedMedianPreReducer (hence the [WIP] flag).