### PR TITLE
[FLINK-2034] [docs]  Add vision and roadmap for ML library to docs

### DIFF
--- a/docs/libs/ml/contribution_guide.md
+++ b/docs/libs/ml/contribution_guide.md
@@ -1,0 +1,26 @@
+---
+title: "FlinkML - Contribution guide"
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+Coming soon. In the meantime, check our list of [open issues on JIRA](https://issues.apache.org/jira/browse/FLINK-1748?jql=component%20%3D%20%22Machine%20Learning%20Library%22%20AND%20project%20%3D%20FLINK%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC)

--- a/docs/libs/ml/index.md
+++ b/docs/libs/ml/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Machine Learning Library"
+title: "FlinkML - Machine Learning for Flink"
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -20,97 +20,17 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The Machine Learning (ML) library for Flink is a new effort to bring scalable ML tools to the Flink
-community. Our goal is is to design and implement a system that is scalable and can deal with
-problems of various sizes, whether your data size is measured in megabytes or terabytes and beyond.
-We call this library FlinkML.
+* This will be replaced by the TOC
+{:toc}
 
-An important concern for developers of ML systems is the amount of glue code that developers are
-forced to write [1] in the process of implementing an end-to-end ML system. Our goal with FlinkML
-is to help developers keep glue code to a minimum. The Flink ecosystem provides a great setting to
-tackle this problem, with its scalable ETL capabilities that can be easily combined inside the same
-program with FlinkML, allowing the development of robust pipelines without the need to use yet
-another technology for data ingestion and data munging.
-
-Another goal for FlinkML is to make the library easy to use. To that end we will be providing
-detailed documentation along with examples for every part of the system. Our aim is that developers
-will be able to get started with writing their ML pipelines quickly, using familiar programming
-concepts and terminology.
-
-Contrary to other data-processing systems, Flink exploits in-memory data streaming, and natively
-executes iterative processing algorithms which are common in ML. We plan to exploit the streaming
-nature of Flink, and provide functionality designed specifically for data streams.
-
-FlinkML will allow data scientists to test their models locally and using subsets of data, and then
-use the same code to run their algorithms at a much larger scale in a cluster setting.
-
-We are inspired by other open source efforts to provide ML systems, in particular
-[scikit-learn](http://scikit-learn.org/) for cleanly specifying ML pipelines, and Spark’s
-[MLLib](https://spark.apache.org/mllib/) for providing ML algorithms that scale with problem and
-cluster sizes.
-
-We already have some of the building blocks for FlinkML in place, and will continue to extend the
-library with more algorithms. An example of how simple it is to create a learning model in
-FlinkML is given below:
-
-{% highlight scala %}
-// LabelbedVector is a feature vector with a label (class or real value)
-val data: DataSet[LabelVector] = ...
-
-val learner = MultipleLinearRegression()
-
-val parameters = ParameterMap()
-  .add(MultipleLinearRegression.Stepsize, 1.0)
-  .add(MultipleLinearRegression.Iterations, 10)
-  .add(MultipleLinearRegression.ConvergenceThreshold, 0.001)
-
-val model = learner.fit(data, parameters)
-{% endhighlight %}
-
-The roadmap below can provide an indication of the algorithms we aim to implement in the coming
-months. Items in **bold** have already been implemented:
+FlinkML is the Machine Learning (ML) library for Flink. It is a new effort in the Flink community,
+with a growing list of algorithms and contributors. With FlinkML we aim to provide 
+scalable ML algorithms, an intuitive API and tools that help minimize glue code in end-to-end ML 
+systems. You can see more details about our goals and where the library is headed in our [vision 
+and roadmap here](vision_roadmap.html).
 
 
-* Pipelines of transformers and learners
-* Data pre-processing
-  * **Feature scaling**
-  * **Polynomial feature base mapper**
-  * Feature hashing
-  * Feature extraction for text
-  * Dimensionality reduction
-* Model selection and performance evaluation
-  * Cross-validation for model selection and evaluation
-* Supervised learning
-  * Optimization framework
-    * **Stochastic Gradient Descent**
-    * L-BFGS
-  * Generalized Linear Models
-    * **Multiple linear regression**
-    * LASSO, Ridge regression
-    * Multi-class Logistic regression
-  * Random forests
-  * **Support Vector Machines**
-* Unsupervised learning
-  * Clustering
-    * K-means clustering
-  * PCA
-* Recommendation
-  * **ALS**
-* Text analytics
-  * LDA
-* Statistical estimation tools
-* Distributed linear algebra
-* Streaming ML
-
-
-**References:**
-
-[1] D. Sculley, G. Holt, D. Golovin, E. Davydov, T. Phillips, D. Ebner, V. Chaudhary,
-and M. Young. _Machine learning: The high interest credit card of technical debt._ In SE4ML:
-Software Engineering for Machine Learning (NIPS 2014 Workshop), 2014.
-
-
-## Link
+## Getting Started
 
 You can use FlinkML in your project by adding the following dependency to your pom.xml
 
@@ -122,16 +42,47 @@ You can use FlinkML in your project by adding the following dependency to your p
 </dependency>
 {% endhighlight %}
 
-## Algorithm Documentation
+## Supported Algorithms
 
-* [Alternating Least Squares (ALS)](als.html)
+### Supervised Learning
+
 * [Communication efficient distributed dual coordinate ascent (CoCoA)](cocoa.html)
 * [Multiple linear regression](multiple_linear_regression.html)
-* [Polynomial Base Feature Mapper](polynomial_base_feature_mapper.html)
-* [Standard Scaler](standard_scaler.html)
 * [Optimization Framework](optimization.html)
 
+### Data Preprocessing
 
-## Metrics Documentation
+* [Polynomial Base Feature Mapper](polynomial_base_feature_mapper.html)
+* [Standard Scaler](standard_scaler.html)
+
+### Recommendation
+
+* [Alternating Least Squares (ALS)](als.html)
+
+### Utilities
 
 * [Distance Metrics](distance_metrics.html)
+
+## Example
+
+We already have some of the building blocks for FlinkML in place, and will continue to extend the
+library with more algorithms. An example of how simple it is to create a learning model in
+FlinkML is given below:
+
+{% highlight scala %}
+// LabeledVector is a feature vector with a label (class or real value)
+val data: DataSet[LabeledVector] = ...
+
+val learner = MultipleLinearRegression()
+  .setStepsize(1.0)
+  .setIterations(100)
+  .setConvergenceThreshold(0.001)
+
+learner.fit(data, parameters)
+
+// The learner can now be used to make predictions using learner.predict()
+{% endhighlight %}
+
+## How to contribute
+
+ TODO (Can include parts of the Pipelines doc)

--- a/docs/libs/ml/index.md
+++ b/docs/libs/ml/index.md
@@ -20,7 +20,99 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+The Machine Learning (ML) library for Flink is a new effort to bring scalable ML tools to the Flink
+community. Our goal is is to design and implement a system that is scalable and can deal with
+problems of various sizes, whether your data size is measured in megabytes or terabytes and beyond.
+We call this library FlinkML.
+
+An important concern for developers of ML systems is the amount of glue code that developers are
+forced to write [1] in the process of implementing an end-to-end ML system. Our goal with FlinkML
+is to help developers keep glue code to a minimum. The Flink ecosystem provides a great setting to
+tackle this problem, with its scalable ETL capabilities that can be easily combined inside the same
+program with FlinkML, allowing the development of robust pipelines without the need to use yet
+another technology for data ingestion and data munging.
+
+Another goal for FlinkML is to make the library easy to use. To that end we will be providing
+detailed documentation along with examples for every part of the system. Our aim is that developers
+will be able to get started with writing their ML pipelines quickly, using familiar programming
+concepts and terminology.
+
+Contrary to other data-processing systems, Flink exploits in-memory data streaming, and natively
+executes iterative processing algorithms which are common in ML. We plan to exploit the streaming
+nature of Flink, and provide functionality designed specifically for data streams.
+
+FlinkML will allow data scientists to test their models locally and using subsets of data, and then
+use the same code to run their algorithms at a much larger scale in a cluster setting.
+
+We are inspired by other open source efforts to provide ML systems, in particular
+[scikit-learn](http://scikit-learn.org/) for cleanly specifying ML pipelines, and Spark’s
+[MLLib](https://spark.apache.org/mllib/) for providing ML algorithms that scale with problem and
+cluster sizes.
+
+We already have some of the building blocks for FlinkML in place, and will continue to extend the
+library with more algorithms. An example of how simple it is to create a learning model in
+FlinkML is given below:
+
+{% highlight scala %}
+// LabelbedVector is a feature vector with a label (class or real value)
+val data: DataSet[LabelVector] = ...
+
+val learner = MultipleLinearRegression()
+
+val parameters = ParameterMap()
+  .add(MultipleLinearRegression.Stepsize, 1.0)
+  .add(MultipleLinearRegression.Iterations, 10)
+  .add(MultipleLinearRegression.ConvergenceThreshold, 0.001)
+
+val model = learner.fit(data, parameters)
+{% endhighlight %}
+
+The roadmap below can provide an indication of the algorithms we aim to implement in the coming
+months. Items in **bold** have already been implemented:
+
+
+* Pipelines of transformers and learners
+* Data pre-processing
+  * **Feature scaling**
+  * **Polynomial feature base mapper**
+  * Feature hashing
+  * Feature extraction for text
+  * Dimensionality reduction
+* Model selection and performance evaluation
+  * Cross-validation for model selection and evaluation
+* Supervised learning
+  * Optimization framework
+    * **Stochastic Gradient Descent**
+    * L-BFGS
+  * Generalized Linear Models
+    * **Multiple linear regression**
+    * LASSO, Ridge regression
+    * Multi-class Logistic regression
+  * Random forests
+  * **Support Vector Machines**
+* Unsupervised learning
+  * Clustering
+    * K-means clustering
+  * PCA
+* Recommendation
+  * **ALS**
+* Text analytics
+  * LDA
+* Statistical estimation tools
+* Distributed linear algebra
+* Streaming ML
+
+
+**References:**
+
+[1] D. Sculley, G. Holt, D. Golovin, E. Davydov, T. Phillips, D. Ebner, V. Chaudhary,
+and M. Young. _Machine learning: The high interest credit card of technical debt._ In SE4ML:
+Software Engineering for Machine Learning (NIPS 2014 Workshop), 2014.
+
+
 ## Link
+
+You can use FlinkML in your project by adding the following dependency to your pom.xml
 
 {% highlight bash %}
 <dependency>
@@ -30,7 +122,7 @@ under the License.
 </dependency>
 {% endhighlight %}
 
-## Algorithms
+## Algorithm Documentation
 
 * [Alternating Least Squares (ALS)](als.html)
 * [Communication efficient distributed dual coordinate ascent (CoCoA)](cocoa.html)
@@ -40,6 +132,6 @@ under the License.
 * [Optimization Framework](optimization.html)
 
 
-## Metrics
+## Metrics Documentation
 
 * [Distance Metrics](distance_metrics.html)

--- a/docs/libs/ml/index.md
+++ b/docs/libs/ml/index.md
@@ -23,6 +23,8 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
+
+
 FlinkML is the Machine Learning (ML) library for Flink. It is a new effort in the Flink community,
 with a growing list of algorithms and contributors. With FlinkML we aim to provide 
 scalable ML algorithms, an intuitive API and tools that help minimize glue code in end-to-end ML 
@@ -63,7 +65,7 @@ You can use FlinkML in your project by adding the following dependency to your p
 
 * [Distance Metrics](distance_metrics.html)
 
-## Example
+## Example & Quickstart guide
 
 We already have some of the building blocks for FlinkML in place, and will continue to extend the
 library with more algorithms. An example of how simple it is to create a learning model in
@@ -82,6 +84,8 @@ learner.fit(data, parameters)
 
 // The learner can now be used to make predictions using learner.predict()
 {% endhighlight %}
+
+For a more comprehensive guide, you can check out our [quickstart guide](quickstart.html)
 
 ## How to contribute
 

--- a/docs/libs/ml/index.md
+++ b/docs/libs/ml/index.md
@@ -20,17 +20,14 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-* This will be replaced by the TOC
-{:toc}
-
-
-
 FlinkML is the Machine Learning (ML) library for Flink. It is a new effort in the Flink community,
 with a growing list of algorithms and contributors. With FlinkML we aim to provide 
-scalable ML algorithms, an intuitive API and tools that help minimize glue code in end-to-end ML 
+scalable ML algorithms, an intuitive API, and tools that help minimize glue code in end-to-end ML 
 systems. You can see more details about our goals and where the library is headed in our [vision 
 and roadmap here](vision_roadmap.html).
 
+* This will be replaced by the TOC
+{:toc}
 
 ## Getting Started
 
@@ -89,4 +86,6 @@ For a more comprehensive guide, you can check out our [quickstart guide](quickst
 
 ## How to contribute
 
- TODO (Can include parts of the Pipelines doc)
+Please check our [roadmap](vision_roadmap.html#roadmap) and [contribution guide](contribution_guide.html). 
+You can also check out our list of
+[unresolved issues on JIRA](https://issues.apache.org/jira/browse/FLINK-1748?jql=component%20%3D%20%22Machine%20Learning%20Library%22%20AND%20project%20%3D%20FLINK%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC)

--- a/docs/libs/ml/optimization.md
+++ b/docs/libs/ml/optimization.md
@@ -231,3 +231,5 @@ val weightVector = weightDS
 // We can now use the weightVector to make predictions
 
 {% endhighlight %}
+
+Note: Some of the Latex math notation was adapted from Apache Spark MLlib's documentation

--- a/docs/libs/ml/quickstart.md
+++ b/docs/libs/ml/quickstart.md
@@ -1,0 +1,26 @@
+---
+title: "FlinkML - Quickstart guide"
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+Coming soon.

--- a/docs/libs/ml/vision_roadmap.md
+++ b/docs/libs/ml/vision_roadmap.md
@@ -57,8 +57,8 @@ cluster sizes.
 ## Roadmap
 
 The roadmap below can provide an indication of the algorithms we aim to implement in the coming
-months. If you are interested in helping out, please check our [contribution guide](???). Items in 
-**bold** have already been implemented:
+months. If you are interested in helping out, please check our [contribution guide](contribution_guide.html).
+Items in **bold** have already been implemented:
 
 * Pipelines of transformers and learners
 * Data pre-processing
@@ -91,8 +91,7 @@ months. If you are interested in helping out, please check our [contribution gui
 * Distributed linear algebra
 * Streaming ML
 
-
-### References:
+**References:**
 
 [1] D. Sculley, G. Holt, D. Golovin, E. Davydov, T. Phillips, D. Ebner, V. Chaudhary,
 and M. Young. _Machine learning: The high interest credit card of technical debt._ In SE4ML:

--- a/docs/libs/ml/vision_roadmap.md
+++ b/docs/libs/ml/vision_roadmap.md
@@ -1,0 +1,99 @@
+---
+title: "FlinkML - Vision and Roadmap"
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+## Vision
+
+The Machine Learning (ML) library for Flink is a new effort to bring scalable ML tools to the Flink
+community. Our goal is is to design and implement a system that is scalable and can deal with
+problems of various sizes, whether your data size is measured in megabytes or terabytes and beyond.
+We call this library FlinkML.
+
+An important concern for developers of ML systems is the amount of glue code that developers are
+forced to write [1] in the process of implementing an end-to-end ML system. Our goal with FlinkML
+is to help developers keep glue code to a minimum. The Flink ecosystem provides a great setting to
+tackle this problem, with its scalable ETL capabilities that can be easily combined inside the same
+program with FlinkML, allowing the development of robust pipelines without the need to use yet
+another technology for data ingestion and data munging.
+
+Another goal for FlinkML is to make the library easy to use. To that end we will be providing
+detailed documentation along with examples for every part of the system. Our aim is that developers
+will be able to get started with writing their ML pipelines quickly, using familiar programming
+concepts and terminology.
+
+Contrary to other data-processing systems, Flink exploits in-memory data streaming, and natively
+executes iterative processing algorithms which are common in ML. We plan to exploit the streaming
+nature of Flink, and provide functionality designed specifically for data streams.
+
+FlinkML will allow data scientists to test their models locally and using subsets of data, and then
+use the same code to run their algorithms at a much larger scale in a cluster setting.
+
+We are inspired by other open source efforts to provide ML systems, in particular
+[scikit-learn](http://scikit-learn.org/) for cleanly specifying ML pipelines, and Spark’s
+[MLLib](https://spark.apache.org/mllib/) for providing ML algorithms that scale with problem and
+cluster sizes.
+
+## Roadmap
+
+The roadmap below can provide an indication of the algorithms we aim to implement in the coming
+months. If you are interested in helping out, please check our [contribution guide](???). Items in 
+**bold** have already been implemented:
+
+* Pipelines of transformers and learners
+* Data pre-processing
+  * **Feature scaling**
+  * **Polynomial feature base mapper**
+  * Feature hashing
+  * Feature extraction for text
+  * Dimensionality reduction
+* Model selection and performance evaluation
+  * Cross-validation for model selection and evaluation
+* Supervised learning
+  * Optimization framework
+    * **Stochastic Gradient Descent**
+    * L-BFGS
+  * Generalized Linear Models
+    * **Multiple linear regression**
+    * LASSO, Ridge regression
+    * Multi-class Logistic regression
+  * Random forests
+  * **Support Vector Machines**
+* Unsupervised learning
+  * Clustering
+    * K-means clustering
+  * PCA
+* Recommendation
+  * **ALS**
+* Text analytics
+  * LDA
+* Statistical estimation tools
+* Distributed linear algebra
+* Streaming ML
+
+
+### References:
+
+[1] D. Sculley, G. Holt, D. Golovin, E. Davydov, T. Phillips, D. Ebner, V. Chaudhary,
+and M. Young. _Machine learning: The high interest credit card of technical debt._ In SE4ML:
+Software Engineering for Machine Learning (NIPS 2014 Workshop), 2014.


### PR DESCRIPTION
We should have a document describing the vision of the Machine Learning library in Flink and an up to date roadmap.
This PR provides that, and the text can also be used in the website.