### PR TITLE
[FLINK-1920] Properly pass command line arguments with spaces to Flink

### DIFF
--- a/docs/libs/ml/index.md
+++ b/docs/libs/ml/index.md
@@ -29,19 +29,9 @@ and roadmap here](vision_roadmap.html).
 * This will be replaced by the TOC
 {:toc}
 
-## Getting Started
-
-You can use FlinkML in your project by adding the following dependency to your pom.xml
-
-{% highlight bash %}
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-ml</artifactId>
-  <version>{{site.version }}</version>
-</dependency>
-{% endhighlight %}
-
 ## Supported Algorithms
+
+FlinkML currently supports the following algorithms:
 
 ### Supervised Learning
 
@@ -62,27 +52,66 @@ You can use FlinkML in your project by adding the following dependency to your p
 
 * [Distance Metrics](distance_metrics.html)
 
-## Example & Quickstart guide
+## Getting Started
 
-We already have some of the building blocks for FlinkML in place, and will continue to extend the
-library with more algorithms. An example of how simple it is to create a learning model in
-FlinkML is given below:
+First, you have to [set up a Flink program](http://ci.apache.org/projects/flink/flink-docs-master/apis/programming_guide.html#linking-with-flink).
+Next, you have to add the FlinkML dependency to the `pom.xml` of your project.  
+
+{% highlight bash %}
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-ml</artifactId>
+  <version>{{site.version }}</version>
+</dependency>
+{% endhighlight %}
+
+Now you can start defining your ML pipelines.
+The following code snippet shows how easy it is to train a multiple linear regression model.
 
 {% highlight scala %}
 // LabeledVector is a feature vector with a label (class or real value)
-val data: DataSet[LabeledVector] = ...
+val trainingData: DataSet[LabeledVector] = ...
+val testingData: DataSet[Vector] = ...
 
-val learner = MultipleLinearRegression()
+val mlr = MultipleLinearRegression()
   .setStepsize(1.0)
   .setIterations(100)
   .setConvergenceThreshold(0.001)
 
-learner.fit(data, parameters)
+mlr.fit(trainingData, parameters)
 
-// The learner can now be used to make predictions using learner.predict()
+// The fitted model can now be used to make predictions
+val predictions: DataSet[LabeledVector] = mlr.predict(testingData)
 {% endhighlight %}
 
-For a more comprehensive guide, you can check out our [quickstart guide](quickstart.html)
+For a more comprehensive guide, please check out our [quickstart guide](quickstart.html)
+
+## Pipelines
+
+A key concept of FlinkML is its [scikit-learn](http://scikit-learn.org) inspired pipelining mechanism.
+It allows you to quickly build complex data analysis pipelines how they appear in every data scientist's daily work.
+
+The following example code shows how easy it is to set up an analysis pipeline with FlinkML.
+
+{% highlight scala %}
+val trainingData: DataSet[LabeledVector] = ...
+val testingData: DataSet[Vector] = ...
+
+val scaler = StandardScaler()
+val polyFeatures = PolynomialFeatures().setDegree(3)
+val mlr = MultipleLinearRegression()
+
+// Construct pipeline
+val pipeline = scaler.chainTransformer(polyFeatures).chainPredictor(mlr)
+
+// Train pipeline
+pipeline.fit(trainingData)
+
+// Calculate predictions
+val predictions: DataSet[LabeledVector] = pipeline.predict(testingData)
+{% endhighlight %} 
+
+An in-depth description of FlinkML's pipelines and their internal workings can be found [here](pipelines.html)
 
 ## How to contribute
 

--- a/docs/libs/ml/pipelines.md
+++ b/docs/libs/ml/pipelines.md
@@ -1,0 +1,211 @@
+---
+mathjax: include
+title: "Pipelines - In-depth Description"
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+## Introduction
+
+The ability to chain together different transformers and predictors is an important feature for
+any Machine Learning (ML) library. In FlinkML we wanted to provide an intuitive API,
+and at the same
+time utilize the capabilities of the Scala language to provide
+type-safe implementations of our pipelines. What we hope to achieve then is an easy to use API,
+that protects users from type errors at pre-flight (before the job is launched) time, thereby
+eliminating cases where long
+running jobs are submitted to the cluster only to see them fail due to some
+error in the series of data transformations that commonly happen in an ML pipeline.
+
+In this guide then we will describe the choices we made during the implementation of chainable
+transformers and predictors in FlinkML, and provide guidelines on how developers can create their
+own algorithms that make use of these capabilities.
+
+## The what and the why
+
+So what do we mean by "ML pipelines"? Pipelines in the ML context can be thought of as chains of
+operations that have some data as input, perform a number of transformations to that data,
+and
+then output the transformed data, either to be used as the input (features) of a predictor
+function, such as a learning model, or just output the transformed data themselves, to be used in
+some other task. The end learner can of course be a part of the pipeline as well.
+ML pipelines can often be complicated sets of operations ([in-depth explanation](http://research.google.com/pubs/pub43146.html)) and
+can become sources of errors for end-to-end learning systems.
+
+The purpose of ML pipelines is then to create a
+framework that can be used to manage the complexity introduced by these chains of operations.
+Pipelines should make it easy for developers to define chained transformations that can be
+applied to the
+training data, in order to create the end features that will be used to train a
+learning model, and then perform the same set of transformations just as easily to unlabeled
+(test) data. Pipelines should also simplify cross-validation and model selection on
+these chains of operations.
+
+Finally, by ensuring that the consecutive links in the pipeline chain "fit together" we also
+avoid costly type errors. Since each step in a pipeline can be a computationally-heavy operation,
+we want to avoid running a pipelined job, unless we are sure that all the input/output pairs in a
+pipeline "fit".
+
+## Pipelines in FlinkML
+
+The building blocks for pipelines in FlinkML can be found in the `ml.pipeline` package.
+FlinkML follows an API inspired by [sklearn](http://scikit-learn.org) which means that we have
+`Estimator`, `Transformer` and `Predictor` interfaces. For an in-depth look at the design of the
+sklearn API the interested reader is referred to [this](http://arxiv.org/abs/1309.0238) paper.
+In short, the `Estimator` is the base class from which `Transformer` and `Predictor` inherit.
+`Estimator` defines a `fit` method, and `Transformer` also defines a `transform` method and
+`Predictor` defines a `predict` method.
+
+The `fit` method of the `Estimator` performs the actual training of the model, for example
+finding the correct weights in a linear regression task, or the mean and standard deviation of
+the data in a feature scaler.
+As evident by the naming, classes that implement
+`Transformer` are transform operations like [scaling the input](standard_scaler.html) and
+`Predictor` implementations are learning algorithms such as [Multiple Linear Regression]
+(multiple_linear_regression.html).
+Pipelines can be created by chaining together a
+number of Transformers, and the final link in a pipeline can be a Predictor or another Transformer.
+Pipelines that end with Predictor cannot be chained any further.
+Below is an example of how a pipeline can be formed:
+
+{% highlight scala %}
+// Training data
+val input: DataSet[LabeledVector] = ...
+// Test data
+val unlabeled: DataSet[Vector] = ...
+
+val scaler = StandardScaler()
+val polyFeatures = PolynomialFeatures()
+val mlr = MultipleLinearRegression()
+
+// Construct the pipeline
+val pipeline = scaler
+  .chainTransformer(polyFeatures)
+  .chainPredictor(mlr)
+
+// Train the pipeline (scaler and multiple linear regression)
+pipeline.fit(input)
+
+// Calculate predictions for the testing data
+val predictions: DataSet[LabeledVector] = pipeline.predict(unlabeled)
+
+{% endhighlight %}
+
+As we mentioned, FlinkML pipelines are type-safe.
+If we tried to chain a transformer with output of type `A` to another with input of type `B` we
+would get an error at pre-flight time if `A` != `B`. FlinkML achieves this kind of type-safety
+through the use of Scala's implicits.
+
+### Scala implicits
+
+If you are not familiar with Scala's implicits we can recommend [this excerpt](https://www.artima.com/pins1ed/implicit-conversions-and-parameters.html)
+from Martin Odersky's "Programming in Scala". In short, implicit conversions allow for ad-hoc
+polymorphism in Scala by providing conversions from one type to another, and implicit values
+provide the compiler with default values that can be supplied to function calls through implicit parameters.
+The combination of implicit conversions and implicit parameters is what allows us to chain transform
+and predict operations together in a type-safe manner.
+
+### Operations
+
+As we mentioned, the trait (abstract class) `Estimator` defines a `fit` method. The method has two
+parameter lists
+(i.e. is a [curried function](http://docs.scala-lang.org/tutorials/tour/currying.html)). The
+first parameter list
+takes the input (training) `DataSet` and the parameters for the estimator. The second parameter
+list takes one `implicit` parameter, of type `FitOperation`. `FitOperation` is a class that also
+defines a `fit` method, and this is where the actual logic of training the concrete Estimators
+should be implemented. The `fit` method of `Estimator` is essentially a wrapper around the  fit
+method of `FitOperation`. The `predict` method of `Predictor` and the `transform` method of
+`Transform` are designed in a similar manner, with a respective operation class.
+
+In these methods the operation object is provided as an implicit parameter.
+Scala will [look for implicits](http://docs.scala-lang.org/tutorials/FAQ/finding-implicits.html)
+in the companion object of a type, so classes that implement these interfaces should provide these 
+objects as implicit objects inside the companion object.
+
+As an example we can look at the `StandardScaler` class. `StandardScaler` extends `Transformer`, so it has access to its `fit` and `transform` functions.
+These two functions expect objects of `FitOperation` and `TransformOperation` as implicit parameters, 
+for the `fit` and `transform` methods respectively, which `StandardScaler` provides in its companion 
+object, through `transformVectors` and `fitVectorStandardScaler`:
+
+{% highlight scala %}
+class StandardScaler extends Transformer[StandardScaler] {
+  ...
+}
+
+object StandardScaler {
+
+  ...
+
+  implicit def fitVectorStandardScaler[T <: Vector] = new FitOperation[StandardScaler, T] {
+    override def fit(instance: StandardScaler, fitParameters: ParameterMap, input: DataSet[T])
+      : Unit = {
+        ...
+      }
+
+  implicit def transformVectors[T <: Vector: VectorConverter: TypeInformation: ClassTag] = {
+      new TransformOperation[StandardScaler, T, T] {
+        override def transform(
+          instance: StandardScaler,
+          transformParameters: ParameterMap,
+          input: DataSet[T])
+        : DataSet[T] = {
+          ...
+        }
+
+}
+
+{% endhighlight %}
+
+Note that `StandardScaler` does **not** override the `fit` method of `Estimator` or the `transform`
+method of `Transformer`. Rather, its implementations of `FitOperation` and `TransformOperation`
+override their respective `fit` and `transform` methods, which are then called by the `fit` and
+`transform` methods of `Estimator` and `Transformer`.  Similarly, a class that implements
+`Predictor` should define an implicit `PredictOperation` object inside its companion object.
+
+#### Types and type safety
+
+Apart from the `fit` and `transform` operations that we listed above, the `StandardScaler` also
+provides `fit` and `transform` operations for input of type `LabeledVector`.
+This allows us to use the  algorithm for input that is labeled or unlabeled, and this happens
+automatically, depending on  the type of the input that we give to the fit and transform
+operations. The correct implicit operation is chosen by the compiler, depending on the input type.
+
+If we try to call the `fit` or `transform` methods with types that are not supported we will get a 
+runtime error before the job is launched. 
+While it would be possible to catch these kinds of errors at compile time as well, the error 
+messages that we are able to provide the user would be much less informative, which is why we chose 
+to throw runtime exceptions instead.
+
+### Chaining
+
+Chaining is achieved by calling `chainTransformer` or `chainPredictor` on a an object
+of a class that implements `Transformer`. These methods return a `ChainedTransformer` or
+`ChainedPredictor` object respectively. As we mentioned, `ChainedTransformer` objects can be
+chained further, while `ChainedPredictor` objects cannot. These classes take care of applying
+fit, transform, and predict operations for a pair of successive transformers or
+a transformer and a predictor. They also act recursively if the length of the
+chain is larger than two, since every `ChainedTransformer` defines a `transform` and `fit`
+operation that can be further chained with more transformers or a predictor.
+
+It is important to note that developers and users do not need to worry about chaining when
+implementing their algorithms, all this is handled automatically by FlinkML.

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -723,13 +723,7 @@ public class CliFrontend {
 
 
 	/**
-	 *
-	 * @param options
-	 * @param classLoader
-	 * @param programName
 	 * @param userParallelism The parallelism requested by the user in the CLI frontend.
-	 * @return
-	 * @throws Exception
 	 */
 	protected Client getClient(CommandLineOptions options, ClassLoader classLoader, String programName, int userParallelism) throws Exception {
 		InetSocketAddress jobManagerAddress;

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -22,6 +22,7 @@ import com.esotericsoftware.kryo.Serializer;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -97,9 +98,9 @@ public class ExecutionConfig implements Serializable {
 	private final List<Entry<Class<?>, Class<? extends Serializer<?>>>> defaultKryoSerializerClasses =
 			new ArrayList<Entry<Class<?>, Class<? extends Serializer<?>>>>();
 
-	private final List<Class<?>> registeredKryoTypes = new ArrayList<Class<?>>();
+	private final LinkedHashSet<Class<?>> registeredKryoTypes = new LinkedHashSet<Class<?>>();
 
-	private final List<Class<?>> registeredPojoTypes = new ArrayList<Class<?>>();
+	private final LinkedHashSet<Class<?>> registeredPojoTypes = new LinkedHashSet<Class<?>>();
 
 	// --------------------------------------------------------------------------------------------
 
@@ -505,11 +506,11 @@ public class ExecutionConfig implements Serializable {
 	/**
 	 * Returns the registered Kryo types.
 	 */
-	public List<Class<?>> getRegisteredKryoTypes() {
+	public LinkedHashSet<Class<?>> getRegisteredKryoTypes() {
 		if (isForceKryoEnabled()) {
 			// if we force kryo, we must also return all the types that
 			// were previously only registered as POJO
-			List<Class<?>> result = new ArrayList<Class<?>>();
+			LinkedHashSet<Class<?>> result = new LinkedHashSet<Class<?>>();
 			result.addAll(registeredKryoTypes);
 			for(Class<?> t : registeredPojoTypes) {
 				if (!result.contains(t)) {
@@ -525,7 +526,7 @@ public class ExecutionConfig implements Serializable {
 	/**
 	 * Returns the registered POJO types.
 	 */
-	public List<Class<?>> getRegisteredPojoTypes() {
+	public LinkedHashSet<Class<?>> getRegisteredPojoTypes() {
 		return registeredPojoTypes;
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ExecutionConfigTest {
+
+	@Test
+	public void testDoubleTypeRegistration() {
+		ExecutionConfig config = new ExecutionConfig();
+		List<Class<?>> types = Arrays.asList((Class<?>)Double.class, Integer.class, Double.class);
+		List<Class<?>> expectedTypes = Arrays.asList((Class<?>)Double.class, Integer.class);
+
+		for(Class<?> tpe: types) {
+			config.registerKryoType(tpe);
+		}
+
+		int counter = 0;
+
+		for(Class<?> tpe: config.getRegisteredKryoTypes()){
+			assertEquals(tpe, expectedTypes.get(counter++));
+		}
+
+		assertTrue(counter == expectedTypes.size());
+	}
+}

--- a/flink-dist/src/main/flink-bin/bin/flink
+++ b/flink-dist/src/main/flink-bin/bin/flink
@@ -36,4 +36,4 @@ export FLINK_ROOT_DIR
 export FLINK_CONF_DIR
 
 # Add HADOOP_CLASSPATH to allow the usage of Hadoop file systems
-$JAVA_RUN $JVM_ARGS "$log_setting" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.client.CliFrontend $*
+$JAVA_RUN $JVM_ARGS "$log_setting" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.client.CliFrontend "$@"

--- a/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
+++ b/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
@@ -52,5 +52,5 @@ log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4
 
 export FLINK_CONF_DIR
 
-$JAVA_RUN $JVM_ARGS -classpath $CC_CLASSPATH:$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR  $log_setting org.apache.flink.client.FlinkYarnSessionCli -ship $bin/../lib/ -j $FLINK_LIB_DIR/flink-dist*.jar $*
+$JAVA_RUN $JVM_ARGS -classpath $CC_CLASSPATH:$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR  $log_setting org.apache.flink.client.FlinkYarnSessionCli -ship $bin/../lib/ -j $FLINK_LIB_DIR/flink-dist*.jar "$@"
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +79,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		this.numFields = fieldSerializers.length;
 		this.executionConfig = executionConfig;
 
-		List<Class<?>> registeredPojoTypes = executionConfig.getRegisteredPojoTypes();
+		LinkedHashSet<Class<?>> registeredPojoTypes = executionConfig.getRegisteredPojoTypes();
 
 		for (int i = 0; i < numFields; i++) {
 			this.fields[i].setAccessible(true);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -63,7 +64,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 	private final List<ExecutionConfig.Entry<Class<?>, Class<? extends Serializer<?>>>> registeredTypesWithSerializerClasses;
 	private final List<ExecutionConfig.Entry<Class<?>, Serializer<?>>> defaultSerializers;
 	private final List<ExecutionConfig.Entry<Class<?>, Class<? extends Serializer<?>>>> defaultSerializerClasses;
-	private final List<Class<?>> registeredTypes;
+	private final LinkedHashSet<Class<?>> registeredTypes;
 
 	private final Class<T> type;
 	
@@ -305,7 +306,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 	// For testing
 	// --------------------------------------------------------------------------------------------
 	
-	Kryo getKryo() {
+	public Kryo getKryo() {
 		checkKryoInitialized();
 		return this.kryo;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -433,8 +433,13 @@ public class Execution implements Serializable {
 	}
 
 	void scheduleOrUpdateConsumers(List<List<ExecutionEdge>> allConsumers) {
-		if (allConsumers.size() > 1) {
+		final int numConsumers = allConsumers.size();
+
+		if (numConsumers > 1) {
 			fail(new IllegalStateException("Currently, only a single consumer group per partition is supported."));
+		}
+		else if (numConsumers == 0) {
+			return;
 		}
 
 		for (ExecutionEdge edge : allConsumers.get(0)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -107,12 +107,16 @@ class NettyClient {
 		bootstrap.handler(new ChannelInitializer<SocketChannel>() {
 			@Override
 			public void initChannel(SocketChannel channel) throws Exception {
-				protocol.setClientChannelPipeline(channel.pipeline());
+				channel.pipeline().addLast(protocol.getClientChannelHandlers());
 			}
 		});
 
 		long end = System.currentTimeMillis();
 		LOG.info("Successful initialization (took {} ms).", (end - start));
+	}
+
+	NettyConfig getConfig() {
+		return config;
 	}
 
 	void shutdown() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -147,8 +147,11 @@ abstract class NettyMessage {
 			else if (msgId == ErrorResponse.ID) {
 				decodedMsg = new ErrorResponse();
 			}
+			else if (msgId == CancelPartitionRequest.ID) {
+				decodedMsg = new CancelPartitionRequest();
+			}
 			else {
-				throw new IllegalStateException("Received unknown message from producer: " + decodedMsg.getClass());
+				throw new IllegalStateException("Received unknown message from producer: " + msg);
 			}
 
 			if (decodedMsg != null) {
@@ -486,6 +489,9 @@ abstract class NettyMessage {
 
 		InputChannelID receiverId;
 
+		public CancelPartitionRequest() {
+		}
+
 		public CancelPartitionRequest(InputChannelID receiverId) {
 			this.receiverId = receiverId;
 		}
@@ -495,7 +501,7 @@ abstract class NettyMessage {
 			ByteBuf result = null;
 
 			try {
-				result = allocateBuffer(allocator, ID);
+				result = allocateBuffer(allocator, ID, 16);
 				receiverId.writeTo(result);
 			}
 			catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -119,7 +119,7 @@ class NettyServer {
 		bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
 			@Override
 			public void initChannel(SocketChannel channel) throws Exception {
-				protocol.setServerChannelPipeline(channel.pipeline());
+				channel.pipeline().addLast(protocol.getServerChannelHandlers());
 			}
 		});
 
@@ -130,7 +130,11 @@ class NettyServer {
 		bindFuture = bootstrap.bind().syncUninterruptibly();
 
 		long end = System.currentTimeMillis();
-		LOG.info("Successful initialization  (took {} ms). Listening on SocketAddress {}.", (end - start), bindFuture.channel().localAddress().toString());
+		LOG.info("Successful initialization (took {} ms). Listening on SocketAddress {}.", (end - start), bindFuture.channel().localAddress().toString());
+	}
+
+	NettyConfig getConfig() {
+		return config;
 	}
 
 	void shutdown() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -429,7 +429,7 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 					success = true;
 				}
 				else {
-					cancelRequestFor(inputChannel.getInputChannelId());
+					cancelRequestFor(stagedBufferResponse.receiverId);
 				}
 
 				stagedBufferResponse = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.CancelPartitionRequest;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
@@ -113,6 +114,11 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
 				if (!taskEventDispatcher.publish(request.partitionId, request.event)) {
 					respondWithError(ctx, new IllegalArgumentException("Task event receiver not found."), request.receiverId);
 				}
+			}
+			else if (msgClazz == CancelPartitionRequest.class) {
+				CancelPartitionRequest request = (CancelPartitionRequest) msg;
+
+				outboundQueue.cancel(request.receiverId);
 			}
 			else {
 				LOG.warn("Received unexpected client request: {}", msg);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/LocalTransportException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/LocalTransportException.java
@@ -16,14 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.io.network.netty.exception;
 
-import io.netty.channel.ChannelHandler;
+import java.net.SocketAddress;
 
-public interface NettyProtocol {
+public class LocalTransportException extends TransportException {
 
-	ChannelHandler[] getServerChannelHandlers();
+	private static final long serialVersionUID = 2366708881288640674L;
 
-	ChannelHandler[] getClientChannelHandlers();
+	public LocalTransportException(String message, SocketAddress address) {
+		super(message, address);
+	}
 
+	public LocalTransportException(String message, SocketAddress address, Throwable cause) {
+		super(message, address, cause);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/RemoteTransportException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/RemoteTransportException.java
@@ -16,14 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.io.network.netty.exception;
 
-import io.netty.channel.ChannelHandler;
+import java.net.SocketAddress;
 
-public interface NettyProtocol {
+public class RemoteTransportException extends TransportException {
 
-	ChannelHandler[] getServerChannelHandlers();
+	private static final long serialVersionUID = 4373615529545893089L;
 
-	ChannelHandler[] getClientChannelHandlers();
+	public RemoteTransportException(String message, SocketAddress address) {
+		super(message, address);
+	}
 
+	public RemoteTransportException(String message, SocketAddress address, Throwable cause) {
+		super(message, address, cause);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/TransportException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/TransportException.java
@@ -16,14 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.io.network.netty.exception;
 
-import io.netty.channel.ChannelHandler;
+import java.io.IOException;
+import java.net.SocketAddress;
 
-public interface NettyProtocol {
+public abstract class TransportException extends IOException {
 
-	ChannelHandler[] getServerChannelHandlers();
+	private static final long serialVersionUID = 3637820720589866570L;
 
-	ChannelHandler[] getClientChannelHandlers();
+	private final SocketAddress address;
 
+	public TransportException(String message, SocketAddress address) {
+		this(message, address, null);
+	}
+
+	public TransportException(String message, SocketAddress address, Throwable cause) {
+		super(message, cause);
+
+		this.address = address;
+	}
+
+	public SocketAddress getAddress() {
+		return address;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -49,7 +49,6 @@ public interface ResultSubpartitionView {
 	 */
 	boolean registerListener(NotificationListener listener) throws IOException;
 
-
 	void releaseAllResources() throws IOException;
 
 	void notifySubpartitionConsumed() throws IOException;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.Channel;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.event.NotificationListener;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.*;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CancelPartitionRequestTest {
+
+	/**
+	 * Verifies that requests for non-existing (failed/cancelled) input channels are properly
+	 * cancelled.
+	 */
+	@Test
+	public void testCancelPartitionRequest() throws Exception {
+
+		NettyServerAndClient serverAndClient = null;
+
+		try {
+			TestPooledBufferProvider outboundBuffers = new TestPooledBufferProvider(16);
+
+			ResultPartitionManager partitions = mock(ResultPartitionManager.class);
+
+			ResultPartitionID pid = new ResultPartitionID();
+
+			CountDownLatch sync = new CountDownLatch(1);
+
+			// Return infinite subpartition
+			when(partitions.createSubpartitionView(eq(pid), eq(0), any(BufferProvider.class)))
+					.thenReturn(new InfiniteSubpartitionView(outboundBuffers, sync));
+
+			PartitionRequestProtocol protocol = new PartitionRequestProtocol(
+					partitions, mock(TaskEventDispatcher.class), mock(NetworkBufferPool.class));
+
+			serverAndClient = initServerAndClient(protocol);
+
+			Channel ch = connect(serverAndClient);
+
+			// Request for non-existing input channel => results in cancel request
+			ch.writeAndFlush(new PartitionRequest(pid, 0, new InputChannelID())).await();
+
+			// Wait for the notification
+			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+				fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+						" ms to be notified about cancelled partition.");
+			}
+		}
+		finally {
+			shutdown(serverAndClient);
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	static class InfiniteSubpartitionView implements ResultSubpartitionView {
+
+		private final BufferProvider bufferProvider;
+
+		private final CountDownLatch sync;
+
+		public InfiniteSubpartitionView(BufferProvider bufferProvider, CountDownLatch sync) {
+			this.bufferProvider = checkNotNull(bufferProvider);
+			this.sync = checkNotNull(sync);
+		}
+
+		@Override
+		public Buffer getNextBuffer() throws IOException, InterruptedException {
+			return bufferProvider.requestBufferBlocking();
+		}
+
+		@Override
+		public boolean registerListener(final NotificationListener listener) throws IOException {
+			return false;
+		}
+
+		@Override
+		public void releaseAllResources() throws IOException {
+			sync.countDown();
+		}
+
+		@Override
+		public void notifySubpartitionConsumed() throws IOException {
+		}
+
+		@Override
+		public boolean isReleased() {
+			return false;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
+import org.apache.flink.runtime.io.network.netty.exception.LocalTransportException;
+import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.createConfig;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClientTransportErrorHandlingTest {
+
+	/**
+	 * Verifies that failed client requests via {@link PartitionRequestClient} are correctly
+	 * attributed to the respective {@link RemoteInputChannel}.
+	 */
+	@Test
+	public void testExceptionOnWrite() throws Exception {
+
+		NettyProtocol protocol = new NettyProtocol() {
+			@Override
+			public ChannelHandler[] getServerChannelHandlers() {
+				return new ChannelHandler[0];
+			}
+
+			@Override
+			public ChannelHandler[] getClientChannelHandlers() {
+				return new PartitionRequestProtocol(
+						mock(ResultPartitionProvider.class),
+						mock(TaskEventDispatcher.class),
+						mock(NetworkBufferPool.class)).getClientChannelHandlers();
+			}
+		};
+
+		// We need a real server and client in this test, because Netty's EmbeddedChannel is
+		// not failing the ChannelPromise of failed writes.
+		NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+
+		Channel ch = connect(serverAndClient);
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Last outbound handler throws Exception after 1st write
+		ch.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+			int writeNum = 0;
+
+			@Override
+			public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+					throws Exception {
+
+				if (writeNum >= 1) {
+					throw new RuntimeException("Expected test exception.");
+				}
+
+				writeNum++;
+				ctx.write(msg, promise);
+			}
+		});
+
+		PartitionRequestClient requestClient = new PartitionRequestClient(
+				ch, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		final CountDownLatch sync = new CountDownLatch(1);
+
+		// Do this with explicit synchronization. Otherwise this is not robust against slow timings
+		// of the callback (e.g. we cannot just verify that it was called once, because there is
+		// a chance that we do this too early).
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				sync.countDown();
+				return null;
+			}
+		}).when(rich[1]).onError(isA(LocalTransportException.class));
+
+		// First request is successful
+		ChannelFuture f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[0], 0);
+		assertTrue(f.await().isSuccess());
+
+		// Second request is *not* successful
+		f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[1], 0);
+		assertFalse(f.await().isSuccess());
+
+		// Only the second channel should be notified about the error
+		verify(rich[0], times(0)).onError(any(LocalTransportException.class));
+
+		// Wait for the notification
+		if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+			fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+					" ms to be notified about the channel error.");
+		}
+
+		shutdown(serverAndClient);
+	}
+
+	/**
+	 * Verifies that {@link NettyMessage.ErrorResponse} messages are correctly wrapped in
+	 * {@link RemoteTransportException} instances.
+	 */
+	@Test
+	public void testWrappingOfRemoteErrorMessage() throws Exception {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		for (RemoteInputChannel r : rich) {
+			when(r.getInputChannelId()).thenReturn(new InputChannelID());
+			handler.addInputChannel(r);
+		}
+
+		// Error msg for channel[0]
+		ch.pipeline().fireChannelRead(new NettyMessage.ErrorResponse(
+				new RuntimeException("Expected test exception"),
+				rich[0].getInputChannelId()));
+
+		try {
+			// Exception should not reach end of pipeline...
+			ch.checkException();
+		}
+		catch (Exception e) {
+			fail("The exception reached the end of the pipeline and "
+					+ "was not handled correctly by the last handler.");
+		}
+
+		verify(rich[0], times(1)).onError(isA(RemoteTransportException.class));
+		verify(rich[1], never()).onError(any(Throwable.class));
+
+		// Fatal error for all channels
+		ch.pipeline().fireChannelRead(new NettyMessage.ErrorResponse(
+				new RuntimeException("Expected test exception")));
+
+		try {
+			// Exception should not reach end of pipeline...
+			ch.checkException();
+		}
+		catch (Exception e) {
+			fail("The exception reached the end of the pipeline and "
+					+ "was not handled correctly by the last handler.");
+		}
+
+		verify(rich[0], times(2)).onError(isA(RemoteTransportException.class));
+		verify(rich[1], times(1)).onError(isA(RemoteTransportException.class));
+	}
+
+	/**
+	 * Verifies that unexpected remote closes are reported as an instance of
+	 * {@link RemoteTransportException}.
+	 */
+	@Test
+	public void testExceptionOnRemoteClose() throws Exception {
+
+		NettyProtocol protocol = new NettyProtocol() {
+			@Override
+			public ChannelHandler[] getServerChannelHandlers() {
+				return new ChannelHandler[] {
+						// Close on read
+						new ChannelInboundHandlerAdapter() {
+							@Override
+							public void channelRead(ChannelHandlerContext ctx, Object msg)
+									throws Exception {
+
+								ctx.channel().close();
+							}
+						}
+				};
+			}
+
+			@Override
+			public ChannelHandler[] getClientChannelHandlers() {
+				return new PartitionRequestProtocol(
+						mock(ResultPartitionProvider.class),
+						mock(TaskEventDispatcher.class),
+						mock(NetworkBufferPool.class)).getClientChannelHandlers();
+			}
+		};
+
+		NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+
+		Channel ch = connect(serverAndClient);
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		final CountDownLatch sync = new CountDownLatch(rich.length);
+
+		Answer<Void> countDownLatch = new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				sync.countDown();
+				return null;
+			}
+		};
+
+		for (RemoteInputChannel r : rich) {
+			doAnswer(countDownLatch).when(r).onError(any(Throwable.class));
+			handler.addInputChannel(r);
+		}
+
+		// Write something to trigger close by server
+		ch.writeAndFlush(Unpooled.buffer().writerIndex(16));
+
+		// Wait for the notification
+		if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+			fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+					" ms to be notified about remote connection close.");
+		}
+
+		// All the registered channels should be notified.
+		for (RemoteInputChannel r : rich) {
+			verify(r).onError(isA(RemoteTransportException.class));
+		}
+
+		shutdown(serverAndClient);
+	}
+
+	/**
+	 * Verifies that fired Exceptions are handled correctly by the pipeline.
+	 */
+	@Test
+	public void testExceptionCaught() throws Exception {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		for (RemoteInputChannel r : rich) {
+			when(r.getInputChannelId()).thenReturn(new InputChannelID());
+			handler.addInputChannel(r);
+		}
+
+		ch.pipeline().fireExceptionCaught(new Exception());
+
+		try {
+			// Exception should not reach end of pipeline...
+			ch.checkException();
+		}
+		catch (Exception e) {
+			fail("The exception reached the end of the pipeline and "
+					+ "was not handled correctly by the last handler.");
+		}
+
+		// ...but all the registered channels should be notified.
+		for (RemoteInputChannel r : rich) {
+			verify(r).onError(isA(LocalTransportException.class));
+		}
+	}
+
+	/**
+	 * Verifies that "Connection reset by peer" Exceptions are special-cased and are reported as
+	 * an instance of {@link RemoteTransportException}.
+	 */
+	@Test
+	public void testConnectionResetByPeer() throws Throwable {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		RemoteInputChannel rich = addInputChannel(handler);
+
+		final Throwable[] error = new Throwable[1];
+
+		// Verify the Exception
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				Throwable cause = (Throwable) invocation.getArguments()[0];
+
+				try {
+					assertEquals(RemoteTransportException.class, cause.getClass());
+					assertNotEquals("Connection reset by peer", cause.getMessage());
+
+					assertEquals(IOException.class, cause.getCause().getClass());
+					assertEquals("Connection reset by peer", cause.getCause().getMessage());
+				}
+				catch (Throwable t) {
+					error[0] = t;
+				}
+
+				return null;
+			}
+		}).when(rich).onError(any(Throwable.class));
+
+		ch.pipeline().fireExceptionCaught(new IOException("Connection reset by peer"));
+
+		assertNull(error[0]);
+	}
+
+	/**
+	 * Verifies that the channel is closed if there is an error *during* error notification.
+	 */
+	@Test
+	public void testChannelClosedOnExceptionDuringErrorNotification() throws Exception {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		RemoteInputChannel rich = addInputChannel(handler);
+
+		doThrow(new RuntimeException("Expected test exception"))
+				.when(rich).onError(any(Throwable.class));
+
+		ch.pipeline().fireExceptionCaught(new Exception());
+
+		assertFalse(ch.isActive());
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------------------------
+
+	private EmbeddedChannel createEmbeddedChannel() {
+		PartitionRequestProtocol protocol = new PartitionRequestProtocol(
+				mock(ResultPartitionProvider.class),
+				mock(TaskEventDispatcher.class),
+				mock(NetworkBufferPool.class));
+
+		return new EmbeddedChannel(protocol.getClientChannelHandlers());
+	}
+
+	private RemoteInputChannel addInputChannel(PartitionRequestClientHandler clientHandler) {
+		RemoteInputChannel rich = createRemoteInputChannel();
+		clientHandler.addInputChannel(rich);
+
+		return rich;
+	}
+
+	private PartitionRequestClientHandler getClientHandler(Channel ch) {
+		return ch.pipeline().get(PartitionRequestClientHandler.class);
+	}
+
+	private RemoteInputChannel createRemoteInputChannel() {
+		return when(mock(RemoteInputChannel.class)
+				.getInputChannelId())
+				.thenReturn(new InputChannelID()).getMock();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -140,6 +140,13 @@ public class NettyMessageSerializationTest {
 			assertEquals(expected.partitionId, actual.partitionId);
 			assertEquals(expected.receiverId, actual.receiverId);
 		}
+
+		{
+			NettyMessage.CancelPartitionRequest expected = new NettyMessage.CancelPartitionRequest(new InputChannelID());
+			NettyMessage.CancelPartitionRequest actual = encodeAndDecode(expected);
+
+			assertEquals(expected.receiverId, actual.receiverId);
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.Channel;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.net.NetUtils;
+import scala.Tuple2;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Test utility for Netty server and client setup.
+ */
+public class NettyTestUtil {
+
+	static int DEFAULT_SEGMENT_SIZE = 1024;
+
+	// ---------------------------------------------------------------------------------------------
+	// NettyServer and NettyClient
+	// ---------------------------------------------------------------------------------------------
+
+	static NettyServer initServer(NettyConfig config, NettyProtocol protocol) throws Exception {
+		final NettyServer server = new NettyServer(config);
+
+		try {
+			server.init(protocol);
+		}
+		catch (Exception e) {
+			if (server != null) {
+				server.shutdown();
+			}
+
+			throw e;
+		}
+
+		return server;
+	}
+
+	static NettyClient initClient(NettyConfig config, NettyProtocol protocol) throws Exception {
+		final NettyClient client = new NettyClient(config);
+
+		try {
+			client.init(protocol);
+		}
+		catch (Exception e) {
+			if (client != null) {
+				client.shutdown();
+			}
+
+			throw e;
+		}
+
+		return client;
+	}
+
+	static NettyServerAndClient initServerAndClient(NettyProtocol protocol) throws Exception {
+		return initServerAndClient(protocol, createConfig());
+	}
+
+	static NettyServerAndClient initServerAndClient(NettyProtocol protocol, NettyConfig config)
+			throws Exception {
+
+		final NettyClient client = initClient(config, protocol);
+		final NettyServer server = initServer(config, protocol);
+
+		return new NettyServerAndClient(server, client);
+	}
+
+	static Channel connect(NettyServerAndClient serverAndClient) throws Exception {
+		return connect(serverAndClient.client(), serverAndClient.server());
+	}
+
+	static Channel connect(NettyClient client, NettyServer server) throws Exception {
+		final NettyConfig config = server.getConfig();
+
+		return client
+				.connect(new InetSocketAddress(config.getServerAddress(), config.getServerPort()))
+				.sync()
+				.channel();
+	}
+
+	static void awaitClose(Channel ch) throws InterruptedException {
+		// Wait for the channel to be closed
+		while (ch.isActive()) {
+			ch.closeFuture().await(1, TimeUnit.SECONDS);
+		}
+	}
+
+	static void shutdown(NettyServerAndClient serverAndClient) {
+		if (serverAndClient != null) {
+			if (serverAndClient.server() != null) {
+				serverAndClient.server().shutdown();
+			}
+
+			if (serverAndClient.client() != null) {
+				serverAndClient.client().shutdown();
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// NettyConfig
+	// ---------------------------------------------------------------------------------------------
+
+	static NettyConfig createConfig() throws Exception {
+		return createConfig(DEFAULT_SEGMENT_SIZE, new Configuration());
+	}
+
+	static NettyConfig createConfig(int segmentSize) throws Exception {
+		return createConfig(segmentSize, new Configuration());
+	}
+
+	static NettyConfig createConfig(Configuration config) throws Exception {
+		return createConfig(DEFAULT_SEGMENT_SIZE, config);
+	}
+
+	static NettyConfig createConfig(int segmentSize, Configuration config) throws Exception {
+		checkArgument(segmentSize > 0);
+		checkNotNull(config);
+
+		return new NettyConfig(
+				InetAddress.getLocalHost(),
+				NetUtils.getAvailablePort(),
+				segmentSize,
+				config);
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	static class NettyServerAndClient extends Tuple2<NettyServer, NettyClient> {
+
+		private static final long serialVersionUID = 4440278728496341931L;
+
+		NettyServerAndClient(NettyServer _1, NettyClient _2) {
+			super(_1, _2);
+		}
+
+		NettyServer server() {
+			return _1();
+		}
+
+		NettyClient client() {
+			return _2();
+		}
+
+		@Override
+		public boolean canEqual(Object that) {
+			return false;
+		}
+
+		@Override
+		public boolean equals(Object that) {
+			return false;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -54,12 +54,14 @@ public class PartitionRequestClientFactoryTest {
 		final Tuple2<NettyServer, NettyClient> netty = createNettyServerAndClient(
 				new NettyProtocol() {
 					@Override
-					public void setServerChannelPipeline(ChannelPipeline channelPipeline) {
+					public ChannelHandler[] getServerChannelHandlers() {
+						return new ChannelHandler[0];
 					}
 
 					@Override
-					public void setClientChannelPipeline(ChannelPipeline channelPipeline) {
-						channelPipeline.addLast(new CountDownLatchOnConnectHandler(syncOnConnect));
+					public ChannelHandler[] getClientChannelHandlers() {
+						return new ChannelHandler[] {
+								new CountDownLatchOnConnectHandler(syncOnConnect)};
 					}
 				});
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
@@ -130,7 +131,13 @@ public class PartitionRequestClientHandlerTest {
 		final PartitionRequestClientHandler client = new PartitionRequestClientHandler();
 		client.addInputChannel(inputChannel);
 
-		client.channelRead(mock(ChannelHandlerContext.class), partitionNotFound);
+		// Mock channel context
+		ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+		when(ctx.channel()).thenReturn(mock(Channel.class));
+
+		client.channelActive(ctx);
+
+		client.channelRead(ctx, partitionNotFound);
 
 		verify(inputChannel, times(1)).onFailedPartitionRequest();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.CancelPartitionRequestTest.InfiniteSubpartitionView;
+import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
+import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.NettyMessageEncoder;
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.PartitionRequest;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.createConfig;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ServerTransportErrorHandlingTest {
+
+	/**
+	 * Verifies remote closes trigger the release of all resources.
+	 */
+	@Test
+	public void testRemoteClose() throws Exception {
+		final TestPooledBufferProvider outboundBuffers = new TestPooledBufferProvider(16);
+
+		final CountDownLatch sync = new CountDownLatch(1);
+
+		final ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
+
+		when(partitionManager
+				.createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferProvider.class)))
+				.thenReturn(new InfiniteSubpartitionView(outboundBuffers, sync));
+
+		NettyProtocol protocol = new NettyProtocol() {
+			@Override
+			public ChannelHandler[] getServerChannelHandlers() {
+				return new PartitionRequestProtocol(
+						partitionManager,
+						mock(TaskEventDispatcher.class),
+						mock(NetworkBufferPool.class)).getServerChannelHandlers();
+			}
+
+			@Override
+			public ChannelHandler[] getClientChannelHandlers() {
+				return new ChannelHandler[] {
+						new NettyMessageEncoder(),
+						// Close on read
+						new ChannelInboundHandlerAdapter() {
+							@Override
+							public void channelRead(ChannelHandlerContext ctx, Object msg)
+									throws Exception {
+
+								ctx.channel().close();
+							}
+						}
+				};
+			}
+		};
+
+		NettyServerAndClient serverAndClient = null;
+
+		try {
+			serverAndClient = initServerAndClient(protocol, createConfig());
+
+			Channel ch = connect(serverAndClient);
+
+			// Write something to trigger close by server
+			ch.writeAndFlush(new PartitionRequest(new ResultPartitionID(), 0, new InputChannelID()));
+
+			// Wait for the notification
+			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+				fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+						" ms to be notified about released partition.");
+			}
+		}
+		finally {
+			shutdown(serverAndClient);
+		}
+	}
+}

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/classification/CoCoA.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/classification/CoCoA.scala
@@ -26,7 +26,7 @@ import scala.util.Random
 import org.apache.flink.api.common.functions.RichMapFunction
 import org.apache.flink.api.scala._
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.ml.common.FlinkTools.ModuloKeyPartitioner
+import org.apache.flink.ml.common.FlinkMLTools.ModuloKeyPartitioner
 import org.apache.flink.ml.common._
 import org.apache.flink.ml.math.Vector
 import org.apache.flink.ml.math.Breeze._
@@ -244,6 +244,11 @@ object CoCoA{
           case Some(weights) => {
             input.map(new PredictionMapper[T]).withBroadcastSet(weights, WEIGHT_VECTOR)
           }
+
+          case None => {
+            throw new RuntimeException("The CoCoA model has not been trained. Call first fit" +
+              "before calling the predict operation.")
+          }
         }
       }
     }
@@ -310,7 +315,7 @@ object CoCoA{
         val numberVectors = input map { x => 1 } reduce { _ + _ }
 
         // Group the input data into blocks in round robin fashion
-        val blockedInputNumberElements = FlinkTools.block(
+        val blockedInputNumberElements = FlinkMLTools.block(
           input,
           blocks,
           Some(ModuloKeyPartitioner)).

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/FlinkMLTools.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/FlinkMLTools.scala
@@ -40,7 +40,38 @@ import scala.reflect.ClassTag
   *  Takes a DataSet of elements T and groups them in n blocks.
   *
   */
-object FlinkTools {
+object FlinkMLTools {
+
+  /** Registers the different FlinkML related types for Kryo serialization
+    *
+    * @param env
+    */
+  def registerFlinkMLTypes(env: ExecutionEnvironment): Unit = {
+
+    // Vector types
+    env.registerType(classOf[org.apache.flink.ml.math.DenseVector])
+    env.registerType(classOf[org.apache.flink.ml.math.SparseVector])
+
+    // Matrix types
+    env.registerType(classOf[org.apache.flink.ml.math.DenseMatrix])
+    env.registerType(classOf[org.apache.flink.ml.math.SparseMatrix])
+
+    // Breeze Vector types
+    env.registerType(classOf[breeze.linalg.DenseVector[_]])
+    env.registerType(classOf[breeze.linalg.SparseVector[_]])
+
+    // Breeze specialized types
+    env.registerType(breeze.linalg.DenseVector.zeros[Double](0).getClass)
+    env.registerType(breeze.linalg.SparseVector.zeros[Double](0).getClass)
+
+    // Breeze Matrix types
+    env.registerType(classOf[breeze.linalg.DenseMatrix[Double]])
+    env.registerType(classOf[breeze.linalg.CSCMatrix[Double]])
+
+    // Breeze specialized types
+    env.registerType(breeze.linalg.DenseMatrix.zeros[Double](0, 0).getClass)
+    env.registerType(breeze.linalg.CSCMatrix.zeros[Double](0, 0).getClass)
+  }
 
   /** Writes a [[DataSet]] to the specified path and returns it as a DataSource for subsequent
     * operations.

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/Breeze.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/Breeze.scala
@@ -78,10 +78,10 @@ object Breeze {
     def asBreeze: BreezeVector[Double] = {
       vector match {
         case dense: DenseVector =>
-          new BreezeDenseVector[Double](dense.data)
+          new breeze.linalg.DenseVector(dense.data)
 
         case sparse: SparseVector =>
-          new BreezeSparseVector[Double](sparse.indices, sparse.data, sparse.size)
+          new BreezeSparseVector(sparse.indices, sparse.data, sparse.size)
       }
     }
   }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/BreezeVectorConverter.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/BreezeVectorConverter.scala
@@ -56,7 +56,10 @@ object BreezeVectorConverter{
             dense.length,
             dense.iterator.toIterable)
         case sparse: BreezeSparseVector[Double] =>
-          new SparseVector(sparse.length, sparse.index, sparse.data)
+          new SparseVector(
+            sparse.used,
+            sparse.index.take(sparse.used),
+            sparse.data.take(sparse.used))
       }
     }
   }
@@ -68,7 +71,10 @@ object BreezeVectorConverter{
         case dense: BreezeDenseVector[Double] => new DenseVector(dense.data)
 
         case sparse: BreezeSparseVector[Double] =>
-          new SparseVector(sparse.length, sparse.index, sparse.data)
+          new SparseVector(
+            sparse.used,
+            sparse.index.take(sparse.used),
+            sparse.data.take(sparse.used))
       }
     }
   }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Estimator.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Estimator.scala
@@ -21,7 +21,7 @@ package org.apache.flink.ml.pipeline
 import scala.reflect.ClassTag
 
 import org.apache.flink.api.scala.DataSet
-import org.apache.flink.ml.common.{ParameterMap, WithParameters}
+import org.apache.flink.ml.common.{FlinkMLTools, ParameterMap, WithParameters}
 
 /** Base trait for Flink's pipeline operators.
   *
@@ -50,6 +50,7 @@ trait Estimator[Self] extends WithParameters with Serializable {
       training: DataSet[Training],
       fitParameters: ParameterMap = ParameterMap.Empty)(implicit
       fitOperation: FitOperation[Self, Training]): Unit = {
+    FlinkMLTools.registerFlinkMLTypes(training.getExecutionEnvironment)
     fitOperation.fit(this, fitParameters, training)
   }
 }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
@@ -21,7 +21,7 @@ package org.apache.flink.ml.pipeline
 import scala.reflect.ClassTag
 
 import org.apache.flink.api.scala.DataSet
-import org.apache.flink.ml.common.{ParameterMap, WithParameters}
+import org.apache.flink.ml.common.{FlinkMLTools, ParameterMap, WithParameters}
 
 /** Predictor trait for Flink's pipeline operators.
   *
@@ -53,6 +53,7 @@ trait Predictor[Self] extends Estimator[Self] with WithParameters with Serializa
       predictParameters: ParameterMap = ParameterMap.Empty)(implicit
       predictor: PredictOperation[Self, Testing, Prediction])
     : DataSet[Prediction] = {
+    FlinkMLTools.registerFlinkMLTypes(testing.getExecutionEnvironment)
     predictor.predict(this, predictParameters, testing)
   }
 }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Transformer.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Transformer.scala
@@ -21,7 +21,7 @@ package org.apache.flink.ml.pipeline
 import scala.reflect.ClassTag
 
 import org.apache.flink.api.scala.DataSet
-import org.apache.flink.ml.common.{ParameterMap, WithParameters}
+import org.apache.flink.ml.common.{FlinkMLTools, ParameterMap, WithParameters}
 
 /** Transformer trait for Flink's pipeline operators.
   *
@@ -60,6 +60,7 @@ trait Transformer[Self <: Transformer[Self]]
       transformParameters: ParameterMap = ParameterMap.Empty)
       (implicit transformOperation: TransformOperation[Self, Input, Output])
     : DataSet[Output] = {
+    FlinkMLTools.registerFlinkMLTypes(input.getExecutionEnvironment)
     transformOperation.transform(that, transformParameters, input)
   }
 

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/StandardScaler.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/StandardScaler.scala
@@ -61,7 +61,6 @@ import scala.reflect.ClassTag
   */
 class StandardScaler extends Transformer[StandardScaler] {
 
-
   var metricsOption: Option[DataSet[(linalg.Vector[Double], linalg.Vector[Double])]] = None
 
   /** Sets the target mean of the transformed data
@@ -183,7 +182,6 @@ object StandardScaler {
             varianceVector.update(i, 1.0)
           }
         }
-
         (metric._2 / metric._1, varianceVector)
       }
     }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -471,12 +471,12 @@ object ALS {
         blockIDPartitioner)
 
       val (userIn, userOut) = persistencePath match {
-        case Some(path) => FlinkTools.persist(uIn, uOut, path + "userIn", path + "userOut")
+        case Some(path) => FlinkMLTools.persist(uIn, uOut, path + "userIn", path + "userOut")
         case None => (uIn, uOut)
       }
 
       val (itemIn, itemOut) = persistencePath match {
-        case Some(path) => FlinkTools.persist(iIn, iOut, path + "itemIn", path + "itemOut")
+        case Some(path) => FlinkMLTools.persist(iIn, iOut, path + "itemIn", path + "itemOut")
         case None => (iIn, iOut)
       }
 
@@ -502,7 +502,7 @@ object ALS {
       }
 
       val pItems = persistencePath match {
-        case Some(path) => FlinkTools.persist(items, path + "items")
+        case Some(path) => FlinkMLTools.persist(items, path + "items")
         case None => items
       }
 

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/common/FlinkMLToolsSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/common/FlinkMLToolsSuite.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common
+
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
+import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.test.util.FlinkTestBase
+import org.scalatest.{FlatSpec, Matchers}
+
+class FlinkMLToolsSuite extends FlatSpec with Matchers with FlinkTestBase {
+  behavior of "FlinkMLTools"
+
+  it should "register the required types" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    FlinkMLTools.registerFlinkMLTypes(env)
+
+    val executionConfig = env.getConfig
+
+    val serializer = new KryoSerializer[Nothing](classOf[Nothing], executionConfig)
+
+    val kryo = serializer.getKryo()
+
+    kryo.getRegistration(classOf[org.apache.flink.ml.math.DenseVector]).getId > 0 should be(true)
+    kryo.getRegistration(classOf[org.apache.flink.ml.math.SparseVector]).getId > 0 should be(true)
+    kryo.getRegistration(classOf[org.apache.flink.ml.math.DenseMatrix]).getId > 0 should be(true)
+    kryo.getRegistration(classOf[org.apache.flink.ml.math.SparseMatrix]).getId > 0 should be(true)
+
+    kryo.getRegistration(classOf[breeze.linalg.DenseMatrix[_]]).getId > 0 should be(true)
+    kryo.getRegistration(classOf[breeze.linalg.CSCMatrix[_]]).getId > 0 should be(true)
+    kryo.getRegistration(classOf[breeze.linalg.DenseVector[_]]).getId > 0 should be(true)
+    kryo.getRegistration(classOf[breeze.linalg.SparseVector[_]]).getId > 0 should be(true)
+
+    kryo.getRegistration(breeze.linalg.DenseVector.zeros[Double](0).getClass).getId > 0 should
+      be(true)
+    kryo.getRegistration(breeze.linalg.SparseVector.zeros[Double](0).getClass).getId > 0 should
+      be(true)
+    kryo.getRegistration(breeze.linalg.DenseMatrix.zeros[Double](0, 0).getClass).getId > 0 should
+      be(true)
+    kryo.getRegistration(breeze.linalg.CSCMatrix.zeros[Double](0, 0).getClass).getId > 0 should
+      be(true)
+  }
+
+}

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/feature/PolynomialFeaturesITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/feature/PolynomialFeaturesITSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.{Matchers, FlatSpec}
 import org.apache.flink.api.scala._
 import org.apache.flink.test.util.FlinkTestBase
 
-class PolynomialBaseITSuite
+class PolynomialFeaturesITSuite
   extends FlatSpec
   with Matchers
   with FlinkTestBase {

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/pipeline/PipelineITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/pipeline/PipelineITSuite.scala
@@ -18,9 +18,12 @@
 
 package org.apache.flink.ml.pipeline
 
+import breeze.linalg
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala._
 import org.apache.flink.ml.common.LabeledVector
-import org.apache.flink.ml.math.DenseVector
+import org.apache.flink.ml.math._
 import org.apache.flink.ml.preprocessing.{PolynomialFeatures, StandardScaler}
 import org.apache.flink.ml.regression.MultipleLinearRegression
 import org.apache.flink.test.util.FlinkTestBase

--- a/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -68,6 +68,7 @@ import org.apache.flink.streaming.connectors.kafka.util.KafkaLocalSystemTime;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JavaDefaultStringSchema;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.StringUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -908,13 +909,13 @@ public class KafkaITCase {
 			while (!(t instanceof SuccessException)) {
 				if(t == null) {
 					LOG.warn("Test failed with exception", good);
-					Assert.fail("Test failed with: " + good.getMessage());
+					Assert.fail("Test failed with: " + StringUtils.stringifyException(good));
 				}
 
 				t = t.getCause();
 				if (limit++ == 20) {
 					LOG.warn("Test failed with exception", good);
-					Assert.fail("Test failed with: " + good.getMessage());
+					Assert.fail("Test failed with: " + StringUtils.stringifyException(good));
 				}
 			}
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -213,5 +213,10 @@ public class StreamNode implements Serializable {
 	public void isolateSlot() {
 		isolatedSlot = true;
 	}
+	
+	@Override
+	public String toString() {
+		return operatorName + ID;
+	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -323,6 +323,7 @@ public class StreamingJobGraphGenerator {
 
 		return downStreamVertex.getInEdges().size() == 1
 				&& outOperator != null
+				&& headOperator != null
 				&& upStreamVertex.getSlotSharingID() == downStreamVertex.getSlotSharingID()
 				&& upStreamVertex.getSlotSharingID() != -1
 				&& (outOperator.getChainingStrategy() == ChainingStrategy.ALWAYS ||
@@ -357,8 +358,8 @@ public class StreamingJobGraphGenerator {
 
 		for (StreamLoop loop : streamGraph.getStreamLoops()) {
 			CoLocationGroup ccg = new CoLocationGroup();
-			AbstractJobVertex tail = jobVertices.get(loop.getTail().getID());
-			AbstractJobVertex head = jobVertices.get(loop.getHead().getID());
+			AbstractJobVertex tail = jobVertices.get(loop.getSink().getID());
+			AbstractJobVertex head = jobVertices.get(loop.getSource().getID());
 
 			ccg.addVertex(head);
 			ccg.addVertex(tail);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingGroupedPreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingGroupedPreReducer.java
@@ -143,6 +143,7 @@ public abstract class SlidingGroupedPreReducer<T> extends SlidingPreReducer<T> {
 	@Override
 	protected void resetCurrent() {
 		currentReducedMap = null;
+		elementsSinceLastPreAggregate = 0;
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducer.java
@@ -89,6 +89,7 @@ public class SlidingTimePreReducer<T> extends SlidingPreReducer<T> {
 
 		if (toRemove > 0 && lastPreAggregateSize == null) {
 			currentReduced = null;
+			elementsSinceLastPreAggregate = 0;
 			toRemove = 0;
 		}
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -87,11 +87,11 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 		streamOperator = configuration.getStreamOperator(userClassLoader);
 		
 		if (streamOperator != null) {
+			// IterationHead and IterationTail don't have an Operator...
+
 			//Create context of the head operator
 			StreamingRuntimeContext headContext = createRuntimeContext(configuration);
 			this.contexts.add(headContext);
-
-			// IterationHead and IterationTail don't have an Operator...
 			streamOperator.setup(outputHandler.getOutput(), headContext);
 		}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.flink.streaming.api;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeDataStream;
@@ -25,11 +30,6 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.util.Collector;
 import org.junit.Test;
-
-import java.util.Collections;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class IterateTest {
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimeGroupedPreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimeGroupedPreReducerTest.java
@@ -23,10 +23,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.streaming.api.operators.windowing.WindowIntegrationTest;
 import org.apache.flink.streaming.api.windowing.StreamWindow;
 import org.apache.flink.streaming.api.windowing.helper.Timestamp;
@@ -37,61 +41,136 @@ import org.junit.Test;
 public class SlidingTimeGroupedPreReducerTest {
 
 	TypeSerializer<Integer> serializer = TypeExtractor.getForObject(1).createSerializer(null);
+	TypeInformation<Tuple2<Integer,Integer>> tupleType = TypeInfoParser.parse("Tuple2<Integer,Integer>");
+
 
 	ReduceFunction<Integer> reducer = new SumReducer();
+	ReduceFunction<Tuple2<Integer, Integer>> tupleReducer = new TupleSumReducer();
+
 
 	KeySelector<Integer, ?> key = new WindowIntegrationTest.ModKey(2);
+	KeySelector<Tuple2<Integer, Integer>, ?> tupleKey = new TupleModKey(2);
 
 	@Test
 	public void testPreReduce1() throws Exception {
-		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+		// This ensures that the buffer is properly cleared after a burst of elements by
+		// replaying the same sequence of elements with a later timestamp and expecting the same
+		// result.
 
-		SlidingTimeGroupedPreReducer<Integer> preReducer = new SlidingTimeGroupedPreReducer<Integer>(
-				reducer, serializer, key, 3, 2, new TimestampWrapper<Integer>(
-						new Timestamp<Integer>() {
+		TestCollector<StreamWindow<Tuple2<Integer, Integer>>> collector = new TestCollector<StreamWindow<Tuple2<Integer, Integer>>>();
 
-							private static final long serialVersionUID = 1L;
+		SlidingTimeGroupedPreReducer<Tuple2<Integer, Integer>> preReducer = new SlidingTimeGroupedPreReducer<Tuple2<Integer, Integer>>(tupleReducer,
+				tupleType.createSerializer(new ExecutionConfig()), tupleKey, 3, 2, new TimestampWrapper<Tuple2<Integer, Integer>>(new Timestamp<Tuple2<Integer, Integer>>() {
 
-							@Override
-							public long getTimestamp(Integer value) {
-								return value;
-							}
-						}, 1));
+			private static final long serialVersionUID = 1L;
 
-		preReducer.store(1);
-		preReducer.store(2);
+			@Override
+			public long getTimestamp(Tuple2<Integer, Integer> value) {
+				return value.f0;
+			}
+		}, 1));
+
+		int timeOffset = 0;
+
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 1, 1));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 2, 2));
 		preReducer.emitWindow(collector);
-		preReducer.store(3);
-		preReducer.store(4);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 3, 3));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 4, 4));
 		preReducer.evict(1);
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(5);
-		preReducer.store(6);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 5, 5));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 6, 6));
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(7);
-		preReducer.store(8);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 7, 7));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 8, 8));
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(9);
-		preReducer.store(10);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 9, 9));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 10, 10));
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(11);
-		preReducer.store(12);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 11, 11));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 12, 12));
 		preReducer.emitWindow(collector);
-		preReducer.store(13);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 13, 13));
 
-		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
-		expected.add(StreamWindow.fromElements(1, 2));
-		expected.add(StreamWindow.fromElements(3, 6));
-		expected.add(StreamWindow.fromElements(5, 10));
-		expected.add(StreamWindow.fromElements(7, 14));
-		expected.add(StreamWindow.fromElements(9, 18));
-		expected.add(StreamWindow.fromElements(11, 22));
+		// ensure that everything is cleared out
+		preReducer.evict(100);
 
-		checkResults(expected, collector.getCollected());
+
+		timeOffset = 25; // a little while later...
+
+		// Repeat the same sequence, this should produce the same result
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 1, 1));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 2, 2));
+		preReducer.emitWindow(collector);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 3, 3));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 4, 4));
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 5, 5));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 6, 6));
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 7, 7));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 8, 8));
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 9, 9));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 10, 10));
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 11, 11));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 12, 12));
+		preReducer.emitWindow(collector);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 13, 13));
+
+		List<StreamWindow<Tuple2<Integer, Integer>>> expected = new ArrayList<StreamWindow<Tuple2<Integer, Integer>>>();
+		timeOffset = 0; // rewind ...
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 2, 2),
+				new Tuple2<Integer, Integer>(timeOffset + 1, 1)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 2, 6),
+				new Tuple2<Integer, Integer>(timeOffset + 3, 3)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 4, 10),
+				new Tuple2<Integer, Integer>(timeOffset + 5, 5)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 6, 14),
+				new Tuple2<Integer, Integer>(timeOffset + 7, 7)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 8, 18),
+				new Tuple2<Integer, Integer>(timeOffset + 9, 9)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 10, 22),
+				new Tuple2<Integer, Integer>(timeOffset + 11, 11)));
+
+		timeOffset = 25; // and back to the future ...
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 2, 2),
+				new Tuple2<Integer, Integer>(timeOffset + 1, 1)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 2, 6),
+				new Tuple2<Integer, Integer>(timeOffset + 3, 3)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 4, 10),
+				new Tuple2<Integer, Integer>(timeOffset + 5, 5)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 6, 14),
+				new Tuple2<Integer, Integer>(timeOffset + 7, 7)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 8, 18),
+				new Tuple2<Integer, Integer>(timeOffset + 9, 9)));
+		expected.add(StreamWindow.fromElements(
+				new Tuple2<Integer, Integer>(timeOffset + 10, 22),
+				new Tuple2<Integer, Integer>(timeOffset + 11, 11)));
+
+		assertEquals(expected, collector.getCollected());
 	}
 
 	protected static void checkResults(List<StreamWindow<Integer>> expected,
@@ -276,5 +355,32 @@ public class SlidingTimeGroupedPreReducerTest {
 			return value1 + value2;
 		}
 
+	}
+
+	private static class TupleSumReducer implements ReduceFunction<Tuple2<Integer, Integer>> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Tuple2<Integer, Integer> reduce(Tuple2<Integer, Integer> value1, Tuple2<Integer, Integer> value2) throws Exception {
+			return new Tuple2<Integer, Integer>(value1.f0, value1.f1 + value2.f1);
+		}
+
+	}
+
+	public static class TupleModKey implements KeySelector<Tuple2<Integer, Integer>, Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		private int m;
+
+		public TupleModKey(int m) {
+			this.m = m;
+		}
+
+		@Override
+		public Integer getKey(Tuple2<Integer, Integer> value) throws Exception {
+			return value.f1 % m;
+		}
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/windowbuffer/SlidingTimePreReducerTest.java
@@ -22,9 +22,13 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.streaming.api.windowing.StreamWindow;
 import org.apache.flink.streaming.api.windowing.helper.Timestamp;
 import org.apache.flink.streaming.api.windowing.helper.TimestampWrapper;
@@ -34,56 +38,106 @@ import org.junit.Test;
 public class SlidingTimePreReducerTest {
 
 	TypeSerializer<Integer> serializer = TypeExtractor.getForObject(1).createSerializer(null);
+	TypeInformation<Tuple2<Integer,Integer>> tupleType = TypeInfoParser.parse("Tuple2<Integer,Integer>");
 
 	ReduceFunction<Integer> reducer = new SumReducer();
+	ReduceFunction<Tuple2<Integer, Integer>> tupleReducer = new TupleSumReducer();
 
 	@Test
 	public void testPreReduce1() throws Exception {
-		TestCollector<StreamWindow<Integer>> collector = new TestCollector<StreamWindow<Integer>>();
+		// This ensures that the buffer is properly cleared after a burst of elements by
+		// replaying the same sequence of elements with a later timestamp and expecting the same
+		// result.
 
-		SlidingTimePreReducer<Integer> preReducer = new SlidingTimePreReducer<Integer>(reducer,
-				serializer, 3, 2, new TimestampWrapper<Integer>(new Timestamp<Integer>() {
+		TestCollector<StreamWindow<Tuple2<Integer, Integer>>> collector = new TestCollector<StreamWindow<Tuple2<Integer, Integer>>>();
+
+		SlidingTimePreReducer<Tuple2<Integer, Integer>> preReducer = new SlidingTimePreReducer<Tuple2<Integer, Integer>>(tupleReducer,
+				tupleType.createSerializer(new ExecutionConfig()), 3, 2, new TimestampWrapper<Tuple2<Integer, Integer>>(new Timestamp<Tuple2<Integer, Integer>>() {
 
 					private static final long serialVersionUID = 1L;
 
 					@Override
-					public long getTimestamp(Integer value) {
-						return value;
+					public long getTimestamp(Tuple2<Integer, Integer> value) {
+						return value.f0;
 					}
 				}, 1));
 
-		preReducer.store(1);
-		preReducer.store(2);
+		int timeOffset = 0;
+
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 1, 1));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 2, 2));
 		preReducer.emitWindow(collector);
-		preReducer.store(3);
-		preReducer.store(4);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 3, 3));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 4, 4));
 		preReducer.evict(1);
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(5);
-		preReducer.store(6);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 5, 5));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 6, 6));
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(7);
-		preReducer.store(8);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 7, 7));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 8, 8));
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(9);
-		preReducer.store(10);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 9, 9));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 10, 10));
 		preReducer.emitWindow(collector);
 		preReducer.evict(2);
-		preReducer.store(11);
-		preReducer.store(12);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 11, 11));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 12, 12));
 		preReducer.emitWindow(collector);
-		preReducer.store(13);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 13, 13));
 
-		List<StreamWindow<Integer>> expected = new ArrayList<StreamWindow<Integer>>();
-		expected.add(StreamWindow.fromElements(3));
-		expected.add(StreamWindow.fromElements(9));
-		expected.add(StreamWindow.fromElements(15));
-		expected.add(StreamWindow.fromElements(21));
-		expected.add(StreamWindow.fromElements(27));
-		expected.add(StreamWindow.fromElements(33));
+		// ensure that everything is cleared out
+		preReducer.evict(100);
+
+
+		timeOffset = 25; // a little while later...
+
+		// Repeat the same sequence, this should produce the same result
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 1, 1));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 2, 2));
+		preReducer.emitWindow(collector);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 3, 3));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 4, 4));
+		preReducer.evict(1);
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 5, 5));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 6, 6));
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 7, 7));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 8, 8));
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 9, 9));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 10, 10));
+		preReducer.emitWindow(collector);
+		preReducer.evict(2);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 11, 11));
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 12, 12));
+		preReducer.emitWindow(collector);
+		preReducer.store(new Tuple2<Integer, Integer>(timeOffset + 13, 13));
+
+		List<StreamWindow<Tuple2<Integer, Integer>>> expected = new ArrayList<StreamWindow<Tuple2<Integer, Integer>>>();
+		timeOffset = 0; // rewind ...
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 1, 3)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 2, 9)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 4, 15)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 6, 21)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 8, 27)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 10, 33)));
+
+		timeOffset = 25; // and back to the future ...
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 1, 3)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 2, 9)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 4, 15)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 6, 21)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 8, 27)));
+		expected.add(StreamWindow.fromElements(new Tuple2<Integer, Integer>(timeOffset + 10, 33)));
+
 
 		assertEquals(expected, collector.getCollected());
 	}
@@ -254,4 +308,16 @@ public class SlidingTimePreReducerTest {
 		}
 
 	}
+
+	private static class TupleSumReducer implements ReduceFunction<Tuple2<Integer, Integer>> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Tuple2<Integer, Integer> reduce(Tuple2<Integer, Integer> value1, Tuple2<Integer, Integer> value2) throws Exception {
+			return new Tuple2<Integer, Integer>(value1.f0, value1.f1 + value2.f1);
+		}
+
+	}
+
 }

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -63,6 +63,7 @@ under the License.
 			<artifactId>flink-yarn</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -57,6 +57,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+
+		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-actor_${scala.binary.version}</artifactId>
 		</dependency>

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.PosixParser;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.CliFrontend;
+import org.apache.flink.client.FlinkYarnSessionCli;
+import org.apache.flink.runtime.yarn.AbstractFlinkYarnClient;
+import org.apache.flink.test.util.TestBaseUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FlinkYarnSessionCliTest {
+
+	@Rule
+	public TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testDynamicProperties() throws IOException {
+
+		Map<String, String> map = new HashMap<String, String>(System.getenv());
+		File tmpFolder = tmp.newFolder();
+		File fakeConf = new File(tmpFolder, "flink-conf.yaml");
+		fakeConf.createNewFile();
+		map.put("FLINK_CONF_DIR", tmpFolder.getAbsolutePath());
+		TestBaseUtils.setEnv(map);
+		Options options = new Options();
+		FlinkYarnSessionCli cli = new FlinkYarnSessionCli("", "");
+		cli.getYARNSessionCLIOptions(options);
+
+		CommandLineParser parser = new PosixParser();
+		CommandLine cmd = null;
+		try {
+			cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar", "-n", "15", "-D", "akka.ask.timeout=5 min"});
+		} catch(Exception e) {
+			e.printStackTrace();
+			Assert.fail("Parsing failed with "+e.getMessage());
+		}
+
+		AbstractFlinkYarnClient flinkYarnClient = cli.createFlinkYarnClient(cmd);
+
+		Assert.assertNotNull(flinkYarnClient);
+
+		List<Tuple2<String, String>> dynProperties = CliFrontend.getDynamicProperties(flinkYarnClient.getDynamicPropertiesEncoded());
+		Assert.assertEquals(1, dynProperties.size());
+		Assert.assertEquals("akka.ask.timeout", dynProperties.get(0).f0);
+		Assert.assertEquals("5 min", dynProperties.get(0).f1);
+	}
+
+}


### PR DESCRIPTION
The actual issue was that we were using `$*` to pass the command line arguments from the scripts to the JVM. It seems that we have to use `"$@` so that arguments with spaces are passed properly.
I've tested this change with `./bin/yarn-session.sh -n 2 -D "akka.ask.timeout=5 min"` (note the space in the configuration value.