### PR TITLE
[FLINK-2003]  Building on some encrypted filesystems leads to "File name too long" error

### DIFF
--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -26,7 +26,7 @@ under the License.
 		<version>0.9-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	
+
 	<artifactId>flink-yarn</artifactId>
 	<name>flink-yarn</name>
 	<packaging>jar</packaging>
@@ -43,7 +43,7 @@ under the License.
 				</exclusion>
 			</exclusions>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients</artifactId>
@@ -76,8 +76,8 @@ under the License.
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
 		</dependency>
-		
-		
+
+
 	</dependencies>
 
 	<build>
@@ -113,6 +113,10 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
+					<args>
+						<arg>-Xmax-classfile-name</arg>
+						<arg>128</arg>
+					</args>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Added limit for length of class names for flink-yarn, to avoid "Filename too long" errors on encrypted filesystems.

I'm not sure if there is a way to do this globally for the whole project (tried doing the same in the project pom and I couldn't get it to work), and what would the potential repercussions be of doing something like that.

PS. Fixed some whitespace errors as well.