### PR TITLE
[FLINK-2037] Provide flink-python.jar in lib/

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -314,6 +314,7 @@ under the License.
 									<exclude>org.apache.flink:flink-java-examples</exclude>
 									<exclude>org.apache.flink:flink-scala-examples</exclude>
 									<exclude>org.apache.flink:flink-streaming-examples</exclude>
+									<exclude>org.apache.flink:flink-python</exclude>
 								</excludes>
 							</artifactSet>
 							<transformers>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -28,6 +28,22 @@ under the License.
 	<includeBaseDirectory>true</includeBaseDirectory>
 	<baseDirectory>flink-${project.version}</baseDirectory>
 
+	<!-- Include flink-python.jar in lib/ -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<unpack>false</unpack>
+			<useTransitiveDependencies>true</useTransitiveDependencies>
+			<useProjectArtifact>false</useProjectArtifact>
+			<useProjectAttachments>false</useProjectAttachments>
+			<useTransitiveFiltering>true</useTransitiveFiltering>
+
+			<includes>
+				<include>org.apache.flink:flink-python</include>
+			</includes>
+		</dependencySet>
+	</dependencySets>
+
 	<files>
 		<!-- copy fat jar -->
 		<file>

--- a/flink-dist/src/main/flink-bin/bin/pyflink2.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink2.sh
@@ -22,4 +22,4 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
-"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/lib/flink-python-0.9-SNAPSHOT.jar "2" "$@"
+"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/lib/flink-python*.jar "2" "$@"

--- a/flink-dist/src/main/flink-bin/bin/pyflink3.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink3.sh
@@ -22,4 +22,5 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
-"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/lib/flink-python-0.9-SNAPSHOT.jar "3" "$@"
+
+"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/lib/flink-python*.jar "3" "$@"


### PR DESCRIPTION
I've tested the change locally with python3.

Please note that the code of `flink-language-binding-generic` is still in `flink-dist.jar`. Only the code of `flink-python` is in the flink-python.jar.
But both modules are not pulling in any external dependencies, there is no risk associated with it.