### PR TITLE
Eager print

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -62,10 +62,12 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 		JobSubmissionResult result = this.client.run(toRun, getParallelism(), wait);
 		if(result instanceof JobExecutionResult) {
+			this.lastJobExecutionResult = (JobExecutionResult) result;
 			return (JobExecutionResult) result;
 		} else {
 			LOG.warn("The Client didn't return a JobExecutionResult");
-			return new JobExecutionResult(result.getJobID(), -1, null);
+			this.lastJobExecutionResult = new JobExecutionResult(result.getJobID(), -1, null);
+			return this.lastJobExecutionResult;
 		}
 	}
 

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/ConnectedComponents.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/ConnectedComponents.java
@@ -111,12 +111,12 @@ public class ConnectedComponents implements ProgramDescription {
 		// emit result
 		if(fileOutput) {
 			result.writeAsCsv(outputPath, "\n", " ");
+
+			// execute program
+			env.execute("Connected Components Example");
 		} else {
 			result.print();
 		}
-		
-		// execute program
-		env.execute("Connected Components Example");
 	}
 	
 	// *************************************************************************

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesBasic.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesBasic.java
@@ -106,12 +106,12 @@ public class EnumTrianglesBasic {
 		// emit result
 		if(fileOutput) {
 			triangles.writeAsCsv(outputPath, "\n", ",");
+
+			// execute program
+			env.execute("Basic Triangle Enumeration Example");
 		} else {
 			triangles.print();
 		}
-
-		// execute program
-		env.execute("Basic Triangle Enumeration Example");
 
 	}
 	

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesOpt.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesOpt.java
@@ -121,12 +121,12 @@ public class EnumTrianglesOpt {
 		// emit result
 		if(fileOutput) {
 			triangles.writeAsCsv(outputPath, "\n", ",");
+			// execute program
+			env.execute("Triangle Enumeration Example");
 		} else {
 			triangles.print();
 		}
-		
-		// execute program
-		env.execute("Triangle Enumeration Example");
+
 		
 	}
 	

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/PageRankBasic.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/PageRankBasic.java
@@ -122,12 +122,12 @@ public class PageRankBasic {
 		// emit result
 		if(fileOutput) {
 			finalPageRanks.writeAsCsv(outputPath, "\n", " ");
+			// execute program
+			env.execute("Basic Page Rank Example");
 		} else {
 			finalPageRanks.print();
 		}
 
-		// execute program
-		env.execute("Basic Page Rank Example");
 		
 	}
 	

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/PiEstimation.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/PiEstimation.java
@@ -70,8 +70,6 @@ public class PiEstimation implements java.io.Serializable {
 
 		System.out.println("We estimate Pi to be:");
 		pi.print();
-
-		env.execute();
 	}
 
 	//*************************************************************************

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/ml/LinearRegression.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/ml/LinearRegression.java
@@ -104,12 +104,13 @@ public class LinearRegression {
 		// emit result
 		if(fileOutput) {
 			result.writeAsText(outputPath);
+			// execute program
+			env.execute("Linear Regression example");
 		} else {
 			result.print();
 		}
 
-		// execute program
-		env.execute("Linear Regression example");
+
 
 	}
 

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/relational/EmptyFieldsCountAccumulator.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/relational/EmptyFieldsCountAccumulator.java
@@ -72,16 +72,17 @@ public class EmptyFieldsCountAccumulator {
 		final DataSet<Tuple> filteredLines = file.filter(new EmptyFieldFilter());
 
 		// Here, we could do further processing with the filtered lines...
-		
+		JobExecutionResult result = null;
 		// output the filtered lines
 		if (outputPath == null) {
 			filteredLines.print();
+			result = env.getLastJobExecutionResult();
 		} else {
 			filteredLines.writeAsCsv(outputPath);
+			// execute program
+			result = env.execute("Accumulator example");
 		}
 
-		// execute program
-		final JobExecutionResult result = env.execute("Accumulator example");
 
 		// get the accumulator result via its registration key
 		final List<Integer> emptyFields = result.getAccumulatorResult(EMPTY_FIELD_ACCUMULATOR);

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/relational/WebLogAnalysis.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/relational/WebLogAnalysis.java
@@ -140,13 +140,11 @@ public class WebLogAnalysis {
 		// emit result
 		if(fileOutput) {
 			result.writeAsCsv(outputPath, "\n", "|");
+			// execute program
+			env.execute("WebLogAnalysis Example");
 		} else {
 			result.print();
 		}
-
-		// execute program
-		env.execute("WebLogAnalysis Example");
-		
 	}
 	
 	// *************************************************************************

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/PojoExample.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/PojoExample.java
@@ -97,12 +97,12 @@ public class PojoExample {
 		
 		if(fileOutput) {
 			counts.writeAsText(outputPath, WriteMode.OVERWRITE);
+			// execute program
+			env.execute("WordCount-Pojo Example");
 		} else {
 			counts.print();
 		}
-		
-		// execute program
-		env.execute("WordCount-Pojo Example");
+
 	}
 	
 	// *************************************************************************

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
@@ -73,13 +73,14 @@ public class WordCount {
 
 		// emit result
 		if(fileOutput) {
-			counts.writeAsCsv(outputPath, "\n", " ");
+			counts.writeAsText(outputPath);
+			// execute program
+			env.execute("WordCount Example");
 		} else {
 			counts.print();
 		}
 		
-		// execute program
-		env.execute("WordCount Example");
+
 	}
 	
 	// *************************************************************************

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
@@ -73,7 +73,7 @@ public class WordCount {
 
 		// emit result
 		if(fileOutput) {
-			counts.writeAsText(outputPath);
+			counts.writeAsCsv(outputPath, "\n", " ");
 			// execute program
 			env.execute("WordCount Example");
 		} else {

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
@@ -96,12 +96,12 @@ object KMeans {
 
     if (fileOutput) {
       clusteredPoints.writeAsCsv(outputPath, "\n", " ")
+      env.execute("Scala KMeans Example")
     }
     else {
       clusteredPoints.print()
     }
 
-    env.execute("Scala KMeans Example")
   }
 
   private def parseParameters(programArguments: Array[String]): Boolean = {

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/ConnectedComponents.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/ConnectedComponents.scala
@@ -98,11 +98,11 @@ object ConnectedComponents {
     }
     if (fileOutput) {
       verticesWithComponents.writeAsCsv(outputPath, "\n", " ")
+      env.execute("Scala Connected Components Example")
     } else {
       verticesWithComponents.print()
     }
 
-    env.execute("Scala Connected Components Example")
   }
  
   private def parseParameters(args: Array[String]): Boolean = {

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/DeltaPageRank.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/DeltaPageRank.scala
@@ -100,6 +100,5 @@ object DeltaPageRank {
 
     iteration.print()
 
-    env.execute("Page Rank")
   }
 }

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesBasic.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesBasic.scala
@@ -91,12 +91,13 @@ object EnumTrianglesBasic {
     // emit result
     if (fileOutput) {
       triangles.writeAsCsv(outputPath, "\n", ",")
+      // execute program
+      env.execute("TriangleEnumeration Example")
     } else {
       triangles.print()
     }
     
-    // execute program
-    env.execute("TriangleEnumeration Example")
+
   }
 
   // *************************************************************************

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesOpt.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesOpt.scala
@@ -117,12 +117,12 @@ object EnumTrianglesOpt {
     // emit result
     if (fileOutput) {
       triangles.writeAsCsv(outputPath, "\n", ",")
+      // execute program
+      env.execute("TriangleEnumeration Example")
     } else {
       triangles.print()
     }
 
-    // execute program
-    env.execute("TriangleEnumeration Example")
   }
 
   // *************************************************************************

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/PageRankBasic.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/PageRankBasic.scala
@@ -128,12 +128,11 @@ object PageRankBasic {
     // emit result
     if (fileOutput) {
       result.writeAsCsv(outputPath, "\n", " ")
+      // execute program
+      env.execute("Basic PageRank Example")
     } else {
       result.print()
     }
-
-    // execute program
-    env.execute("Basic PageRank Example")
   }
 
   // *************************************************************************

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/TransitiveClosureNaive.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/TransitiveClosureNaive.scala
@@ -57,11 +57,11 @@ object  TransitiveClosureNaive {
 
     if (fileOutput) {
       paths.writeAsCsv(outputPath, "\n", " ")
+      env.execute("Scala Transitive Closure Example")
     } else {
       paths.print()
     }
 
-    env.execute("Scala Transitive Closure Example")
 
 
   }

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/misc/PiEstimation.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/misc/PiEstimation.scala
@@ -47,8 +47,6 @@ object PiEstimation {
     println("We estimate Pi to be:")
 
     pi.print()
-
-    env.execute("PiEstimation example")
   }
 
 }

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/ml/LinearRegression.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/ml/LinearRegression.scala
@@ -82,11 +82,11 @@ object LinearRegression {
 
     if (fileOutput) {
       result.writeAsText(outputPath)
+      env.execute("Scala Linear Regression example")
     }
     else {
       result.print()
     }
-    env.execute("Scala Linear Regression example")
   }
 
   /**

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/relational/WebLogAnalysis.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/relational/WebLogAnalysis.scala
@@ -123,11 +123,11 @@ object WebLogAnalysis {
     // emit result
     if (fileOutput) {
       result.writeAsCsv(outputPath, "\n", "|")
+      env.execute("Scala WebLogAnalysis Example")
     } else {
       result.print()
     }
 
-    env.execute("Scala WebLogAnalysis Example")
   }
 
   private var fileOutput: Boolean = false

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/wordcount/WordCount.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/wordcount/WordCount.scala
@@ -57,11 +57,11 @@ object WordCount {
 
     if (fileOutput) {
       counts.writeAsCsv(outputPath, "\n", " ")
+      env.execute("Scala WordCount Example")
     } else {
       counts.print()
     }
 
-    env.execute("Scala WordCount Example")
   }
 
   private def parseParameters(args: Array[String]): Boolean = {

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -30,7 +30,8 @@ public class CollectionEnvironment extends ExecutionEnvironment {
 
 		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.
 		CollectionExecutor exec = new CollectionExecutor(getConfig());
-		return exec.execute(p);
+		this.lastJobExecutionResult = exec.execute(p);
+		return this.lastJobExecutionResult;
 	}
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -47,6 +47,7 @@ import org.apache.flink.api.java.functions.SelectByMaxFunction;
 import org.apache.flink.api.java.functions.SelectByMinFunction;
 import org.apache.flink.api.java.io.CsvOutputFormat;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.api.java.io.PrintingOutputFormat;
 import org.apache.flink.api.java.io.TextOutputFormat;
 import org.apache.flink.api.java.io.TextOutputFormat.TextFormatter;
 import org.apache.flink.api.java.operators.AggregateOperator;

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -18,10 +18,7 @@
 
 package org.apache.flink.api.java;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
@@ -50,7 +47,6 @@ import org.apache.flink.api.java.functions.SelectByMaxFunction;
 import org.apache.flink.api.java.functions.SelectByMinFunction;
 import org.apache.flink.api.java.io.CsvOutputFormat;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.api.java.io.PrintingOutputFormat;
 import org.apache.flink.api.java.io.TextOutputFormat;
 import org.apache.flink.api.java.io.TextOutputFormat.TextFormatter;
 import org.apache.flink.api.java.operators.AggregateOperator;
@@ -86,8 +82,11 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.ExceptionUtils;
 
-import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A DataSet represents a collection of elements of the same type.<br/>
@@ -1336,11 +1335,17 @@ public abstract class DataSet<T> {
 	/**
 	 * Writes a DataSet to the standard output stream (stdout).<br/>
 	 * For each element of the DataSet the result of {@link Object#toString()} is written.
-	 * 
-	 *  @return The DataSink that writes the DataSet.
+	 * This triggers execute() automatically.
 	 */
-	public DataSink<T> print() {
-		return output(new PrintingOutputFormat<T>(false));
+	public void print() {
+		try {
+			List<T> elements = this.collect();
+			for (T e: elements) {
+				System.out.println(e);
+			}
+		} catch (Exception e) {
+			System.out.println("Could not retrieve values for printing: " + ExceptionUtils.stringifyException(e));
+		}
 	}
 
 	/**
@@ -1357,11 +1362,16 @@ public abstract class DataSet<T> {
 	/**
 	 * Writes a DataSet to the standard error stream (stderr).<br/>
 	 * For each element of the DataSet the result of {@link Object#toString()} is written.
-	 * 
-	 * @return The DataSink that writes the DataSet.
 	 */
-	public DataSink<T> printToErr() {
-		return output(new PrintingOutputFormat<T>(true));
+	public void printToErr() {
+		try {
+			List<T> elements = this.collect();
+			for (T e: elements) {
+				System.err.println(e);
+			}
+		} catch (Exception e) {
+			System.err.println("Could not retrieve values for printing: " + e);
+		}
 	}
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -83,7 +83,6 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.AbstractID;
-import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1338,14 +1337,14 @@ public abstract class DataSet<T> {
 	 * For each element of the DataSet the result of {@link Object#toString()} is written.
 	 * This triggers execute() automatically.
 	 */
-	public void print() {
+	public void print() throws Exception{
 		try {
 			List<T> elements = this.collect();
 			for (T e: elements) {
 				System.out.println(e);
 			}
 		} catch (Exception e) {
-			System.out.println("Could not retrieve values for printing: " + ExceptionUtils.stringifyException(e));
+			throw new Exception("Could not retrieve values for printing: ", e);
 		}
 	}
 
@@ -1364,14 +1363,14 @@ public abstract class DataSet<T> {
 	 * Writes a DataSet to the standard error stream (stderr).<br/>
 	 * For each element of the DataSet the result of {@link Object#toString()} is written.
 	 */
-	public void printToErr() {
+	public void printToErr() throws Exception{
 		try {
 			List<T> elements = this.collect();
 			for (T e: elements) {
 				System.err.println(e);
 			}
 		} catch (Exception e) {
-			System.err.println("Could not retrieve values for printing: " + e);
+			throw new Exception("Could not retrieve values for printing: ", e);
 		}
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1338,13 +1338,9 @@ public abstract class DataSet<T> {
 	 * This triggers execute() automatically.
 	 */
 	public void print() throws Exception{
-		try {
-			List<T> elements = this.collect();
-			for (T e: elements) {
-				System.out.println(e);
-			}
-		} catch (Exception e) {
-			throw new Exception("Could not retrieve values for printing: ", e);
+		List<T> elements = this.collect();
+		for (T e: elements) {
+			System.out.println(e);
 		}
 	}
 
@@ -1364,13 +1360,9 @@ public abstract class DataSet<T> {
 	 * For each element of the DataSet the result of {@link Object#toString()} is written.
 	 */
 	public void printToErr() throws Exception{
-		try {
-			List<T> elements = this.collect();
-			for (T e: elements) {
-				System.err.println(e);
-			}
-		} catch (Exception e) {
-			throw new Exception("Could not retrieve values for printing: ", e);
+		List<T> elements = this.collect();
+		for (T e: elements) {
+			System.err.println(e);
 		}
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -94,6 +94,9 @@ import com.google.common.base.Preconditions;
  */
 public abstract class ExecutionEnvironment {
 
+
+	protected JobExecutionResult lastJobExecutionResult;
+
 	private static final Logger LOG = LoggerFactory.getLogger(ExecutionEnvironment.class);
 	
 	/** The environment of the context (local by default, cluster if invoked through command line) */
@@ -231,7 +234,15 @@ public abstract class ExecutionEnvironment {
 	public UUID getId() {
 		return this.executionId;
 	}
-	
+
+	/**
+	 * Returns the {@link org.apache.flink.api.common.JobExecutionResult} of the last executed job.
+	 */
+	public JobExecutionResult getLastJobExecutionResult(){
+		return this.lastJobExecutionResult;
+	}
+
+
 	/**
 	 * Gets the UUID by which this environment is identified, as a string.
 	 * 

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -51,7 +51,8 @@ public class LocalEnvironment extends ExecutionEnvironment {
 		
 		PlanExecutor executor = PlanExecutor.createLocalExecutor(configuration);
 		executor.setPrintStatusDuringExecution(p.getExecutionConfig().isSysoutLoggingEnabled());
-		return executor.executePlan(p);
+		this.lastJobExecutionResult = executor.executePlan(p);
+		return this.lastJobExecutionResult;
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -67,7 +67,9 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		
 		PlanExecutor executor = PlanExecutor.createRemoteExecutor(host, port, jarFiles);
 		executor.setPrintStatusDuringExecution(p.getExecutionConfig().isSysoutLoggingEnabled());
-		return executor.executePlan(p);
+
+		this.lastJobExecutionResult = executor.executePlan(p);
+		return this.lastJobExecutionResult;
 	}
 	
 	@Override

--- a/flink-java/src/test/java/org/apache/flink/api/java/MultipleInvokationsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/MultipleInvokationsTest.java
@@ -36,7 +36,7 @@ public class MultipleInvokationsTest {
 			// ----------- Execution 1 ---------------
 			
 			DataSet<String> data = env.fromElements("Some", "test", "data").name("source1");
-			data.print().name("print1");
+			data.print();
 			data.output(new DiscardingOutputFormat<String>()).name("output1");
 			
 			{

--- a/flink-java/src/test/java/org/apache/flink/api/java/MultipleInvokationsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/MultipleInvokationsTest.java
@@ -36,7 +36,8 @@ public class MultipleInvokationsTest {
 			// ----------- Execution 1 ---------------
 			
 			DataSet<String> data = env.fromElements("Some", "test", "data").name("source1");
-			data.print();
+			//data.print();
+			data.output(new DiscardingOutputFormat<String>()).name("print1");
 			data.output(new DiscardingOutputFormat<String>()).name("output1");
 			
 			{

--- a/flink-java/src/test/java/org/apache/flink/api/java/functions/SemanticPropertiesProjectionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/functions/SemanticPropertiesProjectionTest.java
@@ -28,11 +28,9 @@ import org.apache.flink.api.common.operators.SingleInputSemanticProperties;
 import org.apache.flink.api.common.operators.base.CrossOperatorBase;
 import org.apache.flink.api.common.operators.base.JoinOperatorBase;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.translation.PlanProjectOperator;
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.api.java.tuple.Tuple4;
-import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.tuple.*;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.junit.Test;
 
@@ -73,7 +71,7 @@ public class SemanticPropertiesProjectionTest {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = env.fromCollection(emptyTupleData, tupleTypeInfo);
 
-		tupleDs.project(1, 3, 2).project(0, 3).print();
+		tupleDs.project(1, 3, 2).project(0, 3).output(new DiscardingOutputFormat<Tuple>());
 
 		Plan plan = env.createProgramPlan();
 
@@ -99,7 +97,7 @@ public class SemanticPropertiesProjectionTest {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		DataSet<Tuple4<Integer, Tuple3<String, Integer, Long>, Tuple2<Long, Long>, String>> tupleDs = env.fromCollection(emptyNestedTupleData, nestedTupleTypeInfo);
 
-		tupleDs.project(2, 3, 1).project(2).print();
+		tupleDs.project(2, 3, 1).project(2).output(new DiscardingOutputFormat<Tuple>());
 
 		Plan plan = env.createProgramPlan();
 
@@ -135,7 +133,7 @@ public class SemanticPropertiesProjectionTest {
 		tupleDs.join(tupleDs).where(0).equalTo(0)
 				.projectFirst(2, 3)
 				.projectSecond(1, 4)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple>());
 
 		Plan plan = env.createProgramPlan();
 
@@ -163,7 +161,7 @@ public class SemanticPropertiesProjectionTest {
 		tupleDs.join(tupleDs).where(0).equalTo(0)
 				.projectFirst(2,0)
 				.projectSecond(1,3)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple>());
 
 		Plan plan = env.createProgramPlan();
 
@@ -212,7 +210,7 @@ public class SemanticPropertiesProjectionTest {
 		tupleDs.cross(tupleDs)
 				.projectFirst(2, 3)
 				.projectSecond(1, 4)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple>());
 
 		Plan plan = env.createProgramPlan();
 
@@ -240,7 +238,7 @@ public class SemanticPropertiesProjectionTest {
 		tupleDs.cross(tupleDs)
 				.projectFirst(2, 0)
 				.projectSecond(1,3)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple>());
 
 		Plan plan = env.createProgramPlan();
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/functions/SemanticPropertiesTranslationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/functions/SemanticPropertiesTranslationTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.api.common.operators.util.FieldSet;
 import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFieldsFirst;
 import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFieldsSecond;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.junit.Test;
@@ -55,7 +56,7 @@ public class SemanticPropertiesTranslationTest {
 
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, String, Integer>> input = env.fromElements(new Tuple3<Long, String, Integer>(3l, "test", 42));
-		input.map(new WildcardForwardedMapper<Tuple3<Long,String,Integer>>()).print();
+		input.map(new WildcardForwardedMapper<Tuple3<Long,String,Integer>>()).output(new DiscardingOutputFormat<Tuple3<Long, String, Integer>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -80,7 +81,7 @@ public class SemanticPropertiesTranslationTest {
 
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, String, Integer>> input = env.fromElements(new Tuple3<Long, String, Integer>(3l, "test", 42));
-		input.map(new IndividualForwardedMapper<Long, String, Integer>()).print();
+		input.map(new IndividualForwardedMapper<Long, String, Integer>()).output(new DiscardingOutputFormat<Tuple3<Long, String, Integer>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -102,7 +103,7 @@ public class SemanticPropertiesTranslationTest {
 
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, Long, Long>> input = env.fromElements(new Tuple3<Long, Long, Long>(3l, 2l, 1l));
-		input.map(new ShufflingMapper<Long>()).print();
+		input.map(new ShufflingMapper<Long>()).output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -128,7 +129,7 @@ public class SemanticPropertiesTranslationTest {
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, Long, Long>> input = env.fromElements(new Tuple3<Long, Long, Long>(3l, 2l, 1l));
 		input.map(new NoAnnotationMapper<Tuple3<Long, Long, Long>>()).withForwardedFields("0->1; 2")
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -151,7 +152,7 @@ public class SemanticPropertiesTranslationTest {
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, Long, Long>> input = env.fromElements(new Tuple3<Long, Long, Long>(3l, 2l, 1l));
 		input.map(new ReadSetMapper<Tuple3<Long, Long, Long>>()).withForwardedFields("0->1; 2")
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -174,7 +175,7 @@ public class SemanticPropertiesTranslationTest {
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, Long, Long>> input = env.fromElements(new Tuple3<Long, Long, Long>(3l, 2l, 1l));
 		input.map(new ReadSetMapper<Tuple3<Long, Long, Long>>()).withForwardedFields("0->1; 2")
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -196,7 +197,7 @@ public class SemanticPropertiesTranslationTest {
 
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, Long, Long>> input = env.fromElements(new Tuple3<Long, Long, Long>(3l, 2l, 1l));
-		input.map(new AllForwardedExceptMapper<Tuple3<Long, Long, Long>>()).print();
+		input.map(new AllForwardedExceptMapper<Tuple3<Long, Long, Long>>()).output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -218,7 +219,7 @@ public class SemanticPropertiesTranslationTest {
 
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, Long, Long>> input = env.fromElements(new Tuple3<Long, Long, Long>(3l, 2l, 1l));
-		input.map(new ReadSetMapper<Tuple3<Long, Long, Long>>()).print();
+		input.map(new ReadSetMapper<Tuple3<Long, Long, Long>>()).output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -260,7 +261,7 @@ public class SemanticPropertiesTranslationTest {
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple2<Long, Double>> input2 = env.fromElements(new Tuple2<Long, Double>(3l, 3.1415));
 		input1.join(input2).where(0).equalTo(0).with(new ForwardedBothAnnotationJoin<Long, String, Long, Double>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<String, Double>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -287,7 +288,7 @@ public class SemanticPropertiesTranslationTest {
 		DataSet<Tuple2<Long, Long>> input2 = env.fromElements(new Tuple2<Long, Long>(3l, 2l));
 		input1.join(input2).where(0).equalTo(0).with(new NoAnnotationJoin<Long>())
 				.withForwardedFieldsFirst("0->1; 1->2").withForwardedFieldsSecond("1->0")
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -314,7 +315,7 @@ public class SemanticPropertiesTranslationTest {
 		DataSet<Tuple2<Long, Long>> input2 = env.fromElements(new Tuple2<Long, Long>(3l, 2l));
 		input1.join(input2).where(0).equalTo(0).with(new ReadSetJoin<Long>())
 				.withForwardedFieldsFirst("0->1; 1->2").withForwardedFieldsSecond("1->0")
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -347,7 +348,7 @@ public class SemanticPropertiesTranslationTest {
 		DataSet<Tuple2<Long, Long>> input2 = env.fromElements(new Tuple2<Long, Long>(3l, 2l));
 		input1.join(input2).where(0).equalTo(0).with(new ForwardedFirstAnnotationJoin<Long>())
 				.withForwardedFieldsSecond("1")
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -377,7 +378,7 @@ public class SemanticPropertiesTranslationTest {
 		DataSet<Tuple2<Long, Long>> input2 = env.fromElements(new Tuple2<Long, Long>(3l, 2l));
 		input1.join(input2).where(0).equalTo(0).with(new ForwardedSecondAnnotationJoin<Long>())
 				.withForwardedFieldsFirst("0->1")
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -405,7 +406,7 @@ public class SemanticPropertiesTranslationTest {
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple3<Long, Long, Long>> input2 = env.fromElements(new Tuple3<Long, Long, Long>(3l, 2l, 1l));
 		input1.join(input2).where(0).equalTo(0).with(new AllForwardedExceptJoin<Long>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();
@@ -435,7 +436,7 @@ public class SemanticPropertiesTranslationTest {
 		@SuppressWarnings("unchecked")
 		DataSet<Tuple2<Long, Long>> input2 = env.fromElements(new Tuple2<Long, Long>(3l, 2l));
 		input1.join(input2).where(0).equalTo(0).with(new ReadSetJoin<Long>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		Plan plan = env.createProgramPlan();
 
 		GenericDataSinkBase<?> sink = plan.getDataSinks().iterator().next();

--- a/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/AggregateTranslationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/AggregateTranslationTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.common.operators.GenericDataSinkBase;
 import org.apache.flink.api.common.operators.GenericDataSourceBase;
 import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase;
 import org.apache.flink.api.java.aggregation.Aggregations;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.types.StringValue;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class AggregateTranslationTest {
 			DataSet<Tuple3<Double, StringValue, Long>> initialData = 
 					env.fromElements(new Tuple3<Double, StringValue, Long>(3.141592, new StringValue("foobar"), Long.valueOf(77)));
 			
-			initialData.groupBy(0).aggregate(Aggregations.MIN, 1).and(Aggregations.SUM, 2).print();
+			initialData.groupBy(0).aggregate(Aggregations.MIN, 1).and(Aggregations.SUM, 2).output(new DiscardingOutputFormat<Tuple3<Double, StringValue, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			

--- a/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/CoGroupSortTranslationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/CoGroupSortTranslationTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.operators.base.CoGroupOperatorBase;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.util.Collector;
@@ -54,7 +55,7 @@ public class CoGroupSortTranslationTest implements java.io.Serializable {
 							Collector<Long> out) {}
 				})
 				
-				.print();
+				.output(new DiscardingOutputFormat<Long>());
 			
 			Plan p = env.createProgramPlan();
 			
@@ -98,7 +99,7 @@ public class CoGroupSortTranslationTest implements java.io.Serializable {
 					public void coGroup(Iterable<Tuple2<Long, Long>> first, Iterable<TestPoJo> second, Collector<Long> out) {}
 				})
 				
-				.print();
+				.output(new DiscardingOutputFormat<Long>());
 			
 			Plan p = env.createProgramPlan();
 			

--- a/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/DeltaIterationTranslationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/DeltaIterationTranslationTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.common.operators.base.DeltaIterationBase;
 import org.apache.flink.api.common.operators.base.JoinOperatorBase;
 import org.apache.flink.api.common.operators.base.MapOperatorBase;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DeltaIteration;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.common.functions.RichCoGroupFunction;
@@ -91,7 +92,7 @@ public class DeltaIterationTranslationTest implements java.io.Serializable {
 						joined,
 						joined.map(new NextWorksetMapper()).name(BEFORE_NEXT_WORKSET_MAP));
 				
-				result.print();
+				result.output(new DiscardingOutputFormat<Tuple3<Double, Long, String>>());
 				result.writeAsText("/dev/null");
 			}
 			

--- a/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/DistinctTranslationTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/DistinctTranslationTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DistinctOperator;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -60,7 +61,7 @@ public class DistinctTranslationTest {
 				public String getKey(String value) { return value; }
 			});
 			
-			op.print();
+			op.output(new DiscardingOutputFormat<String>());
 			
 			Plan p = env.createProgramPlan();
 			
@@ -81,7 +82,7 @@ public class DistinctTranslationTest {
 
 			DataSet<Tuple3<Double, StringValue, LongValue>> initialData = getSourceDataSet(env);
 
-			initialData.distinct().print();
+			initialData.distinct().output(new DiscardingOutputFormat<Tuple3<Double, StringValue, LongValue>>());
 
 			Plan p = env.createProgramPlan();
 
@@ -117,7 +118,7 @@ public class DistinctTranslationTest {
 
 			DataSet<CustomType> initialData = getSourcePojoDataSet(env);
 
-			initialData.distinct().print();
+			initialData.distinct().output(new DiscardingOutputFormat<CustomType>());
 
 			Plan p = env.createProgramPlan();
 
@@ -153,7 +154,7 @@ public class DistinctTranslationTest {
 
 			DataSet<Tuple3<Double, StringValue, LongValue>> initialData = getSourceDataSet(env);
 
-			initialData.distinct(1, 2).print();
+			initialData.distinct(1, 2).output(new DiscardingOutputFormat<Tuple3<Double, StringValue, LongValue>>());
 
 			Plan p = env.createProgramPlan();
 
@@ -193,7 +194,7 @@ public class DistinctTranslationTest {
 				public StringValue getKey(Tuple3<Double, StringValue, LongValue> value) {
 					return value.f1;
 				}
-			}).setParallelism(4).print();
+			}).setParallelism(4).output(new DiscardingOutputFormat<Tuple3<Double, StringValue, LongValue>>());
 
 			Plan p = env.createProgramPlan();
 
@@ -237,7 +238,7 @@ public class DistinctTranslationTest {
 
 			DataSet<CustomType> initialData = getSourcePojoDataSet(env);
 
-			initialData.distinct("myInt").print();
+			initialData.distinct("myInt").output(new DiscardingOutputFormat<CustomType>());
 
 			Plan p = env.createProgramPlan();
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/ReduceTranslationTests.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operators/translation/ReduceTranslationTests.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.common.operators.base.ReduceOperatorBase;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.common.functions.RichReduceFunction;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
@@ -54,7 +55,7 @@ public class ReduceTranslationTests implements java.io.Serializable {
 				public Tuple3<Double, StringValue, LongValue> reduce(Tuple3<Double, StringValue, LongValue> value1, Tuple3<Double, StringValue, LongValue> value2) {
 					return value1;
 				}
-			}).print();
+			}).output(new DiscardingOutputFormat<Tuple3<Double, StringValue, LongValue>>());
 			
 			Plan p = env.createProgramPlan();
 			
@@ -96,7 +97,7 @@ public class ReduceTranslationTests implements java.io.Serializable {
 						return value1;
 					}
 				})
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Double, StringValue, LongValue>>());
 			
 			Plan p = env.createProgramPlan();
 			
@@ -143,7 +144,7 @@ public class ReduceTranslationTests implements java.io.Serializable {
 						return value1;
 					}
 				}).setParallelism(4)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Double, StringValue, LongValue>>());
 			
 			Plan p = env.createProgramPlan();
 			

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -58,6 +58,12 @@ under the License.
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-mapreduce-client-jobclient</artifactId>
+			<version>2.2.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<!-- Because flink-tests needs the CompilerTestBsae -->

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -58,12 +58,6 @@ under the License.
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-mapreduce-client-jobclient</artifactId>
-			<version>2.2.0</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<!-- Because flink-tests needs the CompilerTestBsae -->

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/DistinctCompilationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/DistinctCompilationTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.operators.util.FieldList;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DistinctOperator;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
@@ -86,6 +85,7 @@ public class DistinctCompilationTest extends CompilerTestBase implements java.io
 			assertEquals(8, sinkNode.getParallelism());
 		}
 		catch (Exception e) {
+			System.err.println(e.getMessage());
 			e.printStackTrace();
 			fail(e.getClass().getSimpleName() + " in test: " + e.getMessage());
 		}
@@ -146,6 +146,7 @@ public class DistinctCompilationTest extends CompilerTestBase implements java.io
 			assertEquals(8, sinkNode.getParallelism());
 		}
 		catch (Exception e) {
+			System.err.println(e.getMessage());
 			e.printStackTrace();
 			fail(e.getClass().getSimpleName() + " in test: " + e.getMessage());
 		}
@@ -198,6 +199,7 @@ public class DistinctCompilationTest extends CompilerTestBase implements java.io
 			assertEquals(8, sinkNode.getParallelism());
 		}
 		catch (Exception e) {
+			System.err.println(e.getMessage());
 			e.printStackTrace();
 			fail(e.getClass().getSimpleName() + " in test: " + e.getMessage());
 		}

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/DistinctCompilationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/DistinctCompilationTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.operators.util.FieldList;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DistinctOperator;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.plan.OptimizedPlan;

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/BinaryCustomPartitioningCompatibilityTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/BinaryCustomPartitioningCompatibilityTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.optimizer.plan.DualInputPlanNode;
@@ -57,7 +58,7 @@ public class BinaryCustomPartitioningCompatibilityTest extends CompilerTestBase 
 			input1.partitionCustom(partitioner, 1)
 				.join(input2.partitionCustom(partitioner, 0))
 				.where(1).equalTo(0)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Tuple2<Long, Long>, Tuple3<Long, Long, Long>>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -102,7 +103,7 @@ public class BinaryCustomPartitioningCompatibilityTest extends CompilerTestBase 
 				.coGroup(input2.partitionCustom(partitioner, 0))
 				.where(1).equalTo(0)
 				.with(new DummyCoGroupFunction<Tuple2<Long, Long>, Tuple3<Long, Long, Long>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Tuple2<Long, Long>, Tuple3<Long, Long, Long>>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CoGroupCustomPartitioningTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CoGroupCustomPartitioningTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.optimizer.plan.DualInputPlanNode;
@@ -57,7 +58,7 @@ public class CoGroupCustomPartitioningTest extends CompilerTestBase {
 				.where(1).equalTo(0)
 				.withPartitioner(partitioner)
 				.with(new DummyCoGroupFunction<Tuple2<Long, Long>, Tuple3<Long, Long, Long>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Tuple2<Long, Long>, Tuple3<Long, Long, Long>>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -118,7 +119,7 @@ public class CoGroupCustomPartitioningTest extends CompilerTestBase {
 				.where("b").equalTo("a")
 				.withPartitioner(partitioner)
 				.with(new DummyCoGroupFunction<Pojo2, Pojo3>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Pojo2, Pojo3>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -180,7 +181,7 @@ public class CoGroupCustomPartitioningTest extends CompilerTestBase {
 				.where(new Pojo2KeySelector()).equalTo(new Pojo3KeySelector())
 				.withPartitioner(partitioner)
 				.with(new DummyCoGroupFunction<Pojo2, Pojo3>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Pojo2, Pojo3>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -251,7 +252,7 @@ public class CoGroupCustomPartitioningTest extends CompilerTestBase {
 			grouped
 				.coGroup(partitioned).where(0).equalTo(0)
 				.with(new DummyCoGroupFunction<Tuple3<Long,Long,Long>, Tuple3<Long,Long,Long>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Tuple3<Long, Long, Long>, Tuple3<Long, Long, Long>>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CustomPartitioningGlobalOptimizationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CustomPartitioningGlobalOptimizationTest.java
@@ -26,13 +26,14 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.optimizer.plan.DualInputPlanNode;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
-import org.apache.flink.optimizer.testfunctions.IdentityGroupReducerCombinable;
+import org.apache.flink.optimizer.testfunctions.IdentityGroupReducer;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.junit.Test;
@@ -57,8 +58,8 @@ public class CustomPartitioningGlobalOptimizationTest extends CompilerTestBase {
 				.withPartitioner(partitioner);
 
 			joined.groupBy(1).withPartitioner(partitioner)
-				.reduceGroup(new IdentityGroupReducerCombinable<Tuple3<Long,Long,Long>>())
-				.print();
+				.reduceGroup(new IdentityGroupReducer<Tuple3<Long,Long,Long>>())
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CustomPartitioningGlobalOptimizationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CustomPartitioningGlobalOptimizationTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.optimizer.plan.DualInputPlanNode;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
-import org.apache.flink.optimizer.testfunctions.IdentityGroupReducer;
+import org.apache.flink.optimizer.testfunctions.IdentityGroupReducerCombinable;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.junit.Test;
@@ -58,7 +58,7 @@ public class CustomPartitioningGlobalOptimizationTest extends CompilerTestBase {
 				.withPartitioner(partitioner);
 
 			joined.groupBy(1).withPartitioner(partitioner)
-				.reduceGroup(new IdentityGroupReducer<Tuple3<Long,Long,Long>>())
+					.reduceGroup(new IdentityGroupReducerCombinable<Tuple3<Long,Long,Long>>())
 				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 
 			Plan p = env.createProgramPlan();

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CustomPartitioningTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/CustomPartitioningTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
@@ -53,7 +54,7 @@ public class CustomPartitioningTest extends CompilerTestBase {
 			data
 				.partitionCustom(part, 0)
 				.mapPartition(new IdentityPartitionerMapper<Tuple2<Integer,Integer>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -123,7 +124,7 @@ public class CustomPartitioningTest extends CompilerTestBase {
 			data
 				.partitionCustom(part, "a")
 				.mapPartition(new IdentityPartitionerMapper<Pojo>())
-				.print();
+				.output(new DiscardingOutputFormat<Pojo>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -193,7 +194,7 @@ public class CustomPartitioningTest extends CompilerTestBase {
 			data
 				.partitionCustom(part, new TestKeySelectorInt<Pojo>())
 				.mapPartition(new IdentityPartitionerMapper<Pojo>())
-				.print();
+				.output(new DiscardingOutputFormat<Pojo>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingKeySelectorTranslationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingKeySelectorTranslationTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -34,7 +35,7 @@ import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
 import org.apache.flink.optimizer.testfunctions.DummyReducer;
-import org.apache.flink.optimizer.testfunctions.IdentityGroupReducerCombinable;
+import org.apache.flink.optimizer.testfunctions.IdentityGroupReducer;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.junit.Test;
@@ -53,7 +54,7 @@ public class GroupingKeySelectorTranslationTest extends CompilerTestBase {
 			data.groupBy(new TestKeySelector<Tuple2<Integer,Integer>>())
 				.withPartitioner(new TestPartitionerInt())
 				.reduce(new DummyReducer<Tuple2<Integer,Integer>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -84,8 +85,8 @@ public class GroupingKeySelectorTranslationTest extends CompilerTestBase {
 			
 			data.groupBy(new TestKeySelector<Tuple2<Integer,Integer>>())
 				.withPartitioner(new TestPartitionerInt())
-				.reduceGroup(new IdentityGroupReducerCombinable<Tuple2<Integer,Integer>>())
-				.print();
+				.reduceGroup(new IdentityGroupReducer<Tuple2<Integer,Integer>>())
+				.output(new DiscardingOutputFormat<Tuple2<Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -115,8 +116,8 @@ public class GroupingKeySelectorTranslationTest extends CompilerTestBase {
 			data.groupBy(new TestKeySelector<Tuple3<Integer,Integer,Integer>>())
 				.withPartitioner(new TestPartitionerInt())
 				.sortGroup(new TestKeySelector<Tuple3<Integer, Integer, Integer>>(), Order.ASCENDING)
-				.reduceGroup(new IdentityGroupReducerCombinable<Tuple3<Integer,Integer,Integer>>())
-				.print();
+				.reduceGroup(new IdentityGroupReducer<Tuple3<Integer,Integer,Integer>>())
+				.output(new DiscardingOutputFormat<Tuple3<Integer, Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingKeySelectorTranslationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingKeySelectorTranslationTest.java
@@ -35,7 +35,7 @@ import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
 import org.apache.flink.optimizer.testfunctions.DummyReducer;
-import org.apache.flink.optimizer.testfunctions.IdentityGroupReducer;
+import org.apache.flink.optimizer.testfunctions.IdentityGroupReducerCombinable;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.junit.Test;
@@ -85,7 +85,7 @@ public class GroupingKeySelectorTranslationTest extends CompilerTestBase {
 			
 			data.groupBy(new TestKeySelector<Tuple2<Integer,Integer>>())
 				.withPartitioner(new TestPartitionerInt())
-				.reduceGroup(new IdentityGroupReducer<Tuple2<Integer,Integer>>())
+					.reduceGroup(new IdentityGroupReducerCombinable<Tuple2<Integer,Integer>>())
 				.output(new DiscardingOutputFormat<Tuple2<Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
@@ -116,7 +116,7 @@ public class GroupingKeySelectorTranslationTest extends CompilerTestBase {
 			data.groupBy(new TestKeySelector<Tuple3<Integer,Integer,Integer>>())
 				.withPartitioner(new TestPartitionerInt())
 				.sortGroup(new TestKeySelector<Tuple3<Integer, Integer, Integer>>(), Order.ASCENDING)
-				.reduceGroup(new IdentityGroupReducer<Tuple3<Integer,Integer,Integer>>())
+				.reduceGroup(new IdentityGroupReducerCombinable<Tuple3<Integer,Integer,Integer>>())
 				.output(new DiscardingOutputFormat<Tuple3<Integer, Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingPojoTranslationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingPojoTranslationTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
@@ -37,26 +38,26 @@ import org.junit.Test;
 
 @SuppressWarnings("serial")
 public class GroupingPojoTranslationTest extends CompilerTestBase {
-	
+
 	@Test
 	public void testCustomPartitioningTupleReduce() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Pojo2> data = env.fromElements(new Pojo2())
 					.rebalance().setParallelism(4);
-			
+
 			data.groupBy("a").withPartitioner(new TestPartitionerInt())
-				.reduce(new DummyReducer<Pojo2>())
-				.print();
-			
+					.reduce(new DummyReducer<Pojo2>())
+					.output(new DiscardingOutputFormat<Pojo2>());
+
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
-			
+
 			SinkPlanNode sink = op.getDataSinks().iterator().next();
 			SingleInputPlanNode reducer = (SingleInputPlanNode) sink.getInput().getSource();
 			SingleInputPlanNode combiner = (SingleInputPlanNode) reducer.getInput().getSource();
-			
+
 			assertEquals(ShipStrategyType.FORWARD, sink.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.PARTITION_CUSTOM, reducer.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.FORWARD, combiner.getInput().getShipStrategy());
@@ -66,26 +67,26 @@ public class GroupingPojoTranslationTest extends CompilerTestBase {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testCustomPartitioningTupleGroupReduce() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Pojo2> data = env.fromElements(new Pojo2())
 					.rebalance().setParallelism(4);
-			
+
 			data.groupBy("a").withPartitioner(new TestPartitionerInt())
-				.reduceGroup(new IdentityGroupReducerCombinable<Pojo2>())
-				.print();
-			
+					.reduceGroup(new IdentityGroupReducerCombinable<Pojo2>())
+					.output(new DiscardingOutputFormat<Pojo2>());
+
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
-			
+
 			SinkPlanNode sink = op.getDataSinks().iterator().next();
 			SingleInputPlanNode reducer = (SingleInputPlanNode) sink.getInput().getSource();
 			SingleInputPlanNode combiner = (SingleInputPlanNode) reducer.getInput().getSource();
-			
+
 			assertEquals(ShipStrategyType.FORWARD, sink.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.PARTITION_CUSTOM, reducer.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.FORWARD, combiner.getInput().getShipStrategy());
@@ -95,27 +96,27 @@ public class GroupingPojoTranslationTest extends CompilerTestBase {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testCustomPartitioningTupleGroupReduceSorted() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Pojo3> data = env.fromElements(new Pojo3())
 					.rebalance().setParallelism(4);
-			
+
 			data.groupBy("a").withPartitioner(new TestPartitionerInt())
-				.sortGroup("b", Order.ASCENDING)
-				.reduceGroup(new IdentityGroupReducerCombinable<Pojo3>())
-				.print();
-			
+					.sortGroup("b", Order.ASCENDING)
+					.reduceGroup(new IdentityGroupReducerCombinable<Pojo3>())
+					.output(new DiscardingOutputFormat<Pojo3>());
+
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
-			
+
 			SinkPlanNode sink = op.getDataSinks().iterator().next();
 			SingleInputPlanNode reducer = (SingleInputPlanNode) sink.getInput().getSource();
 			SingleInputPlanNode combiner = (SingleInputPlanNode) reducer.getInput().getSource();
-			
+
 			assertEquals(ShipStrategyType.FORWARD, sink.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.PARTITION_CUSTOM, reducer.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.FORWARD, combiner.getInput().getShipStrategy());
@@ -125,28 +126,28 @@ public class GroupingPojoTranslationTest extends CompilerTestBase {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testCustomPartitioningTupleGroupReduceSorted2() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Pojo4> data = env.fromElements(new Pojo4())
 					.rebalance().setParallelism(4);
-			
+
 			data.groupBy("a").withPartitioner(new TestPartitionerInt())
-				.sortGroup("b", Order.ASCENDING)
-				.sortGroup("c", Order.DESCENDING)
-				.reduceGroup(new IdentityGroupReducerCombinable<Pojo4>())
-				.print();
-			
+					.sortGroup("b", Order.ASCENDING)
+					.sortGroup("c", Order.DESCENDING)
+					.reduceGroup(new IdentityGroupReducerCombinable<Pojo4>())
+					.output(new DiscardingOutputFormat<Pojo4>());
+
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
-			
+
 			SinkPlanNode sink = op.getDataSinks().iterator().next();
 			SingleInputPlanNode reducer = (SingleInputPlanNode) sink.getInput().getSource();
 			SingleInputPlanNode combiner = (SingleInputPlanNode) reducer.getInput().getSource();
-			
+
 			assertEquals(ShipStrategyType.FORWARD, sink.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.PARTITION_CUSTOM, reducer.getInput().getShipStrategy());
 			assertEquals(ShipStrategyType.FORWARD, combiner.getInput().getShipStrategy());
@@ -156,15 +157,15 @@ public class GroupingPojoTranslationTest extends CompilerTestBase {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testCustomPartitioningTupleInvalidType() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Pojo2> data = env.fromElements(new Pojo2())
 					.rebalance().setParallelism(4);
-			
+
 			try {
 				data.groupBy("a").withPartitioner(new TestPartitionerLong());
 				fail("Should throw an exception");
@@ -176,19 +177,19 @@ public class GroupingPojoTranslationTest extends CompilerTestBase {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testCustomPartitioningTupleInvalidTypeSorted() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Pojo3> data = env.fromElements(new Pojo3())
 					.rebalance().setParallelism(4);
-			
+
 			try {
 				data.groupBy("a")
-					.sortGroup("b", Order.ASCENDING)
-					.withPartitioner(new TestPartitionerLong());
+						.sortGroup("b", Order.ASCENDING)
+						.withPartitioner(new TestPartitionerLong());
 				fail("Should throw an exception");
 			}
 			catch (InvalidProgramException e) {}
@@ -198,18 +199,18 @@ public class GroupingPojoTranslationTest extends CompilerTestBase {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testCustomPartitioningTupleRejectCompositeKey() {
 		try {
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Pojo2> data = env.fromElements(new Pojo2())
 					.rebalance().setParallelism(4);
-			
+
 			try {
 				data.groupBy("a", "b")
-					.withPartitioner(new TestPartitionerInt());
+						.withPartitioner(new TestPartitionerInt());
 				fail("Should throw an exception");
 			}
 			catch (InvalidProgramException e) {}
@@ -219,35 +220,35 @@ public class GroupingPojoTranslationTest extends CompilerTestBase {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	public static class Pojo2 {
 		public int a;
 		public int b;
-		
+
 	}
-	
+
 	public static class Pojo3 {
 		public int a;
 		public int b;
 		public int c;
 	}
-	
+
 	public static class Pojo4 {
 		public int a;
 		public int b;
 		public int c;
 		public int d;
 	}
-	
+
 	private static class TestPartitionerInt implements Partitioner<Integer> {
 		@Override
 		public int partition(Integer key, int numPartitions) {
 			return 0;
 		}
 	}
-	
+
 	private static class TestPartitionerLong implements Partitioner<Long> {
 		@Override
 		public int partition(Long key, int numPartitions) {

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingTupleTranslationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/GroupingTupleTranslationTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple4;
@@ -51,7 +52,7 @@ public class GroupingTupleTranslationTest extends CompilerTestBase {
 			
 			data.groupBy(0).withPartitioner(new TestPartitionerInt())
 				.sum(1)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -80,7 +81,7 @@ public class GroupingTupleTranslationTest extends CompilerTestBase {
 			
 			data.groupBy(0).withPartitioner(new TestPartitionerInt())
 				.reduce(new DummyReducer<Tuple2<Integer,Integer>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -109,7 +110,7 @@ public class GroupingTupleTranslationTest extends CompilerTestBase {
 			
 			data.groupBy(0).withPartitioner(new TestPartitionerInt())
 				.reduceGroup(new IdentityGroupReducerCombinable<Tuple2<Integer,Integer>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -139,7 +140,7 @@ public class GroupingTupleTranslationTest extends CompilerTestBase {
 			data.groupBy(0).withPartitioner(new TestPartitionerInt())
 				.sortGroup(1, Order.ASCENDING)
 				.reduceGroup(new IdentityGroupReducerCombinable<Tuple3<Integer,Integer,Integer>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Integer, Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -170,7 +171,7 @@ public class GroupingTupleTranslationTest extends CompilerTestBase {
 				.sortGroup(1, Order.ASCENDING)
 				.sortGroup(2, Order.DESCENDING)
 				.reduceGroup(new IdentityGroupReducerCombinable<Tuple4<Integer,Integer,Integer,Integer>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple4<Integer, Integer, Integer, Integer>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/JoinCustomPartitioningTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/custompartition/JoinCustomPartitioningTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.optimizer.plan.DualInputPlanNode;
@@ -55,7 +56,7 @@ public class JoinCustomPartitioningTest extends CompilerTestBase {
 			
 			input1
 				.join(input2, JoinHint.REPARTITION_HASH_FIRST).where(1).equalTo(0).withPartitioner(partitioner)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Tuple2<Long, Long>, Tuple3<Long, Long, Long>>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -114,7 +115,7 @@ public class JoinCustomPartitioningTest extends CompilerTestBase {
 			input1
 				.join(input2, JoinHint.REPARTITION_HASH_FIRST)
 				.where("b").equalTo("a").withPartitioner(partitioner)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Pojo2, Pojo3>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -176,7 +177,7 @@ public class JoinCustomPartitioningTest extends CompilerTestBase {
 				.where(new Pojo2KeySelector())
 				.equalTo(new Pojo3KeySelector())
 				.withPartitioner(partitioner)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Pojo2, Pojo3>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -248,7 +249,7 @@ public class JoinCustomPartitioningTest extends CompilerTestBase {
 			grouped
 				.join(partitioned, JoinHint.REPARTITION_HASH_FIRST).where(0).equalTo(0)
 				.with(new DummyFlatJoinFunction<Tuple3<Long,Long,Long>>())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/DeltaIterationDependenciesTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/DeltaIterationDependenciesTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.optimizer.java;
 
 import static org.junit.Assert.fail;
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.junit.Test;
 
@@ -54,7 +55,7 @@ public class DeltaIterationDependenciesTest extends CompilerTestBase {
 
 			DataSet<Tuple2<Long, Long>> result = deltaIteration.closeWith(delta, nextWorkset);
 
-			result.print();
+			result.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			try {

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/DistinctAndGroupingOptimizerTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/DistinctAndGroupingOptimizerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.optimizer.java;
 
 import static org.junit.Assert.*;
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.junit.Test;
 import org.apache.flink.api.common.Plan;
@@ -48,7 +49,7 @@ public class DistinctAndGroupingOptimizerTest extends CompilerTestBase {
 			data.distinct(0)
 				.groupBy(0)
 				.sum(1)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -84,7 +85,7 @@ public class DistinctAndGroupingOptimizerTest extends CompilerTestBase {
 			data.distinct(1)
 				.groupBy(0)
 				.sum(1)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/GroupReduceCompilationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/GroupReduceCompilationTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.operators.util.FieldList;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.GroupReduceOperator;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.util.CompilerTestBase;
@@ -51,7 +52,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			data.reduceGroup(new RichGroupReduceFunction<Double, Double>() {
 				public void reduce(Iterable<Double> values, Collector<Double> out) {}
 			}).name("reducer")
-			.print();
+			.output(new DiscardingOutputFormat<Double>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -97,7 +98,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			}).name("reducer");
 			
 			reduced.setCombinable(true);
-			reduced.print();
+			reduced.output(new DiscardingOutputFormat<Long>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -148,7 +149,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 				.reduceGroup(new RichGroupReduceFunction<Tuple2<String, Double>, Tuple2<String, Double>>() {
 				public void reduce(Iterable<Tuple2<String, Double>> values, Collector<Tuple2<String, Double>> out) {}
 			}).name("reducer")
-			.print();
+			.output(new DiscardingOutputFormat<Tuple2<String, Double>>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -199,7 +200,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			}).name("reducer");
 			
 			reduced.setCombinable(true);
-			reduced.print();
+			reduced.output(new DiscardingOutputFormat<Tuple2<String, Double>>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -257,7 +258,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 				.reduceGroup(new RichGroupReduceFunction<Tuple2<String, Double>, Tuple2<String, Double>>() {
 				public void reduce(Iterable<Tuple2<String, Double>> values, Collector<Tuple2<String, Double>> out) {}
 			}).name("reducer")
-			.print();
+			.output(new DiscardingOutputFormat<Tuple2<String, Double>>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -317,7 +318,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			}).name("reducer");
 			
 			reduced.setCombinable(true);
-			reduced.print();
+			reduced.output(new DiscardingOutputFormat<Tuple2<String, Double>>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/GroupReduceCompilationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/GroupReduceCompilationTest.java
@@ -51,7 +51,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			data.reduceGroup(new RichGroupReduceFunction<Double, Double>() {
 				public void reduce(Iterable<Double> values, Collector<Double> out) {}
 			}).name("reducer")
-			.print().name("sink");
+			.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -97,7 +97,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			}).name("reducer");
 			
 			reduced.setCombinable(true);
-			reduced.print().name("sink");
+			reduced.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -148,7 +148,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 				.reduceGroup(new RichGroupReduceFunction<Tuple2<String, Double>, Tuple2<String, Double>>() {
 				public void reduce(Iterable<Tuple2<String, Double>> values, Collector<Tuple2<String, Double>> out) {}
 			}).name("reducer")
-			.print().name("sink");
+			.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -199,7 +199,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			}).name("reducer");
 			
 			reduced.setCombinable(true);
-			reduced.print().name("sink");
+			reduced.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -257,7 +257,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 				.reduceGroup(new RichGroupReduceFunction<Tuple2<String, Double>, Tuple2<String, Double>>() {
 				public void reduce(Iterable<Tuple2<String, Double>> values, Collector<Tuple2<String, Double>> out) {}
 			}).name("reducer")
-			.print().name("sink");
+			.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -317,7 +317,7 @@ public class GroupReduceCompilationTest extends CompilerTestBase implements java
 			}).name("reducer");
 			
 			reduced.setCombinable(true);
-			reduced.print().name("sink");
+			reduced.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/IterationCompilerTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/IterationCompilerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DeltaIteration;
 import org.apache.flink.api.java.operators.IterativeDataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -48,7 +49,7 @@ public class IterationCompilerTest extends CompilerTestBase {
 			env.setParallelism(43);
 			
 			IterativeDataSet<Long> iteration = env.generateSequence(-4, 1000).iterate(100);
-			iteration.closeWith(iteration).print();
+			iteration.closeWith(iteration).output(new DiscardingOutputFormat<Long>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -76,7 +77,7 @@ public class IterationCompilerTest extends CompilerTestBase {
 					
 			DeltaIteration<Tuple2<Long, Long>, Tuple2<Long, Long>> iter = input.iterateDelta(input, 100, 0);
 			iter.closeWith(iter.getWorkset(), iter.getWorkset())
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -99,7 +100,7 @@ public class IterationCompilerTest extends CompilerTestBase {
 			
 			iteration.closeWith(
 					iteration.map(new IdentityMapper<Long>()).union(iteration.map(new IdentityMapper<Long>())))
-					.print();
+					.output(new DiscardingOutputFormat<Long>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -150,7 +151,7 @@ public class IterationCompilerTest extends CompilerTestBase {
 				.union(
 						iter.getWorkset().map(new IdentityMapper<Tuple2<Long,Long>>()))
 				)
-			.print();
+			.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/JoinTranslationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/JoinTranslationTest.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.plan.DualInputPlanNode;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
@@ -131,7 +133,7 @@ public class JoinTranslationTest extends CompilerTestBase {
 		DataSet<Long> i1 = env.generateSequence(1, 1000);
 		DataSet<Long> i2 = env.generateSequence(1, 1000);
 		
-		i1.join(i2, hint).where(new IdentityKeySelector<Long>()).equalTo(new IdentityKeySelector<Long>()).print();
+		i1.join(i2, hint).where(new IdentityKeySelector<Long>()).equalTo(new IdentityKeySelector<Long>()).output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 		
 		Plan plan = env.createProgramPlan();
 		

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/OpenIterationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/OpenIterationTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DeltaIteration;
 import org.apache.flink.api.java.operators.IterativeDataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -72,9 +73,9 @@ public class OpenIterationTest extends CompilerTestBase {
 			
 			DataSet<Long> mapped = iteration.map(new IdentityMapper<Long>());
 			
-			iteration.closeWith(mapped).print();
+			iteration.closeWith(mapped).output(new DiscardingOutputFormat<Long>());
 			
-			mapped.print();
+			mapped.output(new DiscardingOutputFormat<Long>());
 			
 			Plan p = env.createProgramPlan();
 			
@@ -164,7 +165,7 @@ public class OpenIterationTest extends CompilerTestBase {
 												.where(0).equalTo(0).projectFirst(1).projectSecond(0);
 			
 			iteration.closeWith(joined, joined)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			try {

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/OpenIterationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/OpenIterationTest.java
@@ -46,7 +46,7 @@ public class OpenIterationTest extends CompilerTestBase {
 			
 			DataSet<Long> mapped = iteration.map(new IdentityMapper<Long>());
 			
-			mapped.print();
+			mapped.output(new DiscardingOutputFormat<Long>());
 			
 			try {
 				env.createProgramPlan();
@@ -105,7 +105,7 @@ public class OpenIterationTest extends CompilerTestBase {
 			
 			DataSet<Tuple2<Long, Long>> mapped = iteration.getSolutionSet().map(new IdentityMapper<Tuple2<Long, Long>>());
 			
-			mapped.print();
+			mapped.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			try {
 				env.createProgramPlan();
@@ -133,7 +133,7 @@ public class OpenIterationTest extends CompilerTestBase {
 			
 			DataSet<Tuple2<Long, Long>> mapped = iteration.getWorkset().map(new IdentityMapper<Tuple2<Long, Long>>());
 			
-			mapped.print();
+			mapped.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			try {
 				env.createProgramPlan();

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/PartitionOperatorTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/PartitionOperatorTest.java
@@ -26,11 +26,12 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
-import org.apache.flink.optimizer.testfunctions.IdentityGroupReducerCombinable;
+import org.apache.flink.optimizer.testfunctions.IdentityGroupReducer;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.junit.Test;
@@ -49,8 +50,8 @@ public class PartitionOperatorTest extends CompilerTestBase {
 					public int partition(Long key, int numPartitions) { return key.intValue(); }
 				}, 1)
 				.groupBy(1)
-				.reduceGroup(new IdentityGroupReducerCombinable<Tuple2<Long,Long>>())
-				.print();
+				.reduceGroup(new IdentityGroupReducer<Tuple2<Long,Long>>())
+				.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/PartitionOperatorTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/PartitionOperatorTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
-import org.apache.flink.optimizer.testfunctions.IdentityGroupReducer;
+import org.apache.flink.optimizer.testfunctions.IdentityGroupReducerCombinable;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class PartitionOperatorTest extends CompilerTestBase {
 					public int partition(Long key, int numPartitions) { return key.intValue(); }
 				}, 1)
 				.groupBy(1)
-				.reduceGroup(new IdentityGroupReducer<Tuple2<Long,Long>>())
+					.reduceGroup(new IdentityGroupReducerCombinable<Tuple2<Long,Long>>())
 				.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			
 			Plan p = env.createProgramPlan();

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/ReduceCompilationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/ReduceCompilationTest.java
@@ -53,7 +53,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return value1 + value2;
 				}
 			}).name("reducer")
-			.print().name("sink");
+			.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -98,7 +98,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return value1 + value2;
 				}
 			}).name("reducer")
-			.print().name("sink");
+			.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -151,7 +151,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return null;
 				}
 			}).name("reducer")
-			.print().name("sink");
+			.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -211,7 +211,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return null;
 				}
 			}).name("reducer")
-			.print().name("sink");
+			.print();
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/ReduceCompilationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/ReduceCompilationTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.operators.util.FieldList;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.common.functions.RichReduceFunction;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.junit.Test;
@@ -53,7 +54,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return value1 + value2;
 				}
 			}).name("reducer")
-			.print();
+			.output(new DiscardingOutputFormat<Double>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -98,7 +99,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return value1 + value2;
 				}
 			}).name("reducer")
-			.print();
+			.output(new DiscardingOutputFormat<Long>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -151,7 +152,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return null;
 				}
 			}).name("reducer")
-			.print();
+			.output(new DiscardingOutputFormat<Tuple2<String, Double>>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);
@@ -211,7 +212,7 @@ public class ReduceCompilationTest extends CompilerTestBase implements java.io.S
 					return null;
 				}
 			}).name("reducer")
-			.print();
+			.output(new DiscardingOutputFormat<Tuple2<String, Double>>()).name("sink");
 			
 			Plan p = env.createProgramPlan();
 			OptimizedPlan op = compileNoStats(p);

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/WorksetIterationsJavaApiCompilerTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/java/WorksetIterationsJavaApiCompilerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.operators.util.FieldList;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DeltaIteration;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
@@ -294,7 +295,7 @@ public class WorksetIterationsJavaApiCompilerTest extends CompilerTestBase {
 				joinedWithSolutionSet;
 		
 		iter.closeWith(nextSolutionSet, nextWorkset)
-			.print();
+			.output(new DiscardingOutputFormat<Tuple3<Long, Long, Long>>());
 		
 		return env.createProgramPlan();
 	}

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/operators/CoGroupOnConflictingPartitioningsTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/operators/CoGroupOnConflictingPartitioningsTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.CompilerException;
 import org.apache.flink.optimizer.Optimizer;
@@ -48,7 +49,7 @@ public class CoGroupOnConflictingPartitioningsTest extends CompilerTestBase {
 			input.coGroup(input).where(0).equalTo(0)
 				.with(new DummyCoGroupFunction<Tuple2<Long, Long>, Tuple2<Long, Long>>())
 				.withParameters(cfg)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Tuple2<Long, Long>, Tuple2<Long, Long>>>());
 			
 			Plan p = env.createProgramPlan();
 			try {

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/operators/JoinOnConflictingPartitioningsTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/operators/JoinOnConflictingPartitioningsTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.CompilerException;
 import org.apache.flink.optimizer.Optimizer;
@@ -46,7 +47,7 @@ public class JoinOnConflictingPartitioningsTest extends CompilerTestBase {
 			
 			input.join(input).where(0).equalTo(0)
 				.withParameters(cfg)
-				.print();
+				.output(new DiscardingOutputFormat<Tuple2<Tuple2<Long, Long>, Tuple2<Long, Long>>>());
 			
 			Plan p = env.createProgramPlan();
 			try {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -1323,9 +1323,10 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   /**
    * Writes a DataSet to the standard output stream (stdout). This uses [[AnyRef.toString]] on
    * each element.
+   * This triggers execute() automatically.
    */
-  def print(): DataSink[T] = {
-    output(new PrintingOutputFormat[T](false))
+  def print() = {
+    javaSet.print()
   }
 
   /**
@@ -1342,8 +1343,8 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    * Writes a DataSet to the standard error stream (stderr). This uses [[AnyRef.toString]] on
    * each element.
    */
-  def printToErr(): DataSink[T] = {
-    output(new PrintingOutputFormat[T](true))
+  def printToErr() = {
+    javaSet.printToErr()
   }
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -131,6 +131,13 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
     javaEnv.getId
   }
 
+
+  /**
+   * retrieves JobExecutionResult from last job execution (for "eager" print)
+   * @return JobExecutionResult form last job execution
+   */
+  def getLastJobExecutionResult = javaEnv.getLastJobExecutionResult
+
   /**
    * Gets the UUID by which this environment is identified, as a string.
    */

--- a/flink-staging/flink-language-binding/flink-language-binding-generic/src/main/java/org/apache/flink/languagebinding/api/java/common/PlanBinder.java
+++ b/flink-staging/flink-language-binding/flink-language-binding-generic/src/main/java/org/apache/flink/languagebinding/api/java/common/PlanBinder.java
@@ -19,6 +19,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.aggregation.Aggregations;
 import org.apache.flink.api.java.io.CsvInputFormat;
+import org.apache.flink.api.java.io.PrintingOutputFormat;
 import org.apache.flink.api.java.operators.AggregateOperator;
 import org.apache.flink.api.java.operators.CrossOperator.DefaultCross;
 import org.apache.flink.api.java.operators.CrossOperator.ProjectCross;
@@ -296,7 +297,7 @@ public abstract class PlanBinder<INFO extends OperationInfo> {
 		int parentID = (Integer) receiver.getRecord(true);
 		DataSet parent = (DataSet) sets.get(parentID);
 		boolean toError = (Boolean) receiver.getRecord();
-		(toError ? parent.printToErr() : parent.print()).name("PrintSink");
+		parent.output(new PrintingOutputFormat(toError));
 	}
 
 	private void createBroadcastVariable() throws IOException {

--- a/flink-staging/flink-spargel/src/test/java/org/apache/flink/spargel/java/SpargelCompilerTest.java
+++ b/flink-staging/flink-spargel/src/test/java/org/apache/flink/spargel/java/SpargelCompilerTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.operators.util.FieldList;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.util.CompilerTestBase;
 import org.junit.Test;
@@ -59,7 +60,7 @@ public class SpargelCompilerTest extends CompilerTestBase {
 				DataSet<Tuple2<Long, Long>> initialVertices = vertexIds.map(new IdAssigner());
 				DataSet<Tuple2<Long, Long>> result = initialVertices.runOperation(VertexCentricIteration.withPlainEdges(edges, new CCUpdater(), new CCMessager(), 100));
 				
-				result.print();
+				result.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			}
 			
 			Plan p = env.createProgramPlan("Spargel Connected Components");
@@ -134,7 +135,7 @@ public class SpargelCompilerTest extends CompilerTestBase {
 				
 				DataSet<Tuple2<Long, Long>> result = initialVertices.runOperation(vcIter);
 				
-				result.print();
+				result.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
 			}
 			
 			Plan p = env.createProgramPlan("Spargel Connected Components");

--- a/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/HDFSTest.java
+++ b/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/HDFSTest.java
@@ -110,8 +110,8 @@ public class HDFSTest {
 			IOUtils.copy(inStream, writer);
 			String resultString = writer.toString();
 
-			Assert.assertEquals("hdfs 10\n" +
-					"hello 10\n", resultString);
+			Assert.assertEquals("(hdfs,10)\n" +
+					"(hello,10)\n", resultString);
 			inStream.close();
 
 		} catch (IOException e) {

--- a/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/HDFSTest.java
+++ b/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/HDFSTest.java
@@ -110,8 +110,8 @@ public class HDFSTest {
 			IOUtils.copy(inStream, writer);
 			String resultString = writer.toString();
 
-			Assert.assertEquals("(hdfs,10)\n" +
-					"(hello,10)\n", resultString);
+			Assert.assertEquals("hdfs 10\n" +
+					"hello 10\n", resultString);
 			inStream.close();
 
 		} catch (IOException e) {

--- a/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/TachyonFileSystemWrapperTest.java
+++ b/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/TachyonFileSystemWrapperTest.java
@@ -141,8 +141,8 @@ public class TachyonFileSystemWrapperTest {
 			IOUtils.copy(inStream, writer);
 			String resultString = writer.toString();
 
-			Assert.assertEquals("hello 10\n" +
-					"tachyon 10\n", resultString);
+			Assert.assertEquals("(hello,10)\n" +
+					"(tachyon,10)\n", resultString);
 
 		} catch(Exception e) {
 			e.printStackTrace();

--- a/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/TachyonFileSystemWrapperTest.java
+++ b/flink-staging/flink-tachyon/src/test/java/org/apache/flink/tachyon/TachyonFileSystemWrapperTest.java
@@ -141,8 +141,8 @@ public class TachyonFileSystemWrapperTest {
 			IOUtils.copy(inStream, writer);
 			String resultString = writer.toString();
 
-			Assert.assertEquals("(hello,10)\n" +
-					"(tachyon,10)\n", resultString);
+			Assert.assertEquals("hello 10\n" +
+					"tachyon 10\n", resultString);
 
 		} catch(Exception e) {
 			e.printStackTrace();

--- a/flink-staging/flink-tez/src/test/java/org/apache/flink/tez/test/WordCountITCase.java
+++ b/flink-staging/flink-tez/src/test/java/org/apache/flink/tez/test/WordCountITCase.java
@@ -37,7 +37,7 @@ public class WordCountITCase extends TezProgramTestBase {
 
     @Override
     protected void postSubmit() throws Exception {
-        compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
+        compareResultsByLinesInMemory(WordCountData.COUNTS_AS_TUPLES, resultPath);
     }
 
     @Override

--- a/flink-staging/flink-tez/src/test/java/org/apache/flink/tez/test/WordCountITCase.java
+++ b/flink-staging/flink-tez/src/test/java/org/apache/flink/tez/test/WordCountITCase.java
@@ -37,7 +37,7 @@ public class WordCountITCase extends TezProgramTestBase {
 
     @Override
     protected void postSubmit() throws Exception {
-        compareResultsByLinesInMemory(WordCountData.COUNTS_AS_TUPLES, resultPath);
+        compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
     }
 
     @Override

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.java.ExecutionEnvironmentFactory;
 
 public class CollectionTestEnvironment extends CollectionEnvironment {
 
-	protected JobExecutionResult latestResult;
-
 	@Override
 	public JobExecutionResult execute() throws Exception {
 		return execute("test job");
@@ -35,7 +33,7 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		JobExecutionResult result = super.execute(jobName);
-		this.latestResult = result;
+		this.lastJobExecutionResult = result;
 		return result;
 	}
 

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
@@ -119,7 +119,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 				// call the test program
 				try {
 					testProgram();
-					this.latestExecutionResult = env.latestResult;
+					this.latestExecutionResult = env.getLastJobExecutionResult();
 				}
 				catch (Exception e) {
 					System.err.println(e.getMessage());
@@ -171,7 +171,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 				// call the test program
 				try {
 					testProgram();
-					this.latestExecutionResult = env.latestResult;
+					this.latestExecutionResult = env.getLastJobExecutionResult();
 				}
 				catch (Exception e) {
 					System.err.println(e.getMessage());
@@ -224,7 +224,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 		// call the test program
 		try {
 			testProgram();
-			this.latestExecutionResult = env.latestResult;
+			this.latestExecutionResult = env.getLastJobExecutionResult();
 		}
 		catch (Exception e) {
 			System.err.println(e.getMessage());

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -36,9 +36,6 @@ public class TestEnvironment extends ExecutionEnvironment {
 
 	private final ForkableFlinkMiniCluster executor;
 
-	protected JobExecutionResult latestResult;
-
-
 	public TestEnvironment(ForkableFlinkMiniCluster executor, int parallelism) {
 		this.executor = executor;
 		setParallelism(parallelism);
@@ -54,8 +51,8 @@ public class TestEnvironment extends ExecutionEnvironment {
 			
 			SerializedJobExecutionResult result = executor.submitJobAndWait(jobGraph, false);
 
-			this.latestResult = result.toJobExecutionResult(getClass().getClassLoader());
-			return this.latestResult;
+			this.lastJobExecutionResult = result.toJobExecutionResult(getClass().getClassLoader());
+			return this.lastJobExecutionResult;
 		}
 		catch (Exception e) {
 			System.err.println(e.getMessage());

--- a/flink-tests/src/test/java/org/apache/flink/test/compiler/iterations/MultipleJoinsWithSolutionSetCompilerTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/compiler/iterations/MultipleJoinsWithSolutionSetCompilerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.aggregation.Aggregations;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichJoinFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.operators.DriverStrategy;
@@ -58,8 +59,8 @@ public class MultipleJoinsWithSolutionSetCompilerTest extends CompilerTestBase {
 			DataSet<Tuple2<Long, Double>> result = constructPlan(inputData, 10);
 			
 			// add two sinks, to test the case of branching after an iteration
-			result.print();
-			result.print();
+			result.output(new DiscardingOutputFormat<Tuple2<Long, Double>>());
+			result.output(new DiscardingOutputFormat<Tuple2<Long, Double>>());
 		
 			Plan p = env.createProgramPlan();
 			

--- a/flink-tests/src/test/java/org/apache/flink/test/compiler/iterations/PageRankCompilerTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/compiler/iterations/PageRankCompilerTest.java
@@ -23,6 +23,7 @@ import static org.apache.flink.api.java.aggregation.Aggregations.SUM;
 import static org.junit.Assert.fail;
 
 import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.plan.BulkIterationPlanNode;
@@ -85,7 +86,7 @@ public class PageRankCompilerTest extends CompilerTestBase{
 					// termination condition
 					.filter(new EpsilonFilter()));
 	
-			finalPageRanks.print();
+			finalPageRanks.output(new DiscardingOutputFormat<Tuple2<Long, Double>>());
 	
 			// get the plan and compile it
 			Plan p = env.createProgramPlan();

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountITCase.java
@@ -36,7 +36,7 @@ public class WordCountITCase extends JavaProgramTestBase {
 
 	@Override
 	protected void postSubmit() throws Exception {
-		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
+		compareResultsByLinesInMemory(WordCountData.COUNTS_AS_TUPLES, resultPath);
 	}
 
 	@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/WordCountITCase.java
@@ -36,7 +36,7 @@ public class WordCountITCase extends JavaProgramTestBase {
 
 	@Override
 	protected void postSubmit() throws Exception {
-		compareResultsByLinesInMemory(WordCountData.COUNTS_AS_TUPLES, resultPath);
+		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
 	}
 
 	@Override

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/DeltaIterationSanityCheckTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/DeltaIterationSanityCheckTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala
 
+import org.apache.flink.test.recordJobs.util.DiscardingOutputFormat
 import org.junit.Test
 import org.apache.flink.api.common.InvalidProgramException
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/DeltaIterationSanityCheckTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/DeltaIterationSanityCheckTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.scala
 
-import org.apache.flink.test.recordJobs.util.DiscardingOutputFormat
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.junit.Test
 import org.apache.flink.api.common.InvalidProgramException
 
@@ -38,7 +38,7 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int, String)])
   }
 
   @Test
@@ -52,7 +52,7 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int,String)])
   }
 
   @Test(expected = classOf[InvalidProgramException])
@@ -66,7 +66,7 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int,String)])
   }
 
   @Test(expected = classOf[InvalidProgramException])
@@ -80,7 +80,8 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()  }
+    iteration.output(new DiscardingOutputFormat[(Int,String)])  
+  }
 
   @Test(expected = classOf[InvalidProgramException])
   def testIncorrectJoinWithSolution3(): Unit = {
@@ -93,7 +94,7 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int,String)])
    }
 
   @Test
@@ -107,7 +108,7 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int,String)])
   }
 
   @Test
@@ -121,7 +122,7 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int,String)])
   }
 
   @Test(expected = classOf[InvalidProgramException])
@@ -135,7 +136,7 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int,String)])
   }
 
   @Test(expected = classOf[InvalidProgramException])
@@ -149,7 +150,8 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()  }
+    iteration.output(new DiscardingOutputFormat[(Int,String)])  
+  }
 
   @Test(expected = classOf[InvalidProgramException])
   def testIncorrectCoGroupWithSolution3(): Unit = {
@@ -162,6 +164,6 @@ class DeltaIterationSanityCheckTest extends Serializable {
       (result, ws)
     }
 
-    iteration.print()
+    iteration.output(new DiscardingOutputFormat[(Int,String)])
   }
 }

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/compiler/PartitionOperatorTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/compiler/PartitionOperatorTranslationTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.compiler
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.optimizer.util.CompilerTestBase
 import org.junit.Test
 import org.junit.Assert._
@@ -38,8 +39,8 @@ class PartitionOperatorTranslationTest extends CompilerTestBase {
           def partition(key: Long, numPartitions: Int): Int = key.intValue()
         }, 1)
         .groupBy(1).reduceGroup( x => x)
-        .print()
-      
+        .output(new DiscardingOutputFormat[Iterator[(Long, Long)]])
+
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
       

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/functions/SemanticPropertiesTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/functions/SemanticPropertiesTranslationTest.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala.functions
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.junit.Assert._
 import org.apache.flink.api.common.functions.RichJoinFunction
 import org.apache.flink.api.common.functions.RichMapFunction
@@ -46,7 +47,8 @@ class SemanticPropertiesTranslationTest {
       val env = ExecutionEnvironment.getExecutionEnvironment
 
       val input = env.fromElements((3L, "test", 42))
-      input.map(new WildcardForwardMapper[(Long, String, Int)]).print()
+      input.map(new WildcardForwardMapper[(Long, String, Int)])
+        .output(new DiscardingOutputFormat[(Long, String, Int)])
 
       val plan = env.createProgramPlan()
 
@@ -83,7 +85,8 @@ class SemanticPropertiesTranslationTest {
       val env = ExecutionEnvironment.getExecutionEnvironment
 
       val input = env.fromElements((3L, "test", 42))
-      input.map(new IndividualForwardMapper[Long, String, Int]).print()
+      input.map(new IndividualForwardMapper[Long, String, Int])
+        .output(new DiscardingOutputFormat[(Long, String, Int)])
 
       val plan = env.createProgramPlan()
 
@@ -120,7 +123,8 @@ class SemanticPropertiesTranslationTest {
       val env = ExecutionEnvironment.getExecutionEnvironment
 
       val input = env.fromElements((3L, "test", 42))
-      input.map(new FieldTwoForwardMapper[Long, String, Int]).print()
+      input.map(new FieldTwoForwardMapper[Long, String, Int])
+        .output(new DiscardingOutputFormat[(Long, String, Int)])
 
       val plan = env.createProgramPlan()
 
@@ -160,7 +164,8 @@ class SemanticPropertiesTranslationTest {
       val input2 = env.fromElements((3L, 3.1415))
 
       input1.join(input2).where(0).equalTo(0)(
-        new ForwardingTupleJoin[Long, String, Long, Double]).print()
+        new ForwardingTupleJoin[Long, String, Long, Double])
+        .output(new DiscardingOutputFormat[(String, Long)])
 
       val plan = env.createProgramPlan()
       val sink: GenericDataSinkBase[_] = plan.getDataSinks.iterator.next
@@ -204,7 +209,8 @@ class SemanticPropertiesTranslationTest {
       val input2 = env.fromElements((3L, 42))
 
       input1.join(input2).where(0).equalTo(0)(
-        new ForwardingBasicJoin[(Long, String), (Long, Int)]).print()
+        new ForwardingBasicJoin[(Long, String), (Long, Int)])
+        .output(new DiscardingOutputFormat[((Long, String), (Long, Int))])
 
       val plan = env.createProgramPlan()
       val sink: GenericDataSinkBase[_] = plan.getDataSinks.iterator.next

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/AggregateTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/AggregateTranslationTest.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.operators.GenericDataSourceBase
 import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase
 
 import org.apache.flink.api.java.aggregation.Aggregations
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.api.scala._
 import org.junit.Assert.{assertEquals, assertTrue, fail}
 import org.junit.Test
@@ -37,7 +38,8 @@ class AggregateTranslationTest {
 
       val initialData = env.fromElements((3.141592, "foobar", 77L))
 
-      initialData.groupBy(0).aggregate(Aggregations.MIN, 1).and(Aggregations.SUM, 2).print()
+      initialData.groupBy(0).aggregate(Aggregations.MIN, 1).and(Aggregations.SUM, 2)
+        .output(new DiscardingOutputFormat[(Double, String, Long)])
 
       val p: Plan = env.createProgramPlan()
       val sink = p.getDataSinks.iterator.next
@@ -55,6 +57,7 @@ class AggregateTranslationTest {
         System.err.println(e.getMessage)
         e.printStackTrace()
         fail("Test caused an error: " + e.getMessage)
+
       }
     }
   }

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupCustomPartitioningTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupCustomPartitioningTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.operators.translation
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.optimizer.util.CompilerTestBase
 import org.junit.Assert._
 import org.junit.Test
@@ -46,7 +47,7 @@ class CoGroupCustomPartitioningTest extends CompilerTestBase {
           .coGroup(input2)
           .where(1).equalTo(0)
           .withPartitioner(partitioner)
-        .print()
+        .output(new DiscardingOutputFormat[(Array[(Long, Long)], Array[(Long, Long, Long)])])
       
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -110,7 +111,7 @@ class CoGroupCustomPartitioningTest extends CompilerTestBase {
           .coGroup(input2)
           .where("b").equalTo("a")
           .withPartitioner(partitioner)
-        .print()
+        .output(new DiscardingOutputFormat[(Array[Pojo2], Array[Pojo3])])
         
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -174,7 +175,7 @@ class CoGroupCustomPartitioningTest extends CompilerTestBase {
           .coGroup(input2)
           .where( _.a ).equalTo( _.b )
           .withPartitioner(partitioner)
-        .print()
+        .output(new DiscardingOutputFormat[(Array[Pojo2], Array[Pojo3])])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupGroupSortTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupGroupSortTranslationTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.operators.translation
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.optimizer.util.CompilerTestBase
 import org.junit.Assert._
 import org.junit.Test
@@ -49,7 +50,7 @@ class CoGroupGroupSortTranslationTest {
           .sortSecondGroup(1, Order.ASCENDING).sortSecondGroup(0, Order.DESCENDING) {
                (first, second) => first.buffered.head
             }
-        .print()
+        .output(new DiscardingOutputFormat[(Long, Long)])
         
       val p = env.createProgramPlan()
       
@@ -92,7 +93,7 @@ class CoGroupGroupSortTranslationTest {
           .sortSecondGroup("c", Order.ASCENDING).sortSecondGroup("a", Order.DESCENDING) {
                (first, second) => first.buffered.head
             }
-          .print()
+          .output(new DiscardingOutputFormat[(Long, Long)])
           
       val p = env.createProgramPlan()
       

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningGroupingKeySelectorTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningGroupingKeySelectorTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.operators.translation
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.optimizer.util.CompilerTestBase
 import org.junit.Assert._
 import org.junit.Test
@@ -40,7 +41,7 @@ class CustomPartitioningGroupingKeySelectorTest extends CompilerTestBase {
       data
         .groupBy( _._1 ).withPartitioner(new TestPartitionerInt())
         .reduce( (a,b) => a )
-        .print()
+        .output(new DiscardingOutputFormat[(Int, Int)])
 
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -73,7 +74,7 @@ class CustomPartitioningGroupingKeySelectorTest extends CompilerTestBase {
       data
         .groupBy( _._1 ).withPartitioner(new TestPartitionerInt())
         .reduce( (a, b) => a)
-        .print()
+        .output(new DiscardingOutputFormat[(Int, Int)])
 
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -107,7 +108,7 @@ class CustomPartitioningGroupingKeySelectorTest extends CompilerTestBase {
         .withPartitioner(new TestPartitionerInt())
         .sortGroup(1, Order.ASCENDING)
         .reduce( (a,b) => a)
-        .print()
+        .output(new DiscardingOutputFormat[(Int, Int, Int)])
 
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -141,7 +142,7 @@ class CustomPartitioningGroupingKeySelectorTest extends CompilerTestBase {
         .withPartitioner(new TestPartitionerInt())
         .sortGroup(_._2, Order.ASCENDING)
         .reduce( (a,b) => a)
-        .print()
+        .output(new DiscardingOutputFormat[(Int, Int, Int)])
 
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -175,7 +176,7 @@ class CustomPartitioningGroupingKeySelectorTest extends CompilerTestBase {
         .sortGroup(1, Order.ASCENDING)
         .sortGroup(2, Order.DESCENDING)
         .reduce( (a,b) => a)
-        .print()
+        .output(new DiscardingOutputFormat[(Int, Int, Int, Int)])
 
       val p = env.createProgramPlan()
       val op = compileNoStats(p)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningGroupingPojoTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningGroupingPojoTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.operators.translation
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.optimizer.util.CompilerTestBase
 import org.junit.Assert._
 import org.junit.Test
@@ -41,7 +42,7 @@ class CustomPartitioningGroupingPojoTest extends CompilerTestBase {
       data
           .groupBy("a").withPartitioner(new TestPartitionerInt())
           .reduce( (a,b) => a )
-          .print()
+          .output(new DiscardingOutputFormat[Pojo2])
       
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -72,7 +73,7 @@ class CustomPartitioningGroupingPojoTest extends CompilerTestBase {
       data
           .groupBy("a").withPartitioner(new TestPartitionerInt())
           .reduceGroup( iter => Seq(iter.next) )
-          .print()
+          .output(new DiscardingOutputFormat[Seq[Pojo2]])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -102,7 +103,7 @@ class CustomPartitioningGroupingPojoTest extends CompilerTestBase {
           .groupBy("a").withPartitioner(new TestPartitionerInt())
           .sortGroup("b", Order.ASCENDING)
           .reduceGroup( iter => Seq(iter.next) )
-          .print()
+          .output(new DiscardingOutputFormat[Seq[Pojo3]])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -133,7 +134,7 @@ class CustomPartitioningGroupingPojoTest extends CompilerTestBase {
           .sortGroup("b", Order.ASCENDING)
           .sortGroup("c", Order.DESCENDING)
           .reduceGroup( iter => Seq(iter.next) )
-          .print()
+          .output(new DiscardingOutputFormat[Seq[Pojo4]])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningGroupingTupleTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningGroupingTupleTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.operators.translation
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.junit.Assert._
 import org.junit.Test
 
@@ -42,7 +43,7 @@ class CustomPartitioningGroupingTupleTest extends CompilerTestBase {
       data.groupBy(0)
           .withPartitioner(new TestPartitionerInt())
           .sum(1)
-          .print()
+          .output(new DiscardingOutputFormat[(Int, Int)])
       
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -73,7 +74,7 @@ class CustomPartitioningGroupingTupleTest extends CompilerTestBase {
       data
           .groupBy(0).withPartitioner(new TestPartitionerInt())
           .reduce( (a,b) => a )
-          .print()
+          .output(new DiscardingOutputFormat[(Int, Int)])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -104,7 +105,7 @@ class CustomPartitioningGroupingTupleTest extends CompilerTestBase {
       data
           .groupBy(0).withPartitioner(new TestPartitionerInt())
           .reduceGroup( iter => Seq(iter.next) )
-          .print()
+          .output(new DiscardingOutputFormat[Seq[(Int, Int)]])
       
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -134,7 +135,7 @@ class CustomPartitioningGroupingTupleTest extends CompilerTestBase {
           .groupBy(0).withPartitioner(new TestPartitionerInt())
           .sortGroup(1, Order.ASCENDING)
           .reduceGroup( iter => Seq(iter.next) )
-          .print()
+          .output(new DiscardingOutputFormat[Seq[(Int, Int, Int)]])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -165,7 +166,7 @@ class CustomPartitioningGroupingTupleTest extends CompilerTestBase {
           .sortGroup(1, Order.ASCENDING)
           .sortGroup(2, Order.DESCENDING)
           .reduceGroup( iter => Seq(iter.next) )
-          .print()
+          .output(new DiscardingOutputFormat[Seq[(Int, Int, Int, Int)]])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CustomPartitioningTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.operators.translation
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.api.scala._
 import org.apache.flink.optimizer.util.CompilerTestBase
 import org.junit.Test
@@ -43,7 +44,7 @@ class CustomPartitioningTest extends CompilerTestBase {
       
       data.partitionCustom(part, 0)
           .mapPartition( x => x )
-          .print()
+          .output(new DiscardingOutputFormat[(Int, Int)])
 
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -113,7 +114,7 @@ class CustomPartitioningTest extends CompilerTestBase {
       data
           .partitionCustom(part, "a")
           .mapPartition( x => x)
-          .print()
+          .output(new DiscardingOutputFormat[Pojo])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -184,7 +185,7 @@ class CustomPartitioningTest extends CompilerTestBase {
       data
           .partitionCustom(part, pojo => pojo.a)
           .mapPartition( x => x)
-          .print()
+          .output(new DiscardingOutputFormat[Pojo])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/DeltaIterationTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/DeltaIterationTranslationTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.api.scala.operators.translation
 import org.apache.flink.api.common.functions.{RichCoGroupFunction, RichMapFunction,
 RichJoinFunction}
 import org.apache.flink.api.common.operators.GenericDataSinkBase
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.api.java.operators.translation.WrappingFunction
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -67,7 +68,7 @@ class DeltaIterationTranslationTest {
         .setParallelism(ITERATION_PARALLELISM)
         .registerAggregator(AGGREGATOR_NAME, new LongSumAggregator)
 
-      result.print()
+      result.output(new DiscardingOutputFormat[(Double, Long, String)])
       result.writeAsText("/dev/null")
 
       val p: Plan = env.createProgramPlan(JOB_NAME)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/DistinctTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/DistinctTranslationTest.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.api.scala.operators.translation
 
 import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.junit.Assert
 import org.junit.Test
 
@@ -31,7 +32,7 @@ class DistinctTranslationTest {
       val input = env.fromElements("1", "2", "1", "3")
 
       val op = input.distinct { x => x}
-      op.print()
+      op.output(new DiscardingOutputFormat[String])
 
       val p = env.createProgramPlan()
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/JoinCustomPartitioningTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/JoinCustomPartitioningTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.operators.translation
 
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.optimizer.util.CompilerTestBase
 import org.junit.Assert._
 import org.junit.Test
@@ -46,7 +47,7 @@ class JoinCustomPartitioningTest extends CompilerTestBase {
           .join(input2, JoinHint.REPARTITION_HASH_FIRST)
           .where(1).equalTo(0)
           .withPartitioner(partitioner)
-        .print()
+        .output(new DiscardingOutputFormat[((Long, Long), (Long, Long, Long))])
       
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -110,7 +111,7 @@ class JoinCustomPartitioningTest extends CompilerTestBase {
           .join(input2, JoinHint.REPARTITION_HASH_FIRST)
           .where("b").equalTo("a")
           .withPartitioner(partitioner)
-        .print()
+        .output(new DiscardingOutputFormat[(Pojo2, Pojo3)])
         
       val p = env.createProgramPlan()
       val op = compileNoStats(p)
@@ -174,7 +175,7 @@ class JoinCustomPartitioningTest extends CompilerTestBase {
           .join(input2, JoinHint.REPARTITION_HASH_FIRST)
           .where( _.a ).equalTo( _.b )
           .withPartitioner(partitioner)
-        .print()
+        .output(new DiscardingOutputFormat[(Pojo2, Pojo3)])
           
       val p = env.createProgramPlan()
       val op = compileNoStats(p)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/ReduceTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/ReduceTranslationTest.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.api.scala.operators.translation
 
 import org.apache.flink.api.common.operators.{GenericDataSourceBase, GenericDataSinkBase}
+import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.api.java.operators.translation.{KeyExtractingMapper,
 PlanUnwrappingReduceOperator}
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
@@ -39,7 +40,8 @@ class ReduceTranslationTest {
       val initialData = env.fromElements((3.141592, "foobar", 77L)).setParallelism(1)
 
 
-      initialData reduce { (v1, v2) => v1 } print()
+      initialData reduce { (v1, v2) => v1 } output(
+        new DiscardingOutputFormat[(Double, String, Long)])
 
       val p = env.createProgramPlan(
 
@@ -70,7 +72,8 @@ class ReduceTranslationTest {
 
       val initialData = env.fromElements((3.141592, "foobar", 77L)).setParallelism(1)
 
-      initialData.groupBy(2) reduce { (v1, v2) => v1 } print()
+      initialData.groupBy(2) reduce { (v1, v2) => v1 } output(
+        new DiscardingOutputFormat[(Double, String, Long)])
 
       val p = env.createProgramPlan()
 
@@ -99,7 +102,8 @@ class ReduceTranslationTest {
 
       val initialData = env.fromElements((3.141592, "foobar", 77L)).setParallelism(1)
 
-      initialData.groupBy { _._2 }. reduce { (v1, v2) => v1 } setParallelism(4) print()
+      initialData.groupBy { _._2 }. reduce { (v1, v2) => v1 } setParallelism(4) output(
+        new DiscardingOutputFormat[(Double, String, Long)])
 
       val p = env.createProgramPlan()
       val sink: GenericDataSinkBase[_] = p.getDataSinks.iterator.next

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -528,8 +528,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			}
 			//String content = FileUtils.readFileToString(taskmanagerOut);
 			// check for some of the wordcount outputs.
-			Assert.assertTrue("Expected string 'da 5' or '(all,2)' not found in string '"+content+"'", content.contains("(da,5)") || content.contains("(all,2)"));
-			Assert.assertTrue("Expected string 'der 29' or '(mind,1)' not found in string'"+content+"'", content.contains("(der,29)") || content.contains("(mind,1)"));
+			Assert.assertTrue("Expected string 'da 5' or '(all,2)' not found in string '"+content+"'", content.contains("da 5") || content.contains("(da,5)") || content.contains("(all,2)"));
+			Assert.assertTrue("Expected string 'der 29' or '(mind,1)' not found in string'"+content+"'",content.contains("der 29") || content.contains("(der,29)") || content.contains("(mind,1)"));
 
 			// check if the heap size for the TaskManager was set correctly
 			File jobmanagerLog = YarnTestBase.findFile("..", new FilenameFilter() {

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -528,8 +528,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			}
 			//String content = FileUtils.readFileToString(taskmanagerOut);
 			// check for some of the wordcount outputs.
-			Assert.assertTrue("Expected string 'da 5' not found in string '"+content+"'", content.contains("(da,5)"));
-			Assert.assertTrue("Expected string 'der 29' not found in string'"+content+"'", content.contains("(der,29)"));
+			Assert.assertTrue("Expected string 'da 5' or '(all,2)' not found in string '"+content+"'", content.contains("(da,5)") || content.contains("(all,2)"));
+			Assert.assertTrue("Expected string 'der 29' or '(mind,1)' not found in string'"+content+"'", content.contains("(der,29)") || content.contains("(mind,1)"));
 
 			// check if the heap size for the TaskManager was set correctly
 			File jobmanagerLog = YarnTestBase.findFile("..", new FilenameFilter() {


### PR DESCRIPTION
Uses collect in print function now.
No need for calling execute() after print().