### PR TITLE
[FLINK-1954] [FLINK-1636] [runtime] Improve partition not found error handling

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -41,7 +41,6 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String DEFAULT_PARALLELISM_KEY_OLD = "parallelization.degree.default";
 
-
 	/**
 	 * Config parameter for the number of re-tries for failed tasks. Setting this
 	 * value to 0 effectively disables fault tolerance.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -46,8 +46,8 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.messages.Messages;
 import org.apache.flink.runtime.messages.TaskMessages.TaskOperationResult;
 import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.runtime.util.SerializedValue;
 import org.apache.flink.runtime.taskmanager.Task;
+import org.apache.flink.runtime.util.SerializedValue;
 import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import scala.concurrent.Future;
@@ -71,7 +71,6 @@ import static org.apache.flink.runtime.execution.ExecutionState.FAILED;
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 import static org.apache.flink.runtime.execution.ExecutionState.RUNNING;
 import static org.apache.flink.runtime.execution.ExecutionState.SCHEDULED;
-
 import static org.apache.flink.runtime.messages.TaskMessages.CancelTask;
 import static org.apache.flink.runtime.messages.TaskMessages.FailIntermediateResultPartitions;
 import static org.apache.flink.runtime.messages.TaskMessages.SubmitTask;
@@ -434,7 +433,7 @@ public class Execution implements Serializable {
 	}
 
 	void scheduleOrUpdateConsumers(List<List<ExecutionEdge>> allConsumers) {
-		if (allConsumers.size() != 1) {
+		if (allConsumers.size() > 1) {
 			fail(new IllegalStateException("Currently, only a single consumer group per partition is supported."));
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -219,6 +219,10 @@ public class ExecutionVertex implements Serializable {
 		return this.jobVertex.getGraph();
 	}
 
+	public Map<IntermediateResultPartitionID, IntermediateResultPartition> getProducedPartitions() {
+		return resultPartitions;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Graph building
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -31,17 +31,21 @@ import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
+import scala.Tuple2;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -80,8 +84,9 @@ public class NetworkEnvironment {
 
 	private ResultPartitionConsumableNotifier partitionConsumableNotifier;
 
-	private boolean isShutdown;
+	private PartitionStateChecker partitionStateChecker;
 
+	private boolean isShutdown;
 
 	/**
 	 * Initializes all network I/O components.
@@ -130,6 +135,14 @@ public class NetworkEnvironment {
 		return partitionConsumableNotifier;
 	}
 
+	public PartitionStateChecker getPartitionStateChecker() {
+		return partitionStateChecker;
+	}
+
+	public Tuple2<Integer, Integer> getPartitionRequestInitialAndMaxBackoff() {
+		return configuration.partitionRequestInitialAndMaxBackoff();
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Association / Disassociation with JobManager / TaskManager
 	// --------------------------------------------------------------------------------------------
@@ -170,6 +183,9 @@ public class NetworkEnvironment {
 				this.taskEventDispatcher = new TaskEventDispatcher();
 				this.partitionConsumableNotifier = new JobManagerResultPartitionConsumableNotifier(
 													jobManagerRef, taskManagerRef, new Timeout(jobManagerTimeout));
+
+				this.partitionStateChecker = new JobManagerPartitionStateChecker(
+						jobManagerRef, taskManagerRef);
 
 				// -----  Network connections  -----
 				final Option<NettyConfig> nettyConfig = configuration.nettyConfig();
@@ -225,6 +241,8 @@ public class NetworkEnvironment {
 
 			partitionConsumableNotifier = null;
 
+			partitionStateChecker = null;
+
 			if (taskEventDispatcher != null) {
 				taskEventDispatcher.clearAll();
 				taskEventDispatcher = null;
@@ -234,8 +252,6 @@ public class NetworkEnvironment {
 			networkBufferPool.destroyAllBufferPools();
 		}
 	}
-
-
 
 	// --------------------------------------------------------------------------------------------
 	//  Task operations
@@ -404,9 +420,9 @@ public class NetworkEnvironment {
 
 		private final Timeout jobManagerMessageTimeout;
 
-		public JobManagerResultPartitionConsumableNotifier(ActorRef jobManager,
-															ActorRef taskManager,
-															Timeout jobManagerMessageTimeout) {
+		public JobManagerResultPartitionConsumableNotifier(
+				ActorRef jobManager, ActorRef taskManager, Timeout jobManagerMessageTimeout) {
+
 			this.jobManager = jobManager;
 			this.taskManager = taskManager;
 			this.jobManagerMessageTimeout = jobManagerMessageTimeout;
@@ -433,6 +449,31 @@ public class NetworkEnvironment {
 					taskManager.tell(failMsg, ActorRef.noSender());
 				}
 			}, AkkaUtils.globalExecutionContext());
+		}
+	}
+
+	private static class JobManagerPartitionStateChecker implements PartitionStateChecker {
+
+		private final ActorRef jobManager;
+
+		private final ActorRef taskManager;
+
+		public JobManagerPartitionStateChecker(ActorRef jobManager, ActorRef taskManager) {
+			this.jobManager = jobManager;
+			this.taskManager = taskManager;
+		}
+
+		@Override
+		public void triggerPartitionStateCheck(
+				JobID jobId,
+				ExecutionAttemptID executionAttemptID,
+				IntermediateDataSetID resultId,
+				ResultPartitionID partitionId) {
+
+			RequestPartitionState msg = new RequestPartitionState(
+					jobId, partitionId, executionAttemptID, resultId);
+
+			jobManager.tell(msg, taskManager);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -47,7 +47,7 @@ public class NettyConfig {
 
 	// ------------------------------------------------------------------------
 
-	static enum TransportType {
+	enum TransportType {
 		NIO, EPOLL, AUTO
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -394,7 +394,7 @@ abstract class NettyMessage {
 
 		@Override
 		public String toString() {
-			return String.format("PartitionRequest(%s)", partitionId);
+			return String.format("PartitionRequest(%s:%d)", partitionId, queueIndex);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionStateChecker.java
@@ -16,30 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.test.exampleJavaPrograms;
+package org.apache.flink.runtime.io.network.netty;
 
-import org.apache.flink.examples.java.wordcount.WordCount;
-import org.apache.flink.test.testdata.WordCountData;
-import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
-public class WordCountITCase extends JavaProgramTestBase {
+public interface PartitionStateChecker {
 
-	protected String textPath;
-	protected String resultPath;
+	void triggerPartitionStateCheck(
+			JobID jobId,
+			ExecutionAttemptID executionId,
+			IntermediateDataSetID resultId,
+			ResultPartitionID partitionId);
 
-	@Override
-	protected void preSubmit() throws Exception {
-		textPath = createTempFile("text.txt", WordCountData.TEXT);
-		resultPath = getTempDirPath("result");
-	}
-
-	@Override
-	protected void postSubmit() throws Exception {
-		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
-	}
-
-	@Override
-	protected void testProgram() throws Exception {
-		WordCount.main(new String[] { textPath, resultPath });
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionNotFoundException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionNotFoundException.java
@@ -16,30 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.test.exampleJavaPrograms;
+package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.examples.java.wordcount.WordCount;
-import org.apache.flink.test.testdata.WordCountData;
-import org.apache.flink.test.util.JavaProgramTestBase;
+import java.io.IOException;
 
-public class WordCountITCase extends JavaProgramTestBase {
+public class PartitionNotFoundException extends IOException {
 
-	protected String textPath;
-	protected String resultPath;
+	private static final long serialVersionUID = 0L;
 
-	@Override
-	protected void preSubmit() throws Exception {
-		textPath = createTempFile("text.txt", WordCountData.TEXT);
-		resultPath = getTempDirPath("result");
+	private final ResultPartitionID partitionId;
+
+	public PartitionNotFoundException(ResultPartitionID partitionId) {
+		this.partitionId = partitionId;
+	}
+
+	public ResultPartitionID getPartitionId() {
+		return partitionId;
 	}
 
 	@Override
-	protected void postSubmit() throws Exception {
-		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath);
-	}
-
-	@Override
-	protected void testProgram() throws Exception {
-		WordCount.main(new String[] { textPath, resultPath });
+	public String getMessage() {
+		return "Partition " + partitionId + " not found.";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -170,13 +170,14 @@ class PipelinedSubpartition extends ResultSubpartition {
 	public PipelinedSubpartitionView createReadView(BufferProvider bufferProvider) {
 		synchronized (buffers) {
 			if (readView != null) {
-				throw new IllegalStateException("Subpartition is being or already has been " +
+				throw new IllegalStateException("Subpartition " + index + " of "
+						+ parent.getPartitionId() + " is being or already has been " +
 						"consumed, but pipelined subpartitions can only be consumed once.");
 			}
 
 			readView = new PipelinedSubpartitionView(this);
 
-			LOG.debug("Created {}.", readView);
+			LOG.debug("Created read view for subpartition {} of partition {}.", index, parent.getPartitionId());
 
 			return readView;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -310,6 +311,8 @@ public class ResultPartition implements BufferPoolOwner {
 
 		checkState(refCnt != -1, "Partition released.");
 		checkState(refCnt > 0, "Partition not pinned.");
+
+		checkElementIndex(index, subpartitions.length, "Subpartition not found.");
 
 		return subpartitions[index].createReadView(bufferProvider);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -73,10 +73,10 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 					partitionId.getPartitionId());
 
 			if (partition == null) {
-				throw new IOException("Unknown partition " + partitionId + ".");
+				throw new PartitionNotFoundException(partitionId);
 			}
 
-			LOG.debug("Requested partition {}.", partition);
+			LOG.debug("Requesting subpartition {} of {}.", subpartitionIndex, partition);
 
 			return partition.createSubpartitionView(subpartitionIndex, bufferProvider);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -25,16 +25,16 @@ import java.io.IOException;
 
 public interface InputGate {
 
-	public int getNumberOfInputChannels();
+	int getNumberOfInputChannels();
 
-	public boolean isFinished();
+	boolean isFinished();
 
-	public void requestPartitions() throws IOException, InterruptedException;
+	void requestPartitions() throws IOException, InterruptedException;
 
-	public BufferOrEvent getNextBufferOrEvent() throws IOException, InterruptedException;
+	BufferOrEvent getNextBufferOrEvent() throws IOException, InterruptedException;
 
-	public void sendTaskEvent(TaskEvent event) throws IOException;
+	void sendTaskEvent(TaskEvent event) throws IOException;
 
-	public void registerListener(EventListener<InputGate> listener);
+	void registerListener(EventListener<InputGate> listener);
 
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.client.{SerializedJobExecutionResult, JobStatusM
 import org.apache.flink.runtime.executiongraph.{ExecutionAttemptID, ExecutionGraph}
 import org.apache.flink.runtime.instance.{InstanceID, Instance}
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID
-import org.apache.flink.runtime.jobgraph.{JobGraph, JobStatus, JobVertexID}
+import org.apache.flink.runtime.jobgraph.{IntermediateDataSetID, JobGraph, JobStatus, JobVertexID}
 
 import scala.collection.JavaConverters._
 
@@ -69,6 +69,21 @@ object JobManagerMessages {
    * @param splitData
    */
   case class NextInputSplit(splitData: Array[Byte])
+
+  /**
+   * Requests the current state of the partition.
+   *
+   * The state of a partition is currently bound to the state of the producing execution.
+   * 
+   * @param jobId The job ID of the job, which produces the partition.
+   * @param partitionId The partition ID of the partition to request the state of.
+   * @param taskExecutionId The execution attempt ID of the task requesting the partition state.
+   * @param taskResultId The input gate ID of the task requesting the partition state.
+   */
+  case class RequestPartitionState(jobId: JobID,
+                                   partitionId: ResultPartitionID,
+                                   taskExecutionId: ExecutionAttemptID,
+                                   taskResultId: IntermediateDataSetID)
 
   /**
    * Notifies the [[org.apache.flink.runtime.jobmanager.JobManager]] about available data for a

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
@@ -18,14 +18,16 @@
 
 package org.apache.flink.runtime.messages
 
-import org.apache.flink.runtime.deployment.{TaskDeploymentDescriptor, InputChannelDeploymentDescriptor}
+import org.apache.flink.runtime.deployment.{InputChannelDeploymentDescriptor, TaskDeploymentDescriptor}
+import org.apache.flink.runtime.execution.ExecutionState
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID
+import org.apache.flink.runtime.jobgraph.{IntermediateDataSetID, IntermediateResultPartitionID}
+import org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState
 import org.apache.flink.runtime.taskmanager.TaskExecutionState
 
 /**
  * A set of messages that control the deployment and the state of Tasks executed
- * on the TaskManager
+ * on the TaskManager.
  */
 object TaskMessages {
 
@@ -79,6 +81,15 @@ object TaskMessages {
   // --------------------------------------------------------------------------
   //  Updates to Intermediate Results
   // --------------------------------------------------------------------------
+
+  /**
+   * Answer to a [[RequestPartitionState]] with the state of the respective partition.
+   */
+  case class PartitionState(
+    taskExecutionId: ExecutionAttemptID,
+    taskResultId: IntermediateDataSetID,
+    partitionId: IntermediateResultPartitionID,
+    state: ExecutionState) extends TaskMessage
 
   /**
    * Base class for messages that update the information about location of input partitions

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
@@ -21,7 +21,9 @@ package org.apache.flink.runtime.taskmanager
 import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
 import org.apache.flink.runtime.io.network.netty.NettyConfig
 
-case class NetworkEnvironmentConfiguration(numNetworkBuffers: Int,
-                                           networkBufferSize: Int,
-                                           ioMode: IOMode,
-                                           nettyConfig: Option[NettyConfig] = None)
+case class NetworkEnvironmentConfiguration(
+  numNetworkBuffers: Int,
+  networkBufferSize: Int,
+  ioMode: IOMode,
+  nettyConfig: Option[NettyConfig] = None,
+  partitionRequestInitialAndMaxBackoff: Tuple2[Integer, Integer] = (50, 3000))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.junit.Test;
 import org.mockito.Mockito;
 import scala.Some;
+import scala.Tuple2;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.net.InetAddress;
@@ -54,7 +55,8 @@ public class NetworkEnvironmentTest {
 		try {
 			NettyConfig nettyConf = new NettyConfig(InetAddress.getLocalHost(), port, BUFFER_SIZE, new Configuration());
 			NetworkEnvironmentConfiguration config = new NetworkEnvironmentConfiguration(
-					NUM_BUFFERS, BUFFER_SIZE, IOManager.IOMode.SYNC, new Some<NettyConfig>(nettyConf));
+					NUM_BUFFERS, BUFFER_SIZE, IOManager.IOMode.SYNC, new Some<NettyConfig>(nettyConf),
+					new Tuple2<Integer, Integer>(0, 0));
 
 			NetworkEnvironment env = new NetworkEnvironment(new FiniteDuration(30, TimeUnit.SECONDS), config);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -21,11 +21,13 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import com.google.common.collect.Lists;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -224,9 +226,12 @@ public class LocalInputChannelTest {
 
 			this.inputGate = new SingleInputGate(
 					"Test Name",
+					new JobID(),
+					new ExecutionAttemptID(),
 					new IntermediateDataSetID(),
 					subpartitionIndex,
-					numberOfInputChannels);
+					numberOfInputChannels,
+					mock(PartitionStateChecker.class));
 
 			// Set buffer pool
 			inputGate.setBufferPool(bufferPool);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
@@ -29,6 +30,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
@@ -36,6 +38,7 @@ import org.apache.flink.runtime.io.network.util.TestTaskEvent;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.junit.Test;
+import scala.Tuple2;
 
 import java.io.IOException;
 
@@ -59,7 +62,7 @@ public class SingleInputGateTest {
 	public void testBasicGetNextLogic() throws Exception {
 		// Setup
 		final SingleInputGate inputGate = new SingleInputGate(
-				"Test Task Name", new IntermediateDataSetID(), 0, 2);
+				"Test Task Name", new JobID(), new ExecutionAttemptID(), new IntermediateDataSetID(), 0, 2, mock(PartitionStateChecker.class));
 
 		final TestInputChannel[] inputChannels = new TestInputChannel[]{
 				new TestInputChannel(inputGate, 0),
@@ -105,7 +108,7 @@ public class SingleInputGateTest {
 		// Setup reader with one local and one unknown input channel
 		final IntermediateDataSetID resultId = new IntermediateDataSetID();
 
-		final SingleInputGate inputGate = new SingleInputGate("Test Task Name", resultId, 0, 2);
+		final SingleInputGate inputGate = new SingleInputGate("Test Task Name", new JobID(), new ExecutionAttemptID(), resultId, 0, 2, mock(PartitionStateChecker.class));
 		final BufferPool bufferPool = mock(BufferPool.class);
 		when(bufferPool.getNumberOfRequiredMemorySegments()).thenReturn(2);
 
@@ -119,7 +122,7 @@ public class SingleInputGateTest {
 		// Unknown
 		ResultPartitionID unknownPartitionId = new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID());
 
-		InputChannel unknown = new UnknownInputChannel(inputGate, 1, unknownPartitionId, partitionManager, taskEventDispatcher, mock(ConnectionManager.class));
+		InputChannel unknown = new UnknownInputChannel(inputGate, 1, unknownPartitionId, partitionManager, taskEventDispatcher, mock(ConnectionManager.class), new Tuple2<Integer, Integer>(0, 0));
 
 		// Set channels
 		inputGate.setInputChannel(localPartitionId.getPartitionId(), local);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestSingleInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestSingleInputGate.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
@@ -29,6 +32,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -48,7 +52,7 @@ public class TestSingleInputGate {
 		checkArgument(numberOfInputChannels >= 1);
 
 		this.inputGate = spy(new SingleInputGate(
-				"Test Task Name", new IntermediateDataSetID(), 0, numberOfInputChannels));
+				"Test Task Name", new JobID(), new ExecutionAttemptID(), new IntermediateDataSetID(), 0, numberOfInputChannels, mock(PartitionStateChecker.class)));
 
 		this.inputChannels = new TestInputChannel[numberOfInputChannels];
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
 import org.junit.Test;
@@ -25,6 +28,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class UnionInputGateTest {
 
@@ -39,8 +43,8 @@ public class UnionInputGateTest {
 	public void testBasicGetNextLogic() throws Exception {
 		// Setup
 		final String testTaskName = "Test Task";
-		final SingleInputGate ig1 = new SingleInputGate(testTaskName, new IntermediateDataSetID(), 0, 3);
-		final SingleInputGate ig2 = new SingleInputGate(testTaskName, new IntermediateDataSetID(), 0, 5);
+		final SingleInputGate ig1 = new SingleInputGate(testTaskName, new JobID(), new ExecutionAttemptID(), new IntermediateDataSetID(), 0, 3, mock(PartitionStateChecker.class));
+		final SingleInputGate ig2 = new SingleInputGate(testTaskName, new JobID(), new ExecutionAttemptID(), new IntermediateDataSetID(), 0, 5, mock(PartitionStateChecker.class));
 
 		final UnionInputGate union = new UnionInputGate(new SingleInputGate[]{ig1, ig2});
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -15,20 +15,64 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.jobmanager;
 
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Status;
+import akka.testkit.JavaTestKit;
 import com.typesafe.config.Config;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState;
+import org.apache.flink.runtime.messages.TaskMessages.PartitionState;
+import org.apache.flink.runtime.testingUtils.TestingCluster;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.ExecutionGraphFound;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.RequestExecutionGraph;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunningOrFinished;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import scala.Some;
 import scala.Tuple2;
 
 import java.net.InetAddress;
 
-import static org.junit.Assert.*;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.testingUtils.TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT;
+import static org.apache.flink.runtime.testingUtils.TestingUtils.startTestingCluster;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class JobManagerTest {
+
+	private static ActorSystem system;
+
+	@BeforeClass
+	public static void setup() {
+		system = AkkaUtils.createLocalActorSystem(new Configuration());
+	}
+
+	@AfterClass
+	public static void teardown() {
+		JavaTestKit.shutdownActorSystem(system);
+	}
 
 	@Test
 	public void testNullHostnameGoesToLocalhost() {
@@ -44,5 +88,114 @@ public class JobManagerTest {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	/**
+	 * Tests responses to partition state requests.
+	 */
+	@Test
+	public void testRequestPartitionState() throws Exception {
+		new JavaTestKit(system) {{
+			// Setup
+			TestingCluster cluster = null;
+
+			try {
+				cluster = startTestingCluster(2, 1, DEFAULT_AKKA_ASK_TIMEOUT());
+
+				final IntermediateDataSetID rid = new IntermediateDataSetID();
+
+				// Create a task
+				final AbstractJobVertex sender = new AbstractJobVertex("Sender");
+				sender.setParallelism(1);
+				sender.setInvokableClass(Tasks.BlockingNoOpInvokable.class); // just block
+				sender.createAndAddResultDataSet(rid, PIPELINED);
+
+				final JobGraph jobGraph = new JobGraph("Blocking test job", sender);
+				final JobID jid = jobGraph.getJobID();
+
+				final ActorRef jm = cluster.getJobManager();
+
+				// Submit the job and wait for all vertices to be running
+				jm.tell(new JobManagerMessages.SubmitJob(jobGraph, false), getTestActor());
+				expectMsgClass(Status.Success.class);
+
+				jm.tell(new WaitForAllVerticesToBeRunningOrFinished(jobGraph.getJobID()),
+						getTestActor());
+
+				expectMsgClass(TestingJobManagerMessages.AllVerticesRunning.class);
+
+				// This is the mock execution ID of the task requesting the state of the partition
+				final ExecutionAttemptID receiver = new ExecutionAttemptID();
+
+				// Request the execution graph to get the runtime info
+				jm.tell(new RequestExecutionGraph(jid), getTestActor());
+
+				final ExecutionGraph eg = expectMsgClass(ExecutionGraphFound.class)
+						.executionGraph();
+
+				final ExecutionVertex vertex = eg.getJobVertex(sender.getID())
+						.getTaskVertices()[0];
+
+				final IntermediateResultPartition partition = vertex.getProducedPartitions()
+						.values().iterator().next();
+
+				final ResultPartitionID partitionId = new ResultPartitionID(
+						partition.getPartitionId(),
+						vertex.getCurrentExecutionAttempt().getAttemptId());
+
+				// - The test ----------------------------------------------------------------------
+
+				// 1. All execution states
+				RequestPartitionState request = new RequestPartitionState(
+						jid, partitionId, receiver, rid);
+
+				for (ExecutionState state : ExecutionState.values()) {
+					ExecutionGraphTestUtils.setVertexState(vertex, state);
+
+					jm.tell(request, getTestActor());
+
+					PartitionState resp = expectMsgClass(PartitionState.class);
+
+					assertEquals(request.taskExecutionId(), resp.taskExecutionId());
+					assertEquals(request.taskResultId(), resp.taskResultId());
+					assertEquals(request.partitionId().getPartitionId(), resp.partitionId());
+					assertEquals(state, resp.state());
+				}
+
+				// 2. Non-existing execution
+				request = new RequestPartitionState(jid, new ResultPartitionID(), receiver, rid);
+
+				jm.tell(request, getTestActor());
+
+				PartitionState resp = expectMsgClass(PartitionState.class);
+
+				assertEquals(request.taskExecutionId(), resp.taskExecutionId());
+				assertEquals(request.taskResultId(), resp.taskResultId());
+				assertEquals(request.partitionId().getPartitionId(), resp.partitionId());
+				assertNull(resp.state());
+
+				// 3. Non-existing job
+				request = new RequestPartitionState(
+						new JobID(), new ResultPartitionID(), receiver, rid);
+
+				jm.tell(request, getTestActor());
+
+				resp = expectMsgClass(PartitionState.class);
+
+				assertEquals(request.taskExecutionId(), resp.taskExecutionId());
+				assertEquals(request.taskResultId(), resp.taskResultId());
+				assertEquals(request.partitionId().getPartitionId(), resp.partitionId());
+				assertNull(resp.state());
+			}
+			catch (Exception e) {
+				e.printStackTrace();
+				fail(e.getMessage());
+			}
+			finally {
+				if (cluster != null) {
+					cluster.shutdown();
+				}
+			}
+		}};
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.junit.Test;
 import scala.Option;
+import scala.Tuple2;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.net.InetAddress;
@@ -79,7 +80,8 @@ public class TaskManagerComponentsStartupShutdownTest {
 					config);
 
 			final NetworkEnvironmentConfiguration netConf = new NetworkEnvironmentConfiguration(
-					32, BUFFER_SIZE, IOManager.IOMode.SYNC, Option.<NettyConfig>empty());
+					32, BUFFER_SIZE, IOManager.IOMode.SYNC, Option.<NettyConfig>empty(),
+					new Tuple2<Integer, Integer>(0, 0));
 
 			final InstanceConnectionInfo connectionInfo = new InstanceConnectionInfo(InetAddress.getLocalHost(), 10000);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -27,49 +27,49 @@ import akka.japi.Creator;
 import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
 import akka.util.Timeout;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.Tasks;
-import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.Messages;
 import org.apache.flink.runtime.messages.RegistrationMessages;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
-import org.apache.flink.runtime.messages.TaskMessages;
 import org.apache.flink.runtime.messages.TaskMessages.CancelTask;
+import org.apache.flink.runtime.messages.TaskMessages.PartitionState;
 import org.apache.flink.runtime.messages.TaskMessages.SubmitTask;
 import org.apache.flink.runtime.messages.TaskMessages.TaskOperationResult;
+import org.apache.flink.runtime.net.NetUtils;
 import org.apache.flink.runtime.testingUtils.TestingTaskManager;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -78,6 +78,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.runtime.messages.JobManagerMessages.ConsumerNotificationResult;
+import static org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState;
+import static org.apache.flink.runtime.messages.JobManagerMessages.ScheduleOrUpdateConsumers;
+import static org.apache.flink.runtime.messages.TaskMessages.UpdateTaskExecutionState;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -160,11 +164,11 @@ public class TaskManagerTest {
 						} while (System.currentTimeMillis() < deadline);
 
 						// task should have switched to running
-						Object toRunning = new TaskMessages.UpdateTaskExecutionState(
+						Object toRunning = new UpdateTaskExecutionState(
 								new TaskExecutionState(jid, eid, ExecutionState.RUNNING));
 
 						// task should have switched to finished
-						Object toFinished = new TaskMessages.UpdateTaskExecutionState(
+						Object toFinished = new UpdateTaskExecutionState(
 								new TaskExecutionState(jid, eid, ExecutionState.FINISHED));
 						
 						deadline = System.currentTimeMillis() + 10000;
@@ -682,6 +686,91 @@ public class TaskManagerTest {
 		}};
 	}
 
+	/**
+	 * Tests that repeated {@link PartitionNotFoundException}s fail the receiver.
+	 */
+	@Test
+	public void testPartitionNotFound() throws Exception {
+
+		new JavaTestKit(system){{
+
+			ActorRef jobManager = null;
+			ActorRef taskManager = null;
+
+			try {
+				final IntermediateDataSetID resultId = new IntermediateDataSetID();
+
+				// Create the JM
+				jobManager = system.actorOf(Props.create(
+						new SimplePartitionStateLookupJobManagerCreator(resultId, getTestActor())));
+
+				final int dataPort = NetUtils.getAvailablePort();
+				taskManager = createTaskManager(jobManager, true, false, dataPort);
+
+				// ---------------------------------------------------------------------------------
+
+				final ActorRef tm = taskManager;
+
+				final JobID jid = new JobID();
+				final JobVertexID vid = new JobVertexID();
+				final ExecutionAttemptID eid = new ExecutionAttemptID();
+
+				final ResultPartitionID partitionId = new ResultPartitionID();
+
+				// Remote location (on the same TM though) for the partition
+				final ResultPartitionLocation loc = ResultPartitionLocation
+						.createRemote(new ConnectionID(
+								new InetSocketAddress("localhost", dataPort), 0));
+
+				final InputChannelDeploymentDescriptor[] icdd =
+						new InputChannelDeploymentDescriptor[] {
+								new InputChannelDeploymentDescriptor(partitionId, loc)};
+
+				final InputGateDeploymentDescriptor igdd =
+						new InputGateDeploymentDescriptor(resultId, 0, icdd);
+
+				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+						jid, vid, eid, "Receiver", 0, 1,
+						new Configuration(), new Configuration(),
+						Tasks.AgnosticReceiver.class.getName(),
+						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+						Collections.singletonList(igdd),
+						Collections.<BlobKey>emptyList(), 0);
+
+				new Within(d) {
+					@Override
+					protected void run() {
+						// Submit the task
+						tm.tell(new SubmitTask(tdd), getTestActor());
+						expectMsgClass(Messages.getAcknowledge().getClass());
+
+						// Wait to be notified about the final execution state by the mock JM
+						TaskExecutionState msg = expectMsgClass(TaskExecutionState.class);
+
+						// The task should fail after repeated requests
+						assertEquals(msg.getExecutionState(), ExecutionState.FAILED);
+						assertEquals(msg.getError(ClassLoader.getSystemClassLoader()).getClass(),
+								PartitionNotFoundException.class);
+					}
+				};
+			}
+			catch(Exception e) {
+				e.printStackTrace();
+				fail(e.getMessage());
+			}
+			finally {
+				if (taskManager != null) {
+					taskManager.tell(Kill.getInstance(), ActorRef.noSender());
+				}
+
+				if (jobManager != null) {
+					jobManager.tell(Kill.getInstance(), ActorRef.noSender());
+				}
+			}
+		}};
+	}
+
+
 	// --------------------------------------------------------------------------------------------
 
 	public static class SimpleJobManager extends UntypedActor {
@@ -693,7 +782,7 @@ public class TaskManagerTest {
 				final ActorRef self = getSelf();
 				getSender().tell(new RegistrationMessages.AcknowledgeRegistration(self, iid, 12345), self);
 			}
-			else if(message instanceof TaskMessages.UpdateTaskExecutionState){
+			else if(message instanceof UpdateTaskExecutionState){
 				getSender().tell(true, getSelf());
 			}
 		}
@@ -703,8 +792,8 @@ public class TaskManagerTest {
 
 		@Override
 		public void onReceive(Object message) throws Exception {
-			if (message instanceof JobManagerMessages.ScheduleOrUpdateConsumers) {
-				getSender().tell(new JobManagerMessages.ConsumerNotificationResult(true, scala.Option.<Throwable>apply(null)), getSelf());
+			if (message instanceof ScheduleOrUpdateConsumers) {
+				getSender().tell(new ConsumerNotificationResult(true, scala.Option.<Throwable>apply(null)), getSelf());
 			} else {
 				super.onReceive(message);
 			}
@@ -721,14 +810,48 @@ public class TaskManagerTest {
 
 		@Override
 		public void onReceive(Object message) throws Exception{
-			if (message instanceof TaskMessages.UpdateTaskExecutionState) {
-				TaskMessages.UpdateTaskExecutionState updateMsg =
-						(TaskMessages.UpdateTaskExecutionState) message;
+			if (message instanceof UpdateTaskExecutionState) {
+				UpdateTaskExecutionState updateMsg =
+						(UpdateTaskExecutionState) message;
 
 				if(validIDs.contains(updateMsg.taskExecutionState().getID())) {
 					getSender().tell(true, getSelf());
 				} else {
 					getSender().tell(false, getSelf());
+				}
+			} else {
+				super.onReceive(message);
+			}
+		}
+	}
+
+	public static class SimplePartitionStateLookupJobManager extends SimpleJobManager {
+
+		private final ActorRef testActor;
+
+		public SimplePartitionStateLookupJobManager(ActorRef testActor) {
+			this.testActor = testActor;
+		}
+
+		@Override
+		public void onReceive(Object message) throws Exception {
+			if (message instanceof RequestPartitionState) {
+				final RequestPartitionState msg = (RequestPartitionState) message;
+
+				PartitionState resp = new PartitionState(
+						msg.taskExecutionId(),
+						msg.taskResultId(),
+						msg.partitionId().getPartitionId(),
+						ExecutionState.RUNNING);
+
+				getSender().tell(resp, getSelf());
+			}
+			else if (message instanceof UpdateTaskExecutionState) {
+				final TaskExecutionState msg = ((UpdateTaskExecutionState) message)
+						.taskExecutionState();
+
+				if (msg.getExecutionState().isTerminal()) {
+					testActor.tell(msg, self());
 				}
 			} else {
 				super.onReceive(message);
@@ -762,11 +885,30 @@ public class TaskManagerTest {
 		}
 	}
 
+	public static class SimplePartitionStateLookupJobManagerCreator implements Creator<SimplePartitionStateLookupJobManager>{
+
+		private final ActorRef testActor;
+
+		public SimplePartitionStateLookupJobManagerCreator(IntermediateDataSetID dataSetId, ActorRef testActor) {
+			this.testActor = testActor;
+		}
+
+		@Override
+		public SimplePartitionStateLookupJobManager create() throws Exception {
+			return new SimplePartitionStateLookupJobManager(testActor);
+		}
+	}
+
 	public static ActorRef createTaskManager(ActorRef jobManager, boolean waitForRegistration) {
+		return createTaskManager(jobManager, waitForRegistration, true, NetUtils.getAvailablePort());
+	}
+
+	public static ActorRef createTaskManager(ActorRef jobManager, boolean waitForRegistration, boolean useLocalCommunication, int dataPort) {
 		ActorRef taskManager = null;
 		try {
 			Configuration cfg = new Configuration();
 			cfg.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 10);
+			cfg.setInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY, dataPort);
 
 			Option<String> jobMangerUrl = Option.apply(jobManager.path().toString());
 
@@ -774,7 +916,7 @@ public class TaskManagerTest {
 					cfg, system, "localhost",
 					Option.<String>empty(),
 					jobMangerUrl,
-					true, TestingTaskManager.class);
+					useLocalCommunication, TestingTaskManager.class);
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -23,6 +23,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Kill;
 import akka.actor.Props;
 
+import com.google.common.collect.Maps;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobKey;
@@ -38,7 +39,10 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
@@ -51,7 +55,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -64,8 +70,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -560,7 +569,7 @@ public class TaskTest {
 	}
 
 	@Test
-	public void testExecutionFailesAfterTaskMarkedFailed() {
+	public void testExecutionFailsAfterTaskMarkedFailed() {
 		try {
 			Task task = createTask(InvokableWithExceptionOnTrigger.class);
 			task.registerExecutionListener(listenerActor);
@@ -592,6 +601,78 @@ public class TaskTest {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testOnPartitionStateUpdate() throws Exception {
+		IntermediateDataSetID resultId = new IntermediateDataSetID();
+		ResultPartitionID partitionId = new ResultPartitionID();
+
+		SingleInputGate inputGate = mock(SingleInputGate.class);
+		when(inputGate.getConsumedResultId()).thenReturn(resultId);
+
+		final Task task = createTask(InvokableBlockingInInvoke.class);
+
+		// Set the mock input gate
+		setInputGate(task, inputGate);
+
+		// Expected task state for each partition state
+		final Map<ExecutionState, ExecutionState> expected = Maps
+				.newHashMapWithExpectedSize(ExecutionState.values().length);
+
+		// Fail the task for unexpected states
+		for (ExecutionState state : ExecutionState.values()) {
+			expected.put(state, ExecutionState.FAILED);
+		}
+
+		expected.put(ExecutionState.RUNNING, ExecutionState.RUNNING);
+
+		expected.put(ExecutionState.CANCELED, ExecutionState.CANCELING);
+		expected.put(ExecutionState.CANCELING, ExecutionState.CANCELING);
+		expected.put(ExecutionState.FAILED, ExecutionState.CANCELING);
+
+		for (ExecutionState state : ExecutionState.values()) {
+			setState(task, ExecutionState.RUNNING);
+
+			task.onPartitionStateUpdate(resultId, partitionId.getPartitionId(), state);
+
+			ExecutionState newTaskState = task.getExecutionState();
+
+			assertEquals(expected.get(state), newTaskState);
+		}
+
+		verify(inputGate, times(1)).retriggerPartitionRequest(eq(partitionId.getPartitionId()));
+	}
+
+	// ------------------------------------------------------------------------
+
+	private void setInputGate(Task task, SingleInputGate inputGate) {
+		try {
+			Field f = Task.class.getDeclaredField("inputGates");
+			f.setAccessible(true);
+			f.set(task, new SingleInputGate[]{inputGate});
+
+			Map<IntermediateDataSetID, SingleInputGate> byId = Maps.newHashMapWithExpectedSize(1);
+			byId.put(inputGate.getConsumedResultId(), inputGate);
+
+			f = Task.class.getDeclaredField("inputGatesById");
+			f.setAccessible(true);
+			f.set(task, byId);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Modifying the task state failed", e);
+		}
+	}
+
+	private void setState(Task task, ExecutionState state) {
+		try {
+			Field f = Task.class.getDeclaredField("executionState");
+			f.setAccessible(true);
+			f.set(task, state);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Modifying the task state failed", e);
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -30,20 +30,20 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ClassLoaderITCase {
-	
+
 	private static final String INPUT_SPLITS_PROG_JAR_FILE = "target/customsplit-test-jar.jar";
 
 	private static final String STREAMING_PROG_JAR_FILE = "target/streamingclassloader-test-jar.jar";
 
 	private static final String KMEANS_JAR_PATH = "target/kmeans-test-jar.jar";
-	
+
 	@Test
 	public void testJobWithCustomInputFormat() {
 		try {
 			Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, 2);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 2);
-			
+
 			ForkableFlinkMiniCluster testCluster = new ForkableFlinkMiniCluster(config, false);
 
 			try {


### PR DESCRIPTION
**Problem**: cancelling of tasks sometimes leads to misleading error messages about "not found partitions". This is an artifact of task cancelling. If a task (consumer) consumes data from another remote task (producer), its sends a partition request over the network. If the producer fails concurrently with this
request, the request returns with a PartitioNotFoundException to the consumer. If this error message is received *before* the consumer is cancelled (as a result of the failing producer), you see the misleading error being attributed to the consumer. This makes it hard to trace the root cause of the problem (the
failing producer).

**Solution**: when a consumer receives a remote PartitionNotFoundException, it asks the central job manager whether the producer is still running or has failed.

If the producer is still running, the partition request is send again (using an exponential back off with default max back off of 3s). If the following requests fail again, the consumer fails with a PartitionNotFoundException.

If the producer has failed, the consumer is cancelled.

If the producer is not running and has not failed, there is a bug either in the consumer task setup (e.g. requesting a non-existing result) or in the network stack (e.g. unsafe publication of produced results), in which case the error is attributed to the consumer.

---

The new Akka messages introduced with this change are only exchanged in error cases and don't affect normal operation.

Normal operation (not affected by this change):
```
TM1 => TM2: request result
TM2 => TM1: result
```

Error case:
```
TM1=>TM2: request result
TM2=>TM1: PartitionNotFoundException
TM1=>JM: check partition state
JM=>TM1: retrigger request -OR- cancel consumer
```