### PR TITLE
[FLINK-2175] Allow multiple jobs in single jar file + [FLINK-2176] Add support for ProgramDesctiption interface in clients

### DIFF
--- a/docs/apis/web_client.md
+++ b/docs/apis/web_client.md
@@ -56,11 +56,13 @@ You can **upload** a Flink program as a jar file. To **execute** an uploaded pro
 
 If the *“Show optimizer plan”* option is enabled (default), the *plan view* is display next, otherwise the job is directly submitted to the JobManager for execution.
 
-In case the jar's manifest file does not specify the program class, you can specify it before the argument list as:
+The web interface can also handle multiple Flink jobs within a single jar file. To use this feature, package all required class files of all jobs into a single jar and specify the entry classes for each job as comma-separated-values in *program-class* argument within the jar's manifest file. The job view displays each entry class and you can pick any of them to preview the plan and/or submit the job to the JobManager. In case the jar's manifest file does not specify any entry class, you can specify it before the argument list as:
 
 ```
 -c <assemblerClass> <programArgs...>
 ```
+
+Furthermore, for each entry class implementing ```ProgramDescription``` interface, the provided description is shown as tooltip for the job (see {% gh_link flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCountMeta.java  "WordCountMeta example" %}).
 
 ### Plan View
 

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -378,6 +378,16 @@ public class CliFrontend {
 			else {
 				System.out.println("JSON plan could not be generated.");
 			}
+
+			String description = program.getDescription();
+			if (description != null) {
+				System.out.println();
+				System.out.println(description);
+			}
+			else {
+				System.out.println();
+				System.out.println("No description provided.");
+			}
 			return 0;
 		}
 		catch (Throwable t) {

--- a/flink-clients/src/main/java/org/apache/flink/client/web/JobsServlet.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/web/JobsServlet.java
@@ -27,6 +27,8 @@ import java.util.Comparator;
 import java.util.GregorianCalendar;
 import java.util.Iterator;
 import java.util.List;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -38,6 +40,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.flink.client.program.PackagedProgram;
 
 /**
  * A servlet that accepts uploads of pact programs, returns a listing of the
@@ -138,11 +141,26 @@ public class JobsServlet extends HttpServlet {
 					continue;
 				}
 
+				JarFile jar = new JarFile(files[i]);
+				Manifest manifest = jar.getManifest();
+				String assemblerClass = null;
+				if (manifest != null) {
+					assemblerClass = manifest.getMainAttributes().getValue(PackagedProgram.MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS);
+					if (assemblerClass == null) {
+						assemblerClass = manifest.getMainAttributes().getValue(PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS);
+					}
+				}
+				if (assemblerClass == null) {
+					assemblerClass = "";
+				} else {
+					assemblerClass = '\t' + assemblerClass;
+				}
+
 				cal.setTimeInMillis(files[i].lastModified());
 				writer.println(files[i].getName() + '\t' + (cal.get(GregorianCalendar.MONTH) + 1) + '/'
 					+ cal.get(GregorianCalendar.DAY_OF_MONTH) + '/' + cal.get(GregorianCalendar.YEAR) + ' '
 					+ cal.get(GregorianCalendar.HOUR_OF_DAY) + ':' + cal.get(GregorianCalendar.MINUTE) + ':'
-					+ cal.get(GregorianCalendar.SECOND));
+					+ cal.get(GregorianCalendar.SECOND) + assemblerClass);
 			}
 		} else if (action.equals(ACTION_DELETE_VALUE)) {
 			String filename = req.getParameter(FILENAME_PARAM_NAME);

--- a/flink-clients/src/main/java/org/apache/flink/client/web/PactJobJSONServlet.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/web/PactJobJSONServlet.java
@@ -44,6 +44,8 @@ public class PactJobJSONServlet extends HttpServlet {
 
 	private static final String JOB_PARAM_NAME = "job";
 
+	private static final String CLASS_PARAM_NAME = "assemblerClass";
+
 	// ------------------------------------------------------------------------
 
 	private final File jobStoreDirectory; // the directory in which the jobs are stored
@@ -74,7 +76,7 @@ public class PactJobJSONServlet extends HttpServlet {
 		// create the pact plan
 		PackagedProgram pactProgram;
 		try {
-			pactProgram = new PackagedProgram(jarFile, new String[0]);
+			pactProgram = new PackagedProgram(jarFile, req.getParameter(CLASS_PARAM_NAME), new String[0]);
 		}
 		catch (Throwable t) {
 			LOG.info("Instantiating the PactProgram for '" + jarFile.getName() + "' failed.", t);

--- a/flink-clients/src/main/resources/web-docs/js/program.js
+++ b/flink-clients/src/main/resources/web-docs/js/program.js
@@ -150,7 +150,9 @@ function createJobList(data)
 {
   var markup = "";
   
-  var lines = data.split("\n");
+  var entries = data.split("#_#");
+  
+  var lines = entries[0].split("\n");
   for (var i = 0; i < lines.length; i++)
   {
     if (lines[i] == null || lines[i].length == 0) {
@@ -179,9 +181,10 @@ function createJobList(data)
     markup += '<td><p class="JobListItemsDate">' + date + '</p></td>';
     markup += '<td width="30px"><img class="jobItemDeleteIcon" src="img/delete-icon.png" width="24" height="24" /></td></tr>';
     
+    var i = 0;
     for (var idx in classes) {
       markup += '<tr><td width="30px;"><input id="' + classes[idx] + '" class="jobItemCheckbox" type="checkbox"></td>';
-      markup += '<td colspan="3"><p class="JobListItemsDate">' + classes[idx] + '</p></td></tr>';
+      markup += '<td colspan="3"><p class="JobListItemsDate" title="' + entries[++i] + '">' + classes[idx] + '</p></td></tr>';
     }
     markup += '</table></div>';
   }

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCountMeta.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/wordcount/WordCountMeta.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.examples.java.wordcount;
+
+import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.examples.java.wordcount.util.WordCountData;
+
+/**
+ * Same as {@link WorkCount} but implements {@link ProgramDescription} interface.
+ * 
+ * <p>
+ * The input is a plain text file with lines separated by newline characters.
+ * 
+ * <p>
+ * Usage: <code>WordCountProgram [&lt;text path&gt; &lt;result path&gt;]</code><br>
+ * If no parameters are provided, the program is run with default data from {@link WordCountData}.
+ * 
+ * <p>
+ * This example shows:
+ * <ul>
+ * <li>how to provide additional information (using {@link ProgramDescription} interface}, that can be displayed by
+ * Flink clients, ie, {@link bin/flink} and WebClient</li>
+ * </ul>
+ * 
+ */
+public class WordCountMeta extends WordCount implements ProgramDescription {
+
+	public static void main(String[] args) throws Exception {
+		WordCount.main(args);
+	}
+
+	@Override
+	public String getDescription() {
+		return "Simple Word-Count Example\n"
+				+ "Parameters: [<text path> <result path>]\n"
+				+ "If no parameters are provided, the example will run with built-in default data.";
+	}
+}


### PR DESCRIPTION
- program-class and Main-Class can contain multiple comma separated entry classes
- WebClient shows checkbox for each entry class and can display plan for it
- WebClient shows ProgramDescription as tooltip
- CLI shows ProgramDescription in "info" command
- added WordCountMeta example