### PR TITLE
[YARN] Cut off 25% of the heap as a safety margin

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -324,6 +324,11 @@ to set the JM host:port manually. It is recommended to leave this option at 1.
 
 - `yarn.heartbeat-delay` (Default: 5 seconds). Time between heartbeats with the ResourceManager.
 
+
+## System
+
+- `env.java.opts` Custom JVM options
+
 ## Background
 
 ### Configuring the Network Buffers

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -604,7 +604,7 @@ public class ExecutionConfig implements Serializable {
 	}
 
 	/**
-	 * Interface for custom user configuration object registered at the execution config.
+	 * Abstract class for a custom user configuration object registered at the execution config.
 	 *
 	 * This user config is accessible at runtime through
 	 * getRuntimeContext().getExecutionConfig().getUserConfig()

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -551,7 +551,7 @@ public final class ConfigConstants {
 
 	public static final int DEFAULT_YARN_MIN_HEAP_CUTOFF = 384;
 
-	public static final float DEFAULT_YARN_HEAP_CUTOFF_RATIO = 0.15f;
+	public static final float DEFAULT_YARN_HEAP_CUTOFF_RATIO = 0.25f;
 	
 	
 	// ------------------------ File System Behavior ------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/JobManagerInfoServlet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/JobManagerInfoServlet.java
@@ -409,19 +409,29 @@ public class JobManagerInfoServlet extends HttpServlet {
 				wrt.write("\"Job parallelism\": \""+ec.getParallelism()+"\",");
 				wrt.write("\"Object reuse mode\": \""+ec.isObjectReuseEnabled()+"\"");
 				ExecutionConfig.GlobalJobParameters uc = ec.getGlobalJobParameters();
-				Map<String, String> ucVals = uc.toMap();
-				if(ucVals != null) {
-					String ucString = "{";
-					int i = 0;
-					for (Map.Entry<String, String> ucVal: ucVals.entrySet()) {
-						ucString += "\""+ucVal.getKey()+"\":\""+ucVal.getValue()+"\"";
-						if (++i < ucVals.size()) {
-							ucString += ",\n";
+				if(uc != null) {
+					Map<String, String> ucVals = uc.toMap();
+					if (ucVals != null) {
+						String ucString = "{";
+						int i = 0;
+						for (Map.Entry<String, String> ucVal : ucVals.entrySet()) {
+							ucString += "\"" + ucVal.getKey() + "\":\"" + ucVal.getValue() + "\"";
+							if (++i < ucVals.size()) {
+								ucString += ",\n";
+							}
 						}
+						wrt.write(", \"userConfig\": " + ucString + "}");
 					}
-					wrt.write(", \"userConfig\": "+ucString+"}");
+					else {
+						LOG.info("GlobalJobParameters.toMap() did not return anything");
+					}
+				}
+				else {
+					LOG.info("No GlobalJobParameters were set in the execution config");
 				}
 				wrt.write("},");
+			} else {
+				LOG.warn("Unable to retrieve execution config from execution graph");
 			}
 
 			// write accumulators


### PR DESCRIPTION
Users were reporting issues with Flink on YARN because the NodeManager was killing containers due to resource overuse.

When a user requests for example a 4GB TaskManager, we can not just set the -Xmx value to 4G, because then the linux process (thats what YARN is monitoring) is growing bigger than 4GB. Also, YARN is very very strict with that limit.

So what we do is we remove a certain amount of the user specified memory. In the past, we were using 15%, but that was apparently not enough.

I've played around a lot and it seems that 25% is a good value.

This pull request also fixes potential null pointer exceptions in the web frontend and adds thread and classloader logging to the taskamangers.
Please discuss whether you want this.