### PR TITLE
Change FlinkMiniCluster#HOSTNAME to FlinkMiniCluster#hostname to match naming convention.

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -56,7 +56,7 @@ abstract class FlinkMiniCluster(val userConfiguration: Configuration,
 
   // NOTE: THIS MUST BE getByName("localhost"), which is 127.0.0.1 and
   // not getLocalHost(), which may be 127.0.1.1
-  val HOSTNAME = InetAddress.getByName("localhost").getHostAddress()
+  val hostname = InetAddress.getByName("localhost").getHostAddress()
 
   val timeout = AkkaUtils.getTimeout(userConfiguration)
 
@@ -100,7 +100,7 @@ abstract class FlinkMiniCluster(val userConfiguration: Configuration,
       val port = configuration.getInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY,
         ConfigConstants.DEFAULT_JOB_MANAGER_IPC_PORT)
 
-      AkkaUtils.getAkkaConfig(configuration, Some((HOSTNAME, port)))
+      AkkaUtils.getAkkaConfig(configuration, Some((hostname, port)))
     }
   }
 
@@ -115,7 +115,7 @@ abstract class FlinkMiniCluster(val userConfiguration: Configuration,
 
     val resolvedPort = if(port != 0) port + index else port
 
-    AkkaUtils.getAkkaConfig(configuration, Some((HOSTNAME, resolvedPort)))
+    AkkaUtils.getAkkaConfig(configuration, Some((hostname, resolvedPort)))
   }
 
   def startTaskManagerActorSystem(index: Int): ActorSystem = {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -105,7 +105,7 @@ class LocalFlinkMiniCluster(userConfiguration: Configuration, singleActorSystem:
     }
 
     TaskManager.startTaskManagerComponentsAndActor(config, system,
-                                                   HOSTNAME, // network interface to bind to
+                                                   hostname, // network interface to bind to
                                                    Some(taskManagerActorName), // actor name
                                                    jobManagerPath, // job manager akka URL
                                                    localExecution, // start network stack?
@@ -206,7 +206,7 @@ class LocalFlinkMiniCluster(userConfiguration: Configuration, singleActorSystem:
   def getDefaultConfig: Configuration = {
     val config: Configuration = new Configuration()
 
-    config.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, HOSTNAME)
+    config.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, hostname)
 
     config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, 1)
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -74,7 +74,7 @@ class TestingCluster(userConfiguration: Configuration, singleActorSystem: Boolea
     }
 
     TaskManager.startTaskManagerComponentsAndActor(configuration, system,
-                                                   HOSTNAME,
+                                                   hostname,
                                                    Some(tmActorName),
                                                    jobManagerPath,
                                                    numTaskManagers == 1,

--- a/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
+++ b/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
@@ -116,7 +116,7 @@ class ForkableFlinkMiniCluster(userConfiguration: Configuration, singleActorSyst
       None
     }
 
-    TaskManager.startTaskManagerComponentsAndActor(config, system, HOSTNAME,
+    TaskManager.startTaskManagerComponentsAndActor(config, system, hostname,
         Some(TaskManager.TASK_MANAGER_NAME + index), jobManagerAkkaUrl, localExecution,
          classOf[TestingTaskManager])
   }


### PR DESCRIPTION
The FlinkMiniCluster contain member variable called HOSTNAME which all caps. The naming of al caps usually reserved for constants and static variable.

The PR is changing the name of the variable and the usages.