### PR TITLE
[FLINK-1848] Fix for file paths with Windows drive letters

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
@@ -260,7 +260,11 @@ public class Path implements IOReadableWritable, Serializable {
 		path = path.replaceAll("/+", "/");
 
 		// remove tailing separator
-		if(!path.equals(SEPARATOR) && path.endsWith(SEPARATOR)) {
+		if(!path.equals(SEPARATOR) &&         		// UNIX root path
+				!path.matches("/\\p{Alpha}+:/") &&  // Windows root path
+				path.endsWith(SEPARATOR))
+		{
+			// remove tailing slash
 			path = path.substring(0, path.length() - SEPARATOR.length());
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -228,8 +228,13 @@ public class LocalFileSystem extends FileSystem {
 	 */
 	public boolean mkdirs(final Path f) throws IOException {
 
-		final Path parent = f.getParent();
 		final File p2f = pathToFile(f);
+
+		if(p2f.isDirectory()) {
+			return true;
+		}
+
+		final Path parent = f.getParent();
 		return (parent == null || mkdirs(parent)) && (p2f.mkdir() || p2f.isDirectory());
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/fs/PathTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/PathTest.java
@@ -117,11 +117,23 @@ public class PathTest {
 		p = new Path("y:/my/abs/windows/path");
 		assertTrue(p.isAbsolute());
 
+		p = new Path("/y:/my/abs/windows/path");
+		assertTrue(p.isAbsolute());
+
 		p = new Path("b:\\my\\abs\\windows\\path");
+		assertTrue(p.isAbsolute());
+
+		p = new Path("/c:/my/dir");
+		assertTrue(p.isAbsolute());
+
+		p = new Path("/C:/");
 		assertTrue(p.isAbsolute());
 
 		p = new Path("C:");
 		assertFalse(p.isAbsolute());
+
+		p = new Path("C:/");
+		assertTrue(p.isAbsolute());
 
 		p = new Path("C:my\\relative\\path");
 		assertFalse(p.isAbsolute());


### PR DESCRIPTION
Paths with Windows drive letters can be used to specify `FileDataSource` and `FileDataSink` tasks.
I verified the fix on a Windows box.