### PR TITLE
 [FLINK-1954] [FLINK-1957] [runtime] Improve error handling of transport failures

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -107,12 +107,16 @@ class NettyClient {
 		bootstrap.handler(new ChannelInitializer<SocketChannel>() {
 			@Override
 			public void initChannel(SocketChannel channel) throws Exception {
-				protocol.setClientChannelPipeline(channel.pipeline());
+				channel.pipeline().addLast(protocol.getClientChannelHandlers());
 			}
 		});
 
 		long end = System.currentTimeMillis();
 		LOG.info("Successful initialization (took {} ms).", (end - start));
+	}
+
+	NettyConfig getConfig() {
+		return config;
 	}
 
 	void shutdown() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -119,7 +119,7 @@ class NettyServer {
 		bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
 			@Override
 			public void initChannel(SocketChannel channel) throws Exception {
-				protocol.setServerChannelPipeline(channel.pipeline());
+				channel.pipeline().addLast(protocol.getServerChannelHandlers());
 			}
 		});
 
@@ -130,7 +130,11 @@ class NettyServer {
 		bindFuture = bootstrap.bind().syncUninterruptibly();
 
 		long end = System.currentTimeMillis();
-		LOG.info("Successful initialization  (took {} ms). Listening on SocketAddress {}.", (end - start), bindFuture.channel().localAddress().toString());
+		LOG.info("Successful initialization (took {} ms). Listening on SocketAddress {}.", (end - start), bindFuture.channel().localAddress().toString());
+	}
+
+	NettyConfig getConfig() {
+		return config;
 	}
 
 	void shutdown() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.CancelPartitionRequest;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
@@ -113,6 +114,11 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
 				if (!taskEventDispatcher.publish(request.partitionId, request.event)) {
 					respondWithError(ctx, new IllegalArgumentException("Task event receiver not found."), request.receiverId);
 				}
+			}
+			else if (msgClazz == CancelPartitionRequest.class) {
+				CancelPartitionRequest request = (CancelPartitionRequest) msg;
+
+				outboundQueue.cancel(request.receiverId);
 			}
 			else {
 				LOG.warn("Received unexpected client request: {}", msg);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/LocalTransportException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/LocalTransportException.java
@@ -16,14 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.io.network.netty.exception;
 
-import io.netty.channel.ChannelHandler;
+import java.net.SocketAddress;
 
-public interface NettyProtocol {
+public class LocalTransportException extends TransportException {
 
-	ChannelHandler[] getServerChannelHandlers();
+	private static final long serialVersionUID = 2366708881288640674L;
 
-	ChannelHandler[] getClientChannelHandlers();
+	public LocalTransportException(String message, SocketAddress address) {
+		super(message, address);
+	}
 
+	public LocalTransportException(String message, SocketAddress address, Throwable cause) {
+		super(message, address, cause);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/RemoteTransportException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/RemoteTransportException.java
@@ -16,14 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.io.network.netty.exception;
 
-import io.netty.channel.ChannelHandler;
+import java.net.SocketAddress;
 
-public interface NettyProtocol {
+public class RemoteTransportException extends TransportException {
 
-	ChannelHandler[] getServerChannelHandlers();
+	private static final long serialVersionUID = 4373615529545893089L;
 
-	ChannelHandler[] getClientChannelHandlers();
+	public RemoteTransportException(String message, SocketAddress address) {
+		super(message, address);
+	}
 
+	public RemoteTransportException(String message, SocketAddress address, Throwable cause) {
+		super(message, address, cause);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/TransportException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/exception/TransportException.java
@@ -16,14 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.io.network.netty.exception;
 
-import io.netty.channel.ChannelHandler;
+import java.io.IOException;
+import java.net.SocketAddress;
 
-public interface NettyProtocol {
+public abstract class TransportException extends IOException {
 
-	ChannelHandler[] getServerChannelHandlers();
+	private static final long serialVersionUID = 3637820720589866570L;
 
-	ChannelHandler[] getClientChannelHandlers();
+	private final SocketAddress address;
 
+	public TransportException(String message, SocketAddress address) {
+		this(message, address, null);
+	}
+
+	public TransportException(String message, SocketAddress address, Throwable cause) {
+		super(message, cause);
+
+		this.address = address;
+	}
+
+	public SocketAddress getAddress() {
+		return address;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -49,7 +49,6 @@ public interface ResultSubpartitionView {
 	 */
 	boolean registerListener(NotificationListener listener) throws IOException;
 
-
 	void releaseAllResources() throws IOException;
 
 	void notifySubpartitionConsumed() throws IOException;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.Channel;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.event.NotificationListener;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.*;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CancelPartitionRequestTest {
+
+	/**
+	 * Verifies that requests for non-existing (failed/cancelled) input channels are properly
+	 * cancelled.
+	 */
+	@Test
+	public void testCancelPartitionRequest() throws Exception {
+
+		NettyServerAndClient serverAndClient = null;
+
+		try {
+			TestPooledBufferProvider outboundBuffers = new TestPooledBufferProvider(16);
+
+			ResultPartitionManager partitions = mock(ResultPartitionManager.class);
+
+			ResultPartitionID pid = new ResultPartitionID();
+
+			CountDownLatch sync = new CountDownLatch(1);
+
+			// Return infinite subpartition
+			when(partitions.createSubpartitionView(eq(pid), eq(0), any(BufferProvider.class)))
+					.thenReturn(new InfiniteSubpartitionView(outboundBuffers, sync));
+
+			PartitionRequestProtocol protocol = new PartitionRequestProtocol(
+					partitions, mock(TaskEventDispatcher.class), mock(NetworkBufferPool.class));
+
+			serverAndClient = initServerAndClient(protocol);
+
+			Channel ch = connect(serverAndClient);
+
+			// Request for non-existing input channel => results in cancel request
+			ch.writeAndFlush(new PartitionRequest(pid, 0, new InputChannelID())).await();
+
+			// Wait for the notification
+			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+				fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+						" ms to be notified about cancelled partition.");
+			}
+		}
+		finally {
+			shutdown(serverAndClient);
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	static class InfiniteSubpartitionView implements ResultSubpartitionView {
+
+		private final BufferProvider bufferProvider;
+
+		private final CountDownLatch sync;
+
+		public InfiniteSubpartitionView(BufferProvider bufferProvider, CountDownLatch sync) {
+			this.bufferProvider = checkNotNull(bufferProvider);
+			this.sync = checkNotNull(sync);
+		}
+
+		@Override
+		public Buffer getNextBuffer() throws IOException, InterruptedException {
+			return bufferProvider.requestBufferBlocking();
+		}
+
+		@Override
+		public boolean registerListener(final NotificationListener listener) throws IOException {
+			return false;
+		}
+
+		@Override
+		public void releaseAllResources() throws IOException {
+			sync.countDown();
+		}
+
+		@Override
+		public void notifySubpartitionConsumed() throws IOException {
+		}
+
+		@Override
+		public boolean isReleased() {
+			return false;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
+import org.apache.flink.runtime.io.network.netty.exception.LocalTransportException;
+import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.createConfig;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClientTransportErrorHandlingTest {
+
+	/**
+	 * Verifies that failed client requests via {@link PartitionRequestClient} are correctly
+	 * attributed to the respective {@link RemoteInputChannel}.
+	 */
+	@Test
+	public void testExceptionOnWrite() throws Exception {
+
+		NettyProtocol protocol = new NettyProtocol() {
+			@Override
+			public ChannelHandler[] getServerChannelHandlers() {
+				return new ChannelHandler[0];
+			}
+
+			@Override
+			public ChannelHandler[] getClientChannelHandlers() {
+				return new PartitionRequestProtocol(
+						mock(ResultPartitionProvider.class),
+						mock(TaskEventDispatcher.class),
+						mock(NetworkBufferPool.class)).getClientChannelHandlers();
+			}
+		};
+
+		// We need a real server and client in this test, because Netty's EmbeddedChannel is
+		// not failing the ChannelPromise of failed writes.
+		NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+
+		Channel ch = connect(serverAndClient);
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Last outbound handler throws Exception after 1st write
+		ch.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+			int writeNum = 0;
+
+			@Override
+			public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+					throws Exception {
+
+				if (writeNum >= 1) {
+					throw new RuntimeException("Expected test exception.");
+				}
+
+				writeNum++;
+				ctx.write(msg, promise);
+			}
+		});
+
+		PartitionRequestClient requestClient = new PartitionRequestClient(
+				ch, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		final CountDownLatch sync = new CountDownLatch(1);
+
+		// Do this with explicit synchronization. Otherwise this is not robust against slow timings
+		// of the callback (e.g. we cannot just verify that it was called once, because there is
+		// a chance that we do this too early).
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				sync.countDown();
+				return null;
+			}
+		}).when(rich[1]).onError(isA(LocalTransportException.class));
+
+		// First request is successful
+		ChannelFuture f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[0], 0);
+		assertTrue(f.await().isSuccess());
+
+		// Second request is *not* successful
+		f = requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[1], 0);
+		assertFalse(f.await().isSuccess());
+
+		// Only the second channel should be notified about the error
+		verify(rich[0], times(0)).onError(any(LocalTransportException.class));
+
+		// Wait for the notification
+		if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+			fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+					" ms to be notified about the channel error.");
+		}
+
+		shutdown(serverAndClient);
+	}
+
+	/**
+	 * Verifies that {@link NettyMessage.ErrorResponse} messages are correctly wrapped in
+	 * {@link RemoteTransportException} instances.
+	 */
+	@Test
+	public void testWrappingOfRemoteErrorMessage() throws Exception {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		for (RemoteInputChannel r : rich) {
+			when(r.getInputChannelId()).thenReturn(new InputChannelID());
+			handler.addInputChannel(r);
+		}
+
+		// Error msg for channel[0]
+		ch.pipeline().fireChannelRead(new NettyMessage.ErrorResponse(
+				new RuntimeException("Expected test exception"),
+				rich[0].getInputChannelId()));
+
+		try {
+			// Exception should not reach end of pipeline...
+			ch.checkException();
+		}
+		catch (Exception e) {
+			fail("The exception reached the end of the pipeline and "
+					+ "was not handled correctly by the last handler.");
+		}
+
+		verify(rich[0], times(1)).onError(isA(RemoteTransportException.class));
+		verify(rich[1], never()).onError(any(Throwable.class));
+
+		// Fatal error for all channels
+		ch.pipeline().fireChannelRead(new NettyMessage.ErrorResponse(
+				new RuntimeException("Expected test exception")));
+
+		try {
+			// Exception should not reach end of pipeline...
+			ch.checkException();
+		}
+		catch (Exception e) {
+			fail("The exception reached the end of the pipeline and "
+					+ "was not handled correctly by the last handler.");
+		}
+
+		verify(rich[0], times(2)).onError(isA(RemoteTransportException.class));
+		verify(rich[1], times(1)).onError(isA(RemoteTransportException.class));
+	}
+
+	/**
+	 * Verifies that unexpected remote closes are reported as an instance of
+	 * {@link RemoteTransportException}.
+	 */
+	@Test
+	public void testExceptionOnRemoteClose() throws Exception {
+
+		NettyProtocol protocol = new NettyProtocol() {
+			@Override
+			public ChannelHandler[] getServerChannelHandlers() {
+				return new ChannelHandler[] {
+						// Close on read
+						new ChannelInboundHandlerAdapter() {
+							@Override
+							public void channelRead(ChannelHandlerContext ctx, Object msg)
+									throws Exception {
+
+								ctx.channel().close();
+							}
+						}
+				};
+			}
+
+			@Override
+			public ChannelHandler[] getClientChannelHandlers() {
+				return new PartitionRequestProtocol(
+						mock(ResultPartitionProvider.class),
+						mock(TaskEventDispatcher.class),
+						mock(NetworkBufferPool.class)).getClientChannelHandlers();
+			}
+		};
+
+		NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+
+		Channel ch = connect(serverAndClient);
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		final CountDownLatch sync = new CountDownLatch(rich.length);
+
+		Answer<Void> countDownLatch = new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				sync.countDown();
+				return null;
+			}
+		};
+
+		for (RemoteInputChannel r : rich) {
+			doAnswer(countDownLatch).when(r).onError(any(Throwable.class));
+			handler.addInputChannel(r);
+		}
+
+		// Write something to trigger close by server
+		ch.writeAndFlush(Unpooled.buffer().writerIndex(16));
+
+		// Wait for the notification
+		if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+			fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+					" ms to be notified about remote connection close.");
+		}
+
+		// All the registered channels should be notified.
+		for (RemoteInputChannel r : rich) {
+			verify(r).onError(isA(RemoteTransportException.class));
+		}
+
+		shutdown(serverAndClient);
+	}
+
+	/**
+	 * Verifies that fired Exceptions are handled correctly by the pipeline.
+	 */
+	@Test
+	public void testExceptionCaught() throws Exception {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		// Create input channels
+		RemoteInputChannel[] rich = new RemoteInputChannel[] {
+				createRemoteInputChannel(), createRemoteInputChannel()};
+
+		for (RemoteInputChannel r : rich) {
+			when(r.getInputChannelId()).thenReturn(new InputChannelID());
+			handler.addInputChannel(r);
+		}
+
+		ch.pipeline().fireExceptionCaught(new Exception());
+
+		try {
+			// Exception should not reach end of pipeline...
+			ch.checkException();
+		}
+		catch (Exception e) {
+			fail("The exception reached the end of the pipeline and "
+					+ "was not handled correctly by the last handler.");
+		}
+
+		// ...but all the registered channels should be notified.
+		for (RemoteInputChannel r : rich) {
+			verify(r).onError(isA(LocalTransportException.class));
+		}
+	}
+
+	/**
+	 * Verifies that "Connection reset by peer" Exceptions are special-cased and are reported as
+	 * an instance of {@link RemoteTransportException}.
+	 */
+	@Test
+	public void testConnectionResetByPeer() throws Throwable {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		RemoteInputChannel rich = addInputChannel(handler);
+
+		final Throwable[] error = new Throwable[1];
+
+		// Verify the Exception
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				Throwable cause = (Throwable) invocation.getArguments()[0];
+
+				try {
+					assertEquals(RemoteTransportException.class, cause.getClass());
+					assertNotEquals("Connection reset by peer", cause.getMessage());
+
+					assertEquals(IOException.class, cause.getCause().getClass());
+					assertEquals("Connection reset by peer", cause.getCause().getMessage());
+				}
+				catch (Throwable t) {
+					error[0] = t;
+				}
+
+				return null;
+			}
+		}).when(rich).onError(any(Throwable.class));
+
+		ch.pipeline().fireExceptionCaught(new IOException("Connection reset by peer"));
+
+		assertNull(error[0]);
+	}
+
+	/**
+	 * Verifies that the channel is closed if there is an error *during* error notification.
+	 */
+	@Test
+	public void testChannelClosedOnExceptionDuringErrorNotification() throws Exception {
+		EmbeddedChannel ch = createEmbeddedChannel();
+
+		PartitionRequestClientHandler handler = getClientHandler(ch);
+
+		RemoteInputChannel rich = addInputChannel(handler);
+
+		doThrow(new RuntimeException("Expected test exception"))
+				.when(rich).onError(any(Throwable.class));
+
+		ch.pipeline().fireExceptionCaught(new Exception());
+
+		assertFalse(ch.isActive());
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------------------------
+
+	private EmbeddedChannel createEmbeddedChannel() {
+		PartitionRequestProtocol protocol = new PartitionRequestProtocol(
+				mock(ResultPartitionProvider.class),
+				mock(TaskEventDispatcher.class),
+				mock(NetworkBufferPool.class));
+
+		return new EmbeddedChannel(protocol.getClientChannelHandlers());
+	}
+
+	private RemoteInputChannel addInputChannel(PartitionRequestClientHandler clientHandler) {
+		RemoteInputChannel rich = createRemoteInputChannel();
+		clientHandler.addInputChannel(rich);
+
+		return rich;
+	}
+
+	private PartitionRequestClientHandler getClientHandler(Channel ch) {
+		return ch.pipeline().get(PartitionRequestClientHandler.class);
+	}
+
+	private RemoteInputChannel createRemoteInputChannel() {
+		return when(mock(RemoteInputChannel.class)
+				.getInputChannelId())
+				.thenReturn(new InputChannelID()).getMock();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.Channel;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.net.NetUtils;
+import scala.Tuple2;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Test utility for Netty server and client setup.
+ */
+public class NettyTestUtil {
+
+	static int DEFAULT_SEGMENT_SIZE = 1024;
+
+	// ---------------------------------------------------------------------------------------------
+	// NettyServer and NettyClient
+	// ---------------------------------------------------------------------------------------------
+
+	static NettyServer initServer(NettyConfig config, NettyProtocol protocol) throws Exception {
+		final NettyServer server = new NettyServer(config);
+
+		try {
+			server.init(protocol);
+		}
+		catch (Exception e) {
+			if (server != null) {
+				server.shutdown();
+			}
+
+			throw e;
+		}
+
+		return server;
+	}
+
+	static NettyClient initClient(NettyConfig config, NettyProtocol protocol) throws Exception {
+		final NettyClient client = new NettyClient(config);
+
+		try {
+			client.init(protocol);
+		}
+		catch (Exception e) {
+			if (client != null) {
+				client.shutdown();
+			}
+
+			throw e;
+		}
+
+		return client;
+	}
+
+	static NettyServerAndClient initServerAndClient(NettyProtocol protocol) throws Exception {
+		return initServerAndClient(protocol, createConfig());
+	}
+
+	static NettyServerAndClient initServerAndClient(NettyProtocol protocol, NettyConfig config)
+			throws Exception {
+
+		final NettyClient client = initClient(config, protocol);
+		final NettyServer server = initServer(config, protocol);
+
+		return new NettyServerAndClient(server, client);
+	}
+
+	static Channel connect(NettyServerAndClient serverAndClient) throws Exception {
+		return connect(serverAndClient.client(), serverAndClient.server());
+	}
+
+	static Channel connect(NettyClient client, NettyServer server) throws Exception {
+		final NettyConfig config = server.getConfig();
+
+		return client
+				.connect(new InetSocketAddress(config.getServerAddress(), config.getServerPort()))
+				.sync()
+				.channel();
+	}
+
+	static void awaitClose(Channel ch) throws InterruptedException {
+		// Wait for the channel to be closed
+		while (ch.isActive()) {
+			ch.closeFuture().await(1, TimeUnit.SECONDS);
+		}
+	}
+
+	static void shutdown(NettyServerAndClient serverAndClient) {
+		if (serverAndClient != null) {
+			if (serverAndClient.server() != null) {
+				serverAndClient.server().shutdown();
+			}
+
+			if (serverAndClient.client() != null) {
+				serverAndClient.client().shutdown();
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// NettyConfig
+	// ---------------------------------------------------------------------------------------------
+
+	static NettyConfig createConfig() throws Exception {
+		return createConfig(DEFAULT_SEGMENT_SIZE, new Configuration());
+	}
+
+	static NettyConfig createConfig(int segmentSize) throws Exception {
+		return createConfig(segmentSize, new Configuration());
+	}
+
+	static NettyConfig createConfig(Configuration config) throws Exception {
+		return createConfig(DEFAULT_SEGMENT_SIZE, config);
+	}
+
+	static NettyConfig createConfig(int segmentSize, Configuration config) throws Exception {
+		checkArgument(segmentSize > 0);
+		checkNotNull(config);
+
+		return new NettyConfig(
+				InetAddress.getLocalHost(),
+				NetUtils.getAvailablePort(),
+				segmentSize,
+				config);
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	static class NettyServerAndClient extends Tuple2<NettyServer, NettyClient> {
+
+		private static final long serialVersionUID = 4440278728496341931L;
+
+		NettyServerAndClient(NettyServer _1, NettyClient _2) {
+			super(_1, _2);
+		}
+
+		NettyServer server() {
+			return _1();
+		}
+
+		NettyClient client() {
+			return _2();
+		}
+
+		@Override
+		public boolean canEqual(Object that) {
+			return false;
+		}
+
+		@Override
+		public boolean equals(Object that) {
+			return false;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -54,12 +54,14 @@ public class PartitionRequestClientFactoryTest {
 		final Tuple2<NettyServer, NettyClient> netty = createNettyServerAndClient(
 				new NettyProtocol() {
 					@Override
-					public void setServerChannelPipeline(ChannelPipeline channelPipeline) {
+					public ChannelHandler[] getServerChannelHandlers() {
+						return new ChannelHandler[0];
 					}
 
 					@Override
-					public void setClientChannelPipeline(ChannelPipeline channelPipeline) {
-						channelPipeline.addLast(new CountDownLatchOnConnectHandler(syncOnConnect));
+					public ChannelHandler[] getClientChannelHandlers() {
+						return new ChannelHandler[] {
+								new CountDownLatchOnConnectHandler(syncOnConnect)};
 					}
 				});
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
@@ -130,7 +131,13 @@ public class PartitionRequestClientHandlerTest {
 		final PartitionRequestClientHandler client = new PartitionRequestClientHandler();
 		client.addInputChannel(inputChannel);
 
-		client.channelRead(mock(ChannelHandlerContext.class), partitionNotFound);
+		// Mock channel context
+		ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+		when(ctx.channel()).thenReturn(mock(Channel.class));
+
+		client.channelActive(ctx);
+
+		client.channelRead(ctx, partitionNotFound);
 
 		verify(inputChannel, times(1)).onFailedPartitionRequest();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.CancelPartitionRequestTest.InfiniteSubpartitionView;
+import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
+import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.NettyMessageEncoder;
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.PartitionRequest;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.createConfig;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ServerTransportErrorHandlingTest {
+
+	/**
+	 * Verifies remote closes trigger the release of all resources.
+	 */
+	@Test
+	public void testRemoteClose() throws Exception {
+		final TestPooledBufferProvider outboundBuffers = new TestPooledBufferProvider(16);
+
+		final CountDownLatch sync = new CountDownLatch(1);
+
+		final ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
+
+		when(partitionManager
+				.createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferProvider.class)))
+				.thenReturn(new InfiniteSubpartitionView(outboundBuffers, sync));
+
+		NettyProtocol protocol = new NettyProtocol() {
+			@Override
+			public ChannelHandler[] getServerChannelHandlers() {
+				return new PartitionRequestProtocol(
+						partitionManager,
+						mock(TaskEventDispatcher.class),
+						mock(NetworkBufferPool.class)).getServerChannelHandlers();
+			}
+
+			@Override
+			public ChannelHandler[] getClientChannelHandlers() {
+				return new ChannelHandler[] {
+						new NettyMessageEncoder(),
+						// Close on read
+						new ChannelInboundHandlerAdapter() {
+							@Override
+							public void channelRead(ChannelHandlerContext ctx, Object msg)
+									throws Exception {
+
+								ctx.channel().close();
+							}
+						}
+				};
+			}
+		};
+
+		NettyServerAndClient serverAndClient = null;
+
+		try {
+			serverAndClient = initServerAndClient(protocol, createConfig());
+
+			Channel ch = connect(serverAndClient);
+
+			// Write something to trigger close by server
+			ch.writeAndFlush(new PartitionRequest(new ResultPartitionID(), 0, new InputChannelID()));
+
+			// Wait for the notification
+			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
+				fail("Timed out after waiting for " + TestingUtils.TESTING_DURATION().toMillis() +
+						" ms to be notified about released partition.");
+			}
+		}
+		finally {
+			shutdown(serverAndClient);
+		}
+	}
+}


### PR DESCRIPTION
*Problem*: Failures in the network stack were not properly handled and correctly attributed.

*Solution*: Failures are always attributeed to the client (consumer). This change introduces `TransportException`, which indicates whether the problem ocurred locally or remotely. This makes it easy to reason about the source of a problem.

This is based on #705. Review second commit only.