### PR TITLE
[FLINK-2096] Remove implicit conversion from Window Stream to Stream

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/package.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/package.scala
@@ -48,9 +48,6 @@ package object scala {
 
   implicit def seqToFlinkSource[T: ClassTag: TypeInformation](scalaSeq: Seq[T]) : DataStream[T] =
     StreamExecutionEnvironment.getExecutionEnvironment.fromCollection(scalaSeq)
-    
-  implicit def windowedToDataStream[R](windowedStream: WindowedDataStream[R]): DataStream[R] =
-    windowedStream.flatten      
 
   private[flink] def fieldNames2Indices(
       typeInfo: TypeInformation[_],


### PR DESCRIPTION
This causes unexpected behaviour, for example in:

ds.window(...).map(..)

The user would expect some kind of windowing to take place. The
windowing, however, cancels out with the implicitly inserted flatten()
call.