### PR TITLE
[tez] Fix initialization of MemoryManager.

### DIFF
--- a/flink-staging/flink-tez/src/main/java/org/apache/flink/tez/runtime/TezRuntimeEnvironment.java
+++ b/flink-staging/flink-tez/src/main/java/org/apache/flink/tez/runtime/TezRuntimeEnvironment.java
@@ -27,16 +27,13 @@ import org.apache.flink.runtime.memorymanager.MemoryManager;
 public class TezRuntimeEnvironment {
 
 	private static int DEFAULT_PAGE_SIZE = 32768;
-	private static int DEFAULT_NUM_SLOTS = 10;
 
 	private final IOManager ioManager;
 
 	private final MemoryManager memoryManager;
 
 	public TezRuntimeEnvironment(long totalMemory) {
-		int pageSize = DEFAULT_PAGE_SIZE;
-		int numSlots = DEFAULT_NUM_SLOTS;
-		this.memoryManager = new DefaultMemoryManager(totalMemory, numSlots, pageSize, true);
+		this.memoryManager = new DefaultMemoryManager(totalMemory, 1, DefaultMemoryManager.DEFAULT_PAGE_SIZE, true);
 		this.ioManager = new IOManagerAsync();
 	}
 


### PR DESCRIPTION
The memory manager in Tez is currently initialized as if it were shared between 10 concurrently executing tasks. This reduces the amount of memory available to a single task.

Because the memory manager is only used by one task at a time, we should configure it like that to avoid wasting memory.