### PR TITLE
[FLINK-2047] [ml]  Rename CoCoA to SVM

### DIFF
--- a/docs/libs/ml/index.md
+++ b/docs/libs/ml/index.md
@@ -35,7 +35,7 @@ FlinkML currently supports the following algorithms:
 
 ### Supervised Learning
 
-* [Communication efficient distributed dual coordinate ascent (CoCoA)](cocoa.html)
+* [SVM using Communication efficient distributed dual coordinate ascent (CoCoA)](svm.html)
 * [Multiple linear regression](multiple_linear_regression.html)
 * [Optimization Framework](optimization.html)
 

--- a/docs/libs/ml/svm.md
+++ b/docs/libs/ml/svm.md
@@ -1,6 +1,6 @@
 ---
 mathjax: include
-title: Communication efficient distributed dual coordinate ascent (CoCoA)
+title: SVM using Communication efficient distributed dual coordinate ascent (CoCoA)
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -26,8 +26,8 @@ under the License.
 
 ## Description
 
-Implements the communication-efficient distributed dual coordinate ascent algorithm with hinge-loss function. 
-The algorithm can be used to train a SVM with soft-margin.
+Implements an SVM with soft-margin using the communication-efficient distributed dual coordinate 
+ascent algorithm with hinge-loss function. 
 The algorithm solves the following minimization problem:
   
 $$\min_{\mathbf{w} \in \mathbb{R}^d} \frac{\lambda}{2} \left\lVert \mathbf{w} \right\rVert^2 + \frac{1}{n} \sum_{i=1}^n l_{i}\left(\mathbf{w}^T\mathbf{x}_i\right)$$
@@ -58,7 +58,7 @@ The implementation of this algorithm is based on the work of
 
 ## Parameters
 
-The CoCoA implementation can be controlled by the following parameters:
+The SVM implementation can be controlled by the following parameters:
 
    <table class="table table-bordered">
     <thead>
@@ -121,7 +121,7 @@ The CoCoA implementation can be controlled by the following parameters:
             Defines the initial step size for the updates of the weight vector. 
             The larger the step size is, the larger will be the contribution of the weight vector updates to the next weight vector value. 
             The effective scaling of the updates is $\frac{stepsize}{blocks}$.
-            This value has to be tuned in case that the algorithm becomes instable. 
+            This value has to be tuned in case that the algorithm becomes unstable. 
             (Default value: <strong>1.0</strong>)
           </p>
         </td>
@@ -145,8 +145,8 @@ The CoCoA implementation can be controlled by the following parameters:
 // Read the training data set
 val trainingDS: DataSet[LabeledVector] = env.readSVMFile(pathToTrainingFile)
 
-// Create the CoCoA learner
-val svm = CoCoA()
+// Create the SVM learner
+val svm = SVM()
 .setBlocks(10)
 .setIterations(10)
 .setLocalIterations(10)

--- a/docs/libs/ml/svm.md
+++ b/docs/libs/ml/svm.md
@@ -142,8 +142,8 @@ The SVM implementation can be controlled by the following parameters:
 ## Examples
 
 {% highlight scala %}
-// Read the training data set
-val trainingDS: DataSet[LabeledVector] = env.readSVMFile(pathToTrainingFile)
+// Read the training data set, from a LibSVM formatted file
+val trainingDS: DataSet[LabeledVector] = env.readLibSVM(pathToTrainingFile)
 
 // Create the SVM learner
 val svm = SVM()

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
@@ -23,14 +23,14 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.apache.flink.api.scala._
 import org.apache.flink.test.util.FlinkTestBase
 
-class CoCoAITSuite extends FlatSpec with Matchers with FlinkTestBase {
+class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
 
-  behavior of "The CoCoA implementation"
+  behavior of "The SVM using CoCoA implementation"
 
   it should "train a SVM" in {
     val env = ExecutionEnvironment.getExecutionEnvironment
 
-    val cocoa = CoCoA().
+    val cocoa = SVM().
     setBlocks(env.getParallelism).
     setIterations(100).
     setLocalIterations(100).


### PR DESCRIPTION
The CoCoA algorithm as implemented functions as an SVM classifier.

As CoCoA mostly concerns the optimization process and not the actual learning algorithm, it makes sense to rename the learner to SVM which users are more familiar with.