### PR TITLE
[FLINK-2089] [runtime] Fix possible duplicate buffer release

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
  */
 public interface RecordSerializer<T extends IOReadableWritable> {
 
-	public static enum SerializationResult {
+	enum SerializationResult {
 		PARTIAL_RECORD_MEMORY_SEGMENT_FULL(false, true),
 		FULL_RECORD_MEMORY_SEGMENT_FULL(true, true),
 		FULL_RECORD(true, false);
@@ -57,6 +57,8 @@ public interface RecordSerializer<T extends IOReadableWritable> {
 	SerializationResult setNextBuffer(Buffer buffer) throws IOException;
 
 	Buffer getCurrentBuffer();
+
+	void clearCurrentBuffer();
 	
 	void clear();
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -153,6 +153,11 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	}
 
 	@Override
+	public void clearCurrentBuffer() {
+		targetBuffer = null;
+	}
+
+	@Override
 	public void clear() {
 		this.targetBuffer = null;
 		this.position = 0;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -86,6 +86,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 
 					if (buffer != null) {
 						writer.writeBuffer(buffer, targetChannel);
+						serializer.clearCurrentBuffer();
 					}
 
 					buffer = writer.getBufferProvider().requestBufferBlocking();
@@ -108,6 +109,8 @@ public class RecordWriter<T extends IOReadableWritable> {
 					}
 
 					writer.writeBuffer(buffer, targetChannel);
+					serializer.clearCurrentBuffer();
+
 					writer.writeEvent(event, targetChannel);
 
 					buffer = writer.getBufferProvider().requestBufferBlocking();
@@ -127,8 +130,8 @@ public class RecordWriter<T extends IOReadableWritable> {
 			synchronized (serializer) {
 				Buffer buffer = serializer.getCurrentBuffer();
 				if (buffer != null) {
-
 					writer.writeBuffer(buffer, targetChannel);
+					serializer.clearCurrentBuffer();
 
 					buffer = writer.getBufferProvider().requestBufferBlocking();
 					serializer.setNextBuffer(buffer);
@@ -145,11 +148,13 @@ public class RecordWriter<T extends IOReadableWritable> {
 
 			synchronized (serializer) {
 				Buffer buffer = serializer.getCurrentBuffer();
-				serializer.clear();
 
 				if (buffer != null) {
+					// Only clear the serializer after the buffer was written out.
 					writer.writeBuffer(buffer, targetChannel);
 				}
+
+				serializer.clear();
 			}
 		}
 	}
@@ -158,7 +163,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 		if (serializers != null) {
 			for (RecordSerializer<?> s : serializers) {
 				Buffer b = s.getCurrentBuffer();
-				if (b != null && !b.isRecycled()) {
+				if (b != null) {
 					b.recycle();
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -134,7 +134,7 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
 	}
 
 	private void respondWithError(ChannelHandlerContext ctx, Throwable error, InputChannelID sourceId) {
-		LOG.debug("Responding with error {}.", error);
+		LOG.debug("Responding with error: {}.", error.getClass());
 
 		ctx.writeAndFlush(new NettyMessage.ErrorResponse(error, sourceId));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -22,8 +22,13 @@ import org.apache.flink.runtime.event.task.TaskEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import scala.Tuple2;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * An input channel consumes a single {@link ResultSubpartitionView}.
@@ -43,10 +48,41 @@ public abstract class InputChannel {
 
 	protected final SingleInputGate inputGate;
 
-	protected InputChannel(SingleInputGate inputGate, int channelIndex, ResultPartitionID partitionId) {
-		this.inputGate = inputGate;
+	// - Asynchronous error notification --------------------------------------
+
+	private final AtomicReference<Throwable> cause = new AtomicReference<Throwable>();
+
+	// - Partition request backoff --------------------------------------------
+
+	/** The initial backoff (in ms). */
+	private final int initialBackoff;
+
+	/** The maximum backoff (in ms). */
+	private final int maxBackoff;
+
+	/** The current backoff (in ms) */
+	private int currentBackoff;
+
+	protected InputChannel(
+			SingleInputGate inputGate,
+			int channelIndex,
+			ResultPartitionID partitionId,
+			Tuple2<Integer, Integer> initialAndMaxBackoff) {
+
+		checkArgument(channelIndex >= 0);
+
+		int initial = initialAndMaxBackoff._1();
+		int max = initialAndMaxBackoff._2();
+
+		checkArgument(initial >= 0 && initial <= max);
+
+		this.inputGate = checkNotNull(inputGate);
 		this.channelIndex = channelIndex;
-		this.partitionId = partitionId;
+		this.partitionId = checkNotNull(partitionId);
+
+		this.initialBackoff = initial;
+		this.maxBackoff = max;
+		this.currentBackoff = initial == 0 ? -1 : 0;
 	}
 
 	// ------------------------------------------------------------------------
@@ -109,4 +145,74 @@ public abstract class InputChannel {
 	 */
 	abstract void releaseAllResources() throws IOException;
 
+	// ------------------------------------------------------------------------
+	// Error notification
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Checks for an error and rethrows it if one was reported.
+	 */
+	protected void checkError() throws IOException {
+		final Throwable t = cause.get();
+
+		if (t != null) {
+			if (t instanceof IOException) {
+				throw (IOException) t;
+			}
+			else {
+				throw new IOException(t);
+			}
+		}
+	}
+
+	/**
+	 * Atomically sets an error for this channel and notifies the input gate about available data to
+	 * trigger querying this channel by the task thread.
+	 */
+	protected void setError(Throwable cause) {
+		if (this.cause.compareAndSet(null, checkNotNull(cause))) {
+			// Notify the input gate.
+			notifyAvailableBuffer();
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Partition request exponential backoff
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns the current backoff in ms.
+	 */
+	protected int getCurrentBackoff() {
+		return currentBackoff <= 0 ? 0 : currentBackoff;
+	}
+
+	/**
+	 * Increases the current backoff and returns whether the operation was successful.
+	 *
+	 * @return <code>true</code>, iff the operation was successful. Otherwise, <code>false</code>.
+	 */
+	protected boolean increaseBackoff() {
+		// Backoff is disabled
+		if (currentBackoff < 0) {
+			return false;
+		}
+
+		// This is the first time backing off
+		if (currentBackoff == 0) {
+			currentBackoff = initialBackoff;
+
+			return true;
+		}
+
+		// Continue backing off
+		else if (currentBackoff < maxBackoff) {
+			currentBackoff = Math.min(currentBackoff * 2, maxBackoff);
+
+			return true;
+		}
+
+		// Reached maximum backoff
+		return false;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -23,14 +23,18 @@ import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.util.event.NotificationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Tuple2;
 
 import java.io.IOException;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -41,6 +45,8 @@ import static com.google.common.base.Preconditions.checkState;
 public class LocalInputChannel extends InputChannel implements NotificationListener {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LocalInputChannel.class);
+
+	private final Object requestLock = new Object();
 
 	/** The local partition manager. */
 	private final ResultPartitionManager partitionManager;
@@ -62,7 +68,19 @@ public class LocalInputChannel extends InputChannel implements NotificationListe
 			ResultPartitionManager partitionManager,
 			TaskEventDispatcher taskEventDispatcher) {
 
-		super(inputGate, channelIndex, partitionId);
+		this(inputGate, channelIndex, partitionId, partitionManager, taskEventDispatcher,
+				new Tuple2<Integer, Integer>(0, 0));
+	}
+
+	LocalInputChannel(
+			SingleInputGate inputGate,
+			int channelIndex,
+			ResultPartitionID partitionId,
+			ResultPartitionManager partitionManager,
+			TaskEventDispatcher taskEventDispatcher,
+			Tuple2<Integer, Integer> initialAndMaxBackoff) {
+
+		super(inputGate, channelIndex, partitionId, initialAndMaxBackoff);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventDispatcher = checkNotNull(taskEventDispatcher);
@@ -74,23 +92,59 @@ public class LocalInputChannel extends InputChannel implements NotificationListe
 
 	@Override
 	void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
-		if (subpartitionView == null) {
-			LOG.debug("{}: Requesting LOCAL subpartition {} of partition {}.",
-					this, subpartitionIndex, partitionId);
-
-			subpartitionView = partitionManager.createSubpartitionView(
-					partitionId, subpartitionIndex, inputGate.getBufferProvider());
-
+		// The lock is required to request only once in the presence of retriggered requests.
+		synchronized (requestLock) {
 			if (subpartitionView == null) {
-				throw new IOException("Error requesting subpartition.");
-			}
+				LOG.debug("{}: Requesting LOCAL subpartition {} of partition {}.",
+						this, subpartitionIndex, partitionId);
 
-			getNextLookAhead();
+				try {
+					subpartitionView = partitionManager.createSubpartitionView(
+							partitionId, subpartitionIndex, inputGate.getBufferProvider());
+				}
+				catch (PartitionNotFoundException notFound) {
+					if (increaseBackoff()) {
+						inputGate.retriggerPartitionRequest(partitionId.getPartitionId());
+						return;
+					}
+					else {
+						throw notFound;
+					}
+				}
+
+				if (subpartitionView == null) {
+					throw new IOException("Error requesting subpartition.");
+				}
+
+				getNextLookAhead();
+			}
+		}
+	}
+
+	/**
+	 * Retriggers a subpartition request.
+	 */
+	void retriggerSubpartitionRequest(Timer timer, final int subpartitionIndex) throws IOException, InterruptedException {
+		synchronized (requestLock) {
+			checkState(subpartitionView == null, "Already requested partition.");
+
+			timer.schedule(new TimerTask() {
+				@Override
+				public void run() {
+					try {
+						requestSubpartition(subpartitionIndex);
+					}
+					catch (Throwable t) {
+						setError(t);
+					}
+				}
+			}, getCurrentBackoff());
 		}
 	}
 
 	@Override
 	Buffer getNextBuffer() throws IOException, InterruptedException {
+		checkError();
 		checkState(subpartitionView != null, "Queried for a buffer before requesting the subpartition.");
 
 		// After subscribe notification
@@ -119,6 +173,7 @@ public class LocalInputChannel extends InputChannel implements NotificationListe
 
 	@Override
 	void sendTaskEvent(TaskEvent event) throws IOException {
+		checkError();
 		checkState(subpartitionView != null, "Tried to send task event to producer before requesting the subpartition.");
 
 		if (!taskEventDispatcher.publish(partitionId, event)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -34,9 +34,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -55,12 +53,6 @@ public class RemoteInputChannel extends InputChannel {
 
 	/** The connection manager to use connect to the remote partition provider. */
 	private final ConnectionManager connectionManager;
-
-	/**
-	 * An asynchronous error notification. Set by either the network I/O thread or the thread
-	 * failing a partition request.
-	 */
-	private final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 
 	/**
 	 * The received buffers. Received buffers are enqueued by the network I/O thread and the queue
@@ -83,12 +75,6 @@ public class RemoteInputChannel extends InputChannel {
 	 */
 	private int expectedSequenceNumber = 0;
 
-	/** The current backoff time (in ms) for partition requests. */
-	private int nextRequestBackoffMs;
-
-	/** The maximum backoff time (in ms) after which a request fails */
-	private final int maxRequestBackoffMs;
-
 	RemoteInputChannel(
 			SingleInputGate inputGate,
 			int channelIndex,
@@ -108,15 +94,10 @@ public class RemoteInputChannel extends InputChannel {
 			ConnectionManager connectionManager,
 			Tuple2<Integer, Integer> initialAndMaxBackoff) {
 
-		super(inputGate, channelIndex, partitionId);
+		super(inputGate, channelIndex, partitionId, initialAndMaxBackoff);
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
-
-		checkArgument(initialAndMaxBackoff._1() <= initialAndMaxBackoff._2());
-
-		this.nextRequestBackoffMs = initialAndMaxBackoff._1();
-		this.maxRequestBackoffMs = initialAndMaxBackoff._2();
 	}
 
 	// ------------------------------------------------------------------------
@@ -143,17 +124,9 @@ public class RemoteInputChannel extends InputChannel {
 	void retriggerSubpartitionRequest(int subpartitionIndex) throws IOException, InterruptedException {
 		checkState(partitionRequestClient != null, "Missing initial subpartition request.");
 
-		// Disabled
-		if (nextRequestBackoffMs == 0) {
-			failPartitionRequest();
-		}
-		else if (nextRequestBackoffMs <= maxRequestBackoffMs) {
-			partitionRequestClient.requestSubpartition(partitionId, subpartitionIndex, this, nextRequestBackoffMs);
-
-			// Exponential backoff
-			nextRequestBackoffMs = nextRequestBackoffMs < maxRequestBackoffMs
-					? Math.min(nextRequestBackoffMs * 2, maxRequestBackoffMs)
-					: maxRequestBackoffMs + 1; // Fail the next request
+		if (increaseBackoff()) {
+			partitionRequestClient.requestSubpartition(
+					partitionId, subpartitionIndex, this, getCurrentBackoff());
 		}
 		else {
 			failPartitionRequest();
@@ -230,7 +203,7 @@ public class RemoteInputChannel extends InputChannel {
 	}
 
 	public void failPartitionRequest() {
-		onError(new PartitionNotFoundException(partitionId));
+		setError(new PartitionNotFoundException(partitionId));
 	}
 
 	@Override
@@ -305,26 +278,7 @@ public class RemoteInputChannel extends InputChannel {
 	}
 
 	public void onError(Throwable cause) {
-		if (error.compareAndSet(null, cause)) {
-			// Notify the input gate to trigger querying of this channel
-			notifyAvailableBuffer();
-		}
-	}
-
-	/**
-	 * Checks whether this channel got notified about an error.
-	 */
-	private void checkError() throws IOException {
-		final Throwable t = error.get();
-
-		if (t != null) {
-			if (t instanceof IOException) {
-				throw (IOException) t;
-			}
-			else {
-				throw new IOException(t);
-			}
-		}
+		setError(cause);
 	}
 
 	public static class BufferReorderingException extends IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -56,7 +56,7 @@ public class UnknownInputChannel extends InputChannel {
 			ConnectionManager connectionManager,
 			Tuple2<Integer, Integer> partitionRequestInitialAndMaxBackoff) {
 
-		super(gate, channelIndex, partitionId);
+		super(gate, channelIndex, partitionId, partitionRequestInitialAndMaxBackoff);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventDispatcher = checkNotNull(taskEventDispatcher);
@@ -116,6 +116,6 @@ public class UnknownInputChannel extends InputChannel {
 	}
 
 	public LocalInputChannel toLocalInputChannel() {
-		return new LocalInputChannel(inputGate, channelIndex, partitionId, partitionManager, taskEventDispatcher);
+		return new LocalInputChannel(inputGate, channelIndex, partitionId, partitionManager, taskEventDispatcher, partitionRequestInitialAndMaxBackoff);
 	}
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
@@ -26,4 +26,4 @@ case class NetworkEnvironmentConfiguration(
   networkBufferSize: Int,
   ioMode: IOMode,
   nettyConfig: Option[NettyConfig] = None,
-  partitionRequestInitialAndMaxBackoff: Tuple2[Integer, Integer] = (50, 3000))
+  partitionRequestInitialAndMaxBackoff: Tuple2[Integer, Integer] = (500, 3000))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.util.TestBufferFactory;
+import org.apache.flink.types.IntValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@PrepareForTest(ResultPartitionWriter.class)
+@RunWith(PowerMockRunner.class)
+public class RecordWriterTest {
+
+	// ---------------------------------------------------------------------------------------------
+	// Resource release tests
+	// ---------------------------------------------------------------------------------------------
+
+	@Test
+	public void testClearBuffersAfterEmit() throws Exception {
+		final Buffer buffer = TestBufferFactory.createBuffer(32);
+
+		BufferProvider bufferProvider = createBufferProvider(buffer);
+		ResultPartitionWriter partitionWriter = createResultPartitionWriter(bufferProvider);
+
+		RecordWriter<IntValue> recordWriter = new RecordWriter<IntValue>(partitionWriter);
+
+		// Emit single record, the buffer will not be written out.
+		// Therefore, it needs to be cleared explicitly.
+		recordWriter.emit(new IntValue(0));
+
+		// Verify that a buffer is requested, but not written out.
+		verify(bufferProvider, times(1)).requestBufferBlocking();
+		verify(partitionWriter, never()).writeBuffer(any(Buffer.class), anyInt());
+
+		recordWriter.clearBuffers();
+
+		assertTrue("Buffer not recycled.", buffer.isRecycled());
+	}
+
+	@Test
+	public void testClearBuffersAfterExceptionInFlushWritePartition() throws Exception {
+		// Size of buffer ensures that a single record will fill the buffer.
+		final Buffer buffer = TestBufferFactory.createBuffer(4);
+
+		BufferProvider bufferProvider = createBufferProvider(buffer);
+		ResultPartitionWriter partitionWriter = createResultPartitionWriter(bufferProvider);
+
+		doThrow(new IOException("Expected test exception"))
+				.when(partitionWriter).writeBuffer(eq(buffer), eq(0));
+
+		RecordWriter<IntValue> recordWriter = new RecordWriter<IntValue>(partitionWriter);
+
+		try {
+			// Emit single record, the buffer will not be written out,
+			// because of the Exception. Therefore, it needs to be cleared
+			// explicitly.
+			recordWriter.emit(new IntValue(0));
+
+			fail("Did not throw expected Exception. This means that the record "
+					+ "writer did not request a buffer as expected.");
+		}
+		catch (IOException expected) {
+		}
+
+		// Verify that a buffer is requested, but not written out due to the Exception.
+		verify(bufferProvider, times(1)).requestBufferBlocking();
+		verify(partitionWriter, times(1)).writeBuffer(any(Buffer.class), anyInt());
+
+		recordWriter.clearBuffers();
+
+		assertTrue("Buffer not recycled.", buffer.isRecycled());
+
+	}
+
+	@Test
+	public void testClearBuffersAfterExceptionInEmitWritePartition() throws Exception {
+		// Size of buffer ensures that a single record will NOT fill the buffer.
+		final Buffer buffer = TestBufferFactory.createBuffer(32);
+
+		BufferProvider bufferProvider = createBufferProvider(buffer);
+		ResultPartitionWriter partitionWriter = createResultPartitionWriter(bufferProvider);
+
+		doThrow(new IOException("Expected test exception"))
+				.when(partitionWriter).writeBuffer(eq(buffer), eq(0));
+
+		RecordWriter<IntValue> recordWriter = new RecordWriter<IntValue>(partitionWriter);
+
+		try {
+			recordWriter.emit(new IntValue(0));
+
+			// Verify that a buffer is requested, but not written out.
+			verify(bufferProvider, times(1)).requestBufferBlocking();
+			verify(partitionWriter, never()).writeBuffer(any(Buffer.class), anyInt());
+
+			// Now flush the record.
+			recordWriter.flush();
+
+			fail("Did not throw expected Exception. This means that the record "
+					+ "writer did not request a buffer as expected.");
+		}
+		catch (IOException expected) {
+		}
+
+		// Flushing the buffer tried to write out the buffer.
+		verify(partitionWriter, times(1)).writeBuffer(any(Buffer.class), anyInt());
+
+		recordWriter.clearBuffers();
+
+		assertTrue("Buffer not recycled.", buffer.isRecycled());
+	}
+
+	/**
+	 * Tests a fix for FLINK-2089.
+	 *
+	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-2089">FLINK-2089</a>
+	 */
+	@Test
+	public void testClearBuffersAfterInterruptDuringBlockingBufferRequest() throws Exception {
+		ExecutorService executor = null;
+
+		try {
+			executor = Executors.newSingleThreadExecutor();
+
+			final CountDownLatch sync = new CountDownLatch(2);
+
+			final Buffer buffer = spy(TestBufferFactory.createBuffer(4));
+
+			// Return buffer for first request, but block for all following requests.
+			Answer<Buffer> request = new Answer<Buffer>() {
+				@Override
+				public Buffer answer(InvocationOnMock invocation) throws Throwable {
+					sync.countDown();
+
+					if (sync.getCount() == 1) {
+						return buffer;
+					}
+
+					final Object o = new Object();
+					synchronized (o) {
+						while (true) {
+							o.wait();
+						}
+					}
+				}
+			};
+
+			BufferProvider bufferProvider = mock(BufferProvider.class);
+			when(bufferProvider.requestBufferBlocking()).thenAnswer(request);
+
+			ResultPartitionWriter partitionWriter = createResultPartitionWriter(bufferProvider);
+
+			final RecordWriter<IntValue> recordWriter = new RecordWriter<IntValue>(partitionWriter);
+
+			Future<?> result = executor.submit(new Callable<Void>() {
+				@Override
+				public Void call() throws Exception {
+					IntValue val = new IntValue(0);
+
+					try {
+						recordWriter.emit(val);
+						recordWriter.flush();
+
+						recordWriter.emit(val);
+					}
+					catch (InterruptedException e) {
+						recordWriter.clearBuffers();
+					}
+
+					return null;
+				}
+			});
+
+			sync.await();
+
+			// Interrupt the Thread.
+			//
+			// The second emit call requests a new buffer and blocks the thread.
+			// When interrupting the thread at this point, clearing the buffers
+			// should not recycle any buffer.
+			result.cancel(true);
+
+			recordWriter.clearBuffers();
+
+			// Verify that buffer have been requested, but only one has been written out.
+			verify(bufferProvider, times(2)).requestBufferBlocking();
+			verify(partitionWriter, times(1)).writeBuffer(any(Buffer.class), anyInt());
+
+			// Verify that the written out buffer has only been recycled once
+			// (by the partition writer).
+			assertTrue("Buffer not recycled.", buffer.isRecycled());
+			verify(buffer, times(1)).recycle();
+		}
+		finally {
+			if (executor != null) {
+				executor.shutdown();
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------------------------
+
+	private BufferProvider createBufferProvider(Buffer... buffers)
+			throws IOException, InterruptedException {
+
+		BufferProvider bufferProvider = mock(BufferProvider.class);
+
+		for (int i = 0; i < buffers.length; i++) {
+			when(bufferProvider.requestBufferBlocking()).thenReturn(buffers[i]);
+		}
+
+		return bufferProvider;
+	}
+
+	private ResultPartitionWriter createResultPartitionWriter(BufferProvider bufferProvider)
+			throws IOException {
+
+		ResultPartitionWriter partitionWriter = mock(ResultPartitionWriter.class);
+		when(partitionWriter.getBufferProvider()).thenReturn(checkNotNull(bufferProvider));
+		when(partitionWriter.getNumberOfOutputChannels()).thenReturn(1);
+
+		// Recycle each written buffer.
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				((Buffer) invocation.getArguments()[0]).recycle();
+
+				return null;
+			}
+		}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt());
+
+		return partitionWriter;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.event.task.TaskEvent;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.junit.Test;
+import scala.Tuple2;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class InputChannelTest {
+
+	@Test
+	public void testExponentialBackoff() throws Exception {
+		InputChannel ch = createInputChannel(500, 4000);
+
+		assertEquals(0, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(500, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(1000, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(2000, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(4000, ch.getCurrentBackoff());
+
+		assertFalse(ch.increaseBackoff());
+		assertEquals(4000, ch.getCurrentBackoff());
+	}
+
+	@Test
+	public void testExponentialBackoffCappedAtMax() throws Exception {
+		InputChannel ch = createInputChannel(500, 3000);
+
+		assertEquals(0, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(500, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(1000, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(2000, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(3000, ch.getCurrentBackoff());
+
+		assertFalse(ch.increaseBackoff());
+		assertEquals(3000, ch.getCurrentBackoff());
+	}
+
+	@Test
+	public void testExponentialBackoffSingle() throws Exception {
+		InputChannel ch = createInputChannel(500, 500);
+
+		assertEquals(0, ch.getCurrentBackoff());
+
+		assertTrue(ch.increaseBackoff());
+		assertEquals(500, ch.getCurrentBackoff());
+
+		assertFalse(ch.increaseBackoff());
+		assertEquals(500, ch.getCurrentBackoff());
+	}
+
+	@Test
+	public void testExponentialNoBackoff() throws Exception {
+		InputChannel ch = createInputChannel(0, 0);
+
+		assertEquals(0, ch.getCurrentBackoff());
+
+		assertFalse(ch.increaseBackoff());
+		assertEquals(0, ch.getCurrentBackoff());
+	}
+
+	private InputChannel createInputChannel(int initialBackoff, int maxBackoff) {
+		return new MockInputChannel(
+				mock(SingleInputGate.class),
+				0,
+				new ResultPartitionID(),
+				new Tuple2<Integer, Integer>(initialBackoff, maxBackoff));
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	private static class MockInputChannel extends InputChannel {
+
+		private MockInputChannel(
+				SingleInputGate inputGate,
+				int channelIndex,
+				ResultPartitionID partitionId,
+				Tuple2<Integer, Integer> initialAndMaxBackoff) {
+
+			super(inputGate, channelIndex, partitionId, initialAndMaxBackoff);
+		}
+
+		@Override
+		void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
+		}
+
+		@Override
+		Buffer getNextBuffer() throws IOException, InterruptedException {
+			return null;
+		}
+
+		@Override
+		void sendTaskEvent(TaskEvent event) throws IOException {
+		}
+
+		@Override
+		boolean isReleased() {
+			return false;
+		}
+
+		@Override
+		void notifySubpartitionConsumed() throws IOException {
+		}
+
+		@Override
+		void releaseAllResources() throws IOException {
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -23,11 +23,15 @@ import com.google.common.collect.Lists;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
+import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -40,9 +44,15 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import scala.Tuple2;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -50,7 +60,14 @@ import java.util.concurrent.Future;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode.ASYNC;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class LocalInputChannelTest {
 
@@ -157,6 +174,77 @@ public class LocalInputChannelTest {
 			networkBuffers.destroy();
 			executor.shutdown();
 		}
+	}
+
+	@Test
+	public void testPartitionRequestExponentialBackoff() throws Exception {
+		// Config
+		Tuple2<Integer, Integer> backoff = new Tuple2<Integer, Integer>(500, 3000);
+
+		// Start with initial backoff, then keep doubling, and cap at max.
+		int[] expectedDelays = {backoff._1(), 1000, 2000, backoff._2()};
+
+		// Setup
+		SingleInputGate inputGate = mock(SingleInputGate.class);
+
+		BufferProvider bufferProvider = mock(BufferProvider.class);
+		when(inputGate.getBufferProvider()).thenReturn(bufferProvider);
+
+		ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
+
+		LocalInputChannel ch = createLocalInputChannel(inputGate, partitionManager, backoff);
+
+		when(partitionManager
+				.createSubpartitionView(eq(ch.partitionId), eq(0), eq(bufferProvider)))
+				.thenThrow(new PartitionNotFoundException(ch.partitionId));
+
+		Timer timer = mock(Timer.class);
+		doAnswer(new Answer<Void>() {
+
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				((TimerTask) invocation.getArguments()[0]).run();
+				return null;
+			}
+		}).when(timer).schedule(any(TimerTask.class), anyLong());
+
+		// Initial request
+		ch.requestSubpartition(0);
+		verify(partitionManager)
+				.createSubpartitionView(eq(ch.partitionId), eq(0), eq(bufferProvider));
+
+		// Request subpartition and verify that the actual requests are delayed.
+		for (long expected : expectedDelays) {
+			ch.retriggerSubpartitionRequest(timer, 0);
+
+			verify(timer).schedule(any(TimerTask.class), eq(expected));
+		}
+
+		// Exception after backoff is greater than the maximum backoff.
+		try {
+			ch.retriggerSubpartitionRequest(timer, 0);
+			ch.getNextBuffer();
+			fail("Did not throw expected exception.");
+		}
+		catch (Exception expected) {
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	private LocalInputChannel createLocalInputChannel(
+			SingleInputGate inputGate,
+			ResultPartitionManager partitionManager,
+			Tuple2<Integer, Integer> initialAndMaxRequestBackoff)
+			throws IOException, InterruptedException {
+
+		return new LocalInputChannel(
+				inputGate,
+				0,
+				new ResultPartitionID(),
+				partitionManager,
+				mock(TaskEventDispatcher.class),
+				initialAndMaxRequestBackoff);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import akka.actor.ActorRef;
+import akka.pattern.Patterns;
+import akka.util.Timeout;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.io.network.api.reader.RecordReader;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
+import org.apache.flink.runtime.jobgraph.AbstractJobVertex;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmanager.JobManager;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.messages.JobManagerMessages.CancellationSuccess;
+import org.apache.flink.runtime.messages.JobManagerMessages.CurrentJobStatus;
+import org.apache.flink.runtime.messages.JobManagerMessages.JobNotFound;
+import org.apache.flink.runtime.testingUtils.TestingCluster;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.types.IntValue;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
+import static org.apache.flink.runtime.messages.JobManagerMessages.CancellationFailure;
+import static org.apache.flink.runtime.messages.JobManagerMessages.RequestJobStatus;
+import static org.junit.Assert.fail;
+
+public class TaskCancelTest {
+
+	@Test
+	public void testCancelUnion() throws Exception {
+		// Test config
+		int numberOfSources = 8;
+		int sourceParallelism = 4;
+
+		TestingCluster flink = null;
+
+		try {
+			// Start a cluster for the given test config
+			final Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, 2);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, sourceParallelism);
+			config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
+			config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY, 4096);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY, 2048);
+
+			flink = new TestingCluster(config, false);
+
+			// Setup
+			final JobGraph jobGraph = new JobGraph("Cancel Big Union");
+
+			AbstractJobVertex[] sources = new AbstractJobVertex[numberOfSources];
+			SlotSharingGroup group = new SlotSharingGroup();
+
+			// Create multiple sources
+			for (int i = 0; i < sources.length; i++) {
+				sources[i] = new AbstractJobVertex("Source " + i);
+				sources[i].setInvokableClass(InfiniteSource.class);
+				sources[i].setParallelism(sourceParallelism);
+				sources[i].setSlotSharingGroup(group);
+
+				jobGraph.addVertex(sources[i]);
+				group.addVertexToGroup(sources[i].getID());
+			}
+
+			// Union all sources
+			AbstractJobVertex union = new AbstractJobVertex("Union");
+			union.setInvokableClass(AgnosticUnion.class);
+			union.setParallelism(sourceParallelism);
+
+			jobGraph.addVertex(union);
+
+			// Each source creates a separate result
+			for (AbstractJobVertex source : sources) {
+				union.connectNewDataSetAsInput(
+						source,
+						DistributionPattern.POINTWISE,
+						ResultPartitionType.PIPELINED);
+			}
+
+			// Run test
+			JobClient.submitJobDetached(
+					flink.jobManagerActor(), jobGraph, TestingUtils.TESTING_DURATION());
+
+			// Wait for the job to make some progress and then cancel
+			awaitRunning(
+					flink.jobManagerActor(), jobGraph.getJobID(), TestingUtils.TESTING_DURATION());
+
+			Thread.sleep(5000);
+
+			cancelJob(
+					flink.jobManagerActor(), jobGraph.getJobID(), TestingUtils.TESTING_DURATION());
+
+			// Wait for the job to be cancelled
+			JobStatus status = awaitTermination(
+					flink.jobManagerActor(), jobGraph.getJobID(), TestingUtils.TESTING_DURATION());
+
+			if (status == JobStatus.CANCELED) {
+				// Expected :-) All is swell.
+			}
+			else {
+				fail("The job finished with unexpected terminal state " + status + ". "
+						+ "This indicates that there is a bug in the task cancellation.");
+			}
+		}
+		finally {
+			if (flink != null) {
+				flink.shutdown();
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * Requests the {@link JobManager} to cancel a running job.
+	 *
+	 * @param jobManager The JobManager actor.
+	 * @param jobId The JobID of the job to cancel.
+	 * @param timeout Duration in which the JobManager must have responded.
+	 */
+	public static void cancelJob(ActorRef jobManager, JobID jobId, FiniteDuration timeout)
+			throws Exception {
+
+		checkNotNull(jobManager);
+		checkNotNull(jobId);
+		checkNotNull(timeout);
+
+		Future<Object> ask = Patterns.ask(jobManager,
+				new CancelJob(jobId),
+				new Timeout(timeout));
+
+		Object result = Await.result(ask, timeout);
+
+		if (result instanceof CancellationSuccess) {
+			// Success
+			CancellationSuccess success = (CancellationSuccess) result;
+
+			if (!success.jobID().equals(jobId)) {
+				throw new Exception("JobManager responded for wrong job ID. Request: "
+						+ jobId + ", response: " + success.jobID() + ".");
+			}
+		}
+		else if (result instanceof CancellationFailure) {
+			// Failure
+			CancellationFailure failure = (CancellationFailure) result;
+
+			throw new Exception("Failed to cancel job with ID " + failure.jobID() + ".",
+					failure.cause());
+		}
+		else {
+			throw new Exception("Unexpected response to cancel request: " + result);
+		}
+	}
+
+	private void awaitRunning(ActorRef jobManager, JobID jobId, FiniteDuration timeout)
+			throws Exception {
+
+		checkNotNull(jobManager);
+		checkNotNull(jobId);
+		checkNotNull(timeout);
+
+		while (true) {
+			Future<Object> ask = Patterns.ask(jobManager,
+					new RequestJobStatus(jobId),
+					new Timeout(timeout));
+
+			Object result = Await.result(ask, timeout);
+
+			if (result instanceof CurrentJobStatus) {
+				// Success
+				CurrentJobStatus status = (CurrentJobStatus) result;
+
+				if (!status.jobID().equals(jobId)) {
+					throw new Exception("JobManager responded for wrong job ID. Request: "
+							+ jobId + ", response: " + status.jobID() + ".");
+				}
+
+				if (status.status() == JobStatus.RUNNING) {
+					return;
+				}
+				else if (status.status().isTerminalState()) {
+					throw new Exception("JobStatus changed to " + status.status()
+							+ " while waiting for job to start running.");
+				}
+			}
+			else if (result instanceof JobNotFound) {
+				// Not found
+				throw new Exception("Cannot find job with ID " + jobId + ".");
+			}
+			else {
+				throw new Exception("Unexpected response to cancel request: " + result);
+			}
+		}
+
+	}
+
+	private JobStatus awaitTermination(ActorRef jobManager, JobID jobId, FiniteDuration timeout)
+			throws Exception {
+
+		checkNotNull(jobManager);
+		checkNotNull(jobId);
+		checkNotNull(timeout);
+
+		while (true) {
+			Future<Object> ask = Patterns.ask(jobManager,
+					new RequestJobStatus(jobId),
+					new Timeout(timeout));
+
+			Object result = Await.result(ask, timeout);
+
+			if (result instanceof CurrentJobStatus) {
+				// Success
+				CurrentJobStatus status = (CurrentJobStatus) result;
+
+				if (!status.jobID().equals(jobId)) {
+					throw new Exception("JobManager responded for wrong job ID. Request: "
+							+ jobId + ", response: " + status.jobID() + ".");
+				}
+
+				if (status.status().isTerminalState()) {
+					return status.status();
+				}
+			}
+			else if (result instanceof JobNotFound) {
+				throw new Exception("Cannot find job with ID " + jobId + ".");
+			}
+			else {
+				throw new Exception("Unexpected response to cancel request: " + result);
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	public static class InfiniteSource extends AbstractInvokable {
+
+		private RecordWriter<IntValue> writer;
+
+		@Override
+		public void registerInputOutput() {
+			writer = new RecordWriter<IntValue>(getEnvironment().getWriter(0));
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			final IntValue val = new IntValue();
+
+			for (int i = 0; true; i++) {
+				if (Thread.interrupted()) {
+					return;
+				}
+
+				val.setValue(i);
+				writer.emit(val);
+			}
+		}
+	}
+
+	public static class AgnosticUnion extends AbstractInvokable {
+
+		private RecordReader<IntValue> reader;
+
+		@Override
+		public void registerInputOutput() {
+			UnionInputGate union = new UnionInputGate(getEnvironment().getAllInputGates());
+
+			reader = new RecordReader<IntValue>(union, IntValue.class);
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			while (reader.next() != null) {
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -692,10 +692,10 @@ public class TaskManagerTest {
 	}
 
 	/**
-	 * Tests that repeated {@link PartitionNotFoundException}s fail the receiver.
+	 * Tests that repeated remote {@link PartitionNotFoundException}s ultimately fail the receiver.
 	 */
 	@Test
-	public void testPartitionNotFound() throws Exception {
+	public void testRemotePartitionNotFound() throws Exception {
 
 		new JavaTestKit(system){{
 
@@ -775,6 +775,87 @@ public class TaskManagerTest {
 		}};
 	}
 
+	/**
+	 *  Tests that repeated local {@link PartitionNotFoundException}s ultimately fail the receiver.
+	 */
+	@Test
+	public void testLocalPartitionNotFound() throws Exception {
+
+		new JavaTestKit(system){{
+
+			ActorRef jobManager = null;
+			ActorRef taskManager = null;
+
+			try {
+				final IntermediateDataSetID resultId = new IntermediateDataSetID();
+
+				// Create the JM
+				jobManager = system.actorOf(Props.create(
+						new SimplePartitionStateLookupJobManagerCreator(resultId, getTestActor())));
+
+				final int dataPort = NetUtils.getAvailablePort();
+				taskManager = createTaskManager(jobManager, true, true, dataPort);
+
+				// ---------------------------------------------------------------------------------
+
+				final ActorRef tm = taskManager;
+
+				final JobID jid = new JobID();
+				final JobVertexID vid = new JobVertexID();
+				final ExecutionAttemptID eid = new ExecutionAttemptID();
+
+				final ResultPartitionID partitionId = new ResultPartitionID();
+
+				// Local location (on the same TM though) for the partition
+				final ResultPartitionLocation loc = ResultPartitionLocation.createLocal();
+
+				final InputChannelDeploymentDescriptor[] icdd =
+						new InputChannelDeploymentDescriptor[] {
+								new InputChannelDeploymentDescriptor(partitionId, loc)};
+
+				final InputGateDeploymentDescriptor igdd =
+						new InputGateDeploymentDescriptor(resultId, 0, icdd);
+
+				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+						jid, vid, eid, "Receiver", 0, 1,
+						new Configuration(), new Configuration(),
+						Tasks.AgnosticReceiver.class.getName(),
+						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+						Collections.singletonList(igdd),
+						Collections.<BlobKey>emptyList(), 0);
+
+				new Within(d) {
+					@Override
+					protected void run() {
+						// Submit the task
+						tm.tell(new SubmitTask(tdd), getTestActor());
+						expectMsgClass(Messages.getAcknowledge().getClass());
+
+						// Wait to be notified about the final execution state by the mock JM
+						TaskExecutionState msg = expectMsgClass(TaskExecutionState.class);
+
+						// The task should fail after repeated requests
+						assertEquals(msg.getExecutionState(), ExecutionState.FAILED);
+						assertEquals(msg.getError(ClassLoader.getSystemClassLoader()).getClass(),
+								PartitionNotFoundException.class);
+					}
+				};
+			}
+			catch(Exception e) {
+				e.printStackTrace();
+				fail(e.getMessage());
+			}
+			finally {
+				if (taskManager != null) {
+					taskManager.tell(Kill.getInstance(), ActorRef.noSender());
+				}
+
+				if (jobManager != null) {
+					jobManager.tell(Kill.getInstance(), ActorRef.noSender());
+				}
+			}
+		}};
+	}
 
 	// --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR contains multiple independent commits, which address issues discovered while debugging FLINK-2089.

- It adds the partition request backoff logic to local requests as well. The backoffs were introduced recently for remote requests. I've missed that the same problem could also happen for local input channels. The fix was easy and moves the backoff logic to the abstract InputChannel, which both Local and RemoteInputChannel extend.

- The duplicate buffer release was hard to track. In some corner cases, the record serializers were incorrectly holding references to buffers *after* written them out to a result partition. In failure cases, the serializers recycled these buffers too early. The later recycling (by the component, which is actually responsible for this) then resulted in an IllegalStateException.