### PR TITLE
[FLINK-2088] [streaming] [scala] DataStream.name() returns a typed Da…

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -93,7 +93,7 @@ class DataStream[T](javaStream: JavaStream[T]) {
    *
    * @return The named operator
    */
-  def name(name: String) : DataStream[_] = javaStream match {
+  def name(name: String) : DataStream[T] = javaStream match {
     case stream : SingleOutputStreamOperator[_,_] => javaStream.name(name)
     case _ => throw new
         UnsupportedOperationException("Only supported for operators.")


### PR DESCRIPTION
…taStream

Just a quickfix.