### PR TITLE
[FLINK-2104] [ml] Fixes problem with type inference for fallback implicits

### DIFF
--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
@@ -67,24 +67,21 @@ object Predictor{
     *
     * @tparam Self Type of the [[Predictor]]
     * @tparam Testing Type of the testing data
-    * @tparam Prediction Type of the predicted data
     * @return
     */
-  implicit def fallbackPredictOperation[Self: ClassTag, Testing: ClassTag, Prediction: ClassTag]
-    : PredictOperation[Self, Testing, Prediction] = {
-    new PredictOperation[Self, Testing, Prediction] {
+  implicit def fallbackPredictOperation[Self: ClassTag, Testing: ClassTag]
+    : PredictOperation[Self, Testing, Any] = {
+    new PredictOperation[Self, Testing, Any] {
       override def predict(
           instance: Self,
           predictParameters: ParameterMap,
           input: DataSet[Testing])
-        : DataSet[Prediction] = {
+        : DataSet[Any] = {
         val self = implicitly[ClassTag[Self]]
         val testing = implicitly[ClassTag[Testing]]
-        val prediction = implicitly[ClassTag[Prediction]]
 
         throw new RuntimeException("There is no PredictOperation defined for " + self.runtimeClass +
-          " which takes a DataSet[" + testing.runtimeClass + "] as input and returns a DataSet[" +
-          prediction.runtimeClass + "]")
+          " which takes a DataSet[" + testing.runtimeClass + "] as input.")
       }
     }
   }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Transformer.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Transformer.scala
@@ -137,27 +137,24 @@ object Transformer{
     *
     * @tparam Self Type of the [[Transformer]] for which the [[TransformOperation]] is defined
     * @tparam IN Input data type of the [[TransformOperation]]
-    * @tparam OUT Output data type of the [[TransformOperation]]
     * @return
     */
   implicit def fallbackTransformOperation[
       Self: ClassTag,
-      IN: ClassTag,
-      OUT: ClassTag]
-    : TransformOperation[Self, IN, OUT] = {
-    new TransformOperation[Self, IN, OUT] {
+      IN: ClassTag]
+    : TransformOperation[Self, IN, Any] = {
+    new TransformOperation[Self, IN, Any] {
       override def transform(
           instance: Self,
           transformParameters: ParameterMap,
           input: DataSet[IN])
-        : DataSet[OUT] = {
+        : DataSet[Any] = {
         val self = implicitly[ClassTag[Self]]
         val in = implicitly[ClassTag[IN]]
-        val out = implicitly[ClassTag[OUT]]
 
         throw new RuntimeException("There is no TransformOperation defined for " +
           self.runtimeClass +  " which takes a DataSet[" + in.runtimeClass +
-          "] as input and transforms it into a DataSet[" + out.runtimeClass + "]")
+          "] as input.")
       }
     }
   }


### PR DESCRIPTION
The solution seems to be to fix the output type to `Any`. This has the consequence that all following operations will also be fallback operations if they don't support `Any` inputs. But this should be fine since only the first fallback operation will throw an exception stating why the operator could not find a suitable operation.