### PR TITLE
[FLINK-2098] Ensure checkpoints and element emission are in order

### DIFF
--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -309,18 +309,13 @@ parallelism of 1. To create parallel sources the users source function needs to 
 the parallelism of the environment. The parallelism for ParallelSourceFunctions can be changed
 after creation by using `source.setParallelism(parallelism)`.
 
-The `SourceFunction` interface has two methods: `reachedEnd()` and `next()`. The former is used
-by the system to determine whether more input data is available. This method can block if there
-is no data available right now but there might come more data in the future. The `next()` method
-is called to get next data element. This method will only be called if `reachedEnd()` returns 
-false. This method can also block if no data is currently available but more will arrive in the
-future. 
-
-The methods must react to thread interrupt calls and break out of blocking calls with
-`InterruptedException`. The method may ignore interrupt calls and/or swallow InterruptedExceptions,
-if it is guaranteed that the method returns quasi immediately irrespectively of the input.
-This is true for example for file streams, where the call is guaranteed to return after a very
-short I/O delay in the order of milliseconds.
+The `SourceFunction` interface has two methods: `run(SourceContext)` and `cancel()`. The `run()`
+method is not expected to return until the source has either finished by itself or received
+a cancel request. The source can communicate with the outside world using the source context. For
+example, the `emit(element)` method is used to emit one element from the source. Most sources will
+have an infinite while loop inside the `run()` method to read from the input and emit elements.
+Upon invocation of the `cancel()` method the source is required to break out of its internal
+loop and return from the `run()` method.
 
 In addition to the bounded data sources (with similar method signatures as the
 [batch API](programming_guide.html#data-sources)) there are several predefined stream sources

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointedOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointedOperator.java
@@ -19,6 +19,10 @@
 package org.apache.flink.runtime.jobgraph.tasks;
 
 public interface CheckpointedOperator {
-	
+
+	/**
+	 * This method is either called directly by the checkpoint coordinator, or called
+	 * when all incoming channels have reported a barrier
+	 */
 	void triggerCheckpoint(long checkpointId, long timestamp) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointedOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointedOperator.java
@@ -18,11 +18,21 @@
 
 package org.apache.flink.runtime.jobgraph.tasks;
 
+/**
+ * This interface must be implemented by invokable operators (subclasses
+ * of {@link org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable} that
+ * participate in state checkpoints.
+ */
 public interface CheckpointedOperator {
 
 	/**
-	 * This method is either called directly by the checkpoint coordinator, or called
-	 * when all incoming channels have reported a barrier
+	 * This method is either called directly and asynchronously by the checkpoint
+	 * coordinator (in the case of functions that are directly notified - usually
+	 * the data sources), or called synchronously when all incoming channels have
+	 * reported a checkpoint barrier.
+	 * 
+	 * @param checkpointId The ID of the checkpoint, incrementing.
+	 * @param timestamp The timestamp when the checkpoint was triggered at the JobManager.
 	 */
 	void triggerCheckpoint(long checkpointId, long timestamp) throws Exception;
 }

--- a/flink-staging/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseWriteStreamExample.java
+++ b/flink-staging/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseWriteStreamExample.java
@@ -48,17 +48,22 @@ public class HBaseWriteStreamExample {
 
 		// data stream with random numbers
 		DataStream<String> dataStream = env.addSource(new SourceFunction<String>() {
+			private static final long serialVersionUID = 1L;
+
+			private volatile boolean isRunning = true;
 
 			@Override
-			public boolean reachedEnd() throws Exception {
-				return false;
+			public void run(Object checkpointLock, Collector<String> out) throws Exception {
+				while (isRunning) {
+					out.collect(String.valueOf(Math.floor(Math.random() * 100)));
+				}
+
 			}
 
 			@Override
-			public String next() throws Exception {
-				return 	String.valueOf(Math.floor(Math.random() * 100));
+			public void cancel() {
+				isRunning = false;
 			}
-
 		});
 		dataStream.write(new HBaseOutputFormat(), 0L);
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExample.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.api.KafkaSink;
 import org.apache.flink.streaming.util.serialization.JavaDefaultStringSchema;
+import org.apache.flink.util.Collector;
 
 public class KafkaProducerExample {
 
@@ -39,29 +40,25 @@ public class KafkaProducerExample {
 
 		@SuppressWarnings({ "unused", "serial" })
 		DataStream<String> stream1 = env.addSource(new SourceFunction<String>() {
-
-			private int index = 0;
-
 			@Override
-			public boolean reachedEnd() throws Exception {
-				return index >= 20;
-			}
-
-			@Override
-			public String next() throws Exception {
-				if (index < 20) {
-					String result = "message #" + index;
-					index++;
-					return result;
+			public void run(Object checkpointLock, Collector<String> collector) throws Exception {
+				for (int i = 0; i < 20; i++) {
+					collector.collect("message #" + i);
+					Thread.sleep(100L);
 				}
 
-				return "q";
+				collector.collect("q");
 			}
+
+			@Override
+			public void cancel() {
+			}
+
 
 		}).addSink(
 				new KafkaSink<String>(host + ":" + port, topic, new JavaDefaultStringSchema())
 		)
-		.setParallelism(3);
+				.setParallelism(3);
 
 		env.execute();
 	}

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -27,6 +27,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.QueueingConsumer;
+import org.apache.flink.util.Collector;
 
 public class RMQSource<OUT> extends ConnectorSource<OUT> {
 	private static final long serialVersionUID = 1L;
@@ -40,7 +41,7 @@ public class RMQSource<OUT> extends ConnectorSource<OUT> {
 	private transient QueueingConsumer consumer;
 	private transient QueueingConsumer.Delivery delivery;
 
-	OUT out;
+	private transient volatile boolean running;
 
 	public RMQSource(String HOST_NAME, String QUEUE_NAME,
 			DeserializationSchema<OUT> deserializationSchema) {
@@ -70,6 +71,7 @@ public class RMQSource<OUT> extends ConnectorSource<OUT> {
 	@Override
 	public void open(Configuration config) throws Exception {
 		initializeConnection();
+		running = true;
 	}
 
 	@Override
@@ -84,47 +86,21 @@ public class RMQSource<OUT> extends ConnectorSource<OUT> {
 	}
 
 	@Override
-	public boolean reachedEnd() throws Exception {
-		if (out != null) {
-			return true;
-		}
-		try {
+	public void run(Object checkpointLock, Collector<OUT> out) throws Exception {
+		while (running) {
 			delivery = consumer.nextDelivery();
-		} catch (Exception e) {
-			throw new RuntimeException("Error while reading message from RMQ source from " + QUEUE_NAME
-					+ " at " + HOST_NAME, e);
-		}
 
-		out = schema.deserialize(delivery.getBody());
-		if (schema.isEndOfStream(out)) {
-			out = null;
-			return false;
+			OUT result = schema.deserialize(delivery.getBody());
+			if (schema.isEndOfStream(result)) {
+				break;
+			}
+
+			out.collect(result);
 		}
-		return true;
 	}
 
 	@Override
-	public OUT next() throws Exception {
-		if (out != null) {
-			OUT result = out;
-			out = null;
-			return result;
-		}
-
-		try {
-			delivery = consumer.nextDelivery();
-		} catch (Exception e) {
-			throw new RuntimeException("Error while reading message from RMQ source from " + QUEUE_NAME
-					+ " at " + HOST_NAME, e);
-		}
-
-		out = schema.deserialize(delivery.getBody());
-		if (schema.isEndOfStream(out)) {
-			throw new RuntimeException("RMQ source is at end for " + QUEUE_NAME + " at " + HOST_NAME);
-		}
-		OUT result = out;
-		out = null;
-		return result;
+	public void cancel() {
+		running = false;
 	}
-
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-twitter/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterStreaming.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-twitter/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterStreaming.java
@@ -1,19 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 package org.apache.flink.streaming.connectors.twitter;
 
@@ -68,7 +68,7 @@ public class TwitterStreaming {
 				if (LOG.isErrorEnabled()) {
 					LOG.error("Field not found");
 				}
-			} 
+			}
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-twitter/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterTopology.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-twitter/src/main/java/org/apache/flink/streaming/connectors/twitter/TwitterTopology.java
@@ -1,19 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 package org.apache.flink.streaming.connectors.twitter;
 
@@ -26,15 +26,15 @@ import org.apache.flink.util.Collector;
 import org.apache.sling.commons.json.JSONException;
 
 /**
- * This program demonstrate the use of TwitterSource. 
- * Its aim is to count the frequency of the languages of tweets
- */
+* This program demonstrate the use of TwitterSource.
+* Its aim is to count the frequency of the languages of tweets
+*/
 public class TwitterTopology {
 
 	private static final int NUMBEROFTWEETS = 100;
-	
+
 	/**
-	 * FlatMapFunction to determine the language of tweets if possible 
+	 * FlatMapFunction to determine the language of tweets if possible
 	 */
 	public static class SelectLanguageFlatMap extends
 			JSONParseFlatMap<String, String> {
@@ -76,7 +76,7 @@ public class TwitterTopology {
 				.flatMap(new SelectLanguageFlatMap())
 				.map(new MapFunction<String, Tuple2<String, Integer>>() {
 					private static final long serialVersionUID = 1L;
-					
+
 					@Override
 					public Tuple2<String, Integer> map(String value) throws Exception {
 						return new Tuple2<String, Integer>(value, 1);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/ConnectorSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/ConnectorSource.java
@@ -19,12 +19,12 @@ package org.apache.flink.streaming.api.functions.source;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
-import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 
-public abstract class ConnectorSource<OUT> extends RichParallelSourceFunction<OUT> implements ResultTypeQueryable<OUT>{
+public abstract class ConnectorSource<OUT> extends RichParallelSourceFunction<OUT> implements ResultTypeQueryable<OUT> {
 
 	private static final long serialVersionUID = 1L;
+	
 	protected DeserializationSchema<OUT> schema;
 
 	public ConnectorSource(DeserializationSchema<OUT> schema) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
@@ -52,7 +52,7 @@ public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Lon
 	private Map<String, Long> offsetOfFiles;
 	private Map<String, Long> modificationTimes;
 
-	private volatile boolean isRunning;
+	private volatile boolean isRunning = true;
 
 	public FileMonitoringFunction(String path, long interval, WatchType watchType) {
 		this.path = path;
@@ -64,7 +64,6 @@ public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Lon
 
 	@Override
 	public void run(Object checkpointLock, Collector<Tuple3<String, Long, Long>> collector) throws Exception {
-		isRunning = true;
 		FileSystem fileSystem = FileSystem.get(new URI(path));
 
 		while (isRunning) {
@@ -117,11 +116,7 @@ public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Lon
 			return true;
 		} else {
 			Long lastModification = modificationTimes.get(fileName);
-			if (lastModification == null) {
-				return false;
-			} else {
-				return lastModification >= modificationTime;
-			}
+			return lastModification != null && lastModification >= modificationTime;
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
@@ -21,20 +21,18 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FileMonitoringFunction extends RichSourceFunction<Tuple3<String, Long, Long>> {
+public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Long, Long>> {
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger LOG = LoggerFactory.getLogger(FileMonitoringFunction.class);
@@ -51,28 +49,50 @@ public class FileMonitoringFunction extends RichSourceFunction<Tuple3<String, Lo
 	private long interval;
 	private WatchType watchType;
 
-	private FileSystem fileSystem;
 	private Map<String, Long> offsetOfFiles;
 	private Map<String, Long> modificationTimes;
 
-	private Queue<Tuple3<String, Long, Long>> pendingFiles;
+	private volatile boolean isRunning;
 
 	public FileMonitoringFunction(String path, long interval, WatchType watchType) {
 		this.path = path;
 		this.interval = interval;
 		this.watchType = watchType;
+		this.modificationTimes = new HashMap<String, Long>();
+		this.offsetOfFiles = new HashMap<String, Long>();
 	}
 
 	@Override
-	public void open(Configuration parameters) throws Exception {
-		super.open(parameters);
-		this.modificationTimes = new HashMap<String, Long>();
-		this.offsetOfFiles = new HashMap<String, Long>();
-		this.pendingFiles = new LinkedList<Tuple3<String, Long, Long>>();
-		fileSystem = FileSystem.get(new URI(path));
+	public void run(Object checkpointLock, Collector<Tuple3<String, Long, Long>> collector) throws Exception {
+		isRunning = true;
+		FileSystem fileSystem = FileSystem.get(new URI(path));
+
+		while (isRunning) {
+			List<String> files = listNewFiles(fileSystem);
+			for (String filePath : files) {
+				if (watchType == WatchType.ONLY_NEW_FILES
+						|| watchType == WatchType.REPROCESS_WITH_APPENDED) {
+					collector.collect(new Tuple3<String, Long, Long>(filePath, 0L, -1L));
+					offsetOfFiles.put(filePath, -1L);
+				} else if (watchType == WatchType.PROCESS_ONLY_APPENDED) {
+					long offset = 0;
+					long fileSize = fileSystem.getFileStatus(new Path(filePath)).getLen();
+					if (offsetOfFiles.containsKey(filePath)) {
+						offset = offsetOfFiles.get(filePath);
+					}
+
+					collector.collect(new Tuple3<String, Long, Long>(filePath, offset, fileSize));
+					offsetOfFiles.put(filePath, fileSize);
+
+					LOG.info("File processed: {}, {}, {}", filePath, offset, fileSize);
+				}
+			}
+
+			Thread.sleep(interval);
+		}
 	}
 
-	private List<String> listNewFiles() throws IOException {
+	private List<String> listNewFiles(FileSystem fileSystem) throws IOException {
 		List<String> files = new ArrayList<String>();
 
 		FileStatus[] statuses = fileSystem.listStatus(new Path(path));
@@ -105,44 +125,8 @@ public class FileMonitoringFunction extends RichSourceFunction<Tuple3<String, Lo
 		}
 	}
 
-
 	@Override
-	public boolean reachedEnd() throws Exception {
-		return false;
-	}
-
-	@Override
-	public Tuple3<String, Long, Long> next() throws Exception {
-		if (pendingFiles.size() > 0) {
-			return pendingFiles.poll();
-		} else {
-			while (true) {
-				List<String> files = listNewFiles();
-				for (String filePath : files) {
-					if (watchType == WatchType.ONLY_NEW_FILES
-							|| watchType == WatchType.REPROCESS_WITH_APPENDED) {
-						pendingFiles.add(new Tuple3<String, Long, Long>(filePath, 0L, -1L));
-						offsetOfFiles.put(filePath, -1L);
-					} else if (watchType == WatchType.PROCESS_ONLY_APPENDED) {
-						long offset = 0;
-						long fileSize = fileSystem.getFileStatus(new Path(filePath)).getLen();
-						if (offsetOfFiles.containsKey(filePath)) {
-							offset = offsetOfFiles.get(filePath);
-						}
-
-						pendingFiles.add(new Tuple3<String, Long, Long>(filePath, offset, fileSize));
-						offsetOfFiles.put(filePath, fileSize);
-
-						LOG.info("File added to queue: {}, {}, {}", filePath, offset, fileSize);
-					}
-				}
-				if (files.size() > 0) {
-					break;
-				}
-				Thread.sleep(interval);
-			}
-		}
-
-		return pendingFiles.poll();
+	public void cancel() {
+		isRunning = false;
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FileSourceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FileSourceFunction.java
@@ -40,7 +40,7 @@ public class FileSourceFunction<OUT> extends RichParallelSourceFunction<OUT> {
 	private transient InputSplitProvider provider;
 	private transient Iterator<InputSplit> splitIterator;
 
-	private volatile boolean isRunning;
+	private volatile boolean isRunning = true;
 
 	@SuppressWarnings("unchecked")
 	public FileSourceFunction(InputFormat<OUT, ?> format, TypeInformation<OUT> typeInfo) {
@@ -65,7 +65,6 @@ public class FileSourceFunction<OUT> extends RichParallelSourceFunction<OUT> {
 
 	@Override
 	public void close() throws Exception {
-		super.close();
 		format.close();
 	}
 
@@ -118,8 +117,6 @@ public class FileSourceFunction<OUT> extends RichParallelSourceFunction<OUT> {
 
 	@Override
 	public void run(Object checkpointLock, Collector<OUT> out) throws Exception {
-		isRunning = true;
-
 		while (isRunning) {
 			OUT nextElement = serializer.createInstance();
 			nextElement =  format.nextRecord(nextElement);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
@@ -24,11 +24,12 @@ import java.util.Iterator;
 import org.apache.flink.util.Collector;
 
 public class FromElementsFunction<T> implements SourceFunction<T> {
+	
 	private static final long serialVersionUID = 1L;
 
 	private Iterable<T> iterable;
 
-	private volatile boolean isRunning;
+	private volatile boolean isRunning = true;
 
 	public FromElementsFunction(T... elements) {
 		this.iterable = Arrays.asList(elements);
@@ -44,7 +45,6 @@ public class FromElementsFunction<T> implements SourceFunction<T> {
 
 	@Override
 	public void run(Object checkpointLock, Collector<T> out) throws Exception {
-		isRunning = true;
 		Iterator<T> it = iterable.iterator();
 
 		while (isRunning && it.hasNext()) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.api.functions.source;
 
+import org.apache.flink.util.Collector;
+
 import java.util.Iterator;
 
 public class FromIteratorFunction<T> implements SourceFunction<T> {
@@ -25,17 +27,22 @@ public class FromIteratorFunction<T> implements SourceFunction<T> {
 
 	Iterator<T> iterator;
 
+	private volatile boolean isRunning;
+
 	public FromIteratorFunction(Iterator<T> iterator) {
 		this.iterator = iterator;
 	}
 
 	@Override
-	public boolean reachedEnd() throws Exception {
-		return !iterator.hasNext();
+	public void run(Object checkpointLock, Collector<T> out) throws Exception {
+		isRunning = true;
+		while (isRunning && iterator.hasNext()) {
+			out.collect(iterator.next());
+		}
 	}
 
 	@Override
-	public T next() throws Exception {
-		return iterator.next();
+	public void cancel() {
+		isRunning = false;
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
@@ -25,9 +25,9 @@ public class FromIteratorFunction<T> implements SourceFunction<T> {
 
 	private static final long serialVersionUID = 1L;
 
-	Iterator<T> iterator;
+	private final Iterator<T> iterator;
 
-	private volatile boolean isRunning;
+	private volatile boolean isRunning = true;
 
 	public FromIteratorFunction(Iterator<T> iterator) {
 		this.iterator = iterator;
@@ -35,7 +35,6 @@ public class FromIteratorFunction<T> implements SourceFunction<T> {
 
 	@Override
 	public void run(Object checkpointLock, Collector<T> out) throws Exception {
-		isRunning = true;
 		while (isRunning && iterator.hasNext()) {
 			out.collect(iterator.next());
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromSplittableIteratorFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/FromSplittableIteratorFunction.java
@@ -31,7 +31,7 @@ public class FromSplittableIteratorFunction<T> extends RichParallelSourceFunctio
 
 	private transient Iterator<T> iterator;
 
-	private volatile boolean isRunning;
+	private volatile boolean isRunning = true;
 
 	public FromSplittableIteratorFunction(SplittableIterator<T> iterator) {
 		this.fullIterator = iterator;
@@ -47,8 +47,6 @@ public class FromSplittableIteratorFunction<T> extends RichParallelSourceFunctio
 
 	@Override
 	public void run(Object checkpointLock, Collector<T> out) throws Exception {
-		isRunning = true;
-
 		while (isRunning && iterator.hasNext()) {
 			out.collect(iterator.next());
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/ParallelSourceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/ParallelSourceFunction.java
@@ -25,7 +25,7 @@ package org.apache.flink.streaming.api.functions.source;
  * <p>This interface acts only as a marker to tell the system that this source may
  * be executed in parallel. When different parallel instances are required to perform
  * different tasks, use the {@link RichParallelSourceFunction} to get access to the runtime
- * context, which revels information like the number of parallel tasks, and which parallel
+ * context, which reveals information like the number of parallel tasks, and which parallel
  * task the current instance is.
  *
  * @param <OUT> The type of the records produced by this source.

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/RichParallelSourceFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/RichParallelSourceFunction.java
@@ -20,9 +20,14 @@ package org.apache.flink.streaming.api.functions.source;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 
 /**
- * Base class for implementing a data source that has access to context information
- * (via {@link #getRuntimeContext()}) and additional life-cycle methods
- * ({@link #open(org.apache.flink.configuration.Configuration)} and {@link #close()}.
+ * Base class for implementing a parallel data source. Upon execution, the runtime will
+ * execute as many parallel instances of this function function as configured parallelism
+ * of the source.
+ * 
+ * <p>The data source has access to context information (such as the number of parallel
+ * instances of the source, and which parallel instance the current instance is)
+ * via {@link #getRuntimeContext()}. It also provides additional life-cycle methods
+ * ({@link #open(org.apache.flink.configuration.Configuration)} and {@link #close()}.</p>
  *
  * @param <OUT> The type of the records produced by this source.
  */

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -45,7 +45,7 @@ public class SocketTextStreamFunction extends RichSourceFunction<String> {
 	private static final int CONNECTION_TIMEOUT_TIME = 0;
 	private static final int CONNECTION_RETRY_SLEEP = 1000;
 
-	private volatile boolean isRunning = false;
+	private volatile boolean isRunning;
 
 	public SocketTextStreamFunction(String hostname, int port, char delimiter, long maxRetry) {
 		this.hostname = hostname;
@@ -60,6 +60,7 @@ public class SocketTextStreamFunction extends RichSourceFunction<String> {
 		super.open(parameters);
 		socket = new Socket();
 		socket.connect(new InetSocketAddress(hostname, port), CONNECTION_TIMEOUT_TIME);
+		isRunning = true;
 	}
 
 	@Override
@@ -68,7 +69,6 @@ public class SocketTextStreamFunction extends RichSourceFunction<String> {
 	}
 
 	public void streamFromSocket(Collector<String> collector, Socket socket) throws Exception {
-		isRunning = true;
 		try {
 			StringBuffer buffer = new StringBuffer();
 			BufferedReader reader = new BufferedReader(new InputStreamReader(

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -26,6 +26,7 @@ import java.net.Socket;
 import java.net.SocketException;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +45,7 @@ public class SocketTextStreamFunction extends RichSourceFunction<String> {
 	private static final int CONNECTION_TIMEOUT_TIME = 0;
 	private static final int CONNECTION_RETRY_SLEEP = 1000;
 
-	private transient StringBuffer buffer;
-	private transient BufferedReader reader;
-
-	private boolean socketClosed;
-	private transient String nextElement;
+	private volatile boolean isRunning = false;
 
 	public SocketTextStreamFunction(String hostname, int port, char delimiter, long maxRetry) {
 		this.hostname = hostname;
@@ -63,18 +60,81 @@ public class SocketTextStreamFunction extends RichSourceFunction<String> {
 		super.open(parameters);
 		socket = new Socket();
 		socket.connect(new InetSocketAddress(hostname, port), CONNECTION_TIMEOUT_TIME);
-		buffer = new StringBuffer();
-		reader = new BufferedReader(new InputStreamReader(
-				socket.getInputStream()));
-		socketClosed = false;
 	}
 
 	@Override
-	public void close() throws Exception {
-		super.close();
-		if (reader != null) {
-			reader.close();
+	public void run(Object checkpointLock, Collector<String> collector) throws Exception {
+		streamFromSocket(collector, socket);
+	}
+
+	public void streamFromSocket(Collector<String> collector, Socket socket) throws Exception {
+		isRunning = true;
+		try {
+			StringBuffer buffer = new StringBuffer();
+			BufferedReader reader = new BufferedReader(new InputStreamReader(
+					socket.getInputStream()));
+
+			while (isRunning) {
+				int data;
+				try {
+					data = reader.read();
+				} catch (SocketException e) {
+					if (!isRunning) {
+						break;
+					} else {
+						throw e;
+					}
+				}
+
+				if (data == -1) {
+					socket.close();
+					long retry = 0;
+					boolean success = false;
+					while (retry < maxRetry && !success) {
+						if (!retryForever) {
+							retry++;
+						}
+						LOG.warn("Lost connection to server socket. Retrying in "
+								+ (CONNECTION_RETRY_SLEEP / 1000) + " seconds...");
+						try {
+							socket = new Socket();
+							socket.connect(new InetSocketAddress(hostname, port),
+									CONNECTION_TIMEOUT_TIME);
+							success = true;
+						} catch (ConnectException ce) {
+							Thread.sleep(CONNECTION_RETRY_SLEEP);
+						}
+					}
+
+					if (success) {
+						LOG.info("Server socket is reconnected.");
+					} else {
+						LOG.error("Could not reconnect to server socket.");
+						break;
+					}
+					reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+					continue;
+				}
+
+				if (data == delimiter) {
+					collector.collect(buffer.toString());
+					buffer = new StringBuffer();
+				} else if (data != '\r') { // ignore carriage return
+					buffer.append((char) data);
+				}
+			}
+
+			if (buffer.length() > 0) {
+				collector.collect(buffer.toString());
+			}
+		} finally {
+			socket.close();
 		}
+	}
+
+	@Override
+	public void cancel() {
+		isRunning = false;
 		if (socket != null && !socket.isClosed()) {
 			try {
 				socket.close();
@@ -84,81 +144,5 @@ public class SocketTextStreamFunction extends RichSourceFunction<String> {
 				}
 			}
 		}
-
 	}
-
-	public String blockingRead(Socket socket) throws Exception {
-
-		while (true) {
-			int data;
-			try {
-				data = reader.read();
-			} catch (SocketException e) {
-				socketClosed = true;
-				break;
-			}
-
-			if (data == -1) {
-				socket.close();
-				long retry = 0;
-				boolean success = false;
-				while (retry < maxRetry && !success) {
-					if (!retryForever) {
-						retry++;
-					}
-					LOG.warn("Lost connection to server socket. Retrying in "
-							+ (CONNECTION_RETRY_SLEEP / 1000) + " seconds...");
-					try {
-						socket = new Socket();
-						socket.connect(new InetSocketAddress(hostname, port),
-								CONNECTION_TIMEOUT_TIME);
-						success = true;
-					} catch (ConnectException ce) {
-						Thread.sleep(CONNECTION_RETRY_SLEEP);
-					}
-				}
-
-				if (success) {
-					LOG.info("Server socket is reconnected.");
-				} else {
-					LOG.error("Could not reconnect to server socket.");
-					break;
-				}
-				reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-				continue;
-			}
-
-			if (data == delimiter) {
-				String result = buffer.toString();
-				buffer = new StringBuffer();
-				return result;
-			} else if (data != '\r') { // ignore carriage return
-				buffer.append((char) data);
-			}
-		}
-
-		return null;
-	}
-
-
-	@Override
-	public boolean reachedEnd() throws Exception {
-		if (socketClosed) {
-			return false;
-		}
-
-		nextElement = blockingRead(socket);
-
-		return nextElement == null;
-	}
-
-	@Override
-	public String next() throws Exception {
-		if (nextElement == null) {
-			reachedEnd();
-		}
-
-		return nextElement;
-	}
-
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -41,7 +41,7 @@ public abstract class AbstractStreamOperator<OUT> implements StreamOperator<OUT>
 	protected ChainingStrategy chainingStrategy = ChainingStrategy.HEAD;
 
 	@Override
-	public final void setup(Output<OUT> output, RuntimeContext runtimeContext) {
+	public void setup(Output<OUT> output, RuntimeContext runtimeContext) {
 		this.output = output;
 		this.executionConfig = runtimeContext.getExecutionConfig();
 		this.runtimeContext = runtimeContext;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.checkpoint.CheckpointCommitter;
@@ -43,9 +44,15 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function & Serial
 	}
 
 	@Override
+	public final void setup(Output<OUT> output, RuntimeContext runtimeContext) {
+		super.setup(output, runtimeContext);
+		FunctionUtils.setFunctionRuntimeContext(userFunction, runtimeContext);
+	}
+
+
+	@Override
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
-		FunctionUtils.setFunctionRuntimeContext(userFunction, runtimeContext);
 		FunctionUtils.openFunction(userFunction, parameters);
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -18,7 +18,11 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.util.Collector;
 
+/**
+ * {@link StreamOperator} for streaming sources.
+ */
 public class StreamSource<OUT> extends AbstractUdfStreamOperator<OUT, SourceFunction<OUT>> implements StreamOperator<OUT> {
 
 	private static final long serialVersionUID = 1L;
@@ -29,19 +33,11 @@ public class StreamSource<OUT> extends AbstractUdfStreamOperator<OUT, SourceFunc
 		this.chainingStrategy = ChainingStrategy.HEAD;
 	}
 
-	public void run() throws Exception {
-		while (true) {
+	public void run(Object lockingObject, Collector<OUT> collector) throws Exception {
+		userFunction.run(lockingObject, collector);
+	}
 
-			synchronized (userFunction) {
-				if (userFunction.reachedEnd()) {
-					break;
-				}
-
-				OUT result = userFunction.next();
-
-				output.collect(result);
-			}
-			Thread.yield();
-		}
+	public void cancel() {
+		userFunction.cancel();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -86,7 +86,7 @@ public class SourceStreamTask<OUT> extends StreamTask<OUT, StreamSource<OUT>> {
 
 	@Override
 	public void cancel() {
-		streamOperator.cancel();
 		super.cancel();
+		streamOperator.cancel();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -22,6 +22,18 @@ import org.apache.flink.streaming.api.operators.StreamSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Task for executing streaming sources.
+ *
+ * One important aspect of this is that the checkpointing and the emission of elements must never
+ * occur at the same time. The execution must be serial. This is achieved by having the contract
+ * with the StreamFunction that it must only modify its state or emit elements in
+ * a synchronized block that locks on the checkpointLock Object. Also, the modification of the state
+ * and the emission of elements must happen in the same block of code that is protected by the
+ * synchronized block.
+ *
+ * @param <OUT> Type of the output elements of this source.
+ */
 public class SourceStreamTask<OUT> extends StreamTask<OUT, StreamSource<OUT>> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SourceStreamTask.class);
@@ -40,7 +52,7 @@ public class SourceStreamTask<OUT> extends StreamTask<OUT, StreamSource<OUT>> {
 			openOperator();
 			operatorOpen = true;
 
-			streamOperator.run();
+			streamOperator.run(checkpointLock, outputHandler.getOutput());
 
 			closeOperator();
 			operatorOpen = false;
@@ -70,5 +82,11 @@ public class SourceStreamTask<OUT> extends StreamTask<OUT, StreamSource<OUT>> {
 			clearBuffers();
 		}
 
+	}
+
+	@Override
+	public void cancel() {
+		streamOperator.cancel();
+		super.cancel();
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -50,7 +50,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamTask.class);
 
-	private final Object checkpointLock = new Object();
+	protected final Object checkpointLock = new Object();
 
 	protected StreamConfig configuration;
 
@@ -191,9 +191,6 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 	//  Checkpoint and Restore
 	// ------------------------------------------------------------------------
 
-	/**
-	 * Re-injects the user states into the map. Also set the state on the functions.
-	 */
 	@Override
 	public void setInitialState(StateHandle<Serializable> stateHandle) throws Exception {
 		// here, we later resolve the state handle into the actual state by
@@ -230,13 +227,9 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 		}
 	}
 
-	/**
-	 * This method is either called directly by the checkpoint coordinator, or called
-	 * when all incoming channels have reported a barrier
-	 */
 	@Override
 	public void triggerCheckpoint(long checkpointId, long timestamp) throws Exception {
-		
+
 		synchronized (checkpointLock) {
 			if (isRunning) {
 				try {
@@ -293,6 +286,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 				}
 			}
 		}
+
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/ChainedRuntimeContextTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/ChainedRuntimeContextTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.Collector;
 import org.junit.Test;
 
 @SuppressWarnings("serial")
@@ -46,13 +47,11 @@ public class ChainedRuntimeContextTest {
 	private static class TestSource extends RichParallelSourceFunction<Integer> {
 
 		@Override
-		public boolean reachedEnd() throws Exception {
-			return true;
+		public void run(Object checkpointLock, Collector<Integer> out) throws Exception {
 		}
 
 		@Override
-		public Integer next() throws Exception {
-			return null;
+		public void cancel() {
 		}
 
 		@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/TypeFillTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/TypeFillTest.java
@@ -115,18 +115,17 @@ public class TypeFillTest {
 	}
 
 	private class TestSource<T> implements SourceFunction<T> {
-
+		private static final long serialVersionUID = 1L;
 
 		@Override
-		public boolean reachedEnd() throws Exception {
-			return false;
+		public void run(Object checkpointLock, Collector<T> out) throws Exception {
+
 		}
 
 		@Override
-		public T next() throws Exception {
-			return null;
-		}
+		public void cancel() {
 
+		}
 	}
 
 	private class TestMap<T, O> implements MapFunction<T, O> {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamtask/StreamVertexTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamtask/StreamVertexTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.Collector;
 import org.junit.Test;
 
 public class StreamVertexTest {
@@ -44,22 +45,23 @@ public class StreamVertexTest {
 	private static Map<Integer, Integer> data = new HashMap<Integer, Integer>();
 
 	public static class MySource implements SourceFunction<Tuple1<Integer>> {
+		private static final long serialVersionUID = 1L;
+
 		private Tuple1<Integer> tuple = new Tuple1<Integer>(0);
 
 		private int i = 0;
 
 		@Override
-		public boolean reachedEnd() throws Exception {
-			return i >= 10;
+		public void run(Object checkpointLock, Collector<Tuple1<Integer>> out) throws Exception {
+			for (int i = 0; i < 10; i++) {
+				tuple.f0 = i;
+				out.collect(tuple);
+			}
 		}
 
 		@Override
-		public Tuple1<Integer> next() throws Exception {
-			tuple.f0 = i;
-			i++;
-			return tuple;
+		public void cancel() {
 		}
-
 	}
 
 	public static class MyTask extends RichMapFunction<Tuple1<Integer>, Tuple2<Integer, Integer>> {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -1,0 +1,248 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.tasks;
+
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.taskmanager.Task;
+import org.apache.flink.streaming.api.checkpoint.Checkpointed;
+import org.apache.flink.streaming.api.collector.selector.BroadcastOutputSelectorWrapper;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecordSerializer;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Task.class, ResultPartitionWriter.class})
+public class SourceStreamTaskTest extends StreamTaskTestBase {
+
+	private static final int MEMORY_MANAGER_SIZE = 1024 * 1024;
+
+	private static final int NETWORK_BUFFER_SIZE = 1024;
+
+	/**
+	 * This test ensures that the SourceStreamTask properly serializes checkpointing
+	 * and element emission. This also verifies that there are no concurrent invocations
+	 * of the checkpoint method on the source operator.
+	 *
+	 * The source emits elements and performs checkpoints. We have several checkpointer threads
+	 * that fire checkpoint requests at the source task.
+	 *
+	 * If element emission and checkpointing are not in series the count of elements at the
+	 * beginning of a checkpoint and at the end of a checkpoint are not the same because the
+	 * source kept emitting elements while the checkpoint was ongoing.
+	 */
+	@Test
+	public void testDataSourceTask() throws Exception {
+		final int NUM_ELEMENTS = 100;
+		final int NUM_CHECKPOINTS = 100;
+		final int NUM_CHECKPOINTERS = 1;
+		final int CHECKPOINT_INTERVAL = 5; // in ms
+		final int SOURCE_CHECKPOINT_DELAY = 1000; // how many random values we sum up in storeCheckpoint
+		final int SOURCE_READ_DELAY = 1; // in ms
+
+		List<Tuple2<Long, Integer>> outList = new ArrayList<Tuple2<Long, Integer>>();
+
+		super.initEnvironment(MEMORY_MANAGER_SIZE, NETWORK_BUFFER_SIZE);
+
+		StreamSource<Tuple2<Long, Integer>> sourceOperator = new StreamSource<Tuple2<Long, Integer>>(new MockSource(NUM_ELEMENTS, SOURCE_CHECKPOINT_DELAY, SOURCE_READ_DELAY));
+
+		final SourceStreamTask<Tuple2<Long, Integer>> sourceTask = new SourceStreamTask<Tuple2<Long, Integer>>();
+
+		TupleTypeInfo<Tuple2<Long, Integer>> typeInfo = new TupleTypeInfo<Tuple2<Long, Integer>>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+		TypeSerializer<Tuple2<Long, Integer>> serializer = typeInfo.createSerializer(new ExecutionConfig());
+		StreamRecordSerializer<Tuple2<Long, Integer>> streamSerializer = new StreamRecordSerializer<Tuple2<Long, Integer>>(typeInfo, new ExecutionConfig());
+
+		super.addOutput(outList, serializer);
+
+		StreamConfig streamConfig = super.getStreamConfig();
+
+		streamConfig.setStreamOperator(sourceOperator);
+		streamConfig.setChainStart();
+		streamConfig.setOutputSelectorWrapper(new BroadcastOutputSelectorWrapper<Object>());
+		streamConfig.setNumberOfOutputs(1);
+
+		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
+		StreamNode sourceVertex = new StreamNode(null, 0, sourceOperator, "source", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+		StreamNode targetVertexDummy = new StreamNode(null, 1, sourceOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+
+		outEdgesInOrder.add(new StreamEdge(sourceVertex, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>()));
+		streamConfig.setOutEdgesInOrder(outEdgesInOrder);
+		streamConfig.setNonChainedOutputs(outEdgesInOrder);
+		streamConfig.setTypeSerializerOut1(streamSerializer);
+		streamConfig.setVertexID(0);
+
+		super.registerTask(sourceTask);
+
+		ExecutorService executor = Executors.newFixedThreadPool(10);
+		Future[] checkpointerResults = new Future[NUM_CHECKPOINTERS];
+		for (int i = 0; i < NUM_CHECKPOINTERS; i++) {
+			checkpointerResults[i] = executor.submit(new Checkpointer(NUM_CHECKPOINTS, CHECKPOINT_INTERVAL, sourceTask));
+		}
+
+
+		try {
+			sourceTask.invoke();
+		} catch (Exception e) {
+			System.err.println(StringUtils.stringifyException(e));
+			Assert.fail("Invoke method caused exception.");
+		}
+
+		// Get the result from the checkpointers, if these threw an exception it
+		// will be rethrown here
+		for (int i = 0; i < NUM_CHECKPOINTERS; i++) {
+			if (!checkpointerResults[i].isDone()) {
+				checkpointerResults[i].cancel(true);
+			}
+			if (!checkpointerResults[i].isCancelled()) {
+				checkpointerResults[i].get();
+			}
+		}
+
+		Assert.assertEquals(NUM_ELEMENTS, outList.size());
+	}
+
+	private static class MockSource implements SourceFunction<Tuple2<Long, Integer>>, Checkpointed {
+
+		private static final long serialVersionUID = 1;
+
+		private int maxElements;
+		private int checkpointDelay;
+		private int readDelay;
+
+		private volatile int count;
+		private volatile long lastCheckpointId = -1;
+
+		private Semaphore semaphore;
+
+		private volatile boolean isRunning = true;
+
+		public MockSource(int maxElements, int checkpointDelay, int readDelay) {
+			this.maxElements = maxElements;
+			this.checkpointDelay = checkpointDelay;
+			this.readDelay = readDelay;
+			this.count = 0;
+			semaphore = new Semaphore(1);
+		}
+
+		@Override
+		public void run(final Object lockObject, Collector<Tuple2<Long, Integer>> out) {
+			while (isRunning && count < maxElements) {
+				// simulate some work
+				try {
+					Thread.sleep(readDelay);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+
+				synchronized (lockObject) {
+					out.collect(new Tuple2<Long, Integer>(lastCheckpointId, count));
+					count++;
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+
+		@Override
+		public Serializable snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
+			if (!semaphore.tryAcquire()) {
+				Assert.fail("Concurrent invocation of snapshotState.");
+			}
+			int startCount = count;
+			lastCheckpointId = checkpointId;
+
+			long sum = 0;
+			for (int i = 0; i < checkpointDelay; i++) {
+				sum += new Random().nextLong();
+			}
+
+			if (startCount != count) {
+				semaphore.release();
+				// This means that next() was invoked while the snapshot was ongoing
+				Assert.fail("Count is different at start end end of snapshot.");
+			}
+			semaphore.release();
+			return sum;
+		}
+
+		@Override
+		public void restoreState(Serializable state) {
+
+		}
+	}
+
+	/**
+	 * This calls triggerInterrupt on the given task with the given interval.
+	 */
+	private static class Checkpointer implements Callable<Boolean> {
+		private final int numCheckpoints;
+		private final int checkpointInterval;
+		private final AtomicLong checkpointId;
+		private final StreamTask<Tuple2<Long, Integer>, ?> sourceTask;
+
+		public Checkpointer(int numCheckpoints, int checkpointInterval, StreamTask<Tuple2<Long, Integer>, ?> task) {
+			this.numCheckpoints = numCheckpoints;
+			checkpointId = new AtomicLong(0);
+			sourceTask = task;
+			this.checkpointInterval = checkpointInterval;
+		}
+
+		@Override
+		public Boolean call() throws Exception {
+			for (int i = 0; i < numCheckpoints; i++) {
+				long currentCheckpointId = checkpointId.getAndIncrement();
+				sourceTask.triggerCheckpoint(currentCheckpointId, 0L);
+				Thread.sleep(checkpointInterval);
+			}
+			return true;
+		}
+	}
+}
+

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -1,0 +1,277 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.io.network.api.serialization.AdaptiveSpanningRecordDeserializer;
+import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.IteratorWrappingTestSingleInputGate;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
+import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.plugable.DeserializationDelegate;
+import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
+import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.types.Record;
+import org.apache.flink.util.MutableObjectIterator;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StreamMockEnvironment implements Environment {
+
+	private final MemoryManager memManager;
+
+	private final IOManager ioManager;
+
+	private final InputSplitProvider inputSplitProvider;
+
+	private final Configuration jobConfiguration;
+
+	private final Configuration taskConfiguration;
+
+	private final List<InputGate> inputs;
+
+	private final List<ResultPartitionWriter> outputs;
+
+	private final JobID jobID = new JobID();
+
+	private final BroadcastVariableManager bcVarManager = new BroadcastVariableManager();
+
+	private final int bufferSize;
+
+	public StreamMockEnvironment(long memorySize, MockInputSplitProvider inputSplitProvider, int bufferSize) {
+		this.jobConfiguration = new Configuration();
+		this.taskConfiguration = new Configuration();
+		this.inputs = new LinkedList<InputGate>();
+		this.outputs = new LinkedList<ResultPartitionWriter>();
+
+		this.memManager = new DefaultMemoryManager(memorySize, 1);
+		this.ioManager = new IOManagerAsync();
+		this.inputSplitProvider = inputSplitProvider;
+		this.bufferSize = bufferSize;
+	}
+
+	public IteratorWrappingTestSingleInputGate<Record> addInput(MutableObjectIterator<Record> inputIterator) {
+		try {
+			final IteratorWrappingTestSingleInputGate<Record> reader = new IteratorWrappingTestSingleInputGate<Record>(bufferSize, Record.class, inputIterator);
+
+			inputs.add(reader.getInputGate());
+
+			return reader;
+		}
+		catch (Throwable t) {
+			throw new RuntimeException("Error setting up mock readers: " + t.getMessage(), t);
+		}
+	}
+
+	public <T> void addOutput(final List<T> outputList, final TypeSerializer<T> serializer) {
+		try {
+			// The record-oriented writers wrap the buffer writer. We mock it
+			// to collect the returned buffers and deserialize the content to
+			// the output list
+			BufferProvider mockBufferProvider = mock(BufferProvider.class);
+			when(mockBufferProvider.requestBufferBlocking()).thenAnswer(new Answer<Buffer>() {
+
+				@Override
+				public Buffer answer(InvocationOnMock invocationOnMock) throws Throwable {
+					return new Buffer(new MemorySegment(new byte[bufferSize]), mock(BufferRecycler.class));
+				}
+			});
+
+			ResultPartitionWriter mockWriter = mock(ResultPartitionWriter.class);
+			when(mockWriter.getNumberOfOutputChannels()).thenReturn(1);
+			when(mockWriter.getBufferProvider()).thenReturn(mockBufferProvider);
+
+			final RecordDeserializer<DeserializationDelegate<T>> recordDeserializer = new AdaptiveSpanningRecordDeserializer<DeserializationDelegate<T>>();
+			final NonReusingDeserializationDelegate<T> delegate = new NonReusingDeserializationDelegate<T>(serializer);
+
+			// Add records from the buffer to the output list
+			doAnswer(new Answer<Void>() {
+
+				@Override
+				public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+					Buffer buffer = (Buffer) invocationOnMock.getArguments()[0];
+
+					recordDeserializer.setNextBuffer(buffer);
+
+					while (recordDeserializer.hasUnfinishedData()) {
+						RecordDeserializer.DeserializationResult result = recordDeserializer.getNextRecord(delegate);
+
+						if (result.isFullRecord()) {
+							outputList.add(delegate.getInstance());
+						}
+
+						if (result == RecordDeserializer.DeserializationResult.LAST_RECORD_FROM_BUFFER
+								|| result == RecordDeserializer.DeserializationResult.PARTIAL_RECORD) {
+							break;
+						}
+					}
+
+					return null;
+				}
+			}).when(mockWriter).writeBuffer(any(Buffer.class), anyInt());
+
+			outputs.add(mockWriter);
+		}
+		catch (Throwable t) {
+			t.printStackTrace();
+			fail(t.getMessage());
+		}
+	}
+
+	@Override
+	public Configuration getTaskConfiguration() {
+		return this.taskConfiguration;
+	}
+
+	@Override
+	public MemoryManager getMemoryManager() {
+		return this.memManager;
+	}
+
+	@Override
+	public IOManager getIOManager() {
+		return this.ioManager;
+	}
+
+	@Override
+	public JobID getJobID() {
+		return this.jobID;
+	}
+
+	@Override
+	public Configuration getJobConfiguration() {
+		return this.jobConfiguration;
+	}
+
+	@Override
+	public int getNumberOfSubtasks() {
+		return 1;
+	}
+
+	@Override
+	public int getIndexInSubtaskGroup() {
+		return 0;
+	}
+
+	@Override
+	public InputSplitProvider getInputSplitProvider() {
+		return this.inputSplitProvider;
+	}
+
+	@Override
+	public String getTaskName() {
+		return null;
+	}
+
+	@Override
+	public String getTaskNameWithSubtasks() {
+		return null;
+	}
+
+	@Override
+	public ClassLoader getUserClassLoader() {
+		return getClass().getClassLoader();
+	}
+
+	@Override
+	public Map<String, Future<Path>> getDistributedCacheEntries() {
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public ResultPartitionWriter getWriter(int index) {
+		return outputs.get(index);
+	}
+
+	@Override
+	public ResultPartitionWriter[] getAllWriters() {
+		return outputs.toArray(new ResultPartitionWriter[outputs.size()]);
+	}
+
+	@Override
+	public InputGate getInputGate(int index) {
+		return inputs.get(index);
+	}
+
+	@Override
+	public InputGate[] getAllInputGates() {
+		InputGate[] gates = new InputGate[inputs.size()];
+		inputs.toArray(gates);
+		return gates;
+	}
+
+	@Override
+	public JobVertexID getJobVertexId() {
+		return new JobVertexID(new byte[16]);
+	}
+
+	@Override
+	public ExecutionAttemptID getExecutionId() {
+		return new ExecutionAttemptID(0L, 0L);
+	}
+
+	@Override
+	public BroadcastVariableManager getBroadcastVariableManager() {
+		return this.bcVarManager;
+	}
+
+	@Override
+	public void reportAccumulators(Map<String, Accumulator<?, ?>> accumulators) {
+		// discard, this is only for testing
+	}
+
+	@Override
+	public void acknowledgeCheckpoint(long checkpointId) {
+	}
+
+	@Override
+	public void acknowledgeCheckpoint(long checkpointId, StateHandle<?> state) {
+	}
+}
+

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestBase.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestBase.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.record.RecordSerializerFactory;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.partition.consumer.IteratorWrappingTestSingleInputGate;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memorymanager.MemoryManager;
+import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.operators.util.TaskConfig;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.types.Record;
+import org.apache.flink.util.MutableObjectIterator;
+import org.junit.After;
+import org.junit.Assert;
+
+import java.util.List;
+
+
+public abstract class StreamTaskTestBase {
+
+	protected long memorySize = 0;
+
+	protected StreamMockEnvironment mockEnv;
+
+	public void initEnvironment(long memorySize, int bufferSize) {
+		this.memorySize = memorySize;
+		this.mockEnv = new StreamMockEnvironment(this.memorySize, new MockInputSplitProvider(), bufferSize);
+	}
+
+	public IteratorWrappingTestSingleInputGate<Record> addInput(MutableObjectIterator<Record> input, int groupId) {
+		final IteratorWrappingTestSingleInputGate<Record> reader = addInput(input, groupId, true);
+
+		return reader;
+	}
+
+	public IteratorWrappingTestSingleInputGate<Record> addInput(MutableObjectIterator<Record> input, int groupId, boolean read) {
+		final IteratorWrappingTestSingleInputGate<Record> reader = this.mockEnv.addInput(input);
+		TaskConfig conf = new TaskConfig(this.mockEnv.getTaskConfiguration());
+		conf.addInputToGroup(groupId);
+		conf.setInputSerializer(RecordSerializerFactory.get(), groupId);
+
+		if (read) {
+			reader.read();
+		}
+
+		return reader;
+	}
+
+	public <T> void addOutput(List<T> output, TypeSerializer<T> serializer) {
+		this.mockEnv.addOutput(output, serializer);
+		TaskConfig conf = new TaskConfig(this.mockEnv.getTaskConfiguration());
+		conf.addOutputShipStrategy(ShipStrategyType.FORWARD);
+		conf.setOutputSerializer(RecordSerializerFactory.get());
+	}
+
+	public Configuration getConfiguration() {
+		return this.mockEnv.getTaskConfiguration();
+	}
+
+	public StreamConfig getStreamConfig() {
+		return new StreamConfig(this.mockEnv.getTaskConfiguration());
+	}
+
+	public void registerTask(AbstractInvokable task) {
+		task.setEnvironment(this.mockEnv);
+		task.registerInputOutput();
+	}
+
+	public MemoryManager getMemoryManager() {
+		return this.mockEnv.getMemoryManager();
+	}
+
+	@After
+	public void shutdownIOManager() throws Exception {
+		this.mockEnv.getIOManager().shutdown();
+		Assert.assertTrue("IO Manager has not properly shut down.", this.mockEnv.getIOManager().isProperlyShutDown());
+	}
+
+	@After
+	public void shutdownMemoryManager() throws Exception {
+		if (this.memorySize > 0) {
+			MemoryManager memMan = getMemoryManager();
+			if (memMan != null) {
+				Assert.assertTrue("Memory Manager managed memory was not completely freed.", memMan.verifyEmpty());
+				memMan.shutdown();
+			}
+		}
+	}
+}
+

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/MockSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/util/MockSource.java
@@ -34,9 +34,7 @@ public class MockSource<T> {
 		}
 		try {
 			Collector<T> collector = new MockOutput<T>(outputs);
-			while (!sourceFunction.reachedEnd()) {
-				collector.collect(sourceFunction.next());
-			}
+			sourceFunction.run(new Object(), collector);
 		} catch (Exception e) {
 			throw new RuntimeException("Cannot invoke source.", e);
 		}

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/iteration/IterateExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/iteration/IterateExample.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.datastream.IterativeDataStream;
 import org.apache.flink.streaming.api.datastream.SplitDataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.util.Collector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -110,20 +111,24 @@ public class IterateExample {
 
 		private Random rnd = new Random();
 
+		private volatile boolean isRunning = true;
+
 		@Override
-		public boolean reachedEnd() throws Exception {
-			return false;
+		public void run(Object checkpointLock, Collector<Tuple2<Integer, Integer>> collector) throws Exception {
+
+			while (isRunning) {
+				int first = rnd.nextInt(BOUND / 2 - 1) + 1;
+				int second = rnd.nextInt(BOUND / 2 - 1) + 1;
+
+				collector.collect(new Tuple2<Integer, Integer>(first, second));
+				Thread.sleep(500L);
+			}
 		}
 
 		@Override
-		public Tuple2<Integer, Integer> next() throws Exception {
-			int first = rnd.nextInt(BOUND / 2 - 1) + 1;
-			int second = rnd.nextInt(BOUND / 2 - 1) + 1;
-
-			Thread.sleep(500L);
-			return new Tuple2<Integer, Integer>(first, second);
+		public void cancel() {
+			isRunning = false;
 		}
-
 	}
 
 	/**

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
@@ -1,19 +1,19 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.apache.flink.streaming.examples.windowing;
 
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.windowing.policy.CentralActiveTrigger;
 import org.apache.flink.streaming.api.windowing.policy.TumblingEvictionPolicy;
+import org.apache.flink.util.Collector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,24 +55,26 @@ public class SessionWindowing {
 
 		DataStream<Tuple3<String, Long, Integer>> source = env
 				.addSource(new SourceFunction<Tuple3<String, Long, Integer>>() {
-					int index = 0;
+					private static final long serialVersionUID = 1L;
 
 					@Override
-					public boolean reachedEnd() throws Exception {
-						return index >= input.size();
-					}
-
-					@Override
-					public Tuple3<String, Long, Integer> next() throws Exception {
-						Tuple3<String, Long, Integer> result = input.get(index);
-						index++;
-						if (!fileOutput) {
-							System.out.println("Collected: " + result);
-							Thread.sleep(3000);
+					public void run(Object checkpointLock, Collector<Tuple3<String, Long, Integer>> collector)
+							throws Exception {
+						for (Tuple3<String, Long, Integer> value : input) {
+							// We sleep three seconds between every output so we
+							// can see whether we properly detect sessions
+							// before the next start for a specific id
+							collector.collect(value);
+							if (!fileOutput) {
+								System.out.println("Collected: " + value);
+								Thread.sleep(3000);
+							}
 						}
-						return result;
 					}
 
+					@Override
+					public void cancel() {
+					}
 				});
 
 		// We create sessions for each id with max timeout of 3 time units

--- a/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowingExample.java
+++ b/flink-staging/flink-streaming/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowingExample.java
@@ -1,19 +1,19 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.apache.flink.streaming.examples.windowing;
 
@@ -26,17 +26,18 @@ import org.apache.flink.streaming.api.windowing.deltafunction.DeltaFunction;
 import org.apache.flink.streaming.api.windowing.helper.Delta;
 import org.apache.flink.streaming.api.windowing.helper.Time;
 import org.apache.flink.streaming.api.windowing.helper.Timestamp;
+import org.apache.flink.util.Collector;
 
 import java.util.Arrays;
 import java.util.Random;
 
 /**
-* An example of grouped stream windowing where different eviction and trigger
-* policies can be used. A source fetches events from cars every 1 sec
-* containing their id, their current speed (kmh), overall elapsed distance (m)
-* and a timestamp. The streaming example triggers the top speed of each car
-* every x meters elapsed for the last y seconds.
-*/
+ * An example of grouped stream windowing where different eviction and trigger
+ * policies can be used. A source fetches events from cars every 1 sec
+ * containing their id, their current speed (kmh), overall elapsed distance (m)
+ * and a timestamp. The streaming example triggers the top speed of each car
+ * every x meters elapsed for the last y seconds.
+ */
 public class TopSpeedWindowingExample {
 
 	// *************************************************************************
@@ -62,6 +63,9 @@ public class TopSpeedWindowingExample {
 				.window(Time.of(evictionSec, new CarTimestamp()))
 				.every(Delta.of(triggerMeters,
 						new DeltaFunction<Tuple4<Integer, Integer, Double, Long>>() {
+							private static final long serialVersionUID = 1L;
+
+
 							@Override
 							public double getDelta(
 									Tuple4<Integer, Integer, Double, Long> oldDataPoint,
@@ -90,7 +94,7 @@ public class TopSpeedWindowingExample {
 
 		private Random rand = new Random();
 
-		private int carId = 0;
+		private volatile boolean isRunning = true;
 
 		private CarSource(int numOfCars) {
 			speeds = new Integer[numOfCars];
@@ -104,27 +108,29 @@ public class TopSpeedWindowingExample {
 		}
 
 		@Override
-		public boolean reachedEnd() throws Exception {
-			return false;
+		public void run(Object checkpointLock, Collector<Tuple4<Integer, Integer, Double, Long>> collector)
+				throws Exception {
+
+			while (isRunning) {
+				Thread.sleep(1000);
+				for (int carId = 0; carId < speeds.length; carId++) {
+					if (rand.nextBoolean()) {
+						speeds[carId] = Math.min(100, speeds[carId] + 5);
+					} else {
+						speeds[carId] = Math.max(0, speeds[carId] - 5);
+					}
+					distances[carId] += speeds[carId] / 3.6d;
+					Tuple4<Integer, Integer, Double, Long> record = new Tuple4<Integer, Integer, Double, Long>(carId,
+							speeds[carId], distances[carId], System.currentTimeMillis());
+					collector.collect(record);
+				}
+			}
 		}
 
 		@Override
-		public Tuple4<Integer, Integer, Double, Long> next() throws Exception {
-			if (rand.nextBoolean()) {
-				speeds[carId] = Math.min(100, speeds[carId] + 5);
-			} else {
-				speeds[carId] = Math.max(0, speeds[carId] - 5);
-			}
-			distances[carId] += speeds[carId] / 3.6d;
-			Tuple4<Integer, Integer, Double, Long> record = new Tuple4<Integer, Integer, Double, Long>(carId,
-					speeds[carId], distances[carId], System.currentTimeMillis());
-			carId++;
-			if (carId >= speeds.length) {
-				carId = 0;
-			}
-			return record;
+		public void cancel() {
+			isRunning = false;
 		}
-
 	}
 
 	private static class ParseCarData extends
@@ -141,6 +147,7 @@ public class TopSpeedWindowingExample {
 	}
 
 	private static class CarTimestamp implements Timestamp<Tuple4<Integer, Integer, Double, Long>> {
+		private static final long serialVersionUID = 1L;
 
 		@Override
 		public long getTimestamp(Tuple4<Integer, Integer, Double, Long> value) {
@@ -169,8 +176,7 @@ public class TopSpeedWindowingExample {
 				inputPath = args[0];
 				outputPath = args[1];
 			} else {
-				System.err
-						.println("Usage: TopSpeedWindowingExample <input path> <output path>");
+				System.err.println("Usage: TopSpeedWindowingExample <input path> <output path>");
 				return false;
 			}
 		}


### PR DESCRIPTION
Before, it could happen that a streaming source would keep emitting
elements while a checkpoint is being performed. This can lead to
inconsistencies in the checkpoints with other operators.

This also adds a test that checks whether only one checkpoint is
executed at a time and the serial behaviour of checkpointing and
emission.