### PR TITLE
[FLINK-2102] [ml] Add predict operation for LabeledVector

### DIFF
--- a/docs/libs/ml/multiple_linear_regression.md
+++ b/docs/libs/ml/multiple_linear_regression.md
@@ -77,6 +77,14 @@ MultipleLinearRegression predicts for all subtypes of `Vector` the corresponding
 
 * `predict[T <: Vector]: DataSet[T] => DataSet[LabeledVector]`
 
+If we call predict with a `DataSet[LabeledVector]`, we make a prediction on the regression value
+for each example, and return a `DataSet[(Double, Double)]`. In each tuple the first element
+is the true value, as was provided from the input `DataSet[LabeledVector]` and the second element
+is the predicted value. You can then use these `(truth, prediction)` tuples to evaluate
+the algorithm's performance.
+
+* `predict: DataSet[LabeledVector] => DataSet[(Double, Double)]`
+
 ## Parameters
 
   The multiple linear regression implementation can be controlled by the following parameters:

--- a/docs/libs/ml/svm.md
+++ b/docs/libs/ml/svm.md
@@ -74,6 +74,14 @@ SVM predicts for all subtypes of `Vector` the corresponding class label:
 
 * `predict[T <: Vector]: DataSet[T] => DataSet[LabeledVector]`
 
+If we call predict with a `DataSet[LabeledVector]`, we make a prediction on the class label
+for each example, and return a `DataSet[(Double, Double)]`. In each tuple the first element
+is the true value, as was provided from the input `DataSet[LabeledVector]` and the second element
+is the predicted value. You can then use these `(truth, prediction)` tuples to evaluate
+the algorithm's performance.
+
+* `predict: DataSet[LabeledVector] => DataSet[(Double, Double)]`
+
 ## Parameters
 
 The SVM implementation can be controlled by the following parameters:

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/regression/MultipleLinearRegressionITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/regression/MultipleLinearRegressionITSuite.scala
@@ -106,4 +106,28 @@ class MultipleLinearRegressionITSuite
 
     srs should be(RegressionData.expectedPolynomialSquaredResidualSum +- 5)
   }
+
+  it should "make (mostly) correct predictions" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val mlr = MultipleLinearRegression()
+
+    import RegressionData._
+
+    val parameters = ParameterMap()
+
+    parameters.add(MultipleLinearRegression.Stepsize, 1.0)
+    parameters.add(MultipleLinearRegression.Iterations, 10)
+    parameters.add(MultipleLinearRegression.ConvergenceThreshold, 0.001)
+
+    val inputDS = env.fromCollection(data)
+    mlr.fit(inputDS, parameters)
+
+    val predictionPairs = mlr.predict(inputDS)
+
+    val absoluteErrorSum = predictionPairs.collect().map{
+      case (truth, prediction) => Math.abs(truth - prediction)}.sum
+
+    absoluteErrorSum should be < 50.0
+  }
 }


### PR DESCRIPTION
Add predict function for labeled data for SVM and MLR.

These functions return for each example in the input DataSet[LabeledVector] a pair (Double, Double) - (truth, prediction)

This output can then be used to evaluate the performance of the Predictors