### PR TITLE
Fix handling of receiver and sender task failures

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -342,7 +342,7 @@ public class NetworkEnvironment {
 			}
 
 			if (task.isCanceledOrFailed()) {
-				partitionManager.releasePartitionsProducedBy(executionId);
+				partitionManager.releasePartitionsProducedBy(executionId, task.getFailureCause());
 			}
 
 			ResultPartitionWriter[] writers = task.getAllWriters();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -264,19 +264,19 @@ abstract class NettyMessage {
 
 		private static final byte ID = 1;
 
-		Throwable error;
+		Throwable cause;
 
 		InputChannelID receiverId;
 
 		public ErrorResponse() {
 		}
 
-		ErrorResponse(Throwable error) {
-			this.error = error;
+		ErrorResponse(Throwable cause) {
+			this.cause = cause;
 		}
 
-		ErrorResponse(Throwable error, InputChannelID receiverId) {
-			this.error = error;
+		ErrorResponse(Throwable cause, InputChannelID receiverId) {
+			this.cause = cause;
 			this.receiverId = receiverId;
 		}
 
@@ -297,7 +297,7 @@ abstract class NettyMessage {
 
 				oos = new ObjectOutputStream(new DataOutputViewStream(outputView));
 
-				oos.writeObject(error);
+				oos.writeObject(cause);
 
 				if (receiverId != null) {
 					result.writeBoolean(true);
@@ -338,7 +338,7 @@ abstract class NettyMessage {
 					throw new ClassCastException("Read object expected to be of type Throwable, " +
 							"actual type is " + obj.getClass() + ".");
 				} else {
-					error = (Throwable) obj;
+					cause = (Throwable) obj;
 
 					if (buffer.readBoolean()) {
 						receiverId = InputChannelID.fromByteBuf(buffer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
@@ -58,7 +58,12 @@ public class PartitionRequestClient {
 	// If zero, the underlying TCP channel can be safely closed
 	private final AtomicDisposableReferenceCounter closeReferenceCounter = new AtomicDisposableReferenceCounter();
 
-	PartitionRequestClient(Channel tcpChannel, PartitionRequestClientHandler partitionRequestHandler, ConnectionID connectionId, PartitionRequestClientFactory clientFactory) {
+	PartitionRequestClient(
+			Channel tcpChannel,
+			PartitionRequestClientHandler partitionRequestHandler,
+			ConnectionID connectionId,
+			PartitionRequestClientFactory clientFactory) {
+
 		this.tcpChannel = checkNotNull(tcpChannel);
 		this.partitionRequestHandler = checkNotNull(partitionRequestHandler);
 		this.connectionId = checkNotNull(connectionId);
@@ -167,6 +172,9 @@ public class PartitionRequestClient {
 
 			// Make sure to remove the client from the factory
 			clientFactory.destroyPartitionRequestClient(connectionId, this);
+		}
+		else {
+			partitionRequestHandler.cancelRequestFor(inputChannel.getInputChannelId());
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Maps;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.apache.flink.core.memory.MemorySegment;
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,7 +64,7 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 	 * Set of cancelled partition requests. A request is cancelled iff an input channel is cleared
 	 * while data is still coming in for this channel.
 	 */
-	private volatile Set<InputChannelID> cancelled;
+	private final ConcurrentMap<InputChannelID, InputChannelID> cancelled = Maps.newConcurrentMap();
 
 	private ChannelHandlerContext ctx;
 
@@ -83,6 +82,12 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 
 	void removeInputChannel(RemoteInputChannel listener) {
 		inputChannels.remove(listener.getInputChannelId());
+	}
+
+	void cancelRequestFor(InputChannelID inputChannelId) {
+		if (cancelled.putIfAbsent(inputChannelId, inputChannelId) == null) {
+			ctx.writeAndFlush(new NettyMessage.CancelPartitionRequest(inputChannelId));
+		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -180,18 +185,6 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 					ctx.close();
 				}
 			}
-		}
-	}
-
-	private void cancelRequestFor(InputChannelID inputChannelId) {
-		if (cancelled == null) {
-			cancelled = Sets.newConcurrentHashSet();
-		}
-
-		if (!cancelled.contains(inputChannelId)) {
-			ctx.writeAndFlush(new NettyMessage.CancelPartitionRequest(inputChannelId));
-
-			cancelled.add(inputChannelId);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -222,19 +222,19 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 			if (error.isFatalError()) {
 				notifyAllChannelsOfErrorAndClose(new RemoteTransportException(
 						"Fatal error at remote task manager '" + remoteAddr + "'.",
-						remoteAddr, error.error));
+						remoteAddr, error.cause));
 			}
 			else {
 				RemoteInputChannel inputChannel = inputChannels.get(error.receiverId);
 
 				if (inputChannel != null) {
-					if (error.error.getClass() == PartitionNotFoundException.class) {
+					if (error.cause.getClass() == PartitionNotFoundException.class) {
 						inputChannel.onFailedPartitionRequest();
 					}
 					else {
 						inputChannel.onError(new RemoteTransportException(
 								"Error at remote task manager '" + remoteAddr + "'.",
-										remoteAddr, error.error));
+										remoteAddr, error.cause));
 					}
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -242,14 +242,19 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 
 		@Override
 		public void operationComplete(ChannelFuture future) throws Exception {
-			if (future.isSuccess()) {
-				writeAndFlushNextMessageIfPossible(future.channel());
+			try {
+				if (future.isSuccess()) {
+					writeAndFlushNextMessageIfPossible(future.channel());
+				}
+				else if (future.cause() != null) {
+					handleException(future.channel(), future.cause());
+				}
+				else {
+					handleException(future.channel(), new IllegalStateException("Sending cancelled by user."));
+				}
 			}
-			else if (future.cause() != null) {
-				handleException(future.channel(), future.cause());
-			}
-			else {
-				handleException(future.channel(), new IllegalStateException("Sending cancelled by user."));
+			catch (Throwable t) {
+				handleException(future.channel(), t);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -70,4 +70,9 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	public boolean isReleased() {
 		return isReleased.get();
 	}
+
+	@Override
+	public Throwable getFailureCause() {
+		return parent.getFailureCause();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ProducerFailedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ProducerFailedException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.execution.CancelTaskException;
+
+public class ProducerFailedException extends CancelTaskException {
+
+	private static final long serialVersionUID = -1555492656299526395L;
+
+	private final Throwable cause;
+
+	public ProducerFailedException(Throwable cause) {
+		this.cause = cause;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -83,12 +83,16 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 	}
 
 	public void releasePartitionsProducedBy(ExecutionAttemptID executionId) {
+		releasePartitionsProducedBy(executionId, null);
+	}
+
+	public void releasePartitionsProducedBy(ExecutionAttemptID executionId, Throwable cause) {
 		synchronized (registeredPartitions) {
 			final Map<IntermediateResultPartitionID, ResultPartition> partitions =
 					registeredPartitions.row(executionId);
 
 			for (ResultPartition partition : partitions.values()) {
-				partition.release();
+				partition.release(cause);
 			}
 
 			for (IntermediateResultPartitionID partitionId : ImmutableList

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -67,6 +67,10 @@ public abstract class ResultSubpartition {
 		parent.onConsumedSubpartition(index);
 	}
 
+	protected Throwable getFailureCause() {
+		return parent.getFailureCause();
+	}
+
 	abstract public boolean add(Buffer buffer) throws IOException;
 
 	abstract public void finish() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -55,4 +55,6 @@ public interface ResultSubpartitionView {
 
 	boolean isReleased();
 
+	Throwable getFailureCause();
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -160,4 +160,9 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 	public boolean isReleased() {
 		return isReleased.get();
 	}
+
+	@Override
+	public Throwable getFailureCause() {
+		return parent.getFailureCause();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewAsyncIO.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewAsyncIO.java
@@ -190,6 +190,11 @@ class SpilledSubpartitionViewAsyncIO implements ResultSubpartitionView {
 		return isReleased;
 	}
 
+	@Override
+	public Throwable getFailureCause() {
+		return parent.getFailureCause();
+	}
+
 	/**
 	 * Requests buffers from the buffer provider and triggers asynchronous read requests to fill
 	 * them.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewSyncIO.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewSyncIO.java
@@ -111,6 +111,11 @@ class SpilledSubpartitionViewSyncIO implements ResultSubpartitionView {
 		return isReleased.get();
 	}
 
+	@Override
+	public Throwable getFailureCause() {
+		return parent.getFailureCause();
+	}
+
 	/**
 	 * A buffer pool to provide buffer to read the file into.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.event.task.TaskEvent;
+import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
@@ -156,6 +157,9 @@ public abstract class InputChannel {
 		final Throwable t = cause.get();
 
 		if (t != null) {
+			if (t instanceof CancelTaskException) {
+				throw (CancelTaskException) t;
+			}
 			if (t instanceof IOException) {
 				throw (IOException) t;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -75,7 +75,7 @@ public class RemoteInputChannel extends InputChannel {
 	 */
 	private int expectedSequenceNumber = 0;
 
-	RemoteInputChannel(
+	public RemoteInputChannel(
 			SingleInputGate inputGate,
 			int channelIndex,
 			ResultPartitionID partitionId,
@@ -86,7 +86,7 @@ public class RemoteInputChannel extends InputChannel {
 				new Tuple2<Integer, Integer>(0, 0));
 	}
 
-	RemoteInputChannel(
+	public RemoteInputChannel(
 			SingleInputGate inputGate,
 			int channelIndex,
 			ResultPartitionID partitionId,
@@ -193,6 +193,8 @@ public class RemoteInputChannel extends InputChannel {
 				}
 			}
 
+			// The released flag has to be set before closing the connection to ensure that
+			// buffers received concurrently with closing are properly recycled.
 			if (partitionRequestClient != null) {
 				partitionRequestClient.close(this);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -191,5 +191,10 @@ public class CancelPartitionRequestTest {
 		public boolean isReleased() {
 			return false;
 		}
+
+		@Override
+		public Throwable getFailureCause() {
+			return null;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -93,8 +93,8 @@ public class NettyMessageSerializationTest {
 				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError, receiverId);
 				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
 
-				assertEquals(expected.error.getClass(), actual.error.getClass());
-				assertEquals(expected.error.getMessage(), actual.error.getMessage());
+				assertEquals(expected.cause.getClass(), actual.cause.getClass());
+				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
 				assertEquals(receiverId, actual.receiverId);
 			}
 
@@ -105,8 +105,8 @@ public class NettyMessageSerializationTest {
 				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError, receiverId);
 				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
 
-				assertEquals(expected.error.getClass(), actual.error.getClass());
-				assertEquals(expected.error.getMessage(), actual.error.getMessage());
+				assertEquals(expected.cause.getClass(), actual.cause.getClass());
+				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
 				assertEquals(receiverId, actual.receiverId);
 			}
 
@@ -116,8 +116,8 @@ public class NettyMessageSerializationTest {
 				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError);
 				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
 
-				assertEquals(expected.error.getClass(), actual.error.getClass());
-				assertEquals(expected.error.getMessage(), actual.error.getMessage());
+				assertEquals(expected.cause.getClass(), actual.cause.getClass());
+				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
 				assertNull(actual.receiverId);
 				assertTrue(actual.isFatalError());
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -51,6 +51,6 @@ public class PartitionRequestQueueTest {
 		assertEquals(msg.getClass(), NettyMessage.ErrorResponse.class);
 
 		NettyMessage.ErrorResponse err = (NettyMessage.ErrorResponse) msg;
-		assertTrue(err.error instanceof CancelTaskException);
+		assertTrue(err.cause instanceof CancelTaskException);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.runtime.execution.CancelTaskException;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PartitionRequestQueueTest {
+
+	@Test
+	public void testProducerFailedException() throws Exception {
+		PartitionRequestQueue queue = new PartitionRequestQueue();
+
+		EmbeddedChannel ch = new EmbeddedChannel(queue);
+
+		ResultSubpartitionView view = mock(ResultSubpartitionView.class);
+		when(view.isReleased()).thenReturn(true);
+		when(view.getFailureCause()).thenReturn(new RuntimeException("Expected test exception"));
+
+		// Enqueue the erroneous view
+		queue.enqueue(view, new InputChannelID());
+		ch.runPendingTasks();
+
+		// Read the enqueued msg
+		Object msg = ch.readOutbound();
+
+		assertEquals(msg.getClass(), NettyMessage.ErrorResponse.class);
+
+		NettyMessage.ErrorResponse err = (NettyMessage.ErrorResponse) msg;
+		assertTrue(err.error instanceof CancelTaskException);
+	}
+}


### PR DESCRIPTION
**Sender task failures** (1955)
- Produced result partition becomes erroneous with a ProducerFailedException
- Receiver cancels itself when encountering the ProducerFailedException by throwing an instance of CancelTaskException (it may also be cancelled by the JobManager if that call is faster than the detection of the failed producer)
- Reference to Netty channel is released

**Receiver task failures**  (1958)
- Sender keeps going. May be back-pressured when no receiver pulls the data any more.
- Sender may be cancelled by JobManager
- Partition stays sane
- Reference to Netty channel is released 
- Transfer are canceled by a cancel message (receiver to sender)