### PR TITLE
[FLINK-2114] [streaming] Fix null check in PunctuationPolicy.toString()

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/PunctuationPolicy.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/policy/PunctuationPolicy.java
@@ -138,7 +138,10 @@ public class PunctuationPolicy<IN, DATA> implements CloneableTriggerPolicy<IN>,
 
 	@Override
 	public String toString() {
-		return "PunctuationPolicy(" + punctuation + extractor != null ? ", "
-				+ extractor.getClass().getSimpleName() : "" + ")";
+		return "PunctuationPolicy(" + punctuation
+				+ (extractor != null
+					? ", " + extractor.getClass().getSimpleName()
+					: "")
+				+ ")";
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/policy/PunctuationPolicyTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/policy/PunctuationPolicyTest.java
@@ -41,6 +41,7 @@ public class PunctuationPolicyTest {
 				policy.notifyTrigger(new TestObject(0)));
 		assertFalse("There was a punctuation detected which wasn't present. (POS 2)",
 				policy.notifyTrigger(new TestObject(1)));
+		policy.toString();
 	}
 
 	@Test


### PR DESCRIPTION
Added missing parenthesis, and added a call to PunctuationPolicy.toString() in a test.