### PR TITLE
[FLINK-2113][gelly] removed env.execute() after print()

### DIFF
--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/CommunityDetection.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/CommunityDetection.java
@@ -78,11 +78,13 @@ public class CommunityDetection implements ProgramDescription {
 		// emit result
 		if (fileOutput) {
 			communityVertices.writeAsCsv(outputPath, "\n", ",");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("Executing Community Detection Example");
 		} else {
 			communityVertices.print();
 		}
 
-		env.execute("Executing Community Detection Example");
 	}
 
 	@Override

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/ConnectedComponents.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/ConnectedComponents.java
@@ -75,11 +75,14 @@ public class ConnectedComponents implements ProgramDescription {
 		// emit result
 		if (fileOutput) {
 			verticesWithMinIds.writeAsCsv(outputPath, "\n", ",");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("Connected Components Example");
 		} else {
 			verticesWithMinIds.print();
 		}
 
-		env.execute("Connected Components Example");
+
 	}
 
 	@Override

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/EuclideanGraphWeighing.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/EuclideanGraphWeighing.java
@@ -101,11 +101,13 @@ public class EuclideanGraphWeighing implements ProgramDescription {
 		// emit result
 		if (fileOutput) {
 			result.writeAsCsv(outputPath, "\n", ",");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("Euclidean Graph Weighing Example");
 		} else {
 			result.print();
 		}
 
-		env.execute("Euclidean Graph Weighing Example");
 	}
 
 	@Override

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GSAConnectedComponents.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GSAConnectedComponents.java
@@ -66,11 +66,13 @@ public class GSAConnectedComponents implements ProgramDescription {
 		// emit result
 		if (fileOutput) {
 			connectedComponents.writeAsCsv(outputPath, "\n", " ");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("GSA Connected Components");
 		} else {
 			connectedComponents.print();
 		}
 
-		env.execute("GSA Connected Components");
 	}
 
 	@SuppressWarnings("serial")

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GSAPageRank.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GSAPageRank.java
@@ -90,11 +90,13 @@ public class GSAPageRank implements ProgramDescription {
 		// emit result
 		if (fileOutput) {
 			pageRanks.writeAsCsv(outputPath, "\n", "\t");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("GSA Page Ranks");
 		} else {
 			pageRanks.print();
 		}
 
-		env.execute("GSA Page Ranks");
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GSASingleSourceShortestPaths.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/GSASingleSourceShortestPaths.java
@@ -64,11 +64,13 @@ public class GSASingleSourceShortestPaths implements ProgramDescription {
 		// emit result
 		if(fileOutput) {
 			singleSourceShortestPaths.writeAsCsv(outputPath, "\n", " ");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("GSA Single Source Shortest Paths");
 		} else {
 			singleSourceShortestPaths.print();
 		}
 
-		env.execute("GSA Single Source Shortest Paths");
 	}
 
 	@SuppressWarnings("serial")

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/IncrementalSSSP.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/IncrementalSSSP.java
@@ -110,20 +110,24 @@ public class IncrementalSSSP implements ProgramDescription {
 			// Emit results
 			if(fileOutput) {
 				resultedVertices.writeAsCsv(outputPath, "\n", ",");
+
+				// since file sinks are lazy, we trigger the execution explicitly
+				env.execute("Incremental SSSP Example");
 			} else {
 				resultedVertices.print();
 			}
 
-			env.execute("Incremental SSSP Example");
 		} else {
 			// print the vertices
 			if(fileOutput) {
 				vertices.writeAsCsv(outputPath, "\n", ",");
+
+				// since file sinks are lazy, we trigger the execution explicitly
+				env.execute("Incremental SSSP Example");
 			} else {
 				vertices.print();
 			}
 
-			env.execute("Incremental SSSP Example");
 		}
 	}
 

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/JaccardSimilarityMeasure.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/JaccardSimilarityMeasure.java
@@ -89,11 +89,13 @@ public class JaccardSimilarityMeasure implements ProgramDescription {
 		// emit result
 		if (fileOutput) {
 			result.writeAsCsv(outputPath, "\n", ",");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("Executing Jaccard Similarity Measure");
 		} else {
 			result.print();
 		}
 
-		env.execute("Executing Jaccard Similarity Measure");
 	}
 
 	@Override

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/LabelPropagation.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/LabelPropagation.java
@@ -72,12 +72,13 @@ public class LabelPropagation implements ProgramDescription {
 		// Emit results
 		if(fileOutput) {
 			verticesWithCommunity.writeAsCsv(outputPath, "\n", ",");
+
+			// Execute the program
+			env.execute("Label Propagation Example");
 		} else {
 			verticesWithCommunity.print();
 		}
 
-		// Execute the program
-		env.execute("Label Propagation Example");
 	}
 
 	// *************************************************************************

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/MusicProfiles.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/MusicProfiles.java
@@ -145,11 +145,13 @@ public class MusicProfiles implements ProgramDescription {
 
 		if (fileOutput) {
 			verticesWithCommunity.writeAsCsv(communitiesOutputPath, "\n", "\t");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute();
 		} else {
 			verticesWithCommunity.print();
 		}
 
-		env.execute();
 	}
 
 	public static final class ExtractMismatchSongIds implements MapFunction<String, Tuple1<String>> {

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/PageRank.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/PageRank.java
@@ -78,11 +78,13 @@ public class PageRank implements ProgramDescription {
 
 		if (fileOutput) {
 			pageRanks.writeAsCsv(outputPath, "\n", "\t");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute();
 		} else {
 			pageRanks.print();
 		}
 
-		env.execute();
 	}
 
 	@Override

--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/SingleSourceShortestPaths.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/SingleSourceShortestPaths.java
@@ -68,11 +68,13 @@ public class SingleSourceShortestPaths implements ProgramDescription {
 		// emit result
 		if (fileOutput) {
 			singleSourceShortestPaths.writeAsCsv(outputPath, "\n", ",");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("Single Source Shortest Paths Example");
 		} else {
 			singleSourceShortestPaths.print();
 		}
 
-		env.execute("Single Source Shortest Paths Example");
 	}
 
 	@Override


### PR DESCRIPTION
This PR removes all the env.execute() that occur after a Dataset.print() in gelly examples to fit the new functionality. 
@uce can you have a quick look at this?
Thanks!:)