### PR TITLE
[FLINK-2121] Fix the summation in FileInputFormat.addFilesInDir

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -330,7 +330,7 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 
 		// enumerate all files
 		if (file.isDir()) {
-			totalLength += addFilesInDir(file.getPath(), files, totalLength, false);
+			totalLength += addFilesInDir(file.getPath(), files, false);
 		} else {
 			files.add(file);
 			testForUnsplittable(file);
@@ -390,7 +390,7 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 		final FileStatus pathFile = fs.getFileStatus(path);
 
 		if (pathFile.isDir()) {
-			totalLength += addFilesInDir(path, files, totalLength, true);
+			totalLength += addFilesInDir(path, files, true);
 		} else {
 			testForUnsplittable(pathFile);
 
@@ -497,14 +497,16 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	 * Enumerate all files in the directory and recursive if enumerateNestedFiles is true.
 	 * @return the total length of accepted files.
 	 */
-	private long addFilesInDir(Path path, List<FileStatus> files, long length, boolean logExcludedFiles)
+	private long addFilesInDir(Path path, List<FileStatus> files, boolean logExcludedFiles)
 			throws IOException {
 		final FileSystem fs = path.getFileSystem();
+
+		long length = 0;
 
 		for(FileStatus dir: fs.listStatus(path)) {
 			if (dir.isDir()) {
 				if (acceptFile(dir) && enumerateNestedFiles) {
-					length += addFilesInDir(dir.getPath(), files, length, logExcludedFiles);
+					length += addFilesInDir(dir.getPath(), files, logExcludedFiles);
 				} else {
 					if (logExcludedFiles && LOG.isDebugEnabled()) {
 						LOG.debug("Directory "+dir.getPath().toString()+" did not pass the file-filter and is excluded.");

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/EnumerateNestedFilesTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/EnumerateNestedFilesTest.java
@@ -330,10 +330,12 @@ public class EnumerateNestedFilesTest {
 			final long SIZE1 = 2077;
 			final long SIZE2 = 31909;
 			final long SIZE3 = 10;
-			final long TOTAL = SIZE1 + SIZE2 + SIZE3;
+			final long SIZE4 = 71;
+			final long TOTAL = SIZE1 + SIZE2 + SIZE3 + SIZE4;
 
 			String firstLevelDir = TestFileUtils.randomFileName();
 			String secondLevelDir = TestFileUtils.randomFileName();
+			String secondLevelDir2 = TestFileUtils.randomFileName();
 
 			File nestedDir = new File(tempPath + System.getProperty("file.separator") 
 					+ firstLevelDir);
@@ -345,10 +347,16 @@ public class EnumerateNestedFilesTest {
 			insideNestedDir.mkdirs();
 			insideNestedDir.deleteOnExit();
 
+			File insideNestedDir2 = new File(tempPath + System.getProperty("file.separator")
+					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir2);
+			insideNestedDir2.mkdirs();
+			insideNestedDir2.deleteOnExit();
+
 			// create a file in the first-level and two files in the nested dir
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), SIZE1);
 			TestFileUtils.createTempFileInDirectory(insideNestedDir.getAbsolutePath(), SIZE2);
 			TestFileUtils.createTempFileInDirectory(insideNestedDir.getAbsolutePath(), SIZE3);
+			TestFileUtils.createTempFileInDirectory(insideNestedDir2.getAbsolutePath(), SIZE4);
 
 			this.format.setFilePath(new Path(nestedDir.toURI().toString()));
 			this.config.setBoolean("recursive.file.enumeration", true);


### PR DESCRIPTION
Removed the length parameter, and made the length calculation start from 0 instead.
I also added a second inner dir to the test, so now it catches this problem with any directory listing order.