### PR TITLE
[FLINK-2119] Add ExecutionGraph support for batch scheduling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -26,6 +26,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * Result produced by an {@link ExecutionJobVertex}.
+ */
 public class IntermediateResult {
 
 	private final IntermediateDataSetID id;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -24,6 +24,9 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Partition of an {@link IntermediateResult} produced by an {@link ExecutionVertex}.
+ */
 public class IntermediateResultPartition {
 
 	private final IntermediateResult totalResult;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.runtime.jobgraph;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.google.common.collect.Lists;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -28,7 +26,10 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 
-import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * The base class for job vertexes.
@@ -38,8 +39,8 @@ public class JobVertex implements java.io.Serializable {
 	private static final long serialVersionUID = 1L;
 
 	private static final String DEFAULT_NAME = "(unnamed vertex)";
-	
-	
+
+
 	// --------------------------------------------------------------------------------------------
 	// Members that define the structure / topology of the graph
 	// --------------------------------------------------------------------------------------------
@@ -53,7 +54,7 @@ public class JobVertex implements java.io.Serializable {
 	/** List of edges with incoming data. One per Reader. */
 	private final ArrayList<JobEdge> inputs = new ArrayList<JobEdge>();
 
-	/** Number of subtasks to split this task into at runtime.*/
+	/** Number of subtasks to split this task into at runtime. */
 	private int parallelism = -1;
 
 	/** Custom configuration passed to the assigned task at runtime. */
@@ -64,30 +65,40 @@ public class JobVertex implements java.io.Serializable {
 
 	/** Optionally, a source of input splits */
 	private InputSplitSource<?> inputSplitSource;
-	
+
 	/** The name of the vertex */
 	private String name;
-	
+
 	/** Optionally, a sharing group that allows subtasks from different job vertices to run concurrently in one slot */
 	private SlotSharingGroup slotSharingGroup;
-	
+
 	/** The group inside which the vertex subtasks share slots */
 	private CoLocationGroup coLocationGroup;
-	
+
+	/**
+	 * Flag to set this vertex as a source for jobs in {@link ScheduleMode#BATCH_FROM_SOURCES} mode.
+	 */
+	private boolean isBatchSource;
+
+	/**
+	 * A lazily initialized list of successors for produced batch results.
+	 */
+	private List<JobVertexID> batchSuccessors;
+
 	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Constructs a new job vertex and assigns it with the given name.
-	 * 
+	 *
 	 * @param name The name of the new job vertex.
 	 */
 	public JobVertex(String name) {
 		this(name, null);
 	}
-	
+
 	/**
 	 * Constructs a new job vertex and assigns it with the given name.
-	 * 
+	 *
 	 * @param name The name of the new job vertex.
 	 * @param id The id of the job vertex.
 	 */
@@ -95,30 +106,30 @@ public class JobVertex implements java.io.Serializable {
 		this.name = name == null ? DEFAULT_NAME : name;
 		this.id = id == null ? new JobVertexID() : id;
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Returns the ID of this job vertex.
-	 * 
+	 *
 	 * @return The ID of this job vertex
 	 */
 	public JobVertexID getID() {
 		return this.id;
 	}
-	
+
 	/**
 	 * Returns the name of the vertex.
-	 * 
+	 *
 	 * @return The name of the vertex.
 	 */
 	public String getName() {
 		return this.name;
 	}
-	
+
 	/**
 	 * Sets the name of the vertex
-	 * 
+	 *
 	 * @param name The new name.
 	 */
 	public void setName(String name) {
@@ -127,7 +138,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the number of produced intermediate data sets.
-	 * 
+	 *
 	 * @return The number of produced intermediate data sets.
 	 */
 	public int getNumberOfProducedIntermediateDataSets() {
@@ -136,7 +147,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the number of inputs.
-	 * 
+	 *
 	 * @return The number of inputs.
 	 */
 	public int getNumberOfInputs() {
@@ -145,7 +156,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Returns the vertex's configuration object which can be used to pass custom settings to the task at runtime.
-	 * 
+	 *
 	 * @return the vertex's configuration object
 	 */
 	public Configuration getConfiguration() {
@@ -154,24 +165,24 @@ public class JobVertex implements java.io.Serializable {
 		}
 		return this.configuration;
 	}
-	
+
 	public void setInvokableClass(Class<? extends AbstractInvokable> invokable) {
-		Preconditions.checkNotNull(invokable);
+		checkNotNull(invokable);
 		this.invokableClassName = invokable.getName();
 	}
-	
+
 	/**
 	 * Returns the name of the invokable class which represents the task of this vertex.
-	 * 
+	 *
 	 * @return The name of the invokable class, <code>null</code> if not set.
 	 */
 	public String getInvokableClassName() {
 		return this.invokableClassName;
 	}
-	
+
 	/**
 	 * Returns the invokable class which represents the task of this vertex
-	 * 
+	 *
 	 * @param cl The classloader used to resolve user-defined classes
 	 * @return The invokable class, <code>null</code> if it is not set
 	 */
@@ -182,7 +193,7 @@ public class JobVertex implements java.io.Serializable {
 		if (invokableClassName == null) {
 			return null;
 		}
-		
+
 		try {
 			return Class.forName(invokableClassName, true, cl).asSubclass(AbstractInvokable.class);
 		}
@@ -193,10 +204,10 @@ public class JobVertex implements java.io.Serializable {
 			throw new RuntimeException("The user-code class is no subclass of " + AbstractInvokable.class.getName(), e);
 		}
 	}
-	
+
 	/**
 	 * Gets the parallelism of the task.
-	 * 
+	 *
 	 * @return The parallelism of the task.
 	 */
 	public int getParallelism() {
@@ -205,7 +216,7 @@ public class JobVertex implements java.io.Serializable {
 
 	/**
 	 * Sets the parallelism for the task.
-	 * 
+	 *
 	 * @param parallelism The parallelism for the task.
 	 */
 	public void setParallelism(int parallelism) {
@@ -214,7 +225,7 @@ public class JobVertex implements java.io.Serializable {
 		}
 		this.parallelism = parallelism;
 	}
-	
+
 	public InputSplitSource<?> getInputSplitSource() {
 		return inputSplitSource;
 	}
@@ -222,68 +233,68 @@ public class JobVertex implements java.io.Serializable {
 	public void setInputSplitSource(InputSplitSource<?> inputSplitSource) {
 		this.inputSplitSource = inputSplitSource;
 	}
-	
+
 	public List<IntermediateDataSet> getProducedDataSets() {
 		return this.results;
 	}
-	
+
 	public List<JobEdge> getInputs() {
 		return this.inputs;
 	}
-	
+
 	/**
 	 * Associates this vertex with a slot sharing group for scheduling. Different vertices in the same
 	 * slot sharing group can run one subtask each in the same slot.
-	 * 
+	 *
 	 * @param grp The slot sharing group to associate the vertex with.
 	 */
 	public void setSlotSharingGroup(SlotSharingGroup grp) {
 		if (this.slotSharingGroup != null) {
 			this.slotSharingGroup.removeVertexFromGroup(id);
 		}
-		
+
 		this.slotSharingGroup = grp;
 		if (grp != null) {
 			grp.addVertexToGroup(id);
 		}
 	}
-	
+
 	/**
 	 * Gets the slot sharing group that this vertex is associated with. Different vertices in the same
 	 * slot sharing group can run one subtask each in the same slot. If the vertex is not associated with
 	 * a slot sharing group, this method returns {@code null}.
-	 * 
+	 *
 	 * @return The slot sharing group to associate the vertex with, or {@code null}, if not associated with one.
 	 */
 	public SlotSharingGroup getSlotSharingGroup() {
 		return slotSharingGroup;
 	}
-	
+
 	/**
 	 * Tells this vertex to strictly co locate its subtasks with the subtasks of the given vertex.
 	 * Strict co-location implies that the n'th subtask of this vertex will run on the same parallel computing
 	 * instance (TaskManager) as the n'th subtask of the given vertex.
-	 * 
+	 *
 	 * NOTE: Co-location is only possible between vertices in a slot sharing group.
-	 * 
+	 *
 	 * NOTE: This vertex must (transitively) depend on the vertex to be co-located with. That means that the
 	 * respective vertex must be a (transitive) input of this vertex.
-	 * 
+	 *
 	 * @param strictlyCoLocatedWith The vertex whose subtasks to co-locate this vertex's subtasks with.
-	 * 
+	 *
 	 * @throws IllegalArgumentException Thrown, if this vertex and the vertex to co-locate with are not in a common
 	 *                                  slot sharing group.
-	 * 
+	 *
 	 * @see #setSlotSharingGroup(SlotSharingGroup)
 	 */
 	public void setStrictlyCoLocatedWith(JobVertex strictlyCoLocatedWith) {
 		if (this.slotSharingGroup == null || this.slotSharingGroup != strictlyCoLocatedWith.slotSharingGroup) {
 			throw new IllegalArgumentException("Strict co-location requires that both vertices are in the same slot sharing group.");
 		}
-		
+
 		CoLocationGroup thisGroup = this.coLocationGroup;
 		CoLocationGroup otherGroup = strictlyCoLocatedWith.coLocationGroup;
-		
+
 		if (otherGroup == null) {
 			if (thisGroup == null) {
 				CoLocationGroup group = new CoLocationGroup(this, strictlyCoLocatedWith);
@@ -306,15 +317,41 @@ public class JobVertex implements java.io.Serializable {
 			}
 		}
 	}
-	
+
 	public CoLocationGroup getCoLocationGroup() {
 		return coLocationGroup;
 	}
-	
+
 	public void updateCoLocationGroup(CoLocationGroup group) {
 		this.coLocationGroup = group;
 	}
-	
+
+	// --------------------------------------------------------------------------------------------
+
+	public void setAsBatchSource() {
+		isBatchSource = true;
+	}
+
+	public boolean isBatchSource() {
+		return isBatchSource;
+	}
+
+	public void addBatchSuccessors(JobVertex... succ) {
+		checkNotNull(succ);
+
+		if (batchSuccessors == null) {
+			batchSuccessors = Lists.newArrayList();
+		}
+
+		for (JobVertex jv : succ) {
+			batchSuccessors.add(jv.getID());
+		}
+	}
+
+	public List<JobVertexID> getBatchSuccessors() {
+		return batchSuccessors;
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	public IntermediateDataSet createAndAddResultDataSet(ResultPartitionType partitionType) {
@@ -357,45 +394,46 @@ public class JobVertex implements java.io.Serializable {
 	}
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	public boolean isInputVertex() {
 		return this.inputs.isEmpty();
 	}
-	
+
 	public boolean isOutputVertex() {
 		return this.results.isEmpty();
 	}
-	
+
 	public boolean hasNoConnectedInputs() {
 		for (JobEdge edge : inputs) {
 			if (!edge.isIdReference()) {
 				return false;
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
-	 * A hook that can be overwritten by sub classes to implement logic that is called by the 
+	 * A hook that can be overwritten by sub classes to implement logic that is called by the
 	 * master when the job starts.
-	 * 
+	 *
 	 * @param loader The class loader for user defined code.
 	 * @throws Exception The method may throw exceptions which cause the job to fail immediately.
 	 */
 	public void initializeOnMaster(ClassLoader loader) throws Exception {}
-	
+
 	/**
-	 * A hook that can be overwritten by sub classes to implement logic that is called by the 
+	 * A hook that can be overwritten by sub classes to implement logic that is called by the
 	 * master after the job completed.
-	 * 
+	 *
 	 * @param loader The class loader for user defined code.
 	 * @throws Exception The method may throw exceptions which cause the job to fail immediately.
 	 */
-	public void finalizeOnMaster(ClassLoader loader) throws Exception {}
-	
+	public void finalizeOnMaster(ClassLoader loader) throws Exception {
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/ScheduleMode.java
@@ -21,9 +21,14 @@ package org.apache.flink.runtime.jobgraph;
 public enum ScheduleMode {
 
 	/**
-	 * Schedule tasks from sources to sinks with lazy deployment of receiving tasks.
+	 * Schedule tasks from all sources to sinks with lazy deployment of receiving tasks.
 	 */
 	FROM_SOURCES,
+
+	/**
+	 * Schedule tasks from manually configured sources.
+	 */
+	BATCH_FROM_SOURCES,
 
 	BACKTRACKING,
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/BatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/BatchSchedulingTest.java
@@ -1,0 +1,618 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.scheduler;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.io.network.api.reader.RecordReader;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmanager.Tasks;
+import org.apache.flink.runtime.testingUtils.TestingCluster;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.types.IntValue;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.POINTWISE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class BatchSchedulingTest {
+
+	// Test cluster config
+	private final static int NUMBER_OF_TMS = 1;
+	private final static int NUMBER_OF_SLOTS_PER_TM = 2;
+	private final static int PARALLELISM = NUMBER_OF_TMS * NUMBER_OF_SLOTS_PER_TM;
+
+	private final static TestingCluster flink = TestingUtils.startTestingCluster(
+			NUMBER_OF_SLOTS_PER_TM,
+			NUMBER_OF_TMS,
+			TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
+
+	private final static List<Integer> invokeOrder = Lists.newCopyOnWriteArrayList();
+
+	@After
+	public void clearInvokeOrder() throws Exception {
+		invokeOrder.clear();
+	}
+
+	@AfterClass
+	public static void tearDownTestCluster() throws Exception {
+		if (flink != null) {
+			flink.stop();
+		}
+	}
+
+	@Test
+	public void testBatchSchedulingScheduleModeNotSet() throws Exception {
+		// Create the JobGraph
+		JobGraph jobGraph = new JobGraph("testBatchSchedulingScheduleModeNotSet");
+
+		JobVertex v1 = new JobVertex("v1");
+		v1.setInvokableClass(SourceTask.class);
+		v1.setParallelism(PARALLELISM);
+
+		JobVertex v2 = new JobVertex("v2");
+		v2.setInvokableClass(UnionForwarder.class);
+		v2.setParallelism(PARALLELISM);
+
+		v2.connectNewDataSetAsInput(v1, POINTWISE);
+
+		jobGraph.addVertex(v1);
+		jobGraph.addVertex(v2);
+
+		v1.setAsBatchSource();
+		v1.addBatchSuccessors(v2);
+
+		try {
+			// The execution should fail, because we configured a successor without
+			// setting the correct schedule mode.
+			flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
+			fail("Did not throw expected Exception.");
+		}
+		catch (JobExecutionException expected) {
+			assertEquals(IllegalStateException.class, expected.getCause().getClass());
+		}
+	}
+
+	@Test(expected = JobExecutionException.class)
+	public void testBatchSchedulingNoSourceSet() throws Exception {
+		// Create the JobGraph
+		JobGraph jobGraph = new JobGraph("testBatchSchedulingNoSourceSet");
+		jobGraph.setScheduleMode(ScheduleMode.BATCH_FROM_SOURCES);
+
+		JobVertex src = new JobVertex("src");
+
+		jobGraph.addVertex(src);
+
+		// This should throw an Exception, because schedule mode is BATCH,
+		// but no source has been configured.
+		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
+	}
+
+	@Test(expected = JobExecutionException.class)
+	public void testBatchSchedulingSourceWithInput() throws Exception {
+		// Create the JobGraph
+		JobGraph jobGraph = new JobGraph("testBatchSchedulingSourceWithInput");
+		jobGraph.setScheduleMode(ScheduleMode.BATCH_FROM_SOURCES);
+
+		JobVertex v1 = new JobVertex("v1");
+
+		JobVertex v2 = new JobVertex("v2");
+		v2.connectNewDataSetAsInput(v1, POINTWISE);
+
+		jobGraph.addVertex(v1);
+		jobGraph.addVertex(v2);
+
+		v2.setAsBatchSource();
+
+		// This should throw an Exception, because the configured source has an input vertex.
+		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
+	}
+
+	/**
+	 * <pre>
+	 *        O verify
+	 *        |
+	 *        . <------------- denotes a pipelined result
+	 *        O union
+	 *  +----´|`----+
+	 *  |     |     |
+	 *  ■     ■     ■ <------- denotes a blocking result
+	 *  O     O     O
+	 * src0  src1  src2
+	 * </pre>
+	 */
+	@Test
+	public void testBatchSchedulingLegWise() throws Exception {
+		// Create the JobGraph
+		JobGraph jobGraph = new JobGraph("testBatchSchedulingLegWise");
+		jobGraph.setScheduleMode(ScheduleMode.BATCH_FROM_SOURCES);
+
+		// Union
+		JobVertex union = new JobVertex("union");
+		union.setInvokableClass(UnionForwarder.class);
+		union.setParallelism(PARALLELISM);
+		jobGraph.addVertex(union);
+
+		// Create source vertices
+		JobVertex[] src = new JobVertex[3];
+		for (int i = 0; i < src.length; i++) {
+			src[i] = new JobVertex("src " + i);
+			src[i].setInvokableClass(SourceTask.class);
+			src[i].setParallelism(PARALLELISM);
+			src[i].getConfiguration().setInteger("index", i);
+			jobGraph.addVertex(src[i]);
+
+			// Connect sources to union node
+			union.connectNewDataSetAsInput(src[i], POINTWISE, BLOCKING);
+		}
+
+		// Create verify
+		JobVertex verify = new JobVertex("verify");
+		verify.setInvokableClass(VerifyIndexes.class);
+		verify.setParallelism(PARALLELISM);
+		verify.getConfiguration().setInteger("maxIndex", src.length);
+
+		verify.connectNewDataSetAsInput(union, POINTWISE, PIPELINED);
+		jobGraph.addVertex(verify);
+
+		// Slot sharing group for the last pipeline
+		SlotSharingGroup ssg = new SlotSharingGroup(union.getID(), verify.getID());
+		union.setSlotSharingGroup(ssg);
+		verify.setSlotSharingGroup(ssg);
+
+		// - Configure batch scheduling ------------------------------------------------------------
+
+		// src0 is the first to go...
+		src[0].setAsBatchSource();
+
+		src[0].addBatchSuccessors(src[1]); // src0 => src1
+
+		src[1].addBatchSuccessors(src[2]); // src1 => src2
+
+		src[2].addBatchSuccessors(union); // src2 => [union => verify]
+
+		// - Expected invoke order -----------------------------------------------------------------
+
+		setExpectedInvokeOrder(src[0], 1);
+		setExpectedInvokeOrder(src[1], 2);
+		setExpectedInvokeOrder(src[2], 3);
+		setExpectedInvokeOrder(union, 4);
+		setExpectedInvokeOrder(verify, 5);
+
+		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
+
+		// The first vertices have tight expected ordering (batch scheduling)
+		verifyExpectedInvokeOrder(invokeOrder.subList(0, PARALLELISM * 4));
+
+		// The last 2 vertices have loose expected ordering, because they are pipelined
+		verifyExpectedInvokeOrder(invokeOrder.subList(PARALLELISM * 4, invokeOrder.size()),
+				Sets.newHashSet(5));
+	}
+
+	/**
+	 * <pre>
+	 *           O verify
+	 *           |
+	 *           .
+	 *           O union1
+	 *  +-------´ `------+
+	 *  |                |
+	 *  ■                .
+	 *  O                O union0
+	 * src0        +----´|`----+
+	 *             |     |     |
+	 *             ■     ■     ■
+	 *             O     O     O
+	 *            src1  src2  src3
+	 * </pre>
+	 */
+	@Test
+	public void testBatchSchedulingLeftFirst() throws Exception {
+		// Create the JobGraph
+		JobGraph jobGraph = new JobGraph("testBatchSchedulingLeftFirst");
+		jobGraph.setScheduleMode(ScheduleMode.BATCH_FROM_SOURCES);
+
+		// Create source vertices
+		JobVertex[] src = new JobVertex[4];
+		for (int i = 0; i < src.length; i++) {
+			src[i] = new JobVertex("src " + i);
+			src[i].setInvokableClass(SourceTask.class);
+			src[i].setParallelism(PARALLELISM);
+			src[i].getConfiguration().setInteger("index", i);
+			jobGraph.addVertex(src[i]);
+		}
+
+		// Union 0
+		JobVertex union0 = new JobVertex("union0");
+		union0.setParallelism(PARALLELISM);
+		union0.setInvokableClass(UnionForwarder.class);
+		jobGraph.addVertex(union0);
+
+		// Connect sources to union0 node
+		union0.connectNewDataSetAsInput(src[1], POINTWISE, BLOCKING);
+		union0.connectNewDataSetAsInput(src[2], POINTWISE, BLOCKING);
+		union0.connectNewDataSetAsInput(src[3], POINTWISE, BLOCKING);
+
+		// Union
+		JobVertex union1 = new JobVertex("union1");
+		union1.setInvokableClass(UnionForwarder.class);
+		union1.setParallelism(PARALLELISM);
+		jobGraph.addVertex(union1);
+
+		union1.connectNewDataSetAsInput(src[0], POINTWISE, BLOCKING);
+		union1.connectNewDataSetAsInput(union0, POINTWISE, PIPELINED);
+
+		// Create verify
+		JobVertex verify = new JobVertex("verify");
+		verify.setInvokableClass(VerifyIndexes.class);
+		verify.setParallelism(PARALLELISM);
+		verify.getConfiguration().setInteger("maxIndex", src.length);
+
+		verify.connectNewDataSetAsInput(union1, POINTWISE, PIPELINED);
+		jobGraph.addVertex(verify);
+
+		// Slot sharing group for the last pipeline
+		SlotSharingGroup ssg = new SlotSharingGroup(union0.getID(), union1.getID(), verify.getID());
+		union0.setSlotSharingGroup(ssg);
+		union1.setSlotSharingGroup(ssg);
+		verify.setSlotSharingGroup(ssg);
+
+		// - Configure batch scheduling ------------------------------------------------------------
+
+		// src0 is the first to go...
+		src[0].setAsBatchSource();
+
+		src[0].addBatchSuccessors(src[1]); // src0 => src1
+
+		src[1].addBatchSuccessors(src[2]); // src1 => src2
+
+		src[2].addBatchSuccessors(src[3]); // src2 => src3
+
+		src[3].addBatchSuccessors(union0); // src3 => [union0 => union1 => verify]
+
+		// - Expected invoke order -----------------------------------------------------------------
+
+		setExpectedInvokeOrder(src[0], 1);
+		setExpectedInvokeOrder(src[1], 2);
+		setExpectedInvokeOrder(src[2], 3);
+		setExpectedInvokeOrder(src[3], 4);
+		setExpectedInvokeOrder(union0, 5);
+		setExpectedInvokeOrder(union1, 6);
+		setExpectedInvokeOrder(verify, 7);
+
+		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
+
+		// The first vertices have tight expected ordering (batch scheduling)
+		verifyExpectedInvokeOrder(invokeOrder.subList(0, PARALLELISM * 5));
+
+		// The last 2 vertices have loose expected ordering, because they are pipelined
+		verifyExpectedInvokeOrder(invokeOrder.subList(PARALLELISM * 5, invokeOrder.size()),
+				Sets.newHashSet(6, 7));
+	}
+
+	/**
+	 * <pre>
+	 *           O verify
+	 *           |
+	 *           .
+	 *           O union1
+	 *  +-------´ `------+
+	 *  |                |
+	 *  .                ■
+	 *  O                O union0
+	 * src0        +----´|`----+
+	 *             |     |     |
+	 *             ■     ■     ■
+	 *             O     O     O
+	 *            src1  src2  src3
+	 * </pre>
+	 */
+	@Test
+	public void testBatchSchedulingRightFirst() throws Exception {
+		// Create the JobGraph
+		JobGraph jobGraph = new JobGraph("testBatchSchedulingRightFirst");
+		jobGraph.setScheduleMode(ScheduleMode.BATCH_FROM_SOURCES);
+
+		// Create source vertices
+		JobVertex[] src = new JobVertex[4];
+		for (int i = 0; i < src.length; i++) {
+			src[i] = new JobVertex("src " + i);
+			src[i].setInvokableClass(SourceTask.class);
+			src[i].setParallelism(PARALLELISM);
+			src[i].getConfiguration().setInteger("index", i);
+			jobGraph.addVertex(src[i]);
+		}
+
+		// Union 0
+		JobVertex union0 = new JobVertex("union0");
+		union0.setInvokableClass(UnionForwarder.class);
+		union0.setParallelism(PARALLELISM);
+		jobGraph.addVertex(union0);
+
+		// Connect sources to union0 node
+		union0.connectNewDataSetAsInput(src[1], POINTWISE, BLOCKING);
+		union0.connectNewDataSetAsInput(src[2], POINTWISE, BLOCKING);
+		union0.connectNewDataSetAsInput(src[3], POINTWISE, BLOCKING);
+
+		// Union
+		JobVertex union1 = new JobVertex("union1");
+		union1.setInvokableClass(UnionForwarder.class);
+		union1.setParallelism(PARALLELISM);
+		jobGraph.addVertex(union1);
+
+		union1.connectNewDataSetAsInput(src[0], POINTWISE, PIPELINED);
+		union1.connectNewDataSetAsInput(union0, POINTWISE, BLOCKING);
+
+		// Create verify
+		JobVertex verify = new JobVertex("verify");
+		verify.setInvokableClass(VerifyIndexes.class);
+		verify.setParallelism(PARALLELISM);
+		verify.getConfiguration().setInteger("maxIndex", src.length);
+
+		verify.connectNewDataSetAsInput(union1, POINTWISE, PIPELINED);
+		jobGraph.addVertex(verify);
+
+		// Slot sharing group for the last pipeline
+		SlotSharingGroup ssg = new SlotSharingGroup(src[0].getID(), union1.getID(), verify.getID());
+		src[0].setSlotSharingGroup(ssg);
+		union1.setSlotSharingGroup(ssg);
+		verify.setSlotSharingGroup(ssg);
+
+		// - Configure batch scheduling ------------------------------------------------------------
+
+		// src1 is the first to go...
+		src[1].setAsBatchSource();
+
+		src[1].addBatchSuccessors(src[2]); // src1 => src2
+
+		src[2].addBatchSuccessors(src[3]); // src2 => src3
+
+		src[3].addBatchSuccessors(union0); // src3 => union0
+
+		union0.addBatchSuccessors(src[0]); // union0 => [src0 => union1 => verify]
+
+		// - Expected invoke order -----------------------------------------------------------------
+
+		setExpectedInvokeOrder(src[1], 1);
+		setExpectedInvokeOrder(src[2], 2);
+		setExpectedInvokeOrder(src[3], 3);
+		setExpectedInvokeOrder(union0, 4);
+		setExpectedInvokeOrder(src[0], 5);
+		setExpectedInvokeOrder(union1, 6);
+		setExpectedInvokeOrder(verify, 7);
+
+		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
+
+		// The first 5 vertices have tight expected ordering (batch scheduling)
+		verifyExpectedInvokeOrder(invokeOrder.subList(0, PARALLELISM * 5));
+
+		// The last 2 vertices have loose expected ordering, because they are pipelined
+		verifyExpectedInvokeOrder(invokeOrder.subList(PARALLELISM * 5, invokeOrder.size()),
+				Sets.newHashSet(6, 7));
+	}
+
+	/**
+	 * <pre>
+	 *     O block
+	 *     |
+	 *     ■
+	 *     O union
+	 *  +-´ `-+
+	 *  |     |
+	 *  ■     ■
+	 *  O     O
+	 * src0  src1
+	 * </pre>
+	 */
+	@Test
+	public void testBatchSchedulingUpdateRunningTaskFails() throws Exception {
+		// Create the JobGraph
+		JobGraph jobGraph = new JobGraph("testBatchSchedulingUpdateRunningTaskFails");
+		jobGraph.setScheduleMode(ScheduleMode.BATCH_FROM_SOURCES);
+
+		// Create source vertices
+		JobVertex[] src = new JobVertex[2];
+		for (int i = 0; i < src.length; i++) {
+			src[i] = new JobVertex("src " + i);
+			src[i].setInvokableClass(SourceTask.class);
+			src[i].setParallelism(1);
+			src[i].getConfiguration().setInteger("index", i);
+			jobGraph.addVertex(src[i]);
+		}
+
+		// Union
+		JobVertex union = new JobVertex("union");
+		union.setInvokableClass(UnionForwarder.class);
+		union.setParallelism(1);
+		jobGraph.addVertex(union);
+
+		// Needed for the UnionForwarder writer
+		JobVertex nop = new JobVertex("nop");
+		nop.setInvokableClass(Tasks.NoOpInvokable.class);
+		nop.setParallelism(1);
+		jobGraph.addVertex(nop);
+
+		nop.connectNewDataSetAsInput(union, POINTWISE);
+
+		// Connect sources to union node
+		union.connectNewDataSetAsInput(src[0], POINTWISE, BLOCKING);
+		union.connectNewDataSetAsInput(src[1], POINTWISE, BLOCKING);
+
+		// Slot sharing group for the last pipeline
+		SlotSharingGroup ssg = new SlotSharingGroup(src[0].getID(), union.getID(), nop.getID());
+		src[0].setSlotSharingGroup(ssg);
+		union.setSlotSharingGroup(ssg);
+		nop.setSlotSharingGroup(ssg);
+
+		// - Configure batch scheduling ------------------------------------------------------------
+
+		// src0 is the first to go...
+		src[0].setAsBatchSource();
+
+		// This ordering will provoke the union vertex to be already deployed when either src0 or
+		// src1 try to schedule it after being finished. This should then throw an Exception.
+		src[0].addBatchSuccessors(union, src[1]); // src0 => [union] | [src1]
+		src[1].addBatchSuccessors(union);
+
+		try {
+			flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
+			fail("Did not throw expected Exception.");
+		}
+		catch (JobExecutionException expected) {
+			assertEquals(IllegalStateException.class, expected.getCause().getClass());
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	public static class SourceTask extends AbstractInvokable {
+
+		private int index;
+
+		private RecordWriter<IntValue> writer;
+
+		@Override
+		public void registerInputOutput() {
+			index = getTaskConfiguration().getInteger("index", -1);
+			writer = new RecordWriter<IntValue>(getEnvironment().getWriter(0));
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			addInvoke(getTaskConfiguration());
+
+			writer.emit(new IntValue(index));
+			writer.flush();
+		}
+	}
+
+	public static class UnionForwarder extends AbstractInvokable {
+
+		private RecordReader<IntValue> reader;
+
+		private RecordWriter<IntValue> writer;
+
+		@Override
+		public void registerInputOutput() {
+			UnionInputGate union = new UnionInputGate(getEnvironment().getAllInputGates());
+
+			reader = new RecordReader<IntValue>(union, IntValue.class);
+			writer = new RecordWriter<IntValue>(getEnvironment().getWriter(0));
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			addInvoke(getTaskConfiguration());
+
+			IntValue val;
+			while ((val = reader.next()) != null) {
+				writer.emit(val);
+			}
+
+			writer.flush();
+		}
+	}
+
+	public static class VerifyIndexes extends AbstractInvokable {
+
+		private RecordReader<IntValue> reader;
+
+		private int maxIndex;
+		private BitSet receivedIndexes;
+
+		@Override
+		public void registerInputOutput() {
+			maxIndex = getTaskConfiguration().getInteger("maxIndex", -1);
+
+			reader = new RecordReader<IntValue>(getEnvironment().getInputGate(0), IntValue.class);
+			receivedIndexes = new BitSet(maxIndex);
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			addInvoke(getTaskConfiguration());
+
+			IntValue val;
+			while ((val = reader.next()) != null) {
+				int index = val.getValue();
+
+				if (receivedIndexes.get(index)) {
+					throw new IllegalStateException("Duplicate index");
+				}
+
+				receivedIndexes.set(val.getValue());
+			}
+
+			if (receivedIndexes.cardinality() != maxIndex) {
+				throw new IllegalStateException("Missing index");
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	private static void setExpectedInvokeOrder(JobVertex vertex, int expected) {
+		vertex.getConfiguration().setInteger("expectedOrder", expected);
+	}
+
+	private static void addInvoke(Configuration conf) {
+		invokeOrder.add(conf.getInteger("expectedOrder", -1));
+	}
+
+	private static void verifyExpectedInvokeOrder(List<Integer> invokeOrder) {
+		int expected = 0;
+
+		int size = invokeOrder.size();
+		// Expected orders start counting from '1'
+		for (int i = 0; i < size; i++) {
+			if (i % PARALLELISM == 0) {
+				expected++;
+			}
+
+			if (expected != (invokeOrder.get(i))) {
+				fail("Unexpected invoke order: " + invokeOrder);
+			}
+		}
+	}
+
+	private static void verifyExpectedInvokeOrder(List<Integer> invokeOrder, Set<Integer> expected) {
+		int size = invokeOrder.size();
+		for (int i = 0; i < size; i++) {
+			if (!expected.contains(invokeOrder.get(i))) {
+				fail("Unexpected invoke order: " + invokeOrder);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for a newly introduced scheduling mode `BATCH_FROM_SOURCES`. The goal for me was to make this change *minimally invasive* in order to not touch too much core code shortly before the release.

Essentially, this only touches two parts of the codebase: the scheduling action for blocking results and the job vertices.

If you set the scheduling mode to `BATCH_FROM_SOURCES`, you can manually configure which input vertices are used as the sources when scheduling (`setAsBatchSource`). You can then manually specify the successor vertices (`addBatchSuccessor`), which are scheduled after the blocking results are finished. When there are no successors specified manually, the result consumers are scheduled as before. Mixing pipelined and blocking results leads to unspecified behaviour currently (aka it's not a good idea to do this at the moment).

When you have something like this:
```
        O sink
        |
        . <------------- denotes a pipelined result
        O union
  +----´|`----+
  |     |     |
  ■     ■     ■ <------- denotes a blocking result
  O     O     O
 src0  src1  src2
```
You can first first schedule `src0`, `src1`, `src2`, and then continue with the `union-sink` pipeline.

```java
src[0].setAsBatchSource(); // src0 is the first to go...

src[0].addBatchSuccessors(src[1]); // src0 => src1

src[1].addBatchSuccessors(src[2]); // src1 => src2

src[2].addBatchSuccessors(union); // src2 => [union => sink]
```

@StephanEwen or @tillrohrmann will work on the Optimizer/JobGraph counterpart of this and will build the `JobGraph` for programs in batch mode using the methods introduced in this PR. Do you guys think that this minimal support is sufficient for the first version?

(Going over the result partition notification code, I really think it's pressing to refactor it. It is very very hard to understand. The corresponding issue [FLINK-1833](https://issues.apache.org/jira/browse/FLINK-1833) has been created a while back. I want to do this after the release.)