### PR TITLE
[FLINK-1981] add support for GZIP files

### DIFF
--- a/docs/apis/programming_guide.md
+++ b/docs/apis/programming_guide.md
@@ -1814,6 +1814,39 @@ env.readTextFile("file:///path/with.nested/files").withParameters(parameters)
 
 </div>
 </div>
+
+### Read Compressed Files
+
+Flink currently supports transparent decompression of input files if these are marked with an appropriate file extension. In particular, this means that no further configuration of the input formats is necessary and any `FileInputFormat` support the compression, including custom input formats. Please notice that compressed files might not be read in parallel, thus impacting job scalability.
+
+The following table lists the currently supported compression methods.
+
+<br />
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Compression method</th>
+      <th class="text-left">File extensions</th>
+      <th class="text-left" style="width: 20%">Parallelizable</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><strong>DEFLATE</strong></td>
+      <td>`.deflate`</td>
+      <td>no</td>
+    </tr>
+    <tr>
+      <td><strong>GZip</strong></td>
+      <td>`.gz`, `.gzip`</td>
+      <td>no</td>
+    </tr>
+  </tbody>
+</table>
+
+
 [Back to top](#top)
 
 Data Sinks

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -21,10 +21,16 @@ package org.apache.flink.api.common.io;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
+import org.apache.flink.api.common.io.compression.DeflateInflaterInputStreamFactory;
+import org.apache.flink.api.common.io.compression.GzipInflaterInputStreamFactory;
+import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
@@ -68,10 +74,11 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	private static long DEFAULT_OPENING_TIMEOUT;
 
 	/**
-	 * Files with that suffix are unsplittable at a file level
-	 * and compressed.
+	 * A mapping of file extensions to decompression algorithms based on DEFLATE. Such compressions lead to
+	 * unsplittable files.
 	 */
-	protected static final String DEFLATE_SUFFIX = ".deflate";
+	protected static final Map<String, InflaterInputStreamFactory<?>> INFLATER_INPUT_STREAM_FACTORIES =
+			new HashMap<String, InflaterInputStreamFactory<?>>();
 	
 	/**
 	 * The splitLength is set to -1L for reading the whole split.
@@ -80,6 +87,7 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	
 	static {
 		initDefaultsFromConfiguration();
+		initDefaultInflaterInputStreamFactories();
 	}
 	
 	private static void initDefaultsFromConfiguration() {
@@ -94,6 +102,52 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 			DEFAULT_OPENING_TIMEOUT = 300000; // 5 minutes
 		} else {
 			DEFAULT_OPENING_TIMEOUT = to;
+		}
+	}
+
+	private static void initDefaultInflaterInputStreamFactories() {
+		InflaterInputStreamFactory<?>[] defaultFactories = {
+				DeflateInflaterInputStreamFactory.getInstance(),
+				GzipInflaterInputStreamFactory.getInstance()
+		};
+		for (InflaterInputStreamFactory<?> inputStreamFactory : defaultFactories) {
+			for (String fileExtension : inputStreamFactory.getCommonFileExtensions()) {
+				registerInflaterInputStreamFactory(fileExtension, inputStreamFactory);
+			}
+		}
+	}
+
+	/**
+	 * Registers a decompression algorithm through a {@link org.apache.flink.api.common.io.compression.InflaterInputStreamFactory}
+	 * with a file extension for transparent decompression.
+	 * @param fileExtension of the compressed files
+	 * @param factory to create an {@link java.util.zip.InflaterInputStream} that handles the decompression format
+	 */
+	public static void registerInflaterInputStreamFactory(String fileExtension, InflaterInputStreamFactory<?> factory) {
+		synchronized (INFLATER_INPUT_STREAM_FACTORIES) {
+			if (INFLATER_INPUT_STREAM_FACTORIES.put(fileExtension, factory) != null) {
+				LOG.warn("Overwriting an existing decompression algorithm for \"{}\" files.", fileExtension);
+			}
+		}
+	}
+
+	protected static InflaterInputStreamFactory<?> getInflaterInputStreamFactory(String fileExtension) {
+		synchronized (INFLATER_INPUT_STREAM_FACTORIES) {
+			return INFLATER_INPUT_STREAM_FACTORIES.get(fileExtension);
+		}
+	}
+
+	/**
+	 * Returns the extension of a file name (!= a path).
+	 * @return the extension of the file name or {@code null} if there is no extension.
+	 */
+	protected static String extractFileExtension(String fileName) {
+		Validate.notNull(fileName);
+		int lastPeriodIndex = fileName.lastIndexOf('.');
+		if (lastPeriodIndex < 0){
+			return null;
+		} else {
+			return fileName.substring(lastPeriodIndex + 1);
 		}
 	}
 	
@@ -529,11 +583,21 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	}
 
 	protected boolean testForUnsplittable(FileStatus pathFile) {
-		if(pathFile.getPath().getName().endsWith(DEFLATE_SUFFIX)) {
+		if(getInflaterInputStreamFactory(pathFile.getPath()) != null) {
 			unsplittable = true;
 			return true;
 		}
 		return false;
+	}
+
+	private InflaterInputStreamFactory<?> getInflaterInputStreamFactory(Path path) {
+		String fileExtension = extractFileExtension(path.getName());
+		if (fileExtension != null) {
+			return getInflaterInputStreamFactory(fileExtension);
+		} else {
+			return null;
+		}
+
 	}
 
 	/**
@@ -628,9 +692,10 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	 * @see org.apache.flink.api.common.io.InputStreamFSInputWrapper
 	 */
 	protected FSDataInputStream decorateInputStream(FSDataInputStream inputStream, FileInputSplit fileSplit) throws Throwable {
-		// Wrap stream in a extracting (decompressing) stream if file ends with .deflate.
-		if (fileSplit.getPath().getName().endsWith(DEFLATE_SUFFIX)) {
-			return new InflaterInputStreamFSInputWrapper(stream);
+		// Wrap stream in a extracting (decompressing) stream if file ends with a known compression file extension.
+		InflaterInputStreamFactory<?> inflaterInputStreamFactory = getInflaterInputStreamFactory(fileSplit.getPath());
+		if (inflaterInputStreamFactory != null) {
+			return new InputStreamFSInputWrapper(inflaterInputStreamFactory.create(stream));
 		}
 
 		return inputStream;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.Validate;
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.io.compression.DeflateInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.GzipInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
@@ -142,7 +142,7 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	 * @return the extension of the file name or {@code null} if there is no extension.
 	 */
 	protected static String extractFileExtension(String fileName) {
-		Validate.notNull(fileName);
+		Preconditions.checkNotNull(fileName);
 		int lastPeriodIndex = fileName.lastIndexOf('.');
 		if (lastPeriodIndex < 0){
 			return null;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/compression/DeflateInflaterInputStreamFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/compression/DeflateInflaterInputStreamFactory.java
@@ -15,18 +15,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.flink.api.common.io.compression;
 
-
-package org.apache.flink.api.common.io;
-
-import org.apache.flink.core.fs.FSDataInputStream;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.zip.InflaterInputStream;
 
-public class InflaterInputStreamFSInputWrapper extends InputStreamFSInputWrapper {
+/**
+ * Factory for input streams that decompress the "deflate" compression format.
+ */
+public class DeflateInflaterInputStreamFactory implements InflaterInputStreamFactory<InflaterInputStream> {
 
-	public InflaterInputStreamFSInputWrapper(FSDataInputStream inStream) {
-		super(new InflaterInputStream(inStream));
+	private static DeflateInflaterInputStreamFactory INSTANCE = null;
+
+	public static DeflateInflaterInputStreamFactory getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new DeflateInflaterInputStreamFactory();
+		}
+		return INSTANCE;
 	}
 
+	@Override
+	public InflaterInputStream create(InputStream in) throws IOException {
+		return new InflaterInputStream(in);
+	}
+
+	@Override
+	public Collection<String> getCommonFileExtensions() {
+		return Collections.singleton("deflate");
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/compression/GzipInflaterInputStreamFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/compression/GzipInflaterInputStreamFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.io.compression;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Factory for input streams that decompress the GZIP compression format.
+ */
+public class GzipInflaterInputStreamFactory implements InflaterInputStreamFactory<GZIPInputStream> {
+
+	private static GzipInflaterInputStreamFactory INSTANCE = null;
+
+	public static GzipInflaterInputStreamFactory getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new GzipInflaterInputStreamFactory();
+		}
+		return INSTANCE;
+	}
+	@Override
+	public GZIPInputStream create(InputStream in) throws IOException {
+		return new GZIPInputStream(in);
+	}
+
+	@Override
+	public Collection<String> getCommonFileExtensions() {
+		return Arrays.asList("gz", "gzip");
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/compression/InflaterInputStreamFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/compression/InflaterInputStreamFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.io.compression;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.zip.InflaterInputStream;
+
+/**
+ * Creates a new instance of a certain subclass of {@link java.util.zip.InflaterInputStream}.
+ */
+public interface InflaterInputStreamFactory<T extends InflaterInputStream> {
+
+	/**
+	 * Creates a {@link java.util.zip.InflaterInputStream} that wraps the given input stream.
+	 * @param in is the compressed input stream
+	 * @return the inflated input stream
+	 */
+	T create(InputStream in) throws IOException;
+
+	/**
+	 * Lists a collection of typical file extensions (e.g., "gz", "gzip") that are associated with the compression
+	 * algorithm in the {@link java.util.zip.InflaterInputStream} {@code T}.
+	 * @return a (possibly empty) collection of lower-case file extensions, without the period
+	 */
+	Collection<String> getCommonFileExtensions();
+}


### PR DESCRIPTION
* register decompression algorithms with file extensions for extensibility
* fit deflate decompression into this scheme
* add support for GZIP files
* test support for deflate and GZIP files with the CsvInputFormat