### PR TITLE
[docs/javadoc][hotfix] Corrected Join hint and misleadling pointer to Spargel

### DIFF
--- a/docs/apis/iterations.md
+++ b/docs/apis/iterations.md
@@ -24,7 +24,7 @@ Iterative algorithms occur in many domains of data analysis, such as *machine le
 
 Flink programs implement iterative algorithms by defining a **step function** and embedding it into a special iteration operator. There are two  variants of this operator: **Iterate** and **Delta Iterate**. Both operators repeatedly invoke the step function on the current iteration state until a certain termination condition is reached.
 
-Here, we provide background on both operator variants and outline their usage. The [programming guide](programming_guide.html) explain how to implement the operators in both Scala and Java. We also provide a **vertex-centric graph processing API** called [Spargel]({{site.baseurl}}/libs/spargel_guide.html).
+Here, we provide background on both operator variants and outline their usage. The [programming guide](programming_guide.html) explains how to implement the operators in both Scala and Java. We also support both **vertex-centric and gather-sum-apply iterations** through Flink's graph processing API, [Gelly]({{site.baseurl}}/libs/gelly_guide.html).
 
 The following table provides an overview of both operators:
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/base/JoinOperatorBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/base/JoinOperatorBase.java
@@ -68,7 +68,7 @@ public class JoinOperatorBase<IN1, IN2, OUT, FT extends FlatJoinFunction<IN1, IN
 		BROADCAST_HASH_FIRST,
 		
 		/**
-		 * Hint that the second join input is much smaller than the second. This results in
+		 * Hint that the second join input is much smaller than the first. This results in
 		 * broadcasting and hashing the second input, unless the optimizer infers that
 		 * prior existing partitioning is available that is even cheaper to exploit.
 		 */


### PR DESCRIPTION
This PR adds the following patches: 
- in the Iteration programming guide, there was a misleading link to Spargel, which is deprecated; I switched it to point to Gelly;
- while trying to use join hints, I saw that the JavaDoc for BROADCAST_HASH_SECOND was wrong; "Hint that the *second* join input is much smaller than the *second*". Fixed it to be smaller than the first :) 