### PR TITLE
Remove extra HTML tags in TypeInformation JavaDoc class header.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -42,9 +42,6 @@ import java.util.List;
  *   <li>Basic types are indivisible and are considered a single field.</li>
  *   <li>Arrays and collections are one field</li>
  *   <li>Tuples and case classes represent as many fields as the class has fields</li>
- *   <li></li>
- *   <li></li>
- *   <li></li>
  * </ul>
  * <p>
  * To represent this properly, each type has an <i>arity</i> (the number of fields it contains


### PR DESCRIPTION
Simple clean up PR remove extra ```<li>``` HTML tags in TypeInformation JavaDoc class header.