### PR TITLE
[FLINK-2116] [ml] Reusing predict operation for evaluation

### DIFF
--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/ChainedTransformer.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/ChainedTransformer.scala
@@ -39,13 +39,13 @@ case class ChainedTransformer[L <: Transformer[L], R <: Transformer[R]](left: L,
 
 object ChainedTransformer{
 
-  /** [[TransformOperation]] implementation for [[ChainedTransformer]].
+  /** [[TransformDataSetOperation]] implementation for [[ChainedTransformer]].
     *
     * First the transform operation of the left [[Transformer]] is called with the input data. This
     * generates intermediate data which is fed to the right [[Transformer]]'s transform operation.
     *
-    * @param transformOpLeft [[TransformOperation]] for the left [[Transformer]]
-    * @param transformOpRight [[TransformOperation]] for the right [[Transformer]]
+    * @param transformOpLeft [[TransformDataSetOperation]] for the left [[Transformer]]
+    * @param transformOpRight [[TransformDataSetOperation]] for the right [[Transformer]]
     * @tparam L Type of the left [[Transformer]]
     * @tparam R Type of the right [[Transformer]]
     * @tparam I Type of the input data
@@ -59,17 +59,20 @@ object ChainedTransformer{
       I,
       T,
       O](implicit
-      transformOpLeft: TransformOperation[L, I, T],
-      transformOpRight: TransformOperation[R, T, O])
-    : TransformOperation[ChainedTransformer[L,R], I, O] = {
+      transformOpLeft: TransformDataSetOperation[L, I, T],
+      transformOpRight: TransformDataSetOperation[R, T, O])
+    : TransformDataSetOperation[ChainedTransformer[L,R], I, O] = {
 
-    new TransformOperation[ChainedTransformer[L, R], I, O] {
-      override def transform(
+    new TransformDataSetOperation[ChainedTransformer[L, R], I, O] {
+      override def transformDataSet(
           chain: ChainedTransformer[L, R],
           transformParameters: ParameterMap,
           input: DataSet[I]): DataSet[O] = {
-        val intermediateResult = transformOpLeft.transform(chain.left, transformParameters, input)
-        transformOpRight.transform(chain.right, transformParameters, intermediateResult)
+        val intermediateResult = transformOpLeft.transformDataSet(
+          chain.left,
+          transformParameters,
+          input)
+        transformOpRight.transformDataSet(chain.right, transformParameters, intermediateResult)
       }
     }
   }
@@ -81,7 +84,7 @@ object ChainedTransformer{
     * right [[Transformer]].
     *
     * @param leftFitOperation [[FitOperation]] for the left [[Transformer]]
-    * @param leftTransformOperation [[TransformOperation]] for the left [[Transformer]]
+    * @param leftTransformOperation [[TransformDataSetOperation]] for the left [[Transformer]]
     * @param rightFitOperation [[FitOperation]] for the right [[Transformer]]
     * @tparam L Type of the left [[Transformer]]
     * @tparam R Type of the right [[Transformer]]
@@ -91,7 +94,7 @@ object ChainedTransformer{
     */
   implicit def chainedFitOperation[L <: Transformer[L], R <: Transformer[R], I, T](implicit
       leftFitOperation: FitOperation[L, I],
-      leftTransformOperation: TransformOperation[L, I, T],
+      leftTransformOperation: TransformDataSetOperation[L, I, T],
       rightFitOperation: FitOperation[R, T]): FitOperation[ChainedTransformer[L, R], I] = {
     new FitOperation[ChainedTransformer[L, R], I] {
       override def fit(

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
@@ -18,18 +18,19 @@
 
 package org.apache.flink.ml.pipeline
 
-import scala.reflect.ClassTag
+import org.apache.flink.api.common.typeinfo.TypeInformation
 
-import org.apache.flink.api.scala.DataSet
+import org.apache.flink.api.scala._
+import org.apache.flink.ml._
 import org.apache.flink.ml.common.{FlinkMLTools, ParameterMap, WithParameters}
 
 /** Predictor trait for Flink's pipeline operators.
   *
   * A [[Predictor]] calculates predictions for testing data based on the model it learned during
   * the fit operation (training phase). In order to do that, the implementing class has to provide
-  * a [[FitOperation]] and a [[PredictOperation]] implementation for the correct types. The implicit
-  * values should be put into the scope of the companion object of the implementing class to make
-  * them retrievable for the Scala compiler.
+  * a [[FitOperation]] and a [[PredictDataSetOperation]] implementation for the correct types. The
+  * implicit values should be put into the scope of the companion object of the implementing class
+  * to make them retrievable for the Scala compiler.
   *
   * The pipeline mechanism has been inspired by scikit-learn
   *
@@ -39,11 +40,12 @@ trait Predictor[Self] extends Estimator[Self] with WithParameters {
   that: Self =>
 
   /** Predict testing data according the learned model. The implementing class has to provide
-    * a corresponding implementation of [[PredictOperation]] which contains the prediction logic.
+    * a corresponding implementation of [[PredictDataSetOperation]] which contains the prediction
+    * logic.
     *
     * @param testing Testing data which shall be predicted
     * @param predictParameters Additional parameters for the prediction
-    * @param predictor [[PredictOperation]] which encapsulates the prediction logic
+    * @param predictor [[PredictDataSetOperation]] which encapsulates the prediction logic
     * @tparam Testing Type of the testing data
     * @tparam Prediction Type of the prediction data
     * @return
@@ -51,84 +53,132 @@ trait Predictor[Self] extends Estimator[Self] with WithParameters {
   def predict[Testing, Prediction](
       testing: DataSet[Testing],
       predictParameters: ParameterMap = ParameterMap.Empty)(implicit
-      predictor: PredictOperation[Self, Testing, Prediction])
+      predictor: PredictDataSetOperation[Self, Testing, Prediction])
     : DataSet[Prediction] = {
     FlinkMLTools.registerFlinkMLTypes(testing.getExecutionEnvironment)
-    predictor.predict(this, predictParameters, testing)
+    predictor.predictDataSet(this, predictParameters, testing)
+  }
+
+  /** Evaluates the testing data by computing the prediction value and returning a pair of true
+    * label value and prediction value. It is important that the implementation chooses a Testing
+    * type from which it can extract the true label value.
+    *
+    * @param testing
+    * @param evaluateParameters
+    * @param evaluator
+    * @tparam Testing
+    * @tparam PredictionValue
+    * @return
+    */
+  def evaluate[Testing, PredictionValue](
+      testing: DataSet[Testing],
+      evaluateParameters: ParameterMap = ParameterMap.Empty)(implicit
+      evaluator: EvaluateDataSetOperation[Self, Testing, PredictionValue])
+    : DataSet[(PredictionValue, PredictionValue)] = {
+    FlinkMLTools.registerFlinkMLTypes(testing.getExecutionEnvironment)
+    evaluator.evaluateDataSet(this, evaluateParameters, testing)
   }
 }
 
-object Predictor{
+object Predictor {
 
-  /** Fallback [[PredictOperation]] if a [[Predictor]] is called with a not supported input data
-    * type. The fallback [[PredictOperation]] lets the system fail with a [[RuntimeException]]
-    * stating which input and output data types were inferred but for which no [[PredictOperation]]
-    * could be found.
+  /** Default [[PredictDataSetOperation]] which takes a [[PredictOperation]] to calculate a tuple
+    * of testing element and its prediction value.
     *
-    * @tparam Self Type of the [[Predictor]]
-    * @tparam Testing Type of the testing data
+    * Note: We have to put the TypeInformation implicit values for Testing and PredictionValue after
+    * the PredictOperation implicit parameter. Otherwise, if it's defined as a context bound, then
+    * the Scala compiler does not find the implicit [[PredictOperation]] value.
+    *
+    * @param predictOperation
+    * @param testingTypeInformation
+    * @param predictionValueTypeInformation
+    * @tparam Instance
+    * @tparam Model
+    * @tparam Testing
+    * @tparam PredictionValue
     * @return
     */
-  implicit def fallbackPredictOperation[Self: ClassTag, Testing: ClassTag]
-    : PredictOperation[Self, Testing, Any] = {
-    new PredictOperation[Self, Testing, Any] {
-      override def predict(
-          instance: Self,
+  implicit def defaultPredictDataSetOperation[
+      Instance <: Estimator[Instance],
+      Model,
+      Testing,
+      PredictionValue](
+      implicit predictOperation: PredictOperation[Instance, Model, Testing, PredictionValue],
+      testingTypeInformation: TypeInformation[Testing],
+      predictionValueTypeInformation: TypeInformation[PredictionValue])
+    : PredictDataSetOperation[Instance, Testing, (Testing, PredictionValue)] = {
+    new PredictDataSetOperation[Instance, Testing, (Testing, PredictionValue)] {
+      override def predictDataSet(
+          instance: Instance,
           predictParameters: ParameterMap,
           input: DataSet[Testing])
-        : DataSet[Any] = {
-        val self = implicitly[ClassTag[Self]]
-        val testing = implicitly[ClassTag[Testing]]
+        : DataSet[(Testing, PredictionValue)] = {
+        val resultingParameters = instance.parameters ++ predictParameters
 
-        throw new RuntimeException("There is no PredictOperation defined for " + self.runtimeClass +
-          " which takes a DataSet[" + testing.runtimeClass + "] as input.")
+        val model = predictOperation.getModel(instance, resultingParameters)
+
+        implicit val resultTypeInformation = createTypeInformation[(Testing, PredictionValue)]
+
+        input.mapWithBcVariable(model){
+          (element, model) => {
+            (element, predictOperation.predict(element, model))
+          }
+        }
       }
     }
   }
 
-  /** Fallback [[PredictOperation]] for a [[ChainedPredictor]] if a [[TransformOperation]] for
-    * one of the [[Transformer]] and its respective types or the [[PredictOperation]] for the
-    * [[Predictor]] and its respective type could not be found. This is usually the case, if the
-    * the pipeline contains pipeline operators which work on incompatible types.
+  /** Default [[EvaluateDataSetOperation]] which takes a [[PredictOperation]] to calculate a tuple
+    * of true label value and predicted label value.
     *
-    * The fallback [[PredictOperation]] first transforms the input data by calling the transform
-    * method of the [[Transformer]] and then the predict method of the [[Predictor]].
+    * Note: We have to put the TypeInformation implicit values for Testing and PredictionValue after
+    * the PredictOperation implicit parameter. Otherwise, if it's defined as a context bound, then
+    * the Scala compiler does not find the implicit [[PredictOperation]] value.
     *
-    * @param leftTransformOperation [[TransformOperation]] of the [[Transformer]]
-    * @param rightPredictOperation [[PredictOperation]] of the [[Predictor]]
-    * @tparam L Type of the [[Transformer]]
-    * @tparam R Type of the [[Predictor]]
-    * @tparam LI Input type of the [[Transformer]]
-    * @tparam LO Output type of the [[Transformer]]
-    * @tparam RO Prediction type of the [[Predictor]]
+    * @param predictOperation
+    * @param testingTypeInformation
+    * @param predictionValueTypeInformation
+    * @tparam Instance
+    * @tparam Model
+    * @tparam Testing
+    * @tparam PredictionValue
     * @return
     */
-  implicit def fallbackChainedPredictOperation[
-      L <: Transformer[L],
-      R <: Predictor[R],
-      LI,
-      LO,
-      RO](implicit
-      leftTransformOperation: TransformOperation[L, LI, LO],
-      rightPredictOperation: PredictOperation[R, LO, RO]
-      )
-    : PredictOperation[ChainedPredictor[L, R], LI, RO] = {
-    new PredictOperation[ChainedPredictor[L, R], LI, RO] {
-      override def predict(
-          instance: ChainedPredictor[L, R],
-          predictParameters: ParameterMap,
-          input: DataSet[LI]): DataSet[RO] = {
-        val intermediate = instance.transformer.transform(input, predictParameters)
-        instance.predictor.predict(intermediate, predictParameters)
+  implicit def defaultEvaluateDataSetOperation[
+      Instance <: Estimator[Instance],
+      Model,
+      Testing,
+      PredictionValue](
+      implicit predictOperation: PredictOperation[Instance, Model, Testing, PredictionValue],
+      testingTypeInformation: TypeInformation[Testing],
+      predictionValueTypeInformation: TypeInformation[PredictionValue])
+    : EvaluateDataSetOperation[Instance, (Testing, PredictionValue), PredictionValue] = {
+    new EvaluateDataSetOperation[Instance, (Testing, PredictionValue), PredictionValue] {
+      override def evaluateDataSet(
+          instance: Instance,
+          evaluateParameters: ParameterMap,
+          testing: DataSet[(Testing, PredictionValue)])
+        : DataSet[(PredictionValue,  PredictionValue)] = {
+        val resultingParameters = instance.parameters ++ evaluateParameters
+        val model = predictOperation.getModel(instance, resultingParameters)
+
+        implicit val resultTypeInformation = createTypeInformation[(Testing, PredictionValue)]
+
+        testing.mapWithBcVariable(model){
+          (element, model) => {
+            (element._2, predictOperation.predict(element._1, model))
+          }
+        }
       }
     }
   }
 }
 
-/** Type class for the predict operation of [[Predictor]].
+/** Type class for the predict operation of [[Predictor]]. This predict operation works on DataSets.
   *
-  * Predictors have to implement this trait and make the result available as an implicit value or
-  * function in the scope of their companion objects.
+  * [[Predictor]]s either have to implement this trait or the [[PredictOperation]] trait. The
+  * implementation has to be made available as an implicit value or function in the scope of
+  * their companion objects.
   *
   * The first type parameter is the type of the implementing [[Predictor]] class so that the Scala
   * compiler includes the companion object of this class in the search scope for the implicit
@@ -138,10 +188,65 @@ object Predictor{
   * @tparam Testing Type of testing data
   * @tparam Prediction Type of predicted data
   */
-trait PredictOperation[Self, Testing, Prediction]{
-  def predict(
+trait PredictDataSetOperation[Self, Testing, Prediction] extends Serializable{
+
+  /** Calculates the predictions for all elements in the [[DataSet]] input
+    * 
+    * @param instance
+    * @param predictParameters
+    * @param input
+    * @return
+    */
+  def predictDataSet(
       instance: Self,
       predictParameters: ParameterMap,
       input: DataSet[Testing])
     : DataSet[Prediction]
+}
+
+/** Type class for predict operation. It takes an element and the model and then computes the
+  * prediction value for this element.
+  *
+  * It is sufficient for a [[Predictor]] to only implement this trait to support the evaluate and
+  * predict method.
+  *
+  * @tparam Instance
+  * @tparam Model
+  * @tparam Testing
+  * @tparam Prediction
+  */
+trait PredictOperation[Instance, Model, Testing, Prediction] extends Serializable{
+
+  /** Defines how to retrieve the model of the type for which this operation was defined
+    * 
+    * @param instance
+    * @return
+    */
+  def getModel(instance: Instance, predictParameters: ParameterMap): DataSet[Model]
+
+  /** Calculates the prediction for a single element given the model of the [[Predictor]].
+    *
+    * @param value
+    * @param model
+    * @return
+    */
+  def predict(value: Testing, model: Model): Prediction
+}
+
+/** Type class for the evalute operation of [[Predictor]]. This evaluate operation works on
+  * DataSets.
+  *
+  * It takes a [[DataSet]] of some type. For each element of this [[DataSet]] the evaluate method
+  * computes the prediction value and returns a tuple of true label value and prediction value.
+  *
+  * @tparam Instance
+  * @tparam Testing
+  * @tparam PredictionValue
+  */
+trait EvaluateDataSetOperation[Instance, Testing, PredictionValue] extends Serializable{
+  def evaluateDataSet(
+      instance: Instance,
+      evaluateParameters: ParameterMap,
+      testing: DataSet[Testing])
+    : DataSet[(PredictionValue, PredictionValue)]
 }

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/MinMaxScaler.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/MinMaxScaler.scala
@@ -25,7 +25,8 @@ import org.apache.flink.ml._
 import org.apache.flink.ml.common.{LabeledVector, Parameter, ParameterMap}
 import org.apache.flink.ml.math.Breeze._
 import org.apache.flink.ml.math.{BreezeVectorConverter, Vector}
-import org.apache.flink.ml.pipeline.{FitOperation, TransformOperation, Transformer}
+import org.apache.flink.ml.pipeline.{TransformDataSetOperation, FitOperation,
+Transformer}
 import org.apache.flink.ml.preprocessing.MinMaxScaler.{Max, Min}
 
 import scala.reflect.ClassTag
@@ -161,18 +162,18 @@ object MinMaxScaler {
     minMax
   }
 
-  /** [[TransformOperation]] which scales input data of subtype of [[Vector]] with respect to
+  /** [[TransformDataSetOperation]] which scales input data of subtype of [[Vector]] with respect to
     * the calculated minimum and maximum of the training data. The minimum and maximum
     * values of the resulting data is configurable.
     *
     * @tparam T Type of the input and output data which has to be a subtype of [[Vector]]
-    * @return [[TransformOperation]] scaling subtypes of [[Vector]] such that the feature values are
-    *        in the configured range
+    * @return [[TransformDataSetOperation]] scaling subtypes of [[Vector]] such that the feature
+    *        values are in the configured range
     */
   implicit def transformVectors[T <: Vector : BreezeVectorConverter : TypeInformation : ClassTag]
   = {
-    new TransformOperation[MinMaxScaler, T, T] {
-      override def transform(
+    new TransformDataSetOperation[MinMaxScaler, T, T] {
+      override def transformDataSet(
         instance: MinMaxScaler,
         transformParameters: ParameterMap,
         input: DataSet[T])
@@ -201,8 +202,8 @@ object MinMaxScaler {
   }
 
   implicit val transformLabeledVectors = {
-    new TransformOperation[MinMaxScaler, LabeledVector, LabeledVector] {
-      override def transform(instance: MinMaxScaler,
+    new TransformDataSetOperation[MinMaxScaler, LabeledVector, LabeledVector] {
+      override def transformDataSet(instance: MinMaxScaler,
         transformParameters: ParameterMap,
         input: DataSet[LabeledVector]): DataSet[LabeledVector] = {
         val resultingParameters = instance.parameters ++ transformParameters

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/PolynomialFeatures.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/PolynomialFeatures.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.{DataSet, _}
 import org.apache.flink.ml.common.{LabeledVector, Parameter, ParameterMap}
 import org.apache.flink.ml.math.{Vector, VectorBuilder}
-import org.apache.flink.ml.pipeline.{FitOperation, TransformOperation, Transformer}
+import org.apache.flink.ml.pipeline.{FitOperation, TransformDataSetOperation, Transformer}
 import org.apache.flink.ml.preprocessing.PolynomialFeatures.Degree
 
 import scala.reflect.ClassTag
@@ -96,8 +96,8 @@ object PolynomialFeatures{
     }
   }
 
-  /** [[org.apache.flink.ml.pipeline.TransformOperation]] to map a [[Vector]] into the polynomial
-    * feature space.
+  /** [[org.apache.flink.ml.pipeline.TransformDataSetOperation]] to map a [[Vector]] into the
+    * polynomial feature space.
     *
     * @tparam T Subclass of [[Vector]]
     * @return
@@ -105,8 +105,8 @@ object PolynomialFeatures{
   implicit def transformVectorIntoPolynomialBase[
       T <: Vector : VectorBuilder: TypeInformation: ClassTag
     ] = {
-    new TransformOperation[PolynomialFeatures, T, T] {
-      override def transform(
+    new TransformDataSetOperation[PolynomialFeatures, T, T] {
+      override def transformDataSet(
           instance: PolynomialFeatures,
           transformParameters: ParameterMap,
           input: DataSet[T])
@@ -124,13 +124,13 @@ object PolynomialFeatures{
     }
   }
 
-  /** [[org.apache.flink.ml.pipeline.TransformOperation]] to map a [[LabeledVector]] into the
+  /** [[org.apache.flink.ml.pipeline.TransformDataSetOperation]] to map a [[LabeledVector]] into the
     * polynomial feature space
     */
   implicit val transformLabeledVectorIntoPolynomialBase =
-    new TransformOperation[PolynomialFeatures, LabeledVector, LabeledVector] {
+    new TransformDataSetOperation[PolynomialFeatures, LabeledVector, LabeledVector] {
 
-    override def transform(
+    override def transformDataSet(
         instance: PolynomialFeatures,
         transformParameters: ParameterMap,
         input: DataSet[LabeledVector])

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -20,6 +20,7 @@ package org.apache.flink.ml.recommendation
 
 import java.{util, lang}
 
+import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint
 import org.apache.flink.api.scala._
 import org.apache.flink.api.common.operators.Order
 import org.apache.flink.core.memory.{DataOutputView, DataInputView}
@@ -206,8 +207,9 @@ class ALS extends Predictor[ALS] {
 
     factorsOption match {
       case Some((userFactors, itemFactors)) => {
-        val predictions = data.join(userFactors).where(0).equalTo(0)
-          .join(itemFactors).where("_1._2").equalTo(0).map {
+        val predictions = data.join(userFactors, JoinHint.REPARTITION_HASH_SECOND).where(0)
+          .equalTo(0).join(itemFactors, JoinHint.REPARTITION_HASH_SECOND).where("_1._2")
+          .equalTo(0).map {
           triple => {
             val (((uID, iID), uFactors), iFactors) = triple
 
@@ -397,8 +399,8 @@ object ALS {
 
       instance.factorsOption match {
         case Some((userFactors, itemFactors)) => {
-          input.join(userFactors).where(0).equalTo(0)
-            .join(itemFactors).where("_1._2").equalTo(0).map {
+          input.join(userFactors, JoinHint.REPARTITION_HASH_SECOND).where(0).equalTo(0)
+            .join(itemFactors, JoinHint.REPARTITION_HASH_SECOND).where("_1._2").equalTo(0).map {
             triple => {
               val (((uID, iID), uFactors), iFactors) = triple
 

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -25,7 +25,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.common.operators.Order
 import org.apache.flink.core.memory.{DataOutputView, DataInputView}
 import org.apache.flink.ml.common._
-import org.apache.flink.ml.pipeline.{FitOperation, PredictOperation, Predictor}
+import org.apache.flink.ml.pipeline.{FitOperation, PredictDataSetOperation, Predictor}
 import org.apache.flink.types.Value
 import org.apache.flink.util.Collector
 import org.apache.flink.api.common.functions.{Partitioner => FlinkPartitioner, GroupReduceFunction, CoGroupFunction}
@@ -390,8 +390,8 @@ object ALS {
   // ===================================== Operations ==============================================
 
   /** Predict operation which calculates the matrix entry for the given indices  */
-  implicit val predictRating = new PredictOperation[ALS, (Int, Int), (Int ,Int, Double)] {
-    override def predict(
+  implicit val predictRating = new PredictDataSetOperation[ALS, (Int, Int), (Int ,Int, Double)] {
+    override def predictDataSet(
         instance: ALS,
         predictParameters: ParameterMap,
         input: DataSet[(Int, Int)])

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
@@ -40,11 +40,13 @@ class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
 
     val trainingDS = env.fromCollection(Classification.trainingData)
 
+    val testingDS = trainingDS.map(_.vector)
+
     svm.fit(trainingDS)
 
     val weightVector = svm.weightsOption.get.collect().apply(0)
 
-    weightVector.valuesIterator.zip(Classification.expectedWeightVector.valueIterator).foreach {
+    weightVector.valueIterator.zip(Classification.expectedWeightVector.valueIterator).foreach {
       case (weight, expectedWeight) =>
         weight should be(expectedWeight +- 0.1)
     }
@@ -63,11 +65,13 @@ class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
 
     val trainingDS = env.fromCollection(Classification.trainingData)
 
+    val test = trainingDS.map(x => (x.vector, x.label))
+
     svm.fit(trainingDS)
 
     val threshold = 0.0
 
-    val predictionPairs = svm.predict(trainingDS).map {
+    val predictionPairs = svm.evaluate(test).map {
       truthPrediction =>
         val truth = truthPrediction._1
         val prediction = truthPrediction._2

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/preprocessing/PolynomialFeaturesITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/preprocessing/PolynomialFeaturesITSuite.scala
@@ -16,16 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.feature
+package org.apache.flink.ml.preprocessing
 
-import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.api.scala.{ExecutionEnvironment, _}
 import org.apache.flink.ml.common.LabeledVector
 import org.apache.flink.ml.math.DenseVector
-import org.apache.flink.ml.preprocessing.PolynomialFeatures
-import org.scalatest.{Matchers, FlatSpec}
-
-import org.apache.flink.api.scala._
 import org.apache.flink.test.util.FlinkTestBase
+import org.scalatest.{FlatSpec, Matchers}
 
 class PolynomialFeaturesITSuite
   extends FlatSpec

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/regression/MultipleLinearRegressionITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/regression/MultipleLinearRegressionITSuite.scala
@@ -121,9 +121,11 @@ class MultipleLinearRegressionITSuite
     parameters.add(MultipleLinearRegression.ConvergenceThreshold, 0.001)
 
     val inputDS = env.fromCollection(data)
+    val evaluationDS = inputDS.map(x => (x.vector, x.label))
+
     mlr.fit(inputDS, parameters)
 
-    val predictionPairs = mlr.predict(inputDS)
+    val predictionPairs = mlr.evaluate(evaluationDS)
 
     val absoluteErrorSum = predictionPairs.collect().map{
       case (truth, prediction) => Math.abs(truth - prediction)}.sum


### PR DESCRIPTION
This PR adds an `evaluate` method to `Predictor` which takes a `DataSet[Testing]` and returns a `DataSet[(LabelType, LabelType)]`, where the first tuple field is the true label and the second field denotes the predicted label. The evaluation logic is defined via a `EvaluateDataSetOperation`.

Since predicting test data and evaluate test data both use the same prediction logic, a new level  of abstraction was introduced. The old `PredictOperation` is now called `PredictDataSetOperation` and a new `PredictOperation` was defined. The `PredictOperation` takes an element of the dataset as well as the model of the associated `Predictor` and calculates one prediction.

If one wants to implement the predict operation of a `Predictor` then one can do it on the level of `PredictDataSetOperation` which gives you access to the `DataSet` of input elements or on the level of `PredictOperation`. If one chooses the latter, then the system will automatically apply this operation to all elements of the input `DataSet` (see `Predictor.defaultPredictDataSetOperation`).

Having defined a `PredictOperation` allows to automatically call `evaluate` for this `Predictor` without having to define a `EvaluateDataSetOperation`. The only constraint is that the input data has to be `DataSet[(TestingType, LabelType)]`. The input is thus a tuple with a testing value and the true label value. The system will then calculate the prediction for the testing value and return a `DataSet[(LabelType, LabelType)]` where the first field value of the tuple is the true label value and the second field value is the predicted label value.

What do you think of these changes? Will they ease the development of future `Predictor`s?