### PR TITLE
[FLINK-2134] Close Netty channel via CloseRequest msg

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -150,6 +150,9 @@ abstract class NettyMessage {
 			else if (msgId == CancelPartitionRequest.ID) {
 				decodedMsg = new CancelPartitionRequest();
 			}
+			else if (msgId == CloseRequest.ID) {
+				decodedMsg = new CloseRequest();
+			}
 			else {
 				throw new IllegalStateException("Received unknown message from producer: " + msg);
 			}
@@ -518,6 +521,23 @@ abstract class NettyMessage {
 		@Override
 		void readFrom(ByteBuf buffer) throws Exception {
 			receiverId = InputChannelID.fromByteBuf(buffer);
+		}
+	}
+
+	static class CloseRequest extends NettyMessage {
+
+		private static final byte ID = 5;
+
+		public CloseRequest() {
+		}
+
+		@Override
+		ByteBuf write(ByteBufAllocator allocator) throws Exception {
+			return allocateBuffer(allocator, ID, 0);
+		}
+
+		@Override
+		void readFrom(ByteBuf buffer) throws Exception {
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -79,6 +79,12 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		ctx.pipeline().fireUserEventTriggered(receiverId);
 	}
 
+	public void close() {
+		if (ctx != null) {
+			ctx.channel().close();
+		}
+	}
+
 	@Override
 	public void userEventTriggered(ChannelHandlerContext ctx, Object msg) throws Exception {
 		if (msg.getClass() == SequenceNumberingSubpartitionView.class) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.CancelPartitionRequest;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.CloseRequest;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
@@ -119,6 +120,9 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
 				CancelPartitionRequest request = (CancelPartitionRequest) msg;
 
 				outboundQueue.cancel(request.receiverId);
+			}
+			else if (msgClazz == CloseRequest.class) {
+				outboundQueue.close();
 			}
 			else {
 				LOG.warn("Received unexpected client request: {}", msg);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -147,6 +147,13 @@ public class NettyMessageSerializationTest {
 
 			assertEquals(expected.receiverId, actual.receiverId);
 		}
+
+		{
+			NettyMessage.CloseRequest expected = new NettyMessage.CloseRequest();
+			NettyMessage.CloseRequest actual = encodeAndDecode(expected);
+
+			assertEquals(expected.getClass(), actual.getClass());
+		}
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
The failing `SuccessAfterNetworkBuffersFailureITCase` discovered a race between sending backwards events (e.g. from sync task to iteration head task) and closing the TCP channel. The close overtook outstanding backwards task events. This change guarnatees that it is in order by sending a explicit close msg.

(I've also tried other approaches, but this struck me as the simplest solution.)