### PR TITLE
Add CONTRIBUTING.md file with pointers to our guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# How to contribute to Apache Flink
+
+Thank you for your intention to contribute to the Apache Flink project. As an open-source community, we highly appreciate external contributions to our project.
+
+To make the process smooth for the project *committers* (those who review and accept changes) and *contributors* (those who propose new changes via pull requests), there are a few rules to follow.
+
+## Contribution Guidelines
+
+Please check out the [How to Contribute guide](http://flink.apache.org/how-to-contribute.html) to understand how contributions are made.
+There is also a list of [Coding Guidelines](http://flink.apache.org/coding-guidelines.html) that you should follow.
+

--- a/pom.xml
+++ b/pom.xml
@@ -734,6 +734,7 @@ under the License.
 						<!-- Administrative files in the main trunk. -->
 						<exclude>**/README.md</exclude>
 						<exclude>CHANGELOG</exclude>
+						<exclude>CONTRIBUTING.md</exclude>
 						<exclude>CONTRIBUTORS</exclude>
 						<exclude>DEPENDENCIES</exclude>
 						<!-- Build files -->


### PR DESCRIPTION
I propose to add the following file to our source repo to make it easier for GitHub Contributors to find the contribution guidelines.

With such a file in our repository, the screen for opening a pull request will look like this:

![contribguide](https://cloud.githubusercontent.com/assets/89049/7983446/9d5ae782-0ac0-11e5-8df3-ab5f452b214d.png)
