### PR TITLE
Added member currentSplit for FileInputFormat.java

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -120,7 +120,11 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	 * The length of the split that this parallel instance must consume.
 	 */
 	protected transient long splitLength;
-	
+
+	/**
+	 * The current split that this parallel instance must consume.
+	 */
+	protected transient FileInputSplit currentSplit;
 	
 	// --------------------------------------------------------------------------------------------
 	//  The configuration parameters. Configured on the instance and serialized to be shipped.
@@ -588,7 +592,8 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	 */
 	@Override
 	public void open(FileInputSplit fileSplit) throws IOException {
-		
+
+		this.currentSplit = fileSplit;
 		this.splitStart = fileSplit.getStart();
 		this.splitLength = fileSplit.getLength();
 


### PR DESCRIPTION
According to [this stackoverflow discussion] (http://stackoverflow.com/questions/30599616/create-objects-from-input-files-in-apache-flink/30600148?noredirect=1#comment49358891_30600148) with 
@rmetzger the attribute currentSplit is now accessible through FileInputFormat. It provides the split that this parallel instance must consume.

