### PR TITLE
[FLINK-2174] Allow comments in 'slaves' file

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -219,12 +219,9 @@ INTERNAL_HADOOP_CLASSPATHS="$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR"
 # Auxilliary function which extracts the name of host from a line which
 # also potentialy includes topology information and the taskManager type
 extractHostName() {
-    # extract first part of string (before any whitespace characters)
-    SLAVE=$1
-    # Remove types and possible comments
-    if [[ "$SLAVE" =~ ^([0-9a-zA-Z/.-]+).*$ ]]; then
-            SLAVE=${BASH_REMATCH[1]}
-    fi
+    # handle comments: extract first part of string (before first # character)
+    SLAVE=`echo $1 | cut -d'#' -f 1`
+
     # Extract the hostname from the network hierarchy
     if [[ "$SLAVE" =~ ^.*/([0-9a-zA-Z.-]+)$ ]]; then
             SLAVE=${BASH_REMATCH[1]}

--- a/flink-dist/src/main/flink-bin/bin/start-cluster-streaming.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster-streaming.sh
@@ -41,8 +41,8 @@ GOON=true
 while $GOON
 do
     read line || GOON=false
-    if [ -n "$line" ]; then
-        HOST=$( extractHostName $line)
+    HOST=$( extractHostName $line)
+    if [ -n "$HOST" ]; then
         ssh -n $FLINK_SSH_OPTS $HOST -- "nohup /bin/bash -l $FLINK_BIN_DIR/taskmanager.sh start streaming &"
     fi
 done < "$HOSTLIST"

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -41,8 +41,8 @@ GOON=true
 while $GOON
 do
     read line || GOON=false
-    if [ -n "$line" ]; then
-        HOST=$( extractHostName $line)
+    HOST=$( extractHostName $line)
+    if [ -n "$HOST" ]; then
         ssh -n $FLINK_SSH_OPTS $HOST -- "nohup /bin/bash -l $FLINK_BIN_DIR/taskmanager.sh start batch &"
     fi
 done < "$HOSTLIST"

--- a/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
@@ -39,8 +39,8 @@ GOON=true
 while $GOON
 do
     read line || GOON=false
-    if [ -n "$line" ]; then
-        HOST=$( extractHostName $line)
+    HOST=$( extractHostName $line)
+    if [ -n "$HOST" ]; then
         ssh -n $FLINK_SSH_OPTS $HOST -- "nohup /bin/bash $FLINK_BIN_DIR/taskmanager.sh stop &"
     fi
 done < $HOSTLIST


### PR DESCRIPTION
added skipping of #-comments in slaves file in start/stop scripts