### PR TITLE
[FLINK-2150] Added zipWithUniqueIds

### DIFF
--- a/docs/apis/zip_elements_guide.md
+++ b/docs/apis/zip_elements_guide.md
@@ -64,3 +64,43 @@ env.execute()
 will yield the tuples: (0,A), (1,B), (2,C), (3,D), (4,E), (5,F)
 
 [Back to top](#top)
+
+### Zip with an Unique Identifier
+In many cases, one may not need to assign consecutive labels.
+`zipWIthUniqueId` works in a pipelined fashion, speeding up the label assignment process. This method receives a data set as input and returns a new data set of unique id, initial value tuples.
+For example, the following code:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+env.setParallelism(1);
+DataSet<String> in = env.fromElements("A", "B", "C", "D", "E", "F");
+
+DataSet<Tuple2<Long, String>> result = DataSetUtils.zipWithUniqueId(in);
+
+result.writeAsCsv(resultPath, "\n", ",");
+env.execute();
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+import org.apache.flink.api.scala._
+
+val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+env.setParallelism(1)
+val input: DataSet[String] = env.fromElements("A", "B", "C", "D", "E", "F")
+
+val result: DataSet[(Long, String)] = input.zipWithUniqueId
+
+result.writeAsCsv(resultPath, "\n", ",")
+env.execute()
+{% endhighlight %}
+</div>
+
+</div>
+
+will yield the tuples: (0,A), (2,B), (4,C), (6,D), (8,E), (10,F)
+
+[Back to top](#top)

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSetUtils.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSetUtils.scala
@@ -24,9 +24,9 @@ import org.apache.flink.api.java.{utils => jutils}
 import _root_.scala.language.implicitConversions
 import _root_.scala.reflect.ClassTag
 
-
 /**
- * This class provides simple utility methods for zipping elements in a file with an index.
+ * This class provides simple utility methods for zipping elements in a data set with an index
+ * or with a unique identifier.
  */
 
 class DataSetUtils[T](val self: DataSet[T]) extends AnyVal {
@@ -42,9 +42,21 @@ class DataSetUtils[T](val self: DataSet[T]) extends AnyVal {
     wrap(jutils.DataSetUtils.zipWithIndex(self.javaSet))
       .map { t => (t.f0.toLong, t.f1) }
   }
+
+  /**
+   * Method that assigns a unique id to all the elements of the input data set.
+   *
+   * @return a data set of tuple 2 consisting of ids and initial values.
+   */
+  def zipWithUniqueId(implicit ti: TypeInformation[(Long, T)],
+                      ct: ClassTag[(Long, T)]): DataSet[(Long, T)] = {
+    wrap(jutils.DataSetUtils.zipWithUniqueId(self.javaSet))
+      .map { t => (t.f0.toLong, t.f1) }
+  }
 }
 
 object DataSetUtils {
+
   /**
    * Tie the new class to an existing Scala API class: DataSet.
    */

--- a/flink-staging/flink-gelly/src/test/java/org/apache/flink/graph/test/TestGraphUtils.java
+++ b/flink-staging/flink-gelly/src/test/java/org/apache/flink/graph/test/TestGraphUtils.java
@@ -260,17 +260,6 @@ public class TestGraphUtils {
 		return vertices;
 	}
 
-	public static final List<Vertex<Long, Tuple3<Long, Long, Boolean>>> getLongVerticesWithDegrees() {
-		List<Vertex<Long, Tuple3<Long, Long, Boolean>>> vertices = new ArrayList<Vertex<Long, Tuple3<Long, Long, Boolean>>>();
-		vertices.add(new Vertex<Long, Tuple3<Long, Long, Boolean>>(1L, new Tuple3<Long, Long, Boolean>(1L, 2L, true)));
-		vertices.add(new Vertex<Long, Tuple3<Long, Long, Boolean>>(2L, new Tuple3<Long, Long, Boolean>(1L, 1L, true)));
-		vertices.add(new Vertex<Long, Tuple3<Long, Long, Boolean>>(3L, new Tuple3<Long, Long, Boolean>(2L, 2L, true)));
-		vertices.add(new Vertex<Long, Tuple3<Long, Long, Boolean>>(4L, new Tuple3<Long, Long, Boolean>(1L, 1L, true)));
-		vertices.add(new Vertex<Long, Tuple3<Long, Long, Boolean>>(5L, new Tuple3<Long, Long, Boolean>(2L, 1L, true)));
-
-		return vertices;
-	}
-
 	public static final DataSet<Edge<Long, Long>> getDisconnectedLongLongEdgeData(
 				ExecutionEnvironment env) {
 			List<Edge<Long, Long>> edges = new ArrayList<Edge<Long, Long>>();

--- a/flink-tests/src/test/java/org/apache/flink/test/util/DataSetUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/DataSetUtilsITCase.java
@@ -62,6 +62,19 @@ public class DataSetUtilsITCase extends MultipleProgramsTestBase {
 		expectedResult = "0,A\n" + "1,B\n" + "2,C\n" + "3,D\n" + "4,E\n" + "5,F";
 	}
 
+	@Test
+	public void testZipWithUniqueId() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		DataSet<String> in = env.fromElements("A", "B", "C", "D", "E", "F");
+
+		DataSet<Tuple2<Long, String>> result = DataSetUtils.zipWithUniqueId(in);
+
+		result.writeAsCsv(resultPath, "\n", ",");
+		env.execute();
+
+		expectedResult = "0,A\n" + "2,B\n" + "4,C\n" + "6,D\n" + "8,E\n" + "10,F";
+	}
 
 	@After
 	public void after() throws Exception{

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/DataSetUtilsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/DataSetUtilsITCase.scala
@@ -58,6 +58,21 @@ MultipleProgramsTestBase(mode){
     expectedResult = "0,A\n" + "1,B\n" + "2,C\n" + "3,D\n" + "4,E\n" + "5,F"
   }
 
+  @Test
+  @throws(classOf[Exception])
+  def testZipWithUniqueId(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val input: DataSet[String] = env.fromElements("A", "B", "C", "D", "E", "F")
+    val result: DataSet[(Long, String)] = input.zipWithUniqueId
+
+    result.writeAsCsv(resultPath, "\n", ",")
+    env.execute()
+
+    expectedResult = "0,A\n" + "2,B\n" + "4,C\n" + "6,D\n" + "8,E\n" + "10,F"
+  }
+
   @After
   @throws(classOf[Exception])
   def after(): Unit = {


### PR DESCRIPTION
This PR adds a library method that assigns unique labels to vertices. 
The following facts are used:
 * a map function generates an n-bit(n - number of parallel tasks) ID based on its own index
 * with each record, a counter c is increased
 * the unique label is then produced by shifting the counter c by the n-bit mapper ID