### PR TITLE
[FLINK-2054] Add object-reuse switch for streaming

### DIFF
--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -270,6 +270,26 @@ The `DataStream` is the basic data abstraction provided by the Flink Streaming. 
 
 The transformations may return different data stream types allowing more elaborate transformations, for example the `groupBy(…)` method returns a `GroupedDataStream` which can be used for grouped transformations such as aggregating by key. We will discover more elaborate data stream types in the upcoming sections.
 
+### Object Reuse Behavior
+
+Apache Flink is trying to reduce the number of object allocations for better performance.
+
+By default, user defined functions (like `map()` or `reduce()`) are getting new objects on each call
+(or through an iterator). So it is possible to keep references to the objects inside the function
+(for example in a List).
+
+There is a switch at the `ExectionConfig` which allows users to enable the object reuse mode:
+
+```
+env.getExecutionConfig().enableObjectReuse()
+```
+
+For mutable types, Flink will reuse object
+instances. In practice that means that a `map()` function will always receive the same object
+instance (with its fields set to new values). The object reuse mode will lead to better performance
+because fewer objects are created, but the user has to manually take care of what they are doing
+with the object references.
+
 ### Partitioning
 
 Partitioning controls how individual data points of a stream are distributed among the parallel instances of the transformation operators. This also controls the ordering of the records in the `DataStream`. There is partial ordering guarantee for the outputs with respect to the partitioning scheme (outputs produced from each partition are guaranteed to arrive in the order they were produced).

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -37,6 +37,8 @@ public abstract class AbstractStreamOperator<OUT> implements StreamOperator<OUT>
 
 	public transient Output<OUT> output;
 
+	protected boolean inputCopyDisabled = false;
+
 	// A sane default for most operators
 	protected ChainingStrategy chainingStrategy = ChainingStrategy.HEAD;
 
@@ -63,5 +65,18 @@ public abstract class AbstractStreamOperator<OUT> implements StreamOperator<OUT>
 	@Override
 	public final ChainingStrategy getChainingStrategy() {
 		return chainingStrategy;
+	}
+
+	@Override
+	public boolean isInputCopyingDisabled() {
+		return inputCopyDisabled;
+	}
+
+	/**
+	 * Enable object-reuse for this operator instance. This overrides the setting in
+	 * the {@link org.apache.flink.api.common.ExecutionConfig}/
+	 */
+	public void disableInputCopy() {
+		this.inputCopyDisabled = true;
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -49,6 +49,12 @@ public interface StreamOperator<OUT> extends Serializable {
 	 */
 	public void close() throws Exception;
 
+	/**
+	 * An operator can return true here to disable copying of its input elements. This overrides
+	 * the object-reuse setting on the {@link org.apache.flink.api.common.ExecutionConfig}
+	 */
+	public boolean isInputCopyingDisabled();
+
 	public void setChainingStrategy(ChainingStrategy strategy);
 
 	public ChainingStrategy getChainingStrategy();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/StreamWindowBuffer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/StreamWindowBuffer.java
@@ -37,6 +37,7 @@ public class StreamWindowBuffer<T>
 	public StreamWindowBuffer(WindowBuffer<T> buffer) {
 		this.buffer = buffer;
 		setChainingStrategy(ChainingStrategy.FORCE_ALWAYS);
+		disableInputCopy();
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowFlattener.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowFlattener.java
@@ -32,6 +32,7 @@ public class WindowFlattener<T> extends AbstractStreamOperator<T>
 
 	public WindowFlattener() {
 		chainingStrategy = ChainingStrategy.FORCE_ALWAYS;
+		disableInputCopy();
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowFolder.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowFolder.java
@@ -39,6 +39,7 @@ public class WindowFolder<IN, OUT> extends StreamMap<StreamWindow<IN>, StreamWin
 	public WindowFolder(FoldFunction<IN, OUT> folder, OUT initialValue) {
 		super(new WindowFoldFunction<IN, OUT>(folder, initialValue));
 		this.folder = folder;
+		disableInputCopy();
 	}
 
 	private static class WindowFoldFunction<IN, OUT> extends AbstractRichFunction implements

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowMapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowMapper.java
@@ -39,6 +39,7 @@ public class WindowMapper<IN, OUT> extends StreamMap<StreamWindow<IN>, StreamWin
 	public WindowMapper(WindowMapFunction<IN, OUT> mapper) {
 		super(new WindowMap<IN, OUT>(mapper));
 		this.mapper = mapper;
+		disableInputCopy();
 	}
 
 	private static class WindowMap<T, R> extends AbstractRichFunction

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowMerger.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowMerger.java
@@ -38,8 +38,8 @@ public class WindowMerger<T> extends AbstractStreamOperator<StreamWindow<T>>
 
 	public WindowMerger() {
 		this.windows = new HashMap<Integer, StreamWindow<T>>();
-
 		chainingStrategy = ChainingStrategy.FORCE_ALWAYS;
+		disableInputCopy();
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowPartitioner.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowPartitioner.java
@@ -38,6 +38,7 @@ public class WindowPartitioner<T> extends AbstractStreamOperator<StreamWindow<T>
 		this.keySelector = keySelector;
 
 		chainingStrategy = ChainingStrategy.FORCE_ALWAYS;
+		disableInputCopy();
 	}
 
 	public WindowPartitioner(int numberOfSplits) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowReducer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/WindowReducer.java
@@ -39,6 +39,7 @@ public class WindowReducer<IN> extends StreamMap<StreamWindow<IN>, StreamWindow<
 	public WindowReducer(ReduceFunction<IN> reducer) {
 		super(new WindowReduceFunction<IN>(reducer));
 		this.reducer = reducer;
+		disableInputCopy();
 	}
 
 	private static class WindowReduceFunction<T> extends AbstractRichFunction implements


### PR DESCRIPTION
The switch was already there: enableObjectReuse() in ExecutionConfig.
This was simply not considered by the streaming runtime. This change now
draws a copy before forwarding an element to a chained operator when
object reuse is disabled.