### PR TITLE
[release-0.9] Fixed a few trivial issues:

### DIFF
--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/ConnectedComponents.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/ConnectedComponents.java
@@ -55,10 +55,10 @@ import org.apache.flink.examples.java.graph.util.ConnectedComponentsData;
  * Input files are plain text files and must be formatted as follows:
  * <ul>
  * <li>Vertices represented as IDs and separated by new-line characters.<br> 
- * For example <code>"1\n2\n12\n42\n63\n"</code> gives five vertices (1), (2), (12), (42), and (63). 
+ * For example <code>"1\n2\n12\n42\n63"</code> gives five vertices (1), (2), (12), (42), and (63).
  * <li>Edges are represented as pairs for vertex IDs which are separated by space 
  * characters. Edges are separated by new-line characters.<br>
- * For example <code>"1 2\n2 12\n1 12\n42 63\n"</code> gives four (undirected) edges (1)-(2), (2)-(12), (1)-(12), and (42)-(63).
+ * For example <code>"1 2\n2 12\n1 12\n42 63"</code> gives four (undirected) edges (1)-(2), (2)-(12), (1)-(12), and (42)-(63).
  * </ul>
  * 
  * <p>

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesBasic.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesBasic.java
@@ -50,7 +50,7 @@ import org.apache.flink.examples.java.graph.util.EnumTrianglesDataTypes.Triad;
  * <ul>
  * <li>Edges are represented as pairs for vertex IDs which are separated by space 
  * characters. Edges are separated by new-line characters.<br>
- * For example <code>"1 2\n2 12\n1 12\n42 63\n"</code> gives four (undirected) edges (1)-(2), (2)-(12), (1)-(12), and (42)-(63)
+ * For example <code>"1 2\n2 12\n1 12\n42 63"</code> gives four (undirected) edges (1)-(2), (2)-(12), (1)-(12), and (42)-(63)
  * that include a triangle
  * </ul>
  * <pre>

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesOpt.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/EnumTrianglesOpt.java
@@ -60,7 +60,7 @@ import org.apache.flink.examples.java.graph.util.EnumTrianglesDataTypes.Triad;
  * <ul>
  * <li>Edges are represented as pairs for vertex IDs which are separated by space 
  * characters. Edges are separated by new-line characters.<br>
- * For example <code>"1 2\n2 12\n1 12\n42 63\n"</code> gives four (undirected) edges (1)-(2), (2)-(12), (1)-(12), and (42)-(63)
+ * For example <code>"1 2\n2 12\n1 12\n42 63"</code> gives four (undirected) edges (1)-(2), (2)-(12), (1)-(12), and (42)-(63)
  * that include a triangle
  * </ul>
  * <pre>

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/PageRankBasic.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/graph/PageRankBasic.java
@@ -50,10 +50,10 @@ import org.apache.flink.examples.java.graph.util.PageRankData;
  * Input files are plain text files and must be formatted as follows:
  * <ul>
  * <li>Pages represented as an (long) ID separated by new-line characters.<br> 
- * For example <code>"1\n2\n12\n42\n63\n"</code> gives five pages with IDs 1, 2, 12, 42, and 63.
+ * For example <code>"1\n2\n12\n42\n63"</code> gives five pages with IDs 1, 2, 12, 42, and 63.
  * <li>Links are represented as pairs of page IDs which are separated by space 
  * characters. Links are separated by new-line characters.<br>
- * For example <code>"1 2\n2 12\n1 12\n42 63\n"</code> gives four (directed) links (1)->(2), (2)->(12), (1)->(12), and (42)->(63).<br>
+ * For example <code>"1 2\n2 12\n1 12\n42 63"</code> gives four (directed) links (1)->(2), (2)->(12), (1)->(12), and (42)->(63).<br>
  * For this simple implementation it is required that each page has at least one incoming and one outgoing link (a page can point to itself).
  * </ul>
  * 

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/misc/CollectionExecutionExample.java
@@ -31,7 +31,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
  * DataSet transformations are executed on Java collections.
  * 
  * See the "Local Execution" section in the documentation for more details: 
- * 	http://flink.apache.org/docs/latest/local_execution.html
+ * 	http://flink.apache.org/docs/latest/apis/local_execution.html
  * 
  */
 public class CollectionExecutionExample {

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/ConnectedComponents.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/ConnectedComponents.scala
@@ -39,9 +39,9 @@ import org.apache.flink.util.Collector
  * Input files are plain text files and must be formatted as follows:
  *
  *   - Vertices represented as IDs and separated by new-line characters. For example,
- *     `"1\n2\n12\n42\n63\n"` gives five vertices (1), (2), (12), (42), and (63).
+ *     `"1\n2\n12\n42\n63"` gives five vertices (1), (2), (12), (42), and (63).
  *   - Edges are represented as pairs for vertex IDs which are separated by space characters. Edges
- *     are separated by new-line characters. For example `"1 2\n2 12\n1 12\n42 63\n"`
+ *     are separated by new-line characters. For example `"1 2\n2 12\n1 12\n42 63"`
  *     gives four (undirected) edges (1)-(2), (2)-(12), (1)-(12), and (42)-(63).
  *
  * Usage:

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesBasic.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesBasic.scala
@@ -42,7 +42,7 @@ import scala.collection.mutable
  *
  *  - Edges are represented as pairs for vertex IDs which are separated by space
  *   characters. Edges are separated by new-line characters.
- *   For example `"1 2\n2 12\n1 12\n42 63\n"` gives four (undirected) edges (1)-(2), (2)-(12),
+ *   For example `"1 2\n2 12\n1 12\n42 63"` gives four (undirected) edges (1)-(2), (2)-(12),
  *   (1)-(12), and (42)-(63) that include a triangle
  *
  * <pre>

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesOpt.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/EnumTrianglesOpt.scala
@@ -49,7 +49,7 @@ import scala.collection.mutable
  *
  *  - Edges are represented as pairs for vertex IDs which are separated by space
  *    characters. Edges are separated by new-line characters.
- *    For example `"1 2\n2 12\n1 12\n42 63\n"` gives four (undirected) edges (1)-(2), (2)-(12),
+ *    For example `"1 2\n2 12\n1 12\n42 63"` gives four (undirected) edges (1)-(2), (2)-(12),
  *    (1)-(12), and (42)-(63) that include a triangle
  *
  * <pre>

--- a/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/PageRankBasic.scala
+++ b/flink-examples/flink-scala-examples/src/main/scala/org/apache/flink/examples/scala/graph/PageRankBasic.scala
@@ -44,10 +44,10 @@ import scala.collection.JavaConverters._
  * Input files are plain text files and must be formatted as follows:
  *
  *  - Pages represented as an (long) ID separated by new-line characters.
- *    For example `"1\n2\n12\n42\n63\n"` gives five pages with IDs 1, 2, 12, 42, and 63.
+ *    For example `"1\n2\n12\n42\n63"` gives five pages with IDs 1, 2, 12, 42, and 63.
  *  - Links are represented as pairs of page IDs which are separated by space  characters. Links
  *    are separated by new-line characters.
- *    For example `"1 2\n2 12\n1 12\n42 63\n"` gives four (directed) links (1)->(2), (2)->(12),
+ *    For example `"1 2\n2 12\n1 12\n42 63"` gives four (directed) links (1)->(2), (2)->(12),
  *    (1)->(12), and (42)->(63). For this simple implementation it is required that each page has
  *    at least one incoming and one outgoing link (a page can point to itself).
  *

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/extractor/ConcatenatedExtract.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/extractor/ConcatenatedExtract.java
@@ -29,7 +29,7 @@ package org.apache.flink.streaming.api.windowing.extractor;
  *            The output type of the second extractor and the output type of the
  *            over all extraction.
  */
-public class ConcatinatedExtract<FROM, OVER, TO> implements Extractor<FROM, TO> {
+public class ConcatenatedExtract<FROM, OVER, TO> implements Extractor<FROM, TO> {
 
 	/**
 	 * auto-generated id
@@ -51,7 +51,7 @@ public class ConcatinatedExtract<FROM, OVER, TO> implements Extractor<FROM, TO> 
 	 *            extractor as input. Its output is then the result of the over
 	 *            all extraction.
 	 */
-	public ConcatinatedExtract(Extractor<FROM, OVER> e1, Extractor<OVER, TO> e2) {
+	public ConcatenatedExtract(Extractor<FROM, OVER> e1, Extractor<OVER, TO> e2) {
 		this.e1 = e1;
 		this.e2 = e2;
 	}
@@ -61,8 +61,8 @@ public class ConcatinatedExtract<FROM, OVER, TO> implements Extractor<FROM, TO> 
 		return e2.extract(e1.extract(in));
 	}
 
-	public <OUT> ConcatinatedExtract<FROM, TO, OUT> add(Extractor<TO, OUT> e3) {
-		return new ConcatinatedExtract<FROM, TO, OUT>(this, e3);
+	public <OUT> ConcatenatedExtract<FROM, TO, OUT> add(Extractor<TO, OUT> e3) {
+		return new ConcatenatedExtract<FROM, TO, OUT>(this, e3);
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/extractor/ConcatenatedExtractTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/extractor/ConcatenatedExtractTest.java
@@ -20,16 +20,10 @@ package org.apache.flink.streaming.api.windowing.extractor;
 import static org.junit.Assert.*;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.streaming.api.windowing.extractor.ArrayFromTuple;
-import org.apache.flink.streaming.api.windowing.extractor.ConcatinatedExtract;
-import org.apache.flink.streaming.api.windowing.extractor.Extractor;
-import org.apache.flink.streaming.api.windowing.extractor.FieldFromArray;
-import org.apache.flink.streaming.api.windowing.extractor.FieldFromTuple;
-import org.apache.flink.streaming.api.windowing.extractor.FieldsFromArray;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ConcatinatedExtractTest {
+public class ConcatenatedExtractTest {
 
 	private String[] testStringArray1 = { "1", "2", "3" };
 	private int[] testIntArray1 = { 1, 2, 3 };
@@ -57,7 +51,7 @@ public class ConcatinatedExtractTest {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void test1() {
-		Extractor ext = new ConcatinatedExtract(new FieldFromTuple(0), new FieldFromTuple(1))
+		Extractor ext = new ConcatenatedExtract(new FieldFromTuple(0), new FieldFromTuple(1))
 				.add(new FieldsFromArray(Integer.class, 2, 1, 0));
 		int[] expected = { testIntArray3[2], testIntArray3[1], testIntArray3[0] };
 		assertEquals(new Integer(expected[0]), ((Integer[]) ext.extract(testData))[0]);
@@ -68,7 +62,7 @@ public class ConcatinatedExtractTest {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void test2() {
-		Extractor ext = new ConcatinatedExtract(new FieldFromTuple(1), // Tuple2<String[],int[]>[]
+		Extractor ext = new ConcatenatedExtract(new FieldFromTuple(1), // Tuple2<String[],int[]>[]
 				new FieldsFromArray(Tuple2.class, 1)) // Tuple2<String[],int[]>[]
 				.add(new FieldFromArray(0)) // Tuple2<String[],int[]>
 				.add(new ArrayFromTuple(0)) // Object[] (Containing String[])

--- a/flink-staging/flink-streaming/flink-streaming-examples/pom.xml
+++ b/flink-staging/flink-streaming/flink-streaming-examples/pom.xml
@@ -337,6 +337,29 @@ under the License.
 						</configuration>
 					</execution>
 
+					<!-- SessionWindowing -->
+					<execution>
+						<id>SessionWindowing</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>SessionWindowing</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.streaming.examples.windowing.SessionWindowing</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>org/apache/flink/streaming/examples/windowing/SessionWindowing.class</include>
+								<include>org/apache/flink/streaming/examples/windowing/SessionWindowing$*.class</include>
+							</includes>
+						</configuration>
+					</execution>
+
 				</executions>
 			</plugin>
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/examples/scala/PageRankTable.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/examples/scala/PageRankTable.scala
@@ -42,10 +42,10 @@ import _root_.scala.collection.JavaConverters._
 * Input files are plain text files and must be formatted as follows:
 *
 *  - Pages represented as an (long) ID separated by new-line characters.
-*    For example `"1\n2\n12\n42\n63\n"` gives five pages with IDs 1, 2, 12, 42, and 63.
+*    For example `"1\n2\n12\n42\n63"` gives five pages with IDs 1, 2, 12, 42, and 63.
 *  - Links are represented as pairs of page IDs which are separated by space  characters. Links
 *    are separated by new-line characters.
-*    For example `"1 2\n2 12\n1 12\n42 63\n"` gives four (directed) links (1)->(2), (2)->(12),
+*    For example `"1 2\n2 12\n1 12\n42 63"` gives four (directed) links (1)->(2), (2)->(12),
 *    (1)->(12), and (42)->(63). For this simple implementation it is required that each page has
 *    at least one incoming and one outgoing link (a page can point to itself).
 *


### PR DESCRIPTION
- The description of the input format for the graph examples
  showed an example input as having a newline at the end
  of the last line, but CsvInputFormat doesn't allow that
  (it says "Row too short" for the empty line).
- Fixed a link to local_execution.html in a javadoc.
- ConcatenatedExtract had a typo in its name.
- The creation of the jar for the SessionWindowing example was missing
  from the pom.