### PR TITLE
[streaming] Allow force-enabling checkpoints for iterative jobs

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -241,6 +241,37 @@ public abstract class StreamExecutionEnvironment {
 		streamGraph.setCheckpointingInterval(interval);
 		return this;
 	}
+	
+	/**
+	 * Method for force-enabling fault-tolerance. Activates monitoring and
+	 * backup of streaming operator states even for jobs containing iterations.
+	 * 
+	 * Please note that the checkpoint/restore guarantees for iterative jobs are
+	 * only best-effort at the moment. Records inside the loops may be lost
+	 * during failure.
+	 * <p/>
+	 * <p/>
+	 * Setting this option assumes that the job is used in production and thus
+	 * if not stated explicitly otherwise with calling with the
+	 * {@link #setNumberOfExecutionRetries(int numberOfExecutionRetries)} method
+	 * in case of failure the job will be resubmitted to the cluster
+	 * indefinitely.
+	 * 
+	 * @param interval
+	 *            Time interval between state checkpoints in millis
+	 * @param force
+	 *            If true checkpointing will be enabled for iterative jobs as
+	 *            well
+	 */
+	@Deprecated
+	public StreamExecutionEnvironment enableCheckpointing(long interval, boolean force) {
+		streamGraph.setCheckpointingEnabled(true);
+		streamGraph.setCheckpointingInterval(interval);
+		if (force) {
+			streamGraph.forceCheckpoint();
+		}
+		return this;
+	}
 
 	/**
 	 * Method for enabling fault-tolerance. Activates monitoring and backup of

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -398,7 +398,6 @@ public class StreamingJobGraphGenerator {
 
 			JobSnapshottingSettings settings = new JobSnapshottingSettings(
 					triggerVertices, ackVertices, commitVertices, interval);
-			
 			jobGraph.setSnapshotSettings(settings);
 
 			int executionRetries = streamGraph.getExecutionConfig().getNumberOfExecutionRetries();

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -65,6 +65,7 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public void invoke() throws Exception {
+		isRunning = true;
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Iteration source {} invoked", getName());
 		}
@@ -96,6 +97,7 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 		}
 		finally {
 			// Cleanup
+			isRunning = false;
 			outputHandler.flushOutputs();
 			clearBuffers();
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
@@ -57,6 +57,8 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 
 	@Override
 	public void invoke() throws Exception {
+		isRunning = true;
+		
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Iteration sink {} invoked", getName());
 		}
@@ -74,6 +76,7 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 		}
 		finally {
 			// Cleanup
+			isRunning = false;
 			clearBuffers();
 		}
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -229,7 +229,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 
 	@Override
 	public void triggerCheckpoint(long checkpointId, long timestamp) throws Exception {
-
+		
 		synchronized (checkpointLock) {
 			if (isRunning) {
 				try {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
@@ -207,6 +207,22 @@ public class IterateTest {
 		} catch (UnsupportedOperationException e) {
 			// expected behaviour
 		}
+		
+		
+		// Test force checkpointing
+
+		try {
+			env.enableCheckpointing(1, false);
+			env.execute();
+
+			// this statement should never be reached
+			fail();
+		} catch (UnsupportedOperationException e) {
+			// expected behaviour
+		}
+		
+		env.enableCheckpointing(1, true);
+		env.getStreamGraph().getJobGraph();
 
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -118,7 +118,26 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   /**
    * Method for enabling fault-tolerance. Activates monitoring and backup of streaming
    * operator states. Time interval between state checkpoints is specified in in millis.
+   * 
+   * If the force flag is set to true, checkpointing will be enabled for iterative jobs as
+   * well.Please note that the checkpoint/restore guarantees for iterative jobs are
+   * only best-effort at the moment. Records inside the loops may be lost during failure.
    *
+   * Setting this option assumes that the job is used in production and thus if not stated
+   * explicitly otherwise with calling with the
+   * {@link #setNumberOfExecutionRetries(int numberOfExecutionRetries)} method in case of
+   * failure the job will be resubmitted to the cluster indefinitely.
+   */
+  @deprecated
+  def enableCheckpointing(interval : Long, force: Boolean) : StreamExecutionEnvironment = {
+    javaEnv.enableCheckpointing(interval, force)
+    this
+  }
+  
+   /**
+   * Method for enabling fault-tolerance. Activates monitoring and backup of streaming
+   * operator states. Time interval between state checkpoints is specified in in millis.
+   * 
    * Setting this option assumes that the job is used in production and thus if not stated
    * explicitly otherwise with calling with the
    * {@link #setNumberOfExecutionRetries(int numberOfExecutionRetries)} method in case of


### PR DESCRIPTION
It is currently impossible to enable state checkpointing for iterative jobs, because en exception is thrown when creating the jobgraph. This behaviour is motivated by the lack of precise guarantees that we can give with the current fault-tolerance implementations for cyclic graphs.

This PR adds an optional flag to force checkpoints even in case of iterations. The algorithm will take checkpoints periodically as before, but records in transit inside the loop will be lost. 

However even this guarantee is enough for most applications (Machine Learning for instance) and certainly much better than not having anything at all.