### PR TITLE
[release-0.9] [streaming] Logging update for checkpointed streaming topologies

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -60,7 +60,6 @@ public class CheckpointCoordinator {
 	/** The number of recent checkpoints whose IDs are remembered */
 	private static final int NUM_GHOST_CHECKPOINT_IDS = 16;
 	
-	
 	/** Coordinator-wide lock to safeguard the checkpoint updates */
 	private final Object lock = new Object();
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -710,6 +710,7 @@ public class ExecutionGraph implements Serializable {
 								@Override
 								public Object call() throws Exception {
 									try {
+										LOG.info("Delaying retry of job execution for {} ms ...", delayBeforeRetrying);
 										Thread.sleep(delayBeforeRetrying);
 									}
 									catch(InterruptedException e){

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -233,7 +233,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 		synchronized (checkpointLock) {
 			if (isRunning) {
 				try {
-					LOG.info("Starting checkpoint {} on task {}", checkpointId, getName());
+					LOG.debug("Starting checkpoint {} on task {}", checkpointId, getName());
 					
 					// first draw the state that should go into checkpoint
 					StateHandle<Serializable> state;


### PR DESCRIPTION
Also adding a log message when delaying the retry of the execution graph.

This change is motivated by my experience when running checkpointed topologies on a cluster. Some log information had to be lowered to debug as it was coming multiple times a second by default.

We did not log when the execution graph went to sleep for a 100 secs to wait for a possible taskmanager restart. It was quite misleading for me.