### PR TITLE
[FLINK-2203] handling null values for RowSerializer

### DIFF
--- a/flink-staging/flink-table/pom.xml
+++ b/flink-staging/flink-table/pom.xml
@@ -94,6 +94,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/typeinfo/RowSerializer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/typeinfo/RowSerializer.scala
@@ -17,16 +17,21 @@
  */
 package org.apache.flink.api.table.typeinfo
 
-import org.apache.flink.api.table.Row
+import java.util
+
 import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flink.core.memory.{DataOutputView, DataInputView}
-;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer
+import org.apache.flink.api.table.Row
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+
 
 /**
  * Serializer for [[Row]].
  */
 class RowSerializer(fieldSerializers: Array[TypeSerializer[Any]])
   extends TypeSerializer[Row] {
+
+  private def getFieldSerializers = fieldSerializers
 
   override def isImmutableType: Boolean = false
 
@@ -74,11 +79,16 @@ class RowSerializer(fieldSerializers: Array[TypeSerializer[Any]])
 
   override def serialize(value: Row, target: DataOutputView) {
     val len = fieldSerializers.length
-    var i = 0
-    while (i < len) {
-      val serializer = fieldSerializers(i)
-      serializer.serialize(value.productElement(i), target)
-      i += 1
+    (0 to len - 1).foreach {
+      index =>
+        val o: AnyRef = value.productElement(index).asInstanceOf[AnyRef]
+        if (o == null) {
+          target.writeBoolean(true)
+        } else {
+          target.writeBoolean(false)
+          val serializer = fieldSerializers(index)
+          serializer.serialize(value.productElement(index), target)
+        }
     }
   }
 
@@ -89,11 +99,16 @@ class RowSerializer(fieldSerializers: Array[TypeSerializer[Any]])
       throw new RuntimeException("Row arity of reuse and fields do not match.")
     }
 
-    var i = 0
-    while (i < len) {
-      val field = reuse.productElement(i).asInstanceOf[AnyRef]
-      reuse.setField(i, fieldSerializers(i).deserialize(field, source))
-      i += 1
+    (0 to len - 1).foreach {
+      index =>
+        val isNull: Boolean = source.readBoolean
+        if (isNull) {
+          reuse.setField(index, null)
+        } else {
+          val field = reuse.productElement(index).asInstanceOf[AnyRef]
+          val serializer: TypeSerializer[Any] = fieldSerializers(index)
+          reuse.setField(index, serializer.deserialize(field, source))
+        }
     }
     reuse
   }
@@ -102,20 +117,38 @@ class RowSerializer(fieldSerializers: Array[TypeSerializer[Any]])
     val len = fieldSerializers.length
 
     val result = new Row(len)
-    var i = 0
-    while (i < len) {
-      result.setField(i, fieldSerializers(i).deserialize(source))
-      i += 1
+
+    (0 to len - 1).foreach {
+      index =>
+        val isNull: Boolean = source.readBoolean()
+        if (isNull) {
+          result.setField(index, null)
+        } else {
+          val serializer: TypeSerializer[Any] = fieldSerializers(index)
+          result.setField(index, serializer.deserialize(source))
+        }
     }
     result
   }
+
+  private final val booleanSerializer = new BooleanSerializer()
 
   override def copy(source: DataInputView, target: DataOutputView): Unit = {
     val len = fieldSerializers.length
     var i = 0
     while (i < len) {
+      booleanSerializer.copy(source, target)
       fieldSerializers(i).copy(source, target)
       i += 1
+    }
+  }
+
+  override def equals(any: scala.Any): Boolean = {
+    any match {
+      case otherRS: RowSerializer =>
+        val otherFieldSerializers = otherRS.getFieldSerializers.asInstanceOf[Array[AnyRef]]
+        util.Arrays.deepEquals(fieldSerializers.asInstanceOf[Array[AnyRef]], otherFieldSerializers)
+      case _ => false
     }
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/typeinfo/RowSerializer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/typeinfo/RowSerializer.scala
@@ -134,14 +134,15 @@ class RowSerializer(fieldSerializers: Array[TypeSerializer[Any]])
     result
   }
 
-  private final val booleanSerializer = new BooleanSerializer()
-
   override def copy(source: DataInputView, target: DataOutputView): Unit = {
     val len = fieldSerializers.length
     var i = 0
     while (i < len) {
-      booleanSerializer.copy(source, target)
-      fieldSerializers(i).copy(source, target)
+      val isNull = source.readBoolean()
+      target.writeBoolean(isNull)
+      if (!isNull) {
+        fieldSerializers(i).copy(source, target)
+      }
       i += 1
     }
   }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
@@ -18,225 +18,53 @@
 
 package org.apache.flink.api.table.typeinfo
 
-import org.apache.commons.lang3.SerializationUtils
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestOutputView
-import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.common.typeutils.{SerializerTestInstance, TypeSerializer}
 import org.apache.flink.api.table.Row
 import org.junit.Assert._
 import org.junit.Test
 
 class RowSerializerTest {
 
-  private val rowInfo: TypeInformation[Row] = new RowTypeInfo(
-    Seq(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO), Seq("id", "name"))
+  class RowSerializerTestInstance(serializer: TypeSerializer[Row],
+                                  testData: Array[Row])
+    extends SerializerTestInstance(serializer, classOf[Row], -1, testData: _*) {
 
-  private val row1 = new Row(2)
-  row1.setField(0, 1)
-  row1.setField(1, "a")
-
-  private val row2 = new Row(2)
-  row2.setField(0, 2)
-  row2.setField(1, "hello")
-
-  private val testData: Array[Row] = Array(row1, row2)
-
-  private val rowSerializer: TypeSerializer[Row] = rowInfo.createSerializer(new ExecutionConfig)
-
-  @Test
-  def testInstantiate() = {
-    val serializer: TypeSerializer[Row] = rowInfo.createSerializer(new ExecutionConfig)
-    val instance: Row = serializer.createInstance()
-    assertNotNull("The created instance must not be null.", instance)
-    val `type`: Class[Row] = classOf[Row]
-    assertNotNull("The test is corrupt: type class is null.", `type`)
-    assertEquals("Type of the instantiated object is wrong.", `type`, instance.getClass)
-  }
-
-  @Test
-  def testGetLength() = {
-    assertEquals(-1, rowSerializer.getLength)
-  }
-
-  def compareRows(original: Row, copy: Row, msg: String) = {
-    (0 to original.productArity - 1).foreach {
-      index =>
-        val copiedValue: Any = copy.productElement(index)
-        val element: Any = original.productElement(index)
-        assertEquals(msg, element, copiedValue)
+    override protected def deepEquals(message: String, should: Row, is: Row): Unit = {
+      val arity = should.productArity
+      assertEquals(message, arity, is.productArity)
+      var index = 0
+      while (index < arity) {
+        val copiedValue: Any = should.productElement(index)
+        val element: Any = is.productElement(index)
+        assertEquals(message, element, copiedValue)
+        index += 1
+      }
     }
   }
 
   @Test
-  def testCopy() = {
-    testData.foreach {
-      row =>
-        val copy: Row = rowSerializer.copy(row)
-        compareRows(row, copy, "Copied element is not equal to the original element.")
-    }
+  def testRowSerializer(): Unit ={
+
+    val rowInfo: TypeInformation[Row] = new RowTypeInfo(
+      Seq(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO), Seq("id", "name"))
+
+    val row1 = new Row(2)
+    row1.setField(0, 1)
+    row1.setField(1, "a")
+
+    val row2 = new Row(2)
+    row2.setField(0, 2)
+    row2.setField(1, "hello")
+
+    val testData: Array[Row] = Array(row1, row2)
+
+    val rowSerializer: TypeSerializer[Row] = rowInfo.createSerializer(new ExecutionConfig)
+
+    val testInstance = new RowSerializerTestInstance(rowSerializer,testData)
+
+    testInstance.testAll()
   }
-
-  @Test
-  def testCopyIntoNewElements() = {
-    testData.foreach {
-      row =>
-        val copy: Row = rowSerializer.copy(row, rowSerializer.createInstance())
-        compareRows(row, copy, "Copied element is not equal to the original element.")
-    }
-  }
-
-  @Test
-  def testCopyIntoReusedElements() = {
-    val target: Row = rowSerializer.createInstance
-    for (datum <- testData) {
-      val copy: Row = rowSerializer.copy(datum, target)
-      compareRows(datum, copy, "Copied element is not equal to the original element.")
-      assertEquals(target, copy)
-    }
-  }
-
-  @Test
-  def testSerializeIndividually() = {
-    testData.foreach {
-      value =>
-        val out = new TestOutputView()
-        rowSerializer.serialize(value, out)
-        val in = out.getInputView
-
-        assertTrue("No data available during deserialization.", in.available() > 0)
-
-        val deserialized = rowSerializer.deserialize(rowSerializer.createInstance(), in)
-        compareRows(value, deserialized, "Deserialized value is wrong.")
-
-        assertTrue("Trailing data available after deserialization.", in.available() == 0)
-    }
-  }
-
-  @Test
-  def testSerializeIndividuallyReusingValues() = {
-    testData.foreach {
-      value =>
-        val reuseValue: Row = rowSerializer.createInstance
-        val out = new TestOutputView()
-        rowSerializer.serialize(value, out)
-        val in = out.getInputView
-
-        assertTrue("No data available during deserialization.", in.available() > 0)
-
-        val deserialized = rowSerializer.deserialize(reuseValue, in)
-        compareRows(value, deserialized, "Deserialized value is wrong.")
-
-        assertTrue("Trailing data available after deserialization.", in.available() == 0)
-        assertEquals(reuseValue, deserialized)
-    }
-  }
-
-  @Test
-  def testSerializeAsSequenceNoReuse() = {
-
-    val out = new TestOutputView()
-    testData.foreach {
-      value =>
-        rowSerializer.serialize(value, out)
-    }
-
-    val in = out.getInputView
-
-    var num = 0
-    while (in.available() > 0) {
-      val deserialized = rowSerializer.deserialize(in)
-      deserialized.toString()
-
-      compareRows(testData(num), deserialized, "Deserialized value is wrong")
-      num += 1
-    }
-
-    assertEquals("Wrong number of elements deserialized.", testData.length, num)
-  }
-
-  @Test
-  def testSerializeAsSequenceReusingValues() = {
-
-    val out = new TestOutputView()
-    testData.foreach {
-      value =>
-        rowSerializer.serialize(value, out)
-    }
-
-    val in = out.getInputView
-    val reuseValue = rowSerializer.createInstance()
-
-    var num = 0
-    while (in.available() > 0) {
-      val deserialized = rowSerializer.deserialize(reuseValue, in)
-      deserialized.toString()
-
-      compareRows(testData(num), deserialized, "Deserialized value is wrong")
-      assertEquals(deserialized, reuseValue)
-      num += 1
-    }
-
-    assertEquals("Wrong number of elements deserialized.", testData.length, num)
-  }
-
-  @Test
-  def testSerializedCopyIndividually() = {
-
-    testData.foreach {
-      value =>
-        val out = new TestOutputView()
-        rowSerializer.serialize(value, out)
-
-        val source = out.getInputView
-
-        val target = new TestOutputView()
-        rowSerializer.copy(source, target)
-        val toVerify = target.getInputView
-
-        assertTrue("No data available copying.", toVerify.available() > 0)
-
-        val deserialized = rowSerializer.deserialize(rowSerializer.createInstance(), toVerify)
-
-        compareRows(value, deserialized, "Deserialized value is wrong")
-
-        assertTrue("Trailing data available after deserialization.", toVerify.available() == 0);
-    }
-  }
-
-  @Test
-  def testSerializedCopyAsSequence() = {
-    val out = new TestOutputView()
-    testData.foreach {
-      value =>
-        rowSerializer.serialize(value, out);
-    }
-
-    val source = out.getInputView
-    val target = new TestOutputView()
-    testData.indices.foreach {
-      entry =>
-        rowSerializer.copy(source, target);
-    }
-
-    val toVerify = target.getInputView
-    var num = 0
-
-    while (toVerify.available() > 0) {
-      val deserialized = rowSerializer.deserialize(rowSerializer.createInstance(), toVerify)
-
-      compareRows(testData(num), deserialized, "Deserialized value is wrong")
-      num += 1
-    }
-
-    assertEquals("Wrong number of elements copied.", testData.length, num)
-  }
-
-  @Test
-  def testSerializabilityAndEquals() {
-    val ser2 = SerializationUtils.clone(rowSerializer)
-    assertEquals("Copy of the serializer is not equal to the original one.", rowSerializer, ser2)
-  }
-
 
 }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
@@ -56,7 +56,7 @@ class RowSerializerTest {
 
     val row2 = new Row(2)
     row2.setField(0, 2)
-    row2.setField(1, "hello")
+    row2.setField(1, null)
 
     val testData: Array[Row] = Array(row1, row2)
 

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
@@ -29,7 +29,8 @@ import org.junit.Test
 
 class RowSerializerTest {
 
-  private val rowInfo: TypeInformation[Row] = new RowTypeInfo(Seq(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO), Seq("id", "name"))
+  private val rowInfo: TypeInformation[Row] = new RowTypeInfo(
+    Seq(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO), Seq("id", "name"))
 
   private val row1 = new Row(2)
   row1.setField(0, 1)
@@ -234,7 +235,7 @@ class RowSerializerTest {
   @Test
   def testSerializabilityAndEquals() {
     val ser2 = SerializationUtils.clone(rowSerializer)
-    assertEquals("The copy of the serializer is not equal to the original one.", rowSerializer, ser2)
+    assertEquals("Copy of the serializer is not equal to the original one.", rowSerializer, ser2)
   }
 
 

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RowSerializerTest.scala
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.typeinfo
+
+import org.apache.commons.lang3.SerializationUtils
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestOutputView
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.table.Row
+import org.junit.Assert._
+import org.junit.Test
+
+class RowSerializerTest {
+
+  private val rowInfo: TypeInformation[Row] = new RowTypeInfo(Seq(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO), Seq("id", "name"))
+
+  private val row1 = new Row(2)
+  row1.setField(0, 1)
+  row1.setField(1, "a")
+
+  private val row2 = new Row(2)
+  row2.setField(0, 2)
+  row2.setField(1, "hello")
+
+  private val testData: Array[Row] = Array(row1, row2)
+
+  private val rowSerializer: TypeSerializer[Row] = rowInfo.createSerializer(new ExecutionConfig)
+
+  @Test
+  def testInstantiate() = {
+    val serializer: TypeSerializer[Row] = rowInfo.createSerializer(new ExecutionConfig)
+    val instance: Row = serializer.createInstance()
+    assertNotNull("The created instance must not be null.", instance)
+    val `type`: Class[Row] = classOf[Row]
+    assertNotNull("The test is corrupt: type class is null.", `type`)
+    assertEquals("Type of the instantiated object is wrong.", `type`, instance.getClass)
+  }
+
+  @Test
+  def testGetLength() = {
+    assertEquals(-1, rowSerializer.getLength)
+  }
+
+  def compareRows(original: Row, copy: Row, msg: String) = {
+    (0 to original.productArity - 1).foreach {
+      index =>
+        val copiedValue: Any = copy.productElement(index)
+        val element: Any = original.productElement(index)
+        assertEquals(msg, element, copiedValue)
+    }
+  }
+
+  @Test
+  def testCopy() = {
+    testData.foreach {
+      row =>
+        val copy: Row = rowSerializer.copy(row)
+        compareRows(row, copy, "Copied element is not equal to the original element.")
+    }
+  }
+
+  @Test
+  def testCopyIntoNewElements() = {
+    testData.foreach {
+      row =>
+        val copy: Row = rowSerializer.copy(row, rowSerializer.createInstance())
+        compareRows(row, copy, "Copied element is not equal to the original element.")
+    }
+  }
+
+  @Test
+  def testCopyIntoReusedElements() = {
+    val target: Row = rowSerializer.createInstance
+    for (datum <- testData) {
+      val copy: Row = rowSerializer.copy(datum, target)
+      compareRows(datum, copy, "Copied element is not equal to the original element.")
+      assertEquals(target, copy)
+    }
+  }
+
+  @Test
+  def testSerializeIndividually() = {
+    testData.foreach {
+      value =>
+        val out = new TestOutputView()
+        rowSerializer.serialize(value, out)
+        val in = out.getInputView
+
+        assertTrue("No data available during deserialization.", in.available() > 0)
+
+        val deserialized = rowSerializer.deserialize(rowSerializer.createInstance(), in)
+        compareRows(value, deserialized, "Deserialized value is wrong.")
+
+        assertTrue("Trailing data available after deserialization.", in.available() == 0)
+    }
+  }
+
+  @Test
+  def testSerializeIndividuallyReusingValues() = {
+    testData.foreach {
+      value =>
+        val reuseValue: Row = rowSerializer.createInstance
+        val out = new TestOutputView()
+        rowSerializer.serialize(value, out)
+        val in = out.getInputView
+
+        assertTrue("No data available during deserialization.", in.available() > 0)
+
+        val deserialized = rowSerializer.deserialize(reuseValue, in)
+        compareRows(value, deserialized, "Deserialized value is wrong.")
+
+        assertTrue("Trailing data available after deserialization.", in.available() == 0)
+        assertEquals(reuseValue, deserialized)
+    }
+  }
+
+  @Test
+  def testSerializeAsSequenceNoReuse() = {
+
+    val out = new TestOutputView()
+    testData.foreach {
+      value =>
+        rowSerializer.serialize(value, out)
+    }
+
+    val in = out.getInputView
+
+    var num = 0
+    while (in.available() > 0) {
+      val deserialized = rowSerializer.deserialize(in)
+      deserialized.toString()
+
+      compareRows(testData(num), deserialized, "Deserialized value is wrong")
+      num += 1
+    }
+
+    assertEquals("Wrong number of elements deserialized.", testData.length, num)
+  }
+
+  @Test
+  def testSerializeAsSequenceReusingValues() = {
+
+    val out = new TestOutputView()
+    testData.foreach {
+      value =>
+        rowSerializer.serialize(value, out)
+    }
+
+    val in = out.getInputView
+    val reuseValue = rowSerializer.createInstance()
+
+    var num = 0
+    while (in.available() > 0) {
+      val deserialized = rowSerializer.deserialize(reuseValue, in)
+      deserialized.toString()
+
+      compareRows(testData(num), deserialized, "Deserialized value is wrong")
+      assertEquals(deserialized, reuseValue)
+      num += 1
+    }
+
+    assertEquals("Wrong number of elements deserialized.", testData.length, num)
+  }
+
+  @Test
+  def testSerializedCopyIndividually() = {
+
+    testData.foreach {
+      value =>
+        val out = new TestOutputView()
+        rowSerializer.serialize(value, out)
+
+        val source = out.getInputView
+
+        val target = new TestOutputView()
+        rowSerializer.copy(source, target)
+        val toVerify = target.getInputView
+
+        assertTrue("No data available copying.", toVerify.available() > 0)
+
+        val deserialized = rowSerializer.deserialize(rowSerializer.createInstance(), toVerify)
+
+        compareRows(value, deserialized, "Deserialized value is wrong")
+
+        assertTrue("Trailing data available after deserialization.", toVerify.available() == 0);
+    }
+  }
+
+  @Test
+  def testSerializedCopyAsSequence() = {
+    val out = new TestOutputView()
+    testData.foreach {
+      value =>
+        rowSerializer.serialize(value, out);
+    }
+
+    val source = out.getInputView
+    val target = new TestOutputView()
+    testData.indices.foreach {
+      entry =>
+        rowSerializer.copy(source, target);
+    }
+
+    val toVerify = target.getInputView
+    var num = 0
+
+    while (toVerify.available() > 0) {
+      val deserialized = rowSerializer.deserialize(rowSerializer.createInstance(), toVerify)
+
+      compareRows(testData(num), deserialized, "Deserialized value is wrong")
+      num += 1
+    }
+
+    assertEquals("Wrong number of elements copied.", testData.length, num)
+  }
+
+  @Test
+  def testSerializabilityAndEquals() {
+    val ser2 = SerializationUtils.clone(rowSerializer)
+    assertEquals("The copy of the serializer is not equal to the original one.", rowSerializer, ser2)
+  }
+
+
+}


### PR DESCRIPTION
The implementation is similar to what is being done in `PojoSerializer` to handle null values.

A null check is done before attempting to serialize. 
If the value is `null`, boolean `true` is written to the `DataOutputView` and the corresponding fieldSerializer is not used to serialize the null value. If the value is not `null`, boolean `false` and the result from `fieldSerializer.serialize` are written to the `DataOutputView`.
When deserializing, for every element in a `Row`, a boolean is first read from the `DataInputView`. This indicates whether the value for that element is `null`. If the boolean is `false`, the corresponding fieldSerializer's `deserialize` method is called else `null` is set for that field.


The `RowSerializerTest` could not be written by extending `SerializerTestBase` like the `PojoSerializerTest` since generating a `TypeSerializer[Row]` requires information of field serializers. 

Initially, I tried defining a `SerializerTestInstance` and calling its `testAll()` method(like `MultidimensionalArraySerializerTest`). But most of those tests check deep equals which will be false for `Row` (since each row has a map of field values). I added a method to compare all the fields of two given rows and used that instead for all the tests.
