### PR TITLE
[FLINK-2152] Added zipWithIndex 

### DIFF
--- a/docs/apis/dataset_transformations.md
+++ b/docs/apis/dataset_transformations.md
@@ -23,6 +23,8 @@ under the License.
 This document gives a deep-dive into the available transformations on DataSets. For a general introduction to the
 Flink Java API, please refer to the [Programming Guide](programming_guide.html).
 
+For zipping elements in a data set with a dense index, please refer to the [Zip Elements Guide](zip_elements_guide.html).
+
 * This will be replaced by the TOC
 {:toc}
 

--- a/docs/apis/zip_elements_guide.md
+++ b/docs/apis/zip_elements_guide.md
@@ -34,8 +34,7 @@ ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 env.setParallelism(1);
 DataSet<String> in = env.fromElements("A", "B", "C", "D", "E", "F");
 
-DataSetUtils<String> dataSetUtils = new DataSetUtils<String>();
-DataSet<Tuple2<Long, String>> result = dataSetUtils.zipWithIndex(in);
+DataSet<Tuple2<Long, String>> result = DataSetUtils.zipWithIndex(in);
 
 result.writeAsCsv(resultPath, "\n", ",");
 env.execute();

--- a/docs/apis/zip_elements_guide.md
+++ b/docs/apis/zip_elements_guide.md
@@ -29,6 +29,9 @@ This document shows how {% gh_link /flink-java/src/main/java/org/apache/flink/ap
 ### Zip with a Dense Index
 For assigning consecutive labels to the elements, the `zipWithIndex` method should be called. It receives a data set as input and returns a new data set of unique id, initial value tuples.
 For example, the following code:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
 {% highlight java %}
 ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 env.setParallelism(1);
@@ -39,6 +42,25 @@ DataSet<Tuple2<Long, String>> result = DataSetUtils.zipWithIndex(in);
 result.writeAsCsv(resultPath, "\n", ",");
 env.execute();
 {% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+import org.apache.flink.api.scala._
+
+val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+env.setParallelism(1)
+val input: DataSet[String] = env.fromElements("A", "B", "C", "D", "E", "F")
+
+val result: DataSet[(Long, String)] = input.zipWithIndex
+
+result.writeAsCsv(resultPath, "\n", ",")
+env.execute()
+{% endhighlight %}
+</div>
+
+</div>
+
 will yield the tuples: (0,A), (1,B), (2,C), (3,D), (4,E), (5,F)
 
 [Back to top](#top)

--- a/docs/apis/zip_elements_guide.md
+++ b/docs/apis/zip_elements_guide.md
@@ -1,0 +1,45 @@
+---
+title: "Zipping Elements in a DataSet"
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+In certain algorithms, one may need to assign unique identifiers to data set elements.
+This document shows how {% gh_link /flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java "DataSetUtils" %} can be used for that purpose.
+
+* This will be replaced by the TOC
+{:toc}
+
+### Zip with a Dense Index
+For assigning consecutive labels to the elements, the `zipWithIndex` method should be called. It receives a data set as input and returns a new data set of unique id, initial value tuples.
+For example, the following code:
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+env.setParallelism(1);
+DataSet<String> in = env.fromElements("A", "B", "C", "D", "E", "F");
+
+DataSetUtils<String> dataSetUtils = new DataSetUtils<String>();
+DataSet<Tuple2<Long, String>> result = dataSetUtils.zipWithIndex(in);
+
+result.writeAsCsv(resultPath, "\n", ",");
+env.execute();
+{% endhighlight %}
+will yield the tuples: (0,A), (1,B), (2,C), (3,D), (4,E), (5,F)
+
+[Back to top](#top)

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.utils;
+
+import org.apache.flink.api.common.functions.RichMapPartitionFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * This class provides simple utility methods for zipping elements in a file with an index.
+ *
+ * @param <T> The type of the DataSet, i.e., the type of the elements of the DataSet.
+ */
+public class DataSetUtils<T> {
+
+	/**
+	 * Method that goes over all the elements in each partition in order to retireve
+	 * the total number of elements.
+	 *
+	 * @param input the DataSet received as input
+	 * @return a data set containing tuples of subtask index, number of elements mappings.
+	 */
+	public DataSet<Tuple2<Integer, Long>> countElements(DataSet<T> input) {
+		return input.mapPartition(new RichMapPartitionFunction<T, Tuple2<Integer,Long>>() {
+			@Override
+			public void mapPartition(Iterable<T> values, Collector<Tuple2<Integer, Long>> out) throws Exception {
+				long counter = 0;
+				for(T value: values) {
+					counter ++;
+				}
+
+				out.collect(new Tuple2<Integer, Long>(getRuntimeContext().getIndexOfThisSubtask(), counter));
+			}
+		});
+	}
+
+	/**
+	 * Method that takes a set of subtask index, total number of elements mappings
+	 * and assigns ids to all the elements from the input data set.
+	 *
+	 * @param input the input data set
+	 * @return a data set of tuple 2 consisting of consecutive ids and initial values.
+	 */
+	public DataSet<Tuple2<Long, T>> zipWithIndex(DataSet<T> input) {
+
+		DataSet<Tuple2<Integer, Long>> elementCount = countElements(input);
+
+		return input.mapPartition(new RichMapPartitionFunction<T, Tuple2<Long, T>>() {
+
+			long start = 0;
+
+			// compute the offset for each partition
+			@Override
+			public void open(Configuration parameters) throws Exception {
+				super.open(parameters);
+
+				List<Tuple2<Integer, Long>> offsets = getRuntimeContext().getBroadcastVariable("counts");
+
+				Collections.sort(offsets, new Comparator<Tuple2<Integer, Long>>() {
+					@Override
+					public int compare(Tuple2<Integer, Long> o1, Tuple2<Integer, Long> o2) {
+						return compareInts(o1.f0, o2.f0);
+					}
+				});
+
+				for(int i = 0; i < getRuntimeContext().getIndexOfThisSubtask(); i++) {
+					start += offsets.get(i).f1;
+				}
+			}
+
+			@Override
+			public void mapPartition(Iterable<T> values, Collector<Tuple2<Long, T>> out) throws Exception {
+				for(T value: values) {
+					out.collect(new Tuple2<Long, T>(start++, value));
+				}
+			}
+		}).withBroadcastSet(elementCount, "counts");
+	}
+
+	private static int compareInts(long x, int y) {
+		return (x < y) ? -1 : ((x == y) ? 0 : 1);
+	}
+
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
@@ -30,25 +30,23 @@ import java.util.List;
 
 /**
  * This class provides simple utility methods for zipping elements in a file with an index.
- *
- * @param <T> The type of the DataSet, i.e., the type of the elements of the DataSet.
  */
-public class DataSetUtils<T> {
+public class DataSetUtils {
 
 	/**
-	 * Method that goes over all the elements in each partition in order to retireve
+	 * Method that goes over all the elements in each partition in order to retrieve
 	 * the total number of elements.
 	 *
 	 * @param input the DataSet received as input
 	 * @return a data set containing tuples of subtask index, number of elements mappings.
 	 */
-	public DataSet<Tuple2<Integer, Long>> countElements(DataSet<T> input) {
+	private static <T> DataSet<Tuple2<Integer, Long>> countElements(DataSet<T> input) {
 		return input.mapPartition(new RichMapPartitionFunction<T, Tuple2<Integer,Long>>() {
 			@Override
 			public void mapPartition(Iterable<T> values, Collector<Tuple2<Integer, Long>> out) throws Exception {
 				long counter = 0;
 				for(T value: values) {
-					counter ++;
+					counter++;
 				}
 
 				out.collect(new Tuple2<Integer, Long>(getRuntimeContext().getIndexOfThisSubtask(), counter));
@@ -63,7 +61,7 @@ public class DataSetUtils<T> {
 	 * @param input the input data set
 	 * @return a data set of tuple 2 consisting of consecutive ids and initial values.
 	 */
-	public DataSet<Tuple2<Long, T>> zipWithIndex(DataSet<T> input) {
+	public static <T> DataSet<Tuple2<Long, T>> zipWithIndex(DataSet<T> input) {
 
 		DataSet<Tuple2<Integer, Long>> elementCount = countElements(input);
 
@@ -99,7 +97,7 @@ public class DataSetUtils<T> {
 		}).withBroadcastSet(elementCount, "counts");
 	}
 
-	private static int compareInts(long x, int y) {
+	private static int compareInts(int x, int y) {
 		return (x < y) ? -1 : ((x == y) ? 0 : 1);
 	}
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSetUtils.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSetUtils.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.{utils => jutils}
+
+import _root_.scala.language.implicitConversions
+import _root_.scala.reflect.ClassTag
+
+
+/**
+ * This class provides simple utility methods for zipping elements in a file with an index.
+ */
+
+class DataSetUtils[T](val self: DataSet[T]) extends AnyVal {
+
+  /**
+   * Method that takes a set of subtask index, total number of elements mappings
+   * and assigns ids to all the elements from the input data set.
+   *
+   * @return a data set of tuple 2 consisting of consecutive ids and initial values.
+   */
+  def zipWithIndex(implicit ti: TypeInformation[(Long, T)],
+                   ct: ClassTag[(Long, T)]): DataSet[(Long, T)] = {
+    wrap(jutils.DataSetUtils.zipWithIndex(self.javaSet))
+      .map { t => (t.f0.toLong, t.f1) }
+  }
+}
+
+object DataSetUtils {
+  /**
+   * Tie the new class to an existing Scala API class: DataSet.
+   */
+  implicit def utilsToDataSet[T: TypeInformation: ClassTag](dataSet: DataSet[T]) =
+    new DataSetUtils[T](dataSet)
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/util/DataSetUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/DataSetUtilsITCase.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.DataSetUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class DataSetUtilsITCase extends MultipleProgramsTestBase {
+
+	private String resultPath;
+	private String expectedResult;
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	public DataSetUtilsITCase(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Before
+	public void before() throws Exception{
+		resultPath = tempFolder.newFile().toURI().toString();
+	}
+
+	@Test
+	public void testZipWithIndex() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		DataSet<String> in = env.fromElements("A", "B", "C", "D", "E", "F");
+
+		DataSetUtils<String> dataSetUtils = new DataSetUtils<String>();
+		DataSet<Tuple2<Long, String>> result = dataSetUtils.zipWithIndex(in);
+
+		result.writeAsCsv(resultPath, "\n", ",");
+		env.execute();
+
+		expectedResult = "0,A\n" + "1,B\n" + "2,C\n" + "3,D\n" + "4,E\n" + "5,F";
+	}
+
+
+	@After
+	public void after() throws Exception{
+		compareResultsByLinesInMemory(expectedResult, resultPath);
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/util/DataSetUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/DataSetUtilsITCase.java
@@ -54,8 +54,7 @@ public class DataSetUtilsITCase extends MultipleProgramsTestBase {
 		env.setParallelism(1);
 		DataSet<String> in = env.fromElements("A", "B", "C", "D", "E", "F");
 
-		DataSetUtils<String> dataSetUtils = new DataSetUtils<String>();
-		DataSet<Tuple2<Long, String>> result = dataSetUtils.zipWithIndex(in);
+		DataSet<Tuple2<Long, String>> result = DataSetUtils.zipWithIndex(in);
 
 		result.writeAsCsv(resultPath, "\n", ",");
 		env.execute();

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/DataSetUtilsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/DataSetUtilsITCase.scala
@@ -32,23 +32,20 @@ MultipleProgramsTestBase(mode){
 
   private var resultPath: String = null
   private var expectedResult: String = null
-
-  var tempFolder: TemporaryFolder = new TemporaryFolder()
+  private val tempFolder: TemporaryFolder = new TemporaryFolder()
 
   @Rule
-  def getFolder(): TemporaryFolder = {
-    tempFolder;
-  }
+  def getFolder = tempFolder
 
   @Before
   @throws(classOf[Exception])
-  def before {
+  def before(): Unit = {
     resultPath = tempFolder.newFile.toURI.toString
   }
 
   @Test
   @throws(classOf[Exception])
-  def testZipWithIndex {
+  def testZipWithIndex(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
 
@@ -63,7 +60,7 @@ MultipleProgramsTestBase(mode){
 
   @After
   @throws(classOf[Exception])
-  def after {
+  def after(): Unit = {
     TestBaseUtils.compareResultsByLinesInMemory(expectedResult, resultPath)
   }
 }

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/DataSetUtilsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/DataSetUtilsITCase.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.util
+
+import org.apache.flink.api.scala._
+import org.apache.flink.test.util.{MultipleProgramsTestBase, TestBaseUtils}
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.{After, Before, Rule, Test}
+import org.apache.flink.api.scala.DataSetUtils.utilsToDataSet
+
+@RunWith(classOf[Parameterized])
+class DataSetUtilsITCase (mode: MultipleProgramsTestBase.TestExecutionMode) extends
+MultipleProgramsTestBase(mode){
+
+  private var resultPath: String = null
+  private var expectedResult: String = null
+
+  var tempFolder: TemporaryFolder = new TemporaryFolder()
+
+  @Rule
+  def getFolder(): TemporaryFolder = {
+    tempFolder;
+  }
+
+  @Before
+  @throws(classOf[Exception])
+  def before {
+    resultPath = tempFolder.newFile.toURI.toString
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testZipWithIndex {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val input: DataSet[String] = env.fromElements("A", "B", "C", "D", "E", "F")
+    val result: DataSet[(Long, String)] = input.zipWithIndex
+
+    result.writeAsCsv(resultPath, "\n", ",")
+    env.execute()
+
+    expectedResult = "0,A\n" + "1,B\n" + "2,C\n" + "3,D\n" + "4,E\n" + "5,F"
+  }
+
+  @After
+  @throws(classOf[Exception])
+  def after {
+    TestBaseUtils.compareResultsByLinesInMemory(expectedResult, resultPath)
+  }
+}


### PR DESCRIPTION
This PR adds the zipWithIndex utility method to Flink's DataSetUtils as described in the mailing list discussion: http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/The-correct-location-for-zipWithIndex-and-zipWithUniqueId-td6310.html. 

The method could, in the future, be moved to DataSet. 

@fhueske , @tillrohrmann , once we reach a conclusion for this one, I will also update #801 (I wouldn't like to fix unnecessary merge conflicts). 

Once zipWIthUniqueIds is added, I could also explain the difference in the docs. 