### PR TITLE
[build] Merge transitive notice files to shaded notices

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -334,6 +334,7 @@ under the License.
 								</transformer>
 								<!-- The service transformer is needed to merge META-INF/services files -->
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
 							</transformers>
 						</configuration>
 					</execution>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -84,6 +84,7 @@ under the License.
 							<transformers>
 								<!-- The service transformer is needed to merge META-INF/services files -->
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
 							</transformers>
 							<relocations>
 								<relocation>

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-flume/pom.xml
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-flume/pom.xml
@@ -147,6 +147,7 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
 			<plugin>
 				<!-- Override artifactSet configuration to build fat-jar with all dependencies packed. -->
 				<groupId>org.apache.maven.plugins</groupId>
@@ -162,6 +163,9 @@ under the License.
 									<include>org.apache.flume:*</include>
 								</includes>
 							</artifactSet>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-twitter/pom.xml
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-twitter/pom.xml
@@ -86,6 +86,9 @@ under the License.
 									<include>com.twitter:joauth</include>
 								</includes>
 							</artifactSet>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -170,6 +170,9 @@ under the License.
 									<shadedPattern>org.apache.flink.hadoop.shaded.org.jboss.netty</shadedPattern>
 								</relocation>
 							</relocations>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
This is a proposed solution for adding the transitive notice information to our shaded jars. The notice files are simply merged, and are not as readable as the hand edited ones, but each piece of notice information is clearly linkable to a single dependency.

This is the solution that I have seen being used in similar cases, e.g. [here](https://github.com/apache/spark/blob/16fc49617e1dfcbe9122b224f7f63b7bfddb36ce/external/kafka-assembly/pom.xml).