### PR TITLE
[FLINK-2225] [scheduler] Excludes static code paths from co-location constraint to avoid scheduling problems

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -527,8 +527,9 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 			
 			if (this.currentIteration != null) {
 				AbstractJobVertex head = this.iterations.get(this.currentIteration).getHeadTask();
-				// the head may still be null if we descend into the static parts first
-				if (head != null) {
+				// Exclude static code paths from the co-location constraint, because otherwise
+				// their execution determines the deployment slots of the co-location group
+				if (node.isOnDynamicPath()) {
 					targetVertex.setStrictlyCoLocatedWith(head);
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
@@ -29,12 +29,16 @@ import akka.actor.ActorRef;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotAvailabilityListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An instance represents a {@link org.apache.flink.runtime.taskmanager.TaskManager}
  * registered at a JobManager and ready to receive work.
  */
 public class Instance {
+
+	private final static Logger LOG = LoggerFactory.getLogger(Instance.class);
 
 	/** The lock on which to synchronize allocations and failure state changes */
 	private final Object instanceLock = new Object();
@@ -286,6 +290,7 @@ public class Instance {
 		}
 
 		if (slot.markReleased()) {
+			LOG.debug("Return allocated slot {}.", slot);
 			synchronized (instanceLock) {
 				if (isDead) {
 					return false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Slot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Slot.java
@@ -244,11 +244,11 @@ public abstract class Slot {
 
 	@Override
 	public String toString() {
-		return hierarchy() + " - " + instance.getId() + " - " + getStateName(status);
+		return hierarchy() + " - " + instance + " - " + getStateName(status);
 	}
 
 	protected String hierarchy() {
-		return "(" + slotNumber + ")" + (getParent() != null ? getParent().hierarchy() : "");
+		return (getParent() != null ? getParent().hierarchy() : "") + "(" + slotNumber + ")";
 	}
 
 	private static String getStateName(int state) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotSharingGroupAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotSharingGroupAssignment.java
@@ -35,6 +35,8 @@ import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -82,6 +84,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
  * </pre>
  */
 public class SlotSharingGroupAssignment {
+
+	private final static Logger LOG = LoggerFactory.getLogger(SlotSharingGroupAssignment.class);
 
 	/** The lock globally guards against concurrent modifications in the data structures */
 	private final Object lock = new Object();
@@ -485,6 +489,7 @@ public class SlotSharingGroupAssignment {
 
 				// check whether the slot is already released
 				if (simpleSlot.markReleased()) {
+					LOG.debug("Release simple slot {}.", simpleSlot);
 
 					AbstractID groupID = simpleSlot.getGroupID();
 					SharedSlot parent = simpleSlot.getParent();
@@ -581,6 +586,8 @@ public class SlotSharingGroupAssignment {
 			// we remove ourselves from our parent slot
 
 			if (sharedSlot.markReleased()) {
+				LOG.debug("Internally dispose empty shared slot {}.", sharedSlot);
+
 				int parentRemaining = parent.removeDisposedChildSlot(sharedSlot);
 				
 				if (parentRemaining > 0) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -209,7 +209,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 							constraint.lockLocation();
 						}
 						
-						updateLocalityCounters(slotFromGroup.getLocality(), vertex, slotFromGroup.getInstance());
+						updateLocalityCounters(slotFromGroup, vertex);
 						return slotFromGroup;
 					}
 					
@@ -279,7 +279,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 						constraint.lockLocation();
 					}
 					
-					updateLocalityCounters(toUse.getLocality(), vertex, toUse.getInstance());
+					updateLocalityCounters(toUse, vertex);
 				}
 				catch (NoResourceAvailableException e) {
 					throw e;
@@ -303,7 +303,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 				
 				SimpleSlot slot = getFreeSlotForTask(vertex, preferredLocations, forceExternalLocation);
 				if (slot != null) {
-					updateLocalityCounters(slot.getLocality(), vertex, slot.getInstance());
+					updateLocalityCounters(slot, vertex);
 					return slot;
 				}
 				else {
@@ -570,7 +570,9 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 		}
 	}
 	
-	private void updateLocalityCounters(Locality locality, ExecutionVertex vertex, Instance location) {
+	private void updateLocalityCounters(SimpleSlot slot, ExecutionVertex vertex) {
+		Locality locality = slot.getLocality();
+
 		switch (locality) {
 		case UNCONSTRAINED:
 			this.unconstrainedAssignments++;
@@ -588,13 +590,13 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 		if (LOG.isDebugEnabled()) {
 			switch (locality) {
 				case UNCONSTRAINED:
-					LOG.debug("Unconstrained assignment: " + vertex.getTaskNameWithSubtaskIndex() + " --> " + location);
+					LOG.debug("Unconstrained assignment: " + vertex.getTaskNameWithSubtaskIndex() + " --> " + slot);
 					break;
 				case LOCAL:
-					LOG.debug("Local assignment: " + vertex.getTaskNameWithSubtaskIndex() + " --> " + location);
+					LOG.debug("Local assignment: " + vertex.getTaskNameWithSubtaskIndex() + " --> " + slot);
 					break;
 				case NON_LOCAL:
-					LOG.debug("Non-local assignment: " + vertex.getTaskNameWithSubtaskIndex() + " --> " + location);
+					LOG.debug("Non-local assignment: " + vertex.getTaskNameWithSubtaskIndex() + " --> " + slot);
 					break;
 			}
 		}


### PR DESCRIPTION
Including static code paths in the co-location constraints can lead to a slot assignment for the co-location constraints which is not satisfiable. 

This can be caused by a subsequent execution of the static code tasks on the same TM. Then all the following co-located tasks have to be deployed in the same slots. When you have an iteration whose tasks have to be run all simultaneously, then this will lead to an unsatisfiable scheduling case.

The solution is to exclude static code paths from the co-location groups.