### PR TITLE
[FLINK-2230] handling null values for TupleSerializer

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
@@ -18,19 +18,18 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import java.io.IOException;
-
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.types.NullFieldException;
 
+import java.io.IOException;
+import java.util.BitSet;
 
 public final class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> {
 
 	private static final long serialVersionUID = 1L;
-	
+
 	public TupleSerializer(Class<T> tupleClass, TypeSerializer<?>[] fieldSerializers) {
 		super(tupleClass, fieldSerializers);
 	}
@@ -38,9 +37,10 @@ public final class TupleSerializer<T extends Tuple> extends TupleSerializerBase<
 	@Override
 	public TupleSerializer<T> duplicate() {
 		boolean stateful = false;
-		TypeSerializer<?>[] duplicateFieldSerializers = new TypeSerializer<?>[fieldSerializers.length];
+		int fieldCount = fieldSerializers.length;
+		TypeSerializer<?>[] duplicateFieldSerializers = new TypeSerializer<?>[fieldCount];
 
-		for (int i = 0; i < fieldSerializers.length; i++) {
+		for (int i = 0; i < fieldCount; i++) {
 			duplicateFieldSerializers[i] = fieldSerializers[i].duplicate();
 			if (duplicateFieldSerializers[i] != fieldSerializers[i]) {
 				// at least one of them is stateful
@@ -59,11 +59,11 @@ public final class TupleSerializer<T extends Tuple> extends TupleSerializerBase<
 	public T createInstance() {
 		try {
 			T t = tupleClass.newInstance();
-		
+
 			for (int i = 0; i < arity; i++) {
 				t.setField(fieldSerializers[i].createInstance(), i);
 			}
-			
+
 			return t;
 		}
 		catch (Exception e) {
@@ -88,57 +88,106 @@ public final class TupleSerializer<T extends Tuple> extends TupleSerializerBase<
 		}
 	}
 
-	@Override
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        int bitSetSize = (arity / 8) + 1;
+        byte[] buffer = new byte[bitSetSize];
+        source.read(buffer);
+        BitSet bitIndicator = BitSet.valueOf(buffer);
+
+        target.write(bitIndicator.toByteArray());
+
+        for (int i = 0; i < arity; i++) {
+            if (bitIndicator.get(i)) {
+                fieldSerializers[i].copy(source, target);
+            }
+        }
+    }
+
+    @Override
 	public T copy(T from) {
 		T target = instantiateRaw();
 		for (int i = 0; i < arity; i++) {
-			Object copy = fieldSerializers[i].copy(from.getField(i));
-			target.setField(copy, i);
-		}
+            Object field = from.getField(i);
+            if (field != null) {
+                Object copy = fieldSerializers[i].copy(field);
+                target.setField(copy, i);
+            } else {
+                target.setField(null, i);
+            }
+        }
 		return target;
 	}
-	
+
 	@Override
 	public T copy(T from, T reuse) {
 		for (int i = 0; i < arity; i++) {
-			Object copy = fieldSerializers[i].copy(from.getField(i), reuse.getField(i));
-			reuse.setField(copy, i);
+            Object field = from.getField(i);
+            if (field != null) {
+                Object copy = fieldSerializers[i].copy(field);
+                reuse.setField(copy, i);
+            } else {
+                reuse.setField(null, i);
+            }
 		}
-		
 		return reuse;
 	}
 
 	@Override
 	public void serialize(T value, DataOutputView target) throws IOException {
-		for (int i = 0; i < arity; i++) {
-			Object o = value.getField(i);
-			try {
-				fieldSerializers[i].serialize(o, target);
-			} catch (NullPointerException npex) {
-				throw new NullFieldException(i);
-			}
-		}
-	}
+        BitSet bitIndicator = new BitSet(arity);
+        for (int i = 0; i < arity; i++) {
+            Object o = value.getField(i);
+            bitIndicator.set(i,o != null);
+        }
+        target.write(bitIndicator.toByteArray());
+
+        for (int i = 0; i < arity; i++) {
+            Object o = value.getField(i);
+            if (o != null) {
+                fieldSerializers[i].serialize(o, target);
+            }
+        }
+    }
 
 	@Override
 	public T deserialize(DataInputView source) throws IOException {
 		T tuple = instantiateRaw();
+
+        int bitSetSize = (arity/8)+1;
+        byte[] buffer = new byte[bitSetSize];
+        source.read(buffer);
+        BitSet bitIndicator = BitSet.valueOf(buffer);
+
 		for (int i = 0; i < arity; i++) {
-			Object field = fieldSerializers[i].deserialize(source);
-			tuple.setField(field, i);
+            if(!bitIndicator.get(i)){
+                tuple.setField(null,i);
+            } else {
+                Object field = fieldSerializers[i].deserialize(source);
+                tuple.setField(field, i);
+            }
 		}
 		return tuple;
 	}
-	
+
 	@Override
 	public T deserialize(T reuse, DataInputView source) throws IOException {
+        int bitSetSize = (arity/8)+1;
+        byte[] buffer = new byte[bitSetSize];
+        source.read(buffer);
+        BitSet bitIndicator = BitSet.valueOf(buffer);
+
 		for (int i = 0; i < arity; i++) {
-			Object field = fieldSerializers[i].deserialize(reuse.getField(i), source);
-			reuse.setField(field, i);
+            if(!bitIndicator.get(i)){
+                reuse.setField(null,i);
+            } else {
+                Object field = fieldSerializers[i].deserialize(reuse.getField(i), source);
+                reuse.setField(field, i);
+            }
 		}
 		return reuse;
 	}
-	
+
 	private T instantiateRaw() {
 		try {
 			return tupleClass.newInstance();

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTest.java
@@ -207,6 +207,16 @@ public class TupleSerializerTest {
 		runTests(testTuples);
 	}
 
+	@Test
+	public void testTupleWithNull() {
+		@SuppressWarnings("unchecked")
+		Tuple2<Integer,String>[] testTuples = new Tuple2[] {
+				new Tuple2<Integer,String>(0,"a"), new Tuple2<Integer,String>(1,"b"), new Tuple2<Integer,String>(-1,null)
+		};
+
+		runTests(testTuples);
+	}
+
 	private <T extends Tuple> void runTests(T... instances) {
 		try {
 			TupleTypeInfo<T> tupleTypeInfo = (TupleTypeInfo<T>) TypeExtractor.getForObject(instances[0]);

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTestInstance.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTestInstance.java
@@ -19,15 +19,15 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-
 import org.apache.flink.api.common.typeutils.SerializerTestInstance;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.junit.Assert;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TupleSerializerTestInstance<T extends Tuple> extends SerializerTestInstance<T> {
 
@@ -41,8 +41,8 @@ public class TupleSerializerTestInstance<T extends Tuple> extends SerializerTest
 		for (int i = 0; i < shouldTuple.getArity(); i++) {
 			Object should = shouldTuple.getField(i);
 			Object is = isTuple.getField(i);
-			
-			if (should.getClass().isArray()) {
+
+			if (should != null && should.getClass().isArray()) {
 				if (should instanceof boolean[]) {
 					Assert.assertTrue(message, Arrays.equals((boolean[]) should, (boolean[]) is));
 				}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTest.scala
@@ -205,6 +205,12 @@ class TupleSerializerTest {
     runTests(testTuples)
   }
 
+  @Test
+  def testTupleWithNull(): Unit = {
+    val testTuples = Array((0,"a"), (1,"b"), (-1,null))
+    runTests(testTuples)
+  }
+
   private final def runTests[T <: Product : TypeInformation](instances: Array[T]) {
     try {
       // Register the custom Kryo Serializer

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTestInstance.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTestInstance.scala
@@ -17,11 +17,9 @@
  */
 package org.apache.flink.api.scala.runtime
 
+import org.apache.flink.api.common.typeutils.{SerializerTestInstance, TypeSerializer}
 import org.junit.Assert._
-import org.apache.flink.api.common.typeutils.SerializerTestInstance
-import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.junit.Assert
-import org.junit.Test
+import org.junit.{Assert, Test}
 
 
 class TupleSerializerTestInstance[T <: Product] (
@@ -57,7 +55,7 @@ class TupleSerializerTestInstance[T <: Product] (
     for (i <- 0 until shouldTuple.productArity) {
       val should = shouldTuple.productElement(i)
       val is = isTuple.productElement(i)
-      if (should.getClass.isArray) {
+      if (should != null && should.getClass.isArray) {
         should match {
           case booleans: Array[Boolean] =>
             Assert.assertTrue(message, booleans.sameElements(is.asInstanceOf[Array[Boolean]]))


### PR DESCRIPTION
When serializing, we add a `byte[] (BitSet.toByteArray)` before the fields which indicates `null` fields. 

When deserializing, we fetch the `byte[]` and obtain the underlying `BitSet (BitSet.valueOf)`. `BitSet.get(index)` is `false` when the value is `null`. For each field element we check if the its marked as `null` in the `BitSet` and then pass it to the fieldSerializer.