### PR TITLE
[FLINK-2279] [streaming] Add Connected Iteration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/AbstractRichFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/AbstractRichFunction.java
@@ -1,5 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
+c * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
@@ -61,8 +61,12 @@ public class ConnectedDataStream<IN1, IN2> {
 	protected ConnectedDataStream(DataStream<IN1> input1, DataStream<IN2> input2) {
 		this.jobGraphBuilder = input1.streamGraph;
 		this.environment = input1.environment;
-		this.dataStream1 = input1.copy();
-		this.dataStream2 = input2.copy();
+		if (input1 != null) {
+			this.dataStream1 = input1.copy();
+		}
+		if (input2 != null) {
+			this.dataStream2 = input2.copy();
+		}
 
 		if ((input1 instanceof GroupedDataStream) && (input2 instanceof GroupedDataStream)) {
 			this.isGrouped = true;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -539,12 +539,18 @@ public class DataStream<OUT> {
 	 * this IterativeDataStream will be the iteration head. The data stream
 	 * given to the {@link IterativeDataStream#closeWith(DataStream)} method is
 	 * the data stream that will be fed back and used as the input for the
-	 * iteration head. A common usage pattern for streaming iterations is to use
-	 * output splitting to send a part of the closing data stream to the head.
-	 * Refer to {@link #split(OutputSelector)} for more information.
+	 * iteration head. The user can also use different feedback type than the
+	 * input of the iteration and treat the input and feedback streams as a
+	 * {@link ConnectedDataStream} be calling
+	 * {@link IterativeDataStream#withFeedbackType(TypeInfo)}
+	 * <p>
+	 * A common usage pattern for streaming iterations is to use output
+	 * splitting to send a part of the closing data stream to the head. Refer to
+	 * {@link #split(OutputSelector)} for more information.
 	 * <p>
 	 * The iteration edge will be partitioned the same way as the first input of
-	 * the iteration head.
+	 * the iteration head unless it is changed in the
+	 * {@link IterativeDataStream#closeWith(DataStream, boolean)} call.
 	 * <p>
 	 * By default a DataStream with iteration will never terminate, but the user
 	 * can use the maxWaitTime parameter to set a max waiting time for the
@@ -564,12 +570,18 @@ public class DataStream<OUT> {
 	 * this IterativeDataStream will be the iteration head. The data stream
 	 * given to the {@link IterativeDataStream#closeWith(DataStream)} method is
 	 * the data stream that will be fed back and used as the input for the
-	 * iteration head. A common usage pattern for streaming iterations is to use
-	 * output splitting to send a part of the closing data stream to the head.
-	 * Refer to {@link #split(OutputSelector)} for more information.
+	 * iteration head. The user can also use different feedback type than the
+	 * input of the iteration and treat the input and feedback streams as a
+	 * {@link ConnectedDataStream} be calling
+	 * {@link IterativeDataStream#withFeedbackType(TypeInfo)}
+	 * <p>
+	 * A common usage pattern for streaming iterations is to use output
+	 * splitting to send a part of the closing data stream to the head. Refer to
+	 * {@link #split(OutputSelector)} for more information.
 	 * <p>
 	 * The iteration edge will be partitioned the same way as the first input of
-	 * the iteration head.
+	 * the iteration head unless it is changed in the
+	 * {@link IterativeDataStream#closeWith(DataStream, boolean)} call.
 	 * <p>
 	 * By default a DataStream with iteration will never terminate, but the user
 	 * can use the maxWaitTime parameter to set a max waiting time for the
@@ -1309,15 +1321,15 @@ public class DataStream<OUT> {
 		
 		if (iterationID != null) {
 			//This data stream is an input to some iteration
-			addIterationSource(returnStream);
+			addIterationSource(returnStream, null);
 		}
 
 		return returnStream;
 	}
 	
-	private <X> void addIterationSource(DataStream<X> dataStream) {
+	protected <X> void addIterationSource(DataStream<X> dataStream, TypeInformation<?> feedbackType) {
 		Integer id = ++counter;
-		streamGraph.addIterationHead(id, dataStream.getId(), iterationID, iterationWaitTime);
+		streamGraph.addIterationHead(id, dataStream.getId(), iterationID, iterationWaitTime, feedbackType);
 		streamGraph.setParallelism(id, dataStream.getParallelism());
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/IterativeDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/IterativeDataStream.java
@@ -17,6 +17,12 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.TypeInfoParser;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+
 /**
  * The iterative data stream represents the start of an iteration in a
  * {@link DataStream}.
@@ -45,16 +51,13 @@ public class IterativeDataStream<IN> extends
 	 * {@link DataStream#split(org.apache.flink.streaming.api.collector.selector.OutputSelector)}
 	 * for more information.
 	 * 
-	 * 
-	 * 
-	 * 
-	 * @param iterationTail
-	 *            The data stream that is fed back to the next iteration head.
+	 * @param feedbackStream
+	 *            {@link DataStream} that will be used as input to the iteration
+	 *            head.
 	 * @param keepPartitioning
 	 *            If true the feedback partitioning will be kept as it is (not
 	 *            changed to match the input of the iteration head)
-	 * @return Returns the stream that was fed back to the iteration. In most
-	 *         cases no further transformation are applied on this stream.
+	 * @return The feedback stream.
 	 * 
 	 */
 	public DataStream<IN> closeWith(DataStream<IN> iterationTail, boolean keepPartitioning) {
@@ -83,13 +86,164 @@ public class IterativeDataStream<IN> extends
 	 * for more information.
 	 * 
 	 * 
-	 * @param iterationTail
-	 *            The data stream that is fed back to the next iteration head.
-	 * @return Returns the stream that was fed back to the iteration. In most
-	 *         cases no further transformation are applied on this stream.
+	 * @param feedbackStream
+	 *            {@link DataStream} that will be used as input to the
+	 *            iteration head.
+	 * @return The feedback stream.
 	 * 
 	 */
 	public DataStream<IN> closeWith(DataStream<IN> iterationTail) {
 		return closeWith(iterationTail,false);
+	}
+
+	/**
+	 * Changes the feedback type of the iteration and allows the user to apply
+	 * co-transformations on the input and feedback stream, as in a
+	 * {@link ConnectedDataStream}.
+	 * <p>
+	 * For type safety the user needs to define the feedback type
+	 * 
+	 * @param feedbackTypeString
+	 *            String describing the type information of the feedback stream.
+	 * @return A {@link ConnectedIterativeDataStream}.
+	 */
+	public <F> ConnectedIterativeDataStream<IN, F> withFeedbackType(String feedbackTypeString) {
+		return withFeedbackType(TypeInfoParser.<F> parse(feedbackTypeString));
+	}
+
+	/**
+	 * Changes the feedback type of the iteration and allows the user to apply
+	 * co-transformations on the input and feedback stream, as in a
+	 * {@link ConnectedDataStream}.
+	 * <p>
+	 * For type safety the user needs to define the feedback type
+	 * 
+	 * @param feedbackTypeClass
+	 *            Class of the elements in the feedback stream.
+	 * @return A {@link ConnectedIterativeDataStream}.
+	 */
+	public <F> ConnectedIterativeDataStream<IN, F> withFeedbackType(Class<F> feedbackTypeClass) {
+		return withFeedbackType(TypeExtractor.getForClass(feedbackTypeClass));
+	}
+
+	/**
+	 * Changes the feedback type of the iteration and allows the user to apply
+	 * co-transformations on the input and feedback stream, as in a
+	 * {@link ConnectedDataStream}.
+	 * <p>
+	 * For type safety the user needs to define the feedback type
+	 * 
+	 * @param feedbackType
+	 *            The type information of the feedback stream.
+	 * @return A {@link ConnectedIterativeDataStream}.
+	 */
+	public <F> ConnectedIterativeDataStream<IN, F> withFeedbackType(TypeInformation<F> feedbackType) {
+		return new ConnectedIterativeDataStream<IN, F>(this, feedbackType);
+	}
+	
+	/**
+	 * The {@link ConnectedIterativeDataStream} represent a start of an
+	 * iterative part of a streaming program, where the original input of the
+	 * iteration and the feedback of the iteration are connected as in a
+	 * {@link ConnectedDataStream}.
+	 * <p>
+	 * The user can distinguish between the two inputs using co-transformation,
+	 * thus eliminating the need for mapping the inputs and outputs to a common
+	 * type.
+	 * 
+	 * @param <I>
+	 *            Type of the input of the iteration
+	 * @param <F>
+	 *            Type of the feedback of the iteration
+	 */
+	public static class ConnectedIterativeDataStream<I, F> extends ConnectedDataStream<I, F>{
+
+		private IterativeDataStream<I> input;
+		private TypeInformation<F> feedbackType;
+
+		public ConnectedIterativeDataStream(IterativeDataStream<I> input, TypeInformation<F> feedbackType) {
+			super(input, null);
+			this.input = input;
+			this.feedbackType = feedbackType;
+		}
+		
+		@Override
+		public TypeInformation<F> getType2() {
+			return feedbackType;
+		}
+		
+		@Override
+		public <OUT> SingleOutputStreamOperator<OUT, ?> transform(String functionName,
+				TypeInformation<OUT> outTypeInfo, TwoInputStreamOperator<I, F, OUT> operator) {
+
+			@SuppressWarnings({ "unchecked", "rawtypes" })
+			SingleOutputStreamOperator<OUT, ?> returnStream = new SingleOutputStreamOperator(
+					input.environment, outTypeInfo, operator);
+
+			input.streamGraph.addCoOperator(returnStream.getId(), operator, input.getType(),
+					feedbackType, outTypeInfo, functionName);
+
+			input.connectGraph(input, returnStream.getId(), 1);
+			
+			input.addIterationSource(returnStream, feedbackType);
+
+			return returnStream;
+		}
+		
+		/**
+		 * Closes the iteration. This method defines the end of the iterative
+		 * program part that will be fed back to the start of the iteration as
+		 * the second input in the {@link ConnectedDataStream}.
+		 * 
+		 * @param feedbackStream
+		 *            {@link DataStream} that will be used as second input to
+		 *            the iteration head.
+		 * @return The feedback stream.
+		 * 
+		 */
+		public DataStream<F> closeWith(DataStream<F> feedbackStream) {
+			DataStream<F> iterationSink = new DataStreamSink<F>(input.environment, "Iteration Sink",
+					null, null);
+			
+			input.streamGraph.addIterationTail(iterationSink.getId(), feedbackStream.getId(), input.iterationID,
+					input.iterationWaitTime);
+
+			input.connectGraph(feedbackStream, iterationSink.getId(), 0);
+			return feedbackStream;
+		}
+		
+		private UnsupportedOperationException groupingException = new UnsupportedOperationException(
+				"Cannot change the input partitioning of an iteration head directly. Apply the partitioning on the input and feedback streams instead.");
+		
+		@Override
+		public ConnectedDataStream<I, F> groupBy(int keyPosition1, int keyPosition2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> groupBy(int[] keyPositions1, int[] keyPositions2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> groupBy(String field1, String field2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> groupBy(String[] fields1, String[] fields2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> groupBy(KeySelector<I, ?> keySelector1,KeySelector<F, ?> keySelector2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> partitionByHash(int keyPosition1, int keyPosition2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> partitionByHash(int[] keyPositions1, int[] keyPositions2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> partitionByHash(String field1, String field2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> partitionByHash(String[] fields1, String[] fields2) {throw groupingException;}
+		
+		@Override
+		public ConnectedDataStream<I, F> partitionByHash(KeySelector<I, ?> keySelector1, KeySelector<F, ?> keySelector2) {throw groupingException;}
+		
 	}
 }


### PR DESCRIPTION
This PR introduces a new feature that allows the users to treat the iteration head in a streaming iteration as a ConnectedDataStream of the original and feedback input.

This allows the users to write elegant code without wrapper types and flags to distinguish normal input from feedback.