### PR TITLE
[Flink-Gelly] added missing assumption to the pageRank example: this is a simplified implementation of the algorithm so pages…

### DIFF
--- a/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/PageRank.java
+++ b/flink-staging/flink-gelly/src/main/java/org/apache/flink/graph/example/PageRank.java
@@ -36,7 +36,8 @@ import org.apache.flink.util.Collector;
  *
  * The edges input file is expected to contain one edge per line, with long IDs and double
  * values, in the following format:"<sourceVertexID>\t<targetVertexID>\t<edgeValue>".
- *
+ * For this simple implementation it is required that each page has at least one incoming 
+ * and one outgoing link, otherwise the rank will differ from the theoretical value.
  * If no arguments are provided, the example runs with a random graph of 10 vertices
  * and random edge weights.
  *


### PR DESCRIPTION
… must have at least one incoming and one outgoing link