### PR TITLE
[FLINK-2321] [ml]  The seed for the SVM classifier is currently static

### DIFF
--- a/docs/libs/ml/svm.md
+++ b/docs/libs/ml/svm.md
@@ -181,7 +181,7 @@ The SVM implementation can be controlled by the following parameters:
         <p>
           Defines the seed to initialize the random number generator.
           The seed directly controls which data points are chosen for the SDCA method.
-          (Default value: <strong>0</strong>)
+          (Default value: <strong>Random Long Integer</strong>)
         </p>
       </td>
     </tr>

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
@@ -260,7 +260,7 @@ object SVM{
   }
 
   case object Seed extends Parameter[Long] {
-    val defaultValue = Some(0L)
+    val defaultValue = Some(Random.nextLong())
   }
 
   case object ThresholdValue extends Parameter[Double] {


### PR DESCRIPTION
The seed for the SVM algorithm in FlinkML has a default value of 0, meaning that if it's not set, we always have the same seed when running the algorithm.

What should happen instead is that if the seed is not set, it should be a random number.

This PR introduces a random seed instead.