### PR TITLE
[FLINK-2329] [runtime] Introduces InstanceGateway for RPCs from Executions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import akka.actor.ActorRef;
-
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
@@ -30,6 +28,7 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
+import org.apache.flink.runtime.instance.InstanceGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -101,14 +100,20 @@ public class ExecutionVertex implements Serializable {
 
 	// --------------------------------------------------------------------------------------------
 
-	public ExecutionVertex(ExecutionJobVertex jobVertex, int subTaskIndex,
-						IntermediateResult[] producedDataSets, FiniteDuration timeout) {
+	public ExecutionVertex(
+			ExecutionJobVertex jobVertex,
+			int subTaskIndex,
+			IntermediateResult[] producedDataSets,
+			FiniteDuration timeout) {
 		this(jobVertex, subTaskIndex, producedDataSets, timeout, System.currentTimeMillis());
 	}
 
-	public ExecutionVertex(ExecutionJobVertex jobVertex, int subTaskIndex,
-						IntermediateResult[] producedDataSets, FiniteDuration timeout,
-						long createTimestamp) {
+	public ExecutionVertex(
+			ExecutionJobVertex jobVertex,
+			int subTaskIndex,
+			IntermediateResult[] producedDataSets,
+			FiniteDuration timeout,
+			long createTimestamp) {
 		this.jobVertex = jobVertex;
 		this.subTaskIndex = subTaskIndex;
 
@@ -125,7 +130,12 @@ public class ExecutionVertex implements Serializable {
 
 		this.priorExecutions = new CopyOnWriteArrayList<Execution>();
 
-		this.currentExecution = new Execution(this, 0, createTimestamp, timeout);
+		this.currentExecution = new Execution(
+			getExecutionGraph().getExecutionContext(),
+			this,
+			0,
+			createTimestamp,
+			timeout);
 
 		// create a co-location scheduling hint, if necessary
 		CoLocationGroup clg = jobVertex.getCoLocationGroup();
@@ -412,8 +422,12 @@ public class ExecutionVertex implements Serializable {
 
 			if (state == FINISHED || state == CANCELED || state == FAILED) {
 				priorExecutions.add(execution);
-				currentExecution = new Execution(this, execution.getAttemptNumber()+1,
-						System.currentTimeMillis(), timeout);
+				currentExecution = new Execution(
+					getExecutionGraph().getExecutionContext(),
+					this,
+					execution.getAttemptNumber()+1,
+					System.currentTimeMillis(),
+					timeout);
 
 				CoLocationGroup grp = jobVertex.getCoLocationGroup();
 				if (grp != null) {
@@ -451,9 +465,9 @@ public class ExecutionVertex implements Serializable {
 			
 			// send only if we actually have a target
 			if (slot != null) {
-				ActorRef taskManager = slot.getInstance().getTaskManager();
-				if (taskManager != null) {
-					taskManager.tell(message, ActorRef.noSender());
+				InstanceGateway gateway = slot.getInstance().getInstanceGateway();
+				if (gateway != null) {
+					gateway.tell(message);
 				}
 			}
 			else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/AkkaInstanceGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/AkkaInstanceGateway.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorRef;
+import akka.pattern.Patterns;
+import akka.util.Timeout;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * InstanceGateway implementation which uses Akka to communicate with remote instances.
+ */
+public class AkkaInstanceGateway implements InstanceGateway {
+
+	/** ActorRef of the remote instance */
+	private final ActorRef taskManager;
+
+	public AkkaInstanceGateway(ActorRef taskManager) {
+		this.taskManager = taskManager;
+	}
+
+	/**
+	 * Sends a message asynchronously and returns its response. The response to the message is
+	 * returned as a future.
+	 *
+	 * @param message Message to be sent
+	 * @param timeout Timeout until the Future is completed with an AskTimeoutException
+	 * @return Future which contains the response to the sent message
+	 */
+	@Override
+	public Future<Object> ask(Object message, FiniteDuration timeout) {
+		return Patterns.ask(taskManager, message, new Timeout(timeout));
+	}
+
+	/**
+	 * Sends a message asynchronously without a result.
+	 *
+	 * @param message Message to be sent
+	 */
+	@Override
+	public void tell(Object message) {
+		taskManager.tell(message, ActorRef.noSender());
+	}
+
+	/**
+	 * Forwards a message. For the receiver of this message it looks as if sender has sent the
+	 * message.
+	 *
+	 * @param message Message to be sent
+	 * @param sender Sender of the forwarded message
+	 */
+	@Override
+	public void forward(Object message, ActorRef sender) {
+		taskManager.tell(message, sender);
+	}
+
+	/**
+	 * Retries to send asynchronously a message up to numberRetries times. The response to this
+	 * message is returned as a future. The message is re-sent if the number of retries is not yet
+	 * exceeded and if an exception occurred while sending it.
+	 *
+	 * @param message Message to be sent
+	 * @param numberRetries Number of times to retry sending the message
+	 * @param timeout Timeout for each sending attempt
+	 * @param executionContext ExecutionContext which is used to send the message multiple times
+	 * @return Future of the response to the sent message
+	 */
+	@Override
+	public Future<Object> retry(
+			Object message,
+			int numberRetries,
+			FiniteDuration timeout,
+			ExecutionContext executionContext) {
+
+		return AkkaUtils.retry(
+			taskManager,
+			message,
+			numberRetries,
+			executionContext,
+			timeout);
+	}
+
+	/**
+	 * Returns the ActorPath of the remote instance.
+	 *
+	 * @return ActorPath of the remote instance.
+	 */
+	@Override
+	public String path() {
+		return taskManager.path().toString();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceGateway.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorRef;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Interface to abstract the communication with an Instance.
+ *
+ * It allows to avoid direct interaction with an ActorRef.
+ */
+public interface InstanceGateway {
+
+	/**
+	 * Sends a message asynchronously and returns its response. The response to the message is
+	 * returned as a future.
+	 *
+	 * @param message Message to be sent
+	 * @param timeout Timeout until the Future is completed with an AskTimeoutException
+	 * @return Future which contains the response to the sent message
+	 */
+	Future<Object> ask(Object message, FiniteDuration timeout);
+
+	/**
+	 * Sends a message asynchronously without a result.
+	 *
+	 * @param message Message to be sent
+	 */
+	void tell(Object message);
+
+	/**
+	 * Forwards a message. For the receiver of this message it looks as if sender has sent the
+	 * message.
+	 *
+	 * @param message Message to be sent
+	 * @param sender Sender of the forwarded message
+	 */
+	void forward(Object message, ActorRef sender);
+
+	/**
+	 * Retries to send asynchronously a message up to numberRetries times. The response to this
+	 * message is returned as a future. The message is re-sent if the number of retries is not yet
+	 * exceeded and if an exception occurred while sending it.
+	 *
+	 * @param message Message to be sent
+	 * @param numberRetries Number of times to retry sending the message
+	 * @param timeout Timeout for each sending attempt
+	 * @param executionContext ExecutionContext which is used to send the message multiple times
+	 * @return Future of the response to the sent message
+	 */
+	Future<Object> retry(
+			Object message,
+			int numberRetries,
+			FiniteDuration timeout,
+			ExecutionContext executionContext);
+
+	/**
+	 * Returns the path of the remote instance.
+	 *
+	 * @return Path of the remote instance.
+	 */
+	String path();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
@@ -149,8 +149,9 @@ public class InstanceManager {
 				id = new InstanceID();
 			} while (registeredHostsById.containsKey(id));
 
+			InstanceGateway instanceGateway = new AkkaInstanceGateway(taskManager);
 
-			Instance host = new Instance(taskManager, connectionInfo, id, resources, numberOfSlots);
+			Instance host = new Instance(instanceGateway, connectionInfo, id, resources, numberOfSlots);
 
 			registeredHostsById.put(id, host);
 			registeredHostsByConnection.put(taskManager, host);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
@@ -146,8 +146,7 @@ public class SetupInfoServlet extends HttpServlet {
 				long time = new Date().getTime() - instance.getLastHeartBeat();
 
 				try {
-					objInner.put("inetAdress", instance.getInstanceConnectionInfo().getInetAdress());
-					objInner.put("ipcPort", instance.getTaskManager().path().address().hostPort());
+					objInner.put("path", instance.getInstanceGateway().path());
 					objInner.put("dataPort", instance.getInstanceConnectionInfo().dataPort());
 					objInner.put("timeSinceLastHeartbeat", time / 1000);
 					objInner.put("slotsNumber", instance.getTotalNumberOfSlots());

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -224,7 +224,7 @@ function processTMdata(json) {
                                "</div>";
 
             var content = "<tr id=\""+tmRowIdCssName+"\">" +
-		                "<td style=\"width:20%\">"+tm.inetAdress+" <br> IPC Port: "+tm.ipcPort+", Data Port: "+tm.dataPort+"</td>" + // first row: TaskManager
+		                "<td style=\"width:20%\">"+tm.path+" <br> Data Port: "+tm.dataPort+"</td>" + // first row: TaskManager
 		                "<td id=\""+tmRowIdCssName+"-memory\">"+tmMemoryBox+"</td>" + // second row: memory statistics
 		                "<td id=\""+tmRowIdCssName+"-info\"><i>Loading Information</i></td>" + // Information
 		                "</tr>";

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -41,8 +41,6 @@ object AkkaUtils {
 
   val INF_TIMEOUT = 21474835 seconds
 
-  var globalExecutionContext: ExecutionContext = ExecutionContext.global
-
   /**
    * Creates a local actor system without remoting.
    *

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -59,6 +59,7 @@ import akka.actor._
 
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.concurrent.forkjoin.ForkJoinPool
 import scala.language.postfixOps
 import scala.collection.JavaConverters._
 
@@ -89,16 +90,18 @@ import scala.collection.JavaConverters._
  * - [[JobStatusChanged]] indicates that the status of job (RUNNING, CANCELING, FINISHED, etc.) has
  * changed. This message is sent by the ExecutionGraph.
  */
-class JobManager(protected val flinkConfiguration: Configuration,
-                 protected val instanceManager: InstanceManager,
-                 protected val scheduler: FlinkScheduler,
-                 protected val libraryCacheManager: BlobLibraryCacheManager,
-                 protected val archive: ActorRef,
-                 protected val accumulatorManager: AccumulatorManager,
-                 protected val defaultExecutionRetries: Int,
-                 protected val delayBetweenRetries: Long,
-                 protected val timeout: FiniteDuration,
-                 protected val mode: StreamingMode)
+class JobManager(
+    protected val flinkConfiguration: Configuration,
+    protected val executionContext: ExecutionContext,
+    protected val instanceManager: InstanceManager,
+    protected val scheduler: FlinkScheduler,
+    protected val libraryCacheManager: BlobLibraryCacheManager,
+    protected val archive: ActorRef,
+    protected val accumulatorManager: AccumulatorManager,
+    protected val defaultExecutionRetries: Int,
+    protected val delayBetweenRetries: Long,
+    protected val timeout: FiniteDuration,
+    protected val mode: StreamingMode)
   extends Actor with ActorLogMessages with ActorSynchronousLogging {
 
   /** List of current jobs running jobs */
@@ -117,7 +120,7 @@ class JobManager(protected val flinkConfiguration: Configuration,
 
     // disconnect the registered task managers
     instanceManager.getAllRegisteredInstances.asScala.foreach {
-      _.getTaskManager ! Disconnect("JobManager is shutting down")
+      _.getInstanceGateway().tell(Disconnect("JobManager is shutting down"))
     }
 
     archive ! PoisonPill
@@ -136,7 +139,6 @@ class JobManager(protected val flinkConfiguration: Configuration,
     }
 
     log.debug(s"Job manager ${self.path} is completely stopped.")
-
   }
 
   /**
@@ -411,8 +413,8 @@ class JobManager(protected val flinkConfiguration: Configuration,
     case message: AccumulatorMessage => handleAccumulatorMessage(message)
 
     case RequestStackTrace(instanceID) =>
-      val taskManager = instanceManager.getRegisteredInstanceById(instanceID).getTaskManager
-      taskManager forward SendStackTrace
+      val gateway = instanceManager.getRegisteredInstanceById(instanceID).getInstanceGateway
+      gateway.forward(SendStackTrace, sender)
 
     case Terminated(taskManager) =>
       if (instanceManager.isRegistered(taskManager)) {
@@ -480,10 +482,18 @@ class JobManager(protected val flinkConfiguration: Configuration,
         }
 
         // see if there already exists an ExecutionGraph for the corresponding job ID
-        executionGraph = currentJobs.getOrElseUpdate(jobGraph.getJobID,
-          (new ExecutionGraph(jobGraph.getJobID, jobGraph.getName,
-            jobGraph.getJobConfiguration, timeout, jobGraph.getUserJarBlobKeys, userCodeLoader),
-            JobInfo(sender(), System.currentTimeMillis())))._1
+        executionGraph = currentJobs.getOrElseUpdate(
+          jobGraph.getJobID,
+          (new ExecutionGraph(
+            executionContext,
+            jobGraph.getJobID,
+            jobGraph.getName,
+            jobGraph.getJobConfiguration,
+            timeout,
+            jobGraph.getUserJarBlobKeys,
+            userCodeLoader),
+            JobInfo(sender(), System.currentTimeMillis()))
+        )._1
 
         // configure the execution graph
         val jobNumberRetries = if (jobGraph.getNumberOfExecutionRetries >= 0) {
@@ -1008,8 +1018,8 @@ object JobManager {
    * @param configuration The configuration from which to parse the config values.
    * @return The members for a default JobManager.
    */
-  def createJobManagerComponents(configuration: Configuration) :
-    (InstanceManager, FlinkScheduler, BlobLibraryCacheManager,
+  def createJobManagerComponents(configuration: Configuration)
+    : (ExecutionContext, InstanceManager, FlinkScheduler, BlobLibraryCacheManager,
       Props, AccumulatorManager, Int, Long, FiniteDuration, Int) = {
 
     val timeout: FiniteDuration = AkkaUtils.getTimeout(configuration)
@@ -1045,6 +1055,8 @@ object JobManager {
 
     val accumulatorManager: AccumulatorManager = new AccumulatorManager(Math.min(1, archiveCount))
 
+    val executionContext = ExecutionContext.fromExecutor(new ForkJoinPool())
+
     var blobServer: BlobServer = null
     var instanceManager: InstanceManager = null
     var scheduler: FlinkScheduler = null
@@ -1053,7 +1065,7 @@ object JobManager {
     try {
       blobServer = new BlobServer(configuration)
       instanceManager = new InstanceManager()
-      scheduler = new FlinkScheduler()
+      scheduler = new FlinkScheduler(executionContext)
       libraryCacheManager = new BlobLibraryCacheManager(blobServer, cleanupInterval)
 
       instanceManager.addInstanceListener(scheduler)
@@ -1076,8 +1088,16 @@ object JobManager {
       }
     }
 
-    (instanceManager, scheduler, libraryCacheManager, archiveProps, accumulatorManager,
-      executionRetries, delayBetweenRetries, timeout, archiveCount)
+    (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      archiveProps,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      archiveCount)
   }
 
   /**
@@ -1116,9 +1136,16 @@ object JobManager {
                             archiverActorName: Option[String],
                             streamingMode: StreamingMode): (ActorRef, ActorRef) = {
 
-    val (instanceManager, scheduler, libraryCacheManager, archiveProps, accumulatorManager,
-      executionRetries, delayBetweenRetries,
-      timeout, _) = createJobManagerComponents(configuration)
+    val (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      archiveProps,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      _) = createJobManagerComponents(configuration)
 
     // start the archiver with the given name, or without (avoid name conflicts)
     val archiver: ActorRef = archiverActorName match {
@@ -1126,9 +1153,19 @@ object JobManager {
       case None => actorSystem.actorOf(archiveProps)
     }
 
-    val jobManagerProps = Props(classOf[JobManager], configuration, instanceManager, scheduler,
-        libraryCacheManager, archiver, accumulatorManager, executionRetries,
-        delayBetweenRetries, timeout, streamingMode)
+    val jobManagerProps = Props(
+      classOf[JobManager],
+      configuration,
+      executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      archiver,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      streamingMode)
 
     val jobManager: ActorRef = jobMangerActorName match {
       case Some(actorName) => actorSystem.actorOf(jobManagerProps, actorName)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -65,6 +65,7 @@ import org.apache.flink.runtime.util.{MathUtils, EnvironmentInformation}
 
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.concurrent.forkjoin.ForkJoinPool
 import scala.util.{Failure, Success}
 import scala.collection.JavaConverters._
 
@@ -1357,14 +1358,16 @@ object TaskManager {
   @throws(classOf[IllegalConfigurationException])
   @throws(classOf[IOException])
   @throws(classOf[Exception])
-  def startTaskManagerComponentsAndActor(configuration: Configuration,
-                                         actorSystem: ActorSystem,
-                                         taskManagerHostname: String,
-                                         taskManagerActorName: Option[String],
-                                         jobManagerPath: Option[String],
-                                         localTaskManagerCommunication: Boolean,
-                                         streamingMode: StreamingMode,
-                                         taskManagerClass: Class[_ <: TaskManager]): ActorRef = {
+  def startTaskManagerComponentsAndActor(
+      configuration: Configuration,
+      actorSystem: ActorSystem,
+      taskManagerHostname: String,
+      taskManagerActorName: Option[String],
+      jobManagerPath: Option[String],
+      localTaskManagerCommunication: Boolean,
+      streamingMode: StreamingMode,
+      taskManagerClass: Class[_ <: TaskManager])
+    : ActorRef = {
 
     // get and check the JobManager config
     val jobManagerAkkaUrl: String = jobManagerPath.getOrElse {
@@ -1374,17 +1377,20 @@ object TaskManager {
     }
 
     val (taskManagerConfig : TaskManagerConfiguration,
-         netConfig: NetworkEnvironmentConfiguration,
-         connectionInfo: InstanceConnectionInfo)
-
-         = parseTaskManagerConfiguration(configuration, taskManagerHostname,
-                                         localTaskManagerCommunication)
+      netConfig: NetworkEnvironmentConfiguration,
+      connectionInfo: InstanceConnectionInfo
+    ) = parseTaskManagerConfiguration(
+      configuration,
+      taskManagerHostname,
+      localTaskManagerCommunication)
 
     // pre-start checks
     checkTempDirs(taskManagerConfig.tmpDirPaths)
 
+    val executionContext = ExecutionContext.fromExecutor(new ForkJoinPool())
+
     // we start the network first, to make sure it can allocate its buffers first
-    val network = new NetworkEnvironment(taskManagerConfig.timeout, netConfig)
+    val network = new NetworkEnvironment(executionContext, taskManagerConfig.timeout, netConfig)
 
     // computing the amount of memory to use depends on how much memory is available
     // it strictly needs to happen AFTER the network stack has been initialized

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,6 +44,7 @@ public class AllVerticesIteratorTest {
 			v4.setParallelism(2);
 			
 			ExecutionGraph eg = Mockito.mock(ExecutionGraph.class);
+			Mockito.when(eg.getExecutionContext()).thenReturn(TestingUtils.directExecutionContext());
 					
 			ExecutionJobVertex ejv1 = new ExecutionJobVertex(eg, v1, 1,
 					AkkaUtils.getDefaultTimeout());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -99,7 +100,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -137,7 +143,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -198,7 +209,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -446,7 +462,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -496,7 +517,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v5, v4));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 			fail("Attached wrong jobgraph");
@@ -551,7 +577,11 @@ public class ExecutionGraphConstructionTest {
 			
 			List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jobId,
+					jobName,
+					cfg,
 					AkkaUtils.getDefaultTimeout());
 			try {
 				eg.attachJobGraph(ordered);
@@ -591,7 +621,11 @@ public class ExecutionGraphConstructionTest {
 			
 			List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jobId,
+					jobName,
+					cfg,
 					AkkaUtils.getDefaultTimeout());
 
 			try {
@@ -657,7 +691,11 @@ public class ExecutionGraphConstructionTest {
 			
 			JobGraph jg = new JobGraph(jobId, jobName, v1, v2, v3, v4, v5, v6, v7, v8);
 			
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jobId,
+					jobName,
+					cfg,
 					AkkaUtils.getDefaultTimeout());
 			eg.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -24,18 +24,11 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 
-import akka.actor.Actor;
-import akka.testkit.TestActorRef;
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.Status;
-import akka.actor.UntypedActor;
-import akka.japi.Creator;
-import akka.testkit.JavaTestKit;
-
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.instance.BaseTestingInstanceGateway;
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
+import org.apache.flink.runtime.instance.InstanceGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.api.common.JobID;
@@ -46,25 +39,11 @@ import org.apache.flink.runtime.messages.TaskMessages;
 import org.apache.flink.runtime.messages.TaskMessages.TaskOperationResult;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import scala.concurrent.ExecutionContext;
 
 @SuppressWarnings("serial")
 public class ExecutionVertexCancelTest {
-
-	private static ActorSystem system;
-
-	@BeforeClass
-	public static void setup(){
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-	}
-
-	@AfterClass
-	public static void teardown(){
-		JavaTestKit.shutdownActorSystem(system);
-		system = null;
-	}
 
 	// --------------------------------------------------------------------------------------------
 	//  Canceling in different states
@@ -127,388 +106,350 @@ public class ExecutionVertexCancelTest {
 
 	@Test
 	public void testCancelConcurrentlyToDeploying_CallsNotOvertaking() {
-		new JavaTestKit(system){{
-			try {
-				final JobVertexID jid = new JobVertexID();
-				final ActionQueue actions = new ActionQueue();
+		try {
+			final JobVertexID jid = new JobVertexID();
 
-				TestingUtils.setExecutionContext(new TestingUtils.QueuedActionExecutionContext(
-						actions));
-
-				final ExecutionJobVertex ejv = getExecutionVertex(jid);
-
-				final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-						AkkaUtils.getDefaultTimeout());
-				final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
-
-				setVertexState(vertex, ExecutionState.SCHEDULED);
-				assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
-
-				ActorRef taskManager = TestActorRef.create(system, Props.create(new
-						CancelSequenceTaskManagerCreator(new TaskOperationResult(execId, true),
-						new TaskOperationResult(execId, false))));
-
-				Instance instance = getInstance(taskManager);
-				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
-
-				vertex.deployToSlot(slot);
+			final TestingUtils.QueuedActionExecutionContext executionContext = TestingUtils.queuedActionExecutionContext();
+			final TestingUtils.ActionQueue actions = executionContext.actionQueue();
 
 
-				assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
+			final ExecutionJobVertex ejv = getExecutionVertex(
+				jid,
+				executionContext
+			);
 
-				vertex.cancel();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-				assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			setVertexState(vertex, ExecutionState.SCHEDULED);
+			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
 
-				// first action happens (deploy)
-				actions.triggerNextAction();
-				assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					executionContext,
+					new TaskOperationResult(execId, true),
+					new TaskOperationResult(execId, false));
 
-				// the deploy call found itself in canceling after it returned and needs to send a cancel call
-				// the call did not yet execute, so it is still in canceling
-				assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-				// second action happens (cancel call from cancel function)
-				actions.triggerNextAction();
+			vertex.deployToSlot(slot);
 
-				// TaskManager reports back (canceling done)
-				vertex.getCurrentExecutionAttempt().cancelingComplete();
+			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 
-				// should properly set state to cancelled
-				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			vertex.cancel();
 
-				// trigger the correction canceling call
-				actions.triggerNextAction();
-				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-				assertTrue(slot.isReleased());
+			// first action happens (deploy)
+			actions.triggerNextAction();
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-				assertNull(vertex.getFailureCause());
+			// the deploy call found itself in canceling after it returned and needs to send a cancel call
+			// the call did not yet execute, so it is still in canceling
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-				assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-				assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-				assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-			}
-			catch(Exception e) {
-				e.printStackTrace();
-				fail(e.getMessage());
-			}
-			finally {
-				TestingUtils.setGlobalExecutionContext();
-			}
-		}};
+			// second action happens (cancel call from cancel function)
+			actions.triggerNextAction();
+
+			// TaskManager reports back (canceling done)
+			vertex.getCurrentExecutionAttempt().cancelingComplete();
+
+			// should properly set state to cancelled
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+
+			// trigger the correction canceling call
+			actions.triggerNextAction();
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+
+			assertTrue(slot.isReleased());
+
+			assertNull(vertex.getFailureCause());
+
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelConcurrentlyToDeploying_CallsOvertaking() {
-		new JavaTestKit(system){
-			{
-				try {
-					final JobVertexID jid = new JobVertexID();
-					final ActionQueue actions = new ActionQueue();
+		try {
+			final JobVertexID jid = new JobVertexID();
 
-					TestingUtils.setExecutionContext(new TestingUtils
-							.QueuedActionExecutionContext(actions));
+			final TestingUtils.QueuedActionExecutionContext executionContext = TestingUtils.queuedActionExecutionContext();
+			final TestingUtils.ActionQueue actions = executionContext.actionQueue();
 
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, executionContext);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					setVertexState(vertex, ExecutionState.SCHEDULED);
-					assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
+			setVertexState(vertex, ExecutionState.SCHEDULED);
+			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
 
-					// task manager cancel sequence mock actor
-					// first return NOT SUCCESS (task not found, cancel call overtook deploy call), then success (cancel call after deploy call)
-					TestActorRef<? extends Actor> taskManager = TestActorRef.create(system, Props.create(new
-							CancelSequenceTaskManagerCreator(new
-							TaskOperationResult(execId, false), new TaskOperationResult(execId, true))));
+			// task manager cancel sequence mock actor
+			// first return NOT SUCCESS (task not found, cancel call overtook deploy call), then success (cancel call after deploy call)
+			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					executionContext,
+					new	TaskOperationResult(execId, false),
+					new TaskOperationResult(execId, true)
+			);
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					vertex.deployToSlot(slot);
+			vertex.deployToSlot(slot);
 
-					assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
+			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					// first action happens (deploy)
-					Runnable deployAction = actions.popNextAction();
-					Runnable cancelAction = actions.popNextAction();
+			// first action happens (deploy)
+			Runnable deployAction = actions.popNextAction();
+			Runnable cancelAction = actions.popNextAction();
 
-					// cancel call first
-					cancelAction.run();
-					// process onComplete callback
-					actions.triggerNextAction();
+			// cancel call first
+			cancelAction.run();
+			// process onComplete callback
+			actions.triggerNextAction();
 
-					// did not find the task, not properly cancelled, stay in canceling
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			// did not find the task, not properly cancelled, stay in canceling
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					// deploy action next
-					deployAction.run();
+			// deploy action next
+			deployAction.run();
 
-					// the deploy call found itself in canceling after it returned and needs to send a cancel call
-					// the call did not yet execute, so it is still in canceling
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			// the deploy call found itself in canceling after it returned and needs to send a cancel call
+			// the call did not yet execute, so it is still in canceling
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					vertex.getCurrentExecutionAttempt().cancelingComplete();
+			vertex.getCurrentExecutionAttempt().cancelingComplete();
 
-					assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNull(vertex.getFailureCause());
+			assertNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelFromRunning() {
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final TestActorRef<? extends Actor> taskManager = TestActorRef.create(system,
-							Props.create(new CancelSequenceTaskManagerCreator(new
-									TaskOperationResult(execId, true))));
+			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					TestingUtils.directExecutionContext(),
+					new TaskOperationResult(execId, true));
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
-					vertex.getCurrentExecutionAttempt().cancelingComplete(); // responce by task manager once actially canceled
+			vertex.cancel();
+			vertex.getCurrentExecutionAttempt().cancelingComplete(); // responce by task manager once actially canceled
 
-					assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNull(vertex.getFailureCause());
+			assertNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testRepeatedCancelFromRunning() {
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
+		try {
 
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final ActorRef taskManager = TestActorRef.create(system, Props.create(new
-							CancelSequenceTaskManagerCreator(new
-							TaskOperationResult(execId, true))));
+			final InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					TestingUtils.directExecutionContext(),
+					new TaskOperationResult(execId, true)
+			);
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					// callback by TaskManager after canceling completes
-					vertex.getCurrentExecutionAttempt().cancelingComplete();
+			// callback by TaskManager after canceling completes
+			vertex.getCurrentExecutionAttempt().cancelingComplete();
 
-					assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNull(vertex.getFailureCause());
+			assertNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelFromRunningDidNotFindTask() {
 		// this may happen when the task finished or failed while the call was in progress
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final ActorRef taskManager = TestActorRef.create(system,Props.create(new
-							CancelSequenceTaskManagerCreator(new
-							TaskOperationResult(execId, false))));
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			final InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					TestingUtils.directExecutionContext(),
+					new TaskOperationResult(execId, false)
+			);
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					vertex.cancel();
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			vertex.cancel();
 
-					assertNull(vertex.getFailureCause());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertNull(vertex.getFailureCause());
+
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelCallFails() {
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
 
-					final ActorRef taskManager = TestActorRef.create(system, Props.create(new
-							CancelSequenceTaskManagerCreator()));
+			final InstanceGateway gateway = new CancelSequenceInstanceGateway(TestingUtils.directExecutionContext());
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(gateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
+			assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNotNull(vertex.getFailureCause());
+			assertNotNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.FAILED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.FAILED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testSendCancelAndReceiveFail() {
-		new JavaTestKit(system) {
-			{
-				try {
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execID = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execID = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final ActorRef taskManager = system.actorOf(
-							Props.create(new CancelSequenceTaskManagerCreator(
-									new TaskOperationResult(execID, true)
-							)));
+			final InstanceGateway gateway = new CancelSequenceInstanceGateway(
+					TestingUtils.defaultExecutionContext(),
+					new TaskOperationResult(execID, true));
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(gateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertTrue(vertex.getExecutionState() == ExecutionState.CANCELING || vertex.getExecutionState() == ExecutionState.FAILED);
+			assertTrue(vertex.getExecutionState() == ExecutionState.CANCELING || vertex.getExecutionState() == ExecutionState.FAILED);
 
-					vertex.getCurrentExecutionAttempt().markFailed(new Throwable("test"));
+			vertex.getCurrentExecutionAttempt().markFailed(new Throwable("test"));
 
-					assertTrue(vertex.getExecutionState() == ExecutionState.CANCELED || vertex.getExecutionState() == ExecutionState.FAILED);
+			assertTrue(vertex.getExecutionState() == ExecutionState.CANCELED || vertex.getExecutionState() == ExecutionState.FAILED);
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertEquals(0, vertex.getExecutionGraph().getRegisteredExecutions().size());
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}
-			}
-		};
+			assertEquals(0, vertex.getExecutionGraph().getRegisteredExecutions().size());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -541,7 +482,7 @@ public class ExecutionVertexCancelTest {
 			// deploying after canceling from CREATED needs to raise an exception, because
 			// the scheduler (or any caller) needs to know that the slot should be released
 			try {
-				Instance instance = getInstance(ActorRef.noSender());
+				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				vertex.deployToSlot(slot);
@@ -584,7 +525,7 @@ public class ExecutionVertexCancelTest {
 						AkkaUtils.getDefaultTimeout());
 				setVertexState(vertex, ExecutionState.CANCELING);
 
-				Instance instance = getInstance(ActorRef.noSender());
+				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				vertex.deployToSlot(slot);
@@ -600,7 +541,7 @@ public class ExecutionVertexCancelTest {
 				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 						AkkaUtils.getDefaultTimeout());
 
-				Instance instance = getInstance(ActorRef.noSender());
+				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				setVertexResource(vertex, slot);
@@ -621,39 +562,33 @@ public class ExecutionVertexCancelTest {
 		}
 	}
 
-	public static class CancelSequenceTaskManagerCreator implements Creator<CancelSequenceTaskManager> {
+	public static class CancelSequenceInstanceGateway extends BaseTestingInstanceGateway {
 		private final TaskOperationResult[] results;
-		public CancelSequenceTaskManagerCreator(TaskOperationResult ... results){
-			this.results = results;
+		private int index = -1;
+
+		public CancelSequenceInstanceGateway(ExecutionContext executionContext, TaskOperationResult ... result) {
+			super(executionContext);
+			this.results = result;
 		}
 
 		@Override
-		public CancelSequenceTaskManager create() throws Exception {
-			return new CancelSequenceTaskManager(results);
-		}
-	}
-
-	public static class CancelSequenceTaskManager extends UntypedActor{
-		private final TaskOperationResult[] results;
-		private int index;
-
-		public CancelSequenceTaskManager(TaskOperationResult[] results){
-			this.results = results;
-			index = -1;
-		}
-
-		@Override
-		public void onReceive(Object message) throws Exception {
-			if(message instanceof TaskMessages.SubmitTask){
-				getSender().tell(Messages.getAcknowledge(), getSelf());
-			}else if(message instanceof TaskMessages.CancelTask){
+		public Object handleMessage(Object message) throws Exception {
+			Object result;
+			if(message instanceof TaskMessages.SubmitTask) {
+				result = Messages.getAcknowledge();
+			} else if(message instanceof TaskMessages.CancelTask) {
 				index++;
+
 				if(index >= results.length){
-					getSender().tell(new Status.Failure(new IOException("RPC call failed.")), getSelf());
-				}else {
-					getSender().tell(results[index], getSelf());
+					throw new IOException("RPC call failed.");
+				} else {
+					result = results[index];
 				}
+			} else {
+				result = null;
 			}
+
+			return result;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -56,7 +57,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -91,7 +97,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -127,7 +138,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -164,7 +180,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -199,7 +220,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -254,7 +280,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -300,7 +331,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
@@ -18,11 +18,10 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import akka.actor.ActorRef;
-
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -34,6 +33,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 
 import scala.concurrent.duration.FiniteDuration;
@@ -78,7 +78,7 @@ public class TerminalStateDeadlockTest {
 			InstanceConnectionInfo ci = new InstanceConnectionInfo(address, 12345);
 				
 			HardwareDescription resources = new HardwareDescription(4, 4000000, 3000000, 2000000);
-			Instance instance = new Instance(ActorRef.noSender(), ci, new InstanceID(), resources, 4);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, ci, new InstanceID(), resources, 4);
 
 			this.resource = instance.allocateSimpleSlot(new JobID());
 		}
@@ -116,7 +116,7 @@ public class TerminalStateDeadlockTest {
 				vertices = Arrays.asList(v1, v2);
 			}
 			
-			final Scheduler scheduler = new Scheduler();
+			final Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			final Executor executor = Executors.newFixedThreadPool(4);
 			
@@ -181,7 +181,7 @@ public class TerminalStateDeadlockTest {
 		private volatile boolean done;
 
 		TestExecGraph(JobID jobId) {
-			super(jobId, "test graph", EMPTY_CONFIG, TIMEOUT);
+			super(TestingUtils.defaultExecutionContext(), jobId, "test graph", EMPTY_CONFIG, TIMEOUT);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -39,41 +40,13 @@ import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import scala.concurrent.duration.FiniteDuration;
-import akka.actor.Actor;
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.testkit.JavaTestKit;
-import akka.testkit.TestActorRef;
 
 public class VertexLocationConstraintTest {
 
 	private static final FiniteDuration timeout = new FiniteDuration(100, TimeUnit.SECONDS);
-	
-	private static ActorSystem system;
-	
-	private static TestActorRef<? extends Actor> taskManager;
-	
-	
-	@BeforeClass
-	public static void setup() {
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-		
-		taskManager = TestActorRef.create(system,
-				Props.create(ExecutionGraphTestUtils.SimpleAcknowledgingTaskManager.class));
-	}
-
-	@AfterClass
-	public static void teardown() {
-		JavaTestKit.shutdownActorSystem(system);
-		system = null;
-	}
-	
 	
 	@Test
 	public void testScheduleWithConstraint1() {
@@ -91,7 +64,7 @@ public class VertexLocationConstraintTest {
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			Instance instance3 = getInstance(address3, 6789, hostname3);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			scheduler.newInstanceAvailable(instance2);
 			scheduler.newInstanceAvailable(instance3);
@@ -102,7 +75,12 @@ public class VertexLocationConstraintTest {
 			jobVertex.setParallelism(2);
 			JobGraph jg = new JobGraph("test job", jobVertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -157,7 +135,7 @@ public class VertexLocationConstraintTest {
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			Instance instance3 = getInstance(address3, 6789, hostname3);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			scheduler.newInstanceAvailable(instance2);
 			scheduler.newInstanceAvailable(instance3);
@@ -168,7 +146,12 @@ public class VertexLocationConstraintTest {
 			jobVertex.setParallelism(2);
 			JobGraph jg = new JobGraph("test job", jobVertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -219,7 +202,7 @@ public class VertexLocationConstraintTest {
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			Instance instance3 = getInstance(address3, 6789, hostname3);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			scheduler.newInstanceAvailable(instance2);
 			scheduler.newInstanceAvailable(instance3);
@@ -238,7 +221,12 @@ public class VertexLocationConstraintTest {
 			
 			JobGraph jg = new JobGraph("test job", jobVertex1, jobVertex2);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex1.getID());
@@ -290,7 +278,7 @@ public class VertexLocationConstraintTest {
 			Instance instance1 = getInstance(address1, 6789, hostname1);
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			
 			// prepare the execution graph
@@ -299,7 +287,12 @@ public class VertexLocationConstraintTest {
 			jobVertex.setParallelism(1);
 			JobGraph jg = new JobGraph("test job", jobVertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -343,7 +336,7 @@ public class VertexLocationConstraintTest {
 			Instance instance1 = getInstance(address1, 6789, hostname1);
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			
 			// prepare the execution graph
@@ -362,7 +355,12 @@ public class VertexLocationConstraintTest {
 			jobVertex1.setSlotSharingGroup(sharingGroup);
 			jobVertex2.setSlotSharingGroup(sharingGroup);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex1.getID());
@@ -395,12 +393,17 @@ public class VertexLocationConstraintTest {
 			JobVertex vertex = new JobVertex("test vertex", new JobVertexID());
 			JobGraph jg = new JobGraph("test job", vertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(vertex));
 			
 			ExecutionVertex ev = eg.getAllVertices().get(vertex.getID()).getTaskVertices()[0];
 			
-			Instance instance = ExecutionGraphTestUtils.getInstance(ActorRef.noSender());
+			Instance instance = ExecutionGraphTestUtils.getInstance(DummyInstanceGateway.INSTANCE);
 			ev.setLocationConstraintHosts(Collections.singletonList(instance));
 			
 			assertNotNull(ev.getPreferredLocations());
@@ -431,6 +434,12 @@ public class VertexLocationConstraintTest {
 		when(connection.getHostname()).thenReturn(hostname);
 		when(connection.getFQDNHostname()).thenReturn(hostname);
 		
-		return new Instance(taskManager, connection, new InstanceID(), hardwareDescription, 1);
+		return new Instance(
+				new ExecutionGraphTestUtils.SimpleInstanceGateway(
+						TestingUtils.defaultExecutionContext()),
+				connection,
+				new InstanceID(),
+				hardwareDescription,
+				1);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 
 public class VertexSlotSharingTest {
@@ -68,7 +69,11 @@ public class VertexSlotSharingTest {
 			
 			List<JobVertex> vertices = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 			
-			ExecutionGraph eg = new ExecutionGraph(new JobID(), "test job", new Configuration(),
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					new JobID(),
+					"test job",
+					new Configuration(),
 					AkkaUtils.getDefaultTimeout());
 			eg.attachJobGraph(vertices);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/BaseTestingInstanceGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/BaseTestingInstanceGateway.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorPath;
+import akka.actor.ActorRef;
+import akka.dispatch.Futures;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Abstract base class for testing {@link InstanceGateway} instances. The implementing subclass
+ * only has to provide an implementation for handleMessage which contains the logic to treat
+ * different messages.
+ */
+abstract public class BaseTestingInstanceGateway implements InstanceGateway {
+	/**
+	 * {@link ExecutionContext} which is used to execute the futures.
+	 */
+	private final ExecutionContext executionContext;
+
+	public BaseTestingInstanceGateway(ExecutionContext executionContext) {
+		this.executionContext = executionContext;
+	}
+
+	@Override
+	public Future<Object> ask(Object message, FiniteDuration timeout) {
+		try {
+			final Object result = handleMessage(message);
+
+			return Futures.future(new Callable<Object>() {
+				@Override
+				public Object call() throws Exception {
+					return result;
+				}
+			}, executionContext);
+
+		} catch (final Exception e) {
+			// if an exception occurred in the handleMessage method then return it as part of the future
+			return Futures.future(new Callable<Object>() {
+				@Override
+				public Object call() throws Exception {
+					throw e;
+				}
+			}, executionContext);
+		}
+	}
+
+	/**
+	 * Handles the supported messages by this InstanceGateway
+	 *
+	 * @param message Message to handle
+	 * @return Result
+	 * @throws Exception
+	 */
+	abstract public Object handleMessage(Object message) throws Exception;
+
+	@Override
+	public void tell(Object message) {}
+
+	@Override
+	public void forward(Object message, ActorRef sender) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<Object> retry(Object message, int numberRetries, FiniteDuration timeout, ExecutionContext executionContext) {
+		return ask(message, timeout);
+	}
+
+	@Override
+	public String path() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyInstanceGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyInstanceGateway.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorPath;
+import akka.actor.ActorRef;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Dummy {@link InstanceGateway} implementation used for testing.
+ */
+public class DummyInstanceGateway implements InstanceGateway {
+	public static final DummyInstanceGateway INSTANCE = new DummyInstanceGateway();
+
+	@Override
+	public Future<Object> ask(Object message, FiniteDuration timeout) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void tell(Object message) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void forward(Object message, ActorRef sender) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<Object> retry(Object message, int numberRetries, FiniteDuration timeout, ExecutionContext executionContext) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String path() {
+		return "DummyInstanceGateway";
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.*;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 
-import akka.actor.ActorRef;
 import org.apache.flink.api.common.JobID;
 import org.junit.Test;
 
@@ -39,7 +38,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 4);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 4);
 
 			assertEquals(4, instance.getTotalNumberOfSlots());
 			assertEquals(4, instance.getNumberOfAvailableSlots());
@@ -100,7 +99,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 
@@ -130,7 +129,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 
-import akka.actor.ActorRef;
-
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.api.common.JobID;
 
@@ -148,7 +146,7 @@ public class SimpleSlotTest {
 		InetAddress address = InetAddress.getByName("127.0.0.1");
 		InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-		Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 1);
+		Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 1);
 		return instance.allocateSimpleSlot(new JobID());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.net.NetUtils;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 import org.mockito.Mockito;
 import scala.Some;
@@ -58,7 +59,10 @@ public class NetworkEnvironmentTest {
 					NUM_BUFFERS, BUFFER_SIZE, IOManager.IOMode.SYNC, new Some<NettyConfig>(nettyConf),
 					new Tuple2<Integer, Integer>(0, 0));
 
-			NetworkEnvironment env = new NetworkEnvironment(new FiniteDuration(30, TimeUnit.SECONDS), config);
+			NetworkEnvironment env = new NetworkEnvironment(
+				TestingUtils.defaultExecutionContext(),
+				new FiniteDuration(30, TimeUnit.SECONDS),
+				config);
 
 			assertFalse(env.isShutdown());
 			assertFalse(env.isAssociated());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleWithCoLocationHintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleWithCoLocationHintTest.java
@@ -27,33 +27,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import akka.actor.ActorSystem;
-import akka.testkit.JavaTestKit;
-
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ScheduleWithCoLocationHintTest {
-
-	private static ActorSystem system;
-
-	@BeforeClass
-	public static void setup(){
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-		TestingUtils.setCallingThreadDispatcher(system);
-	}
-
-	@AfterClass
-	public static void teardown(){
-		TestingUtils.setGlobalExecutionContext();
-		JavaTestKit.shutdownActorSystem(system);
-	}
 
 	@Test
 	public void scheduleAllSharedAndCoLocated() {
@@ -61,7 +42,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			scheduler.newInstanceAvailable(getRandomInstance(2));
 			scheduler.newInstanceAvailable(getRandomInstance(2));
@@ -187,7 +168,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid3 = new JobVertexID();
 			JobVertexID jid4 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -231,7 +212,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid2 = new JobVertexID();
 			JobVertexID jid3 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -276,7 +257,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid3 = new JobVertexID();
 			JobVertexID jid4 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			scheduler.newInstanceAvailable(getRandomInstance(1));
 			scheduler.newInstanceAvailable(getRandomInstance(1));
 			scheduler.newInstanceAvailable(getRandomInstance(1));
@@ -338,7 +319,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid2 = new JobVertexID();
 			JobVertexID jid3 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -407,7 +388,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -461,7 +442,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid2 = new JobVertexID();
 			JobVertexID jidx = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -519,7 +500,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -581,7 +562,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
@@ -25,11 +25,7 @@ import static org.apache.flink.runtime.jobmanager.scheduler.SchedulerTestUtils.g
 import static org.junit.Assert.*;
 
 import org.apache.flink.runtime.instance.SimpleSlot;
-import akka.actor.ActorSystem;
-import akka.testkit.JavaTestKit;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -47,24 +43,11 @@ import org.apache.flink.runtime.instance.Instance;
  * Tests for the {@link Scheduler} when scheduling individual tasks.
  */
 public class SchedulerIsolatedTasksTest {
-	private static ActorSystem system;
 
-	@BeforeClass
-	public static void setup(){
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-		TestingUtils.setCallingThreadDispatcher(system);
-	}
-
-	@AfterClass
-	public static void teardown(){
-		TestingUtils.setGlobalExecutionContext();
-		JavaTestKit.shutdownActorSystem(system);
-	}
-	
 	@Test
 	public void testAddAndRemoveInstance() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			Instance i1 = getRandomInstance(2);
 			Instance i2 = getRandomInstance(2);
@@ -128,7 +111,7 @@ public class SchedulerIsolatedTasksTest {
 	@Test
 	public void testScheduleImmediately() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			assertEquals(0, scheduler.getNumberOfAvailableSlots());
 			
 			scheduler.newInstanceAvailable(getRandomInstance(2));
@@ -197,12 +180,10 @@ public class SchedulerIsolatedTasksTest {
 		final int NUM_SLOTS_PER_INSTANCE = 3;
 		final int NUM_TASKS_TO_SCHEDULE = 2000;
 
-		TestingUtils.setGlobalExecutionContext();
-
 		try {
 			// note: since this test asynchronously releases slots, the executor needs release workers.
 			// doing the release call synchronous can lead to a deadlock
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 
 			for (int i = 0; i < NUM_INSTANCES; i++) {
 				scheduler.newInstanceAvailable(getRandomInstance((int) (Math.random() * NUM_SLOTS_PER_INSTANCE) + 1));
@@ -287,15 +268,13 @@ public class SchedulerIsolatedTasksTest {
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
-		} finally {
-			TestingUtils.setCallingThreadDispatcher(system);
 		}
 	}
 	
 	@Test
 	public void testScheduleWithDyingInstances() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			Instance i1 = getRandomInstance(2);
 			Instance i2 = getRandomInstance(2);
@@ -355,7 +334,7 @@ public class SchedulerIsolatedTasksTest {
 	@Test
 	public void testSchedulingLocation() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			Instance i1 = getRandomInstance(2);
 			Instance i2 = getRandomInstance(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -29,9 +29,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import akka.actor.ActorRef;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -66,7 +66,7 @@ public class SchedulerTestUtils {
 		final long GB = 1024L*1024*1024;
 		HardwareDescription resources = new HardwareDescription(4, 4*GB, 3*GB, 2*GB);
 		
-		return new Instance(ActorRef.noSender(), ci, new InstanceID(), resources, numSlots);
+		return new Instance(DummyInstanceGateway.INSTANCE, ci, new InstanceID(), resources, numSlots);
 	}
 	
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 
 import org.apache.flink.runtime.messages.TaskManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 import scala.Option;
 import scala.Tuple2;
@@ -89,7 +90,10 @@ public class TaskManagerComponentsStartupShutdownTest {
 
 			final MemoryManager memManager = new DefaultMemoryManager(32 * BUFFER_SIZE, 1, BUFFER_SIZE, false);
 			final IOManager ioManager = new IOManagerAsync(TMP_DIR);
-			final NetworkEnvironment network = new NetworkEnvironment(timeout, netConf);
+			final NetworkEnvironment network = new NetworkEnvironment(
+				TestingUtils.defaultExecutionContext(),
+				timeout,
+				netConf);
 			final int numberOfSlots = 1;
 
 			// create the task manager

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
@@ -177,12 +177,12 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
           jm ! NotifyWhenJobStatus(jobGraph.getJobID, JobStatus.RESTARTING)
           jm ! RequestWorkingTaskManager(jobGraph.getJobID)
 
-          val WorkingTaskManager(tm) = expectMsgType[WorkingTaskManager]
+          val WorkingTaskManager(gatewayOption) = expectMsgType[WorkingTaskManager]
 
-          tm match {
-            case ActorRef.noSender => fail("There has to be at least one task manager on which" +
+          gatewayOption match {
+            case None => fail("There has to be at least one task manager on which" +
               "the tasks are running.")
-            case t => t ! PoisonPill
+            case Some(gateway) => gateway.tell(PoisonPill)
           }
 
           expectMsg(JobStatusIs(jobGraph.getJobID, JobStatus.RESTARTING))

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -60,16 +60,34 @@ class TestingCluster(userConfiguration: Configuration,
 
   override def startJobManager(actorSystem: ActorSystem): ActorRef = {
 
-    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager,
-    executionRetries, delayBetweenRetries,
-    timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
+    val (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      _,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      archiveCount) = JobManager.createJobManagerComponents(configuration)
     
     val testArchiveProps = Props(new MemoryArchivist(archiveCount) with TestingMemoryArchivist)
     val archive = actorSystem.actorOf(testArchiveProps, JobManager.ARCHIVE_NAME)
     
-    val jobManagerProps = Props(new JobManager(configuration, instanceManager, scheduler,
-      libraryCacheManager, archive, accumulatorManager, executionRetries,
-      delayBetweenRetries, timeout, streamingMode) with TestingJobManager)
+    val jobManagerProps = Props(
+      new JobManager(
+        configuration,
+        executionContext,
+        instanceManager,
+        scheduler,
+        libraryCacheManager,
+        archive,
+        accumulatorManager,
+        executionRetries,
+        delayBetweenRetries,
+        timeout,
+        streamingMode)
+      with TestingJobManager)
 
     actorSystem.actorOf(jobManagerProps, JobManager.JOB_MANAGER_NAME)
   }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -106,11 +106,10 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
 
 
     case NotifyWhenJobRemoved(jobID) =>
-      val tms = instanceManager.getAllRegisteredInstances.map(_.getTaskManager)
+      val gateways = instanceManager.getAllRegisteredInstances.map(_.getInstanceGateway)
 
-      val responses = tms.map{
-        tm =>
-          (tm ? NotifyWhenJobRemoved(jobID))(timeout).mapTo[Boolean]
+      val responses = gateways.map{
+        gateway => gateway.ask(NotifyWhenJobRemoved(jobID), timeout).mapTo[Boolean]
       }
 
       import context.dispatcher
@@ -135,17 +134,17 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
       currentJobs.get(jobID) match {
         case Some((eg, _)) =>
           if(eg.getAllExecutionVertices.isEmpty){
-            sender ! WorkingTaskManager(ActorRef.noSender)
+            sender ! WorkingTaskManager(None)
           } else {
             val resource = eg.getAllExecutionVertices.head.getCurrentAssignedResource
 
             if(resource == null){
-              sender ! WorkingTaskManager(ActorRef.noSender)
+              sender ! WorkingTaskManager(None)
             } else {
-              sender ! WorkingTaskManager(resource.getInstance().getTaskManager)
+              sender ! WorkingTaskManager(Some(resource.getInstance().getInstanceGateway))
             }
           }
-        case None => sender ! WorkingTaskManager(ActorRef.noSender)
+        case None => sender ! WorkingTaskManager(None)
       }
 
     case NotifyWhenJobStatus(jobID, state) =>

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.testingUtils
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.executiongraph.ExecutionGraph
+import org.apache.flink.runtime.instance.InstanceGateway
 import org.apache.flink.runtime.jobgraph.JobStatus
 
 object TestingJobManagerMessages {
@@ -43,7 +44,7 @@ object TestingJobManagerMessages {
   case class NotifyWhenJobRemoved(jobID: JobID)
 
   case class RequestWorkingTaskManager(jobID: JobID)
-  case class WorkingTaskManager(taskManager: ActorRef)
+  case class WorkingTaskManager(gatewayOption: Option[InstanceGateway])
 
   case class NotifyWhenJobStatus(jobID: JobID, state: JobStatus)
   case class JobStatusIs(jobID: JobID, state: JobStatus)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -18,14 +18,12 @@
 
 package org.apache.flink.runtime.testingUtils
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.CallingThreadDispatcher
+import com.google.common.util.concurrent.MoreExecutors
 
 import com.typesafe.config.ConfigFactory
 
 import org.apache.flink.configuration.{ConfigConstants, Configuration}
 import org.apache.flink.runtime.akka.AkkaUtils
-import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.ActionQueue
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
@@ -67,19 +65,33 @@ object TestingUtils {
     new TestingCluster(config)
   }
 
-  def setGlobalExecutionContext(): Unit = {
-    AkkaUtils.globalExecutionContext = ExecutionContext.global
+  /** Returns the global [[ExecutionContext]] which is a [[scala.concurrent.forkjoin.ForkJoinPool]]
+    * with a default parallelism equal to the number of available cores.
+    *
+    * @return ExecutionContext.global
+    */
+  def defaultExecutionContext = ExecutionContext.global
+
+  /** Returns an [[ExecutionContext]] which uses the current thread to execute the runnable.
+    *
+    * @return Direct [[ExecutionContext]] which executes runnables directly
+    */
+  def directExecutionContext = ExecutionContext.fromExecutor(MoreExecutors.directExecutor())
+
+  /** @return A new [[QueuedActionExecutionContext]] */
+  def queuedActionExecutionContext = {
+    new QueuedActionExecutionContext(new ActionQueue())
   }
 
-  def setCallingThreadDispatcher(system: ActorSystem): Unit = {
-    AkkaUtils.globalExecutionContext = system.dispatchers.lookup(CallingThreadDispatcher.Id)
-  }
+  /** [[ExecutionContext]] which queues [[Runnable]] up in an [[ActionQueue]] instead of
+    * execution them. If the automatic execution mode is activated, then the [[Runnable]] are
+    * executed.
+    *
+    * @param actionQueue
+    */
+  class QueuedActionExecutionContext private[testingUtils] (val actionQueue: ActionQueue)
+    extends ExecutionContext {
 
-  def setExecutionContext(context: ExecutionContext): Unit = {
-    AkkaUtils.globalExecutionContext = context
-  }
-
-  class QueuedActionExecutionContext(queue: ActionQueue) extends ExecutionContext {
     var automaticExecution = false
 
     def toggleAutomaticExecution() = {
@@ -90,12 +102,34 @@ object TestingUtils {
       if(automaticExecution){
         runnable.run()
       }else {
-        queue.queueAction(runnable)
+        actionQueue.queueAction(runnable)
       }
     }
 
     override def reportFailure(t: Throwable): Unit = {
       t.printStackTrace()
+    }
+  }
+
+  /** Queue which stores [[Runnable]] */
+  class ActionQueue {
+    private val runnables = scala.collection.mutable.Queue[Runnable]()
+
+    def triggerNextAction {
+      val r = runnables.dequeue
+      r.run()
+    }
+
+    def popNextAction: Runnable = {
+      runnables.dequeue()
+    }
+
+    def queueAction(r: Runnable) {
+      runnables.enqueue(r)
+    }
+
+    def isEmpty: Boolean = {
+      runnables.isEmpty
     }
   }
 }

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -30,8 +30,8 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.StreamingMode;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -148,7 +148,7 @@ public class TestBaseUtils {
 				}
 
 				Future<Iterable<Object>> bcVariableManagerFutureResponses = Futures.sequence(
-						bcVariableManagerResponseFutures, AkkaUtils.globalExecutionContext());
+						bcVariableManagerResponseFutures, TestingUtils.defaultExecutionContext());
 
 				Iterable<Object> responses = Await.result(bcVariableManagerFutureResponses, timeout);
 
@@ -158,7 +158,7 @@ public class TestBaseUtils {
 				}
 
 				Future<Iterable<Object>> numActiveConnectionsFutureResponses = Futures.sequence(
-						numActiveConnectionsResponseFutures, AkkaUtils.globalExecutionContext());
+						numActiveConnectionsResponseFutures, TestingUtils.defaultExecutionContext());
 
 				responses = Await.result(numActiveConnectionsFutureResponses, timeout);
 

--- a/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
+++ b/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
@@ -80,16 +80,38 @@ class ForkableFlinkMiniCluster(userConfiguration: Configuration,
 
   override def startJobManager(actorSystem: ActorSystem): ActorRef = {
 
-    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager,
-    executionRetries, delayBetweenRetries,
-    timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
+    val (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      _,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      archiveCount) = JobManager.createJobManagerComponents(configuration)
 
-    val testArchiveProps = Props(new MemoryArchivist(archiveCount) with TestingMemoryArchivist)
+    val testArchiveProps = Props(
+      new MemoryArchivist(
+        archiveCount)
+      with TestingMemoryArchivist)
+
     val archive = actorSystem.actorOf(testArchiveProps, JobManager.ARCHIVE_NAME)
     
-    val jobManagerProps = Props(new JobManager(configuration, instanceManager, scheduler,
-      libraryCacheManager, archive, accumulatorManager, executionRetries,
-      delayBetweenRetries, timeout, streamingMode) with TestingJobManager)
+    val jobManagerProps = Props(
+      new JobManager(
+        configuration,
+        executionContext,
+        instanceManager,
+        scheduler,
+        libraryCacheManager,
+        archive,
+        accumulatorManager,
+        executionRetries,
+        delayBetweenRetries,
+        timeout,
+        streamingMode)
+      with TestingJobManager)
 
     val jobManager = actorSystem.actorOf(jobManagerProps, JobManager.JOB_MANAGER_NAME)
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
@@ -110,9 +110,15 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
           jm ! RequestWorkingTaskManager(jobID)
 
-          val tm = expectMsgType[WorkingTaskManager].taskManager
-          // kill one task manager
-          tm ! PoisonPill
+          val gatewayOption = expectMsgType[WorkingTaskManager].gatewayOption
+
+          gatewayOption match {
+            case Some(gateway) =>
+              // kill one task manager
+              gateway.tell(PoisonPill)
+
+            case None => fail("Could not retrieve a working task manager.")
+          }
 
           val failure = expectMsgType[Failure]
 

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMaster.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMaster.scala
@@ -235,16 +235,34 @@ object ApplicationMaster {
 
     // start all the components inside the job manager
     LOG.debug("Starting JobManager components")
-    val (instanceManager, scheduler, libraryCacheManager, archiveProps, accumulatorManager,
-                   executionRetries, delayBetweenRetries,
-                   timeout, _) = JobManager.createJobManagerComponents(configuration)
+    val (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      archiveProps,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      _) = JobManager.createJobManagerComponents(configuration)
 
     // start the archiver
     val archiver: ActorRef = jobManagerSystem.actorOf(archiveProps, JobManager.ARCHIVE_NAME)
 
-    val jobManagerProps = Props(new JobManager(configuration, instanceManager, scheduler,
-      libraryCacheManager, archiver, accumulatorManager, executionRetries,
-      delayBetweenRetries, timeout, streamingMode) with ApplicationMasterActor)
+    val jobManagerProps = Props(
+      new JobManager(
+        configuration,
+        executionContext,
+        instanceManager,
+        scheduler,
+        libraryCacheManager,
+        archiver,
+        accumulatorManager,
+        executionRetries,
+        delayBetweenRetries,
+        timeout,
+        streamingMode)
+      with ApplicationMasterActor)
 
     LOG.debug("Starting JobManager actor")
     val jobManager = JobManager.startActor(jobManagerProps, jobManagerSystem)

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterActor.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterActor.scala
@@ -103,7 +103,7 @@ trait ApplicationMasterActor extends ActorLogMessages {
 
       instanceManager.getAllRegisteredInstances.asScala foreach {
         instance =>
-          instance.getTaskManager ! StopYarnSession(status, diag)
+          instance.getInstanceGateway.tell(StopYarnSession(status, diag))
       }
 
       rmClientOption foreach {


### PR DESCRIPTION
This PR replaces the direct `ActorRef` interaction from within `Executions` with an `InstanceGateway`. The `InstanceGateway` is an abstraction which encapsulates the RPC logic. This allows to more easily separate the `Execution` logic from the used Akka framework. 

The default implementation `AkkaInstanceGateway` simply forwards the messages to the provided `ActorRef` which represents the remote instance.

The `InstanceGateway` will allow us to add leader session IDs to all messages, which are sent to a `TaskManager`, transparently, without having to pass this information through the `ExecutionGraph` to the `Executions`.

The additional abstraction layer allows to write more light-weight tests, too. As a consequence, many test cases which needed an `ActorSystem` to start a simple testing actor which mimicked the remote end, could now be simplified using a simple `InstanceGateway` implementation and thus getting rid off testing `ActorSystems`.

In the wake of refactoring, I also replaced the `AkkaUtils.globalExecutionContext` with a non global one. At the moment, the `JobManager` and the `TaskManager` both start a single `ForkJoinPool` which is used as the `ExecutionContext` for all futures and future handlers. The default parallelism is the number of cores available on the system. It would now also be possible to use even more fine grained `ExecutionContexts`, e.g. giving each `ExecutionGraph` a distinct `ExecutionContext`.