### PR TITLE
Make streaming iterations more robust

### DIFF
--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -81,6 +81,7 @@ under the License.
                 <li><a href="{{ apis }}/iterations.html">Iterations</a></li>
                 <li><a href="{{ apis }}/java8.html">Java 8</a></li>
                 <li><a href="{{ apis }}/hadoop_compatibility.html">Hadoop Compatability <span class="badge">Beta</span></a></li>
+                <li><a href="{{ apis }}/storm_compatibility.html">Storm Compatability <span class="badge">Beta</span></a></li>
               </ul>
             </li>
 

--- a/docs/apis/programming_guide.md
+++ b/docs/apis/programming_guide.md
@@ -958,6 +958,19 @@ val result = in.partitionByHash(0).mapPartition { ... }
     </tr>
     </tr>
     <tr>
+      <td><strong>Custom Partitioning</strong></td>
+      <td>
+        <p>Manually specify a partitioning over the data.
+          <br/>
+          <i>Note</i>: This method works only on single field keys.</p>
+{% highlight scala %}
+val in: DataSet[(Int, String)] = // [...]
+val result = in
+  .partitionCustom(partitioner: Partitioner[K], key)
+{% endhighlight %}
+      </td>
+    </tr>
+    <tr>
       <td><strong>Sort Partition</strong></td>
       <td>
         <p>Locally sorts all partitions of a data set on a specified field in a specified order. 

--- a/docs/apis/storm_compatibility.md
+++ b/docs/apis/storm_compatibility.md
@@ -1,0 +1,155 @@
+---
+title: "Storm Compatibility"
+is_beta: true
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+[Flink streaming](streaming_guide.html) is compatible with Apache Storm interfaces and therefore allows
+reusing code that was implemented for Storm.
+
+You can:
+
+- execute a whole Storm `Topology` in Flink.
+- use Storm `Spout`/`Bolt` as source/operator in Flink streaming programs.
+
+This document shows how to use existing Storm code with Flink.
+
+* This will be replaced by the TOC
+{:toc}
+
+### Project Configuration
+
+Support for Storm is contained in the `flink-storm-compatibility-core` Maven module.
+The code resides in the `org.apache.flink.stormcompatibility` package.
+
+Add the following dependency to your `pom.xml` if you want to execute Storm code in Flink.
+
+~~~xml
+<dependency>
+	<groupId>org.apache.flink</groupId>
+	<artifactId>flink-storm-compatibility-core</artifactId>
+	<version>{{site.version}}</version>
+</dependency>
+~~~
+
+**Please note**: `flink-storm-compatibility-core` is not part of the provided binary Flink distribution. Thus, you need to include `flink-storm-compatiblitly-core` classes (and their dependencies) in your program jar that is submitted to Flink's JobManager.
+
+### Execute Storm Topologies
+
+Flink provides a Storm compatible API (`org.apache.flink.stormcompatibility.api`) that offers replacements for the following classes:
+
+- `TopologyBuilder` replaced by `FlinkTopologyBuilder`
+- `StormSubmitter` replaced by `FlinkSubmitter`
+- `NimbusClient` and `Client` replaced by `FlinkClient`
+- `LocalCluster` replaced by `FlinkLocalCluster`
+
+In order to submit a Storm topology to Flink, it is sufficient to replace the used Storm classed with their Flink replacements in the original Storm client code that assembles the topology.
+If a topology is executed in a remote cluster, parameters `nimbus.host` and `nimbus.thrift.port` are used as `jobmanger.rpc.address` and `jobmanger.rpc.port`, respectively.
+If a parameter is not specified, the value is taken from `flink-conf.yaml`.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+~~~java
+FlinkTopologyBuilder builder = new FlinkTopologyBuilder(); // replaces: TopologyBuilder builder = new FlinkTopology();
+
+builder.setSpout("source", new StormFileSpout(inputFilePath));
+builder.setBolt("tokenizer", new StormBoltTokenizer()).shuffleGrouping("source");
+builder.setBolt("counter", new StormBoltCounter()).fieldsGrouping("tokenizer", new Fields("word"));
+builder.setBolt("sink", new StormBoltFileSink(outputFilePath)).shuffleGrouping("counter");
+
+Config conf = new Config();
+if(runLocal) { // submit to test cluster
+	FlinkLocalCluster cluster = new FlinkLocalCluster(); // replaces: LocalCluster cluster = new LocalCluster();
+	cluster.submitTopology("WordCount", conf, builder.createTopology());
+} else { // submit to remote cluster
+	// optional
+	// conf.put(Config.NIMBUS_HOST, "remoteHost");
+	// conf.put(Config.NIMBUS_THRIFT_PORT, 6123);
+	FlinkSubmitter.submitTopology("WordCount", conf, builder.createTopology()); // replaces: StormSubmitter.submitTopology(topologyId, conf, builder.createTopology());
+}
+~~~
+</div>
+</div>
+
+### Embed Storm Operators in Flink Streaming Programs 
+
+As an alternative, Spouts and Bolts can be embedded into regular streaming programs.
+The Storm compatibility layer offers a wrapper classes for each, namely `StormSpoutWrapper` and `StormBoltWrapper` (`org.apache.flink.stormcompatibility.wrappers`).
+
+Per default, both wrappers convert Storm output tuples to Flink's `Tuple` types (ie, `Tuple1` to `Tuple25` according to the number of fields of the Storm tuples).
+For single field output tuples a conversion to the field's data type is also possible (eg, `String` instead of `Tuple1<String>`).
+
+Because Flink cannot infer the output field types of Storm operators, it is required to specify the output type manually.
+In order to get the correct `TypeInformation` object, Flink's `TypeExtractor` can be used.
+
+#### Embed Spouts
+
+In order to use a Spout as Flink source, use `StreamExecutionEnvironment.addSource(SourceFunction, TypeInformation)`.
+The Spout object is handed to the constructor of `StormSpoutWrapper<OUT>` that serves as first argument to `addSource(...)`.
+The generic type declaration `OUT` specifies the type of the source output stream.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+~~~java
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+// stream has `raw` type (single field output streams only)
+DataStream<String> rawInput = env.addSource(
+	new StormSpoutWrapper<String>(new StormFileSpout(localFilePath), true), // Spout source, 'true' for raw type
+	TypeExtractor.getForClass(String.class)); // output type
+
+// process data stream
+[...]
+~~~
+</div>
+</div>
+
+If a Spout emits a finite number of tuples, `StormFiniteSpoutWrapper` can be used instead of `StormSpoutWrapper`.
+Using `StormFiniteSpoutWrapper` allows the Flink program to shut down automatically after all data is processed.
+If `StormSpoutWrapper` is used, the program will run until it is [canceled](cli.html) manually.
+
+
+#### Embed Bolts
+
+In order to use a Bolt as Flink operator, use `DataStream.transform(String, TypeInformation, OneInputStreamOperator)`.
+The Bolt object is handed to the constructor of `StormBoltWrapper<IN,OUT>` that serves as last argument to `transform(...)`.
+The generic type declarations `IN` and `OUT` specify the type of the operator's input and output stream, respectively.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+~~~java
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+DataStream<String> text = env.readTextFile(localFilePath);
+
+DataStream<Tuple2<String, Integer>> counts = text.transform(
+	"tokenizer", // operator name
+	TypeExtractor.getForObject(new Tuple2<String, Integer>("", 0)), // output type
+	new StormBoltWrapper<String, Tuple2<String, Integer>>(new StormBoltTokenizer())); // Bolt operator
+
+// do further processing
+[...]
+~~~
+</div>
+</div>
+
+### Storm Compatibility Examples
+
+You can find more examples in Maven module `flink-storm-compatibilty-examples`.
+

--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -311,6 +311,25 @@ Usage: `dataStream.broadcast()`
  * *Global*: All data points are directed to the first instance of the operator. 
 Usage: `dataStream.global()`
 
+Custom partitioning can also be used by giving a Partitioner function and a single field key to partition on, similarly to the batch API.
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+DataStream<Tuple2<String,Integer>> in = // [...]
+DataStream<Tuple2<String,Integer>> result =in
+    .partitionCustom(Partitioner<K> partitioner, key)
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+
+{% highlight scala %}
+val in: DataSet[(Int, String)] = // [...]
+val result = in
+    .partitionCustom(partitioner: Partitioner[K], key)
+{% endhighlight %}
+</div>
+</div>
+
 By default *Forward* partitioning is used. 
 
 Partitioning does not remain in effect after a transformation, so it needs to be set again for subsequent operations.

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/excamation/ExclamationTopology.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/excamation/ExclamationTopology.java
@@ -21,7 +21,7 @@ import org.apache.flink.examples.java.wordcount.util.WordCountData;
 import org.apache.flink.stormcompatibility.api.FlinkTopologyBuilder;
 import org.apache.flink.stormcompatibility.excamation.stormoperators.ExclamationBolt;
 import org.apache.flink.stormcompatibility.util.OutputFormatter;
-import org.apache.flink.stormcompatibility.util.SimpleOutputFormatter;
+import org.apache.flink.stormcompatibility.util.RawOutputFormatter;
 import org.apache.flink.stormcompatibility.util.StormBoltFileSink;
 import org.apache.flink.stormcompatibility.util.StormBoltPrintSink;
 import org.apache.flink.stormcompatibility.util.StormFileSpout;
@@ -36,7 +36,7 @@ public class ExclamationTopology {
 	public final static String firstBoltId = "exclamation1";
 	public final static String secondBoltId = "exclamation2";
 	public final static String sinkId = "sink";
-	private final static OutputFormatter formatter = new SimpleOutputFormatter();
+	private final static OutputFormatter formatter = new RawOutputFormatter();
 
 	public static FlinkTopologyBuilder buildTopology() {
 		final FlinkTopologyBuilder builder = new FlinkTopologyBuilder();

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/RawOutputFormatter.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/RawOutputFormatter.java
@@ -20,12 +20,13 @@ package org.apache.flink.stormcompatibility.util;
 
 import backtype.storm.tuple.Tuple;
 
-public class SimpleOutputFormatter implements OutputFormatter {
-	private static final long serialVersionUID = 6349573860144270338L;
+public class RawOutputFormatter implements OutputFormatter {
+	private static final long serialVersionUID = 8685668993521259832L;
 
 	@Override
 	public String format(final Tuple input) {
-		return input.getValues().toString();
+		assert (input.size() == 1);
+		return input.getValue(0).toString();
 	}
 
 }

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/StormBoltFileSink.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/StormBoltFileSink.java
@@ -34,6 +34,10 @@ public final class StormBoltFileSink extends AbstractStormBoltSink {
 	private final String path;
 	private BufferedWriter writer;
 
+	public StormBoltFileSink(final String path) {
+		this(path, new SimpleOutputFormatter());
+	}
+
 	public StormBoltFileSink(final String path, final OutputFormatter formatter) {
 		super(formatter);
 		this.path = path;

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1128,14 +1128,14 @@ public abstract class DataSet<T> {
 	
 	/**
 	 * Partitions a DataSet on the key returned by the selector, using a custom partitioner.
-	 * This method takes the key selector t get the key to partition on, and a partitioner that
+	 * This method takes the key selector to get the key to partition on, and a partitioner that
 	 * accepts the key type.
 	 * <p>
 	 * Note: This method works only on single field keys, i.e. the selector cannot return tuples
 	 * of fields.
 	 * 
 	 * @param partitioner The partitioner to assign partitions to keys.
-	 * @param keyExtractor The KeyExtractor with which the DataSet is hash-partitioned.
+	 * @param keyExtractor The KeyExtractor with which the DataSet is partitioned.
 	 * @return The partitioned DataSet.
 	 * 
 	 * @see KeySelector

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -1197,7 +1197,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
 
   /**
    * Partitions a DataSet on the key returned by the selector, using a custom partitioner.
-   * This method takes the key selector t get the key to partition on, and a partitioner that
+   * This method takes the key selector to get the key to partition on, and a partitioner that
    * accepts the key type.
    * <p>
    * Note: This method works only on single field keys, i.e. the selector cannot return tuples

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.Partitioner;
-import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
@@ -498,7 +497,7 @@ public class DataStream<OUT> {
 	 * @return The partitioned DataStream.
 	 * @see KeySelector
 	 */
-	public <K extends Comparable<K>> DataStream<OUT> partitionCustom(Partitioner<K> partitioner, KeySelector<OUT, K> keySelector) {
+	public <K> DataStream<OUT> partitionCustom(Partitioner<K> partitioner, KeySelector<OUT, K> keySelector) {
 		return setConnectionType(new CustomPartitionerWrapper<K, OUT>(clean(partitioner), clean(keySelector)));
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SplitDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/SplitDataStream.java
@@ -57,8 +57,8 @@ public class SplitDataStream<OUT> extends DataStream<OUT> {
 
 		DataStream<OUT> returnStream = copy();
 
-		for (DataStream<OUT> ds : returnStream.unionizedStreams) {
-			ds.userDefinedNames = Arrays.asList(outputNames);
+		for (DataStream<OUT> ds : returnStream.unionedStreams) {
+			ds.selectedNames = Arrays.asList(outputNames);
 		}
 		return returnStream;
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -206,12 +206,12 @@ public class StreamConfig implements Serializable {
 		}
 	}
 
-	public void setIterationId(Integer iterationId) {
-		config.setInteger(ITERATION_ID, iterationId);
+	public void setIterationId(String iterationId) {
+		config.setString(ITERATION_ID, iterationId);
 	}
 
-	public Integer getIterationId() {
-		return config.getInteger(ITERATION_ID, 0);
+	public String getIterationId() {
+		return config.getString(ITERATION_ID, "");
 	}
 
 	public void setIterationWaitTime(long time) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -46,7 +46,7 @@ public class StreamEdge implements Serializable {
 	 * output selection).
 	 */
 	final private List<String> selectedNames;
-	final private StreamPartitioner<?> outputPartitioner;
+	private StreamPartitioner<?> outputPartitioner;
 
 	public StreamEdge(StreamNode sourceVertex, StreamNode targetVertex, int typeNumber,
 			List<String> selectedNames, StreamPartitioner<?> outputPartitioner) {
@@ -86,6 +86,10 @@ public class StreamEdge implements Serializable {
 
 	public StreamPartitioner<?> getPartitioner() {
 		return outputPartitioner;
+	}
+	
+	public void setPartitioner(StreamPartitioner<?> partitioner) {
+		this.outputPartitioner = partitioner;
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamLoop.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamLoop.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+
+/**
+ * Object for representing loops in streaming programs.
+ * 
+ */
+public class StreamLoop {
+
+	private Integer loopID;
+
+	private List<StreamNode> headOperators = new ArrayList<StreamNode>();
+	private List<StreamNode> tailOperators = new ArrayList<StreamNode>();
+	private List<StreamPartitioner<?>> tailPartitioners = new ArrayList<StreamPartitioner<?>>();
+	private List<List<String>> tailSelectedNames = new ArrayList<List<String>>();
+
+	private boolean coIteration = false;
+	private TypeInformation<?> feedbackType = null;
+
+	private long timeout;
+	private boolean tailPartitioning = false;
+
+	private List<Tuple2<StreamNode, StreamNode>> sourcesAndSinks = new ArrayList<Tuple2<StreamNode, StreamNode>>();
+
+	public StreamLoop(Integer loopID, long timeout, TypeInformation<?> feedbackType) {
+		this.loopID = loopID;
+		this.timeout = timeout;
+		if (feedbackType != null) {
+			this.feedbackType = feedbackType;
+			coIteration = true;
+			tailPartitioning = true;
+		}
+	}
+
+	public Integer getID() {
+		return loopID;
+	}
+
+	public long getTimeout() {
+		return timeout;
+	}
+
+	public boolean isCoIteration() {
+		return coIteration;
+	}
+
+	public TypeInformation<?> getFeedbackType() {
+		return feedbackType;
+	}
+
+	public void addSourceSinkPair(StreamNode source, StreamNode sink) {
+		this.sourcesAndSinks.add(new Tuple2<StreamNode, StreamNode>(source, sink));
+	}
+
+	public List<Tuple2<StreamNode, StreamNode>> getSourceSinkPairs() {
+		return this.sourcesAndSinks;
+	}
+
+	public void addHeadOperator(StreamNode head) {
+		this.headOperators.add(head);
+	}
+
+	public void addTailOperator(StreamNode tail, StreamPartitioner<?> partitioner,
+			List<String> selectedNames) {
+		this.tailOperators.add(tail);
+		this.tailPartitioners.add(partitioner);
+		this.tailSelectedNames.add(selectedNames);
+	}
+
+	public void applyTailPartitioning() {
+		this.tailPartitioning = true;
+	}
+
+	public boolean keepsPartitioning() {
+		return tailPartitioning;
+	}
+
+	public List<StreamNode> getHeads() {
+		return headOperators;
+	}
+
+	public List<StreamNode> getTails() {
+		return tailOperators;
+	}
+
+	public List<StreamPartitioner<?>> getTailPartitioners() {
+		return tailPartitioners;
+	}
+
+	public List<List<String>> getTailSelectedNames() {
+		return tailSelectedNames;
+	}
+
+	@Override
+	public String toString() {
+		return "ID: " + loopID + "\n" + "Head: " + headOperators + "\n" + "Tail: " + tailOperators
+				+ "\n" + "TP: " + tailPartitioners + "\n" + "TSN: " + tailSelectedNames;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.partitioner;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * Partitioner that selects the channel with a user defined partitioner function on a key.
+ *
+ * @param <K>
+ *            Type of the key
+ * @param <T>
+ *            Type of the data
+ */
+public class CustomPartitionerWrapper<K, T> extends StreamPartitioner<T> {
+	private static final long serialVersionUID = 1L;
+
+	private int[] returnArray = new int[1];
+	Partitioner<K> partitioner;
+	KeySelector<T, K> keySelector;
+
+	public CustomPartitionerWrapper(Partitioner<K> partitioner, KeySelector<T, K> keySelector) {
+		super(PartitioningStrategy.CUSTOM);
+		this.partitioner = partitioner;
+		this.keySelector = keySelector;
+	}
+
+	@Override
+	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,
+			int numberOfOutputChannels) {
+
+		K key = record.getInstance().getKey(keySelector);
+
+		returnArray[0] = partitioner.partition(key,
+				numberOfOutputChannels);
+
+		return returnArray;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -49,4 +49,9 @@ public class RebalancePartitioner<T> extends StreamPartitioner<T> {
 	public StreamPartitioner<T> copy() {
 		return new RebalancePartitioner<T>(forward);
 	}
+	
+	@Override
+	public String toString() {
+		return forward ? "ForwardPartitioner" : "RebalancePartitioner";
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
@@ -45,4 +45,9 @@ public abstract class StreamPartitioner<T> implements
 	public StreamPartitioner<T> copy() {
 		return this;
 	}
+	
+	@Override
+	public String toString() {
+		return this.getClass().getSimpleName();
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
@@ -27,7 +27,7 @@ public abstract class StreamPartitioner<T> implements
 
 	public enum PartitioningStrategy {
 
-		FORWARD, DISTRIBUTE, SHUFFLE, BROADCAST, GLOBAL, GROUPBY
+		FORWARD, DISTRIBUTE, SHUFFLE, BROADCAST, GLOBAL, GROUPBY, CUSTOM
 
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -48,12 +48,12 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 		super.registerInputOutput();
 		outputHandler = new OutputHandler<OUT>(this);
 
-		Integer iterationId = configuration.getIterationId();
+		String iterationId = configuration.getIterationId();
 		iterationWaitTime = configuration.getIterationWaitTime();
 		shouldWait = iterationWaitTime > 0;
 
 		try {
-			BlockingQueueBroker.instance().handIn(iterationId.toString()+"-" 
+			BlockingQueueBroker.instance().handIn(iterationId+"-" 
 					+getEnvironment().getIndexInSubtaskGroup(), dataChannel);
 		} catch (Exception e) {
 			throw new RuntimeException(e);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
@@ -30,7 +30,7 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamIterationTail.class);
 
-	private Integer iterationId;
+	private String iterationId;
 
 	@SuppressWarnings("rawtypes")
 	private BlockingQueue<StreamRecord> dataChannel;
@@ -47,7 +47,7 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 			iterationId = configuration.getIterationId();
 			iterationWaitTime = configuration.getIterationWaitTime();
 			shouldWait = iterationWaitTime > 0;
-			dataChannel = BlockingQueueBroker.instance().get(iterationId.toString()+"-"
+			dataChannel = BlockingQueueBroker.instance().get(iterationId+"-"
 					+getEnvironment().getIndexInSubtaskGroup());
 		} catch (Exception e) {
 			throw new StreamTaskException(String.format(

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/util/keys/KeySelectorUtil.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/util/keys/KeySelectorUtil.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.util.keys;
 import java.lang.reflect.Array;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.common.typeutils.TypeComparator;
@@ -69,6 +70,45 @@ public class KeySelectorUtil {
 		TypeComparator<X> comparator = ((CompositeType<X>) typeInfo).createComparator(
 				logicalKeyPositions, orders, 0, executionConfig);
 		return new ComparableKeySelector<X>(comparator, keyLength);
+	}
+
+	public static <X, K> KeySelector<X, K> getSelectorForOneKey(Keys<X> keys, Partitioner<K> partitioner, TypeInformation<X> typeInfo,
+			ExecutionConfig executionConfig) {
+		if (partitioner != null) {
+			keys.validateCustomPartitioner(partitioner, null);
+		}
+
+		int[] logicalKeyPositions = keys.computeLogicalKeyPositions();
+
+		if (logicalKeyPositions.length != 1) {
+			throw new IllegalArgumentException("There must be exactly 1 key specified");
+		}
+
+		TypeComparator<X> comparator = ((CompositeType<X>) typeInfo).createComparator(
+				logicalKeyPositions, new boolean[1], 0, executionConfig);
+		return new OneKeySelector<X, K>(comparator);
+	}
+
+	public static class OneKeySelector<IN, K> implements KeySelector<IN, K> {
+
+		private static final long serialVersionUID = 1L;
+
+		private TypeComparator<IN> comparator;
+		private Object[] keyArray;
+		private K key;
+
+		public OneKeySelector(TypeComparator<IN> comparator) {
+			this.comparator = comparator;
+			keyArray = new Object[1];
+		}
+
+		@Override
+		public K getKey(IN value) throws Exception {
+			comparator.extractKeys(value, keyArray, 0);
+			key = (K) keyArray[0];
+			return key;
+		}
+
 	}
 
 	public static class ComparableKeySelector<IN> implements KeySelector<IN, Tuple> {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/IterateTest.java
@@ -18,175 +18,318 @@
 package org.apache.flink.streaming.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
+import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeDataStream;
 import org.apache.flink.streaming.api.datastream.IterativeDataStream.ConnectedIterativeDataStream;
+import org.apache.flink.streaming.api.datastream.SplitDataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.co.CoFlatMapFunction;
+import org.apache.flink.streaming.api.functions.co.CoMapFunction;
+import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamGraph;
-import org.apache.flink.streaming.api.graph.StreamGraph.StreamLoop;
+import org.apache.flink.streaming.api.graph.StreamLoop;
+import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ShufflePartitioner;
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.util.Collector;
 import org.junit.Test;
 
-public class IterateTest {
+@SuppressWarnings({ "unchecked", "unused", "serial" })
+public class IterateTest extends StreamingMultipleProgramsTestBase {
 
 	private static final long MEMORYSIZE = 32;
 	private static boolean iterated[];
 	private static int PARALLELISM = 2;
 
-	public static final class IterationHead extends RichFlatMapFunction<Boolean, Boolean> {
+	@Test
+	public void testException() throws Exception {
 
-		private static final long serialVersionUID = 1L;
+		StreamExecutionEnvironment env = new TestStreamEnvironment(PARALLELISM, MEMORYSIZE);
+		DataStream<Integer> source = env.fromElements(1, 10);
+		IterativeDataStream<Integer> iter1 = source.iterate();
+		IterativeDataStream<Integer> iter2 = source.iterate();
 
-		@Override
-		public void flatMap(Boolean value, Collector<Boolean> out) throws Exception {
-			int indx = getRuntimeContext().getIndexOfThisSubtask();
-			if (value) {
-				iterated[indx] = true;
-			} else {
-				out.collect(value);
-			}
-
+		iter1.closeWith(iter1.map(NoOpIntMap));
+		// Check for double closing
+		try {
+			iter1.closeWith(iter1.map(NoOpIntMap));
+			fail();
+		} catch (Exception e) {
 		}
 
-	}
-
-	public static final class IterationTail extends RichFlatMapFunction<Boolean, Boolean> {
-
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public void flatMap(Boolean value, Collector<Boolean> out) throws Exception {
-			out.collect(true);
-
+		// Check for closing iteration without head
+		try {
+			iter2.closeWith(iter1.map(NoOpIntMap));
+			fail();
+		} catch (Exception e) {
 		}
 
-	}
+		iter2.map(NoOpIntMap);
 
-	public static final class MySink implements SinkFunction<Boolean> {
-
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public void invoke(Boolean tuple) {
+		// Check for executing with empty iteration
+		try {
+			env.execute();
+			fail();
+		} catch (Exception e) {
 		}
-	}
-
-	public static final class NoOpMap implements MapFunction<Boolean, Boolean> {
-
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public Boolean map(Boolean value) throws Exception {
-			return value;
-		}
-
-	}
-
-	public StreamExecutionEnvironment constructIterativeJob(StreamExecutionEnvironment env) {
-		env.setBufferTimeout(10);
-
-		DataStream<Boolean> source = env.fromCollection(Collections.nCopies(PARALLELISM, false));
-
-		IterativeDataStream<Boolean> iteration = source.iterate(3000);
-
-		DataStream<Boolean> increment = iteration.flatMap(new IterationHead()).flatMap(
-				new IterationTail());
-
-		iteration.closeWith(increment).addSink(new MySink());
-		return env;
 	}
 
 	@Test
-	public void testColocation() throws Exception {
-		StreamExecutionEnvironment env = new TestStreamEnvironment(4, MEMORYSIZE);
+	public void testImmutabilityWithCoiteration() {
+		StreamExecutionEnvironment env = new TestStreamEnvironment(PARALLELISM, MEMORYSIZE);
+		DataStream<Integer> source = env.fromElements(1, 10);
 
-		IterativeDataStream<Boolean> it = env.fromElements(true).rebalance().map(new NoOpMap())
-				.iterate();
+		IterativeDataStream<Integer> iter1 = source.iterate();
+		// Calling withFeedbackType should create a new iteration
+		ConnectedIterativeDataStream<Integer, String> iter2 = iter1.withFeedbackType(String.class);
 
-		DataStream<Boolean> head = it.map(new NoOpMap()).setParallelism(2).name("HeadOperator");
-
-		it.closeWith(head.map(new NoOpMap()).setParallelism(3).name("TailOperator")).print();
-
-		JobGraph graph = env.getStreamGraph().getJobGraph();
-
-		JobVertex itSource = null;
-		JobVertex itSink = null;
-		JobVertex headOp = null;
-		JobVertex tailOp = null;
-
-		for (JobVertex vertex : graph.getVertices()) {
-			if (vertex.getName().contains("IterationSource")) {
-				itSource = vertex;
-			} else if (vertex.getName().contains("IterationSink")) {
-				itSink = vertex;
-			} else if (vertex.getName().contains("HeadOperator")) {
-				headOp = vertex;
-			} else if (vertex.getName().contains("TailOp")) {
-				tailOp = vertex;
-			}
-		}
-
-		assertTrue(itSource.getCoLocationGroup() != null);
-		assertEquals(itSource.getCoLocationGroup(), itSink.getCoLocationGroup());
-		assertEquals(headOp.getParallelism(), 2);
-		assertEquals(tailOp.getParallelism(), 3);
-		assertEquals(itSource.getParallelism(), itSink.getParallelism());
-	}
-
-	@SuppressWarnings("unchecked")
-	@Test
-	public void testPartitioning() throws Exception {
-		StreamExecutionEnvironment env = new TestStreamEnvironment(4, MEMORYSIZE);
-
-		IterativeDataStream<Boolean> it = env.fromElements(true).iterate();
-
-		IterativeDataStream<Boolean> it2 = env.fromElements(true).iterate();
-
-		DataStream<Boolean> head = it.map(new NoOpMap()).name("Head1").broadcast();
-		DataStream<Boolean> head2 = it2.map(new NoOpMap()).name("Head2").broadcast();
-
-		it.closeWith(head.union(head.map(new NoOpMap()).shuffle()), true);
-		it2.closeWith(head2, false);
+		iter1.closeWith(iter1.map(NoOpIntMap));
+		iter2.closeWith(iter2.map(NoOpCoMap));
 
 		StreamGraph graph = env.getStreamGraph();
 
-		for (StreamLoop loop : graph.getStreamLoops()) {
-			StreamEdge tailToSink = loop.getSink().getInEdges().get(0);
-			if (tailToSink.getSourceVertex().getOperatorName().contains("Head1")) {
-				assertTrue(tailToSink.getPartitioner() instanceof BroadcastPartitioner);
-				assertTrue(loop.getSink().getInEdges().get(1).getPartitioner() instanceof ShufflePartitioner);
-			} else {
-				assertTrue(tailToSink.getPartitioner() instanceof RebalancePartitioner);
-			}
-		}
+		graph.getJobGraph();
 
+		assertEquals(2, graph.getStreamLoops().size());
+		for (StreamLoop loop : graph.getStreamLoops()) {
+			assertEquals(loop.getHeads(), loop.getTails());
+			List<Tuple2<StreamNode, StreamNode>> sourceSinkPairs = loop.getSourceSinkPairs();
+			assertEquals(1, sourceSinkPairs.size());
+		}
 	}
 
 	@Test
-	public void test() throws Exception {
-		StreamExecutionEnvironment env = new TestStreamEnvironment(PARALLELISM, MEMORYSIZE);
+	public void testmultipleHeadsTailsSimple() {
+		StreamExecutionEnvironment env = new TestStreamEnvironment(4, MEMORYSIZE);
+		DataStream<Integer> source1 = env.fromElements(1, 2, 3, 4, 5).shuffle();
+		DataStream<Integer> source2 = env.fromElements(1, 2, 3, 4, 5);
+
+		IterativeDataStream<Integer> iter1 = source1.union(source2).iterate();
+
+		DataStream<Integer> head1 = iter1.map(NoOpIntMap);
+		DataStream<Integer> head2 = iter1.map(NoOpIntMap).setParallelism(2);
+		DataStream<Integer> head3 = iter1.map(NoOpIntMap).setParallelism(2)
+				.addSink(new NoOpSink<Integer>());
+		DataStream<Integer> head4 = iter1.map(NoOpIntMap).addSink(new NoOpSink<Integer>());
+
+		SplitDataStream<Integer> source3 = env.fromElements(1, 2, 3, 4, 5).split(
+				new OutputSelector<Integer>() {
+
+					@Override
+					public Iterable<String> select(Integer value) {
+						return value % 2 == 0 ? Arrays.asList("even") : Arrays.asList("odd");
+					}
+				});
+
+		iter1.closeWith(source3.select("even").union(
+				head1.map(NoOpIntMap).broadcast().setParallelism(1), head2.shuffle()));
+
+		StreamGraph graph = env.getStreamGraph();
+
+		JobGraph jg = graph.getJobGraph();
+
+		assertEquals(1, graph.getStreamLoops().size());
+		StreamLoop loop = new ArrayList<StreamLoop>(graph.getStreamLoops()).get(0);
+
+		assertEquals(4, loop.getHeads().size());
+		assertEquals(3, loop.getTails().size());
+
+		assertEquals(1, loop.getSourceSinkPairs().size());
+		Tuple2<StreamNode, StreamNode> pair = loop.getSourceSinkPairs().get(0);
+
+		assertEquals(pair.f0.getParallelism(), pair.f1.getParallelism());
+		assertEquals(4, pair.f0.getOutEdges().size());
+		assertEquals(3, pair.f1.getInEdges().size());
+
+		for (StreamEdge edge : pair.f0.getOutEdges()) {
+			assertTrue(edge.getPartitioner() instanceof ShufflePartitioner);
+		}
+		for (StreamEdge edge : pair.f1.getInEdges()) {
+			assertTrue(edge.getPartitioner() instanceof RebalancePartitioner);
+		}
+
+		assertTrue(loop.getTailSelectedNames().contains(Arrays.asList("even")));
+
+		// Test co-location
+
+		JobVertex itSource1 = null;
+		JobVertex itSink1 = null;
+
+		for (JobVertex vertex : jg.getVertices()) {
+			if (vertex.getName().contains("IterationSource")) {
+				itSource1 = vertex;
+			} else if (vertex.getName().contains("IterationSink")) {
+
+				itSink1 = vertex;
+
+			}
+		}
+
+		assertTrue(itSource1.getCoLocationGroup() != null);
+		assertEquals(itSource1.getCoLocationGroup(), itSink1.getCoLocationGroup());
+	}
+
+	@Test
+	public void testmultipleHeadsTailsWithTailPartitioning() {
+		StreamExecutionEnvironment env = new TestStreamEnvironment(4, MEMORYSIZE);
+		DataStream<Integer> source1 = env.fromElements(1, 2, 3, 4, 5).shuffle();
+		DataStream<Integer> source2 = env.fromElements(1, 2, 3, 4, 5);
+
+		IterativeDataStream<Integer> iter1 = source1.union(source2).iterate();
+
+		DataStream<Integer> head1 = iter1.map(NoOpIntMap);
+		DataStream<Integer> head2 = iter1.map(NoOpIntMap).setParallelism(2).name("shuffle");
+		DataStream<Integer> head3 = iter1.map(NoOpIntMap).setParallelism(2)
+				.addSink(new NoOpSink<Integer>());
+		DataStream<Integer> head4 = iter1.map(NoOpIntMap).addSink(new NoOpSink<Integer>());
+
+		SplitDataStream<Integer> source3 = env.fromElements(1, 2, 3, 4, 5).name("split")
+				.split(new OutputSelector<Integer>() {
+
+					@Override
+					public Iterable<String> select(Integer value) {
+						return value % 2 == 0 ? Arrays.asList("even") : Arrays.asList("odd");
+					}
+				});
+
+		iter1.closeWith(
+				source3.select("even").union(
+						head1.map(NoOpIntMap).broadcast().setParallelism(1).name("bc"),
+						head2.shuffle()), true);
+
+		StreamGraph graph = env.getStreamGraph();
+
+		JobGraph jg = graph.getJobGraph();
+
+		assertEquals(1, graph.getStreamLoops().size());
+
+		StreamLoop loop = new ArrayList<StreamLoop>(graph.getStreamLoops()).get(0);
+
+		assertEquals(4, loop.getHeads().size());
+		assertEquals(3, loop.getTails().size());
+
+		assertEquals(2, loop.getSourceSinkPairs().size());
+		List<Tuple2<StreamNode, StreamNode>> pairs = loop.getSourceSinkPairs();
+		Tuple2<StreamNode, StreamNode> pair1 = pairs.get(0).f0.getParallelism() == 2 ? pairs.get(0)
+				: pairs.get(1);
+		Tuple2<StreamNode, StreamNode> pair2 = pairs.get(0).f0.getParallelism() == 4 ? pairs.get(0)
+				: pairs.get(1);
+
+		assertEquals(pair1.f0.getParallelism(), pair1.f1.getParallelism());
+		assertEquals(2, pair1.f0.getParallelism());
+		assertEquals(2, pair1.f0.getOutEdges().size());
+		assertEquals(3, pair1.f1.getInEdges().size());
+
+		for (StreamEdge edge : pair1.f0.getOutEdges()) {
+			assertTrue(edge.getPartitioner() instanceof RebalancePartitioner);
+			assertEquals(2, edge.getTargetVertex().getParallelism());
+		}
+		for (StreamEdge edge : pair1.f1.getInEdges()) {
+			String tailName = edge.getSourceVertex().getOperatorName();
+			if (tailName.equals("split")) {
+				assertTrue(edge.getPartitioner() instanceof RebalancePartitioner);
+			} else if (tailName.equals("bc")) {
+				assertTrue(edge.getPartitioner() instanceof BroadcastPartitioner);
+			} else if (tailName.equals("shuffle")) {
+				assertTrue(edge.getPartitioner() instanceof ShufflePartitioner);
+			}
+
+		}
+
+		assertEquals(pair2.f0.getParallelism(), pair2.f1.getParallelism());
+		assertEquals(4, pair2.f0.getParallelism());
+		assertEquals(2, pair2.f0.getOutEdges().size());
+		assertEquals(3, pair2.f1.getInEdges().size());
+
+		for (StreamEdge edge : pair2.f0.getOutEdges()) {
+			assertTrue(edge.getPartitioner() instanceof RebalancePartitioner);
+			assertEquals(4, edge.getTargetVertex().getParallelism());
+		}
+		for (StreamEdge edge : pair2.f1.getInEdges()) {
+			String tailName = edge.getSourceVertex().getOperatorName();
+			if (tailName.equals("split")) {
+				assertTrue(edge.getPartitioner() instanceof RebalancePartitioner);
+			} else if (tailName.equals("bc")) {
+				assertTrue(edge.getPartitioner() instanceof BroadcastPartitioner);
+			} else if (tailName.equals("shuffle")) {
+				assertTrue(edge.getPartitioner() instanceof ShufflePartitioner);
+			}
+
+		}
+
+		assertTrue(loop.getTailSelectedNames().contains(Arrays.asList("even")));
+
+		// Test co-location
+
+		JobVertex itSource1 = null;
+		JobVertex itSource2 = null;
+		JobVertex itSink1 = null;
+		JobVertex itSink2 = null;
+
+		for (JobVertex vertex : jg.getVertices()) {
+			if (vertex.getName().contains("IterationSource")) {
+				if (vertex.getName().contains("_0")) {
+					itSource1 = vertex;
+				} else if (vertex.getName().contains("_1")) {
+					itSource2 = vertex;
+				}
+			} else if (vertex.getName().contains("IterationSink")) {
+				if (vertex.getName().contains("_0")) {
+					itSink1 = vertex;
+				} else if (vertex.getName().contains("_1")) {
+					itSink2 = vertex;
+				}
+			}
+		}
+
+		assertTrue(itSource1.getCoLocationGroup() != null);
+		assertTrue(itSource2.getCoLocationGroup() != null);
+
+		assertEquals(itSource1.getCoLocationGroup(), itSink1.getCoLocationGroup());
+		assertEquals(itSource2.getCoLocationGroup(), itSink2.getCoLocationGroup());
+		assertNotEquals(itSource1.getCoLocationGroup(), itSource2.getCoLocationGroup());
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void testSimpleIteration() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(PARALLELISM);
 		iterated = new boolean[PARALLELISM];
 
-		env = constructIterativeJob(env);
+		DataStream<Boolean> source = env
+				.fromCollection(Collections.nCopies(PARALLELISM * 2, false));
+
+		IterativeDataStream<Boolean> iteration = source.iterate(3000);
+
+		DataStream<Boolean> increment = iteration.flatMap(new IterationHead()).map(NoOpBoolMap);
+
+		iteration.map(NoOpBoolMap).addSink(new NoOpSink());
+
+		iteration.closeWith(increment).addSink(new NoOpSink());
 
 		env.execute();
 
@@ -195,55 +338,135 @@ public class IterateTest {
 		}
 
 	}
-	
+
 	@Test
 	public void testCoIteration() throws Exception {
-		StreamExecutionEnvironment env = new TestStreamEnvironment(2, MEMORYSIZE);
-		
-		
-		ConnectedIterativeDataStream<Integer, String> coIt =  env.fromElements(0, 0).iterate(2000).withFeedbackType("String");
-		
-		try{
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(2);
+
+		ConnectedIterativeDataStream<Integer, String> coIt = env.fromElements(0, 0).iterate(2000)
+				.withFeedbackType("String");
+
+		try {
 			coIt.groupBy(1, 2);
 			fail();
-		} catch (UnsupportedOperationException e){}
-		
-		DataStream<String> head = coIt.flatMap(new CoFlatMapFunction<Integer, String, String>() {
+		} catch (UnsupportedOperationException e) {
+		}
 
-			private static final long serialVersionUID = 1L;
+		DataStream<String> head = coIt
+				.flatMap(new RichCoFlatMapFunction<Integer, String, String>() {
+
+					private static final long serialVersionUID = 1L;
+					boolean seenFromSource = false;
+
+					@Override
+					public void flatMap1(Integer value, Collector<String> out) throws Exception {
+						out.collect(((Integer) (value + 1)).toString());
+					}
+
+					@Override
+					public void flatMap2(String value, Collector<String> out) throws Exception {
+						Integer intVal = Integer.valueOf(value);
+						if (intVal < 2) {
+							out.collect(((Integer) (intVal + 1)).toString());
+						}
+						if (intVal == 1000 || intVal == 2000) {
+							seenFromSource = true;
+						}
+					}
+
+					@Override
+					public void close() {
+						assertTrue(seenFromSource);
+					}
+				});
+
+		coIt.map(new CoMapFunction<Integer, String, String>() {
 
 			@Override
-			public void flatMap1(Integer value, Collector<String> out) throws Exception {
-				out.collect(((Integer) (value + 1)).toString());
+			public String map1(Integer value) throws Exception {
+				return value.toString();
 			}
 
 			@Override
-			public void flatMap2(String value, Collector<String> out) throws Exception {
-				Integer intVal = Integer.valueOf(value);
-				if(intVal < 2){
-					out.collect(((Integer) (intVal + 1)).toString());
-				}
-				
+			public String map2(String value) throws Exception {
+				return value;
 			}
-		});
-		
-		coIt.closeWith(head.broadcast());
-	
+		}).setParallelism(1).addSink(new NoOpSink<String>());
+
+		coIt.closeWith(head.broadcast().union(env.fromElements("1000", "2000").rebalance()));
+
 		head.addSink(new TestSink()).setParallelism(1);
-		
+
 		env.execute();
-		
-		assertEquals(new HashSet<String>(Arrays.asList("1","1","2","2","2","2")), TestSink.collected);
+
+		Collections.sort(TestSink.collected);
+		assertEquals(Arrays.asList("1", "1", "2", "2", "2", "2"), TestSink.collected);
+		assertEquals(2, new ArrayList<StreamLoop>(env.getStreamGraph().getStreamLoops()).get(0)
+				.getSourceSinkPairs().size());
 
 	}
 
 	@Test
+	public void testGroupByFeedback() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(3);
+
+		KeySelector<Integer, Integer> key = new KeySelector<Integer, Integer>() {
+
+			@Override
+			public Integer getKey(Integer value) throws Exception {
+				return value % 3;
+			}
+		};
+
+		DataStream<Integer> source = env.fromElements(1, 2, 3);
+
+		IterativeDataStream<Integer> it = source.groupBy(key).iterate(3000);
+
+		DataStream<Integer> head = it.flatMap(new RichFlatMapFunction<Integer, Integer>() {
+
+			int received = 0;
+			int key = -1;
+
+			@Override
+			public void flatMap(Integer value, Collector<Integer> out) throws Exception {
+				received++;
+				if (key == -1) {
+					key = value % 3;
+				} else {
+					assertEquals(key, value % 3);
+				}
+				if (value > 0) {
+					out.collect(value - 1);
+				}
+			}
+
+			@Override
+			public void close() {
+				assertTrue(received > 1);
+			}
+		});
+
+		it.closeWith(head.groupBy(key).union(head.map(NoOpIntMap).setParallelism(2).groupBy(key)),
+				true).addSink(new NoOpSink<Integer>());
+
+		env.execute();
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
 	public void testWithCheckPointing() throws Exception {
 		StreamExecutionEnvironment env = new TestStreamEnvironment(PARALLELISM, MEMORYSIZE);
-
-		env = constructIterativeJob(env);
-
 		env.enableCheckpointing();
+
+		DataStream<Boolean> source = env
+				.fromCollection(Collections.nCopies(PARALLELISM * 2, false));
+
+		IterativeDataStream<Boolean> iteration = source.iterate(3000);
+
+		iteration.closeWith(iteration.flatMap(new IterationHead()));
+
 		try {
 			env.execute();
 
@@ -252,8 +475,7 @@ public class IterateTest {
 		} catch (UnsupportedOperationException e) {
 			// expected behaviour
 		}
-		
-		
+
 		// Test force checkpointing
 
 		try {
@@ -265,22 +487,75 @@ public class IterateTest {
 		} catch (UnsupportedOperationException e) {
 			// expected behaviour
 		}
-		
+
 		env.enableCheckpointing(1, true);
 		env.getStreamGraph().getJobGraph();
-
 	}
-	
-	public static class TestSink implements SinkFunction<String>{
+
+	public static final class IterationHead extends RichFlatMapFunction<Boolean, Boolean> {
+		public void flatMap(Boolean value, Collector<Boolean> out) throws Exception {
+			int indx = getRuntimeContext().getIndexOfThisSubtask();
+			if (value) {
+				iterated[indx] = true;
+			} else {
+				out.collect(true);
+			}
+		}
+	}
+
+	public static final class NoOpSink<T> extends RichSinkFunction<T> {
+		private List<T> received;
+
+		public void invoke(T tuple) {
+			received.add(tuple);
+		}
+
+		public void open(Configuration conf) {
+			received = new ArrayList<T>();
+		}
+
+		public void close() {
+			assertTrue(received.size() > 0);
+		}
+	}
+
+	public static CoMapFunction<Integer, String, String> NoOpCoMap = new CoMapFunction<Integer, String, String>() {
+
+		public String map1(Integer value) throws Exception {
+			return value.toString();
+		}
+
+		public String map2(String value) throws Exception {
+			return value;
+		}
+	};
+
+	public static MapFunction<Integer, Integer> NoOpIntMap = new MapFunction<Integer, Integer>() {
+
+		public Integer map(Integer value) throws Exception {
+			return value;
+		}
+
+	};
+
+	public static MapFunction<Boolean, Boolean> NoOpBoolMap = new MapFunction<Boolean, Boolean>() {
+
+		public Boolean map(Boolean value) throws Exception {
+			return value;
+		}
+
+	};
+
+	public static class TestSink implements SinkFunction<String> {
 
 		private static final long serialVersionUID = 1L;
-		public static Set<String> collected = new HashSet<String>();
-		
+		public static List<String> collected = new ArrayList<String>();
+
 		@Override
 		public void invoke(String value) throws Exception {
 			collected.add(value);
 		}
-		
+
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/PartitionerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/PartitionerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.TestListResultSink;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.junit.Test;
+
+/**
+ * IT case that tests the different stream partitioning schemes.
+ */
+public class PartitionerTest {
+
+	public static final int PARALLELISM = 3;
+	public static final int MEMORY_SIZE = 32;
+
+	@Test
+	public void partitionerTest() {
+
+		TestListResultSink<Tuple2<Integer, String>> hashPartitionResultSink =
+				new TestListResultSink<Tuple2<Integer, String>>();
+		TestListResultSink<Tuple2<Integer, String>> customPartitionResultSink =
+				new TestListResultSink<Tuple2<Integer, String>>();
+		TestListResultSink<Tuple2<Integer, String>> broadcastPartitionResultSink =
+				new TestListResultSink<Tuple2<Integer, String>>();
+		TestListResultSink<Tuple2<Integer, String>> forwardPartitionResultSink =
+				new TestListResultSink<Tuple2<Integer, String>>();
+		TestListResultSink<Tuple2<Integer, String>> rebalancePartitionResultSink =
+				new TestListResultSink<Tuple2<Integer, String>>();
+		TestListResultSink<Tuple2<Integer, String>> globalPartitionResultSink =
+				new TestListResultSink<Tuple2<Integer, String>>();
+
+
+		StreamExecutionEnvironment env = new TestStreamEnvironment(PARALLELISM, MEMORY_SIZE);
+		DataStream<Tuple1<String>> src = env.fromElements(
+				new Tuple1<String>("a"),
+				new Tuple1<String>("b"),
+				new Tuple1<String>("b"),
+				new Tuple1<String>("a"),
+				new Tuple1<String>("a"),
+				new Tuple1<String>("c"),
+				new Tuple1<String>("a")
+		);
+
+		// partition by hash
+		src
+				.partitionByHash(0)
+				.map(new SubtaskIndexAssigner())
+				.addSink(hashPartitionResultSink);
+
+		// partition custom
+		DataStream<Tuple2<Integer, String>> partitionCustom = src
+				.partitionCustom(new Partitioner<String>() {
+					@Override
+					public int partition(String key, int numPartitions) {
+						if (key.equals("c")) {
+							return 2;
+						} else {
+							return 0;
+						}
+					}
+				}, 0)
+				.map(new SubtaskIndexAssigner());
+
+		partitionCustom.addSink(customPartitionResultSink);
+
+		// partition broadcast
+		src.broadcast().map(new SubtaskIndexAssigner()).addSink(broadcastPartitionResultSink);
+
+		// partition forward
+		src.map(new SubtaskIndexAssigner()).addSink(forwardPartitionResultSink);
+
+		// partition rebalance
+		src.rebalance().map(new SubtaskIndexAssigner()).addSink(rebalancePartitionResultSink);
+
+		// partition global
+		src.global().map(new SubtaskIndexAssigner()).addSink(globalPartitionResultSink);
+
+		try {
+			env.execute();
+		} catch (Exception e) {
+			fail(e.getMessage());
+		}
+
+		List<Tuple2<Integer, String>> hashPartitionResult = hashPartitionResultSink.getResult();
+		List<Tuple2<Integer, String>> customPartitionResult = customPartitionResultSink.getResult();
+		List<Tuple2<Integer, String>> broadcastPartitionResult = broadcastPartitionResultSink.getResult();
+		List<Tuple2<Integer, String>> forwardPartitionResult = forwardPartitionResultSink.getResult();
+		List<Tuple2<Integer, String>> rebalancePartitionResult = rebalancePartitionResultSink.getResult();
+		List<Tuple2<Integer, String>> globalPartitionResult = globalPartitionResultSink.getResult();
+
+		verifyHashPartitioning(hashPartitionResult);
+		verifyCustomPartitioning(customPartitionResult);
+		verifyBroadcastPartitioning(broadcastPartitionResult);
+		verifyRebalancePartitioning(forwardPartitionResult);
+		verifyRebalancePartitioning(rebalancePartitionResult);
+		verifyGlobalPartitioning(globalPartitionResult);
+	}
+
+	private static void verifyHashPartitioning(List<Tuple2<Integer, String>> hashPartitionResult) {
+		HashMap<String, Integer> verifier = new HashMap<String, Integer>();
+		for (Tuple2<Integer, String> elem : hashPartitionResult) {
+			Integer subtaskIndex = verifier.get(elem.f1);
+			if (subtaskIndex == null) {
+				verifier.put(elem.f1, elem.f0);
+			} else if (subtaskIndex != elem.f0) {
+				fail();
+			}
+		}
+	}
+
+	private static void verifyCustomPartitioning(List<Tuple2<Integer, String>> customPartitionResult) {
+		for (Tuple2<Integer, String> stringWithSubtask : customPartitionResult) {
+			if (stringWithSubtask.f1.equals("c")) {
+				assertEquals(new Integer(2), stringWithSubtask.f0);
+			} else {
+				assertEquals(new Integer(0), stringWithSubtask.f0);
+			}
+		}
+	}
+
+	private static void verifyBroadcastPartitioning(List<Tuple2<Integer, String>> broadcastPartitionResult) {
+		List<Tuple2<Integer, String>> expected = Arrays.asList(
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(0, "b"),
+				new Tuple2<Integer, String>(0, "b"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(0, "c"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(1, "b"),
+				new Tuple2<Integer, String>(1, "b"),
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(1, "c"),
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(2, "a"),
+				new Tuple2<Integer, String>(2, "b"),
+				new Tuple2<Integer, String>(2, "b"),
+				new Tuple2<Integer, String>(2, "a"),
+				new Tuple2<Integer, String>(2, "a"),
+				new Tuple2<Integer, String>(2, "c"),
+				new Tuple2<Integer, String>(2, "a"));
+
+		assertEquals(
+				new HashSet<Tuple2<Integer, String>>(expected),
+				new HashSet<Tuple2<Integer, String>>(broadcastPartitionResult));
+	}
+
+	private static void verifyRebalancePartitioning(List<Tuple2<Integer, String>> rebalancePartitionResult) {
+		List<Tuple2<Integer, String>> expected = Arrays.asList(
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(1, "b"),
+				new Tuple2<Integer, String>(2, "b"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(2, "c"),
+				new Tuple2<Integer, String>(0, "a"));
+
+		assertEquals(
+				new HashSet<Tuple2<Integer, String>>(expected),
+				new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult));
+	}
+
+	private static void verifyGlobalPartitioning(List<Tuple2<Integer, String>> globalPartitionResult) {
+		List<Tuple2<Integer, String>> expected = Arrays.asList(
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(0, "b"),
+				new Tuple2<Integer, String>(0, "b"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(0, "c"),
+				new Tuple2<Integer, String>(0, "a"));
+
+		assertEquals(
+				new HashSet<Tuple2<Integer, String>>(expected),
+				new HashSet<Tuple2<Integer, String>>(globalPartitionResult));
+	}
+
+	private static class SubtaskIndexAssigner
+			extends RichMapFunction<Tuple1<String>, Tuple2<Integer, String>> {
+
+		private int indexOfSubtask;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+			RuntimeContext runtimeContext = getRuntimeContext();
+			indexOfSubtask = runtimeContext.getIndexOfThisSubtask();
+		}
+
+		@Override
+		public Tuple2<Integer, String> map(Tuple1<String> value) throws Exception {
+			return new Tuple2<Integer, String>(indexOfSubtask, value.f0);
+		}
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -78,6 +78,10 @@ class DataStream[T](javaStream: JavaStream[T]) {
    * Returns the parallelism of this operation.
    */
   def getParallelism = javaStream.getParallelism
+  
+  def getPartitioner = javaStream.getPartitioner
+  
+  def getSelectedNames = javaStream.getSelectedNames
 
   /**
    * Returns the execution config.


### PR DESCRIPTION
This PR reworks the way iterations are constructed in the streamgraph from the previous eager approach to do it when we actually create the jobgraph.

This new approach solves many know and unknown issues that the previous approach had, such as issues with multiple tail and head operators (FLINK-2328), issues with partitioning on the feedback stream, issues with ConnectedIterations and immutability of the IterativeDataStream etc.

I also included a new set of tests to validate all the expected functionality:

-Test for simple and connected iterations with more heads and tails
-Parallelism, partitioning and co-location checks
-Tests for the exceptions thrown during job creation for invalid iterative topologies