### PR TITLE
[FLINK-2353] Respect JobConfigurable interface in Hadoop mapred wrappers

### DIFF
--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -1319,6 +1319,9 @@ Another way of exposing user defined operator state for the Flink runtime for ch
 
 When the user defined function implements the `Checkpointed` interface, the `snapshotState(…)` and `restoreState(…)` methods will be executed to draw and restore function state.
 
+In addition to that, user functions can also implement the `CheckpointNotifier` interface to receive notifications on completed checkpoints via the `notifyCheckpointComplete(long checkpointId)` method.
+Note that there is no guarantee for the user function to receive a notification if a failure happens between checkpoint completion and notification. The notifications should hence be treated in a way that notifications from later checkpoints can subsume missing notifications.
+
 For example the same counting, reduce function shown for `OperatorState`s by using the `Checkpointed` interface instead:
 
 {% highlight java %}

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
@@ -34,6 +34,7 @@ import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobConfigurable;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.slf4j.Logger;
@@ -82,7 +83,13 @@ public abstract class HadoopInputFormatBase<K, V, T> implements InputFormat<T, H
 	
 	@Override
 	public void configure(Configuration parameters) {
-		// nothing to do
+		// configure MR InputFormat if necessary
+		if(this.mapredInputFormat instanceof Configurable) {
+			((Configurable)this.mapredInputFormat).setConf(this.jobConf);
+		}
+		else if(this.mapredInputFormat instanceof JobConfigurable) {
+			((JobConfigurable)this.mapredInputFormat).configure(this.jobConf);
+		}
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormatBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormatBase.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.mapred.FileOutputCommitter;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobConfigurable;
 import org.apache.hadoop.mapred.JobContext;
 import org.apache.hadoop.mapred.JobID;
 import org.apache.hadoop.mapred.RecordWriter;
@@ -67,8 +68,12 @@ public abstract class HadoopOutputFormatBase<K, V, T> implements OutputFormat<T>
 
 	@Override
 	public void configure(Configuration parameters) {
-		if(this.mapredOutputFormat instanceof Configurable){
+		// configure MR OutputFormat if necessary
+		if(this.mapredOutputFormat instanceof Configurable) {
 			((Configurable)this.mapredOutputFormat).setConf(this.jobConf);
+		}
+		else if(this.mapredOutputFormat instanceof JobConfigurable) {
+			((JobConfigurable)this.mapredOutputFormat).configure(this.jobConf);
 		}
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.io.LocatableInputSplit;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.io.WritableFactories;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobConfigurable;
 
 /**
  * A wrapper that represents an input split from the Hadoop mapred API as
@@ -112,6 +113,9 @@ public class HadoopInputSplit extends LocatableInputSplit {
 
 		if (hadoopInputSplit instanceof Configurable) {
 			((Configurable) hadoopInputSplit).setConf(this.jobConf);
+		}
+		else if (hadoopInputSplit instanceof JobConfigurable) {
+			((JobConfigurable) hadoopInputSplit).configure(this.jobConf);
 		}
 		hadoopInputSplit.readFields(in);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -30,10 +30,8 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
-import org.apache.flink.runtime.messages.checkpoint.ConfirmCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
 import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
-import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.runtime.util.SerializedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -375,11 +373,8 @@ public class CheckpointCoordinator {
 				Execution ee = ev.getCurrentExecutionAttempt();
 				if (ee != null) {
 					ExecutionAttemptID attemptId = ee.getAttemptId();
-					StateForTask stateForTask = completed.getState(ev.getJobvertexId());
-					SerializedValue<StateHandle<?>> taskState = (stateForTask != null) ? stateForTask.getState() : null;
-					ConfirmCheckpoint confirmMessage = new ConfirmCheckpoint(job, attemptId, checkpointId, 
-							timestamp, taskState);
-					ev.sendMessageToCurrentExecution(confirmMessage, ee.getAttemptId());
+					NotifyCheckpointComplete notifyMessage = new NotifyCheckpointComplete(job, attemptId, checkpointId, timestamp);
+					ev.sendMessageToCurrentExecution(notifyMessage, ee.getAttemptId());
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SuccessfulCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SuccessfulCheckpoint.java
@@ -18,14 +18,11 @@
 
 package org.apache.flink.runtime.checkpoint;
 
-import com.google.common.collect.Maps;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * A successful checkpoint describes a checkpoint after all required tasks acknowledged it (with their state)
@@ -41,9 +38,7 @@ public class SuccessfulCheckpoint {
 	
 	private final long timestamp;
 	
-	private final Map<JobVertexID, StateForTask> vertexToState;
-	
-	private final List<StateForTask> states; 
+	private final List<StateForTask> states;
 
 
 	public SuccessfulCheckpoint(JobID job, long checkpointID, long timestamp, List<StateForTask> states) {
@@ -51,10 +46,6 @@ public class SuccessfulCheckpoint {
 		this.checkpointID = checkpointID;
 		this.timestamp = timestamp;
 		this.states = states;
-		vertexToState = Maps.newHashMap();
-		for(StateForTask state : states){
-			vertexToState.put(state.getOperatorId(), state);
-		}
 	}
 
 	public JobID getJobId() {
@@ -71,17 +62,6 @@ public class SuccessfulCheckpoint {
 
 	public List<StateForTask> getStates() {
 		return states;
-	}
-
-	/**
-	 * Returns the task state included in the checkpoint for a given JobVertexID if it exists or 
-	 * null if no state is included for that id.
-	 * 
-	 * @param jobVertexID
-	 * @return
-	 */
-	public StateForTask getState(JobVertexID jobVertexID) {
-		return vertexToState.get(jobVertexID);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -168,6 +168,10 @@ public class ExecutionVertex implements Serializable {
 				getTotalNumberOfParallelSubtasks());
 	}
 
+	public int getSubTaskIndex() {
+		return subTaskIndex;
+	}
+
 	public int getTotalNumberOfParallelSubtasks() {
 		return this.jobVertex.getParallelism();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/AkkaInstanceGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/AkkaInstanceGateway.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorRef;
+import akka.pattern.Patterns;
+import akka.util.Timeout;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * InstanceGateway implementation which uses Akka to communicate with remote instances.
+ */
+public class AkkaInstanceGateway implements InstanceGateway {
+
+	/** ActorRef of the remote instance */
+	private final ActorRef taskManager;
+
+	public AkkaInstanceGateway(ActorRef taskManager) {
+		this.taskManager = taskManager;
+	}
+
+	/**
+	 * Sends a message asynchronously and returns its response. The response to the message is
+	 * returned as a future.
+	 *
+	 * @param message Message to be sent
+	 * @param timeout Timeout until the Future is completed with an AskTimeoutException
+	 * @return Future which contains the response to the sent message
+	 */
+	@Override
+	public Future<Object> ask(Object message, FiniteDuration timeout) {
+		return Patterns.ask(taskManager, message, new Timeout(timeout));
+	}
+
+	/**
+	 * Sends a message asynchronously without a result.
+	 *
+	 * @param message Message to be sent
+	 */
+	@Override
+	public void tell(Object message) {
+		taskManager.tell(message, ActorRef.noSender());
+	}
+
+	/**
+	 * Forwards a message. For the receiver of this message it looks as if sender has sent the
+	 * message.
+	 *
+	 * @param message Message to be sent
+	 * @param sender Sender of the forwarded message
+	 */
+	@Override
+	public void forward(Object message, ActorRef sender) {
+		taskManager.tell(message, sender);
+	}
+
+	/**
+	 * Retries to send asynchronously a message up to numberRetries times. The response to this
+	 * message is returned as a future. The message is re-sent if the number of retries is not yet
+	 * exceeded and if an exception occurred while sending it.
+	 *
+	 * @param message Message to be sent
+	 * @param numberRetries Number of times to retry sending the message
+	 * @param timeout Timeout for each sending attempt
+	 * @param executionContext ExecutionContext which is used to send the message multiple times
+	 * @return Future of the response to the sent message
+	 */
+	@Override
+	public Future<Object> retry(
+			Object message,
+			int numberRetries,
+			FiniteDuration timeout,
+			ExecutionContext executionContext) {
+
+		return AkkaUtils.retry(
+			taskManager,
+			message,
+			numberRetries,
+			executionContext,
+			timeout);
+	}
+
+	/**
+	 * Returns the ActorPath of the remote instance.
+	 *
+	 * @return ActorPath of the remote instance.
+	 */
+	@Override
+	public String path() {
+		return taskManager.path().toString();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceGateway.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorRef;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Interface to abstract the communication with an Instance.
+ *
+ * It allows to avoid direct interaction with an ActorRef.
+ */
+public interface InstanceGateway {
+
+	/**
+	 * Sends a message asynchronously and returns its response. The response to the message is
+	 * returned as a future.
+	 *
+	 * @param message Message to be sent
+	 * @param timeout Timeout until the Future is completed with an AskTimeoutException
+	 * @return Future which contains the response to the sent message
+	 */
+	Future<Object> ask(Object message, FiniteDuration timeout);
+
+	/**
+	 * Sends a message asynchronously without a result.
+	 *
+	 * @param message Message to be sent
+	 */
+	void tell(Object message);
+
+	/**
+	 * Forwards a message. For the receiver of this message it looks as if sender has sent the
+	 * message.
+	 *
+	 * @param message Message to be sent
+	 * @param sender Sender of the forwarded message
+	 */
+	void forward(Object message, ActorRef sender);
+
+	/**
+	 * Retries to send asynchronously a message up to numberRetries times. The response to this
+	 * message is returned as a future. The message is re-sent if the number of retries is not yet
+	 * exceeded and if an exception occurred while sending it.
+	 *
+	 * @param message Message to be sent
+	 * @param numberRetries Number of times to retry sending the message
+	 * @param timeout Timeout for each sending attempt
+	 * @param executionContext ExecutionContext which is used to send the message multiple times
+	 * @return Future of the response to the sent message
+	 */
+	Future<Object> retry(
+			Object message,
+			int numberRetries,
+			FiniteDuration timeout,
+			ExecutionContext executionContext);
+
+	/**
+	 * Returns the path of the remote instance.
+	 *
+	 * @return Path of the remote instance.
+	 */
+	String path();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
@@ -149,8 +149,9 @@ public class InstanceManager {
 				id = new InstanceID();
 			} while (registeredHostsById.containsKey(id));
 
+			InstanceGateway instanceGateway = new AkkaInstanceGateway(taskManager);
 
-			Instance host = new Instance(taskManager, connectionInfo, id, resources, numberOfSlots);
+			Instance host = new Instance(instanceGateway, connectionInfo, id, resources, numberOfSlots);
 
 			registeredHostsById.put(id, host);
 			registeredHostsByConnection.put(taskManager, host);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointNotificationOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointNotificationOperator.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.runtime.jobgraph.tasks;
 
-import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.runtime.util.SerializedValue;
 
-public interface CheckpointCommittingOperator {
+public interface CheckpointNotificationOperator {
 	
-	void confirmCheckpoint(long checkpointId, SerializedValue<StateHandle<?>> state) throws Exception;
+	void notifyCheckpointComplete(long checkpointId) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
@@ -146,8 +146,7 @@ public class SetupInfoServlet extends HttpServlet {
 				long time = new Date().getTime() - instance.getLastHeartBeat();
 
 				try {
-					objInner.put("inetAdress", instance.getInstanceConnectionInfo().getInetAdress());
-					objInner.put("ipcPort", instance.getTaskManager().path().address().hostPort());
+					objInner.put("path", instance.getInstanceGateway().path());
 					objInner.put("dataPort", instance.getInstanceConnectionInfo().dataPort());
 					objInner.put("timeSinceLastHeartbeat", time / 1000);
 					objInner.put("slotsNumber", instance.getTotalNumberOfSlots());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/NotifyCheckpointComplete.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/NotifyCheckpointComplete.java
@@ -20,29 +20,22 @@ package org.apache.flink.runtime.messages.checkpoint;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.runtime.util.SerializedValue;
 
 /**
  * This message is sent from the {@link org.apache.flink.runtime.jobmanager.JobManager} to the
  * {@link org.apache.flink.runtime.taskmanager.TaskManager} to tell a task that the checkpoint
  * has been confirmed and that the task can commit the checkpoint to the outside world.
  */
-public class ConfirmCheckpoint extends AbstractCheckpointMessage implements java.io.Serializable {
+public class NotifyCheckpointComplete extends AbstractCheckpointMessage implements java.io.Serializable {
 
 	private static final long serialVersionUID = 2094094662279578953L;
 
 	/** The timestamp associated with the checkpoint */
 	private final long timestamp;
 
-	/** The stateHandle associated with the checkpoint confirmation message*/
-	private final SerializedValue<StateHandle<?>> state;
-	
-	public ConfirmCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, long timestamp, 
-		SerializedValue<StateHandle<?>> state) {
+	public NotifyCheckpointComplete(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, long timestamp) {
 		super(job, taskExecutionId, checkpointId);
 		this.timestamp = timestamp;
-		this.state = state;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -53,14 +46,6 @@ public class ConfirmCheckpoint extends AbstractCheckpointMessage implements java
 
 	// --------------------------------------------------------------------------------------------
 
-	/**
-	 * Returns the stateHandle that was included in the confirmed checkpoint for a given task or null
-	 * if no state was commited in that checkpoint.
-	 */
-	public SerializedValue<StateHandle<?>> getState() {
-		return state;
-	}
-	
 	@Override
 	public int hashCode() {
 		return super.hashCode() + (int) (timestamp ^ (timestamp >>> 32));
@@ -71,8 +56,8 @@ public class ConfirmCheckpoint extends AbstractCheckpointMessage implements java
 		if (this == o) {
 			return true;
 		}
-		else if (o instanceof ConfirmCheckpoint) {
-			ConfirmCheckpoint that = (ConfirmCheckpoint) o;
+		else if (o instanceof NotifyCheckpointComplete) {
+			NotifyCheckpointComplete that = (NotifyCheckpointComplete) o;
 			return this.timestamp == that.timestamp && super.equals(o);
 		}
 		else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
@@ -89,10 +89,14 @@ public class EnvironmentInformation {
 		try {
 			return UserGroupInformation.getCurrentUser().getShortUserName();
 		}
+		catch (LinkageError e) {
+			// hadoop classes are not in the classpath
+			LOG.debug("Cannot determine user/group information using Hadoop utils. " +
+					"Hadoop classes not loaded or compatible", e);
+		}
 		catch (Throwable t) {
-			if (LOG.isDebugEnabled() && !(t instanceof ClassNotFoundException)) {
-				LOG.debug("Cannot determine user/group information using Hadoop utils.", t);
-			}
+			// some other error occurred that we should log and make known
+			LOG.warn("Error while accessing user/group information via Hadoop utils.", t);
 		}
 		
 		String user = System.getProperty("user.name");

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/taskmanager.js
@@ -224,7 +224,7 @@ function processTMdata(json) {
                                "</div>";
 
             var content = "<tr id=\""+tmRowIdCssName+"\">" +
-		                "<td style=\"width:20%\">"+tm.inetAdress+" <br> IPC Port: "+tm.ipcPort+", Data Port: "+tm.dataPort+"</td>" + // first row: TaskManager
+		                "<td style=\"width:20%\">"+tm.path+" <br> Data Port: "+tm.dataPort+"</td>" + // first row: TaskManager
 		                "<td id=\""+tmRowIdCssName+"-memory\">"+tmMemoryBox+"</td>" + // second row: memory statistics
 		                "<td id=\""+tmRowIdCssName+"-info\"><i>Loading Information</i></td>" + // Information
 		                "</tr>";

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -41,8 +41,6 @@ object AkkaUtils {
 
   val INF_TIMEOUT = 21474835 seconds
 
-  var globalExecutionContext: ExecutionContext = ExecutionContext.global
-
   /**
    * Creates a local actor system without remoting.
    *

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import grizzled.slf4j.Logger
 
 import org.apache.flink.configuration.{Configuration, ConfigConstants, GlobalConfiguration, IllegalConfigurationException}
-import org.apache.flink.runtime.messages.checkpoint.{ConfirmCheckpoint, TriggerCheckpoint, AbstractCheckpointMessage}
+import org.apache.flink.runtime.messages.checkpoint.{NotifyCheckpointComplete, TriggerCheckpoint, AbstractCheckpointMessage}
 import org.apache.flink.runtime.{StreamingMode, ActorSynchronousLogging, ActorLogMessages}
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.blob.{BlobService, BlobCache}
@@ -425,17 +425,16 @@ extends Actor with ActorLogMessages with ActorSynchronousLogging {
           log.debug(s"Taskmanager received a checkpoint request for unknown task $taskExecutionId.")
         }
 
-      case message: ConfirmCheckpoint =>
+      case message: NotifyCheckpointComplete =>
         val taskExecutionId = message.getTaskExecutionId
         val checkpointId = message.getCheckpointId
         val timestamp = message.getTimestamp
-        val state = message.getState
 
         log.debug(s"Receiver ConfirmCheckpoint ${checkpointId}@${timestamp} for $taskExecutionId.")
 
         val task = runningTasks.get(taskExecutionId)
         if (task != null) {
-          task.confirmCheckpoint(checkpointId, state)
+          task.notifyCheckpointComplete(checkpointId)
         } else {
           log.debug(
             s"Taskmanager received a checkpoint confirmation for unknown task $taskExecutionId.")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
-import org.apache.flink.runtime.messages.checkpoint.ConfirmCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
 import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
 import org.junit.Test;
 
@@ -199,8 +199,8 @@ public class CheckpointCoordinatorTest {
 			
 			// validate that the relevant tasks got a confirmation message
 			{
-				ConfirmCheckpoint confirmMessage1 = new ConfirmCheckpoint(jid, attemptID1, checkpointId, timestamp, null);
-				ConfirmCheckpoint confirmMessage2 = new ConfirmCheckpoint(jid, attemptID2, checkpointId, timestamp, null);
+				NotifyCheckpointComplete confirmMessage1 = new NotifyCheckpointComplete(jid, attemptID1, checkpointId, timestamp);
+				NotifyCheckpointComplete confirmMessage2 = new NotifyCheckpointComplete(jid, attemptID2, checkpointId, timestamp);
 				verify(vertex1, times(1)).sendMessageToCurrentExecution(eq(confirmMessage1), eq(attemptID1));
 				verify(vertex2, times(1)).sendMessageToCurrentExecution(eq(confirmMessage2), eq(attemptID2));
 			}
@@ -237,8 +237,8 @@ public class CheckpointCoordinatorTest {
 				verify(vertex1, times(1)).sendMessageToCurrentExecution(eq(expectedMessage1), eq(attemptID1));
 				verify(vertex2, times(1)).sendMessageToCurrentExecution(eq(expectedMessage2), eq(attemptID2));
 
-				ConfirmCheckpoint confirmMessage1 = new ConfirmCheckpoint(jid, attemptID1, checkpointIdNew, timestampNew, null);
-				ConfirmCheckpoint confirmMessage2 = new ConfirmCheckpoint(jid, attemptID2, checkpointIdNew, timestampNew, null);
+				NotifyCheckpointComplete confirmMessage1 = new NotifyCheckpointComplete(jid, attemptID1, checkpointIdNew, timestampNew);
+				NotifyCheckpointComplete confirmMessage2 = new NotifyCheckpointComplete(jid, attemptID2, checkpointIdNew, timestampNew);
 				verify(vertex1, times(1)).sendMessageToCurrentExecution(eq(confirmMessage1), eq(attemptID1));
 				verify(vertex2, times(1)).sendMessageToCurrentExecution(eq(confirmMessage2), eq(attemptID2));
 			}
@@ -343,7 +343,7 @@ public class CheckpointCoordinatorTest {
 			
 			// the first confirm message should be out
 			verify(commitVertex, times(1)).sendMessageToCurrentExecution(
-					new ConfirmCheckpoint(jid, commitAttemptID, checkpointId1, timestamp1, null), commitAttemptID);
+					new NotifyCheckpointComplete(jid, commitAttemptID, checkpointId1, timestamp1), commitAttemptID);
 			
 			// send the last remaining ack for the second checkpoint
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID3, checkpointId2));
@@ -355,7 +355,7 @@ public class CheckpointCoordinatorTest {
 
 			// the second commit message should be out
 			verify(commitVertex, times(1)).sendMessageToCurrentExecution(
-					new ConfirmCheckpoint(jid, commitAttemptID, checkpointId2, timestamp2, null), commitAttemptID);
+					new NotifyCheckpointComplete(jid, commitAttemptID, checkpointId2, timestamp2), commitAttemptID);
 			
 			// validate the committed checkpoints
 			List<SuccessfulCheckpoint> scs = coord.getSuccessfulCheckpoints();
@@ -482,7 +482,7 @@ public class CheckpointCoordinatorTest {
 
 			// the first confirm message should be out
 			verify(commitVertex, times(1)).sendMessageToCurrentExecution(
-					new ConfirmCheckpoint(jid, commitAttemptID, checkpointId2, timestamp2, null), commitAttemptID);
+					new NotifyCheckpointComplete(jid, commitAttemptID, checkpointId2, timestamp2), commitAttemptID);
 
 			// send the last remaining ack for the first checkpoint. This should not do anything
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID3, checkpointId1));
@@ -551,7 +551,7 @@ public class CheckpointCoordinatorTest {
 
 			// no confirm message must have been sent
 			verify(commitVertex, times(0))
-					.sendMessageToCurrentExecution(any(ConfirmCheckpoint.class), any(ExecutionAttemptID.class));
+					.sendMessageToCurrentExecution(any(NotifyCheckpointComplete.class), any(ExecutionAttemptID.class));
 			
 			coord.shutdown();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,6 +44,7 @@ public class AllVerticesIteratorTest {
 			v4.setParallelism(2);
 			
 			ExecutionGraph eg = Mockito.mock(ExecutionGraph.class);
+			Mockito.when(eg.getExecutionContext()).thenReturn(TestingUtils.directExecutionContext());
 					
 			ExecutionJobVertex ejv1 = new ExecutionJobVertex(eg, v1, 1,
 					AkkaUtils.getDefaultTimeout());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -99,7 +100,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -137,7 +143,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -198,7 +209,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -446,7 +462,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -496,7 +517,12 @@ public class ExecutionGraphConstructionTest {
 		
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v5, v4));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 			fail("Attached wrong jobgraph");
@@ -551,7 +577,11 @@ public class ExecutionGraphConstructionTest {
 			
 			List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jobId,
+					jobName,
+					cfg,
 					AkkaUtils.getDefaultTimeout());
 			try {
 				eg.attachJobGraph(ordered);
@@ -591,7 +621,11 @@ public class ExecutionGraphConstructionTest {
 			
 			List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jobId,
+					jobName,
+					cfg,
 					AkkaUtils.getDefaultTimeout());
 
 			try {
@@ -657,7 +691,11 @@ public class ExecutionGraphConstructionTest {
 			
 			JobGraph jg = new JobGraph(jobId, jobName, v1, v2, v3, v4, v5, v6, v7, v8);
 			
-			ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg,
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jobId,
+					jobName,
+					cfg,
 					AkkaUtils.getDefaultTimeout());
 			eg.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -24,18 +24,11 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 
-import akka.actor.Actor;
-import akka.testkit.TestActorRef;
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.Status;
-import akka.actor.UntypedActor;
-import akka.japi.Creator;
-import akka.testkit.JavaTestKit;
-
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.instance.BaseTestingInstanceGateway;
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
+import org.apache.flink.runtime.instance.InstanceGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.api.common.JobID;
@@ -46,25 +39,11 @@ import org.apache.flink.runtime.messages.TaskMessages;
 import org.apache.flink.runtime.messages.TaskMessages.TaskOperationResult;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import scala.concurrent.ExecutionContext;
 
 @SuppressWarnings("serial")
 public class ExecutionVertexCancelTest {
-
-	private static ActorSystem system;
-
-	@BeforeClass
-	public static void setup(){
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-	}
-
-	@AfterClass
-	public static void teardown(){
-		JavaTestKit.shutdownActorSystem(system);
-		system = null;
-	}
 
 	// --------------------------------------------------------------------------------------------
 	//  Canceling in different states
@@ -127,388 +106,350 @@ public class ExecutionVertexCancelTest {
 
 	@Test
 	public void testCancelConcurrentlyToDeploying_CallsNotOvertaking() {
-		new JavaTestKit(system){{
-			try {
-				final JobVertexID jid = new JobVertexID();
-				final ActionQueue actions = new ActionQueue();
+		try {
+			final JobVertexID jid = new JobVertexID();
 
-				TestingUtils.setExecutionContext(new TestingUtils.QueuedActionExecutionContext(
-						actions));
-
-				final ExecutionJobVertex ejv = getExecutionVertex(jid);
-
-				final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-						AkkaUtils.getDefaultTimeout());
-				final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
-
-				setVertexState(vertex, ExecutionState.SCHEDULED);
-				assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
-
-				ActorRef taskManager = TestActorRef.create(system, Props.create(new
-						CancelSequenceTaskManagerCreator(new TaskOperationResult(execId, true),
-						new TaskOperationResult(execId, false))));
-
-				Instance instance = getInstance(taskManager);
-				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
-
-				vertex.deployToSlot(slot);
+			final TestingUtils.QueuedActionExecutionContext executionContext = TestingUtils.queuedActionExecutionContext();
+			final TestingUtils.ActionQueue actions = executionContext.actionQueue();
 
 
-				assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
+			final ExecutionJobVertex ejv = getExecutionVertex(
+				jid,
+				executionContext
+			);
 
-				vertex.cancel();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-				assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			setVertexState(vertex, ExecutionState.SCHEDULED);
+			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
 
-				// first action happens (deploy)
-				actions.triggerNextAction();
-				assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					executionContext,
+					new TaskOperationResult(execId, true),
+					new TaskOperationResult(execId, false));
 
-				// the deploy call found itself in canceling after it returned and needs to send a cancel call
-				// the call did not yet execute, so it is still in canceling
-				assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-				// second action happens (cancel call from cancel function)
-				actions.triggerNextAction();
+			vertex.deployToSlot(slot);
 
-				// TaskManager reports back (canceling done)
-				vertex.getCurrentExecutionAttempt().cancelingComplete();
+			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 
-				// should properly set state to cancelled
-				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			vertex.cancel();
 
-				// trigger the correction canceling call
-				actions.triggerNextAction();
-				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-				assertTrue(slot.isReleased());
+			// first action happens (deploy)
+			actions.triggerNextAction();
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-				assertNull(vertex.getFailureCause());
+			// the deploy call found itself in canceling after it returned and needs to send a cancel call
+			// the call did not yet execute, so it is still in canceling
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-				assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-				assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-				assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-			}
-			catch(Exception e) {
-				e.printStackTrace();
-				fail(e.getMessage());
-			}
-			finally {
-				TestingUtils.setGlobalExecutionContext();
-			}
-		}};
+			// second action happens (cancel call from cancel function)
+			actions.triggerNextAction();
+
+			// TaskManager reports back (canceling done)
+			vertex.getCurrentExecutionAttempt().cancelingComplete();
+
+			// should properly set state to cancelled
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+
+			// trigger the correction canceling call
+			actions.triggerNextAction();
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+
+			assertTrue(slot.isReleased());
+
+			assertNull(vertex.getFailureCause());
+
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelConcurrentlyToDeploying_CallsOvertaking() {
-		new JavaTestKit(system){
-			{
-				try {
-					final JobVertexID jid = new JobVertexID();
-					final ActionQueue actions = new ActionQueue();
+		try {
+			final JobVertexID jid = new JobVertexID();
 
-					TestingUtils.setExecutionContext(new TestingUtils
-							.QueuedActionExecutionContext(actions));
+			final TestingUtils.QueuedActionExecutionContext executionContext = TestingUtils.queuedActionExecutionContext();
+			final TestingUtils.ActionQueue actions = executionContext.actionQueue();
 
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, executionContext);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					setVertexState(vertex, ExecutionState.SCHEDULED);
-					assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
+			setVertexState(vertex, ExecutionState.SCHEDULED);
+			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
 
-					// task manager cancel sequence mock actor
-					// first return NOT SUCCESS (task not found, cancel call overtook deploy call), then success (cancel call after deploy call)
-					TestActorRef<? extends Actor> taskManager = TestActorRef.create(system, Props.create(new
-							CancelSequenceTaskManagerCreator(new
-							TaskOperationResult(execId, false), new TaskOperationResult(execId, true))));
+			// task manager cancel sequence mock actor
+			// first return NOT SUCCESS (task not found, cancel call overtook deploy call), then success (cancel call after deploy call)
+			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					executionContext,
+					new	TaskOperationResult(execId, false),
+					new TaskOperationResult(execId, true)
+			);
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					vertex.deployToSlot(slot);
+			vertex.deployToSlot(slot);
 
-					assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
+			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					// first action happens (deploy)
-					Runnable deployAction = actions.popNextAction();
-					Runnable cancelAction = actions.popNextAction();
+			// first action happens (deploy)
+			Runnable deployAction = actions.popNextAction();
+			Runnable cancelAction = actions.popNextAction();
 
-					// cancel call first
-					cancelAction.run();
-					// process onComplete callback
-					actions.triggerNextAction();
+			// cancel call first
+			cancelAction.run();
+			// process onComplete callback
+			actions.triggerNextAction();
 
-					// did not find the task, not properly cancelled, stay in canceling
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			// did not find the task, not properly cancelled, stay in canceling
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					// deploy action next
-					deployAction.run();
+			// deploy action next
+			deployAction.run();
 
-					// the deploy call found itself in canceling after it returned and needs to send a cancel call
-					// the call did not yet execute, so it is still in canceling
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			// the deploy call found itself in canceling after it returned and needs to send a cancel call
+			// the call did not yet execute, so it is still in canceling
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					vertex.getCurrentExecutionAttempt().cancelingComplete();
+			vertex.getCurrentExecutionAttempt().cancelingComplete();
 
-					assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNull(vertex.getFailureCause());
+			assertNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelFromRunning() {
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final TestActorRef<? extends Actor> taskManager = TestActorRef.create(system,
-							Props.create(new CancelSequenceTaskManagerCreator(new
-									TaskOperationResult(execId, true))));
+			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					TestingUtils.directExecutionContext(),
+					new TaskOperationResult(execId, true));
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
-					vertex.getCurrentExecutionAttempt().cancelingComplete(); // responce by task manager once actially canceled
+			vertex.cancel();
+			vertex.getCurrentExecutionAttempt().cancelingComplete(); // responce by task manager once actially canceled
 
-					assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNull(vertex.getFailureCause());
+			assertNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testRepeatedCancelFromRunning() {
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
+		try {
 
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final ActorRef taskManager = TestActorRef.create(system, Props.create(new
-							CancelSequenceTaskManagerCreator(new
-							TaskOperationResult(execId, true))));
+			final InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					TestingUtils.directExecutionContext(),
+					new TaskOperationResult(execId, true)
+			);
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					// callback by TaskManager after canceling completes
-					vertex.getCurrentExecutionAttempt().cancelingComplete();
+			// callback by TaskManager after canceling completes
+			vertex.getCurrentExecutionAttempt().cancelingComplete();
 
-					assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNull(vertex.getFailureCause());
+			assertNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelFromRunningDidNotFindTask() {
 		// this may happen when the task finished or failed while the call was in progress
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final ActorRef taskManager = TestActorRef.create(system,Props.create(new
-							CancelSequenceTaskManagerCreator(new
-							TaskOperationResult(execId, false))));
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			final InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+					TestingUtils.directExecutionContext(),
+					new TaskOperationResult(execId, false)
+			);
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			Instance instance = getInstance(instanceGateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					vertex.cancel();
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
+			vertex.cancel();
 
-					assertNull(vertex.getFailureCause());
+			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertNull(vertex.getFailureCause());
+
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testCancelCallFails() {
-		new JavaTestKit(system) {
-			{
-				try {
-					TestingUtils.setCallingThreadDispatcher(system);
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
 
-					final ActorRef taskManager = TestActorRef.create(system, Props.create(new
-							CancelSequenceTaskManagerCreator()));
+			final InstanceGateway gateway = new CancelSequenceInstanceGateway(TestingUtils.directExecutionContext());
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(gateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
+			assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertNotNull(vertex.getFailureCause());
+			assertNotNull(vertex.getFailureCause());
 
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-					assertTrue(vertex.getStateTimestamp(ExecutionState.FAILED) > 0);
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}finally{
-					TestingUtils.setGlobalExecutionContext();
-				}
-			}
-		};
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
+			assertTrue(vertex.getStateTimestamp(ExecutionState.FAILED) > 0);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test
 	public void testSendCancelAndReceiveFail() {
-		new JavaTestKit(system) {
-			{
-				try {
-					final JobVertexID jid = new JobVertexID();
-					final ExecutionJobVertex ejv = getExecutionVertex(jid);
+		try {
+			final JobVertexID jid = new JobVertexID();
+			final ExecutionJobVertex ejv = getExecutionVertex(jid);
 
-					final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
-							AkkaUtils.getDefaultTimeout());
-					final ExecutionAttemptID execID = vertex.getCurrentExecutionAttempt().getAttemptId();
+			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
+					AkkaUtils.getDefaultTimeout());
+			final ExecutionAttemptID execID = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-					final ActorRef taskManager = system.actorOf(
-							Props.create(new CancelSequenceTaskManagerCreator(
-									new TaskOperationResult(execID, true)
-							)));
+			final InstanceGateway gateway = new CancelSequenceInstanceGateway(
+					TestingUtils.defaultExecutionContext(),
+					new TaskOperationResult(execID, true));
 
-					Instance instance = getInstance(taskManager);
-					SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
+			Instance instance = getInstance(gateway);
+			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
-					setVertexState(vertex, ExecutionState.RUNNING);
-					setVertexResource(vertex, slot);
+			setVertexState(vertex, ExecutionState.RUNNING);
+			setVertexResource(vertex, slot);
 
-					assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
+			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
-					vertex.cancel();
+			vertex.cancel();
 
-					assertTrue(vertex.getExecutionState() == ExecutionState.CANCELING || vertex.getExecutionState() == ExecutionState.FAILED);
+			assertTrue(vertex.getExecutionState() == ExecutionState.CANCELING || vertex.getExecutionState() == ExecutionState.FAILED);
 
-					vertex.getCurrentExecutionAttempt().markFailed(new Throwable("test"));
+			vertex.getCurrentExecutionAttempt().markFailed(new Throwable("test"));
 
-					assertTrue(vertex.getExecutionState() == ExecutionState.CANCELED || vertex.getExecutionState() == ExecutionState.FAILED);
+			assertTrue(vertex.getExecutionState() == ExecutionState.CANCELED || vertex.getExecutionState() == ExecutionState.FAILED);
 
-					assertTrue(slot.isReleased());
+			assertTrue(slot.isReleased());
 
-					assertEquals(0, vertex.getExecutionGraph().getRegisteredExecutions().size());
-				} catch (Exception e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}
-			}
-		};
+			assertEquals(0, vertex.getExecutionGraph().getRegisteredExecutions().size());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -541,7 +482,7 @@ public class ExecutionVertexCancelTest {
 			// deploying after canceling from CREATED needs to raise an exception, because
 			// the scheduler (or any caller) needs to know that the slot should be released
 			try {
-				Instance instance = getInstance(ActorRef.noSender());
+				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				vertex.deployToSlot(slot);
@@ -584,7 +525,7 @@ public class ExecutionVertexCancelTest {
 						AkkaUtils.getDefaultTimeout());
 				setVertexState(vertex, ExecutionState.CANCELING);
 
-				Instance instance = getInstance(ActorRef.noSender());
+				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				vertex.deployToSlot(slot);
@@ -600,7 +541,7 @@ public class ExecutionVertexCancelTest {
 				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 						AkkaUtils.getDefaultTimeout());
 
-				Instance instance = getInstance(ActorRef.noSender());
+				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				setVertexResource(vertex, slot);
@@ -621,39 +562,33 @@ public class ExecutionVertexCancelTest {
 		}
 	}
 
-	public static class CancelSequenceTaskManagerCreator implements Creator<CancelSequenceTaskManager> {
+	public static class CancelSequenceInstanceGateway extends BaseTestingInstanceGateway {
 		private final TaskOperationResult[] results;
-		public CancelSequenceTaskManagerCreator(TaskOperationResult ... results){
-			this.results = results;
+		private int index = -1;
+
+		public CancelSequenceInstanceGateway(ExecutionContext executionContext, TaskOperationResult ... result) {
+			super(executionContext);
+			this.results = result;
 		}
 
 		@Override
-		public CancelSequenceTaskManager create() throws Exception {
-			return new CancelSequenceTaskManager(results);
-		}
-	}
-
-	public static class CancelSequenceTaskManager extends UntypedActor{
-		private final TaskOperationResult[] results;
-		private int index;
-
-		public CancelSequenceTaskManager(TaskOperationResult[] results){
-			this.results = results;
-			index = -1;
-		}
-
-		@Override
-		public void onReceive(Object message) throws Exception {
-			if(message instanceof TaskMessages.SubmitTask){
-				getSender().tell(Messages.getAcknowledge(), getSelf());
-			}else if(message instanceof TaskMessages.CancelTask){
+		public Object handleMessage(Object message) throws Exception {
+			Object result;
+			if(message instanceof TaskMessages.SubmitTask) {
+				result = Messages.getAcknowledge();
+			} else if(message instanceof TaskMessages.CancelTask) {
 				index++;
+
 				if(index >= results.length){
-					getSender().tell(new Status.Failure(new IOException("RPC call failed.")), getSelf());
-				}else {
-					getSender().tell(results[index], getSelf());
+					throw new IOException("RPC call failed.");
+				} else {
+					result = results[index];
 				}
+			} else {
+				result = null;
 			}
+
+			return result;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -56,7 +57,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -91,7 +97,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -127,7 +138,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -164,7 +180,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -199,7 +220,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -254,7 +280,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -300,7 +331,12 @@ public class PointwisePatternTest {
 	
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 
-		ExecutionGraph eg = new ExecutionGraph(jobId, jobName, cfg, AkkaUtils.getDefaultTimeout());
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				jobName,
+				cfg,
+				AkkaUtils.getDefaultTimeout());
 		try {
 			eg.attachJobGraph(ordered);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
@@ -18,11 +18,10 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import akka.actor.ActorRef;
-
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -34,6 +33,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 
 import scala.concurrent.duration.FiniteDuration;
@@ -78,7 +78,7 @@ public class TerminalStateDeadlockTest {
 			InstanceConnectionInfo ci = new InstanceConnectionInfo(address, 12345);
 				
 			HardwareDescription resources = new HardwareDescription(4, 4000000, 3000000, 2000000);
-			Instance instance = new Instance(ActorRef.noSender(), ci, new InstanceID(), resources, 4);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, ci, new InstanceID(), resources, 4);
 
 			this.resource = instance.allocateSimpleSlot(new JobID());
 		}
@@ -116,7 +116,7 @@ public class TerminalStateDeadlockTest {
 				vertices = Arrays.asList(v1, v2);
 			}
 			
-			final Scheduler scheduler = new Scheduler();
+			final Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			final Executor executor = Executors.newFixedThreadPool(4);
 			
@@ -181,7 +181,7 @@ public class TerminalStateDeadlockTest {
 		private volatile boolean done;
 
 		TestExecGraph(JobID jobId) {
-			super(jobId, "test graph", EMPTY_CONFIG, TIMEOUT);
+			super(TestingUtils.defaultExecutionContext(), jobId, "test graph", EMPTY_CONFIG, TIMEOUT);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -39,41 +40,13 @@ import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import scala.concurrent.duration.FiniteDuration;
-import akka.actor.Actor;
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.testkit.JavaTestKit;
-import akka.testkit.TestActorRef;
 
 public class VertexLocationConstraintTest {
 
 	private static final FiniteDuration timeout = new FiniteDuration(100, TimeUnit.SECONDS);
-	
-	private static ActorSystem system;
-	
-	private static TestActorRef<? extends Actor> taskManager;
-	
-	
-	@BeforeClass
-	public static void setup() {
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-		
-		taskManager = TestActorRef.create(system,
-				Props.create(ExecutionGraphTestUtils.SimpleAcknowledgingTaskManager.class));
-	}
-
-	@AfterClass
-	public static void teardown() {
-		JavaTestKit.shutdownActorSystem(system);
-		system = null;
-	}
-	
 	
 	@Test
 	public void testScheduleWithConstraint1() {
@@ -91,7 +64,7 @@ public class VertexLocationConstraintTest {
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			Instance instance3 = getInstance(address3, 6789, hostname3);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			scheduler.newInstanceAvailable(instance2);
 			scheduler.newInstanceAvailable(instance3);
@@ -102,7 +75,12 @@ public class VertexLocationConstraintTest {
 			jobVertex.setParallelism(2);
 			JobGraph jg = new JobGraph("test job", jobVertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -157,7 +135,7 @@ public class VertexLocationConstraintTest {
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			Instance instance3 = getInstance(address3, 6789, hostname3);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			scheduler.newInstanceAvailable(instance2);
 			scheduler.newInstanceAvailable(instance3);
@@ -168,7 +146,12 @@ public class VertexLocationConstraintTest {
 			jobVertex.setParallelism(2);
 			JobGraph jg = new JobGraph("test job", jobVertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -219,7 +202,7 @@ public class VertexLocationConstraintTest {
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			Instance instance3 = getInstance(address3, 6789, hostname3);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			scheduler.newInstanceAvailable(instance2);
 			scheduler.newInstanceAvailable(instance3);
@@ -238,7 +221,12 @@ public class VertexLocationConstraintTest {
 			
 			JobGraph jg = new JobGraph("test job", jobVertex1, jobVertex2);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex1.getID());
@@ -290,7 +278,7 @@ public class VertexLocationConstraintTest {
 			Instance instance1 = getInstance(address1, 6789, hostname1);
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			
 			// prepare the execution graph
@@ -299,7 +287,12 @@ public class VertexLocationConstraintTest {
 			jobVertex.setParallelism(1);
 			JobGraph jg = new JobGraph("test job", jobVertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -343,7 +336,7 @@ public class VertexLocationConstraintTest {
 			Instance instance1 = getInstance(address1, 6789, hostname1);
 			Instance instance2 = getInstance(address2, 6789, hostname2);
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			scheduler.newInstanceAvailable(instance1);
 			
 			// prepare the execution graph
@@ -362,7 +355,12 @@ public class VertexLocationConstraintTest {
 			jobVertex1.setSlotSharingGroup(sharingGroup);
 			jobVertex2.setSlotSharingGroup(sharingGroup);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex1.getID());
@@ -395,12 +393,17 @@ public class VertexLocationConstraintTest {
 			JobVertex vertex = new JobVertex("test vertex", new JobVertexID());
 			JobGraph jg = new JobGraph("test job", vertex);
 			
-			ExecutionGraph eg = new ExecutionGraph(jg.getJobID(), jg.getName(), jg.getJobConfiguration(), timeout);
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					jg.getJobID(),
+					jg.getName(),
+					jg.getJobConfiguration(),
+					timeout);
 			eg.attachJobGraph(Collections.singletonList(vertex));
 			
 			ExecutionVertex ev = eg.getAllVertices().get(vertex.getID()).getTaskVertices()[0];
 			
-			Instance instance = ExecutionGraphTestUtils.getInstance(ActorRef.noSender());
+			Instance instance = ExecutionGraphTestUtils.getInstance(DummyInstanceGateway.INSTANCE);
 			ev.setLocationConstraintHosts(Collections.singletonList(instance));
 			
 			assertNotNull(ev.getPreferredLocations());
@@ -431,6 +434,12 @@ public class VertexLocationConstraintTest {
 		when(connection.getHostname()).thenReturn(hostname);
 		when(connection.getFQDNHostname()).thenReturn(hostname);
 		
-		return new Instance(taskManager, connection, new InstanceID(), hardwareDescription, 1);
+		return new Instance(
+				new ExecutionGraphTestUtils.SimpleInstanceGateway(
+						TestingUtils.defaultExecutionContext()),
+				connection,
+				new InstanceID(),
+				hardwareDescription,
+				1);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 
 public class VertexSlotSharingTest {
@@ -68,7 +69,11 @@ public class VertexSlotSharingTest {
 			
 			List<JobVertex> vertices = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 			
-			ExecutionGraph eg = new ExecutionGraph(new JobID(), "test job", new Configuration(),
+			ExecutionGraph eg = new ExecutionGraph(
+					TestingUtils.defaultExecutionContext(),
+					new JobID(),
+					"test job",
+					new Configuration(),
 					AkkaUtils.getDefaultTimeout());
 			eg.attachJobGraph(vertices);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/BaseTestingInstanceGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/BaseTestingInstanceGateway.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorPath;
+import akka.actor.ActorRef;
+import akka.dispatch.Futures;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Abstract base class for testing {@link InstanceGateway} instances. The implementing subclass
+ * only has to provide an implementation for handleMessage which contains the logic to treat
+ * different messages.
+ */
+abstract public class BaseTestingInstanceGateway implements InstanceGateway {
+	/**
+	 * {@link ExecutionContext} which is used to execute the futures.
+	 */
+	private final ExecutionContext executionContext;
+
+	public BaseTestingInstanceGateway(ExecutionContext executionContext) {
+		this.executionContext = executionContext;
+	}
+
+	@Override
+	public Future<Object> ask(Object message, FiniteDuration timeout) {
+		try {
+			final Object result = handleMessage(message);
+
+			return Futures.future(new Callable<Object>() {
+				@Override
+				public Object call() throws Exception {
+					return result;
+				}
+			}, executionContext);
+
+		} catch (final Exception e) {
+			// if an exception occurred in the handleMessage method then return it as part of the future
+			return Futures.future(new Callable<Object>() {
+				@Override
+				public Object call() throws Exception {
+					throw e;
+				}
+			}, executionContext);
+		}
+	}
+
+	/**
+	 * Handles the supported messages by this InstanceGateway
+	 *
+	 * @param message Message to handle
+	 * @return Result
+	 * @throws Exception
+	 */
+	abstract public Object handleMessage(Object message) throws Exception;
+
+	@Override
+	public void tell(Object message) {}
+
+	@Override
+	public void forward(Object message, ActorRef sender) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<Object> retry(Object message, int numberRetries, FiniteDuration timeout, ExecutionContext executionContext) {
+		return ask(message, timeout);
+	}
+
+	@Override
+	public String path() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyInstanceGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyInstanceGateway.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.instance;
+
+import akka.actor.ActorPath;
+import akka.actor.ActorRef;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Dummy {@link InstanceGateway} implementation used for testing.
+ */
+public class DummyInstanceGateway implements InstanceGateway {
+	public static final DummyInstanceGateway INSTANCE = new DummyInstanceGateway();
+
+	@Override
+	public Future<Object> ask(Object message, FiniteDuration timeout) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void tell(Object message) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void forward(Object message, ActorRef sender) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<Object> retry(Object message, int numberRetries, FiniteDuration timeout, ExecutionContext executionContext) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String path() {
+		return "DummyInstanceGateway";
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.*;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 
-import akka.actor.ActorRef;
 import org.apache.flink.api.common.JobID;
 import org.junit.Test;
 
@@ -39,7 +38,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 4);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 4);
 
 			assertEquals(4, instance.getTotalNumberOfSlots());
 			assertEquals(4, instance.getNumberOfAvailableSlots());
@@ -100,7 +99,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 
@@ -130,7 +129,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 
-import akka.actor.ActorRef;
-
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.api.common.JobID;
 
@@ -148,7 +146,7 @@ public class SimpleSlotTest {
 		InetAddress address = InetAddress.getByName("127.0.0.1");
 		InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-		Instance instance = new Instance(ActorRef.noSender(), connection, new InstanceID(), hardwareDescription, 1);
+		Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 1);
 		return instance.allocateSimpleSlot(new JobID());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.net.NetUtils;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 import org.mockito.Mockito;
 import scala.Some;
@@ -58,7 +59,10 @@ public class NetworkEnvironmentTest {
 					NUM_BUFFERS, BUFFER_SIZE, IOManager.IOMode.SYNC, new Some<NettyConfig>(nettyConf),
 					new Tuple2<Integer, Integer>(0, 0));
 
-			NetworkEnvironment env = new NetworkEnvironment(new FiniteDuration(30, TimeUnit.SECONDS), config);
+			NetworkEnvironment env = new NetworkEnvironment(
+				TestingUtils.defaultExecutionContext(),
+				new FiniteDuration(30, TimeUnit.SECONDS),
+				config);
 
 			assertFalse(env.isShutdown());
 			assertFalse(env.isAssociated());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleWithCoLocationHintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleWithCoLocationHintTest.java
@@ -27,33 +27,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import akka.actor.ActorSystem;
-import akka.testkit.JavaTestKit;
-
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ScheduleWithCoLocationHintTest {
-
-	private static ActorSystem system;
-
-	@BeforeClass
-	public static void setup(){
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-		TestingUtils.setCallingThreadDispatcher(system);
-	}
-
-	@AfterClass
-	public static void teardown(){
-		TestingUtils.setGlobalExecutionContext();
-		JavaTestKit.shutdownActorSystem(system);
-	}
 
 	@Test
 	public void scheduleAllSharedAndCoLocated() {
@@ -61,7 +42,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			scheduler.newInstanceAvailable(getRandomInstance(2));
 			scheduler.newInstanceAvailable(getRandomInstance(2));
@@ -187,7 +168,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid3 = new JobVertexID();
 			JobVertexID jid4 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -231,7 +212,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid2 = new JobVertexID();
 			JobVertexID jid3 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -276,7 +257,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid3 = new JobVertexID();
 			JobVertexID jid4 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			scheduler.newInstanceAvailable(getRandomInstance(1));
 			scheduler.newInstanceAvailable(getRandomInstance(1));
 			scheduler.newInstanceAvailable(getRandomInstance(1));
@@ -338,7 +319,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid2 = new JobVertexID();
 			JobVertexID jid3 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -407,7 +388,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -461,7 +442,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid2 = new JobVertexID();
 			JobVertexID jidx = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -519,7 +500,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);
@@ -581,7 +562,7 @@ public class ScheduleWithCoLocationHintTest {
 			JobVertexID jid1 = new JobVertexID();
 			JobVertexID jid2 = new JobVertexID();
 			
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.directExecutionContext());
 			
 			Instance i1 = getRandomInstance(1);
 			Instance i2 = getRandomInstance(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerIsolatedTasksTest.java
@@ -25,11 +25,7 @@ import static org.apache.flink.runtime.jobmanager.scheduler.SchedulerTestUtils.g
 import static org.junit.Assert.*;
 
 import org.apache.flink.runtime.instance.SimpleSlot;
-import akka.actor.ActorSystem;
-import akka.testkit.JavaTestKit;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -47,24 +43,11 @@ import org.apache.flink.runtime.instance.Instance;
  * Tests for the {@link Scheduler} when scheduling individual tasks.
  */
 public class SchedulerIsolatedTasksTest {
-	private static ActorSystem system;
 
-	@BeforeClass
-	public static void setup(){
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
-		TestingUtils.setCallingThreadDispatcher(system);
-	}
-
-	@AfterClass
-	public static void teardown(){
-		TestingUtils.setGlobalExecutionContext();
-		JavaTestKit.shutdownActorSystem(system);
-	}
-	
 	@Test
 	public void testAddAndRemoveInstance() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			Instance i1 = getRandomInstance(2);
 			Instance i2 = getRandomInstance(2);
@@ -128,7 +111,7 @@ public class SchedulerIsolatedTasksTest {
 	@Test
 	public void testScheduleImmediately() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			assertEquals(0, scheduler.getNumberOfAvailableSlots());
 			
 			scheduler.newInstanceAvailable(getRandomInstance(2));
@@ -197,12 +180,10 @@ public class SchedulerIsolatedTasksTest {
 		final int NUM_SLOTS_PER_INSTANCE = 3;
 		final int NUM_TASKS_TO_SCHEDULE = 2000;
 
-		TestingUtils.setGlobalExecutionContext();
-
 		try {
 			// note: since this test asynchronously releases slots, the executor needs release workers.
 			// doing the release call synchronous can lead to a deadlock
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 
 			for (int i = 0; i < NUM_INSTANCES; i++) {
 				scheduler.newInstanceAvailable(getRandomInstance((int) (Math.random() * NUM_SLOTS_PER_INSTANCE) + 1));
@@ -287,15 +268,13 @@ public class SchedulerIsolatedTasksTest {
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
-		} finally {
-			TestingUtils.setCallingThreadDispatcher(system);
 		}
 	}
 	
 	@Test
 	public void testScheduleWithDyingInstances() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			Instance i1 = getRandomInstance(2);
 			Instance i2 = getRandomInstance(2);
@@ -355,7 +334,7 @@ public class SchedulerIsolatedTasksTest {
 	@Test
 	public void testSchedulingLocation() {
 		try {
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 			
 			Instance i1 = getRandomInstance(2);
 			Instance i2 = getRandomInstance(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -29,9 +29,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import akka.actor.ActorRef;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.instance.DummyInstanceGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -66,7 +66,7 @@ public class SchedulerTestUtils {
 		final long GB = 1024L*1024*1024;
 		HardwareDescription resources = new HardwareDescription(4, 4*GB, 3*GB, 2*GB);
 		
-		return new Instance(ActorRef.noSender(), ci, new InstanceID(), resources, numSlots);
+		return new Instance(DummyInstanceGateway.INSTANCE, ci, new InstanceID(), resources, numSlots);
 	}
 	
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.*;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.messages.checkpoint.ConfirmCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
 import org.apache.flink.runtime.state.StateHandle;
@@ -38,7 +38,7 @@ public class CheckpointMessagesTest {
 	@Test
 	public void testTriggerAndConfirmCheckpoint() {
 		try {
-			ConfirmCheckpoint cc = new ConfirmCheckpoint(new JobID(), new ExecutionAttemptID(), 45287698767345L, 467L, null);
+			NotifyCheckpointComplete cc = new NotifyCheckpointComplete(new JobID(), new ExecutionAttemptID(), 45287698767345L, 467L);
 			testSerializabilityEqualsHashCode(cc);
 			
 			TriggerCheckpoint tc = new TriggerCheckpoint(new JobID(), new ExecutionAttemptID(), 347652734L, 7576752L);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 
 import org.apache.flink.runtime.messages.TaskManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 import scala.Option;
 import scala.Tuple2;
@@ -89,7 +90,10 @@ public class TaskManagerComponentsStartupShutdownTest {
 
 			final MemoryManager memManager = new DefaultMemoryManager(32 * BUFFER_SIZE, 1, BUFFER_SIZE, false);
 			final IOManager ioManager = new IOManagerAsync(TMP_DIR);
-			final NetworkEnvironment network = new NetworkEnvironment(timeout, netConf);
+			final NetworkEnvironment network = new NetworkEnvironment(
+				TestingUtils.defaultExecutionContext(),
+				timeout,
+				netConf);
 			final int numberOfSlots = 1;
 
 			// create the task manager

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/EnvironmentInformationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/EnvironmentInformationTest.java
@@ -30,12 +30,20 @@ public class EnvironmentInformationTest {
 	public void testJavaMemory() {
 		try {
 			long fullHeap = EnvironmentInformation.getMaxJvmHeapMemory();
-			long free = EnvironmentInformation.getSizeOfFreeHeapMemory();
 			long freeWithGC = EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag();
 			
 			assertTrue(fullHeap > 0);
-			assertTrue(free >= 0);
 			assertTrue(freeWithGC >= 0);
+
+			try {
+				long free = EnvironmentInformation.getSizeOfFreeHeapMemory();
+				assertTrue(free >= 0);
+			}
+			catch (RuntimeException e) {
+				// this may only occur if the Xmx is not set
+				assertEquals(Long.MAX_VALUE, EnvironmentInformation.getMaxJvmHeapMemory());
+			}
+			
 			
 			// we cannot make these assumptions, because the test JVM may grow / shrink during the GC
 			// assertTrue(free <= fullHeap);

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
@@ -177,12 +177,12 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
           jm ! NotifyWhenJobStatus(jobGraph.getJobID, JobStatus.RESTARTING)
           jm ! RequestWorkingTaskManager(jobGraph.getJobID)
 
-          val WorkingTaskManager(tm) = expectMsgType[WorkingTaskManager]
+          val WorkingTaskManager(gatewayOption) = expectMsgType[WorkingTaskManager]
 
-          tm match {
-            case ActorRef.noSender => fail("There has to be at least one task manager on which" +
+          gatewayOption match {
+            case None => fail("There has to be at least one task manager on which" +
               "the tasks are running.")
-            case t => t ! PoisonPill
+            case Some(gateway) => gateway.tell(PoisonPill)
           }
 
           expectMsg(JobStatusIs(jobGraph.getJobID, JobStatus.RESTARTING))

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -60,16 +60,34 @@ class TestingCluster(userConfiguration: Configuration,
 
   override def startJobManager(actorSystem: ActorSystem): ActorRef = {
 
-    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager,
-    executionRetries, delayBetweenRetries,
-    timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
+    val (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      _,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      archiveCount) = JobManager.createJobManagerComponents(configuration)
     
     val testArchiveProps = Props(new MemoryArchivist(archiveCount) with TestingMemoryArchivist)
     val archive = actorSystem.actorOf(testArchiveProps, JobManager.ARCHIVE_NAME)
     
-    val jobManagerProps = Props(new JobManager(configuration, instanceManager, scheduler,
-      libraryCacheManager, archive, accumulatorManager, executionRetries,
-      delayBetweenRetries, timeout, streamingMode) with TestingJobManager)
+    val jobManagerProps = Props(
+      new JobManager(
+        configuration,
+        executionContext,
+        instanceManager,
+        scheduler,
+        libraryCacheManager,
+        archive,
+        accumulatorManager,
+        executionRetries,
+        delayBetweenRetries,
+        timeout,
+        streamingMode)
+      with TestingJobManager)
 
     actorSystem.actorOf(jobManagerProps, JobManager.JOB_MANAGER_NAME)
   }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -106,11 +106,10 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
 
 
     case NotifyWhenJobRemoved(jobID) =>
-      val tms = instanceManager.getAllRegisteredInstances.map(_.getTaskManager)
+      val gateways = instanceManager.getAllRegisteredInstances.map(_.getInstanceGateway)
 
-      val responses = tms.map{
-        tm =>
-          (tm ? NotifyWhenJobRemoved(jobID))(timeout).mapTo[Boolean]
+      val responses = gateways.map{
+        gateway => gateway.ask(NotifyWhenJobRemoved(jobID), timeout).mapTo[Boolean]
       }
 
       import context.dispatcher
@@ -135,17 +134,17 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
       currentJobs.get(jobID) match {
         case Some((eg, _)) =>
           if(eg.getAllExecutionVertices.isEmpty){
-            sender ! WorkingTaskManager(ActorRef.noSender)
+            sender ! WorkingTaskManager(None)
           } else {
             val resource = eg.getAllExecutionVertices.head.getCurrentAssignedResource
 
             if(resource == null){
-              sender ! WorkingTaskManager(ActorRef.noSender)
+              sender ! WorkingTaskManager(None)
             } else {
-              sender ! WorkingTaskManager(resource.getInstance().getTaskManager)
+              sender ! WorkingTaskManager(Some(resource.getInstance().getInstanceGateway))
             }
           }
-        case None => sender ! WorkingTaskManager(ActorRef.noSender)
+        case None => sender ! WorkingTaskManager(None)
       }
 
     case NotifyWhenJobStatus(jobID, state) =>

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.testingUtils
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.executiongraph.ExecutionGraph
+import org.apache.flink.runtime.instance.InstanceGateway
 import org.apache.flink.runtime.jobgraph.JobStatus
 
 object TestingJobManagerMessages {
@@ -43,7 +44,7 @@ object TestingJobManagerMessages {
   case class NotifyWhenJobRemoved(jobID: JobID)
 
   case class RequestWorkingTaskManager(jobID: JobID)
-  case class WorkingTaskManager(taskManager: ActorRef)
+  case class WorkingTaskManager(gatewayOption: Option[InstanceGateway])
 
   case class NotifyWhenJobStatus(jobID: JobID, state: JobStatus)
   case class JobStatusIs(jobID: JobID, state: JobStatus)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -18,14 +18,12 @@
 
 package org.apache.flink.runtime.testingUtils
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.CallingThreadDispatcher
+import com.google.common.util.concurrent.MoreExecutors
 
 import com.typesafe.config.ConfigFactory
 
 import org.apache.flink.configuration.{ConfigConstants, Configuration}
 import org.apache.flink.runtime.akka.AkkaUtils
-import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.ActionQueue
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
@@ -67,19 +65,33 @@ object TestingUtils {
     new TestingCluster(config)
   }
 
-  def setGlobalExecutionContext(): Unit = {
-    AkkaUtils.globalExecutionContext = ExecutionContext.global
+  /** Returns the global [[ExecutionContext]] which is a [[scala.concurrent.forkjoin.ForkJoinPool]]
+    * with a default parallelism equal to the number of available cores.
+    *
+    * @return ExecutionContext.global
+    */
+  def defaultExecutionContext = ExecutionContext.global
+
+  /** Returns an [[ExecutionContext]] which uses the current thread to execute the runnable.
+    *
+    * @return Direct [[ExecutionContext]] which executes runnables directly
+    */
+  def directExecutionContext = ExecutionContext.fromExecutor(MoreExecutors.directExecutor())
+
+  /** @return A new [[QueuedActionExecutionContext]] */
+  def queuedActionExecutionContext = {
+    new QueuedActionExecutionContext(new ActionQueue())
   }
 
-  def setCallingThreadDispatcher(system: ActorSystem): Unit = {
-    AkkaUtils.globalExecutionContext = system.dispatchers.lookup(CallingThreadDispatcher.Id)
-  }
+  /** [[ExecutionContext]] which queues [[Runnable]] up in an [[ActionQueue]] instead of
+    * execution them. If the automatic execution mode is activated, then the [[Runnable]] are
+    * executed.
+    *
+    * @param actionQueue
+    */
+  class QueuedActionExecutionContext private[testingUtils] (val actionQueue: ActionQueue)
+    extends ExecutionContext {
 
-  def setExecutionContext(context: ExecutionContext): Unit = {
-    AkkaUtils.globalExecutionContext = context
-  }
-
-  class QueuedActionExecutionContext(queue: ActionQueue) extends ExecutionContext {
     var automaticExecution = false
 
     def toggleAutomaticExecution() = {
@@ -90,12 +102,34 @@ object TestingUtils {
       if(automaticExecution){
         runnable.run()
       }else {
-        queue.queueAction(runnable)
+        actionQueue.queueAction(runnable)
       }
     }
 
     override def reportFailure(t: Throwable): Unit = {
       t.printStackTrace()
+    }
+  }
+
+  /** Queue which stores [[Runnable]] */
+  class ActionQueue {
+    private val runnables = scala.collection.mutable.Queue[Runnable]()
+
+    def triggerNextAction {
+      val r = runnables.dequeue
+      r.run()
+    }
+
+    def popNextAction: Runnable = {
+      runnables.dequeue()
+    }
+
+    def queueAction(r: Runnable) {
+      runnables.enqueue(r)
+    }
+
+    def isEmpty: Boolean = {
+      runnables.isEmpty
     }
   }
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/api/persistent/PersistentKafkaSource.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/api/persistent/PersistentKafkaSource.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.connectors.kafka.api.persistent;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,12 +40,12 @@ import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkMarshallingError;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.commons.collections.map.LinkedMap;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.streaming.api.checkpoint.CheckpointCommitter;
+import org.apache.flink.streaming.api.checkpoint.CheckpointNotifier;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedAsynchronously;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.zookeeper.data.Stat;
@@ -67,13 +66,14 @@ import com.google.common.base.Preconditions;
  */
 public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> implements
 		ResultTypeQueryable<OUT>,
-		CheckpointCommitter {
+		CheckpointNotifier, CheckpointedAsynchronously<long[]> {
 
 	private static final long serialVersionUID = 287845877188312621L;
 	
 	private static final Logger LOG = LoggerFactory.getLogger(PersistentKafkaSource.class);
 
-	
+	private final LinkedMap pendingCheckpoints = new LinkedMap();
+
 	private final String topicName;
 	private final DeserializationSchema<OUT> deserializationSchema;
 	
@@ -82,9 +82,11 @@ public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> 
 	private transient ConsumerConnector consumer;
 	
 	private transient ZkClient zkClient;
-	private transient OperatorState<long[]> lastOffsets;
-	private transient long[] commitedOffsets; // maintain committed offsets, to avoid committing the same over and over again.
-	
+
+	private transient long[] lastOffsets;			// Current offset (backuped state)
+	protected transient long[] commitedOffsets; 	// maintain committed offsets, to avoid committing the same over and over again.
+	private transient long[] restoreState;			// set by the restore() method, used by open() to valdiate the restored state.
+
 	private volatile boolean running;
 	
 	/**
@@ -145,23 +147,26 @@ public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> 
 		// most likely the number of offsets we're going to store here will be lower than the number of partitions.
 		int numPartitions = getNumberOfPartitions();
 		LOG.debug("The topic {} has {} partitions", topicName, numPartitions);
-		this.lastOffsets = getRuntimeContext().getOperatorState("offset", new long[numPartitions], false);
+		this.lastOffsets = new long[numPartitions];
 		this.commitedOffsets = new long[numPartitions];
+
 		// check if there are offsets to restore
-		if (!Arrays.equals(lastOffsets.value(), new long[numPartitions])) {
-			if (lastOffsets.value().length != numPartitions) {
-				throw new IllegalStateException("There are "+lastOffsets.value().length+" offsets to restore for topic "+topicName+" but " +
+		if (restoreState != null) {
+			if (restoreState.length != numPartitions) {
+				throw new IllegalStateException("There are "+restoreState.length+" offsets to restore for topic "+topicName+" but " +
 						"there are only "+numPartitions+" in the topic");
 			}
 
-			LOG.info("Setting restored offsets {} in ZooKeeper", Arrays.toString(lastOffsets.value()));
-			setOffsetsInZooKeeper(lastOffsets.value());
+			LOG.info("Setting restored offsets {} in ZooKeeper", Arrays.toString(restoreState));
+			setOffsetsInZooKeeper(restoreState);
+			this.lastOffsets = restoreState;
 		} else {
 			// initialize empty offsets
-			Arrays.fill(this.lastOffsets.value(), -1);
+			Arrays.fill(this.lastOffsets, -1);
 		}
 		Arrays.fill(this.commitedOffsets, 0); // just to make it clear
-		
+
+		pendingCheckpoints.clear();
 		running = true;
 	}
 
@@ -175,7 +180,7 @@ public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> 
 		
 		while (running && iteratorToRead.hasNext()) {
 			MessageAndMetadata<byte[], byte[]> message = iteratorToRead.next();
-			if(lastOffsets.value()[message.partition()] >= message.offset()) {
+			if(lastOffsets[message.partition()] >= message.offset()) {
 				LOG.info("Skipping message with offset {} from partition {}", message.offset(), message.partition());
 				continue;
 			}
@@ -188,7 +193,7 @@ public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> 
 
 			// make the state update and the element emission atomic
 			synchronized (checkpointLock) {
-				lastOffsets.value()[message.partition()] = message.offset();
+				lastOffsets[message.partition()] = message.offset();
 				ctx.collect(next);
 			}
 
@@ -210,19 +215,63 @@ public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> 
 		zkClient.close();
 	}
 
+	// -----------------  State Checkpointing -----------------
+
+	@Override
+	public long[] snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
+		if (lastOffsets == null) {
+			LOG.warn("State snapshot requested on not yet opened source. Returning null");
+			return null;
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Snapshotting state. Offsets: {}, checkpoint id {}, timestamp {}",
+					Arrays.toString(lastOffsets), checkpointId, checkpointTimestamp);
+		}
+
+		long[] currentOffsets = Arrays.copyOf(lastOffsets, lastOffsets.length);
+
+		// the map may be asynchronously updates when committing to Kafka, so we synchronize
+		synchronized (pendingCheckpoints) {
+			pendingCheckpoints.put(checkpointId, currentOffsets);
+		}
+
+		return currentOffsets;
+	}
+
+	@Override
+	public void restoreState(long[] state) {
+		LOG.info("The state will be restored to {} in the open() method", Arrays.toString(state));
+		this.restoreState = Arrays.copyOf(state, state.length);
+	}
+
 	
 	/**
 	 * Notification on completed checkpoints
 	 * @param checkpointId The ID of the checkpoint that has been completed.
 	 * @throws Exception 
 	 */
-	@Override
-	public void commitCheckpoint(long checkpointId, String stateName, StateHandle<Serializable> state) throws Exception {
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
 		LOG.info("Commit checkpoint {}", checkpointId);
 
 		long[] checkpointOffsets;
 
-		checkpointOffsets = (long[]) state.getState();
+		// the map may be asynchronously updates when snapshotting state, so we synchronize
+		synchronized (pendingCheckpoints) {
+			final int posInMap = pendingCheckpoints.indexOf(checkpointId);
+			if (posInMap == -1) {
+				LOG.warn("Unable to find pending checkpoint for id {}", checkpointId);
+				return;
+			}
+
+			checkpointOffsets = (long[]) pendingCheckpoints.remove(posInMap);
+			// remove older checkpoints in map:
+			if (!pendingCheckpoints.isEmpty()) {
+				for(int i = 0; i < posInMap; i++) {
+					pendingCheckpoints.remove(0);
+				}
+			}
+		}
 
 		if (LOG.isInfoEnabled()) {
 			LOG.info("Committing offsets {} to ZooKeeper", Arrays.toString(checkpointOffsets));
@@ -254,11 +303,15 @@ public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> 
 	}
 
 	protected void setOffset(int partition, long offset) {
-		if(commitedOffsets[partition] < offset) {
-			setOffset(zkClient, consumerConfig.groupId(), topicName, partition, offset);
-			commitedOffsets[partition] = offset;
-		} else {
-			LOG.debug("Ignoring offset {} for partition {} because it is already committed", offset, partition);
+		// synchronize because notifyCheckpointComplete is called using asynchronous worker threads (= multiple checkpoints might be confirmed concurrently)
+		synchronized (commitedOffsets) {
+			if(commitedOffsets[partition] < offset) {
+				LOG.info("Committed offsets {}, partition={}, offset={}, locking on {}", Arrays.toString(commitedOffsets), partition, offset, commitedOffsets.hashCode());
+				setOffset(zkClient, consumerConfig.groupId(), topicName, partition, offset);
+				commitedOffsets[partition] = offset;
+			} else {
+				LOG.debug("Ignoring offset {} for partition {} because it is already committed", offset, partition);
+			}
 		}
 	}
 
@@ -304,7 +357,6 @@ public class PersistentKafkaSource<OUT> extends RichParallelSourceFunction<OUT> 
 	public TypeInformation<OUT> getProducedType() {
 		return deserializationSchema.getProducedType();
 	}
-
 
 	// ---------------------- Zookeeper Serializer copied from Kafka (because it has private access there)  -----------------
 

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/util/UtilsTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/util/UtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.kafka.util;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.connectors.kafka.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UtilsTest {
+
+	/**
+	 * Ensure that the returned byte array has the expected size
+	 */
+	@Test
+	public void testTypeInformationSerializationSchema() {
+		final ExecutionConfig ec = new ExecutionConfig();
+
+		Tuple2<Integer, Integer> test = new Tuple2<Integer, Integer>(1,666);
+
+		Utils.TypeInformationSerializationSchema<Tuple2<Integer, Integer>> ser = new Utils.TypeInformationSerializationSchema<Tuple2<Integer, Integer>>(test, ec);
+
+		byte[] res = ser.serialize(test);
+		Assert.assertEquals(8, res.length);
+
+		Tuple2<Integer, Integer> another = ser.deserialize(res);
+		Assert.assertEquals(test.f0, another.f0);
+		Assert.assertEquals(test.f1, another.f1);
+	}
+
+	@Test
+	public void testGrowing() {
+		final ExecutionConfig ec = new ExecutionConfig();
+
+		Tuple2<Integer, byte[]> test1 = new Tuple2<Integer, byte[]>(1, new byte[16]);
+
+		Utils.TypeInformationSerializationSchema<Tuple2<Integer, byte[]>> ser = new Utils.TypeInformationSerializationSchema<Tuple2<Integer, byte[]>>(test1, ec);
+
+		byte[] res = ser.serialize(test1);
+		Assert.assertEquals(24, res.length);
+		Tuple2<Integer, byte[]> another = ser.deserialize(res);
+		Assert.assertEquals(16, another.f1.length);
+
+		test1 = new Tuple2<Integer, byte[]>(1, new byte[26]);
+
+		res = ser.serialize(test1);
+		Assert.assertEquals(34, res.length);
+		another = ser.deserialize(res);
+		Assert.assertEquals(26, another.f1.length);
+
+		test1 = new Tuple2<Integer, byte[]>(1, new byte[1]);
+
+		res = ser.serialize(test1);
+		Assert.assertEquals(9, res.length);
+		another = ser.deserialize(res);
+		Assert.assertEquals(1, another.f1.length);
+	}
+
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointNotifier.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointNotifier.java
@@ -15,19 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.streaming.api.checkpoint;
-
-import java.io.Serializable;
-
-import org.apache.flink.runtime.state.StateHandle;
 
 /**
  * This interface must be implemented by functions/operations that want to receive
  * a commit notification once a checkpoint has been completely acknowledged by all
  * participants.
  */
-public interface CheckpointCommitter {
+public interface CheckpointNotifier {
 
 	/**
 	 * This method is called as a notification once a distributed checkpoint has been completed.
@@ -36,9 +31,7 @@ public interface CheckpointCommitter {
 	 * fail any more.
 	 * 
 	 * @param checkpointId The ID of the checkpoint that has been completed.
-	 * @param stateName The name of the committed state
-	 * @param checkPointedState Handle to the state that was checkpointed with this checkpoint id.
-	 * @throws Exception 
+	 * @throws Exception
 	 */
-	void commitCheckpoint(long checkpointId, String stateName, StateHandle<Serializable> checkPointedState) throws Exception;
+	void notifyCheckpointComplete(long checkpointId) throws Exception;
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -394,15 +394,16 @@ public class StreamingJobGraphGenerator {
 			List<JobVertexID> ackVertices = new ArrayList<JobVertexID>(jobVertices.size());
 
 			// collect the vertices that receive "commit checkpoint" messages
-			// currently, these are only the sources
+			// currently, these are all certices
 			List<JobVertexID> commitVertices = new ArrayList<JobVertexID>();
 			
 			
 			for (JobVertex vertex : jobVertices.values()) {
 				if (vertex.isInputVertex()) {
 					triggerVertices.add(vertex.getID());
-					commitVertices.add(vertex.getID());
 				}
+				// TODO: add check whether the user function implements the checkpointing interface
+				commitVertices.add(vertex.getID());
 				ackVertices.add(vertex.getID());
 			}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -30,7 +30,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.PartitionedStateHandle;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StateHandleProvider;
-import org.apache.flink.streaming.api.checkpoint.CheckpointCommitter;
+import org.apache.flink.streaming.api.checkpoint.CheckpointNotifier;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.state.StreamOperatorState;
 import org.apache.flink.streaming.runtime.tasks.StreamingRuntimeContext;
@@ -134,11 +134,10 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function & Serial
 
 	}
 
-	public void confirmCheckpointCompleted(long checkpointId, String stateName,
-			StateHandle<Serializable> checkpointedState) throws Exception {
-		if (userFunction instanceof CheckpointCommitter) {
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		if (userFunction instanceof CheckpointNotifier) {
 			try {
-				((CheckpointCommitter) userFunction).commitCheckpoint(checkpointId, stateName, checkpointedState);
+				((CheckpointNotifier) userFunction).notifyCheckpointComplete(checkpointId);
 			} catch (Exception e) {
 				throw new Exception("Error while confirming checkpoint " + checkpointId + " to the stream function", e);
 			}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/StatefulStreamOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/StatefulStreamOperator.java
@@ -36,5 +36,5 @@ public interface StatefulStreamOperator<OUT> extends StreamOperator<OUT> {
 
 	Tuple2<StateHandle<Serializable>, Map<String, PartitionedStateHandle>> getStateSnapshotFromFunction(long checkpointId, long timestamp) throws Exception;
 
-	void confirmCheckpointCompleted(long checkpointId, String stateName, StateHandle<Serializable> checkpointedState) throws Exception;
+	void notifyCheckpointComplete(long checkpointId) throws Exception;
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/resources/log4j-test.properties
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/resources/log4j-test.properties
@@ -17,7 +17,7 @@
 ################################################################################
 
 # Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=OFF, A1
+log4j.rootLogger=INFO, A1
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -30,8 +30,8 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.StreamingMode;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -148,7 +148,7 @@ public class TestBaseUtils {
 				}
 
 				Future<Iterable<Object>> bcVariableManagerFutureResponses = Futures.sequence(
-						bcVariableManagerResponseFutures, AkkaUtils.globalExecutionContext());
+						bcVariableManagerResponseFutures, TestingUtils.defaultExecutionContext());
 
 				Iterable<Object> responses = Await.result(bcVariableManagerFutureResponses, timeout);
 
@@ -158,7 +158,7 @@ public class TestBaseUtils {
 				}
 
 				Future<Iterable<Object>> numActiveConnectionsFutureResponses = Futures.sequence(
-						numActiveConnectionsResponseFutures, AkkaUtils.globalExecutionContext());
+						numActiveConnectionsResponseFutures, TestingUtils.defaultExecutionContext());
 
 				responses = Await.result(numActiveConnectionsFutureResponses, timeout);
 

--- a/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
+++ b/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
@@ -80,16 +80,38 @@ class ForkableFlinkMiniCluster(userConfiguration: Configuration,
 
   override def startJobManager(actorSystem: ActorSystem): ActorRef = {
 
-    val (instanceManager, scheduler, libraryCacheManager, _, accumulatorManager,
-    executionRetries, delayBetweenRetries,
-    timeout, archiveCount) = JobManager.createJobManagerComponents(configuration)
+    val (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      _,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      archiveCount) = JobManager.createJobManagerComponents(configuration)
 
-    val testArchiveProps = Props(new MemoryArchivist(archiveCount) with TestingMemoryArchivist)
+    val testArchiveProps = Props(
+      new MemoryArchivist(
+        archiveCount)
+      with TestingMemoryArchivist)
+
     val archive = actorSystem.actorOf(testArchiveProps, JobManager.ARCHIVE_NAME)
     
-    val jobManagerProps = Props(new JobManager(configuration, instanceManager, scheduler,
-      libraryCacheManager, archive, accumulatorManager, executionRetries,
-      delayBetweenRetries, timeout, streamingMode) with TestingJobManager)
+    val jobManagerProps = Props(
+      new JobManager(
+        configuration,
+        executionContext,
+        instanceManager,
+        scheduler,
+        libraryCacheManager,
+        archive,
+        accumulatorManager,
+        executionRetries,
+        delayBetweenRetries,
+        timeout,
+        streamingMode)
+      with TestingJobManager)
 
     val jobManager = actorSystem.actorOf(jobManagerProps, JobManager.JOB_MANAGER_NAME)
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
@@ -23,26 +23,35 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
 import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.functions.RichReduceFunction;
 import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.streaming.api.checkpoint.CheckpointNotifier;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.test.util.ForkableFlinkMiniCluster;
+import org.apache.flink.util.Collector;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A simple test that runs a streaming topology with checkpointing enabled.
@@ -87,9 +96,8 @@ public class StreamCheckpointingITCase {
 			fail("Failed to stop test cluster: " + e.getMessage());
 		}
 	}
-	
-	
-	
+
+
 	/**
 	 * Runs the following program:
 	 *

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
@@ -110,9 +110,15 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
           jm ! RequestWorkingTaskManager(jobID)
 
-          val tm = expectMsgType[WorkingTaskManager].taskManager
-          // kill one task manager
-          tm ! PoisonPill
+          val gatewayOption = expectMsgType[WorkingTaskManager].gatewayOption
+
+          gatewayOption match {
+            case Some(gateway) =>
+              // kill one task manager
+              gateway.tell(PoisonPill)
+
+            case None => fail("Could not retrieve a working task manager.")
+          }
 
           val failure = expectMsgType[Failure]
 

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
@@ -467,7 +467,11 @@ public abstract class YarnTestBase {
 			// check if thread died
 			if(!runner.isAlive()) {
 				sendOutput();
-				Assert.fail("Runner thread died before the test was finished. Return value = " +runner.getReturnValue());
+				if(runner.getReturnValue() != 0) {
+					Assert.fail("Runner thread died before the test was finished. Return value = " + runner.getReturnValue());
+				} else {
+					LOG.info("Runner stopped earlier than expected with return value = 0");
+				}
 			}
 		}
 		sendOutput();

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMaster.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMaster.scala
@@ -235,16 +235,34 @@ object ApplicationMaster {
 
     // start all the components inside the job manager
     LOG.debug("Starting JobManager components")
-    val (instanceManager, scheduler, libraryCacheManager, archiveProps, accumulatorManager,
-                   executionRetries, delayBetweenRetries,
-                   timeout, _) = JobManager.createJobManagerComponents(configuration)
+    val (executionContext,
+      instanceManager,
+      scheduler,
+      libraryCacheManager,
+      archiveProps,
+      accumulatorManager,
+      executionRetries,
+      delayBetweenRetries,
+      timeout,
+      _) = JobManager.createJobManagerComponents(configuration)
 
     // start the archiver
     val archiver: ActorRef = jobManagerSystem.actorOf(archiveProps, JobManager.ARCHIVE_NAME)
 
-    val jobManagerProps = Props(new JobManager(configuration, instanceManager, scheduler,
-      libraryCacheManager, archiver, accumulatorManager, executionRetries,
-      delayBetweenRetries, timeout, streamingMode) with ApplicationMasterActor)
+    val jobManagerProps = Props(
+      new JobManager(
+        configuration,
+        executionContext,
+        instanceManager,
+        scheduler,
+        libraryCacheManager,
+        archiver,
+        accumulatorManager,
+        executionRetries,
+        delayBetweenRetries,
+        timeout,
+        streamingMode)
+      with ApplicationMasterActor)
 
     LOG.debug("Starting JobManager actor")
     val jobManager = JobManager.startActor(jobManagerProps, jobManagerSystem)

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterActor.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterActor.scala
@@ -103,7 +103,7 @@ trait ApplicationMasterActor extends ActorLogMessages {
 
       instanceManager.getAllRegisteredInstances.asScala foreach {
         instance =>
-          instance.getTaskManager ! StopYarnSession(status, diag)
+          instance.getInstanceGateway.tell(StopYarnSession(status, diag))
       }
 
       rmClientOption foreach {


### PR DESCRIPTION
Hadoop's mapred API features the `JobConfigurable` interface which offers a function `configure(JobConf)` to configure user-defined classes such as InputFormats, OutputFormats, and InputSplits.

Flink's Hadoop compatibility wrappers do not respect this interface.

Only the last commit is part of this commit due to sync problems of GH mirror.