### PR TITLE
[FLINK-2332] [runtime] Adds leader session IDs and registration session IDs

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/FlinkUntypedActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/FlinkUntypedActor.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.akka;
+
+import akka.actor.UntypedActor;
+import org.apache.flink.runtime.messages.JobManagerMessages.LeaderSessionMessage;
+import org.apache.flink.runtime.messages.RequiresLeaderSessionID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+
+import java.util.UUID;
+
+/**
+ * Base class for Flink's actors implemented with Java. Actors inheriting from this class
+ * automatically log received messages when the debug log level is activated. Furthermore,
+ * they filter out {@link LeaderSessionMessage} with the wrong leader session ID. If a message
+ * of type {@link RequiresLeaderSessionID} without being wrapped in a LeaderSessionMessage is
+ * detected, then an Exception is thrown.
+ *
+ * In order to implement the actor behavior, an implementing subclass has to override the method
+ * handleMessage, which defines how messages are processed. Furthermore, the subclass has to provide
+ * a leader session ID option which is returned by getLeaderSessionID.
+ */
+public abstract class FlinkUntypedActor extends UntypedActor {
+	protected static Logger LOG = LoggerFactory.getLogger(FlinkUntypedActor.class);
+
+	/**
+	 * This method is called by Akka if a new message has arrived for the actor. It logs the
+	 * processing time of the incoming message if the logging level is set to debug. After logging
+	 * the handleLeaderSessionID method is called.
+	 *
+	 * Important: This method cannot be overriden. The actor specific message handling logic is
+	 * implemented by the method handleMessage.
+	 *
+	 * @param message Incoming message
+	 * @throws Exception
+	 */
+	@Override
+	public final void onReceive(Object message) throws Exception {
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("Received message {} at {} from {}.", message, getSelf().path(), getSender());
+
+			long start = System.nanoTime();
+
+			handleLeaderSessionID(message);
+
+			long duration = (System.nanoTime() - start)/ 1000000;
+
+			LOG.debug("Handled message {} in {} ms from {}.", message, duration, getSender());
+		} else {
+			handleLeaderSessionID(message);
+		}
+	}
+
+	/**
+	 * This method filters out {@link LeaderSessionMessage} whose leader session ID is not equal
+	 * to the actors leader session ID. If a message of type {@link RequiresLeaderSessionID}
+	 * arrives, then an Exception is thrown, because these messages have to be wrapped in a
+	 * {@link LeaderSessionMessage}.
+	 *
+	 * @param message Incoming message
+	 * @throws Exception
+	 */
+	private void handleLeaderSessionID(Object message) throws Exception {
+		if(message instanceof LeaderSessionMessage) {
+			LeaderSessionMessage msg = (LeaderSessionMessage) message;
+
+			if(msg.leaderSessionID().isDefined() && getLeaderSessionID().isDefined()) {
+				if(getLeaderSessionID().equals(msg.leaderSessionID())) {
+					// finally call method to handle message
+					handleMessage(msg.message());
+				} else {
+					handleDiscardedMessage(msg);
+				}
+			} else {
+				handleDiscardedMessage(msg);
+			}
+		} else if (message instanceof RequiresLeaderSessionID) {
+			throw new Exception("Received a message " + message + " without a leader session " +
+					"ID, even though it requires to have one.");
+		} else {
+			// call method to handle message
+			handleMessage(message);
+		}
+	}
+
+	private void handleDiscardedMessage(Object msg) {
+		LOG.debug("Discard message {} because the leader session ID was not correct.", msg);
+	}
+
+	/**
+	 * This method contains the actor logic which defines how to react to incoming messages.
+	 *
+	 * @param message Incoming message
+	 * @throws Exception
+	 */
+	protected abstract void handleMessage(Object message) throws Exception;
+
+	/**
+	 * Returns the current leader session ID associcated with this actor.
+	 * @return
+	 */
+	protected abstract Option<UUID> getLeaderSessionID();
+
+	/**
+	 * This method should be called for every outgoing message. It wraps messages which require
+	 * a leader session ID (indicated by {@link RequiresLeaderSessionID}) in a
+	 * {@link LeaderSessionMessage} with the actor's leader session ID.
+	 *
+	 * This method can be overriden to implement a different decoration behavior.
+	 *
+	 * @param message Message to be decorated
+	 * @return The deocrated message
+	 */
+	protected Object decorateMessage(Object message) {
+		if(message instanceof  RequiresLeaderSessionID) {
+			return new LeaderSessionMessage(getLeaderSessionID(), message);
+		} else {
+			return message;
+		}
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
@@ -18,26 +18,38 @@
 
 package org.apache.flink.runtime.checkpoint;
 
-import akka.actor.UntypedActor;
+import com.google.common.base.Preconditions;
+import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.ExecutionGraphMessages;
+import scala.Option;
+
+import java.util.UUID;
 
 /**
  * This actor listens to changes in the JobStatus and activates or deactivates the periodic
  * checkpoint scheduler.
  */
-public class CheckpointCoordinatorDeActivator extends UntypedActor {
+public class CheckpointCoordinatorDeActivator extends FlinkUntypedActor {
 
 	private final CheckpointCoordinator coordinator;
 	private final long interval;
+	private final Option<UUID> leaderSessionID;
 	
-	public CheckpointCoordinatorDeActivator(CheckpointCoordinator coordinator, long interval) {
+	public CheckpointCoordinatorDeActivator(
+			CheckpointCoordinator coordinator,
+			long interval,
+			Option<UUID> leaderSessionID) {
+		Preconditions.checkNotNull(coordinator, "The checkpointCoordinator must not be null.");
+		Preconditions.checkNotNull(leaderSessionID, "The leaderSesssionID must not be null.");
+
 		this.coordinator = coordinator;
 		this.interval = interval;
+		this.leaderSessionID = leaderSessionID;
 	}
 
 	@Override
-	public void onReceive(Object message) {
+	public void handleMessage(Object message) {
 		if (message instanceof ExecutionGraphMessages.JobStatusChanged) {
 			JobStatus status = ((ExecutionGraphMessages.JobStatusChanged) message).newJobStatus();
 			
@@ -52,5 +64,10 @@ public class CheckpointCoordinatorDeActivator extends UntypedActor {
 		}
 		
 		// we ignore all other messages
+	}
+
+	@Override
+	public Option<UUID> getLeaderSessionID() {
+		return leaderSessionID;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
@@ -22,37 +22,47 @@ import akka.actor.ActorRef;
 import akka.actor.PoisonPill;
 import akka.actor.Status;
 import akka.actor.Terminated;
-import akka.actor.UntypedActor;
+import com.google.common.base.Preconditions;
+import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.ExecutionGraphMessages;
 import org.apache.flink.runtime.messages.JobClientMessages;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.slf4j.Logger;
+import scala.Option;
+
+import java.util.UUID;
 
 /**
  * Actor which constitutes the bridge between the non-actor code and the JobManager. The JobClient
  * is used to submit jobs to the JobManager and to request the port of the BlobManager.
  */
-public class JobClientActor extends UntypedActor {
+public class JobClientActor extends FlinkUntypedActor {
 	
 	private final ActorRef jobManager;
 	private final Logger logger;
 	private final boolean sysoutUpdates;
-	
+
+	// leader session ID of the JobManager when this actor was created
+	private final Option<UUID> leaderSessionID;
+
+	// Actor which submits a job to the JobManager via this actor
 	private ActorRef submitter;
-	
-	
-	public JobClientActor(ActorRef jobManager, Logger logger, boolean sysoutUpdates) {
-		if (jobManager == null || logger == null) {
-			throw new NullPointerException();
-		}
-		this.jobManager = jobManager;
-		this.logger = logger;
+
+	public JobClientActor(
+			ActorRef jobManager,
+			Logger logger,
+			boolean sysoutUpdates,
+			Option<UUID> leaderSessionID) {
+		this.jobManager = Preconditions.checkNotNull(jobManager, "The JobManager ActorRef must not be null.");
+		this.logger = Preconditions.checkNotNull(logger, "The logger must not be null.");
+		this.leaderSessionID = Preconditions.checkNotNull(leaderSessionID, "The leader session ID option must not be null.");
+
 		this.sysoutUpdates = sysoutUpdates;
 	}
 	
 	@Override
-	public void onReceive(Object message) {
+	protected void handleMessage(Object message) {
 		
 		// =========== State Change Messages ===============
 
@@ -73,14 +83,17 @@ public class JobClientActor extends UntypedActor {
 				JobGraph jobGraph = ((JobClientMessages.SubmitJobAndWait) message).jobGraph();
 				if (jobGraph == null) {
 					logger.error("Received null JobGraph");
-					sender().tell(new Status.Failure(new Exception("JobGraph is null")), getSelf());
+					sender().tell(
+							decorateMessage(new Status.Failure(new Exception("JobGraph is null"))),
+							getSelf());
 				}
 				else {
 					logger.info("Sending message to JobManager {} to submit job {} ({}) and wait for progress",
 							jobManager.path().toString(), jobGraph.getName(), jobGraph.getJobID());
 
 					this.submitter = getSender();
-					jobManager.tell(new JobManagerMessages.SubmitJob(jobGraph, true), getSelf());
+					jobManager.tell(
+							decorateMessage(new JobManagerMessages.SubmitJob(jobGraph, true)), getSelf());
 					
 					// make sure we notify the sender when the connection got lost
 					getContext().watch(jobManager);
@@ -90,10 +103,12 @@ public class JobClientActor extends UntypedActor {
 				// repeated submission - tell failure to sender and kill self
 				String msg = "Received repeated 'SubmitJobAndWait'";
 				logger.error(msg);
-				getSender().tell(new Status.Failure(new Exception(msg)), ActorRef.noSender());
+				getSender().tell(
+						decorateMessage(new Status.Failure(new Exception(msg))),
+						ActorRef.noSender());
 
 				getContext().unwatch(jobManager);
-				getSelf().tell(PoisonPill.getInstance(), ActorRef.noSender());
+				getSelf().tell(decorateMessage(PoisonPill.getInstance()), ActorRef.noSender());
 			}
 		}
 		// acknowledgement to submit job is only logged, our original
@@ -102,12 +117,12 @@ public class JobClientActor extends UntypedActor {
 			// forward the success to the original job submitter
 			logger.debug("Received JobResultSuccess message from JobManager");
 			if (this.submitter != null) {
-				this.submitter.tell(message, getSelf());
+				this.submitter.tell(decorateMessage(message), getSelf());
 			}
 			
 			// we are done, stop ourselves
 			getContext().unwatch(jobManager);
-			getSelf().tell(PoisonPill.getInstance(), ActorRef.noSender());
+			getSelf().tell(decorateMessage(PoisonPill.getInstance()), ActorRef.noSender());
 		}
 		else if (message instanceof Status.Success) {
 			// job was successfully submitted :-)
@@ -117,7 +132,7 @@ public class JobClientActor extends UntypedActor {
 			// job execution failed, inform the actor that submitted the job
 			logger.debug("Received failure from JobManager", ((Status.Failure) message).cause());
 			if (submitter != null) {
-				submitter.tell(message, sender());
+				submitter.tell(decorateMessage(message), sender());
 			}
 		}
 
@@ -128,7 +143,7 @@ public class JobClientActor extends UntypedActor {
 			if (jobManager.equals(target)) {
 				String msg = "Lost connection to JobManager " + jobManager.path();
 				logger.info(msg);
-				submitter.tell(new Status.Failure(new Exception(msg)), getSelf());
+				submitter.tell(decorateMessage(new Status.Failure(new Exception(msg))), getSelf());
 			} else {
 				logger.error("Received 'Terminated' for unknown actor " + target);
 			}
@@ -140,7 +155,12 @@ public class JobClientActor extends UntypedActor {
 			logger.error("JobClient received unknown message: " + message);
 		}
 	}
-	
+
+	@Override
+	protected Option<UUID> getLeaderSessionID() {
+		return leaderSessionID;
+	}
+
 	private void logAndPrintMessage(Object message) {
 		logger.info(message.toString());
 		if (sysoutUpdates) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
-import org.apache.flink.runtime.instance.InstanceGateway;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -361,7 +361,7 @@ public class Execution implements Serializable {
 			vertex.getExecutionGraph().registerExecution(this);
 
 			final Instance instance = slot.getInstance();
-			final InstanceGateway gateway = instance.getInstanceGateway();
+			final ActorGateway gateway = instance.getActorGateway();
 
 			final Future<Object> deployAction = gateway.ask(new SubmitTask(deployment), timeout);
 
@@ -848,7 +848,7 @@ public class Execution implements Serializable {
 
 		if (slot != null) {
 
-			final InstanceGateway gateway = slot.getInstance().getInstanceGateway();
+			final ActorGateway gateway = slot.getInstance().getActorGateway();
 
 			Future<Object> cancelResult = gateway.retry(
 				new CancelTask(attemptId),
@@ -881,7 +881,7 @@ public class Execution implements Serializable {
 			final Instance instance = slot.getInstance();
 
 			if (instance.isAlive()) {
-				final InstanceGateway gateway = instance.getInstanceGateway();
+				final ActorGateway gateway = instance.getActorGateway();
 
 				// TODO For some tests this could be a problem when querying too early if all resources were released
 				gateway.tell(new FailIntermediateResultPartitions(attemptId));
@@ -901,7 +901,7 @@ public class Execution implements Serializable {
 
 		if (consumerSlot != null) {
 			final Instance instance = consumerSlot.getInstance();
-			final InstanceGateway gateway = instance.getInstanceGateway();
+			final ActorGateway gateway = instance.getActorGateway();
 
 			Future<Object> futureUpdate = gateway.ask(updatePartitionInfo, timeout);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import akka.actor.ActorRef;
-
 import akka.actor.ActorSystem;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.accumulators.Accumulator;
@@ -32,6 +30,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -50,6 +49,7 @@ import org.apache.flink.util.InstantiationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -63,6 +63,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -166,10 +167,10 @@ public class ExecutionGraph implements Serializable {
 
 	/** Listeners that receive messages when the entire job switches it status (such as from
 	 * RUNNING to FINISHED) */
-	private final List<ActorRef> jobStatusListenerActors;
+	private final List<ActorGateway> jobStatusListenerActors;
 
 	/** Listeners that receive messages whenever a single task execution changes its status */
-	private final List<ActorRef> executionListenerActors;
+	private final List<ActorGateway> executionListenerActors;
 
 	/** Timestamps (in milliseconds as returned by {@code System.currentTimeMillis()} when
 	 * the execution graph transitioned into a certain state. The index into this array is the
@@ -287,8 +288,8 @@ public class ExecutionGraph implements Serializable {
 		this.verticesInCreationOrder = new ArrayList<ExecutionJobVertex>();
 		this.currentExecutions = new ConcurrentHashMap<ExecutionAttemptID, Execution>();
 
-		this.jobStatusListenerActors  = new CopyOnWriteArrayList<ActorRef>();
-		this.executionListenerActors = new CopyOnWriteArrayList<ActorRef>();
+		this.jobStatusListenerActors  = new CopyOnWriteArrayList<ActorGateway>();
+		this.executionListenerActors = new CopyOnWriteArrayList<ActorGateway>();
 
 		this.stateTimestamps = new long[JobStatus.values().length];
 		this.stateTimestamps[JobStatus.CREATED.ordinal()] = System.currentTimeMillis();
@@ -340,12 +341,14 @@ public class ExecutionGraph implements Serializable {
 		return scheduleMode;
 	}
 
-	public void enableSnaphotCheckpointing(long interval, long checkpointTimeout,
-											List<ExecutionJobVertex> verticesToTrigger,
-											List<ExecutionJobVertex> verticesToWaitFor,
-											List<ExecutionJobVertex> verticesToCommitTo,
-											ActorSystem actorSystem)
-	{
+	public void enableSnapshotCheckpointing(
+			long interval,
+			long checkpointTimeout,
+			List<ExecutionJobVertex> verticesToTrigger,
+			List<ExecutionJobVertex> verticesToWaitFor,
+			List<ExecutionJobVertex> verticesToCommitTo,
+			ActorSystem actorSystem,
+			Option<UUID> leaderSessionID) {
 		// simple sanity checks
 		if (interval < 10 || checkpointTimeout < 10) {
 			throw new IllegalArgumentException();
@@ -363,12 +366,22 @@ public class ExecutionGraph implements Serializable {
 		
 		// create the coordinator that triggers and commits checkpoints and holds the state 
 		snapshotCheckpointsEnabled = true;
-		checkpointCoordinator = new CheckpointCoordinator(jobID, NUMBER_OF_SUCCESSFUL_CHECKPOINTS_TO_RETAIN,
-				checkpointTimeout, tasksToTrigger, tasksToWaitFor, tasksToCommitTo, userClassLoader);
+		checkpointCoordinator = new CheckpointCoordinator(
+				jobID,
+				NUMBER_OF_SUCCESSFUL_CHECKPOINTS_TO_RETAIN,
+				checkpointTimeout,
+				tasksToTrigger,
+				tasksToWaitFor,
+				tasksToCommitTo,
+				userClassLoader);
 		
 		// the periodic checkpoint scheduler is activated and deactivated as a result of
 		// job status changes (running -> on, all other states -> off)
-		registerJobStatusListener(checkpointCoordinator.createJobStatusListener(actorSystem, interval));
+		registerJobStatusListener(
+				checkpointCoordinator.createJobStatusListener(
+						actorSystem,
+						interval,
+						leaderSessionID));
 	}
 	
 	public void disableSnaphotCheckpointing() {
@@ -998,13 +1011,13 @@ public class ExecutionGraph implements Serializable {
 	//  Listeners & Observers
 	// --------------------------------------------------------------------------------------------
 
-	public void registerJobStatusListener(ActorRef listener) {
+	public void registerJobStatusListener(ActorGateway listener) {
 		if (listener != null) {
 			this.jobStatusListenerActors.add(listener);
 		}
 	}
 
-	public void registerExecutionListener(ActorRef listener) {
+	public void registerExecutionListener(ActorGateway listener) {
 		if (listener != null) {
 			this.executionListenerActors.add(listener);
 		}
@@ -1016,8 +1029,8 @@ public class ExecutionGraph implements Serializable {
 			ExecutionGraphMessages.JobStatusChanged message =
 					new ExecutionGraphMessages.JobStatusChanged(jobID, newState, System.currentTimeMillis(), error);
 
-			for (ActorRef listener: jobStatusListenerActors) {
-				listener.tell(message, ActorRef.noSender());
+			for (ActorGateway listener: jobStatusListenerActors) {
+				listener.tell(message);
 			}
 		}
 	}
@@ -1035,8 +1048,8 @@ public class ExecutionGraph implements Serializable {
 																	executionID, newExecutionState,
 																	System.currentTimeMillis(), message);
 
-			for (ActorRef listener : executionListenerActors) {
-				listener.tell(actorMessage, ActorRef.noSender());
+			for (ActorGateway listener : executionListenerActors) {
+				listener.tell(actorMessage);
 			}
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
-import org.apache.flink.runtime.instance.InstanceGateway;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -469,7 +469,7 @@ public class ExecutionVertex implements Serializable {
 			
 			// send only if we actually have a target
 			if (slot != null) {
-				InstanceGateway gateway = slot.getInstance().getInstanceGateway();
+				ActorGateway gateway = slot.getInstance().getActorGateway();
 				if (gateway != null) {
 					gateway.tell(message);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/ActorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/ActorGateway.java
@@ -19,16 +19,19 @@
 package org.apache.flink.runtime.instance;
 
 import akka.actor.ActorRef;
+import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.util.UUID;
+
 /**
- * Interface to abstract the communication with an Instance.
+ * Interface to abstract the communication with an actor.
  *
  * It allows to avoid direct interaction with an ActorRef.
  */
-public interface InstanceGateway {
+public interface ActorGateway {
 
 	/**
 	 * Sends a message asynchronously and returns its response. The response to the message is
@@ -48,13 +51,21 @@ public interface InstanceGateway {
 	void tell(Object message);
 
 	/**
+	 * Sends a message asynchronously without a result with sender being the sender.
+	 *
+	 * @param message Message to be sent
+	 * @param sender Sender of the message
+	 */
+	void tell(Object message, ActorGateway sender);
+
+	/**
 	 * Forwards a message. For the receiver of this message it looks as if sender has sent the
 	 * message.
 	 *
 	 * @param message Message to be sent
 	 * @param sender Sender of the forwarded message
 	 */
-	void forward(Object message, ActorRef sender);
+	void forward(Object message, ActorGateway sender);
 
 	/**
 	 * Retries to send asynchronously a message up to numberRetries times. The response to this
@@ -79,4 +90,18 @@ public interface InstanceGateway {
 	 * @return Path of the remote instance.
 	 */
 	String path();
+
+	/**
+	 * Returns the underlying actor with which is communicated
+	 *
+	 * @return ActorRef of the target actor
+	 */
+	ActorRef actor();
+
+	/**
+	 * Returns the leaderSessionID associated with the remote actor or None.
+	 *
+	 * @return Leader session ID if its associated with this gateway, otherwise None
+	 */
+	Option<UUID> leaderSessionID();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
@@ -42,7 +42,7 @@ public class Instance {
 	private final Object instanceLock = new Object();
 
 	/** The instacne gateway to communicate with the instance */
-	private final InstanceGateway instanceGateway;
+	private final ActorGateway actorGateway;
 
 	/** The instance connection information for the data transfer. */
 	private final InstanceConnectionInfo connectionInfo;
@@ -79,19 +79,19 @@ public class Instance {
 	/**
 	 * Constructs an instance reflecting a registered TaskManager.
 	 *
-	 * @param instanceGateway The instance gateway to communicate with the remote instance
+	 * @param actorGateway The actor gateway to communicate with the remote instance
 	 * @param connectionInfo The remote connection where the task manager receives requests.
 	 * @param id The id under which the taskManager is registered.
 	 * @param resources The resources available on the machine.
 	 * @param numberOfSlots The number of task slots offered by this taskManager.
 	 */
 	public Instance(
-			InstanceGateway instanceGateway,
+			ActorGateway actorGateway,
 			InstanceConnectionInfo connectionInfo,
 			InstanceID id,
 			HardwareDescription resources,
 			int numberOfSlots) {
-		this.instanceGateway = instanceGateway;
+		this.actorGateway = actorGateway;
 		this.connectionInfo = connectionInfo;
 		this.instanceId = id;
 		this.resources = resources;
@@ -335,8 +335,8 @@ public class Instance {
 	 *
 	 * @return InstanceGateway associated with this instance
 	 */
-	public InstanceGateway getInstanceGateway() {
-		return instanceGateway;
+	public ActorGateway getActorGateway() {
+		return actorGateway;
 	}
 
 	public InstanceConnectionInfo getInstanceConnectionInfo() {
@@ -390,6 +390,6 @@ public class Instance {
 	@Override
 	public String toString() {
 		return String.format("%s @ %s - %d slots - URL: %s", instanceId, connectionInfo.getHostname(),
-				numberOfSlots, (instanceGateway != null ? instanceGateway.path() : "No instance gateway"));
+				numberOfSlots, (actorGateway != null ? actorGateway.path() : "No instance gateway"));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
@@ -146,7 +146,7 @@ public class SetupInfoServlet extends HttpServlet {
 				long time = new Date().getTime() - instance.getLastHeartBeat();
 
 				try {
-					objInner.put("path", instance.getInstanceGateway().path());
+					objInner.put("path", instance.getActorGateway().path());
 					objInner.put("dataPort", instance.getInstanceConnectionInfo().dataPort());
 					objInner.put("timeSinceLastHeartbeat", time / 1000);
 					objInner.put("slotsNumber", instance.getTotalNumberOfSlots());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/RequiresLeaderSessionID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/RequiresLeaderSessionID.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages;
+
+/**
+ * Marks messages to be sent wrapped in a
+ * {@link org.apache.flink.runtime.messages.JobManagerMessages.LeaderSessionMessage}
+ */
+public interface RequiresLeaderSessionID {}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/LeaderSessionMessageDecorator.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/LeaderSessionMessageDecorator.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime
+
+import java.util.UUID
+
+import org.apache.flink.runtime.messages.JobManagerMessages.LeaderSessionMessage
+import org.apache.flink.runtime.messages.RequiresLeaderSessionID
+
+/** [[MessageDecorator]] which wraps [[RequiresLeaderSessionID]] messages in a
+  * [[LeaderSessionMessage]] with the given leader session ID.
+  *
+  * @param leaderSessionID Leader session ID which is associated with the
+  *                        [[RequiresLeaderSessionID]] message
+  */
+class LeaderSessionMessageDecorator(val leaderSessionID: Option[UUID]) extends MessageDecorator {
+
+  /** Wraps [[RequiresLeaderSessionID]] messages in a [[LeaderSessionMessage]].
+    *
+    * @param message Message to decorate
+    * @return Decorated message
+    */
+  override def decorate(message: Any): Any = {
+    message match {
+      case msg: RequiresLeaderSessionID =>
+        LeaderSessionMessage(leaderSessionID, msg)
+      case msg => msg
+    }
+  }
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/LeaderSessionMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/LeaderSessionMessages.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime
+
+import java.util.UUID
+
+import org.apache.flink.runtime.messages.JobManagerMessages.LeaderSessionMessage
+import org.apache.flink.runtime.messages.RequiresLeaderSessionID
+
+/** Mixin to filter out [[LeaderSessionMessage]] which contain an invalid leader session id.
+  * Messages which contain a valid leader session ID are unwrapped and forwarded to the actor.
+  *
+  */
+trait LeaderSessionMessages extends FlinkActor {
+  protected def leaderSessionID: Option[UUID]
+
+  abstract override def receive: Receive = {
+    case LeaderSessionMessage(id, msg) =>
+      // Filter out messages which have not the correct leader session ID
+      (leaderSessionID, id) match {
+        case (Some(currentID), Some(msgID)) =>
+          if(currentID.equals(msgID)) {
+            // correct leader session ID
+            super.receive(msg)
+          } else {
+            // discard message because of incorrect leader session ID
+            handleDiscardedMessage(msg)
+          }
+
+        case _ => handleDiscardedMessage(msg)
+      }
+    case msg: RequiresLeaderSessionID =>
+      throw new Exception(s"Received a message $msg without a leader session ID, even though" +
+        " it requires to have one.")
+    case msg =>
+      // pass the message to the parent's receive method for further processing
+      super.receive(msg)
+  }
+
+  private def handleDiscardedMessage(msg: Any): Unit = {
+    log.debug(s"Discard message $msg because the leader session ID was not correct.")
+  }
+
+  /** Wrap [[RequiresLeaderSessionID]] messages in a [[LeaderSessionMessage]]
+    *
+    * @param message The message to decorate
+    * @return The decorated message
+    */
+  override def decorateMessage(message: Any): Any = {
+    message match {
+      case msg: RequiresLeaderSessionID =>
+        LeaderSessionMessage(leaderSessionID, super.decorateMessage(msg))
+
+      case msg => super.decorateMessage(msg)
+    }
+  }
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/LogMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/LogMessages.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime
+
+/** Mixin to add message logging if the debug log level is activated
+  *
+  */
+trait LogMessages extends FlinkActor {
+  abstract override def receive: Receive = {
+    val _receive = super.receive
+
+    new Receive {
+      override def isDefinedAt(x: Any): Boolean = _receive.isDefinedAt(x)
+
+      override def apply(x: Any): Unit = {
+        if (!log.isDebugEnabled) {
+          _receive(x)
+        }
+        else {
+          log.debug(s"Received message $x at ${context.self.path} from ${context.sender()}.")
+
+          val start = System.nanoTime()
+
+          _receive(x)
+
+          val duration = (System.nanoTime() - start) / 1000000
+          log.debug(s"Handled message $x in $duration ms from ${context.sender()}.")
+        }
+      }
+    }
+  }
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/MessageDecorator.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/MessageDecorator.scala
@@ -18,14 +18,15 @@
 
 package org.apache.flink.runtime
 
-import _root_.akka.actor.Actor
-import grizzled.slf4j.Logger
-
-/** Adds a logger to an [[akka.actor.Actor]] implementation
+/** Base trait for message decorators
   *
   */
-trait ActorSynchronousLogging {
-  self: Actor =>
+trait MessageDecorator {
 
-  lazy val log = Logger(getClass)
+  /** Decorates a message
+    *
+    * @param message Message to decorate
+    * @return Decorated message
+    */
+  def decorate(message: Any): Any
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -62,8 +62,10 @@ object AkkaUtils {
    *                         parameter is None, then a local actor system will be created.
    * @return created actor system
    */
-  def createActorSystem(configuration: Configuration,
-                        listeningAddress: Option[(String, Int)]): ActorSystem = {
+  def createActorSystem(
+      configuration: Configuration,
+      listeningAddress: Option[(String, Int)])
+    : ActorSystem = {
     val akkaConfig = getAkkaConfig(configuration, listeningAddress)
     createActorSystem(akkaConfig)
   }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ExecutionGraphMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ExecutionGraphMessages.scala
@@ -45,11 +45,18 @@ object ExecutionGraphMessages {
    * @param timestamp of the execution state change
    * @param optionalMessage
    */
-  case class ExecutionStateChanged(jobID: JobID, vertexID: JobVertexID,
-                                   taskName: String, totalNumberOfSubTasks: Int, subtaskIndex: Int,
-                                   executionID: ExecutionAttemptID,
-                                   newExecutionState: ExecutionState, timestamp: Long,
-                                   optionalMessage: String){
+  case class ExecutionStateChanged(
+      jobID: JobID,
+      vertexID: JobVertexID,
+      taskName: String,
+      totalNumberOfSubTasks: Int,
+      subtaskIndex: Int,
+      executionID: ExecutionAttemptID,
+      newExecutionState: ExecutionState,
+      timestamp: Long,
+      optionalMessage: String)
+    extends RequiresLeaderSessionID {
+
     override def toString: String = {
       val oMsg = if (optionalMessage != null) {
         s"\n$optionalMessage"
@@ -69,8 +76,12 @@ object ExecutionGraphMessages {
    * @param timestamp
    * @param error
    */
-  case class JobStatusChanged(jobID: JobID, newJobStatus: JobStatus, timestamp: Long,
-                              error: Throwable){
+  case class JobStatusChanged(
+      jobID: JobID,
+      newJobStatus: JobStatus,
+      timestamp: Long,
+      error: Throwable)
+    extends RequiresLeaderSessionID {
     override def toString: String = {
       s"${timestampToString(timestamp)}\tJob execution switched to status $newJobStatus."
     }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
@@ -39,7 +39,7 @@ object Messages {
    *
    * @param reason The reason for disconnecting, to be displayed in log and error messages.
    */
-  case class Disconnect(reason: String)
+  case class Disconnect(reason: String) extends RequiresLeaderSessionID
 
   /**
    * Accessor for the case object instance, to simplify Java interoperability.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/RegistrationMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/RegistrationMessages.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.messages
 
+import java.util.UUID
+
 import akka.actor.ActorRef
 import org.apache.flink.runtime.instance.{InstanceConnectionInfo, InstanceID, HardwareDescription}
 
@@ -32,7 +34,9 @@ object RegistrationMessages {
   /**
    * Marker trait for registration messages.
    */
-  trait RegistrationMessage
+  trait RegistrationMessage {
+    def registrationSessionID: UUID
+  }
 
   /**
    * Triggers the TaskManager to attempt a registration at the JobManager.
@@ -42,10 +46,12 @@ object RegistrationMessages {
    * @param deadline Optional deadline until when the registration must be completed.
    * @param attempt The attempt number, for logging.
    */
-  case class TriggerTaskManagerRegistration(jobManagerAkkaURL: String,
-                                            timeout: FiniteDuration,
-                                            deadline: Option[Deadline],
-                                            attempt: Int)
+  case class TriggerTaskManagerRegistration(
+      registrationSessionID: UUID,
+      jobManagerAkkaURL: String,
+      timeout: FiniteDuration,
+      deadline: Option[Deadline],
+      attempt: Int)
     extends RegistrationMessage
 
   /**
@@ -57,10 +63,12 @@ object RegistrationMessages {
    * @param resources The TaskManagers resources.
    * @param numberOfSlots The number of processing slots offered by the TaskManager.
    */
-  case class RegisterTaskManager(taskManager: ActorRef,
-                                 connectionInfo: InstanceConnectionInfo,
-                                 resources: HardwareDescription,
-                                 numberOfSlots: Int)
+  case class RegisterTaskManager(
+      registrationSessionID: UUID,
+      taskManager: ActorRef,
+      connectionInfo: InstanceConnectionInfo,
+      resources: HardwareDescription,
+      numberOfSlots: Int)
     extends RegistrationMessage
 
   /**
@@ -71,7 +79,12 @@ object RegistrationMessages {
    *                   JobManager.
    * @param blobPort The server port where the JobManager's BLOB service runs.
    */
-  case class AcknowledgeRegistration(jobManager: ActorRef, instanceID: InstanceID, blobPort: Int)
+  case class AcknowledgeRegistration(
+      registrationSessionID: UUID,
+      leaderSessionID: UUID,
+      jobManager: ActorRef,
+      instanceID: InstanceID,
+      blobPort: Int)
     extends RegistrationMessage
 
   /**
@@ -80,7 +93,12 @@ object RegistrationMessages {
    * @param instanceID The instance ID under which the TaskManager is registered.
    * @param blobPort The server port where the JobManager's BLOB service runs.
    */
-  case class AlreadyRegistered(jobManager: ActorRef, instanceID: InstanceID, blobPort: Int)
+  case class AlreadyRegistered(
+      registrationSessionID: UUID,
+      leaderSessionID: UUID,
+      jobManager: ActorRef,
+      instanceID: InstanceID,
+      blobPort: Int)
     extends RegistrationMessage
 
   /**
@@ -89,6 +107,6 @@ object RegistrationMessages {
    *
    * @param reason Reason why the task manager registration was refused
    */
-  case class RefuseRegistration(reason: String)
+  case class RefuseRegistration(registrationSessionID: UUID, reason: String)
     extends RegistrationMessage
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
@@ -47,7 +47,7 @@ object TaskMessages {
    * @param tasks Descriptor which contains the information to start the task.
    */
   case class SubmitTask(tasks: TaskDeploymentDescriptor)
-    extends TaskMessage
+    extends TaskMessage with RequiresLeaderSessionID
 
   /**
    * Cancels the task associated with [[attemptID]]. The result is sent back to the sender as a
@@ -56,7 +56,7 @@ object TaskMessages {
    * @param attemptID The task's execution attempt ID.
    */
   case class CancelTask(attemptID: ExecutionAttemptID)
-    extends TaskMessage
+    extends TaskMessage with RequiresLeaderSessionID
 
   /**
    * Triggers a fail of specified task from the outside (as opposed to the task throwing
@@ -86,15 +86,16 @@ object TaskMessages {
    * Answer to a [[RequestPartitionState]] with the state of the respective partition.
    */
   case class PartitionState(
-    taskExecutionId: ExecutionAttemptID,
-    taskResultId: IntermediateDataSetID,
-    partitionId: IntermediateResultPartitionID,
-    state: ExecutionState) extends TaskMessage
+      taskExecutionId: ExecutionAttemptID,
+      taskResultId: IntermediateDataSetID,
+      partitionId: IntermediateResultPartitionID,
+      state: ExecutionState)
+    extends TaskMessage with RequiresLeaderSessionID
 
   /**
    * Base class for messages that update the information about location of input partitions
    */
-  abstract sealed class UpdatePartitionInfo extends TaskMessage {
+  abstract sealed class UpdatePartitionInfo extends TaskMessage with RequiresLeaderSessionID {
     def executionID: ExecutionAttemptID
   }
 
@@ -104,9 +105,10 @@ object TaskMessages {
    * @param resultId The input reader to update.
    * @param partitionInfo The partition info update.
    */
-  case class UpdateTaskSinglePartitionInfo(executionID: ExecutionAttemptID,
-                                           resultId: IntermediateDataSetID,
-                                           partitionInfo: InputChannelDeploymentDescriptor)
+  case class UpdateTaskSinglePartitionInfo(
+      executionID: ExecutionAttemptID,
+      resultId: IntermediateDataSetID,
+      partitionInfo: InputChannelDeploymentDescriptor)
     extends UpdatePartitionInfo
 
   /**
@@ -115,8 +117,8 @@ object TaskMessages {
    * @param partitionInfos List of input gates with channel descriptors to update.
    */
   case class UpdateTaskMultiplePartitionInfos(
-                    executionID: ExecutionAttemptID,
-                    partitionInfos: Seq[(IntermediateDataSetID, InputChannelDeploymentDescriptor)])
+      executionID: ExecutionAttemptID,
+      partitionInfos: Seq[(IntermediateDataSetID, InputChannelDeploymentDescriptor)])
     extends UpdatePartitionInfo
 
   /**
@@ -126,7 +128,7 @@ object TaskMessages {
    * @param executionID The task's execution attempt ID.
    */
   case class FailIntermediateResultPartitions(executionID: ExecutionAttemptID)
-    extends TaskMessage
+    extends TaskMessage with RequiresLeaderSessionID
 
 
   // --------------------------------------------------------------------------
@@ -140,7 +142,7 @@ object TaskMessages {
    * @param taskExecutionState The changed task state
    */
   case class UpdateTaskExecutionState(taskExecutionState: TaskExecutionState)
-    extends TaskMessage
+    extends TaskMessage with RequiresLeaderSessionID
 
   /**
    * Response message to updates in the task state. Send for example as a response to
@@ -152,11 +154,11 @@ object TaskMessages {
    * @param success indicating whether the operation has been successful
    * @param description Optional description for unsuccessful results.
    */
-  case class TaskOperationResult(executionID: ExecutionAttemptID,
-                                 success: Boolean,
-                                 description: String)
-    extends TaskMessage
-  {
+  case class TaskOperationResult(
+      executionID: ExecutionAttemptID,
+      success: Boolean,
+      description: String)
+    extends TaskMessage {
     def this(executionID: ExecutionAttemptID, success: Boolean) = this(executionID, success, "")
   }
 
@@ -166,10 +168,10 @@ object TaskMessages {
   // --------------------------------------------------------------------------
 
   def createUpdateTaskMultiplePartitionInfos(
-                               executionID: ExecutionAttemptID,
-                               resultIDs: java.util.List[IntermediateDataSetID],
-                               partitionInfos: java.util.List[InputChannelDeploymentDescriptor]):
-  UpdateTaskMultiplePartitionInfos = {
+      executionID: ExecutionAttemptID,
+      resultIDs: java.util.List[IntermediateDataSetID],
+      partitionInfos: java.util.List[InputChannelDeploymentDescriptor])
+    : UpdateTaskMultiplePartitionInfos = {
 
     require(resultIDs.size() == partitionInfos.size(),
       "ResultIDs must have the same length as partitionInfos.")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.akka;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Kill;
+import akka.actor.Props;
+import akka.testkit.JavaTestKit;
+import akka.testkit.TestActorRef;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.RequiresLeaderSessionID;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.Option;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class FlinkUntypedActorTest {
+
+	private static ActorSystem actorSystem;
+
+	@BeforeClass
+	public static void setup() {
+		actorSystem = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
+	}
+
+	@AfterClass
+	public static void teardown() {
+		JavaTestKit.shutdownActorSystem(actorSystem);
+	}
+
+	@Test
+	public void testLeaderSessionMessageFilteringOfFlinkUntypedActor() {
+		final Option<UUID> leaderSessionID = Option.apply(UUID.randomUUID());
+		final Option<UUID> oldSessionID = Option.apply(UUID.randomUUID());
+
+		TestActorRef<PlainFlinkUntypedActor> actor = null;
+
+		try {
+			actor = TestActorRef.create(
+					actorSystem, Props.create(PlainFlinkUntypedActor.class, leaderSessionID));
+
+			final PlainFlinkUntypedActor underlyingActor = actor.underlyingActor();
+
+			actor.tell(new JobManagerMessages.LeaderSessionMessage(leaderSessionID, 1), ActorRef.noSender());
+			actor.tell(new JobManagerMessages.LeaderSessionMessage(oldSessionID, 2), ActorRef.noSender());
+			actor.tell(new JobManagerMessages.LeaderSessionMessage(leaderSessionID, 2), ActorRef.noSender());
+			actor.tell(1, ActorRef.noSender());
+
+			assertEquals(3, underlyingActor.getMessageCounter());
+
+		} finally {
+			stopActor(actor);
+		}
+	}
+
+	@Test
+	public void testThrowingExceptionWhenReceivingNonWrappedRequiresLeaderSessionIDMessage() {
+		final Option<UUID> leaderSessionID = Option.apply(UUID.randomUUID());
+
+		TestActorRef<PlainFlinkUntypedActor> actor = null;
+
+		try{
+			final Props props = Props.create(PlainFlinkUntypedActor.class, leaderSessionID);
+			actor = TestActorRef.create(actorSystem, props);
+
+			actor.receive(new JobManagerMessages.LeaderSessionMessage(leaderSessionID, 1));
+
+			try {
+				actor.receive(new PlainRequiresLeaderSessionID());
+
+				fail("Expected an exception to be thrown, because a RequiresLeaderSessionID" +
+						"message was sent without being wrapped in LeaderSessionMessage.");
+			} catch (Exception e) {
+				assertEquals("Received a message PlainRequiresLeaderSessionID " +
+						"without a leader session ID, even though it requires to have one.",
+						e.getMessage());
+			}
+
+		} finally {
+			stopActor(actor);
+		}
+	}
+
+	private static void stopActor(ActorRef actor) {
+		if(actor != null) {
+			actor.tell(Kill.getInstance(), ActorRef.noSender());
+		}
+	}
+
+
+	static class PlainFlinkUntypedActor extends FlinkUntypedActor {
+
+		private Option<UUID> leaderSessionID;
+
+		private int messageCounter;
+
+		public PlainFlinkUntypedActor(Option<UUID> leaderSessionID) {
+			this.leaderSessionID = leaderSessionID;
+			this.messageCounter = 0;
+		}
+
+		@Override
+		protected void handleMessage(Object message) throws Exception {
+			messageCounter++;
+		}
+
+		@Override
+		protected Option<UUID> getLeaderSessionID() {
+			return leaderSessionID;
+		}
+
+		public int getMessageCounter() {
+			return messageCounter;
+		}
+	}
+
+	static class PlainRequiresLeaderSessionID implements RequiresLeaderSessionID {
+		@Override
+		public String toString() {
+			return "PlainRequiresLeaderSessionID";
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -92,7 +92,7 @@ public class ExecutionGraphDeploymentTest {
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jid2);
 			ExecutionVertex vertex = ejv.getTaskVertices()[3];
 
-			ExecutionGraphTestUtils.SimpleInstanceGateway instanceGateway = new ExecutionGraphTestUtils.SimpleInstanceGateway(TestingUtils.directExecutionContext());
+			ExecutionGraphTestUtils.SimpleActorGateway instanceGateway = new ExecutionGraphTestUtils.SimpleActorGateway(TestingUtils.directExecutionContext());
 
 			final Instance instance = getInstance(instanceGateway);
 
@@ -295,7 +295,7 @@ public class ExecutionGraphDeploymentTest {
 		for (int i = 0; i < dop1 + dop2; i++) {
 			scheduler.newInstanceAvailable(
 					ExecutionGraphTestUtils.getInstance(
-							new ExecutionGraphTestUtils.SimpleInstanceGateway(
+							new ExecutionGraphTestUtils.SimpleActorGateway(
 									TestingUtils.directExecutionContext())));
 		}
 		assertEquals(dop1 + dop2, scheduler.getNumberOfAvailableSlots());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -24,18 +24,17 @@ import static org.mockito.Mockito.spy;
 
 import java.lang.reflect.Field;
 import java.net.InetAddress;
-import java.util.LinkedList;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.instance.BaseTestingInstanceGateway;
+import org.apache.flink.runtime.instance.BaseTestingActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
-import org.apache.flink.runtime.instance.InstanceGateway;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -101,11 +100,11 @@ public class ExecutionGraphTestUtils {
 	//  utility mocking methods
 	// --------------------------------------------------------------------------------------------
 
-	public static Instance getInstance(final InstanceGateway gateway) throws Exception {
+	public static Instance getInstance(final ActorGateway gateway) throws Exception {
 		return getInstance(gateway, 1);
 	}
 
-	public static Instance getInstance(final InstanceGateway gateway, final int numberOfSlots) throws Exception {
+	public static Instance getInstance(final ActorGateway gateway, final int numberOfSlots) throws Exception {
 		HardwareDescription hardwareDescription = new HardwareDescription(4, 2L*1024*1024*1024, 1024*1024*1024, 512*1024*1024);
 		InetAddress address = InetAddress.getByName("127.0.0.1");
 		InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
@@ -113,10 +112,10 @@ public class ExecutionGraphTestUtils {
 		return new Instance(gateway, connection, new InstanceID(), hardwareDescription, numberOfSlots);
 	}
 
-	public static class SimpleInstanceGateway extends BaseTestingInstanceGateway {
+	public static class SimpleActorGateway extends BaseTestingActorGateway {
 		public TaskDeploymentDescriptor lastTDD;
 
-		public SimpleInstanceGateway(ExecutionContext executionContext){
+		public SimpleActorGateway(ExecutionContext executionContext){
 			super(executionContext);
 		}
 
@@ -140,8 +139,8 @@ public class ExecutionGraphTestUtils {
 		}
 	}
 
-	public static class SimpleFailingInstanceGateway extends BaseTestingInstanceGateway {
-		public SimpleFailingInstanceGateway(ExecutionContext executionContext) {
+	public static class SimpleFailingActorGateway extends BaseTestingActorGateway {
+		public SimpleFailingActorGateway(ExecutionContext executionContext) {
 			super(executionContext);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
@@ -63,7 +63,7 @@ public class ExecutionStateProgressTest {
 			// mock resources and mock taskmanager
 			for (ExecutionVertex ee : ejv.getTaskVertices()) {
 				SimpleSlot slot = getInstance(
-						new SimpleInstanceGateway(
+						new SimpleActorGateway(
 								TestingUtils.defaultExecutionContext())
 				).allocateSimpleSlot(jid);
 				ee.deployToSlot(slot);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -26,9 +26,9 @@ import java.io.IOException;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.instance.BaseTestingInstanceGateway;
-import org.apache.flink.runtime.instance.DummyInstanceGateway;
-import org.apache.flink.runtime.instance.InstanceGateway;
+import org.apache.flink.runtime.instance.BaseTestingActorGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.api.common.JobID;
@@ -125,12 +125,12 @@ public class ExecutionVertexCancelTest {
 			setVertexState(vertex, ExecutionState.SCHEDULED);
 			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
 
-			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+			ActorGateway actorGateway = new CancelSequenceActorGateway(
 					executionContext,
 					new TaskOperationResult(execId, true),
 					new TaskOperationResult(execId, false));
 
-			Instance instance = getInstance(instanceGateway);
+			Instance instance = getInstance(actorGateway);
 			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 			vertex.deployToSlot(slot);
@@ -195,13 +195,13 @@ public class ExecutionVertexCancelTest {
 
 			// task manager cancel sequence mock actor
 			// first return NOT SUCCESS (task not found, cancel call overtook deploy call), then success (cancel call after deploy call)
-			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+			ActorGateway actorGateway = new CancelSequenceActorGateway(
 					executionContext,
 					new	TaskOperationResult(execId, false),
 					new TaskOperationResult(execId, true)
 			);
 
-			Instance instance = getInstance(instanceGateway);
+			Instance instance = getInstance(actorGateway);
 			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 			vertex.deployToSlot(slot);
@@ -258,11 +258,11 @@ public class ExecutionVertexCancelTest {
 					AkkaUtils.getDefaultTimeout());
 			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-			InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+			ActorGateway actorGateway = new CancelSequenceActorGateway(
 					TestingUtils.directExecutionContext(),
 					new TaskOperationResult(execId, true));
 
-			Instance instance = getInstance(instanceGateway);
+			Instance instance = getInstance(actorGateway);
 			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 			setVertexState(vertex, ExecutionState.RUNNING);
@@ -299,12 +299,12 @@ public class ExecutionVertexCancelTest {
 					AkkaUtils.getDefaultTimeout());
 			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-			final InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+			final ActorGateway actorGateway = new CancelSequenceActorGateway(
 					TestingUtils.directExecutionContext(),
 					new TaskOperationResult(execId, true)
 			);
 
-			Instance instance = getInstance(instanceGateway);
+			Instance instance = getInstance(actorGateway);
 			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 			setVertexState(vertex, ExecutionState.RUNNING);
@@ -350,12 +350,12 @@ public class ExecutionVertexCancelTest {
 			final ExecutionAttemptID execId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 
-			final InstanceGateway instanceGateway = new CancelSequenceInstanceGateway(
+			final ActorGateway actorGateway = new CancelSequenceActorGateway(
 					TestingUtils.directExecutionContext(),
 					new TaskOperationResult(execId, false)
 			);
 
-			Instance instance = getInstance(instanceGateway);
+			Instance instance = getInstance(actorGateway);
 			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 			setVertexState(vertex, ExecutionState.RUNNING);
@@ -386,7 +386,7 @@ public class ExecutionVertexCancelTest {
 			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 					AkkaUtils.getDefaultTimeout());
 
-			final InstanceGateway gateway = new CancelSequenceInstanceGateway(TestingUtils.directExecutionContext());
+			final ActorGateway gateway = new CancelSequenceActorGateway(TestingUtils.directExecutionContext());
 
 			Instance instance = getInstance(gateway);
 			SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
@@ -423,7 +423,7 @@ public class ExecutionVertexCancelTest {
 					AkkaUtils.getDefaultTimeout());
 			final ExecutionAttemptID execID = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-			final InstanceGateway gateway = new CancelSequenceInstanceGateway(
+			final ActorGateway gateway = new CancelSequenceActorGateway(
 					TestingUtils.defaultExecutionContext(),
 					new TaskOperationResult(execID, true));
 
@@ -482,7 +482,7 @@ public class ExecutionVertexCancelTest {
 			// deploying after canceling from CREATED needs to raise an exception, because
 			// the scheduler (or any caller) needs to know that the slot should be released
 			try {
-				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
+				Instance instance = getInstance(DummyActorGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				vertex.deployToSlot(slot);
@@ -525,7 +525,7 @@ public class ExecutionVertexCancelTest {
 						AkkaUtils.getDefaultTimeout());
 				setVertexState(vertex, ExecutionState.CANCELING);
 
-				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
+				Instance instance = getInstance(DummyActorGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				vertex.deployToSlot(slot);
@@ -541,7 +541,7 @@ public class ExecutionVertexCancelTest {
 				ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 						AkkaUtils.getDefaultTimeout());
 
-				Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
+				Instance instance = getInstance(DummyActorGateway.INSTANCE);
 				SimpleSlot slot = instance.allocateSimpleSlot(new JobID());
 
 				setVertexResource(vertex, slot);
@@ -562,11 +562,11 @@ public class ExecutionVertexCancelTest {
 		}
 	}
 
-	public static class CancelSequenceInstanceGateway extends BaseTestingInstanceGateway {
+	public static class CancelSequenceActorGateway extends BaseTestingActorGateway {
 		private final TaskOperationResult[] results;
 		private int index = -1;
 
-		public CancelSequenceInstanceGateway(ExecutionContext executionContext, TaskOperationResult ... result) {
+		public CancelSequenceActorGateway(ExecutionContext executionContext, TaskOperationResult... result) {
 			super(executionContext);
 			this.results = result;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -43,7 +43,7 @@ public class ExecutionVertexDeploymentTest {
 
 			// mock taskmanager to simply accept the call
 			Instance instance = getInstance(
-					new SimpleInstanceGateway(TestingUtils.directExecutionContext()));
+					new SimpleActorGateway(TestingUtils.directExecutionContext()));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
@@ -81,7 +81,7 @@ public class ExecutionVertexDeploymentTest {
 			final ExecutionJobVertex ejv = getExecutionVertex(jid, TestingUtils.directExecutionContext());
 
 			final Instance instance = getInstance(
-					new SimpleInstanceGateway(TestingUtils.directExecutionContext()));
+					new SimpleActorGateway(TestingUtils.directExecutionContext()));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
@@ -124,7 +124,7 @@ public class ExecutionVertexDeploymentTest {
 					AkkaUtils.getDefaultTimeout());
 
 			final Instance instance = getInstance(
-					new SimpleInstanceGateway(TestingUtils.defaultExecutionContext()));
+					new SimpleActorGateway(TestingUtils.defaultExecutionContext()));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
@@ -171,7 +171,7 @@ public class ExecutionVertexDeploymentTest {
 					AkkaUtils.getDefaultTimeout());
 
 			final Instance instance = getInstance(
-					new SimpleFailingInstanceGateway(TestingUtils.directExecutionContext()));
+					new SimpleFailingActorGateway(TestingUtils.directExecutionContext()));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
@@ -201,7 +201,7 @@ public class ExecutionVertexDeploymentTest {
 					AkkaUtils.getDefaultTimeout());
 
 			final Instance instance = getInstance(
-					new SimpleFailingInstanceGateway(TestingUtils.directExecutionContext()));
+					new SimpleFailingActorGateway(TestingUtils.directExecutionContext()));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
@@ -244,7 +244,7 @@ public class ExecutionVertexDeploymentTest {
 			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 					AkkaUtils.getDefaultTimeout());
 
-			final Instance instance = getInstance(new SimpleInstanceGateway(TestingUtils.directExecutionContext()));
+			final Instance instance = getInstance(new SimpleActorGateway(TestingUtils.directExecutionContext()));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
@@ -286,7 +286,7 @@ public class ExecutionVertexDeploymentTest {
 			final ExecutionAttemptID eid = vertex.getCurrentExecutionAttempt().getAttemptId();
 
 			final Instance instance = getInstance(
-					new ExecutionVertexCancelTest.CancelSequenceInstanceGateway(
+					new ExecutionVertexCancelTest.CancelSequenceActorGateway(
 							context,
 							new TaskOperationResult(eid, false),
 							new TaskOperationResult(eid, true)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.*;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.instance.DummyInstanceGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -47,7 +47,7 @@ public class ExecutionVertexSchedulingTest {
 					AkkaUtils.getDefaultTimeout());
 
 			// a slot than cannot be deployed to
-			final Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
+			final Instance instance = getInstance(DummyActorGateway.INSTANCE);
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 			
 			slot.releaseSlot();
@@ -77,7 +77,7 @@ public class ExecutionVertexSchedulingTest {
 					AkkaUtils.getDefaultTimeout());
 
 			// a slot than cannot be deployed to
-			final Instance instance = getInstance(DummyInstanceGateway.INSTANCE);
+			final Instance instance = getInstance(DummyActorGateway.INSTANCE);
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			slot.releaseSlot();
@@ -113,7 +113,7 @@ public class ExecutionVertexSchedulingTest {
 			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 					AkkaUtils.getDefaultTimeout());
 
-			final Instance instance = getInstance(new ExecutionGraphTestUtils.SimpleInstanceGateway(TestingUtils.defaultExecutionContext()));
+			final Instance instance = getInstance(new ExecutionGraphTestUtils.SimpleActorGateway(TestingUtils.defaultExecutionContext()));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			Scheduler scheduler = mock(Scheduler.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LocalInputSplitsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LocalInputSplitsTest.java
@@ -377,7 +377,7 @@ public class LocalInputSplitsTest {
 		when(connection.getFQDNHostname()).thenReturn(hostname);
 		
 		return new Instance(
-				new ExecutionGraphTestUtils.SimpleInstanceGateway(
+				new ExecutionGraphTestUtils.SimpleActorGateway(
 						TestingUtils.defaultExecutionContext()),
 				connection,
 				new InstanceID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.instance.DummyInstanceGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -78,7 +78,7 @@ public class TerminalStateDeadlockTest {
 			InstanceConnectionInfo ci = new InstanceConnectionInfo(address, 12345);
 				
 			HardwareDescription resources = new HardwareDescription(4, 4000000, 3000000, 2000000);
-			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, ci, new InstanceID(), resources, 4);
+			Instance instance = new Instance(DummyActorGateway.INSTANCE, ci, new InstanceID(), resources, 4);
 
 			this.resource = instance.allocateSimpleSlot(new JobID());
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.flink.runtime.instance.DummyInstanceGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -403,7 +403,7 @@ public class VertexLocationConstraintTest {
 			
 			ExecutionVertex ev = eg.getAllVertices().get(vertex.getID()).getTaskVertices()[0];
 			
-			Instance instance = ExecutionGraphTestUtils.getInstance(DummyInstanceGateway.INSTANCE);
+			Instance instance = ExecutionGraphTestUtils.getInstance(DummyActorGateway.INSTANCE);
 			ev.setLocationConstraintHosts(Collections.singletonList(instance));
 			
 			assertNotNull(ev.getPreferredLocations());
@@ -435,7 +435,7 @@ public class VertexLocationConstraintTest {
 		when(connection.getFQDNHostname()).thenReturn(hostname);
 		
 		return new Instance(
-				new ExecutionGraphTestUtils.SimpleInstanceGateway(
+				new ExecutionGraphTestUtils.SimpleActorGateway(
 						TestingUtils.defaultExecutionContext()),
 				connection,
 				new InstanceID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyActorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyActorGateway.java
@@ -18,40 +18,51 @@
 
 package org.apache.flink.runtime.instance;
 
-import akka.actor.ActorPath;
 import akka.actor.ActorRef;
+import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.util.UUID;
+
 /**
- * Dummy {@link InstanceGateway} implementation used for testing.
+ * Dummy {@link ActorGateway} implementation used for testing.
  */
-public class DummyInstanceGateway implements InstanceGateway {
-	public static final DummyInstanceGateway INSTANCE = new DummyInstanceGateway();
+public class DummyActorGateway implements ActorGateway {
+	public static final DummyActorGateway INSTANCE = new DummyActorGateway();
 
 	@Override
 	public Future<Object> ask(Object message, FiniteDuration timeout) {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
-	public void tell(Object message) {
-		throw new UnsupportedOperationException();
-	}
+	public void tell(Object message) {}
 
 	@Override
-	public void forward(Object message, ActorRef sender) {
-		throw new UnsupportedOperationException();
-	}
+	public void tell(Object message, ActorGateway sender) {}
+
+	@Override
+	public void forward(Object message, ActorGateway sender) {}
 
 	@Override
 	public Future<Object> retry(Object message, int numberRetries, FiniteDuration timeout, ExecutionContext executionContext) {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
 	public String path() {
 		return "DummyInstanceGateway";
+	}
+
+	@Override
+	public ActorRef actor() {
+		return ActorRef.noSender();
+	}
+
+	@Override
+	public Option<UUID> leaderSessionID() {
+		return Option.<UUID>empty();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.UUID;
 
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
@@ -41,6 +42,8 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import scala.Option;
+import scala.Some;
 
 /**
  * Tests for {@link org.apache.flink.runtime.instance.InstanceManager}.
@@ -48,6 +51,8 @@ import org.junit.Test;
 public class InstanceManagerTest{
 
 	static ActorSystem system;
+
+	static Option<UUID> leaderSessionID = new Some<UUID>(UUID.randomUUID());
 
 	@BeforeClass
 	public static void setup(){
@@ -80,9 +85,9 @@ public class InstanceManagerTest{
 			final JavaTestKit probe2 = new JavaTestKit(system);
 			final JavaTestKit probe3 = new JavaTestKit(system);
 
-			cm.registerTaskManager(probe1.getRef(), ici1, hardwareDescription, 1);
-			cm.registerTaskManager(probe2.getRef(), ici2, hardwareDescription, 2);
-			cm.registerTaskManager(probe3.getRef(), ici3, hardwareDescription, 5);
+			cm.registerTaskManager(probe1.getRef(), ici1, hardwareDescription, 1, leaderSessionID);
+			cm.registerTaskManager(probe2.getRef(), ici2, hardwareDescription, 2, leaderSessionID);
+			cm.registerTaskManager(probe3.getRef(), ici3, hardwareDescription, 5, leaderSessionID);
 			
 			assertEquals(3, cm.getNumberOfRegisteredTaskManagers());
 			assertEquals(8, cm.getTotalNumberOfSlots());
@@ -120,13 +125,13 @@ public class InstanceManagerTest{
 			InstanceConnectionInfo ici = new InstanceConnectionInfo(address, dataPort);
 
 			JavaTestKit probe = new JavaTestKit(system);
-			InstanceID i = cm.registerTaskManager(probe.getRef(), ici, resources, 1);
+			InstanceID i = cm.registerTaskManager(probe.getRef(), ici, resources, 1, leaderSessionID);
 
 			assertNotNull(i);
 			assertEquals(1, cm.getNumberOfRegisteredTaskManagers());
 			assertEquals(1, cm.getTotalNumberOfSlots());
 			
-			InstanceID next = cm.registerTaskManager(probe.getRef(), ici, resources, 1);
+			InstanceID next = cm.registerTaskManager(probe.getRef(), ici, resources, 1, leaderSessionID);
 			assertNull(next);
 			
 			assertEquals(1, cm.getNumberOfRegisteredTaskManagers());
@@ -161,9 +166,9 @@ public class InstanceManagerTest{
 			JavaTestKit probe2 = new JavaTestKit(system);
 			JavaTestKit probe3 = new JavaTestKit(system);
 			
-			InstanceID i1 = cm.registerTaskManager(probe1.getRef(), ici1, hardwareDescription, 1);
-			InstanceID i2 = cm.registerTaskManager(probe2.getRef(), ici2, hardwareDescription, 1);
-			InstanceID i3 = cm.registerTaskManager(probe3.getRef(), ici3, hardwareDescription, 1);
+			InstanceID i1 = cm.registerTaskManager(probe1.getRef(), ici1, hardwareDescription, 1, leaderSessionID);
+			InstanceID i2 = cm.registerTaskManager(probe2.getRef(), ici2, hardwareDescription, 1, leaderSessionID);
+			InstanceID i3 = cm.registerTaskManager(probe3.getRef(), ici3, hardwareDescription, 1, leaderSessionID);
 
 			// report some immediate heart beats
 			assertTrue(cm.reportHeartBeat(i1, new byte[] {}));
@@ -216,7 +221,7 @@ public class InstanceManagerTest{
 				InstanceConnectionInfo ici = new InstanceConnectionInfo(address, 20000);
 
 				JavaTestKit probe = new JavaTestKit(system);
-				cm.registerTaskManager(probe.getRef(), ici, resources, 1);
+				cm.registerTaskManager(probe.getRef(), ici, resources, 1, leaderSessionID);
 				fail("Should raise exception in shutdown state");
 			}
 			catch (IllegalStateException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
@@ -38,7 +38,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 4);
+			Instance instance = new Instance(DummyActorGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 4);
 
 			assertEquals(4, instance.getTotalNumberOfSlots());
 			assertEquals(4, instance.getNumberOfAvailableSlots());
@@ -99,7 +99,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(DummyActorGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 
@@ -129,7 +129,7 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-			Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(DummyActorGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
@@ -146,7 +146,7 @@ public class SimpleSlotTest {
 		InetAddress address = InetAddress.getByName("127.0.0.1");
 		InstanceConnectionInfo connection = new InstanceConnectionInfo(address, 10001);
 
-		Instance instance = new Instance(DummyInstanceGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 1);
+		Instance instance = new Instance(DummyActorGateway.INSTANCE, connection, new InstanceID(), hardwareDescription, 1);
 		return instance.allocateSimpleSlot(new JobID());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.io.network;
 
 import static org.junit.Assert.*;
 
-import akka.actor.ActorRef;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.net.NetUtils;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
-import org.mockito.Mockito;
 import scala.Some;
 import scala.Tuple2;
 import scala.concurrent.duration.FiniteDuration;
@@ -78,9 +77,9 @@ public class NetworkEnvironmentTest {
 			assertNull(env.getPartitionManager());
 
 			// associate the environment with some mock actors
-			ActorRef jmActor = Mockito.mock(ActorRef.class);
-			ActorRef tmActor = Mockito.mock(ActorRef.class);
-			env.associateWithTaskManagerAndJobManager(jmActor, tmActor);
+			env.associateWithTaskManagerAndJobManager(
+					DummyActorGateway.INSTANCE,
+					DummyActorGateway.INSTANCE);
 
 			assertNotNull(env.getConnectionManager());
 			assertNotNull(env.getPartitionConsumableNotifier());
@@ -103,9 +102,10 @@ public class NetworkEnvironmentTest {
 			assertTrue(localPool.isDestroyed());
 
 			// associate once again
-			jmActor = Mockito.mock(ActorRef.class);
-			tmActor = Mockito.mock(ActorRef.class);
-			env.associateWithTaskManagerAndJobManager(jmActor, tmActor);
+			env.associateWithTaskManagerAndJobManager(
+					DummyActorGateway.INSTANCE,
+					DummyActorGateway.INSTANCE
+			);
 
 			assertNotNull(env.getConnectionManager());
 			assertNotNull(env.getPartitionConsumableNotifier());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -102,7 +102,7 @@ public class PartialConsumePipelinedResultTest {
 
 		JobClient.submitJobAndWait(
 				jobClient,
-				flink.getJobManager(),
+				flink.getJobManagerGateway(),
 				jobGraph,
 				TestingUtils.TESTING_DURATION(),
 				false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -20,13 +20,13 @@ package org.apache.flink.runtime.jobmanager;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import akka.pattern.Patterns;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.StreamingMode;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.JobManagerMessages;
@@ -51,10 +51,10 @@ import static org.junit.Assert.fail;
  */
 public class JobSubmitTest {
 
-	private static final long TIMEOUT = 5000;
+	private static final FiniteDuration timeout = new FiniteDuration(5000, TimeUnit.MILLISECONDS);
 
 	private static ActorSystem jobManagerSystem;
-	private static ActorRef jobManager;
+	private static ActorGateway jobManager;
 
 	@BeforeClass
 	public static void setupJobManager() {
@@ -62,7 +62,18 @@ public class JobSubmitTest {
 
 		scala.Option<Tuple2<String, Object>> listeningAddress = scala.Option.empty();
 		jobManagerSystem = AkkaUtils.createActorSystem(config, listeningAddress);
-		jobManager = JobManager.startJobManagerActors(config, jobManagerSystem, StreamingMode.BATCH_ONLY)._1();
+		ActorRef jobManagerActorRef = JobManager.startJobManagerActors(
+				config,
+				jobManagerSystem,
+				StreamingMode.BATCH_ONLY)._1();
+
+		try {
+			jobManager = JobManager.getJobManagerGateway(jobManagerActorRef, timeout);
+		} catch (Exception e) {
+			fail("Could not retrieve the JobManager gateway. " + e.getMessage());
+		}
+
+
 	}
 
 	@AfterClass
@@ -81,8 +92,8 @@ public class JobSubmitTest {
 			JobGraph jg = new JobGraph("test job", jobVertex);
 
 			// request the blob port from the job manager
-			Future<Object> future = Patterns.ask(jobManager, JobManagerMessages.getRequestBlobManagerPort(), TIMEOUT);
-			int blobPort = (Integer) Await.result(future, new FiniteDuration(TIMEOUT, TimeUnit.MILLISECONDS));
+			Future<Object> future = jobManager.ask(JobManagerMessages.getRequestBlobManagerPort(), timeout);
+			int blobPort = (Integer) Await.result(future, timeout);
 
 			// upload two dummy bytes and add their keys to the job graph as dependencies
 			BlobKey key1, key2;
@@ -102,10 +113,9 @@ public class JobSubmitTest {
 			jg.addBlob(key2);
 
 			// submit the job
-			Future<Object> submitFuture = Patterns.ask(jobManager,
-					new JobManagerMessages.SubmitJob(jg, false), TIMEOUT);
+			Future<Object> submitFuture = jobManager.ask(new JobManagerMessages.SubmitJob(jg, false), timeout);
 			try {
-				Await.result(submitFuture, new FiniteDuration(TIMEOUT, TimeUnit.MILLISECONDS));
+				Await.result(submitFuture, timeout);
 			}
 			catch (JobExecutionException e) {
 				// that is what we expect
@@ -142,10 +152,9 @@ public class JobSubmitTest {
 			JobGraph jg = new JobGraph("test job", jobVertex);
 
 			// submit the job
-			Future<Object> submitFuture = Patterns.ask(jobManager,
-					new JobManagerMessages.SubmitJob(jg, false), TIMEOUT);
+			Future<Object> submitFuture = jobManager.ask(new JobManagerMessages.SubmitJob(jg, false), timeout);
 			try {
-				Await.result(submitFuture, new FiniteDuration(TIMEOUT, TimeUnit.MILLISECONDS));
+				Await.result(submitFuture, timeout);
 			}
 			catch (JobExecutionException e) {
 				// that is what we expect

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.instance.DummyInstanceGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -66,7 +66,7 @@ public class SchedulerTestUtils {
 		final long GB = 1024L*1024*1024;
 		HardwareDescription resources = new HardwareDescription(4, 4*GB, 3*GB, 2*GB);
 		
-		return new Instance(DummyInstanceGateway.INSTANCE, ci, new InstanceID(), resources, numSlots);
+		return new Instance(DummyActorGateway.INSTANCE, ci, new InstanceID(), resources, numSlots);
 	}
 	
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/ForwardingActorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/ForwardingActorGateway.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import org.apache.flink.runtime.instance.BaseTestingActorGateway;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Testing {@link org.apache.flink.runtime.instance.ActorGateway} which stores all handled messages
+ * in a {@link BlockingQueue}.
+ */
+public class ForwardingActorGateway extends BaseTestingActorGateway {
+
+	private final BlockingQueue<Object> queue;
+
+	public ForwardingActorGateway(BlockingQueue<Object> queue) {
+		super(TestingUtils.directExecutionContext());
+
+		this.queue = queue;
+	}
+
+	@Override
+	public Object handleMessage(Object message) throws Exception {
+		// don't do anything with the message, but storing it in queue
+		queue.add(message);
+
+		return null;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -18,13 +18,8 @@
 
 package org.apache.flink.runtime.taskmanager;
 
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.UntypedActor;
-
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -34,6 +29,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.filecache.FileCache;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
@@ -44,9 +40,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointNotificationOperator;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointedOperator;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import scala.concurrent.duration.FiniteDuration;
@@ -65,25 +59,8 @@ public class TaskAsyncCallTest {
 
 	private static final int NUM_CALLS = 1000;
 	
-	private static ActorSystem actorSystem;
-	
 	private static OneShotLatch awaitLatch;
 	private static OneShotLatch triggerLatch;
-
-	// ------------------------------------------------------------------------
-	//  Init & Shutdown
-	// ------------------------------------------------------------------------
-
-	@BeforeClass
-	public static void startActorSystem() {
-		actorSystem = AkkaUtils.createLocalActorSystem(new Configuration());
-	}
-
-	@AfterClass
-	public static void shutdown() {
-		actorSystem.shutdown();
-		actorSystem.awaitTermination();
-	}
 
 	@Before
 	public void createQueuesAndActors() {
@@ -176,8 +153,8 @@ public class TaskAsyncCallTest {
 				mock(IOManager.class),
 				networkEnvironment,
 				mock(BroadcastVariableManager.class),
-				actorSystem.actorOf(Props.create(BlackHoleActor.class)),
-				actorSystem.actorOf(Props.create(BlackHoleActor.class)),
+				DummyActorGateway.INSTANCE,
+				DummyActorGateway.INSTANCE,
 				new FiniteDuration(60, TimeUnit.SECONDS),
 				libCache,
 				mock(FileCache.class));
@@ -235,11 +212,5 @@ public class TaskAsyncCallTest {
 				}
 			}
 		}
-	}
-	
-	public static class BlackHoleActor extends UntypedActor {
-
-		@Override
-		public void onReceive(Object message) {}
 	}
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/FlinkActorTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/FlinkActorTest.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.akka
+
+import java.util.UUID
+
+import akka.actor.{Props, Kill, ActorRef, ActorSystem}
+import akka.testkit.{TestActorRef, TestKit}
+import grizzled.slf4j.Logger
+import org.apache.flink.runtime.akka.FlinkUntypedActorTest.PlainRequiresLeaderSessionID
+import org.apache.flink.runtime.messages.JobManagerMessages.LeaderSessionMessage
+import org.apache.flink.runtime.{LeaderSessionMessages, FlinkActor}
+import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FunSuiteLike, Matchers, BeforeAndAfterAll}
+
+@RunWith(classOf[JUnitRunner])
+class FlinkActorTest(_system: ActorSystem)
+  extends TestKit(_system)
+  with FunSuiteLike
+  with Matchers
+  with BeforeAndAfterAll {
+
+  def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  test("A Flink actor should only accept LeaderSessionMessages with a valid leader session id") {
+    val leaderSessionID = Some(UUID.randomUUID())
+    val oldSessionID = Some(UUID.randomUUID())
+
+    val props = Props(classOf[PlainFlinkActor], leaderSessionID)
+
+    val actor = TestActorRef[PlainFlinkActor](props)
+
+    actor ! LeaderSessionMessage(leaderSessionID, 1)
+    actor ! LeaderSessionMessage(oldSessionID, 1)
+    actor ! LeaderSessionMessage(leaderSessionID, 1)
+
+    actor ! 1
+
+    actor.underlyingActor.counter should be (3)
+  }
+
+  test("A Flink actor should throw an exception when receiving an unwrapped " +
+    "RequiresLeaderSessionID message") {
+    val leaderSessionID = Some(UUID.randomUUID())
+
+    val props = Props(classOf[PlainFlinkActor], leaderSessionID)
+    val actor = TestActorRef[PlainFlinkActor](props)
+
+    actor.receive(LeaderSessionMessage(leaderSessionID, 1))
+    actor.receive(1)
+
+    try {
+      actor.receive(new PlainRequiresLeaderSessionID)
+
+      fail("Expected an exception, because an RequiresLeaderSessionID message was sent to the " +
+        "FlinkActor without being wrapped in a LeaderSessionMessage.")
+    } catch {
+      case e: Exception =>
+        e.getMessage should be("Received a message PlainRequiresLeaderSessionID without a " +
+          "leader session ID, even though it requires to have one.")
+    }
+  }
+
+  def stopActor(actor: ActorRef): Unit = {
+    actor ! Kill
+  }
+
+}
+
+class PlainFlinkActor(val leaderSessionID: Option[UUID])
+  extends FlinkActor
+  with LeaderSessionMessages {
+
+  val log = Logger(getClass)
+
+  var counter = 0
+
+  /** Handle incoming messages
+    *
+    * @return
+    */
+  override def handleMessage: Receive = {
+    case _ => counter += 1
+  }
+}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.executiongraph
 import org.apache.flink.api.common.JobID
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.akka.AkkaUtils
-import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.SimpleInstanceGateway
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.SimpleActorGateway
 import org.apache.flink.runtime.jobgraph.{JobStatus, JobGraph, JobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
@@ -36,7 +36,7 @@ class ExecutionGraphRestartTest extends WordSpecLike with Matchers {
     "be manually restartable" in {
       try {
         val instance = ExecutionGraphTestUtils.getInstance(
-          new SimpleInstanceGateway(TestingUtils.directExecutionContext))
+          new SimpleActorGateway(TestingUtils.directExecutionContext))
 
         val scheduler = new Scheduler(TestingUtils.defaultExecutionContext)
         scheduler.newInstanceAvailable(instance)
@@ -83,7 +83,7 @@ class ExecutionGraphRestartTest extends WordSpecLike with Matchers {
     "restart itself automatically" in {
       try {
         val instance = ExecutionGraphTestUtils.getInstance(
-          new SimpleInstanceGateway(TestingUtils.directExecutionContext))
+          new SimpleActorGateway(TestingUtils.directExecutionContext))
 
         val scheduler = new Scheduler(TestingUtils.defaultExecutionContext)
         scheduler.newInstanceAvailable(instance)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.executiongraph
 import org.apache.flink.api.common.JobID
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.akka.AkkaUtils
-import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.SimpleInstanceGateway
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.SimpleActorGateway
 import org.apache.flink.runtime.jobgraph.{JobStatus, JobGraph, JobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
@@ -34,9 +34,9 @@ class TaskManagerLossFailsTasksTest extends WordSpecLike with Matchers {
     "fail the assigned tasks" in {
       try {
         val instance1 = ExecutionGraphTestUtils.getInstance(
-          new SimpleInstanceGateway(TestingUtils.defaultExecutionContext), 10)
+          new SimpleActorGateway(TestingUtils.defaultExecutionContext), 10)
         val instance2 = ExecutionGraphTestUtils.getInstance(
-          new SimpleInstanceGateway(TestingUtils.defaultExecutionContext), 10)
+          new SimpleActorGateway(TestingUtils.defaultExecutionContext), 10)
 
         val scheduler = new Scheduler(TestingUtils.defaultExecutionContext)
         scheduler.newInstanceAvailable(instance1)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
@@ -25,15 +25,19 @@ import org.apache.flink.runtime.jobgraph.{JobGraph, DistributionPattern, JobVert
 import org.apache.flink.runtime.jobmanager.Tasks.{Receiver, Sender}
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
 import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmitJob}
-import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
-import scala.collection.convert.WrapAsJava
 
 @RunWith(classOf[JUnitRunner])
-class CoLocationConstraintITCase(_system: ActorSystem) extends TestKit(_system) with
-ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with WrapAsJava{
+class CoLocationConstraintITCase(_system: ActorSystem)
+    extends TestKit(_system)
+    with ImplicitSender
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaTestingUtils {
   def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
 
   /**
@@ -64,11 +68,11 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with WrapA
       val jobGraph = new JobGraph("Pointwise job", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
-      val jm = cluster.getJobManager
+      val gateway = cluster.getJobManagerGateway
 
       try {
         within(TestingUtils.TESTING_DURATION) {
-          jm ! SubmitJob(jobGraph, false)
+          gateway.tell(SubmitJob(jobGraph, false), self)
           expectMsg(Success(jobGraph.getJobID))
 
           expectMsgType[JobResultSuccess]

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmanager
 
 import java.net.InetAddress
+import java.util.UUID
 
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit}
@@ -63,25 +64,36 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
 
         var id1: InstanceID = null
         var id2: InstanceID = null
+        val registrationSessionID = UUID.randomUUID()
 
         // task manager 1
         within(1 second) {
-          jm ! RegisterTaskManager(tmDummy1, connectionInfo1, hardwareDescription, 1)
+          jm ! RegisterTaskManager(
+            registrationSessionID,
+            tmDummy1,
+            connectionInfo1,
+            hardwareDescription,
+            1)
 
           val response = receiveOne(1 second)
           response match {
-            case AcknowledgeRegistration(_, id, _) => id1 = id
+            case AcknowledgeRegistration(registrationSessionID, _,  _, id, _) => id1 = id
             case _ => fail("Wrong response message: " + response)
           }
         }
 
         // task manager 2
         within(1 second) {
-          jm ! RegisterTaskManager(tmDummy2, connectionInfo2, hardwareDescription, 1)
+          jm ! RegisterTaskManager(
+            registrationSessionID,
+            tmDummy2,
+            connectionInfo2,
+            hardwareDescription,
+            1)
 
           val response = receiveOne(1 second)
           response match {
-            case AcknowledgeRegistration(_, id, _) => id2 = id
+            case AcknowledgeRegistration(registrationSessionID, _, _, id, _) => id2 = id
             case _ => fail("Wrong response message: " + response)
           }
         }
@@ -105,11 +117,28 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
       try {
         val connectionInfo = new InstanceConnectionInfo(InetAddress.getLocalHost,1)
         val hardwareDescription = HardwareDescription.extractFromSystem(10)
+
+        val registrationSessionID = UUID.randomUUID()
         
         within(1 second) {
-          jm ! RegisterTaskManager(tmDummy, connectionInfo, hardwareDescription, 1)
-          jm ! RegisterTaskManager(tmDummy, connectionInfo, hardwareDescription, 1)
-          jm ! RegisterTaskManager(tmDummy, connectionInfo, hardwareDescription, 1)
+          jm ! RegisterTaskManager(
+            registrationSessionID,
+            tmDummy,
+            connectionInfo,
+            hardwareDescription,
+            1)
+          jm ! RegisterTaskManager(
+            registrationSessionID,
+            tmDummy,
+            connectionInfo,
+            hardwareDescription,
+            1)
+          jm ! RegisterTaskManager(
+            registrationSessionID,
+            tmDummy,
+            connectionInfo,
+            hardwareDescription,
+            1)
 
           expectMsgType[AcknowledgeRegistration]
           expectMsgType[AlreadyRegistered]

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
@@ -25,14 +25,19 @@ import org.apache.flink.runtime.jobgraph.{JobVertex, DistributionPattern, JobGra
 import org.apache.flink.runtime.jobmanager.Tasks.{Sender, AgnosticBinaryReceiver, Receiver}
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
 import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultSuccess, SubmitJob}
-import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 @RunWith(classOf[JUnitRunner])
-class SlotSharingITCase(_system: ActorSystem) extends TestKit(_system) with ImplicitSender with
-WordSpecLike with Matchers with BeforeAndAfterAll {
+class SlotSharingITCase(_system: ActorSystem)
+  extends TestKit(_system)
+  with ImplicitSender
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaTestingUtils {
   def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
 
   override def afterAll(): Unit = {
@@ -61,11 +66,11 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
-      val jm = cluster.getJobManager
+      val jmGateway = cluster.getJobManagerGateway
 
       try {
         within(TestingUtils.TESTING_DURATION) {
-          jm ! SubmitJob(jobGraph, false)
+          jmGateway.tell(SubmitJob(jobGraph, false), self)
           expectMsg(Success(jobGraph.getJobID))
           expectMsgType[JobResultSuccess]
 
@@ -105,10 +110,11 @@ WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobGraph = new JobGraph("Bipartite job", sender1, sender2, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
-      val jm = cluster.getJobManager
+      val jmGateway = cluster.getJobManagerGateway
+
       try {
         within(TestingUtils.TESTING_DURATION) {
-          jm ! SubmitJob(jobGraph, false)
+          jmGateway.tell(SubmitJob(jobGraph, false), self)
           expectMsg(Success(jobGraph.getJobID))
           expectMsgType[JobResultSuccess]
         }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
@@ -27,14 +27,19 @@ import org.apache.flink.runtime.jobmanager.Tasks.{BlockingReceiver, Sender}
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
 import org.apache.flink.runtime.messages.JobManagerMessages.SubmitJob
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
-import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 @RunWith(classOf[JUnitRunner])
-class TaskManagerFailsWithSlotSharingITCase(_system: ActorSystem) extends TestKit(_system) with
-ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
+class TaskManagerFailsWithSlotSharingITCase(_system: ActorSystem)
+  extends TestKit(_system)
+  with ImplicitSender
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaTestingUtils {
 
   def this() = this(ActorSystem("TestingActorSystem", TestingUtils.testConfig))
 
@@ -64,15 +69,15 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks/2, 2)
-      val jm = cluster.getJobManager
+      val jmGateway = cluster.getJobManagerGateway
       val taskManagers = cluster.getTaskManagers
 
       try{
         within(TestingUtils.TESTING_DURATION) {
-          jm ! SubmitJob(jobGraph, false)
+          jmGateway.tell(SubmitJob(jobGraph, false), self)
           expectMsg(Success(jobGraph.getJobID))
 
-          jm ! WaitForAllVerticesToBeRunningOrFinished(jobID)
+          jmGateway.tell(WaitForAllVerticesToBeRunningOrFinished(jobID), self)
 
           expectMsg(AllVerticesRunning(jobID))
 
@@ -113,15 +118,15 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks/2, 2)
-      val jm = cluster.getJobManager
+      val jmGateway = cluster.getJobManagerGateway
       val taskManagers = cluster.getTaskManagers
 
       try{
         within(TestingUtils.TESTING_DURATION) {
-          jm ! SubmitJob(jobGraph, false)
+          jmGateway.tell(SubmitJob(jobGraph, false), self)
           expectMsg(Success(jobGraph.getJobID))
 
-          jm ! WaitForAllVerticesToBeRunningOrFinished(jobID)
+          jmGateway.tell(WaitForAllVerticesToBeRunningOrFinished(jobID), self)
           expectMsg(AllVerticesRunning(jobID))
 
           //kill task manager

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/ScalaTestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/ScalaTestingUtils.scala
@@ -18,27 +18,20 @@
 
 package org.apache.flink.runtime.testingUtils
 
-import org.apache.flink.runtime.{FlinkActor}
-import org.apache.flink.runtime.jobmanager.MemoryArchivist
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.{ExecutionGraphNotFound, ExecutionGraphFound, RequestExecutionGraph}
+import akka.actor.ActorRef
+import org.apache.flink.runtime.instance.{ActorGateway, AkkaActorGateway}
 
-/**
- * Mixin for the [[MemoryArchivist]] to support testing messages
- */
-trait TestingMemoryArchivist extends FlinkActor {
-  self: MemoryArchivist =>
+/** Mixing for testing utils
+  *
+  */
+trait ScalaTestingUtils {
 
-  abstract override def handleMessage: Receive = {
-    handleTestingMessage orElse super.handleMessage
-  }
-
-  def handleTestingMessage: Receive = {
-    case RequestExecutionGraph(jobID) =>
-      val executionGraph = graphs.get(jobID)
-      
-      executionGraph match {
-        case Some(graph) => sender ! decorateMessage(ExecutionGraphFound(jobID, graph))
-        case None => sender ! decorateMessage(ExecutionGraphNotFound(jobID))
-      }
+  /** Converts an [[ActorRef]] into a new [[AkkaActorGateway]] with None leader session ID
+    *
+    * @param actor ActorRef for which the ActorGateway is constructed
+    * @return [[ActorGateway]] encapsulating the given [[ActorRef]]
+    */
+  implicit def actorRef2InstanceGateway(actor: ActorRef): ActorGateway = {
+    new AkkaActorGateway(actor, None)
   }
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID
 import org.apache.flink.api.common.accumulators.Accumulator
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry
 import org.apache.flink.runtime.executiongraph.{ExecutionAttemptID, ExecutionGraph}
-import org.apache.flink.runtime.instance.InstanceGateway
+import org.apache.flink.runtime.instance.ActorGateway
 import org.apache.flink.runtime.jobgraph.JobStatus
 import java.util.Map
 
@@ -47,7 +47,7 @@ object TestingJobManagerMessages {
   case class NotifyWhenJobRemoved(jobID: JobID)
 
   case class RequestWorkingTaskManager(jobID: JobID)
-  case class WorkingTaskManager(gatewayOption: Option[InstanceGateway])
+  case class WorkingTaskManager(gatewayOption: Option[ActorGateway])
 
   case class NotifyWhenJobStatus(jobID: JobID, state: JobStatus)
   case class JobStatusIs(jobID: JobID, state: JobStatus)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
@@ -26,8 +26,10 @@ import org.apache.flink.runtime.instance.InstanceConnectionInfo
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
 import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.memorymanager.DefaultMemoryManager
+import org.apache.flink.runtime.messages.JobManagerMessages.{ResponseLeaderSessionID,
+RequestLeaderSessionID}
 import org.apache.flink.runtime.messages.Messages.Disconnect
-import org.apache.flink.runtime.messages.TaskMessages.{TaskInFinalState, UpdateTaskExecutionState}
+import org.apache.flink.runtime.messages.TaskMessages.{UpdateTaskExecutionState, TaskInFinalState}
 import org.apache.flink.runtime.taskmanager.{TaskManagerConfiguration, TaskManager}
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobRemoved
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
@@ -36,21 +38,34 @@ import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-/**
- * Subclass of the [[TaskManager]] to support testing messages
- */
-class TestingTaskManager(config: TaskManagerConfiguration,
-                         connectionInfo: InstanceConnectionInfo,
-                         jobManagerAkkaURL: String,
-                         memoryManager: DefaultMemoryManager,
-                         ioManager: IOManager,
-                         network: NetworkEnvironment,
-                         numberOfSlots: Int)
-  extends TaskManager(config, connectionInfo, jobManagerAkkaURL,
-                      memoryManager, ioManager, network, numberOfSlots) {
+/** Subclass of the [[TaskManager]] to support testing messages
+  *
+  * @param config
+  * @param connectionInfo
+  * @param jobManagerAkkaURL
+  * @param memoryManager
+  * @param ioManager
+  * @param network
+  * @param numberOfSlots
+  */
+class TestingTaskManager(
+    config: TaskManagerConfiguration,
+    connectionInfo: InstanceConnectionInfo,
+    jobManagerAkkaURL: String,
+    memoryManager: DefaultMemoryManager,
+    ioManager: IOManager,
+    network: NetworkEnvironment,
+    numberOfSlots: Int)
+  extends TaskManager(
+    config,
+    connectionInfo,
+    jobManagerAkkaURL,
+    memoryManager,
+    ioManager,
+    network,
+    numberOfSlots) {
 
   import scala.collection.JavaConverters._
-
 
   val waitForRemoval = scala.collection.mutable.HashMap[ExecutionAttemptID, Set[ActorRef]]()
   val waitForJobRemoval = scala.collection.mutable.HashMap[JobID, Set[ActorRef]]()
@@ -60,18 +75,19 @@ class TestingTaskManager(config: TaskManagerConfiguration,
 
   var disconnectDisabled = false
 
-
-  override def receiveWithLogMessages = {
-    receiveTestMessages orElse super.receiveWithLogMessages
-  }
-
   /**
    * Handler for testing related messages
    */
-  def receiveTestMessages: Receive = {
+  override def handleMessage: Receive = {
+    handleTestingMessage orElse super.handleMessage
+  }
+
+  def handleTestingMessage: Receive = {
     case NotifyWhenTaskIsRunning(executionID) => {
       Option(runningTasks.get(executionID)) match {
-        case Some(task) if task.getExecutionState == ExecutionState.RUNNING => sender ! true
+        case Some(task) if task.getExecutionState == ExecutionState.RUNNING =>
+          sender ! decorateMessage(true)
+
         case _ =>
           val listeners = waitForRunning.getOrElse(executionID, Set())
           waitForRunning += (executionID -> (listeners + sender))
@@ -79,7 +95,7 @@ class TestingTaskManager(config: TaskManagerConfiguration,
     }
 
     case RequestRunningTasks =>
-      sender ! ResponseRunningTasks(runningTasks.asScala.toMap)
+      sender ! decorateMessage(ResponseRunningTasks(runningTasks.asScala.toMap))
       
     case NotifyWhenTaskRemoved(executionID) =>
       Option(runningTasks.get(executionID)) match {
@@ -88,7 +104,7 @@ class TestingTaskManager(config: TaskManagerConfiguration,
           waitForRemoval += (executionID -> (set + sender))
         case None =>
           if(unregisteredTasks.contains(executionID)) {
-            sender ! true
+            sender ! decorateMessage(true)
           } else {
               val set = waitForRemoval.getOrElse(executionID, Set())
               waitForRemoval += (executionID -> (set + sender))
@@ -96,17 +112,19 @@ class TestingTaskManager(config: TaskManagerConfiguration,
       }
 
     case TaskInFinalState(executionID) =>
-      super.receiveWithLogMessages(TaskInFinalState(executionID))
+      super.handleMessage(TaskInFinalState(executionID))
       waitForRemoval.remove(executionID) match {
-        case Some(actors) => for(actor <- actors) actor ! true
+        case Some(actors) => for(actor <- actors) actor ! decorateMessage(true)
         case None =>
       }
 
       unregisteredTasks += executionID
       
     case RequestBroadcastVariablesWithReferences =>
-      sender ! ResponseBroadcastVariablesWithReferences(
-        bcVarManager.getNumberOfVariablesWithReferences)
+      sender ! decorateMessage(
+        ResponseBroadcastVariablesWithReferences(
+          bcVarManager.getNumberOfVariablesWithReferences)
+      )
 
     case RequestNumActiveConnections =>
       val numActive = if (network.isAssociated) {
@@ -114,30 +132,36 @@ class TestingTaskManager(config: TaskManagerConfiguration,
                       } else {
                         0
                       }
-      sender ! ResponseNumActiveConnections(numActive)
+      sender ! decorateMessage(ResponseNumActiveConnections(numActive))
 
     case NotifyWhenJobRemoved(jobID) =>
       if(runningTasks.values.asScala.exists(_.getJobID == jobID)){
         val set = waitForJobRemoval.getOrElse(jobID, Set())
         waitForJobRemoval += (jobID -> (set + sender))
         import context.dispatcher
-        context.system.scheduler.scheduleOnce(200 milliseconds, this.self, CheckIfJobRemoved(jobID))
+        context.system.scheduler.scheduleOnce(
+          200 milliseconds,
+          this.self,
+          decorateMessage(CheckIfJobRemoved(jobID)))
       }else{
         waitForJobRemoval.get(jobID) match {
-          case Some(listeners) => (listeners + sender) foreach (_ ! true)
-          case None => sender ! true
+          case Some(listeners) => (listeners + sender) foreach (_ ! decorateMessage(true))
+          case None => sender ! decorateMessage(true)
         }
       }
 
     case CheckIfJobRemoved(jobID) =>
       if(runningTasks.values.asScala.forall(_.getJobID != jobID)){
         waitForJobRemoval.remove(jobID) match {
-          case Some(listeners) => listeners foreach (_ ! true)
+          case Some(listeners) => listeners foreach (_ ! decorateMessage(true))
           case None =>
         }
       } else {
         import context.dispatcher
-        context.system.scheduler.scheduleOnce(200 milliseconds, this.self, CheckIfJobRemoved(jobID))
+        context.system.scheduler.scheduleOnce(
+          200 milliseconds,
+          this.self,
+          decorateMessage(CheckIfJobRemoved(jobID)))
       }
 
     case NotifyWhenJobManagerTerminated(jobManager) =>
@@ -160,23 +184,23 @@ class TestingTaskManager(config: TaskManagerConfiguration,
       }
 
     case msg@Terminated(jobManager) =>
-      super.receiveWithLogMessages(msg)
+      super.handleMessage(msg)
 
       waitForJobManagerToBeTerminated.remove(jobManager.path.name) foreach {
         _ foreach {
-          _ ! JobManagerTerminated(jobManager)
+          _ ! decorateMessage(JobManagerTerminated(jobManager))
         }
       }
 
     case msg:Disconnect =>
       if (!disconnectDisabled) {
-        super.receiveWithLogMessages(msg)
+        super.handleMessage(msg)
 
         val jobManager = sender()
 
         waitForJobManagerToBeTerminated.remove(jobManager.path.name) foreach {
           _ foreach {
-            _ ! JobManagerTerminated(jobManager)
+            _ ! decorateMessage(JobManagerTerminated(jobManager))
           }
         }
       }
@@ -185,12 +209,15 @@ class TestingTaskManager(config: TaskManagerConfiguration,
       disconnectDisabled = true
 
     case msg @ UpdateTaskExecutionState(taskExecutionState) =>
-      super.receiveWithLogMessages(msg)
+      super.handleMessage(msg)
 
       if(taskExecutionState.getExecutionState == ExecutionState.RUNNING) {
         waitForRunning.get(taskExecutionState.getID) foreach {
-          _ foreach (_ ! true)
+          _ foreach (_ ! decorateMessage(true))
         }
       }
+
+    case RequestLeaderSessionID =>
+      sender() ! ResponseLeaderSessionID(leaderSessionID)
   }
 }

--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/resources/log4j-test.properties
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target = System.err

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/resources/log4j-test.properties
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/resources/log4j-test.properties
@@ -17,7 +17,7 @@
 ################################################################################
 
 # Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=INFO, A1
+log4j.rootLogger=OFF, A1
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender

--- a/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancellingTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancellingTestBase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.cancelling;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import akka.actor.ActorRef;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobCancellationException;
@@ -115,7 +114,7 @@ public abstract class CancellingTestBase {
 				public void run() {
 					try {
 						Thread.sleep(msecsTillCanceling);
-						executor.getJobManager().tell(new JobManagerMessages.CancelJob(jobGraph.getJobID()), ActorRef.noSender());
+						executor.getJobManagerGateway().tell(new JobManagerMessages.CancelJob(jobGraph.getJobID()));
 					}
 					catch (Throwable t) {
 						error.set(t);

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -32,12 +32,17 @@ import org.apache.flink.runtime.jobmanager.Tasks.{BlockingNoOpInvokable, NoOpInv
 import org.apache.flink.runtime.messages.JobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.{JobManagerTerminated, NotifyWhenJobManagerTerminated}
-import org.apache.flink.runtime.testingUtils.TestingUtils
+import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
 import org.apache.flink.test.util.ForkableFlinkMiniCluster
 
 @RunWith(classOf[JUnitRunner])
-class JobManagerFailsITCase(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-with WordSpecLike with Matchers with BeforeAndAfterAll {
+class JobManagerFailsITCase(_system: ActorSystem)
+  extends TestKit(_system)
+  with ImplicitSender
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaTestingUtils {
 
   def this() = this(ActorSystem("TestingActorSystem", AkkaUtils.getDefaultAkkaConfig))
 
@@ -52,18 +57,18 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
       val cluster = startDeathwatchCluster(num_slots, 1)
 
       val tm = cluster.getTaskManagers(0)
-      val jm = cluster.getJobManager
+      val jmGateway = cluster.getJobManagerGateway
 
       // disable disconnect message to test death watch
       tm ! DisableDisconnect
 
       try{
-        jm ! RequestNumberRegisteredTaskManager
+        jmGateway.tell(RequestNumberRegisteredTaskManager, self)
         expectMsg(1)
 
-        tm ! NotifyWhenJobManagerTerminated(jm)
+        tm ! NotifyWhenJobManagerTerminated(jmGateway.actor)
 
-        jm ! PoisonPill
+        jmGateway.tell(PoisonPill, self)
 
         expectMsgClass(classOf[JobManagerTerminated])
 
@@ -71,7 +76,7 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
         cluster.waitForTaskManagersToBeRegistered()
 
-        cluster.getJobManager ! RequestNumberRegisteredTaskManager
+        cluster.getJobManagerGateway.tell(RequestNumberRegisteredTaskManager, self)
 
         expectMsg(1)
       } finally {
@@ -94,27 +99,27 @@ with WordSpecLike with Matchers with BeforeAndAfterAll {
 
       val cluster = startDeathwatchCluster(num_slots / 2, 2)
 
-      var jm = cluster.getJobManager
+      var jmGateway = cluster.getJobManagerGateway
       val tm = cluster.getTaskManagers(0)
 
       try {
         within(TestingUtils.TESTING_DURATION) {
-          jm ! SubmitJob(jobGraph, false)
+          jmGateway.tell(SubmitJob(jobGraph, false), self)
           expectMsg(Success(jobGraph.getJobID))
 
-          tm ! NotifyWhenJobManagerTerminated(jm)
+          tm.tell(NotifyWhenJobManagerTerminated(jmGateway.actor()), self)
 
-          jm ! PoisonPill
+          jmGateway.tell(PoisonPill, self)
 
           expectMsgClass(classOf[JobManagerTerminated])
 
           cluster.restartJobManager()
 
-          jm = cluster.getJobManager
+          jmGateway = cluster.getJobManagerGateway
 
           cluster.waitForTaskManagersToBeRegistered()
 
-          jm ! SubmitJob(jobGraph2, false)
+          jmGateway.tell(SubmitJob(jobGraph2, false), self)
 
           val failure = expectMsgType[Success]
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerLeaderSessionIDITSuite.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerLeaderSessionIDITSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.runtime.jobmanager
+
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.actor.Status.Success
+import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.runtime.akka.AkkaUtils
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable
+import org.apache.flink.runtime.jobgraph.{JobGraph, JobVertex}
+import org.apache.flink.runtime.messages.JobManagerMessages.{LeaderSessionMessage, CancelJob,
+JobResultSuccess, SubmitJob}
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.{AllVerticesRunning,
+WaitForAllVerticesToBeRunning}
+import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
+import org.junit.runner.RunWith
+import org.scalatest.{FunSuiteLike, Matchers, BeforeAndAfterAll}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class JobManagerLeaderSessionIDITSuite(_system: ActorSystem)
+  extends TestKit(_system)
+  with ImplicitSender
+  with FunSuiteLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaTestingUtils {
+
+  val numTaskManagers = 2
+  val taskManagerNumSlots = 2
+  val numSlots = numTaskManagers * taskManagerNumSlots
+
+  val cluster = TestingUtils.startTestingCluster(
+    taskManagerNumSlots,
+    numTaskManagers,
+    TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT);
+
+  def this() = this(ActorSystem("TestingActorSystem", AkkaUtils.getDefaultAkkaConfig))
+
+  override def afterAll(): Unit = {
+    cluster.stop()
+    TestKit.shutdownActorSystem(system)
+  }
+
+  test("A JobManager should not process CancelJob messages with the wrong leader session ID") {
+    val sender = new JobVertex("BlockingSender");
+    sender.setParallelism(numSlots)
+    sender.setInvokableClass(classOf[BlockingUntilSignalNoOpInvokable])
+    val jobGraph = new JobGraph("TestJob", sender)
+
+    val oldSessionID = Option(UUID.randomUUID())
+
+    val jmGateway = cluster.getJobManagerGateway()
+    val jm = jmGateway.actor()
+
+    within(TestingUtils.TESTING_DURATION) {
+      jmGateway.tell(SubmitJob(jobGraph, false), self)
+
+      expectMsg(Success(jobGraph.getJobID))
+
+      jmGateway.tell(WaitForAllVerticesToBeRunning(jobGraph.getJobID), self)
+
+      expectMsg(AllVerticesRunning(jobGraph.getJobID))
+
+      jm ! LeaderSessionMessage(oldSessionID, CancelJob(jobGraph.getJobID))
+
+      BlockingUntilSignalNoOpInvokable.triggerExecution()
+
+      expectMsgType[JobResultSuccess]
+    }
+  }
+}
+
+class BlockingUntilSignalNoOpInvokable extends AbstractInvokable {
+  override def registerInputOutput(): Unit = {
+
+  }
+
+  override def invoke(): Unit = {
+    BlockingUntilSignalNoOpInvokable.lock.synchronized{
+      BlockingUntilSignalNoOpInvokable.lock.wait()
+    }
+  }
+}
+
+object BlockingUntilSignalNoOpInvokable {
+  val lock = new Object
+
+  def triggerExecution(): Unit = {
+    lock.synchronized{
+      lock.notifyAll()
+    }
+  }
+}

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
@@ -25,26 +25,31 @@ import org.apache.flink.runtime.memorymanager.DefaultMemoryManager
 import org.apache.flink.runtime.taskmanager.{NetworkEnvironmentConfiguration, TaskManagerConfiguration, TaskManager}
 import org.apache.flink.yarn.Messages.StopYarnSession
 
-/**
- * An extension of the TaskManager that listens for additional YARN related
- * messages.
- */
-class YarnTaskManager(config: TaskManagerConfiguration,
-                      connectionInfo: InstanceConnectionInfo,
-                      jobManagerAkkaURL: String,
-                      memoryManager: DefaultMemoryManager,
-                      ioManager: IOManager,
-                      network: NetworkEnvironment,
-                      numberOfSlots: Int)
-  extends TaskManager(config, connectionInfo, jobManagerAkkaURL,
-                      memoryManager, ioManager, network, numberOfSlots) {
+/** An extension of the TaskManager that listens for additional YARN related
+  * messages.
+  */
+class YarnTaskManager(
+    config: TaskManagerConfiguration,
+    connectionInfo: InstanceConnectionInfo,
+    jobManagerAkkaURL: String,
+    memoryManager: DefaultMemoryManager,
+    ioManager: IOManager,
+    network: NetworkEnvironment,
+    numberOfSlots: Int)
+  extends TaskManager(
+    config,
+    connectionInfo,
+    jobManagerAkkaURL,
+    memoryManager,
+    ioManager,
+    network,
+    numberOfSlots) {
 
-
-  override def receiveWithLogMessages: Receive = {
-    receiveYarnMessages orElse super.receiveWithLogMessages
+  override def handleMessage: Receive = {
+    handleYarnMessages orElse super.handleMessage
   }
 
-  def receiveYarnMessages: Receive = {
+  def handleYarnMessages: Receive = {
     case StopYarnSession(status, diagnostics) =>
       log.info(s"Stopping YARN TaskManager with final application status $status " +
         s"and diagnostics: $diagnostics")


### PR DESCRIPTION
## Registration Session IDs

Introduces registration session IDs for all registration messages. Upon receiving a registration message, this ID is checked and if not correct, the message is discarded. That way, it is possible to distinguish old registration messages which are delayed from valid ones. 

In the current implementation, a static registration session ID is assigned when the `TaskManager` actor is created. However, with support for high availability, where the leader can change while trying to register at old leader, it becomes important to distinguish old from new registration messages.

## Leader Session IDs

In order to support high availability, we not only have to distinguish the old from the new registration messages, but also control messages which are sent to and from the `JobManager` and the `TaskManager`. In order to filter out possibly old messages, this PR introduces a leader session ID which denotes the currently valid messages. However, unlike the registration session ID, leader session IDs are assigned to messages transparently. 

Messages which extend the `RequiresLeaderSessionID` interface will be wrapped in a `LeaderSessionMessage` which also contains the currently known leader session ID. At the receiving end, the `LeaderSessionMessages` are unpacked and the received leader session ID is compared to the currently stored leader session ID. If both IDs are the same, the wrapped message is processed. If not, then wrapped message will be discarded.

In order to support this behaviour, the PR introduces a new `FlinkActor` for Scala actors and a `FlinkUntypedActor` for Java actors. Both actors provide a `decorateMessage` method which allows sub types of the `FlinkActor`/`FlinkUntypedActor` to decorate outgoing messages. Therefore, all implementing classes are supposed to call `decorateMessage` before sending a message to another actor.

The `FlinkUntypedActor` already comes with support for message logging and leader session message filtering. Furthermore, its `decorateMessage` method implementation checks for each message if it's an subtype of `RequiresLeaderSessionID` or not and if it is the case, then wraps this message in a `LeaderSessionMessage`. The receive method of this class, will then take care to unwrap the messages accordingly.

In order to have the same behavior with Scala actors one has to extend the `FlinkActor` and mixin the `LeaderSessionMessages` and `LoggingMessages` mixins. They effectively do the same as the `FlinkUntypedActor`, but offer a better extensibility of the Scala actors in the future.

In case that a `RequiresLeaderSessionID` message is received without being wrapped in a `LeaderSessionMessage` by a FlinkActor, an exception is thrown, which effectively terminates the execution of the actor. The reason for this is that a unwrapped message might leave the system in an inconsistent state if it's a message from an old leader. Furthermore, since not every `RequiresLeaderSessionID` message requires a response, it is not possible to notify the sender of the wrong message about the missing leader session ID.

## ActorGateway refactoring

In order to guarantee the similar wrapping behaviour when one sends messages outside of an actor, the former `InstanceGateway` has been refactored to `ActorGateway` and all `ActorRef` interactions have been replaced by `ActorGateway` instances. Only the web server still uses `ActorRefs`, because it is about to be refactored anyway (see #677). However, the PR #677 should be updated accordingly. 

`AkkaActorGateway` implements the `ActorGateway` and makes sure that all `RequiresLeaderSessionID` messages are wrapped correctly in a `LeaderSessionMessage`. In order to make this happen, the `AkkaActorGateway` is given the current leader session ID upon creation. For any actor interaction from outside of an actor, this class should be used. Using this abstraction will allow us to easily extend the decoration behaviour of messages in the future, too. 

## Style formatting

The PR also contains some Scala style harmonisation of old Scala code.

## TL;DR

In order to support leader session IDs all Flink actors should extend `FlinkUntypedActor` or `FlinkActor` with `LeaderSessionMessages` and `LogMessages` mixins. Whenever a message is sent from within an actor, the message should be decorated by calling `decorateMessage`. When messages are sent from outside of an actor, the `AkkaActorGateway` should be used instead of directly using `ActorRef`. That way, we guarantee the proper wrapping of the messages.