### PR TITLE
[FLINK-2368][ml]Adds convergence criteria

### DIFF
--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/Convergence.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/Convergence.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common
+
+import org.apache.flink.api.scala.DataSet
+import org.apache.flink.ml._
+
+/** Base trait for defining convergence criteria
+  * User must override the isConverged method
+  *
+  */
+trait Convergence[Data,Model] extends Serializable{
+
+  /** Checks for convergence. Every algorithm will call the checkCOnvergence method to provide
+    * all the necessary information to the user defined criterion
+    * @param data The data set being used for learning
+    * @param prev Solution before the iteration
+    * @param curr Solution after the iteration
+    *
+    */
+  final def converged(
+      data: DataSet[Data],
+      prev: DataSet[Model],
+      curr: DataSet[Model])
+    : DataSet[_] = {
+    isConverged(data, prev, curr)
+  }
+
+  /** User must override one of the following two methods and provide an implementation to
+    * check if the iteration process has converged. This will be used in conjunction with any
+    * other convergence criteria the algorithm designer has in mind.
+    * If the iteration must be stopped, user must an empty data set.
+    *
+    */
+  def isConverged(data: DataSet[Data], prev: DataSet[Model], curr: DataSet[Model]): DataSet[_] = {
+    isConverged(prev, curr)
+  }
+
+  def isConverged(prev: DataSet[Model], curr: DataSet[Model]): DataSet[_] ={
+    prev
+  }
+}

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
@@ -37,13 +37,15 @@ class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
     setLocalIterations(100).
     setRegularization(0.002).
     setStepsize(0.1).
-    setSeed(0)
+    setSeed(0).
+    setConvergenceCriteria(new SVMConvergenceWeights)
 
     val trainingDS = env.fromCollection(Classification.trainingData)
 
     svm.fit(trainingDS)
 
     val weightVector = svm.weightsOption.get.collect().head
+
 
     weightVector.valueIterator.zip(Classification.expectedWeightVector.valueIterator).foreach {
       case (weight, expectedWeight) =>


### PR DESCRIPTION
Adds a convergence criteria class which allows the user to decide whether they want to terminate training at any point, based on the solutions before and after an iteration. 

Adding the first example to the SVM trainer.[Not finished yet].
