### PR TITLE
[FLINK-2371] improve AccumulatorLiveITCase

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorSnapshot.java
@@ -40,9 +40,9 @@ public class AccumulatorSnapshot implements Serializable {
 	private final ExecutionAttemptID executionAttemptID;
 
 	/**
-	 * Flink internal accumulators which can be serialized using the system class loader.
+	 * Flink internal accumulators which can be deserialized using the system class loader.
 	 */
-	private final Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> flinkAccumulators;
+	private final SerializedValue<Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>> flinkAccumulators;
 
 	/**
 	 * Serialized user accumulators which may require the custom user class loader.
@@ -54,7 +54,7 @@ public class AccumulatorSnapshot implements Serializable {
 							Map<String, Accumulator<?, ?>> userAccumulators) throws IOException {
 		this.jobID = jobID;
 		this.executionAttemptID = executionAttemptID;
-		this.flinkAccumulators = flinkAccumulators;
+		this.flinkAccumulators = new SerializedValue<Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>>(flinkAccumulators);
 		this.userAccumulators = new SerializedValue<Map<String, Accumulator<?, ?>>>(userAccumulators);
 	}
 
@@ -70,8 +70,8 @@ public class AccumulatorSnapshot implements Serializable {
 	 * Gets the Flink (internal) accumulators values.
 	 * @return the serialized map
 	 */
-	public Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> getFlinkAccumulators() {
-		return flinkAccumulators;
+	public Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> deserializeFlinkAccumulators() throws IOException, ClassNotFoundException {
+		return flinkAccumulators.deserializeValue(ClassLoader.getSystemClassLoader());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -141,9 +141,10 @@ public class ExecutionGraph implements Serializable {
 	 * @param accumulatorSnapshot The serialized flink and user-defined accumulators
 	 */
 	public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
-		Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> flinkAccumulators = accumulatorSnapshot.getFlinkAccumulators();
+		Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> flinkAccumulators;
 		Map<String, Accumulator<?, ?>> userAccumulators;
 		try {
+			flinkAccumulators = accumulatorSnapshot.deserializeFlinkAccumulators();
 			userAccumulators = accumulatorSnapshot.deserializeUserAccumulators(userClassLoader);
 
 			ExecutionAttemptID execID = accumulatorSnapshot.getExecutionAttemptID();
@@ -889,7 +890,7 @@ public class ExecutionGraph implements Serializable {
 					Map<String, Accumulator<?, ?>> userAccumulators = null;
 					try {
 						AccumulatorSnapshot accumulators = state.getAccumulators();
-						flinkAccumulators = accumulators.getFlinkAccumulators();
+						flinkAccumulators = accumulators.deserializeFlinkAccumulators();
 						userAccumulators = accumulators.deserializeUserAccumulators(userClassLoader);
 					} catch (Exception e) {
 						// Exceptions would be thrown in the future here

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -400,16 +400,12 @@ class JobManager(
       import scala.collection.JavaConverters._
       sender ! RegisteredTaskManagers(instanceManager.getAllRegisteredInstances.asScala)
 
-    case Heartbeat(instanceID, metricsReport, accumulators, asyncAccumulatorUpdate) =>
+    case Heartbeat(instanceID, metricsReport, accumulators) =>
       log.debug(s"Received hearbeat message from $instanceID.")
 
-      if (asyncAccumulatorUpdate) {
-        Future {
-          updateAccumulators(accumulators)
-        }(context.dispatcher)
-      } else {
+      Future {
         updateAccumulators(accumulators)
-      }
+      }(context.dispatcher)
 
       instanceManager.reportHeartBeat(instanceID, metricsReport)
 
@@ -767,6 +763,10 @@ class JobManager(
     }
   }
 
+  /**
+   * Updates the accumulators reported from a task manager via the Heartbeat message.
+   * @param accumulators list of accumulator snapshots
+   */
   private def updateAccumulators(accumulators : Seq[AccumulatorSnapshot]) = {
     accumulators foreach {
       case accumulatorEvent =>

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -54,10 +54,9 @@ object TaskManagerMessages {
    * @param instanceID The instance ID of the reporting TaskManager.
    * @param metricsReport utf-8 encoded JSON metrics report from the metricRegistry.
    * @param accumulators Accumulators of tasks serialized as Tuple2[internal, user-defined]
-   * @param asyncAccumulatorUpdate Update accumulators asynchronously (set to false in testing)
    */
   case class Heartbeat(instanceID: InstanceID, metricsReport: Array[Byte],
-     accumulators: Seq[AccumulatorSnapshot], asyncAccumulatorUpdate : Boolean = true)
+     accumulators: Seq[AccumulatorSnapshot])
 
 
   // --------------------------------------------------------------------------

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -54,9 +54,10 @@ object TaskManagerMessages {
    * @param instanceID The instance ID of the reporting TaskManager.
    * @param metricsReport utf-8 encoded JSON metrics report from the metricRegistry.
    * @param accumulators Accumulators of tasks serialized as Tuple2[internal, user-defined]
+   * @param asyncAccumulatorUpdate Update accumulators asynchronously (set to false in testing)
    */
   case class Heartbeat(instanceID: InstanceID, metricsReport: Array[Byte],
-     accumulators: Seq[AccumulatorSnapshot])
+     accumulators: Seq[AccumulatorSnapshot], asyncAccumulatorUpdate : Boolean = true)
 
 
   // --------------------------------------------------------------------------

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -155,7 +155,7 @@ extends Actor with ActorLogMessages with ActorSynchronousLogging {
 
   private var blobService: Option[BlobService] = None
   private var libraryCacheManager: Option[LibraryCacheManager] = None
-  private var currentJobManager: Option[ActorRef] = None
+  protected var currentJobManager: Option[ActorRef] = None
 
   private var instanceID: InstanceID = null
 
@@ -936,7 +936,7 @@ extends Actor with ActorLogMessages with ActorSynchronousLogging {
    * Sends a heartbeat message to the JobManager (if connected) with the current
    * metrics report.
    */
-  private def sendHeartbeatToJobManager(): Unit = {
+  protected def sendHeartbeatToJobManager(): Unit = {
     try {
       log.debug("Sending heartbeat to JobManager")
       val metricsReport: Array[Byte] = metricRegistryMapper.writeValueAsBytes(metricRegistry)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -27,8 +27,10 @@ import org.apache.flink.runtime.jobgraph.JobStatus
 import org.apache.flink.runtime.jobmanager.{JobManager, MemoryArchivist}
 import org.apache.flink.runtime.messages.ExecutionGraphMessages.JobStatusChanged
 import org.apache.flink.runtime.messages.Messages.Disconnect
+import org.apache.flink.runtime.messages.TaskManagerMessages.Heartbeat
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.AccumulatorsChanged
 
 import scala.collection.convert.WrapAsScala
 import scala.concurrent.Future
@@ -54,6 +56,8 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
 
   val waitForJobStatus = scala.collection.mutable.HashMap[JobID,
     collection.mutable.HashMap[JobStatus, Set[ActorRef]]]()
+
+  val waitForAccumulatorUpdate = scala.collection.mutable.HashMap[JobID, (Boolean, Set[ActorRef])]()
 
   var disconnectDisabled = false
 
@@ -130,6 +134,47 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
         }
       }
 
+    case NotifyWhenAccumulatorChange(jobID) =>
+
+      val (updated, registered) = waitForAccumulatorUpdate.
+        getOrElse(jobID, (false, Set[ActorRef]()))
+      waitForAccumulatorUpdate += jobID -> (updated, registered + sender)
+      sender ! true
+
+    /**
+     * Notification from the task manager that changed accumulator are transferred on next
+     * Hearbeat. We need to keep this state to notify the listeners on next Heartbeat report.
+     */
+    case AccumulatorsChanged(jobID: JobID) =>
+      waitForAccumulatorUpdate.get(jobID) match {
+        case Some((updated, registered)) =>
+          waitForAccumulatorUpdate.put(jobID, (true, registered))
+        case None =>
+      }
+
+    /**
+     * Disabled async processing of accumulator values and send accumulators to the listeners if
+     * we previously received an [[AccumulatorsChanged]] message.
+     */
+    case msg : Heartbeat =>
+      val newMsg = msg.copy(asyncAccumulatorUpdate = false)
+      super.receiveWithLogMessages(newMsg)
+
+      waitForAccumulatorUpdate foreach {
+        case (jobID, (updated, actors)) if updated =>
+          val accumulators = currentJobs.get(jobID) match {
+            case Some((graph, jobInfo)) =>
+              val flinkAccumulators = graph.getFlinkAccumulators
+              val userAccumulators = graph.aggregateUserAccumulators
+              actors foreach {
+                actor => actor ! UpdatedAccumulators(jobID, flinkAccumulators, userAccumulators)
+              }
+            case None =>
+          }
+          waitForAccumulatorUpdate.put(jobID, (false, actors))
+        case _ =>
+      }
+
     case RequestWorkingTaskManager(jobID) =>
       currentJobs.get(jobID) match {
         case Some((eg, _)) =>
@@ -147,15 +192,6 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
         case None => sender ! WorkingTaskManager(None)
       }
 
-    case RequestAccumulatorValues(jobID) =>
-
-      val (flinkAccumulators, userAccumulators) = currentJobs.get(jobID) match {
-        case Some((graph, jobInfo)) =>
-          (graph.getFlinkAccumulators, graph.aggregateUserAccumulators)
-        case None => null
-      }
-
-      sender ! RequestAccumulatorValuesResponse(jobID, flinkAccumulators, userAccumulators)
 
     case NotifyWhenJobStatus(jobID, state) =>
       val jobStatusListener = waitForJobStatus.getOrElseUpdate(jobID,

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -157,12 +157,11 @@ trait TestingJobManager extends ActorLogMessages with WrapAsScala {
      * we previously received an [[AccumulatorsChanged]] message.
      */
     case msg : Heartbeat =>
-      val newMsg = msg.copy(asyncAccumulatorUpdate = false)
-      super.receiveWithLogMessages(newMsg)
+      super.receiveWithLogMessages(msg)
 
       waitForAccumulatorUpdate foreach {
         case (jobID, (updated, actors)) if updated =>
-          val accumulators = currentJobs.get(jobID) match {
+          currentJobs.get(jobID) match {
             case Some((graph, jobInfo)) =>
               val flinkAccumulators = graph.getFlinkAccumulators
               val userAccumulators = graph.aggregateUserAccumulators

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -20,12 +20,12 @@ package org.apache.flink.runtime.testingUtils
 
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
+import org.apache.flink.api.common.accumulators.Accumulator
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry
 import org.apache.flink.runtime.executiongraph.{ExecutionAttemptID, ExecutionGraph}
 import org.apache.flink.runtime.instance.InstanceGateway
 import org.apache.flink.runtime.jobgraph.JobStatus
 import java.util.Map
-import org.apache.flink.api.common.accumulators.Accumulator
 
 object TestingJobManagerMessages {
 
@@ -57,8 +57,18 @@ object TestingJobManagerMessages {
   case class NotifyWhenTaskManagerTerminated(taskManager: ActorRef)
   case class TaskManagerTerminated(taskManager: ActorRef)
 
-  case class RequestAccumulatorValues(jobID: JobID)
-  case class RequestAccumulatorValuesResponse(jobID: JobID,
+  /* Registers a listener to receive a message when accumulators changed.
+   * The change must be explicitly triggered by the TestingTaskManager which can receive an
+   * [[AccumulatorChanged]] message by a task that changed the accumulators. This message is then
+   * forwarded to the JobManager which will send the accumulators in the [[UpdatedAccumulators]]
+   * message when the next Heartbeat occurs.
+   * */
+  case class NotifyWhenAccumulatorChange(jobID: JobID)
+
+  /**
+   * Reports updated accumulators back to the listener.
+   */
+  case class UpdatedAccumulators(jobID: JobID,
     flinkAccumulators: Map[ExecutionAttemptID, Map[AccumulatorRegistry.Metric, Accumulator[_,_]]],
     userAccumulators: Map[String, Accumulator[_,_]])
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
@@ -51,7 +51,14 @@ object TestingTaskManagerMessages {
   case class NotifyWhenJobManagerTerminated(jobManager: ActorRef)
 
   case class JobManagerTerminated(jobManager: ActorRef)
-  
+
+  /**
+   * Message to give a hint to the task manager that accumulator values were updated in the task.
+   * This message is forwarded to the job manager which knows that it needs to notify listeners
+   * of accumulator updates.
+   */
+  case class AccumulatorsChanged(jobID: JobID)
+
   // --------------------------------------------------------------------------
   // Utility methods to allow simpler case object access from Java
   // --------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
@@ -21,7 +21,9 @@ package org.apache.flink.test.accumulators;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Status;
+import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
+import akka.util.Timeout;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
@@ -46,41 +48,51 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.*;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.Collector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
 
 /**
- * Test the availability of accumulator results during runtime.
+ * Tests the availability of accumulator results during runtime. The test case tests a user-defined
+ * accumulator and Flink's internal accumulators for two consecutive tasks.
  */
-@SuppressWarnings("serial")
 public class AccumulatorLiveITCase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(AccumulatorLiveITCase.class);
 
 	private static ActorSystem system;
 	private static ActorRef jobManager;
+	private static ActorRef taskManager;
+	private static JobID jobID;
 
-	// name of accumulator
+	// name of user accumulator
 	private static String NAME = "test";
-	// time to wait between changing the accumulator value
-	private static long WAIT_TIME = TaskManager.HEARTBEAT_INTERVAL().toMillis() + 500;
 
 	// number of heartbeat intervals to check
-	private static int NUM_ITERATIONS = 3;
-	// numer of retries in case the expected value is not seen
-	private static int NUM_RETRIES = 10;
+	private static final int NUM_ITERATIONS = 5;
 
 	private static List<String> inputData = new ArrayList<String>(NUM_ITERATIONS);
+
+	private static final FiniteDuration TIMEOUT = new FiniteDuration(10, TimeUnit.SECONDS);
 
 
 	@Before
@@ -88,6 +100,7 @@ public class AccumulatorLiveITCase {
 		system = AkkaUtils.createLocalActorSystem(new Configuration());
 		TestingCluster testingCluster = TestingUtils.startTestingCluster(1, 1, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
 		jobManager = testingCluster.getJobManager();
+		taskManager = testingCluster.getTaskManagersAsJava().get(0);
 
 		// generate test data
 		for (int i=0; i < NUM_ITERATIONS; i++) {
@@ -109,124 +122,156 @@ public class AccumulatorLiveITCase {
 			ExecutionEnvironment env = new PlanExtractor();
 			DataSet<String> input = env.fromCollection(inputData);
 			input
-					.flatMap(new Tokenizer())
 					.flatMap(new WaitingUDF())
 					.output(new WaitingOutputFormat());
 			env.execute();
 
-			/** Extract job graph **/
+			// Extract job graph and set job id for the task to notify of accumulator changes.
 			JobGraph jobGraph = getOptimizedPlan(((PlanExtractor) env).plan);
+			jobID = jobGraph.getJobID();
 
+			// register for accumulator changes
+			jobManager.tell(new TestingJobManagerMessages.NotifyWhenAccumulatorChange(jobID), getRef());
+			expectMsgEquals(true);
+
+			// submit job
 			jobManager.tell(new JobManagerMessages.SubmitJob(jobGraph, false), getRef());
 			expectMsgClass(Status.Success.class);
 
-			/* Check for accumulator values */
-			int i = 0, retries = 0;
-			int expectedAccVal = 0;
-			while(i <= NUM_ITERATIONS) {
-				if (retries > 0) {
-					// retry fast
-					Thread.sleep(WAIT_TIME / NUM_RETRIES);
-				} else {
-					// wait for heartbeat interval
-					Thread.sleep(WAIT_TIME);
-				}
 
-				jobManager.tell(new RequestAccumulatorValues(jobGraph.getJobID()), getRef());
-				RequestAccumulatorValuesResponse response =
-						expectMsgClass(RequestAccumulatorValuesResponse.class);
+			ExecutionAttemptID mapperTaskID = null;
 
-				Map<String, Accumulator<?, ?>> userAccumulators = response.userAccumulators();
-				Map<ExecutionAttemptID, Map<AccumulatorRegistry.Metric, Accumulator<?,?>>> flinkAccumulators =
-						response.flinkAccumulators();
+			TestingJobManagerMessages.UpdatedAccumulators msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+			Map<ExecutionAttemptID, Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>> flinkAccumulators = msg.flinkAccumulators();
+			Map<String, Accumulator<?, ?>> userAccumulators = msg.userAccumulators();
 
-				if (checkUserAccumulators(expectedAccVal, userAccumulators) && checkFlinkAccumulators(i == NUM_ITERATIONS, i, i * 4, flinkAccumulators)) {
-//					System.out.println("Passed round " + i);
-					// We passed this round
-					i += 1;
-					expectedAccVal += i;
-					retries = 0;
-				} else {
-					if (retries < NUM_RETRIES) {
-//						System.out.println("retrying for the " + retries + " time.");
-						// try again
-						retries += 1;
-					} else {
-						fail("Failed in round #" + i + " after " + retries + " retries.");
-					}
+			// find out the first task's execution attempt id
+			for (Map.Entry<ExecutionAttemptID, ?> entry : flinkAccumulators.entrySet()) {
+				if (entry.getValue() != null) {
+					mapperTaskID = entry.getKey();
+					break;
 				}
 			}
+
+			/* Check for accumulator values */
+			if(checkUserAccumulators(0, userAccumulators) && checkFlinkAccumulators(mapperTaskID, 0, 0, 0, 0, flinkAccumulators)) {
+				LOG.info("Passed initial check for map task.");
+			} else {
+				fail("Wrong accumulator results when map task begins execution.");
+			}
+
+
+			int expectedAccVal = 0;
+			ExecutionAttemptID sinkTaskID = null;
+
+			/* for mapper task */
+			for (int i = 1; i <= NUM_ITERATIONS; i++) {
+				expectedAccVal += i;
+
+				// receive message
+				msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+				flinkAccumulators = msg.flinkAccumulators();
+				userAccumulators = msg.userAccumulators();
+
+				LOG.info("{}", flinkAccumulators);
+				LOG.info("{}", userAccumulators);
+
+				if (checkUserAccumulators(expectedAccVal, userAccumulators) && checkFlinkAccumulators(mapperTaskID, 0, i, 0, i * 4, flinkAccumulators)) {
+					LOG.info("Passed round " + i);
+				} else {
+					fail("Failed in round #" + i);
+				}
+			}
+
+			msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+			flinkAccumulators = msg.flinkAccumulators();
+			userAccumulators = msg.userAccumulators();
+
+			// find the second's task id
+			for (ExecutionAttemptID key : flinkAccumulators.keySet()) {
+				if (key != mapperTaskID) {
+					sinkTaskID = key;
+					break;
+				}
+			}
+
+			if(checkUserAccumulators(expectedAccVal, userAccumulators) && checkFlinkAccumulators(sinkTaskID, 0, 0, 0, 0, flinkAccumulators)) {
+				LOG.info("Passed initial check for sink task.");
+			} else {
+				fail("Wrong accumulator results when sink task begins execution.");
+			}
+
+			/* for sink task */
+			for (int i = 1; i <= NUM_ITERATIONS; i++) {
+
+				// receive message
+				msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+
+				flinkAccumulators = msg.flinkAccumulators();
+				userAccumulators = msg.userAccumulators();
+
+				LOG.info("{}", flinkAccumulators);
+				LOG.info("{}", userAccumulators);
+
+				if (checkUserAccumulators(expectedAccVal, userAccumulators) && checkFlinkAccumulators(sinkTaskID, i, 0, i*4, 0, flinkAccumulators)) {
+					LOG.info("Passed round " + i);
+				} else {
+					fail("Failed in round #" + i);
+				}
+			}
+
+			expectMsgClass(JobManagerMessages.JobResultSuccess.class);
 
 		}};
 	}
 
 	private static boolean checkUserAccumulators(int expected, Map<String, Accumulator<?,?>> accumulatorMap) {
-//		System.out.println("checking user accumulators");
+		LOG.info("checking user accumulators");
 		return accumulatorMap.containsKey(NAME) && expected == ((IntCounter)accumulatorMap.get(NAME)).getLocalValue();
 	}
 
-	private static boolean checkFlinkAccumulators(boolean lastRound, int expectedRecords, int expectedBytes,
+	private static boolean checkFlinkAccumulators(ExecutionAttemptID taskKey, int expectedRecordsIn, int expectedRecordsOut, int expectedBytesIn, int expectedBytesOut,
 												  Map<ExecutionAttemptID, Map<AccumulatorRegistry.Metric, Accumulator<?,?>>> accumulatorMap) {
-//		System.out.println("checking flink accumulators");
+		LOG.info("checking flink accumulators");
 
-		for(Map<AccumulatorRegistry.Metric, Accumulator<?,?>> taskMap : accumulatorMap.values()) {
-			if (taskMap != null) {
-				for (Map.Entry<AccumulatorRegistry.Metric, Accumulator<?, ?>> entry : taskMap.entrySet()) {
-					switch (entry.getKey()) {
-						/**
-						 * The following two cases are for the DataSource and Map task
-						 */
-						case NUM_RECORDS_OUT:
-							if (!lastRound) {
-								if(((LongCounter) entry.getValue()).getLocalValue() != expectedRecords) {
-									return false;
-								}
-							}
-							break;
-						case NUM_BYTES_OUT:
-							if (!lastRound) {
-								if (((LongCounter) entry.getValue()).getLocalValue() != expectedBytes) {
-									return false;
-								}
-							}
-							break;
-						/**
-						 * The following two cases are for the DataSink task
-						 */
-						case NUM_RECORDS_IN:
-							// check if we are in last round and in current task accumulator map
-							if (lastRound && ((LongCounter)taskMap.get(AccumulatorRegistry.Metric.NUM_RECORDS_OUT)).getLocalValue() == 0) {
-								if (((LongCounter) entry.getValue()).getLocalValue() != expectedRecords) {
-									return false;
-								}
-							}
-							break;
-						case NUM_BYTES_IN:
-							if (lastRound && ((LongCounter)taskMap.get(AccumulatorRegistry.Metric.NUM_RECORDS_OUT)).getLocalValue() == 0) {
-								if (((LongCounter) entry.getValue()).getLocalValue() != expectedBytes) {
-									return false;
-								}
-							}
-							break;
-						default:
-							fail("Unknown accumulator found.");
+		Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> taskMap = accumulatorMap.get(taskKey);
+		assertTrue(accumulatorMap.size() > 0);
+
+		for (Map.Entry<AccumulatorRegistry.Metric, Accumulator<?, ?>> entry : taskMap.entrySet()) {
+			switch (entry.getKey()) {
+				/**
+				 * The following two cases are for the DataSource and Map task
+				 */
+				case NUM_RECORDS_OUT:
+					if(((LongCounter) entry.getValue()).getLocalValue() != expectedRecordsOut) {
+						return false;
 					}
-				}
+					break;
+				case NUM_BYTES_OUT:
+					if (((LongCounter) entry.getValue()).getLocalValue() != expectedBytesOut) {
+						return false;
+					}
+					break;
+				/**
+				 * The following two cases are for the DataSink task
+				 */
+				case NUM_RECORDS_IN:
+					if (((LongCounter) entry.getValue()).getLocalValue() != expectedRecordsIn) {
+						return false;
+					}
+					break;
+				case NUM_BYTES_IN:
+					if (((LongCounter) entry.getValue()).getLocalValue() != expectedBytesIn) {
+						return false;
+					}
+					break;
+				default:
+					fail("Unknown accumulator found.");
 			}
 		}
 		return true;
 	}
 
-
-	public static class Tokenizer implements FlatMapFunction<String, String> {
-
-		@Override
-		public void flatMap(String value, Collector<String> out) throws Exception {
-			for (String str : value.split("\n")) {
-				out.collect(str);
-			}
-		}
-	}
 
 	/**
 	 * UDF that waits for at least the heartbeat interval's duration.
@@ -238,43 +283,55 @@ public class AccumulatorLiveITCase {
 		@Override
 		public void open(Configuration parameters) throws Exception {
 			getRuntimeContext().addAccumulator(NAME, counter);
+			notifyTaskManagerOfAccumulatorUpdate();
 		}
 
 		@Override
 		public void flatMap(String value, Collector<Integer> out) throws Exception {
-			/* Wait here to check the accumulator value in the meantime */
-			Thread.sleep(WAIT_TIME);
 			int val = Integer.valueOf(value);
 			counter.add(val);
 			out.collect(val);
+			LOG.debug("Emitting value {}.", value);
+			notifyTaskManagerOfAccumulatorUpdate();
 		}
+
 	}
 
 	private static class WaitingOutputFormat implements OutputFormat<Integer> {
 
 		@Override
 		public void configure(Configuration parameters) {
-
 		}
 
 		@Override
 		public void open(int taskNumber, int numTasks) throws IOException {
-
+			notifyTaskManagerOfAccumulatorUpdate();
 		}
 
 		@Override
 		public void writeRecord(Integer record) throws IOException {
+			notifyTaskManagerOfAccumulatorUpdate();
 		}
 
 		@Override
 		public void close() throws IOException {
-			try {
-//				System.out.println("starting output task");
-				Thread.sleep(WAIT_TIME);
-			} catch (InterruptedException e) {
-				fail("Interrupted test.");
-			}
 		}
+	}
+
+	/**
+	 * Notify task manager of accumulator update and wait until the Heartbeat containing the message
+	 * has been reported.
+	 */
+	public static void notifyTaskManagerOfAccumulatorUpdate() {
+		new JavaTestKit(system) {{
+			Timeout timeout = new Timeout(Duration.create(5, "seconds"));
+			Future<Object> ask = Patterns.ask(taskManager, new TestingTaskManagerMessages.AccumulatorsChanged(jobID), timeout);
+			try {
+				Object result = Await.result(ask, timeout.duration());
+			} catch (Exception e) {
+				fail("Failed to notify task manager of accumulator update.");
+			}
+		}};
 	}
 
 	/**


### PR DESCRIPTION
Instead of using Thread.sleep() to synchronize the checks of the
accumulator values, we rely on message passing here to synchronize the
task process.

Therefore, we let the task process signal to the task manager that it
has updated its accumulator values. The task manager lets the job
manager know and sends out the heartbeat which contains the
accumulators. When the job manager receives the accumulators and has
been notified previously, it sends a message to the subscribed test case
with the current accumulators.

This assures that all processes are always synchronized correctly and we
can verify the live accumulator results correctly.

In the course of rewriting the test, I had to change two things in the
implementation:

a) User accumulators are now immediately serialized as well. Otherwise,
Akka does not serialize in local one VM setups and passes the live
accumulator map through.

b) The asynchronous update of the accumulators can be disabled for
tests. This was necessary because we cannot guarantee when the Future
for updating the accumulators is executed. In real setups this is
neglectable.