### PR TITLE
[FLINK-2205] Fix confusing entries in JM UI Job Config. section

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/JobManagerInfoServlet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/JobManagerInfoServlet.java
@@ -441,7 +441,7 @@ public class JobManagerInfoServlet extends HttpServlet {
 			if(ec != null) {
 				wrt.write("\"executionConfig\": {");
 				wrt.write("\"Execution Mode\": \""+ec.getExecutionMode()+"\",");
-				wrt.write("\"Number of execution retries\": \""+ec.getNumberOfExecutionRetries()+"\",");
+				wrt.write("\"Max. number of execution retries\": \""+ec.getNumberOfExecutionRetries()+"\",");
 				wrt.write("\"Job parallelism\": \""+ec.getParallelism()+"\",");
 				wrt.write("\"Object reuse mode\": \""+ec.isObjectReuseEnabled()+"\"");
 				ExecutionConfig.GlobalJobParameters uc = ec.getGlobalJobParameters();

--- a/flink-runtime/src/main/resources/web-docs-infoserver/js/analyzer.js
+++ b/flink-runtime/src/main/resources/web-docs-infoserver/js/analyzer.js
@@ -107,6 +107,10 @@ function analyzeTime(json, stacked) {
 		$.each(job.executionConfig, function(key, value) {
 			if(key == "userConfig") {
 				return;
+			} else if(key == "Max. number of execution retries" && value == -1) {
+				value = "deactivated";
+			} else if(key == "Job parallelism" && value == -1) {
+				value = "auto";
 			}
 			configTable += "<tr><td>"+key+"</td><td>"+value+"</td></tr>";
 		});


### PR DESCRIPTION
Default display for 'Number of execution retries' is now 'deactivated' and for 'Job parallelism' is 'auto', as suggested in JIRA.