### PR TITLE
[FLINK-2231] Create a Serializer for Scala Enumerations.

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
@@ -303,6 +303,8 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
           traversable match {
             case TypeRef(_, _, elemTpe :: Nil) =>
 
+              import compat._ // this is needed in order to compile in Scala 2.11
+
               // determine whether we can find an implicit for the CanBuildFrom because
               // TypeInformationGen requires this. This catches the case where a user
               // has a custom class that implements Iterable[], for example.

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
@@ -18,11 +18,7 @@
 package org.apache.flink.api.scala.codegen
 
 import scala.language.postfixOps
-
 import scala.reflect.macros.Context
-import scala.reflect.classTag
-import scala.reflect.ClassTag
-import scala.Option.option2Iterable
 
 // These are only used internally while analyzing Scala types in TypeAnalyzer and TypeInformationGen
 
@@ -47,6 +43,8 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
 
   case class EitherDescriptor(id: Int, tpe: Type, left: UDTDescriptor, right: UDTDescriptor)
     extends UDTDescriptor
+
+  case class EnumValueDescriptor(id: Int, tpe: Type, enum: ModuleSymbol) extends UDTDescriptor
 
   case class TryDescriptor(id: Int, tpe: Type, elem: UDTDescriptor) extends UDTDescriptor
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
@@ -21,9 +21,7 @@ import java.lang.reflect.{Field, Modifier}
 
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo._
-
 import org.apache.flink.api.common.typeutils._
-import org.apache.flink.api.java.tuple.Tuple
 import org.apache.flink.api.java.typeutils._
 import org.apache.flink.api.scala.typeutils.{CaseClassSerializer, CaseClassTypeInfo}
 import org.apache.flink.types.Value
@@ -32,7 +30,6 @@ import org.apache.hadoop.io.Writable
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.language.postfixOps
-
 import scala.reflect.macros.Context
 
 private[flink] trait TypeInformationGen[C <: Context] {
@@ -65,6 +62,8 @@ private[flink] trait TypeInformationGen[C <: Context] {
     case n: NothingDesciptor => reify { null.asInstanceOf[TypeInformation[T]] }
 
     case e: EitherDescriptor => mkEitherTypeInfo(e)
+
+    case e: EnumValueDescriptor => mkEnumValueTypeInfo(e)
 
     case tr: TryDescriptor => mkTryTypeInfo(tr)
 
@@ -145,6 +144,19 @@ private[flink] trait TypeInformationGen[C <: Context] {
         $eitherClass,
         $leftTypeInfo,
         $rightTypeInfo)
+    """
+
+    c.Expr[TypeInformation[T]](result)
+  }
+
+  def mkEnumValueTypeInfo[T: c.WeakTypeTag](d: EnumValueDescriptor): c.Expr[TypeInformation[T]] = {
+
+    val enumValueClass = c.Expr[Class[T]](Literal(Constant(weakTypeOf[T])))
+
+    val result = q"""
+      import org.apache.flink.api.scala.typeutils.EnumValueTypeInfo
+
+      new EnumValueTypeInfo[${d.enum.typeSignature}](${d.enum}, $enumValueClass)
     """
 
     c.Expr[TypeInformation[T]](result)

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueComparator.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueComparator.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeutils.TypeComparator
+import org.apache.flink.core.memory.{DataOutputView, DataInputView, MemorySegment}
+
+/**
+ * Comparator for [[Enumeration]] values.
+ */
+@SerialVersionUID(1000L)
+class EnumValueComparator[E <: Enumeration](ascComp: Boolean) extends TypeComparator[E#Value] {
+
+  type T = E#Value
+
+  @transient
+  private var reference: T = null
+
+  // We cannot use the Clone Constructor from Scala so we have to do it manually
+  def duplicate: TypeComparator[T] = {
+    new EnumValueComparator[E](ascComp)
+  }
+
+  // --------------------------------------------------------------------------------------------
+  //  Comparator Methods
+  // --------------------------------------------------------------------------------------------
+
+  override def compareSerialized(firstSource: DataInputView, secondSource: DataInputView): Int = {
+    val i1: Int = firstSource.readInt
+    val i2: Int = secondSource.readInt
+    val comp: Int = if (i1 < i2) -1 else if (i1 == i2) 0 else 1
+    if (ascComp) comp else -comp
+  }
+
+  def supportsNormalizedKey: Boolean = {
+    true
+  }
+
+  def getNormalizeKeyLen: Int = {
+    4
+  }
+
+  def isNormalizedKeyPrefixOnly(keyBytes: Int): Boolean = {
+    keyBytes < 4
+  }
+
+  override def putNormalizedKey(v: T, tgt: MemorySegment, offset: Int, numBytes: Int): Unit = {
+    val value: Int = v.id - Integer.MIN_VALUE
+
+    // see IntValue for an explanation of the logic
+    if (numBytes == 4) {
+      // default case, full normalized key
+      tgt.putIntBigEndian(offset, value)
+    }
+    else if (numBytes <= 0) {
+    }
+    else if (numBytes < 4) {
+      var i: Int = 0
+      while (numBytes - i > 0) {
+        tgt.put(offset + i, (value >>> ((3 - i) << 3)).toByte)
+        i += 1
+      }
+    }
+    else {
+      tgt.putLongBigEndian(offset, value)
+      var i: Int = 4
+      while (i < numBytes) {
+        tgt.put(offset + i, 0.toByte)
+        i += 1
+      }
+    }
+  }
+
+  override def hash(record: T): Int = record.##
+
+  override def setReference(toCompare: T): Unit = {
+    this.reference = toCompare
+  }
+
+  override def equalToReference(candidate: T): Boolean = {
+    candidate == reference
+  }
+
+  override def compareToReference(refComparator: TypeComparator[T]): Int = {
+    val comp = refComparator.asInstanceOf[this.type].reference.id.compareTo(this.reference.id)
+    if (ascComp) comp else -comp
+  }
+
+  override def compare(first: E#Value, second: E#Value): Int = {
+    val cmp = first.id.compareTo(second.id)
+    if (ascComp) cmp else -cmp
+  }
+
+  override def invertNormalizedKey(): Boolean = {
+    !ascComp
+  }
+
+  override def writeWithKeyNormalization(record: T, target: DataOutputView): Unit = {
+    throw new UnsupportedOperationException
+  }
+
+  override def supportsSerializationWithKeyNormalization(): Boolean = {
+    false
+  }
+
+  override def extractKeys(record: AnyRef, target: Array[AnyRef], index: Int): Int = {
+    target(index) = record
+    1
+  }
+
+  override lazy val getFlatComparators: Array[TypeComparator[_]] = {
+    Array(this)
+  }
+
+  override def readWithKeyDenormalization(reuse: T, source: DataInputView): T = {
+    throw new UnsupportedOperationException
+  }
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.common.typeutils.base.IntSerializer
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+
+/**
+ * Serializer for [[Enumeration]] values.
+ */
+class EnumValueSerializer[E <: Enumeration](val enum: E) extends TypeSerializer[E#Value] {
+
+  type T = E#Value
+
+  val intSerializer = new IntSerializer()
+
+  override def duplicate: EnumValueSerializer[E] = this
+
+  override def createInstance: T = enum(0)
+
+  override def isImmutableType: Boolean = true
+
+  override def getLength: Int = intSerializer.getLength
+
+  override def copy(from: T): T = enum.apply(from.id)
+
+  override def copy(from: T, reuse: T): T = copy(from)
+
+  override def copy(src: DataInputView, tgt: DataOutputView): Unit = intSerializer.copy(src, tgt)
+
+  override def serialize(v: T, tgt: DataOutputView): Unit = intSerializer.serialize(v.id, tgt)
+
+  override def deserialize(source: DataInputView): T = enum(intSerializer.deserialize(source))
+
+  override def deserialize(reuse: T, source: DataInputView): T = deserialize(source)
+
+  override def equals(obj: Any): Boolean = {
+    if (obj != null && obj.isInstanceOf[EnumValueSerializer[_]]) {
+      val other = obj.asInstanceOf[EnumValueSerializer[_]]
+      this.enum == other.enum
+    } else {
+      false
+    }
+  }
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
+import org.apache.flink.api.common.typeutils.{TypeComparator, TypeSerializer}
+
+import scala.collection.JavaConverters._
+
+/**
+ * TypeInformation for [[Enumeration]] values.
+ */
+class EnumValueTypeInfo[E <: Enumeration](enum: E, clazz: Class[E#Value])
+  extends TypeInformation[E#Value] with AtomicType[E#Value] {
+
+  type T = E#Value
+
+  override def isBasicType: Boolean = false
+  override def isTupleType: Boolean = false
+  override def isKeyType: Boolean = true
+  override def getTotalFields: Int = 1
+  override def getArity: Int = 1
+  override def getTypeClass = clazz
+  override def getGenericParameters = List.empty[TypeInformation[_]].asJava
+
+
+  def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = {
+    new EnumValueSerializer[E](enum)
+  }
+
+  override def createComparator(ascOrder: Boolean, config: ExecutionConfig): TypeComparator[T] = {
+    new EnumValueComparator[E](ascOrder)
+  }
+
+  override def toString = clazz.getCanonicalName
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/EnumValueComparatorTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/EnumValueComparatorTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.runtime
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeutils.{ComparatorTestBase, TypeComparator, TypeSerializer}
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.typeutils.EnumValueTypeInfo
+
+
+class EnumValueComparatorTest extends ComparatorTestBase[Suit.Value] {
+
+  protected def createComparator(ascending: Boolean): TypeComparator[Suit.Value] = {
+    val ti = createTypeInformation[Suit.Value]
+    ti.asInstanceOf[EnumValueTypeInfo[Suit.type]].createComparator(ascending, new ExecutionConfig)
+  }
+
+  protected def createSerializer: TypeSerializer[Suit.Value] = {
+    val ti = createTypeInformation[Suit.Value]
+    ti.createSerializer(new ExecutionConfig)
+  }
+
+  protected def getSortedTestData: Array[Suit.Value] = {
+    dataISD
+  }
+
+  private val dataISD = Array(
+    Suit.Clubs,
+    Suit.Diamonds,
+    Suit.Hearts,
+    Suit.Spades
+  )
+}
+
+object Suit extends Enumeration {
+  type Suit = Value
+  val Clubs, Diamonds, Hearts, Spades = Value
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
@@ -18,14 +18,13 @@
 package org.apache.flink.api.scala.runtime
 
 import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
-import org.junit.Assert._
-
-import org.apache.flink.api.common.typeutils.{TypeSerializer, SerializerTestInstance}
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.junit.{Assert, Test}
-
+import org.apache.flink.api.common.typeutils.{SerializerTestInstance, TypeSerializer}
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.typeutils.EnumValueTypeInfo
+import org.junit.Assert._
+import org.junit.{Assert, Test}
 
 import scala.util.{Failure, Success}
 
@@ -68,6 +67,12 @@ class ScalaSpecialTypesSerializerTest {
   }
 
   @Test
+  def testEnumValue(): Unit = {
+    val testData = Array(WeekDay.Mon, WeekDay.Fri, WeekDay.Tue, WeekDay.Sun, WeekDay.Wed)
+    runTests(testData)
+  }
+
+  @Test
   def testTry(): Unit = {
     val testData = Array(Success("Hell"), Failure(new RuntimeException("test")))
     runTests(testData)
@@ -93,8 +98,11 @@ class ScalaSpecialTypesSerializerTest {
       val typeInfo = implicitly[TypeInformation[T]]
       val serializer = typeInfo.createSerializer(new ExecutionConfig)
       val typeClass = typeInfo.getTypeClass
-      val test =
+      val test = if (typeInfo.isInstanceOf[EnumValueTypeInfo[_]]) {
+        new ScalaSpecialTypesSerializerTestInstance[T](serializer, typeClass, 4, instances)
+      } else {
         new ScalaSpecialTypesSerializerTestInstance[T](serializer, typeClass, -1, instances)
+      }
       test.testAll()
     } catch {
       case e: Exception => {
@@ -157,5 +165,10 @@ class ScalaSpecialTypesSerializerTestInstance[T](
         super.deepEquals(message, should, is)
     }
   }
+}
+
+object WeekDay extends Enumeration {
+  type WeekDay = Value
+  val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
 }
 


### PR DESCRIPTION
This closes FLINK-2231.

The code should work for all objects which follow [the Enumeration idiom outlined in the ScalaDoc](http://www.scala-lang.org/api/2.11.5/index.html#scala.Enumeration).

The second commit fixes a compilation error in IntelliJ when the 'scala_2.11' profile is active.

The third commit removes the boilerplate code from the `EnumValueComparator` by delegating to an `IntComparator`, you can either discard or squash it while merging depending on your preference.

Bear in mind the FIXME at line 370 in `TypeAnalyzer.scala`. The commented out code is better, but unfortunately doesn't work with Scala 2.10, so I used the FQN workaround.