### PR TITLE
[FLINK-2405] [streaming] Added stateful functions to Scala DataStreams

### DIFF
--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -621,6 +621,50 @@ dataStream.filter{ _ != 0 }
     </tr>
 
     <tr>
+      <td><strong>MapWithState</strong></td>
+      <td>
+        <p>Takes one element and produces one element using a stateful function. Note that the user state object needs to be serializable.
+	<br/>
+	<br/>
+	A map that produces a rolling average per key:</p>
+{% highlight scala %}
+dataStream.keyBy(..).mapWithState((in, state: Option[(Long, Int)]) => state match {
+	case Some((sum, count)) => ((sum + in)/(count + 1), Some((sum + in, count + 1)))
+	case None => (in, Some((in, 1)))
+})
+{% endhighlight %}
+      </td>
+    </tr>
+
+    <tr>
+      <td><strong>FlatMapWithState</strong></td>
+      <td>
+        <p>Takes one element and produces zero, one, or more elements using a stateful function. Note that the user state object needs to be serializable.</p>
+{% highlight scala %}
+dataStream.flatMapWithState((I,Option[S]) => (Traversable[O], Option[S]))
+{% endhighlight %}
+      </td>
+    </tr>
+
+    <tr>
+      <td><strong>FilterWithState</strong></td>
+      <td>
+       <p>Evaluates a stateful boolean function for each element and retains those for which the function returns true. Note that the user state object needs to be serializable.
+       	<br/>
+	<br/>
+        A filter that only keeps the first 10 elements at each operator instance:
+        </p>
+{% highlight scala %}
+dataStream.filterWithState((in, count: Option[Int]) => count match {
+	case Some(c) => (c < 10, Some(c+1))
+	case None => (true, Some(1))
+})
+{% endhighlight %}
+      </td>
+    </tr>
+
+
+    <tr>
       <td><strong>Reduce</strong></td>
       <td>
         <p>Combines a stream of elements into another stream by repeatedly combining two elements

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamingRuntimeContext.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamingRuntimeContext.java
@@ -146,7 +146,7 @@ public class StreamingRuntimeContext extends RuntimeUDFContext {
 				return new PartitionedStreamOperatorState(provider, statePartitioner, cl);
 			} else {
 				throw new RuntimeException(
-						"A partitioning key must be provided for pastitioned state.");
+						"Partitioned state can only be used with KeyedDataStreams.");
 			}
 		} else {
 			return new StreamOperatorState(provider);

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -483,9 +483,9 @@ class DataStream[T](javaStream: JavaStream[T]) {
       override def map(in: T): R = {
         applyWithState(in, cleanFun)
       }
+
+      val partitioned = isStatePartitioned
     }
-    
-    setStatePartitioning(mapper)
     
     map(mapper)
   }
@@ -552,10 +552,10 @@ class DataStream[T](javaStream: JavaStream[T]) {
       override def flatMap(in: T, out: Collector[R]): Unit = {
         applyWithState(in, cleanFun) foreach out.collect
       }
+
+      val partitioned = isStatePartitioned
     }
 
-    setStatePartitioning(flatMapper)
-    
     flatMap(flatMapper)
   }
 
@@ -601,17 +601,15 @@ class DataStream[T](javaStream: JavaStream[T]) {
       override def filter(in: T): Boolean = {
         applyWithState(in, cleanFun)
       }
+
+      val partitioned = isStatePartitioned
     }
-    
-    setStatePartitioning(filterFun) 
     
     filter(filterFun)
   }
 
-  private[flink] def setStatePartitioning(fun: StatefulFunction[_, _, _]) = {
-    if (javaStream.isInstanceOf[KeyedDataStream[T]]) {
-      fun.partitionStateByKey
-    }
+  private[flink] def isStatePartitioned: Boolean = {
+    javaStream.isInstanceOf[KeyedDataStream[T]]
   }
 
   /**

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
@@ -30,10 +30,7 @@ import org.apache.flink.api.common.state.OperatorState
 trait StatefulFunction[I, O, S] extends RichFunction {
 
   var state: OperatorState[Option[S]] = _
-  var partitioned: Boolean = false
-
-  def partitionStateByKey = { partitioned = true }
-  def isPartitioned = partitioned
+  val partitioned: Boolean
 
   def applyWithState(in: I, fun: (I, Option[S]) => (O, Option[S])): O = {
     val (o, s) = fun(in, state.value)
@@ -42,6 +39,6 @@ trait StatefulFunction[I, O, S] extends RichFunction {
   }
 
   override def open(c: Configuration) = {
-    state = getRuntimeContext().getOperatorState("state", None, isPartitioned)
+    state = getRuntimeContext().getOperatorState("state", None, partitioned)
   }
 }

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala.function
+
+import org.apache.flink.api.common.functions.RichFunction
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.api.common.state.OperatorState
+
+/**
+ * Trait implementing the functionality necessary to apply stateful functions in 
+ * RichFunctions without exposing the OperatorStates to the user. The user should
+ * call the applyWithState method in his own RichFunction implementation.
+ */
+trait StatefulFunction[I, O, S] extends RichFunction {
+
+  var state: OperatorState[Option[S]] = _
+  var partitioned: Boolean = false
+
+  def partitionStateByKey = { partitioned = true }
+  def isPartitioned = partitioned
+
+  def applyWithState(in: I, fun: (I, Option[S]) => (O, Option[S])): O = {
+    val (o, s) = fun(in, state.value)
+    state.update(s)
+    o
+  }
+
+  override def open(c: Configuration) = {
+    state = getRuntimeContext().getOperatorState("state", None, isPartitioned)
+  }
+}

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/test/java/org/apache/flink/streaming/scala/api/StatefulFunctionITCase.java
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/test/java/org/apache/flink/streaming/scala/api/StatefulFunctionITCase.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.scala.api;
+
+import org.apache.flink.streaming.api.scala.StateTestPrograms;
+import org.apache.flink.streaming.util.StreamingProgramTestBase;
+
+public class StatefulFunctionITCase extends StreamingProgramTestBase {
+
+	@Override
+	protected void testProgram() throws Exception {
+		StateTestPrograms.testStatefulFunctions();
+	}
+}
+

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -315,12 +315,12 @@ class DataStreamTest {
     val statefulMap1 = src.mapWithState((in, state: Option[Long]) => (in, None))
     assert(getFunctionForDataStream(statefulMap1).isInstanceOf[MapFunction[_,_]])
     assert(!getFunctionForDataStream(statefulMap1).
-        asInstanceOf[StatefulFunction[_,_,_]].isPartitioned)
+        asInstanceOf[StatefulFunction[_,_,_]].partitioned)
     
     val statefulMap2 = src.keyBy(x=>x).mapWithState(
         (in, state: Option[Long]) => (in, None))
     assert(getFunctionForDataStream(statefulMap2).
-        asInstanceOf[StatefulFunction[_,_,_]].isPartitioned)
+        asInstanceOf[StatefulFunction[_,_,_]].partitioned)
     
     val flatMapFunction = new FlatMapFunction[Long, Int] {
       override def flatMap(value: Long, out: Collector[Int]): Unit = {}
@@ -335,12 +335,12 @@ class DataStreamTest {
     val statefulfMap1 = src.flatMapWithState((in, state: Option[Long]) => (List(in), None))
     assert(getFunctionForDataStream(statefulfMap1).isInstanceOf[FlatMapFunction[_, _]])
     assert(!getFunctionForDataStream(statefulfMap1).
-        asInstanceOf[StatefulFunction[_, _, _]].isPartitioned)
+        asInstanceOf[StatefulFunction[_, _, _]].partitioned)
 
     val statefulfMap2 = src.keyBy(x=>x).flatMapWithState(
         (in, state: Option[Long]) => (List(in), None))
     assert(getFunctionForDataStream(statefulfMap2).
-        asInstanceOf[StatefulFunction[_, _, _]].isPartitioned)
+        asInstanceOf[StatefulFunction[_, _, _]].partitioned)
    
     val filterFunction = new FilterFunction[Int] {
       override def filter(value: Int): Boolean = false
@@ -356,12 +356,12 @@ class DataStreamTest {
     val statefulFilter1 = src.filterWithState((in, state: Option[Long]) => (true, None))
     assert(getFunctionForDataStream(statefulFilter1).isInstanceOf[FilterFunction[_]])
     assert(!getFunctionForDataStream(statefulFilter1).
-        asInstanceOf[StatefulFunction[_, _, _]].isPartitioned)
+        asInstanceOf[StatefulFunction[_, _, _]].partitioned)
 
     val statefulFilter2 = src.keyBy(x=>x).filterWithState(
         (in, state: Option[Long]) => (false, None))
     assert(getFunctionForDataStream(statefulFilter2).
-        asInstanceOf[StatefulFunction[_, _, _]].isPartitioned)
+        asInstanceOf[StatefulFunction[_, _, _]].partitioned)
    
     try {
       streamGraph.getStreamEdge(map.getId, unionFilter.getId)

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StateTestPrograms.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StateTestPrograms.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
+import java.util.HashSet
+
+/**
+ * Test programs for stateful functions.
+ */
+object StateTestPrograms {
+
+  def testStatefulFunctions(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    
+    // test stateful map
+    env.generateSequence(0, 10).setParallelism(1).
+      mapWithState((in, count: Option[Long]) =>
+        count match {
+          case Some(c) => ((in - c), Some(c + 1))
+          case None => (in, Some(1L))
+        }).setParallelism(1).
+      addSink(new RichSinkFunction[Long]() {
+        var allZero = true
+        override def invoke(in: Long) = {
+          if (in != 0) allZero = false
+        }
+        override def close() = {
+          assert(allZero)
+        }
+      })
+
+    // test stateful flatmap
+    env.fromElements("Fir st-", "Hello world").flatMapWithState((w, s: Option[String]) =>
+      s match {
+        case Some(s) => (w.split(" ").toList.map(s + _), Some(w))
+        case None => (List(w), Some(w))
+      }).setParallelism(1).
+      addSink(new RichSinkFunction[String]() {
+        val received = new HashSet[String]()
+        override def invoke(in: String) = { received.add(in) }
+        override def close() = {
+          assert(received.size() == 3)
+          assert(received.contains("Fir st-"))
+          assert(received.contains("Fir st-Hello"))
+          assert(received.contains("Fir st-world"))
+        }
+      }).setParallelism(1)
+
+    // test stateful filter
+    env.generateSequence(1, 10).keyBy(_ % 2).filterWithState((in, state: Option[Int]) =>
+      state match {
+        case Some(s) => (s < 2, Some(s + 1))
+        case None => (true, Some(1))
+      }).addSink(new RichSinkFunction[Long]() {
+      var numOdd = 0
+      var numEven = 0
+      override def invoke(in: Long) = {
+        if (in % 2 == 0) { numEven += 1 } else { numOdd += 1 }
+      }
+      override def close() = {
+        assert(numOdd == 2)
+        assert(numEven == 2)
+      }
+    }).setParallelism(1)
+
+    env.execute("Stateful test")
+  }
+
+}


### PR DESCRIPTION
This PR introduces 3 new API methods for the Scala DataStreams that extend the standard Map, FlatMap, and Filter function with state.

**These methods are:**
*for a DataStream[T]*
* **mapWithState**(fun: (T, Option[S]) => (R, Option[S])): DataStream[R]
* **flatMapWithState**( fun: (T, Option[S]) => (TraversableOnce[R], Option[S])): DataStream[R]
* **filterWithState**(fun: (T, Option[S]) => (Boolean, Option[S])): DataStream[T]

State partitioning is applied whenever the transformations are applied on a KeyedDataStream. Otherwise local state is used. Please refer to these concepts in:
https://cwiki.apache.org/confluence/display/FLINK/Stateful+Stream+Processing.

I also added an IT case to check the functionality