### PR TITLE
[FLINK-2406] [FLINK-2402] Abstract the BarrierBuffers and add a "at least once" version (BarrierTracker)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
@@ -301,9 +301,19 @@ public abstract class IOManager {
 	 * 
 	 * @return The number of temporary file directories.
 	 */
-	public int getNumberOfTempDirs() {
+	public int getNumberOfSpillingDirectories() {
 		return this.paths.length;
 	}
+
+	/**
+	 * Gets the directories that the I/O manager spills to.
+	 * 
+	 * @return The directories that the I/O manager spills to.
+	 */
+	public File[] getSpillingDirectories() {
+		return this.paths;
+	}
+	
 	
 	protected int getNextPathNum() {
 		final int next = this.nextPath;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -19,263 +19,259 @@ package org.apache.flink.streaming.runtime.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.Set;
+import java.util.ArrayDeque;
 
-import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
-import org.apache.flink.runtime.io.network.api.reader.AbstractReader;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.util.event.EventListener;
 import org.apache.flink.streaming.runtime.tasks.CheckpointBarrier;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The barrier buffer is responsible for implementing the blocking behaviour described
- * here: {@link CheckpointBarrier}.
- *
- * <p>
- * To avoid back-pressuring the
- * readers, we buffer up the new data received from the blocked channels until
- * the blocks are released.
+ * The barrier buffer is {@link CheckpointBarrierHandler} that blocks inputs with barriers until
+ * all inputs have received the barrier for a given checkpoint.
+ * 
+ *<p>To avoid back-pressuring the input streams (which may cause distributed deadlocks), the
+ * BarrierBuffer continues receiving buffers from the blocked channels and stores them internally until 
+ * the blocks are released.</p>
  */
-public class BarrierBuffer {
+public class BarrierBuffer implements CheckpointBarrierHandler {
 
 	private static final Logger LOG = LoggerFactory.getLogger(BarrierBuffer.class);
+	
+	/** The gate that the buffer draws its input from */
+	private final InputGate inputGate;
 
-	private Queue<SpillingBufferOrEvent> nonProcessed = new LinkedList<SpillingBufferOrEvent>();
-	private Queue<SpillingBufferOrEvent> blockedNonProcessed = new LinkedList<SpillingBufferOrEvent>();
+	/** Flags that indicate whether a channel is currently blocked/buffered */
+	private final boolean[] blockedChannels;
+	
+	/** The total number of channels that this buffer handles data from */
+	private final int totalNumberOfInputChannels;
 
-	private Set<Integer> blockedChannels = new HashSet<Integer>();
-	private int totalNumberOfInputChannels;
+	private final SpillReader spillReader;
+	private final BufferSpiller bufferSpiller;
+	
+	private ArrayDeque<SpillingBufferOrEvent> nonProcessed = new ArrayDeque<SpillingBufferOrEvent>();
+	private ArrayDeque<SpillingBufferOrEvent> blockedNonProcessed = new ArrayDeque<SpillingBufferOrEvent>();
 
-	private CheckpointBarrier currentBarrier;
+	/** Handler that receives the checkpoint notifications */
+	private EventListener<CheckpointBarrier> checkpointHandler;
 
-	private AbstractReader reader;
+	/** The ID of the checkpoint for which we expect barriers */
+	private long currentCheckpointId = -1L;
 
-	private InputGate inputGate;
+	/** The number of received barriers (= number of blocked/buffered channels) */
+	private long numReceivedBarriers;
+	
+	/** Flag to indicate whether we have drawn all available input */
+	private boolean endOfStream;
 
-	private SpillReader spillReader;
-	private BufferSpiller bufferSpiller;
-
-	private boolean inputFinished = false;
-
-	private BufferOrEvent endOfStreamEvent = null;
-
-	private long lastCheckpointId = Long.MIN_VALUE;
-
-	public BarrierBuffer(InputGate inputGate, AbstractReader reader) {
+	
+	public BarrierBuffer(InputGate inputGate, IOManager ioManager) throws IOException {
 		this.inputGate = inputGate;
-		totalNumberOfInputChannels = inputGate.getNumberOfInputChannels();
-		this.reader = reader;
-		try {
-			this.bufferSpiller = new BufferSpiller();
-			this.spillReader = new SpillReader();
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-
+		this.totalNumberOfInputChannels = inputGate.getNumberOfInputChannels();
+		this.blockedChannels = new boolean[this.totalNumberOfInputChannels];
+		
+		this.bufferSpiller = new BufferSpiller(ioManager);
+		this.spillReader = new SpillReader();
 	}
 
-	/**
-	 * Get then next non-blocked non-processed {@link BufferOrEvent}. Returns null if
-	 * none available.
-	 * 
-	 * @throws IOException
-	 */
-	private BufferOrEvent getNonProcessed() throws IOException {
-		SpillingBufferOrEvent nextNonProcessed;
+	// ------------------------------------------------------------------------
+	//  Buffer and barrier handling
+	// ------------------------------------------------------------------------
 
-		while ((nextNonProcessed = nonProcessed.poll()) != null) {
-			BufferOrEvent boe = nextNonProcessed.getBufferOrEvent();
-			if (isBlocked(boe.getChannelIndex())) {
-				blockedNonProcessed.add(new SpillingBufferOrEvent(boe, bufferSpiller, spillReader));
-			} else {
-				return boe;
+	@Override
+	public BufferOrEvent getNextNonBlocked() throws IOException, InterruptedException {
+		while (true) {
+			// process buffered BufferOrEvents before grabbing new ones
+			final SpillingBufferOrEvent nextBuffered = nonProcessed.pollFirst();
+			final BufferOrEvent next = nextBuffered == null ?
+					inputGate.getNextBufferOrEvent() :
+					nextBuffered.getBufferOrEvent();
+			
+			if (next != null) {
+				if (isBlocked(next.getChannelIndex())) {
+					// if the channel is blocked we, we just store the BufferOrEvent
+					blockedNonProcessed.add(new SpillingBufferOrEvent(next, bufferSpiller, spillReader));
+				}
+				else if (next.isBuffer() || next.getEvent().getClass() != CheckpointBarrier.class) {
+					return next;
+				}
+				else if (!endOfStream) {
+					// process barriers only if there is a chance of the checkpoint completing
+					processBarrier((CheckpointBarrier) next.getEvent(), next.getChannelIndex());
+				}
+			}
+			else if (!endOfStream) {
+				// end of stream. we feed the data that is still buffered
+				endOfStream = true;
+				releaseBlocks();
+				return getNextNonBlocked();
+			}
+			else {
+				return null;
+			}
+		}
+	}
+	
+	private void processBarrier(CheckpointBarrier receivedBarrier, int channelIndex) throws IOException {
+		final long barrierId = receivedBarrier.getId();
+
+		if (numReceivedBarriers > 0) {
+			// subsequent barrier of a checkpoint.
+			if (barrierId == currentCheckpointId) {
+				// regular case
+				onBarrier(channelIndex);
+			}
+			else if (barrierId > currentCheckpointId) {
+				// we did not complete the current checkpoint
+				LOG.warn("Received checkpoint barrier for checkpoint {} before completing current checkpoint {}. " +
+						"Skipping current checkpoint.", barrierId, currentCheckpointId);
+
+				releaseBlocks();
+				currentCheckpointId = barrierId;
+				onBarrier(channelIndex);
+			}
+			else {
+				// ignore trailing barrier from aborted checkpoint
+				return;
+			}
+			
+		}
+		else if (barrierId > currentCheckpointId) {
+			// first barrier of a new checkpoint
+			currentCheckpointId = barrierId;
+			onBarrier(channelIndex);
+		}
+		else {
+			// trailing barrier from previous (skipped) checkpoint
+			return;
+		}
+
+		// check if we have all barriers
+		if (numReceivedBarriers == totalNumberOfInputChannels) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Received all barrier, triggering checkpoint {} at {}",
+						receivedBarrier.getId(), receivedBarrier.getTimestamp());
+			}
+
+			if (checkpointHandler != null) {
+				checkpointHandler.onEvent(receivedBarrier);
+			}
+			
+			releaseBlocks();
+		}
+	}
+	
+	@Override
+	public void registerCheckpointEventHandler(EventListener<CheckpointBarrier> checkpointHandler) {
+		if (this.checkpointHandler == null) {
+			this.checkpointHandler = checkpointHandler;
+		}
+		else {
+			throw new IllegalStateException("BarrierBuffer already has a registered checkpoint handler");
+		}
+	}
+	
+	@Override
+	public boolean isEmpty() {
+		return nonProcessed.isEmpty() && blockedNonProcessed.isEmpty();
+	}
+
+	@Override
+	public void cleanup() throws IOException {
+		bufferSpiller.close();
+		File spillfile1 = bufferSpiller.getSpillFile();
+		if (spillfile1 != null) {
+			if (!spillfile1.delete()) {
+				LOG.warn("Cannot remove barrier buffer spill file: " + spillfile1.getAbsolutePath());
 			}
 		}
 
-		return null;
+		spillReader.close();
+		File spillfile2 = spillReader.getSpillFile();
+		if (spillfile2 != null) {
+			if (!spillfile2.delete()) {
+				LOG.warn("Cannot remove barrier buffer spill file: " + spillfile2.getAbsolutePath());
+			}
+		}
 	}
-
+	
 	/**
 	 * Checks whether the channel with the given index is blocked.
 	 * 
-	 * @param channelIndex The channel index to check
+	 * @param channelIndex The channel index to check.
+	 * @return True if the channel is blocked, false if not.
 	 */
 	private boolean isBlocked(int channelIndex) {
-		return blockedChannels.contains(channelIndex);
+		return blockedChannels[channelIndex];
 	}
-
-	/**
-	 * Checks whether all channels are blocked meaning that barriers have been
-	 * received from all channels
-	 */
-	private boolean isAllBlocked() {
-		return blockedChannels.size() == totalNumberOfInputChannels;
-	}
-
-	/**
-	 * Returns the next non-blocked {@link BufferOrEvent}. This is a blocking operator.
-	 */
-	public BufferOrEvent getNextNonBlocked() throws IOException, InterruptedException {
-		// If there are non-processed buffers from the previously blocked ones,
-		// we get the next
-		BufferOrEvent bufferOrEvent = getNonProcessed();
-
-		if (bufferOrEvent != null) {
-			return bufferOrEvent;
-		} else if (blockedNonProcessed.isEmpty() && inputFinished) {
-			return endOfStreamEvent;
-		} else {
-			// If no non-processed, get new from input
-			while (true) {
-				if (!inputFinished) {
-					// We read the next buffer from the inputgate
-					bufferOrEvent = inputGate.getNextBufferOrEvent();
-
-					if (!bufferOrEvent.isBuffer()
-							&& bufferOrEvent.getEvent() instanceof EndOfPartitionEvent) {
-						if (inputGate.isFinished()) {
-							// store the event for later if the channel is
-							// closed
-							endOfStreamEvent = bufferOrEvent;
-							inputFinished = true;
-						}
-
-					} else {
-						if (isBlocked(bufferOrEvent.getChannelIndex())) {
-							// If channel blocked we just store it
-							blockedNonProcessed.add(new SpillingBufferOrEvent(bufferOrEvent,
-									bufferSpiller, spillReader));
-						} else {
-							return bufferOrEvent;
-						}
-					}
-				} else {
-					actOnAllBlocked();
-					return getNextNonBlocked();
-				}
-			}
-		}
-	}
-
+	
 	/**
 	 * Blocks the given channel index, from which a barrier has been received.
 	 * 
-	 * @param channelIndex
-	 *            The channel index to block.
+	 * @param channelIndex The channel index to block.
 	 */
-	private void blockChannel(int channelIndex) {
-		if (!blockedChannels.contains(channelIndex)) {
-			blockedChannels.add(channelIndex);
+	private void onBarrier(int channelIndex) throws IOException {
+		if (!blockedChannels[channelIndex]) {
+			blockedChannels[channelIndex] = true;
+			numReceivedBarriers++;
+			
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Channel blocked with index: " + channelIndex);
+				LOG.debug("Received barrier from channel " + channelIndex);
 			}
-			if (isAllBlocked()) {
-				actOnAllBlocked();
-			}
-
-		} else {
-			throw new RuntimeException("Tried to block an already blocked channel");
+		}
+		else {
+			throw new IOException("Stream corrupt: Repeated barrier for same checkpoint and input stream");
 		}
 	}
 
 	/**
 	 * Releases the blocks on all channels.
 	 */
-	private void releaseBlocks() {
-		if (!nonProcessed.isEmpty()) {
-			// sanity check
-			throw new RuntimeException("Error in barrier buffer logic");
-		}
-		nonProcessed = blockedNonProcessed;
-		blockedNonProcessed = new LinkedList<SpillingBufferOrEvent>();
-
-		try {
-			spillReader.setSpillFile(bufferSpiller.getSpillFile());
-			bufferSpiller.resetSpillFile();
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-
-		blockedChannels.clear();
-		currentBarrier = null;
+	private void releaseBlocks() throws IOException {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("All barriers received, blocks released");
+			LOG.debug("Releasing blocks");
 		}
+
+		for (int i = 0; i < blockedChannels.length; i++) {
+			blockedChannels[i] = false;
+		}
+		numReceivedBarriers = 0;
+		
+		if (nonProcessed.isEmpty()) {
+			// swap the queues
+			ArrayDeque<SpillingBufferOrEvent> empty = nonProcessed;
+			nonProcessed = blockedNonProcessed;
+			blockedNonProcessed = empty;
+		}
+		else {
+			throw new IllegalStateException("Unconsumed data from previous checkpoint alignment " +
+					"when starting next checkpoint alignment");
+		}
+		
+		// roll over the spill files
+		spillReader.setSpillFile(bufferSpiller.getSpillFile());
+		bufferSpiller.resetSpillFile();
 	}
 
-	/**
-	 * Method that is executed once the barrier has been received from all
-	 * channels.
-	 */
-	private void actOnAllBlocked() {
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("Publishing barrier to the vertex");
-		}
+	// ------------------------------------------------------------------------
+	// For Testing
+	// ------------------------------------------------------------------------
 
-		if (currentBarrier != null && !inputFinished) {
-			reader.publish(currentBarrier);
-			lastCheckpointId = currentBarrier.getId();
-		}
-
-		releaseBlocks();
+	public long getCurrentCheckpointId() {
+		return this.currentCheckpointId;
 	}
-
-	/**
-	 * Processes one {@link org.apache.flink.streaming.runtime.tasks.CheckpointBarrier}
-	 * 
-	 * @param bufferOrEvent The {@link BufferOrEvent} containing the checkpoint barrier
-	 */
-	public void processBarrier(BufferOrEvent bufferOrEvent) {
-		CheckpointBarrier receivedBarrier = (CheckpointBarrier) bufferOrEvent.getEvent();
-
-		if (receivedBarrier.getId() < lastCheckpointId) {
-			// a barrier from an old checkpoint, ignore these
-			return;
-		}
-
-		if (currentBarrier == null) {
-			this.currentBarrier = receivedBarrier;
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Checkpoint barrier received start waiting for checkpoint: {}", receivedBarrier);
-			}
-		} else if (receivedBarrier.getId() > currentBarrier.getId()) {
-			// we have a barrier from a more recent checkpoint, free all locks and start with
-			// this newer checkpoint
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Checkpoint barrier received while waiting on checkpoint {}. Restarting waiting with checkpoint {}: ", currentBarrier, receivedBarrier);
-			}
-			releaseBlocks();
-			currentBarrier = receivedBarrier;
-
-		}
-		blockChannel(bufferOrEvent.getChannelIndex());
-	}
-
-	public void cleanup() throws IOException {
-		bufferSpiller.close();
-		File spillfile1 = bufferSpiller.getSpillFile();
-		if (spillfile1 != null) {
-			spillfile1.delete();
-		}
-
-		spillReader.close();
-		File spillfile2 = spillReader.getSpillFile();
-		if (spillfile2 != null) {
-			spillfile2.delete();
-		}
-	}
-
+	
+	// ------------------------------------------------------------------------
+	// Utilities 
+	// ------------------------------------------------------------------------
+	
+	@Override
 	public String toString() {
-		return nonProcessed.toString() + blockedNonProcessed.toString();
+		return "Non-Processed: " + nonProcessed + " | Blocked: " + blockedNonProcessed;
 	}
-
-	public boolean isEmpty() {
-		return nonProcessed.isEmpty() && blockedNonProcessed.isEmpty();
-	}
-
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.util.event.EventListener;
+import org.apache.flink.streaming.runtime.tasks.CheckpointBarrier;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+
+/**
+ * The BarrierTracker keeps track of what checkpoint barriers have been received from
+ * which input channels. 
+ * 
+ * <p>Unlike the {@link BarrierBuffer}, the BarrierTracker does not block the input
+ * channels that have sent barriers, so it cannot be used to gain "exactly-once" processing
+ * guarantees. It can, however, be used to gain "at least once" processing guarantees.</p>
+ */
+public class BarrierTracker implements CheckpointBarrierHandler {
+
+	private static final int MAX_CHECKPOINTS_TO_TRACK = 50;
+	
+	private final InputGate inputGate;
+	
+	private final int totalNumberOfInputChannels;
+	
+	private final ArrayDeque<CheckpointBarrierCount> pendingCheckpoints;
+	
+	private EventListener<CheckpointBarrier> checkpointHandler;
+	
+	private long latestPendingCheckpointID = -1;
+	
+	public BarrierTracker(InputGate inputGate) {
+		this.inputGate = inputGate;
+		this.totalNumberOfInputChannels = inputGate.getNumberOfInputChannels();
+		this.pendingCheckpoints = new ArrayDeque<CheckpointBarrierCount>();
+	}
+
+	@Override
+	public BufferOrEvent getNextNonBlocked() throws IOException, InterruptedException {
+		while (true) {
+			BufferOrEvent next = inputGate.getNextBufferOrEvent();
+			if (next == null) {
+				return null;
+			}
+			else if (next.isBuffer() || next.getEvent().getClass() != CheckpointBarrier.class) {
+				return next;
+			}
+			else {
+				processBarrier((CheckpointBarrier) next.getEvent());
+			}
+		}
+	}
+
+	@Override
+	public void registerCheckpointEventHandler(EventListener<CheckpointBarrier> checkpointHandler) {
+		if (this.checkpointHandler == null) {
+			this.checkpointHandler = checkpointHandler;
+		}
+		else {
+			throw new IllegalStateException("BarrierTracker already has a registered checkpoint handler");
+		}
+	}
+
+	@Override
+	public void cleanup() {
+		pendingCheckpoints.clear();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return pendingCheckpoints.isEmpty();
+	}
+
+	private void processBarrier(CheckpointBarrier receivedBarrier) {
+		// fast path for single channel trackers
+		if (totalNumberOfInputChannels == 1) {
+			if (checkpointHandler != null) {
+				checkpointHandler.onEvent(receivedBarrier);
+			}
+			return;
+		}
+		
+		// general path for multiple input channels
+		final long barrierId = receivedBarrier.getId();
+
+		// find the checkpoint barrier in the queue of bending barriers
+		CheckpointBarrierCount cbc = null;
+		int pos = 0;
+		
+		for (CheckpointBarrierCount next : pendingCheckpoints) {
+			if (next.checkpointId == barrierId) {
+				cbc = next;
+				break;
+			}
+			pos++;
+		}
+		
+		if (cbc != null) {
+			// add one to the count to that barrier and check for completion
+			int numBarriersNew = cbc.incrementBarrierCount();
+			if (numBarriersNew == totalNumberOfInputChannels) {
+				// checkpoint can be triggered
+				// first, remove this checkpoint and all all prior pending
+				// checkpoints (which are now subsumed)
+				for (int i = 0; i <= pos; i++) {
+					pendingCheckpoints.pollFirst();
+				}
+				
+				// notify the listener
+				if (checkpointHandler != null) {
+					checkpointHandler.onEvent(receivedBarrier);
+				}
+			}
+		}
+		else {
+			// first barrier for that checkpoint ID
+			// add it only if it is newer than the latest checkpoint.
+			// if it is not newer than the latest checkpoint ID, then there cannot be a
+			// successful checkpoint for that ID anyways
+			if (barrierId > latestPendingCheckpointID) {
+				latestPendingCheckpointID = barrierId;
+				pendingCheckpoints.addLast(new CheckpointBarrierCount(barrierId));
+				
+				// make sure we do not track too many checkpoints
+				if (pendingCheckpoints.size() > MAX_CHECKPOINTS_TO_TRACK) {
+					pendingCheckpoints.pollFirst();
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Simple class for a checkpoint ID with a barrier counter.
+	 */
+	private static final class CheckpointBarrierCount {
+		
+		private final long checkpointId;
+		
+		private int barrierCount;
+		
+		private CheckpointBarrierCount(long checkpointId) {
+			this.checkpointId = checkpointId;
+			this.barrierCount = 1;
+		}
+
+		public int incrementBarrierCount() {
+			return ++barrierCount;
+		}
+		
+		@Override
+		public int hashCode() {
+			return (int) ((checkpointId >>> 32) ^ checkpointId) + 17 * barrierCount; 
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof  CheckpointBarrierCount) {
+				CheckpointBarrierCount that = (CheckpointBarrierCount) obj;
+				return this.checkpointId == that.checkpointId && this.barrierCount == that.barrierCount;
+			}
+			else {
+				return false;
+			}
+		}
+
+		@Override
+		public String toString() {
+			return String.format("checkpointID=%d, count=%d", checkpointId, barrierCount);
+		}
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.util.event.EventListener;
+import org.apache.flink.streaming.runtime.tasks.CheckpointBarrier;
+
+import java.io.IOException;
+
+/**
+ * The CheckpointBarrierHandler reacts to checkpoint barrier arriving from the input channels.
+ * Different implementations may either simply track barriers, or block certain inputs on
+ * barriers.
+ */
+public interface CheckpointBarrierHandler {
+
+	/**
+	 * Returns the next {@link BufferOrEvent} that the operator may consume.
+	 * This call blocks until the next BufferOrEvent is available, ir until the stream
+	 * has been determined to be finished.
+	 * 
+	 * @return The next BufferOrEvent, or {@code null}, if the stream is finished.
+	 * @throws java.io.IOException Thrown, if the network or local disk I/O fails.
+	 * @throws java.lang.InterruptedException Thrown, if the thread is interrupted while blocking during
+	 *                                        waiting for the next BufferOrEvent to become available.
+	 */
+	BufferOrEvent getNextNonBlocked() throws IOException, InterruptedException;
+
+	void registerCheckpointEventHandler(EventListener<CheckpointBarrier> checkpointHandler);
+	
+	void cleanup() throws IOException;
+
+	/**
+	 * Checks if the barrier handler has buffered any data internally.
+	 * @return True, if no data is buffered internally, false otherwise.
+	 */
+	boolean isEmpty();
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.event.task.AbstractEvent;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.reader.AbstractReader;
 import org.apache.flink.runtime.io.network.api.reader.ReaderBase;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
@@ -33,6 +34,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
+import org.apache.flink.runtime.util.event.EventListener;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.MultiplexingStreamRecordSerializer;
@@ -63,11 +65,11 @@ public class StreamInputProcessor<IN> extends AbstractReader implements ReaderBa
 
 	// We need to keep track of the channel from which a buffer came, so that we can
 	// appropriately map the watermarks to input channels
-	int currentChannel = -1;
+	private int currentChannel = -1;
 
 	private boolean isFinished;
 
-	private final BarrierBuffer barrierBuffer;
+	private final CheckpointBarrierHandler barrierBuffer;
 
 	private long[] watermarks;
 	private long lastEmittedWatermark;
@@ -75,11 +77,18 @@ public class StreamInputProcessor<IN> extends AbstractReader implements ReaderBa
 	private DeserializationDelegate deserializationDelegate;
 
 	@SuppressWarnings("unchecked")
-	public StreamInputProcessor(InputGate[] inputGates, TypeSerializer<IN> inputSerializer, boolean enableWatermarkMultiplexing) {
+	public StreamInputProcessor(InputGate[] inputGates, TypeSerializer<IN> inputSerializer,
+								EventListener<CheckpointBarrier> checkpointListener,
+								IOManager ioManager,
+								boolean enableWatermarkMultiplexing) throws IOException {
+		
 		super(InputGateUtil.createInputGate(inputGates));
 
-		barrierBuffer = new BarrierBuffer(inputGate, this);
-
+		this.barrierBuffer = new BarrierBuffer(inputGate, ioManager);
+		if (checkpointListener != null) {
+			this.barrierBuffer.registerCheckpointEventHandler(checkpointListener);
+		}
+		
 		StreamRecordSerializer<IN> inputRecordSerializer;
 		if (enableWatermarkMultiplexing) {
 			inputRecordSerializer = new MultiplexingStreamRecordSerializer<IN>(inputSerializer);
@@ -155,24 +164,21 @@ public class StreamInputProcessor<IN> extends AbstractReader implements ReaderBa
 				currentChannel = bufferOrEvent.getChannelIndex();
 				currentRecordDeserializer = recordDeserializers[currentChannel];
 				currentRecordDeserializer.setNextBuffer(bufferOrEvent.getBuffer());
-			} else {
+			}
+			else {
 				// Event received
 				final AbstractEvent event = bufferOrEvent.getEvent();
-
-				if (event instanceof CheckpointBarrier) {
-					barrierBuffer.processBarrier(bufferOrEvent);
-				} else {
-					if (handleEvent(event)) {
-						if (inputGate.isFinished()) {
-							if (!barrierBuffer.isEmpty()) {
-								throw new RuntimeException("BarrierBuffer should be empty at this point");
-							}
-							isFinished = true;
-							return false;
-						} else if (hasReachedEndOfSuperstep()) {
-							return false;
-						} // else: More data is coming...
+				if (handleEvent(event)) {
+					if (inputGate.isFinished()) {
+						if (!barrierBuffer.isEmpty()) {
+							throw new RuntimeException("BarrierBuffer should be empty at this point");
+						}
+						isFinished = true;
+						return false;
 					}
+					else if (hasReachedEndOfSuperstep()) {
+						return false;
+					} // else: More data is coming...
 				}
 			}
 		}
@@ -194,6 +200,7 @@ public class StreamInputProcessor<IN> extends AbstractReader implements ReaderBa
 		}
 	}
 
+	@Override
 	public void cleanup() throws IOException {
 		barrierBuffer.cleanup();
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -31,7 +31,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
-import org.apache.flink.runtime.event.task.TaskEvent;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointNotificationOperator;
@@ -74,7 +73,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 
 	protected ClassLoader userClassLoader;
 	
-	private EventListener<TaskEvent> checkpointBarrierListener;
+	private EventListener<CheckpointBarrier> checkpointBarrierListener;
 
 	public StreamTask() {
 		streamOperator = null;
@@ -106,7 +105,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 			streamOperator.setup(outputHandler.getOutput(), headContext);
 		}
 
-		hasChainedOperators = !(outputHandler.getChainedOperators().size() == 1);
+		hasChainedOperators = outputHandler.getChainedOperators().size() != 1;
 	}
 
 	public String getName() {
@@ -199,7 +198,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 		this.isRunning = false;
 	}
 
-	public EventListener<TaskEvent> getCheckpointBarrierListener() {
+	public EventListener<CheckpointBarrier> getCheckpointBarrierListener() {
 		return this.checkpointBarrierListener;
 	}
 
@@ -211,7 +210,7 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 	@Override
 	public void setInitialState(StateHandle<Serializable> stateHandle) throws Exception {
 
-		// We retrieve end restore the states for the chained oeprators.
+		// We retrieve end restore the states for the chained operators.
 		List<Tuple2<StateHandle<Serializable>, Map<String, PartitionedStateHandle>>> chainedStates = (List<Tuple2<StateHandle<Serializable>, Map<String, PartitionedStateHandle>>>) stateHandle.getState();
 
 		// We restore all stateful chained operators
@@ -310,13 +309,12 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 
 	// ------------------------------------------------------------------------
 
-	private class CheckpointBarrierListener implements EventListener<TaskEvent> {
+	private class CheckpointBarrierListener implements EventListener<CheckpointBarrier> {
 
 		@Override
-		public void onEvent(TaskEvent event) {
+		public void onEvent(CheckpointBarrier barrier) {
 			try {
-				CheckpointBarrier sStep = (CheckpointBarrier) event;
-				triggerCheckpoint(sStep.getId(), sStep.getTimestamp());
+				triggerCheckpoint(barrier.getId(), barrier.getTimestamp());
 			}
 			catch (Exception e) {
 				throw new RuntimeException("Error triggering a checkpoint as the result of receiving checkpoint barrier", e);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -20,11 +20,8 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.event.task.AbstractEvent;
-import org.apache.flink.runtime.event.task.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordSerializer;
@@ -217,16 +214,6 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 
 		public boolean isEvent() {
 			return isEvent;
-		}
-	}
-
-	public static class DummyEvent extends TaskEvent {
-		@Override
-		public void write(DataOutputView out) throws IOException {
-		}
-
-		@Override
-		public void read(DataInputView in) throws IOException {
 		}
 	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.event.task.TaskEvent;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.util.event.EventListener;
+import org.apache.flink.streaming.runtime.tasks.CheckpointBarrier;
+
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the behavior of the barrier tracker.
+ */
+public class BarrierTrackerTest {
+
+	@Test
+	public void testSingleChannelNoBarriers() {
+		try {
+			BufferOrEvent[] sequence = { createBuffer(0), createBuffer(0), createBuffer(0) };
+
+			MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
+			BarrierTracker tracker = new BarrierTracker(gate);
+
+			for (BufferOrEvent boe : sequence) {
+				assertEquals(boe, tracker.getNextNonBlocked());
+			}
+			
+			assertNull(tracker.getNextNonBlocked());
+			assertNull(tracker.getNextNonBlocked());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testMultiChannelNoBarriers() {
+		try {
+			BufferOrEvent[] sequence = { createBuffer(2), createBuffer(2), createBuffer(0),
+					createBuffer(1), createBuffer(0), createBuffer(3),
+					createBuffer(1), createBuffer(1), createBuffer(2)
+			};
+
+			MockInputGate gate = new MockInputGate(4, Arrays.asList(sequence));
+			BarrierTracker tracker = new BarrierTracker(gate);
+
+			for (BufferOrEvent boe : sequence) {
+				assertEquals(boe, tracker.getNextNonBlocked());
+			}
+
+			assertNull(tracker.getNextNonBlocked());
+			assertNull(tracker.getNextNonBlocked());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSingleChannelWithBarriers() {
+		try {
+			BufferOrEvent[] sequence = {
+					createBuffer(0), createBuffer(0), createBuffer(0),
+					createBarrier(1, 0),
+					createBuffer(0), createBuffer(0), createBuffer(0), createBuffer(0),
+					createBarrier(2, 0), createBarrier(3, 0),
+					createBuffer(0), createBuffer(0),
+					createBarrier(4, 0), createBarrier(5, 0), createBarrier(6, 0),
+					createBuffer(0)
+			};
+
+			MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
+			BarrierTracker tracker = new BarrierTracker(gate);
+
+			CheckpointSequenceValidator validator =
+					new CheckpointSequenceValidator(1, 2, 3, 4, 5, 6);
+			tracker.registerCheckpointEventHandler(validator);
+			
+			for (BufferOrEvent boe : sequence) {
+				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+					assertEquals(boe, tracker.getNextNonBlocked());
+				}
+			}
+
+			assertNull(tracker.getNextNonBlocked());
+			assertNull(tracker.getNextNonBlocked());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSingleChannelWithSkippedBarriers() {
+		try {
+			BufferOrEvent[] sequence = {
+					createBuffer(0),
+					createBarrier(1, 0),
+					createBuffer(0), createBuffer(0),
+					createBarrier(3, 0), createBuffer(0),
+					createBarrier(4, 0), createBarrier(6, 0), createBuffer(0),
+					createBarrier(7, 0), createBuffer(0), createBarrier(10, 0),
+					createBuffer(0)
+			};
+
+			MockInputGate gate = new MockInputGate(1, Arrays.asList(sequence));
+			BarrierTracker tracker = new BarrierTracker(gate);
+
+			CheckpointSequenceValidator validator =
+					new CheckpointSequenceValidator(1, 3, 4, 6, 7, 10);
+			tracker.registerCheckpointEventHandler(validator);
+
+			for (BufferOrEvent boe : sequence) {
+				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+					assertEquals(boe, tracker.getNextNonBlocked());
+				}
+			}
+
+			assertNull(tracker.getNextNonBlocked());
+			assertNull(tracker.getNextNonBlocked());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testMultiChannelWithBarriers() {
+		try {
+			BufferOrEvent[] sequence = {
+					createBuffer(0), createBuffer(2), createBuffer(0),
+					createBarrier(1, 1), createBarrier(1, 2),
+					createBuffer(2), createBuffer(1),
+					createBarrier(1, 0),
+					
+					createBuffer(0), createBuffer(0), createBuffer(1), createBuffer(1), createBuffer(2),
+					createBarrier(2, 0), createBarrier(2, 1), createBarrier(2, 2),
+					
+					createBuffer(2), createBuffer(2),
+					createBarrier(3, 2),
+					createBuffer(2), createBuffer(2),
+					createBarrier(3, 0), createBarrier(3, 1),
+					
+					createBarrier(4, 1), createBarrier(4, 2), createBarrier(4, 0),
+					
+					createBuffer(0)
+			};
+
+			MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
+			BarrierTracker tracker = new BarrierTracker(gate);
+
+			CheckpointSequenceValidator validator =
+					new CheckpointSequenceValidator(1, 2, 3, 4);
+			tracker.registerCheckpointEventHandler(validator);
+
+			for (BufferOrEvent boe : sequence) {
+				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+					assertEquals(boe, tracker.getNextNonBlocked());
+				}
+			}
+
+			assertNull(tracker.getNextNonBlocked());
+			assertNull(tracker.getNextNonBlocked());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testMultiChannelSkippingCheckpoints() {
+		try {
+			BufferOrEvent[] sequence = {
+					createBuffer(0), createBuffer(2), createBuffer(0),
+					createBarrier(1, 1), createBarrier(1, 2),
+					createBuffer(2), createBuffer(1),
+					createBarrier(1, 0),
+
+					createBuffer(0), createBuffer(0), createBuffer(1), createBuffer(1), createBuffer(2),
+					createBarrier(2, 0), createBarrier(2, 1), createBarrier(2, 2),
+
+					createBuffer(2), createBuffer(2),
+					createBarrier(3, 2),
+					createBuffer(2), createBuffer(2),
+					
+					// jump to checkpoint 4
+					createBarrier(4, 0),
+					createBuffer(0), createBuffer(1), createBuffer(2),
+					createBarrier(4, 1),
+					createBuffer(1),
+					createBarrier(4, 2),
+					
+					createBuffer(0)
+			};
+
+			MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
+			BarrierTracker tracker = new BarrierTracker(gate);
+
+			CheckpointSequenceValidator validator =
+					new CheckpointSequenceValidator(1, 2, 4);
+			tracker.registerCheckpointEventHandler(validator);
+
+			for (BufferOrEvent boe : sequence) {
+				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+					assertEquals(boe, tracker.getNextNonBlocked());
+				}
+			}
+			
+			assertNull(tracker.getNextNonBlocked());
+			assertNull(tracker.getNextNonBlocked());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * This test validates that the barrier tracker does not immediately
+	 * discard a pending checkpoint as soon as it sees a barrier from a
+	 * later checkpoint from some channel.
+	 * 
+	 * This behavior is crucial, otherwise topologies where different inputs
+	 * have different latency (and that latency is close to or higher than the
+	 * checkpoint interval) may skip many checkpoints, or fail to complete a
+	 * checkpoint all together.
+	 */
+	@Test
+	public void testCompleteCheckpointsOnLateBarriers() {
+		try {
+			BufferOrEvent[] sequence = {
+					// checkpoint 2
+					createBuffer(1), createBuffer(1), createBuffer(0), createBuffer(2),
+					createBarrier(2, 1), createBarrier(2, 0), createBarrier(2, 2),
+					
+					// incomplete checkpoint 3
+					createBuffer(1), createBuffer(0),
+					createBarrier(3, 1), createBarrier(3, 2),
+					
+					// some barriers from checkpoint 4
+					createBuffer(1), createBuffer(0),
+					createBarrier(4, 2), createBarrier(4, 1),
+					createBuffer(1), createBuffer(2),
+	
+					// last barrier from checkpoint 3
+					createBarrier(3, 0),
+					
+					// complete checkpoint 4
+					createBuffer(0), createBarrier(4, 0),
+					
+					// regular checkpoint 5
+					createBuffer(1), createBuffer(2), createBarrier(5, 1), 
+					createBuffer(0), createBarrier(5, 0),
+					createBuffer(1), createBarrier(5, 2),
+					
+					// checkpoint 6 (incomplete),
+					createBuffer(1), createBarrier(6, 1),
+					createBuffer(0), createBarrier(6, 0),
+					
+					// checkpoint 7, with early barriers for checkpoints 8 and 9
+					createBuffer(1), createBarrier(7, 1),
+					createBuffer(0), createBarrier(7, 2),
+					createBuffer(2), createBarrier(8, 2), 
+					createBuffer(0), createBarrier(8, 1),
+					createBuffer(1), createBarrier(9, 1),
+					
+					// complete checkpoint 7, first barriers from checkpoint 10
+					createBarrier(7, 0),
+					createBuffer(0), createBarrier(9, 2),
+					createBuffer(2), createBarrier(10, 2),
+					
+					// complete checkpoint 8 and 9
+					createBarrier(8, 0),
+					createBuffer(1), createBuffer(2), createBarrier(9, 0),
+					
+					// trailing data
+					createBuffer(1), createBuffer(0), createBuffer(2)
+			};
+
+			MockInputGate gate = new MockInputGate(3, Arrays.asList(sequence));
+			BarrierTracker tracker = new BarrierTracker(gate);
+
+			CheckpointSequenceValidator validator =
+					new CheckpointSequenceValidator(2, 3, 4, 5, 7, 8, 9);
+			tracker.registerCheckpointEventHandler(validator);
+
+			for (BufferOrEvent boe : sequence) {
+				if (boe.isBuffer() || boe.getEvent().getClass() != CheckpointBarrier.class) {
+					assertEquals(boe, tracker.getNextNonBlocked());
+				}
+			}
+
+			assertNull(tracker.getNextNonBlocked());
+			assertNull(tracker.getNextNonBlocked());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utils
+	// ------------------------------------------------------------------------
+
+	private static BufferOrEvent createBarrier(long id, int channel) {
+		return new BufferOrEvent(new CheckpointBarrier(id, System.currentTimeMillis()), channel);
+	}
+
+	private static BufferOrEvent createBuffer(int channel) {
+		return new BufferOrEvent(
+				new Buffer(new MemorySegment(new byte[] { 1 }),  DummyBufferRecycler.INSTANCE), channel);
+	}
+	
+	// ------------------------------------------------------------------------
+	//  Testing Mocks
+	// ------------------------------------------------------------------------
+
+	private static class MockInputGate implements InputGate {
+
+		private final int numChannels;
+		private final Queue<BufferOrEvent> boes;
+
+		public MockInputGate(int numChannels, List<BufferOrEvent> boes) {
+			this.numChannels = numChannels;
+			this.boes = new ArrayDeque<BufferOrEvent>(boes);
+		}
+
+		@Override
+		public int getNumberOfInputChannels() {
+			return numChannels;
+		}
+
+		@Override
+		public boolean isFinished() {
+			return boes.isEmpty();
+		}
+
+		@Override
+		public void requestPartitions() {}
+
+		@Override
+		public BufferOrEvent getNextBufferOrEvent() {
+			return boes.poll();
+		}
+
+		@Override
+		public void sendTaskEvent(TaskEvent event) {}
+
+		@Override
+		public void registerListener(EventListener<InputGate> listener) {}
+	}
+
+	private static class CheckpointSequenceValidator implements EventListener<CheckpointBarrier> {
+
+		private final long[] checkpointIDs;
+		
+		private int i = 0;
+
+		private CheckpointSequenceValidator(long... checkpointIDs) {
+			this.checkpointIDs = checkpointIDs;
+		}
+		
+		@Override
+		public void onEvent(CheckpointBarrier barrier) {
+			assertTrue("More checkpoints than expected", i < checkpointIDs.length);
+			assertNotNull(barrier);
+			assertEquals("wrong checkpoint id", checkpointIDs[i++], barrier.getId());
+			assertTrue(barrier.getTimestamp() > 0);
+		}
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/DummyBufferRecycler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/DummyBufferRecycler.java
@@ -16,40 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.api;
+package org.apache.flink.streaming.runtime.io;
 
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.event.task.RuntimeEvent;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 
-
-public class EndOfPartitionEvent extends RuntimeEvent {
-
-	public static final EndOfPartitionEvent INSTANCE = new EndOfPartitionEvent();
+/**
+ * A BufferRecycler that does nothing.
+ */
+public class DummyBufferRecycler implements BufferRecycler {
+	
+	public static final BufferRecycler INSTANCE = new DummyBufferRecycler();
 	
 	
 	@Override
-	public void read(DataInputView in) {
-		// Nothing to do here
-	}
-
-	@Override
-	public void write(DataOutputView out) {
-		// Nothing to do here
-	}
-
-	@Override
-	public int hashCode() {
-		return 1965146673;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		return obj != null && obj.getClass() == EndOfPartitionEvent.class;
-	}
-
-	@Override
-	public String toString() {
-		return getClass().getSimpleName();
-	}
+	public void recycle(MemorySegment memorySegment) {}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBufferOrEventTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBufferOrEventTest.java
@@ -26,9 +26,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
-import org.apache.flink.streaming.runtime.io.BufferSpiller;
-import org.apache.flink.streaming.runtime.io.SpillReader;
-import org.apache.flink.streaming.runtime.io.SpillingBufferOrEvent;
+
 import org.junit.Test;
 
 public class SpillingBufferOrEventTest {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBufferOrEventTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/io/SpillingBufferOrEventTest.java
@@ -22,18 +22,36 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class SpillingBufferOrEventTest {
+	
+	private static IOManager IO_MANAGER;
+	
+	@BeforeClass
+	public static void createIOManager() {
+		IO_MANAGER = new IOManagerAsync();
+	}
+	
+	@AfterClass
+	public static void shutdownIOManager() {
+		IO_MANAGER.shutdown();
+	}
 
+	// ------------------------------------------------------------------------
+	
 	@Test
 	public void testSpilling() throws IOException, InterruptedException {
-		BufferSpiller bsp = new BufferSpiller();
+		BufferSpiller bsp = new BufferSpiller(IO_MANAGER);
 		SpillReader spr = new SpillReader();
 
 		BufferPool pool1 = new NetworkBufferPool(10, 256).createBufferPool(2, true);

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.manual;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.StreamingMode;
+import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+
+import static org.junit.Assert.fail;
+
+public class StreamingScalabilityAndLatency {
+	
+	public static void main(String[] args) throws Exception {
+		if ((Runtime.getRuntime().maxMemory() >>> 20) < 5000) {
+			throw new RuntimeException("This test program needs to run with at least 5GB of heap space.");
+		}
+		
+		final int TASK_MANAGERS = 1;
+		final int SLOTS_PER_TASK_MANAGER = 80;
+		final int PARALLELISM = TASK_MANAGERS * SLOTS_PER_TASK_MANAGER;
+
+		LocalFlinkMiniCluster cluster = null;
+
+		try {
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.LOCAL_INSTANCE_MANAGER_NUMBER_TASK_MANAGER, TASK_MANAGERS);
+			config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 80);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, SLOTS_PER_TASK_MANAGER);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY, 20000);
+
+			config.setInteger("taskmanager.net.server.numThreads", 1);
+			config.setInteger("taskmanager.net.client.numThreads", 1);
+
+			cluster = new LocalFlinkMiniCluster(config, false, StreamingMode.STREAMING);
+			
+			runPartitioningProgram(cluster.getJobManagerRPCPort(), PARALLELISM);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+		finally {
+			if (cluster != null) {
+				cluster.shutdown();
+			}
+		}
+	}
+	
+	private static void runPartitioningProgram(int jobManagerPort, int parallelism) throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", jobManagerPort);
+		env.setParallelism(parallelism);
+		env.getConfig().enableObjectReuse();
+
+		env.setBufferTimeout(5L);
+//		env.enableCheckpointing(1000);
+
+		env
+			.addSource(new TimeStampingSource())
+			.map(new IdMapper<Tuple2<Long, Long>>())
+			.partitionByHash(0)
+			.addSink(new TimestampingSink());
+		
+		env.execute("Partitioning Program");
+	}
+	
+	public static class TimeStampingSource implements ParallelSourceFunction<Tuple2<Long, Long>> {
+
+		private static final long serialVersionUID = -151782334777482511L;
+
+		private volatile boolean running = true;
+		
+		
+		@Override
+		public void run(SourceContext<Tuple2<Long, Long>> ctx) throws Exception {
+			
+			long num = 100;
+			long counter = (long) (Math.random() * 4096);
+			
+			while (running) {
+				if (num < 100) {
+					num++;
+					ctx.collect(new Tuple2<Long, Long>(counter++, 0L));
+				}
+				else {
+					num = 0;
+					ctx.collect(new Tuple2<Long, Long>(counter++, System.currentTimeMillis()));
+				}
+
+				Thread.sleep(1);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+	
+	public static class TimestampingSink implements SinkFunction<Tuple2<Long, Long>> {
+
+		private static final long serialVersionUID = 1876986644706201196L;
+
+		private long maxLatency;
+		private long count; 
+		
+		@Override
+		public void invoke(Tuple2<Long, Long> value) {
+			long ts = value.f1;
+			if (ts != 0L) {
+				long diff = System.currentTimeMillis() - ts;
+				maxLatency = Math.max(diff, maxLatency);
+			}
+			
+			count++;
+			if (count == 5000) {
+				System.out.println("Max latency: " + maxLatency);
+				count = 0;
+				maxLatency = 0;
+			}
+		}
+	}
+
+	public static class IdMapper<T> implements MapFunction<T, T> {
+
+		private static final long serialVersionUID = -6543809409233225099L;
+
+		@Override
+		public T map(T value) {
+			return value;
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/package-info.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/package-info.java
@@ -18,7 +18,7 @@
 
 /**
  * This package contains various tests that are not automatically executed, but
- * need to be manually invoked, because they are extremely heavy of require larger-than-usual
- * JVMs.
+ * need to be manually invoked, because they are extremely heavy, time intensive,
+ * of require larger-than-usual JVMs.
  */
 package org.apache.flink.test.manual;


### PR DESCRIPTION
Currently, the checkpointing mechanism provides "exactly once" guarantees. Part of that is the step that temporarily "aligns" the data streams, performed by the `BarrierBuffer`. This step increases the tuple latency temporarily.

By offering a version that does not provide "exactly-once", but only "at-least-once", we can avoid the latency increase. This is relevant for super-low-latency applications (< 10 ms) that tolerate duplicates.

This pull request does:

  - Add an interface for the functionality of the barrier buffer, to allow adding different implementations
  - Add the `BarrierTracker` which only tracks checkpoint barriers, without aligning the streams.
  - Add broader tests for the BarrierBuffer, including trailing data and barrier races.
  - Checkpoint barriers are handled by the buffer directly, rather than being returned and re-injected.
  - Simplify logic in the BarrierBuffer and fix certain corner cases.
  - Give access to spill directories properly via I/O manager, rather than via GlobalConfiguration singleton.
  - Rename the "BarrierBufferIOTest" to "BarrierBufferMassiveRandomTest"
  - A lot of code style/robustness fixes (proplery define constants, visibility, exception signatures)

@gyfora  and @uce : The reworked variant of the BarrierBuffer eventually returns `null` when all buffers and events have been consumed. The previous impementation repeatedly returned the `EndOfPartitionEvent`. That seemed inconsistent with the implementation of the "vanilla" InputGate, which eventually returns `null` when all partitions have finished.