### PR TITLE
FLINK-2166. Add fromCsvFile() method to TableEnvironment. A tuple based

### DIFF
--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FromCsvITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FromCsvITCase.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.java.table.test;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.io.Files;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.table.TableEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.Table;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+
+@RunWith(Parameterized.class)
+public class FromCsvITCase extends MultipleProgramsTestBase {
+    private String resultPath;
+    private String expected;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    public FromCsvITCase(TestExecutionMode mode) {
+        super(mode);
+    }
+
+    @Before
+    public void before() throws Exception {
+        resultPath = tempFolder.newFile("result").toURI().toString();
+    }
+
+    @After
+    public void after() throws Exception {
+        compareResultsByLinesInMemory(expected, resultPath);
+    }
+
+    private String createInputData(String data) throws Exception {
+        File file = tempFolder.newFile("input");
+        Files.write(data, file, Charsets.UTF_8);
+
+        return file.toURI().toString();
+    }
+
+    @Test
+    public void testParameterizedTuple() throws Exception {
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        TableEnvironment tableEnv = new TableEnvironment();
+        final String inputData = "ABC,2.20,3\nDEF,5.1,5\nDEF,3.30,1\nGHI,3.30,10";
+        final String dataPath = createInputData(inputData);
+        Table table =
+                tableEnv.fromCsvFile(dataPath, env, ParameterizedTuple3.class);
+
+        DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
+        ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+        env.execute();
+
+        expected = "ABC,2.2,3\nDEF,5.1,5\nDEF,3.3,1\nGHI,3.3,10";
+    }
+
+    @Test
+    public void testTuple() throws Exception {
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        TableEnvironment tableEnv = new TableEnvironment();
+        final String inputData = "ABC,2.20,3\nDEF,5.1,5\nDEF,3.30,1\nGHI,3.30,10";
+        final String dataPath = createInputData(inputData);
+        final Path path = new Path(Preconditions.checkNotNull(dataPath,
+                "The file path may not be null."));
+        Table table =
+                tableEnv.fromCsvFile(path, env,
+                        new Class[]{String.class, Float.class, Integer.class});
+
+        DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
+        ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+        env.execute();
+
+        expected = "ABC,2.2,3\nDEF,5.1,5\nDEF,3.3,1\nGHI,3.3,10";
+    }
+
+    @Test
+    public void testTupleWithOptions() throws Exception {
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        TableEnvironment tableEnv = new TableEnvironment();
+        final String inputData = "a*b*c\nABC*2.20*3\nDEF*5.1*5\nDEF*3.30*1\n" +
+                "#this is comment\nbadline\nGHI*3.30*10";
+        final String dataPath = createInputData(inputData);
+        final Path path = new Path(Preconditions.checkNotNull(dataPath,
+                "The file path may not be null."));
+        TableEnvironment.CsvOptions options = new TableEnvironment.CsvOptions();
+        options.setCommentPrefix("#");
+        options.setFieldDelimiter("*");
+        options.setIgnoreInvalidLines(true);
+        options.setSkipFirstLineAsHeader(true);
+        options.setIncludedMask(new boolean[] {true, false, true});
+        Table table =
+                tableEnv.fromCsvFile(path, env,
+                        new Class[]{String.class, Float.class, Integer.class},
+                        "a,b,c", options);
+
+        DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
+        ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+        env.execute();
+
+        expected = "ABC,3.0,0\nDEF,5.0,0\nDEF,1.0,0\nGHI,10.0,0";
+    }
+    @Test
+    public void testPojo() throws Exception {
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        TableEnvironment tableEnv = new TableEnvironment();
+        final String inputData = "ABC,2.20,3\nDEF,5.1,5\nDEF,3.30,1\nGHI,3.30,10";
+        final String dataPath = createInputData(inputData);
+        final Path path = new Path(Preconditions.checkNotNull(dataPath,
+                "The file path may not be null."));
+        Table table =
+                tableEnv.fromCsvFile(path, env, POJOItem.class, "f1,f2,f3");
+
+        DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
+        ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+        env.execute();
+
+        expected = "ABC,2.2,3\nDEF,5.1,5\nDEF,3.3,1\nGHI,3.3,10";
+    }
+
+    public static class ParameterizedTuple3 extends Tuple3<String, Float, Integer>
+            implements ParameterizedType
+    {
+        Type[] types = new Type[] {String.class, Float.class, Integer.class};
+        @Override
+        public Type getOwnerType() {
+            return FromCsvITCase.class;
+        }
+
+        @Override
+        public Type getRawType() {
+            return Tuple3.class;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return types;
+        }
+    }
+
+    public static class POJOItem
+    {
+        public String f1;
+        public Double f2;
+        public Integer f3;
+        public POJOItem()
+        {
+            f1 = "";
+            f2 = 0.0;
+            f3 = 0;
+        }
+    }
+}

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/FromCsvITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/FromCsvITCase.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.table.test
+
+import java.lang.reflect.{Type, ParameterizedType}
+
+import com.google.common.base.{Charsets, Preconditions}
+import com.google.common.io.Files
+import org.apache.flink.api.java.table.TableEnvironment.CsvOptions
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.java.table.TableEnvironment
+import org.apache.flink.api.java.tuple.Tuple3
+import org.apache.flink.api.table.{Row, Table}
+import org.apache.flink.core.fs.{FileSystem, Path}
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
+import org.apache.flink.test.util.{MultipleProgramsTestBase, TestBaseUtils}
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.{After, Before, Rule, Test}
+
+/*TODO: This test is using java api, should change to scala api in the future (or move
+ * [[TableEnvironment]] to shared api?)
+ * */
+@RunWith(classOf[Parameterized])
+class FromCsvITCase (mode: TestExecutionMode) extends MultipleProgramsTestBase(mode){
+  private var resultPath: String = null
+  private var expected: String = ""
+  private val _tempFolder = new TemporaryFolder()
+
+  @Rule
+  def tempFolder = _tempFolder
+
+  @Before
+  def before(): Unit = {
+    resultPath = tempFolder.newFile().toURI.toString
+  }
+
+  @After
+  def after(): Unit = {
+    TestBaseUtils.compareResultsByLinesInMemory(expected, resultPath)
+  }
+
+  def createInputData(data: String): String = {
+    val dataFile = tempFolder.newFile("data")
+    Files.write(data, dataFile, Charsets.UTF_8)
+    dataFile.toURI.toString
+  }
+
+  @Test
+  def testTuple(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tableEnv: TableEnvironment = new TableEnvironment
+    val inputData: String = "ABC,2.20,3\nDEF,5.1,5\nDEF,3.30,1\nGHI,3.30,10"
+    val dataPath: String = createInputData(inputData)
+    val path: Path = new Path(Preconditions.checkNotNull(dataPath))
+    val table: Table = tableEnv.fromCsvFile(path, env,
+      Array[Class[_]](classOf[String], classOf[java.lang.Float],
+      classOf[java.lang.Integer]))
+
+    type JavaDataSet[T] = org.apache.flink.api.java.DataSet[T]
+    val ds: JavaDataSet[Row] = tableEnv.toDataSet(table, classOf[Row])
+    ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE)
+
+    env.execute
+
+    expected = "ABC,2.2,3\nDEF,5.1,5\nDEF,3.3,1\nGHI,3.3,10"
+  }
+
+  @Test
+  def testTupleWithOptions(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tableEnv: TableEnvironment = new TableEnvironment
+    val inputData: String = "ABC*2.20*3\nDEF*5.1*5\nDEF*3.30*1\n" +
+      "#this is comment\nbadline\nGHI*3.30*10"
+    val dataPath: String = createInputData(inputData)
+    val path: Path = new Path(Preconditions.checkNotNull(dataPath))
+    val options: CsvOptions = new CsvOptions
+    options.commentPrefix = "#"
+    options.fieldDelimiter = "*"
+    options.includedMask = Array(true, true, false)
+    options.ignoreInvalidLines = true
+    val table: Table = tableEnv.fromCsvFile(path, env,
+      Array[Class[_]](classOf[String], classOf[java.lang.Float], classOf[java.lang.Integer]),
+      fields = "a,b,c",
+      options
+    )
+
+    type JavaDataSet[T] = org.apache.flink.api.java.DataSet[T]
+    val ds: JavaDataSet[Row] = tableEnv.toDataSet(table, classOf[Row])
+    ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE)
+
+    env.execute
+
+    expected = "ABC,2.2,0\nDEF,5.1,0\nDEF,3.3,0\nGHI,3.3,0"
+  }
+
+}


### PR DESCRIPTION
CsvInputFormat, a pojo based CsvReader or a Parameterized tuple based CsvReader is used to represent the row of the table's types. For tuple based CsvInputFormat, a maximum of 25 fields are supported. An CsvOption class is provided for users to set the csv parsing options such as line delimiter, field delimiter etc in the CsvInputFormat based implementation.

