### PR TITLE
[FLINK-2404]Primitive add methods for Accumulators

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleCounter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleCounter.java
@@ -27,8 +27,15 @@ public class DoubleCounter implements SimpleAccumulator<Double> {
 
 	private double localValue = 0;
 
+	/**
+	 * Consider using {@link #add(double)} instead for primitive double values
+	 */
 	@Override
 	public void add(Double value) {
+		localValue += value;
+	}
+
+	public void add(double value){
 		localValue += value;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntCounter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntCounter.java
@@ -28,8 +28,15 @@ public class IntCounter implements SimpleAccumulator<Integer> {
 
 	private int localValue = 0;
 
+	/**
+	 * Consider using {@link #add(int)} instead for primitive int values
+	 */
 	@Override
 	public void add(Integer value) {
+		localValue += value;
+	}
+
+	public void add(int value){
 		localValue += value;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongCounter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongCounter.java
@@ -26,12 +26,19 @@ public class LongCounter implements SimpleAccumulator<Long> {
 	private static final long serialVersionUID = 1L;
 	
 	private long localValue = 0;
-	
+
+	/**
+	 * Consider using {@link #add(long)} instead for primitive long values
+	 */
 	@Override
 	public void add(Long value) {
 		this.localValue += value;
 	}
-	
+
+	public void add(long value){
+		this.localValue += value;
+	}
+
 	@Override
 	public Long getLocalValue() {
 		return this.localValue;


### PR DESCRIPTION
Adds primitive add value methods to Double, Int and Long counter.

Benchmark: Run independently of Flink on the LongCounter accumulator.
No Add | Long Add | long Add
--------- | ------------- | --------
1458.9 | 2785.7 | 2169.7

[Time for 1e+9 additions]