### PR TITLE
[FLINK-2399] Version checks for Job Manager and Task Manager

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/RegistrationMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/RegistrationMessages.scala
@@ -68,7 +68,8 @@ object RegistrationMessages {
       taskManager: ActorRef,
       connectionInfo: InstanceConnectionInfo,
       resources: HardwareDescription,
-      numberOfSlots: Int)
+      numberOfSlots: Int,
+      TMVersionID: String)
     extends RegistrationMessage
 
   /**
@@ -84,7 +85,8 @@ object RegistrationMessages {
       leaderSessionID: UUID,
       jobManager: ActorRef,
       instanceID: InstanceID,
-      blobPort: Int)
+      blobPort: Int,
+      JMVersionID: String)
     extends RegistrationMessage
 
   /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -67,6 +67,8 @@ public class TaskManagerRegistrationTest {
 	// use one actor system throughout all tests
 	private static ActorSystem actorSystem;
 
+	private String JobManagerID = getClass().getPackage().getImplementationVersion();
+
 	@BeforeClass
 	public static void startActorSystem() {
 		Configuration config = new Configuration();
@@ -300,7 +302,8 @@ public class TaskManagerRegistrationTest {
 										leaderSessionID,
 										fakeJobManager1,
 										new InstanceID(),
-										45234),
+										45234,
+										JobManagerID == null ? "" : JobManagerID),
 								fakeJobManager1);
 					}
 				};
@@ -350,7 +353,8 @@ public class TaskManagerRegistrationTest {
 										leaderSessionID,
 										jm2Closure,
 										new InstanceID(),
-										45234),
+										45234,
+										JobManagerID == null ? "" : JobManagerID),
 								jm2Closure);
 					}
 				};
@@ -446,12 +450,14 @@ public class TaskManagerRegistrationTest {
 
 						// This AcknowledgeRegistration message should be discarded because the
 						// registration session ID is wrong
+
 						tm.tell(new AcknowledgeRegistration(
 									UUID.randomUUID(),
 									falseLeaderSessionID,
 									getTestActor(),
 									new InstanceID(),
-									1),
+									1,
+										JobManagerID == null ? "" : JobManagerID),
 								getTestActor());
 
 						// Valid AcknowledgeRegistration message
@@ -460,7 +466,8 @@ public class TaskManagerRegistrationTest {
 										trueLeaderSessionID,
 										getTestActor(),
 										new InstanceID(),
-										1),
+										1,
+										JobManagerID == null ? "" : JobManagerID),
 								getTestActor());
 
 						Object message = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -109,7 +109,9 @@ public class TaskManagerTest {
 	final static Option<UUID> leaderSessionID = new Some<UUID>(UUID.randomUUID());
 
 	final static MessageDecorator decorator = new LeaderSessionMessageDecorator(leaderSessionID);
-	
+
+	private String JobManagerID = getClass().getPackage().getImplementationVersion();
+
 	@BeforeClass
 	public static void setup() {
 		system = AkkaUtils.createLocalActorSystem(new Configuration());
@@ -151,7 +153,8 @@ public class TaskManagerTest {
 										leaderSessionID.get(),
 										getTestActor(),
 										iid,
-										12345),
+										12345,
+										JobManagerID == null ? "" : JobManagerID),
 								getTestActor());
 					}
 				};
@@ -883,6 +886,7 @@ public class TaskManagerTest {
 	public static class SimpleJobManager extends FlinkUntypedActor {
 
 		private final Option<UUID> leaderSessionID;
+		private String JobManagerID = getClass().getPackage().getImplementationVersion();
 
 		public SimpleJobManager(UUID leaderSessionID) {
 			this.leaderSessionID = Option.apply(leaderSessionID);
@@ -900,7 +904,8 @@ public class TaskManagerTest {
 									leaderSessionID.get(),
 									self,
 									iid,
-									12345)
+									12345,
+									JobManagerID == null ? "" : JobManagerID)
 						),
 						self);
 			}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
@@ -44,6 +44,11 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
 
   def this() = this(AkkaUtils.createLocalActorSystem(new Configuration()))
 
+  var versionID = getClass.getPackage.getImplementationVersion
+  if(versionID == null){
+    versionID = ""
+  }
+
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
   }
@@ -73,11 +78,12 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
             tmDummy1,
             connectionInfo1,
             hardwareDescription,
-            1)
+            1,
+            versionID)
 
           val response = receiveOne(1 second)
           response match {
-            case AcknowledgeRegistration(registrationSessionID, _,  _, id, _) => id1 = id
+            case AcknowledgeRegistration(registrationSessionID, _,  _, id, _, _) => id1 = id
             case _ => fail("Wrong response message: " + response)
           }
         }
@@ -89,11 +95,12 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
             tmDummy2,
             connectionInfo2,
             hardwareDescription,
-            1)
+            1,
+            versionID)
 
           val response = receiveOne(1 second)
           response match {
-            case AcknowledgeRegistration(registrationSessionID, _, _, id, _) => id2 = id
+            case AcknowledgeRegistration(registrationSessionID, _, _, id, _, _) => id2 = id
             case _ => fail("Wrong response message: " + response)
           }
         }
@@ -126,19 +133,22 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
             tmDummy,
             connectionInfo,
             hardwareDescription,
-            1)
+            1,
+            versionID)
           jm ! RegisterTaskManager(
             registrationSessionID,
             tmDummy,
             connectionInfo,
             hardwareDescription,
-            1)
+            1,
+            versionID)
           jm ! RegisterTaskManager(
             registrationSessionID,
             tmDummy,
             connectionInfo,
             hardwareDescription,
-            1)
+            1,
+            versionID)
 
           expectMsgType[AcknowledgeRegistration]
           expectMsgType[AlreadyRegistered]


### PR DESCRIPTION
Both Job Manager and Task Manager now communicate their respective version IDs to each other as part of registration messages.
Version ID is accessed by the information Maven adds in the manifest. However, for enabling the tests to run in IDE[is this necessary?], where the version number is null, added a special provision to set the version ID to "", when it is null.