### PR TITLE
[FLINK-2399] Version checks for Job Manager and Task Manager

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -28,6 +28,13 @@ public final class ConfigConstants {
 	//                            Configuration Keys
 	// ------------------------------------------------------------------------
 	
+	// ---------------------------- Version -------------------------------
+
+	/**
+	 * Version of this flink implementation.
+	 */
+	public static final String FLINK_VERSION_KEY = "flink.version";
+
 	// ---------------------------- Parallelism -------------------------------
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -55,6 +55,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 
 	/** Stores the concrete key/value pairs of this configuration object. */
 	private final HashMap<String, Object> confData;
+
+	/** Stores the version of this implementation of flink */
+	public static final String FLINK_VERSION = "0.10";
 	
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/util/VersionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/VersionUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Version numbers to check compatibility between JobManager, TaskManager and JobClient.
+ */
+public class VersionUtils {
+
+	public static final String FLINK_VERSION = Configuration.FLINK_VERSION;
+	/**
+	 * Lower limit on client versions this job manager can work with.
+	 */
+	public static final String JOB_CLIENT_VERSION_LOWER = "0.9.0";
+
+	/**
+	 * Gets the minimum supported Client version by this Job Manager.
+	 *
+	 * @return Minimum supported client version number.
+	 */
+	public static String getJobClientVersionLower() {
+		return JOB_CLIENT_VERSION_LOWER;
+	}
+
+	/**
+	 * Checks whether the given client version is compatible with this Job Manager
+	 *
+	 * @param clientVersion Version of the client
+	 * @return Whether the given client is compatible with the Job Manager.
+	 */
+	public static boolean isClientCompatible(String clientVersion) {
+		return versionComparator(JOB_CLIENT_VERSION_LOWER, clientVersion) <= 0 && versionComparator(clientVersion, FLINK_VERSION) <= 0;
+	}
+
+	/**
+	 * Checks which of the two given version strings is higher.
+	 *
+	 * @param version1 Version 1
+	 * @param version2 Version 2
+	 * @return 1 if version1 > version2, -1 if version1 < version2 and 0 if version1 = version2
+	 * <p>
+	 * Code taken from <a href = "http://stackoverflow.com/questions/6701948/efficient-way-to-compare-version-strings-in-java">Stack Overflow</a>
+	 */
+	private static int versionComparator(String version1, String version2) {
+		String[] vals1 = version1.split("\\.");
+		String[] vals2 = version2.split("\\.");
+		int i = 0;
+		// set index to first non-equal ordinal or length of shortest version string
+		while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
+			i++;
+		}
+		// compare first non-equal ordinal number
+		if (i < vals1.length && i < vals2.length) {
+			int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
+			return Integer.signum(diff);
+		}
+		// the strings are equal or one string is a substring of the other
+		// e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+		else {
+			return Integer.signum(vals1.length - vals2.length);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileSystem;
@@ -126,6 +127,7 @@ public class JobGraph implements Serializable {
 	public JobGraph(JobID jobId, String jobName) {
 		this.jobID = jobId == null ? new JobID() : jobId;
 		this.jobName = jobName == null ? "(unnamed job)" : jobName;
+		this.jobConfiguration.setString(ConfigConstants.FLINK_VERSION_KEY, Configuration.FLINK_VERSION);
 	}
 	
 	/**


### PR DESCRIPTION
[Reopening #944. The travis build failed somehow. ]
Both Job Manager and Task Manager now communicate their respective version IDs to each other as part of registration messages.
Version ID is accessed by the information Maven adds in the manifest.