### PR TITLE
Cascading changes for compatibility

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
@@ -80,6 +80,10 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		return hadoopInputSplit;
 	}
 
+	public JobConf getJobConf() {
+		return this.jobConf;
+	}
+
 	// ------------------------------------------------------------------------
 	//  Serialization
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/InputFormatVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/InputFormatVertex.java
@@ -71,13 +71,19 @@ public class InputFormatVertex extends JobVertex {
 		catch (Throwable t) {
 			throw new Exception("Instantiating the InputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
 		}
-		
+
+		Thread thread = Thread.currentThread();
+		ClassLoader original = thread.getContextClassLoader();
 		// configure
 		try {
+			thread.setContextClassLoader(loader);
 			inputFormat.configure(cfg.getStubParameters());
 		}
 		catch (Throwable t) {
 			throw new Exception("Configuring the InputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
+		}
+		finally {
+			thread.setContextClassLoader(original);
 		}
 		
 		setInputSplitSource(inputFormat);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -323,14 +323,20 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 		catch (ClassCastException ccex) {
 			throw new RuntimeException("The stub class is not a proper subclass of " + OutputFormat.class.getName(), ccex);
 		}
-		
+
+		Thread thread = Thread.currentThread();
+		ClassLoader original = thread.getContextClassLoader();
 		// configure the stub. catch exceptions here extra, to report them as originating from the user code 
 		try {
+			thread.setContextClassLoader(userCodeClassLoader);
 			this.format.configure(this.config.getStubParameters());
 		}
 		catch (Throwable t) {
 			throw new RuntimeException("The user defined 'configure()' method in the Output Format caused an error: " 
 				+ t.getMessage(), t);
+		}
+		finally {
+			thread.setContextClassLoader(original);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -266,12 +266,18 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 					ccex);
 		}
 
-		// configure the stub. catch exceptions here extra, to report them as originating from the user code 
+		Thread thread = Thread.currentThread();
+		ClassLoader original = thread.getContextClassLoader();
+		// configure the stub. catch exceptions here extra, to report them as originating from the user code
 		try {
+			thread.setContextClassLoader(userCodeClassLoader);
 			this.format.configure(this.config.getStubParameters());
 		}
 		catch (Throwable t) {
 			throw new RuntimeException("The user defined 'configure()' method caused an error: " + t.getMessage(), t);
+		}
+		finally {
+			thread.setContextClassLoader(original);
 		}
 
 		// get the factory for the type serializer


### PR DESCRIPTION
@fhueske and me are working on getting Cascading to run on top of Flink. These two commits introduce changes that were necessary to make the translation possible.

Up to debate is the second commit, which loads the userclassloader before calling `configure` on an InputFormat. This is necessary because Cascading has its own interface that needs to be wrapped inside a Flink `InputFormat`. Usually, all dependencies are loaded upon instantiation of the class. However, Cascading loads its own input format while `configure(config)` is called (via the class name inside the passed config). Without the changes, this leads to a ClassNotFoundException.

Let me know what you think about it. 