### PR TITLE
[FLINK-2425]Provide access to task manager configuration from RuntimeEnvironment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -472,7 +472,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters implement
 
 	// --------------------------------------------------------------------------------------------
 	
-	private <T> void setValueInternal(String key, T value) {
+	<T> void setValueInternal(String key, T value) {
 		if (key == null) {
 			throw new NullPointerException("Key must not be null.");
 		}

--- a/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
  */
 public class UnmodifiableConfiguration extends Configuration {
 
-
 	/** The log object used for debugging. */
 	private static final Logger LOG = LoggerFactory.getLogger(UnmodifiableConfiguration.class);
 
@@ -89,8 +88,13 @@ public class UnmodifiableConfiguration extends Configuration {
 		error();
 	}
 
-	private final void error(){
-		LOG.warn("The unmodifiable configuration object doesn't allow set methods. Silently " +
-				"failing");
+	@Override
+	<T> void setValueInternal(String key, T value){
+		error();
 	}
+
+	private final void error(){
+		throw new UnsupportedOperationException("The unmodifiable configuration object doesn't allow set methods.");
+	}
+	
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unmodifiable version of the Configuration class
+ */
+public class UnmodifiableConfiguration extends Configuration {
+
+
+	/** The log object used for debugging. */
+	private static final Logger LOG = LoggerFactory.getLogger(UnmodifiableConfiguration.class);
+
+	public UnmodifiableConfiguration(Configuration config) {
+		super();
+		super.addAll(config);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  All setter methods must fail.
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public final void setClass(String key, Class<?> klazz) {
+		error();
+	}
+
+	@Override
+	public final void setString(String key, String value) {
+		error();
+	}
+
+	@Override
+	public final void setInteger(String key, int value) {
+		error();
+	}
+
+	@Override
+	public final void setLong(String key, long value) {
+		error();
+	}
+
+	@Override
+	public final void setBoolean(String key, boolean value) {
+		error();
+	}
+
+	@Override
+	public final void setFloat(String key, float value) {
+		error();
+	}
+
+	@Override
+	public final void setDouble(String key, double value) {
+		error();
+	}
+
+	@Override
+	public final void setBytes(String key, byte[] bytes) {
+		error();
+	}
+
+	@Override
+	public final void addAll(Configuration other) {
+		error();
+	}
+
+	@Override
+	public final void addAll(Configuration other, String prefix) {
+		error();
+	}
+
+	private final void error(){
+		LOG.warn("The unmodifiable configuration object doesn't allow set methods. Silently " +
+				"failing");
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * This class verifies that the Unmodifiable Configuration class overrides all setter methods in
+ * Configuration.
+ */
+public class UnmodifiableConfigurationTest {
+
+	private static Configuration pc = new Configuration();
+	private static UnmodifiableConfiguration unConf = new UnmodifiableConfiguration(pc);
+	private static Class clazz = unConf.getClass();
+
+	@Test
+	public void testOverride() throws Exception{
+		unConf.setBoolean("a", false);
+		assertEquals(clazz, clazz.getMethod("setClass", String.class, Class.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("setString", String.class, String.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("setInteger", String.class, int.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("setLong", String.class, long.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("setFloat", String.class, float.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("setDouble", String.class, double.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("setBoolean", String.class, boolean.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("setBytes", String.class, byte[].class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("addAll", Configuration.class).getDeclaringClass());
+		assertEquals(clazz, clazz.getMethod("addAll", Configuration.class, String.class).getDeclaringClass());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.lang.reflect.Method;
+
 /**
  * This class verifies that the Unmodifiable Configuration class overrides all setter methods in
  * Configuration.
@@ -35,16 +37,10 @@ public class UnmodifiableConfigurationTest {
 
 	@Test
 	public void testOverride() throws Exception{
-		unConf.setBoolean("a", false);
-		assertEquals(clazz, clazz.getMethod("setClass", String.class, Class.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("setString", String.class, String.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("setInteger", String.class, int.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("setLong", String.class, long.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("setFloat", String.class, float.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("setDouble", String.class, double.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("setBoolean", String.class, boolean.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("setBytes", String.class, byte[].class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("addAll", Configuration.class).getDeclaringClass());
-		assertEquals(clazz, clazz.getMethod("addAll", Configuration.class, String.class).getDeclaringClass());
+		for(Method m : clazz.getMethods()){
+			if(m.getName().indexOf("set") == 0 || m.getName().indexOf("add") == 0 ) {
+				assertEquals(clazz, m.getDeclaringClass());
+			}
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -72,6 +72,16 @@ public interface Environment {
 	Configuration getTaskConfiguration();
 
 	/**
+	 * @return The task manager configuration
+	 */
+	Configuration getTaskManagerConfiguration();
+
+	/**
+	 * @return Hostname of the task manager
+	 */
+	String getHostname();
+
+	/**
 	 * Returns the job-wide configuration object that was attached to the JobGraph.
 	 *
 	 * @return The job-wide configuration

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -75,6 +75,10 @@ public class RuntimeEnvironment implements Environment {
 
 	private final AccumulatorRegistry accumulatorRegistry;
 
+	private Configuration taskManagerConfiguration;
+
+	private String hostname;
+
 	// ------------------------------------------------------------------------
 
 	public RuntimeEnvironment(
@@ -96,7 +100,8 @@ public class RuntimeEnvironment implements Environment {
 			Map<String, Future<Path>> distCacheEntries,
 			ResultPartitionWriter[] writers,
 			InputGate[] inputGates,
-			ActorGateway jobManager) {
+			ActorGateway jobManager,
+			RuntimeConfiguration taskManagerConfig) {
 		
 		checkArgument(parallelism > 0 && subtaskIndex >= 0 && subtaskIndex < parallelism);
 
@@ -119,8 +124,9 @@ public class RuntimeEnvironment implements Environment {
 		this.writers = checkNotNull(writers);
 		this.inputGates = checkNotNull(inputGates);
 		this.jobManager = checkNotNull(jobManager);
+		this.taskManagerConfiguration = checkNotNull(taskManagerConfig).configuration();
+		this.hostname = taskManagerConfig.hostname();
 	}
-
 
 	// ------------------------------------------------------------------------
 	
@@ -168,7 +174,17 @@ public class RuntimeEnvironment implements Environment {
 	public Configuration getTaskConfiguration() {
 		return taskConfiguration;
 	}
-	
+
+	@Override
+	public Configuration getTaskManagerConfiguration(){
+		return taskManagerConfiguration;
+	}
+
+	@Override
+	public String getHostname(){
+		return hostname;
+	}
+
 	@Override
 	public ClassLoader getUserClassLoader() {
 		return userCodeClassLoader;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -214,6 +214,9 @@ public class Task implements Runnable {
 	 * initialization, to be memory friendly */
 	private volatile SerializedValue<StateHandle<?>> operatorState;
 
+	/** Access to task manager configuration and host names*/
+	private RuntimeConfiguration taskManagerConfig;
+
 	/**
 	 * <p><b>IMPORTANT:</b> This constructor may not start any work that would need to 
 	 * be undone in the case of a failing task deployment.</p>
@@ -227,7 +230,8 @@ public class Task implements Runnable {
 				ActorGateway jobManagerActor,
 				FiniteDuration actorAskTimeout,
 				LibraryCacheManager libraryCache,
-				FileCache fileCache)
+				FileCache fileCache,
+				RuntimeConfiguration taskManagerConfig)
 	{
 		checkArgument(tdd.getNumberOfSubtasks() > 0);
 		checkArgument(tdd.getIndexInSubtaskGroup() >= 0);
@@ -258,6 +262,7 @@ public class Task implements Runnable {
 		this.libraryCache = checkNotNull(libraryCache);
 		this.fileCache = checkNotNull(fileCache);
 		this.network = checkNotNull(networkEnvironment);
+		this.taskManagerConfig = checkNotNull(taskManagerConfig);
 
 		this.executionListenerActors = new CopyOnWriteArrayList<ActorGateway>();
 
@@ -510,7 +515,7 @@ public class Task implements Runnable {
 					userCodeClassLoader, memoryManager, ioManager,
 					broadcastVariableManager, accumulatorRegistry,
 					splitProvider, distributedCacheEntries,
-					writers, inputGates, jobManager);
+					writers, inputGates, jobManager, taskManagerConfig);
 
 			// let the task code create its readers and writers
 			invokable.setEnvironment(env);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/RuntimeConfiguration.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/RuntimeConfiguration.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager
+
+import org.apache.flink.configuration.UnmodifiableConfiguration
+
+case class RuntimeConfiguration(hostname: String, configuration: UnmodifiableConfiguration)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -36,7 +36,7 @@ import com.codahale.metrics.jvm.{MemoryUsageGaugeSet, GarbageCollectorMetricSet}
 import com.fasterxml.jackson.databind.ObjectMapper
 import grizzled.slf4j.Logger
 
-import org.apache.flink.configuration.{Configuration, ConfigConstants, GlobalConfiguration, IllegalConfigurationException}
+import org.apache.flink.configuration._
 
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot
 import org.apache.flink.runtime.messages.checkpoint.{NotifyCheckpointComplete, TriggerCheckpoint, AbstractCheckpointMessage}
@@ -892,7 +892,10 @@ class TaskManager(
         jobManagerGateway,
         config.timeout,
         libCache,
-        fileCache)
+        fileCache,
+        new RuntimeConfiguration(
+          self.path.toSerializationFormat,
+          new UnmodifiableConfiguration(config.configuration)))
 
       log.info(s"Received task ${task.getTaskNameWithSubtasks}")
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.operators.testutils;
 
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
@@ -189,6 +190,16 @@ public class MockEnvironment implements Environment {
 	@Override
 	public Configuration getJobConfiguration() {
 		return this.jobConfiguration;
+	}
+
+	@Override
+	public Configuration getTaskManagerConfiguration(){
+		return new UnmodifiableConfiguration(new Configuration());
+	}
+
+	@Override
+	public String getHostname(){
+		return "localhost";
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -29,6 +30,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.filecache.FileCache;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
@@ -148,16 +150,20 @@ public class TaskAsyncCallTest {
 				Collections.<BlobKey>emptyList(),
 				0);
 
+		ActorGateway taskManagerGateway = DummyActorGateway.INSTANCE;
 		return new Task(tdd,
 				mock(MemoryManager.class),
 				mock(IOManager.class),
 				networkEnvironment,
 				mock(BroadcastVariableManager.class),
-				DummyActorGateway.INSTANCE,
+				taskManagerGateway,
 				DummyActorGateway.INSTANCE,
 				new FiniteDuration(60, TimeUnit.SECONDS),
 				libCache,
-				mock(FileCache.class));
+				mock(FileCache.class),
+				new RuntimeConfiguration(
+						taskManagerGateway.path(),
+						new UnmodifiableConfiguration(new Configuration())));
 	}
 	
 	public static class CheckpointsInOrderInvokable extends AbstractInvokable

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 
 import com.google.common.collect.Maps;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -725,7 +726,10 @@ public class TaskTest {
 				jobManagerGateway,
 				new FiniteDuration(60, TimeUnit.SECONDS),
 				libCache,
-				mock(FileCache.class));
+				mock(FileCache.class),
+				new RuntimeConfiguration(
+						taskManagerGateway.path(),
+						new UnmodifiableConfiguration(new Configuration())));
 	}
 
 	private TaskDeploymentDescriptor createTaskDeploymentDescriptor(Class<? extends AbstractInvokable> invokable) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
@@ -289,6 +290,16 @@ public class StreamMockEnvironment implements Environment {
 
 	@Override
 	public void acknowledgeCheckpoint(long checkpointId, StateHandle<?> state) {
+	}
+
+	@Override
+	public Configuration getTaskManagerConfiguration(){
+		return new UnmodifiableConfiguration(new Configuration());
+	}
+
+	@Override
+	public String getHostname(){
+		return "localhost";
 	}
 }
 


### PR DESCRIPTION
Also fixes [FLINK-2426]: Define an UnmodifiableConfiguration class which doesn't allow modifications to the underlying configuration object.