### PR TITLE
FLINK-2434:org.apache.hadoop:hadoop-yarn-common:jersey-test-framework-grizzly2+ does not match a valid id pattern

### DIFF
--- a/flink-shaded-hadoop/flink-shaded-hadoop1/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop1/pom.xml
@@ -118,7 +118,7 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
-					<artifactId>jersey-test-framework-grizzly2+</artifactId>
+					<artifactId>jersey-test-framework-grizzly2</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>

--- a/flink-shaded-hadoop/flink-shaded-include-yarn/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-include-yarn/pom.xml
@@ -250,7 +250,7 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
-					<artifactId>jersey-test-framework-grizzly2+</artifactId>
+					<artifactId>jersey-test-framework-grizzly2</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
@@ -394,7 +394,7 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
-					<artifactId>jersey-test-framework-grizzly2+</artifactId>
+					<artifactId>jersey-test-framework-grizzly2</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
@@ -538,7 +538,7 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
-					<artifactId>jersey-test-framework-grizzly2+</artifactId>
+					<artifactId>jersey-test-framework-grizzly2</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
@@ -682,7 +682,7 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>
-					<artifactId>jersey-test-framework-grizzly2+</artifactId>
+					<artifactId>jersey-test-framework-grizzly2</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey.jersey-test-framework</groupId>


### PR DESCRIPTION
```org.apache.hadoop:hadoop-yarn-common:jersey-test-framework-grizzly2+ ``` 

does not match a valid id pattern and should be

 ``` org.apache.hadoop:hadoop-yarn-common:jersey-test-framework-grizzly2 ```