### PR TITLE
[FLINK-2409] [webserver] Replaces ActorRefs with ActorGateways in the web servers

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.webmonitor;
 
-import akka.actor.ActorRef;
-
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
@@ -35,6 +33,7 @@ import io.netty.handler.stream.ChunkedWriteHandler;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.webmonitor.files.StaticFileServerHandler;
 import org.apache.flink.runtime.webmonitor.handlers.ExecutionPlanHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JobConfigHandler;
@@ -88,7 +87,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 	private Channel serverChannel;
 
 	
-	public WebRuntimeMonitor(Configuration config, ActorRef jobManager, ActorRef archive) throws IOException {
+	public WebRuntimeMonitor(Configuration config, ActorGateway jobManager, ActorGateway archive) throws IOException {
 		// figure out where our static contents is
 		final String configuredWebRoot = config.getString(ConfigConstants.JOB_MANAGER_WEB_DOC_ROOT_KEY, null);
 		final String flinkRoot = config.getString(ConfigConstants.FLINK_BASE_DIR_PATH_KEY, null);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/RequestJobIdsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/RequestJobIdsHandler.java
@@ -18,10 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
-import akka.actor.ActorRef;
-import akka.pattern.Patterns;
-import akka.util.Timeout;
-
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.webmonitor.JobsWithIDsOverview;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobsWithIDsOverview;
 import org.apache.flink.runtime.webmonitor.JsonFactory;
@@ -40,15 +37,15 @@ import java.util.Map;
  */
 public class RequestJobIdsHandler implements RequestHandler, RequestHandler.JsonResponse {
 	
-	private final ActorRef target;
+	private final ActorGateway target;
 	
 	private final FiniteDuration timeout;
 	
-	public RequestJobIdsHandler(ActorRef target) {
+	public RequestJobIdsHandler(ActorGateway target) {
 		this(target, WebRuntimeMonitor.DEFAULT_REQUEST_TIMEOUT);
 	}
 	
-	public RequestJobIdsHandler(ActorRef target, FiniteDuration timeout) {
+	public RequestJobIdsHandler(ActorGateway target, FiniteDuration timeout) {
 		if (target == null || timeout == null) {
 			throw new NullPointerException();
 		}
@@ -60,8 +57,7 @@ public class RequestJobIdsHandler implements RequestHandler, RequestHandler.Json
 	public String handleRequest(Map<String, String> params) throws Exception {
 		// we need no parameters, get all requests
 		try {
-			Timeout to = new Timeout(timeout); 
-			Future<Object> future = Patterns.ask(target, RequestJobsWithIDsOverview.getInstance(), to);
+			Future<Object> future = target.ask(RequestJobsWithIDsOverview.getInstance(), timeout);
 			JobsWithIDsOverview result = (JobsWithIDsOverview) Await.result(future, timeout);
 			return JsonFactory.generateJobsOverviewJSON(result);
 		}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/RequestOverviewHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/RequestOverviewHandler.java
@@ -18,10 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
-import akka.actor.ActorRef;
-import akka.pattern.Patterns;
-import akka.util.Timeout;
-
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.webmonitor.RequestStatusWithJobIDsOverview;
 import org.apache.flink.runtime.messages.webmonitor.StatusWithJobIDsOverview;
 import org.apache.flink.runtime.webmonitor.JsonFactory;
@@ -39,16 +36,16 @@ import java.util.Map;
  */
 public class RequestOverviewHandler implements  RequestHandler, RequestHandler.JsonResponse {
 	
-	private final ActorRef jobManager;
+	private final ActorGateway jobManager;
 	
 	private final FiniteDuration timeout;
 	
 	
-	public RequestOverviewHandler(ActorRef jobManager) {
+	public RequestOverviewHandler(ActorGateway jobManager) {
 		this(jobManager, WebRuntimeMonitor.DEFAULT_REQUEST_TIMEOUT);
 	}
 	
-	public RequestOverviewHandler(ActorRef jobManager, FiniteDuration timeout) {
+	public RequestOverviewHandler(ActorGateway jobManager, FiniteDuration timeout) {
 		if (jobManager == null || timeout == null) {
 			throw new NullPointerException();
 		}
@@ -59,8 +56,7 @@ public class RequestOverviewHandler implements  RequestHandler, RequestHandler.J
 	@Override
 	public String handleRequest(Map<String, String> params) throws Exception {
 		try {
-			Timeout to = new Timeout(timeout); 
-			Future<Object> future = Patterns.ask(jobManager, RequestStatusWithJobIDsOverview.getInstance(), to);
+			Future<Object> future = jobManager.ask(RequestStatusWithJobIDsOverview.getInstance(), timeout);
 			StatusWithJobIDsOverview result = (StatusWithJobIDsOverview) Await.result(future, timeout);
 			return JsonFactory.generateOverviewWithJobIDsJSON(result);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/SetupInfoServlet.java
@@ -32,10 +32,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import akka.actor.ActorRef;
-import akka.pattern.Patterns;
-import akka.util.Timeout;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.Instance;
 
 import org.apache.flink.runtime.instance.InstanceID;
@@ -67,13 +65,13 @@ public class SetupInfoServlet extends HttpServlet {
 
 
 	final private Configuration configuration;
-	final private ActorRef jobmanager;
+	final private ActorGateway jobmanager;
 	final private FiniteDuration timeout;
 
 
-	public SetupInfoServlet(Configuration conf, ActorRef jm, FiniteDuration timeout) {
+	public SetupInfoServlet(Configuration conf, ActorGateway jobManager, FiniteDuration timeout) {
 		configuration = conf;
-		this.jobmanager = jm;
+		this.jobmanager = jobManager;
 		this.timeout = timeout;
 	}
 
@@ -114,9 +112,9 @@ public class SetupInfoServlet extends HttpServlet {
 
 	private void writeTaskmanagers(HttpServletResponse resp) throws IOException {
 
-		final Future<Object> response = Patterns.ask(jobmanager,
+		final Future<Object> response = jobmanager.ask(
 				JobManagerMessages.getRequestRegisteredTaskManagers(),
-				new Timeout(timeout));
+				timeout);
 
 		Object obj = null;
 
@@ -183,9 +181,9 @@ public class SetupInfoServlet extends HttpServlet {
 		StackTrace message = null;
 		Throwable exception = null;
 
-		final Future<Object> response = Patterns.ask(jobmanager,
+		final Future<Object> response = jobmanager.ask(
 				new RequestStackTrace(instanceID),
-				new Timeout(timeout));
+				timeout);
 
 		try {
 			message = (StackTrace) Await.result(response, timeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/WebInfoServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/web/WebInfoServer.java
@@ -23,12 +23,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 
-import akka.actor.ActorRef;
-
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.webmonitor.WebMonitor;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.server.Server;
@@ -45,7 +45,7 @@ import scala.concurrent.duration.FiniteDuration;
  * This class sets up a web-server that contains a web frontend to display information about running jobs.
  * It instantiates and configures an embedded jetty server.
  */
-public class WebInfoServer {
+public class WebInfoServer implements WebMonitor {
 
 	/** Web root dir in the jar */
 	private static final String WEB_ROOT_DIR = "web-docs-infoserver";
@@ -70,7 +70,7 @@ public class WebInfoServer {
 	 * @throws IOException
 	 *         Thrown, if the server setup failed for an I/O related reason.
 	 */
-	public WebInfoServer(Configuration config, ActorRef jobmanager, ActorRef archive) throws IOException {
+	public WebInfoServer(Configuration config, ActorGateway jobmanager, ActorGateway archive) throws IOException {
 		if (config == null) {
 			throw new IllegalArgumentException("No Configuration has been passed to the web server");
 		}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -171,7 +171,7 @@ class TaskManager(
 
   protected var leaderSessionID: Option[UUID] = None
 
-  private var currentRegistrationSessionID: UUID = UUID.randomUUID()
+  private val currentRegistrationSessionID: UUID = UUID.randomUUID()
 
   // --------------------------------------------------------------------------
   //  Actor messages and life cycle

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.jobmanager.{MemoryArchivist, JobManager}
 import org.apache.flink.runtime.minicluster.FlinkMiniCluster
 import org.apache.flink.runtime.net.NetUtils
 import org.apache.flink.runtime.taskmanager.TaskManager
+import org.apache.flink.runtime.webmonitor.WebMonitor
 
 /**
  * Testing cluster which starts the [[JobManager]] and [[TaskManager]] actors with testing support
@@ -67,7 +68,7 @@ class TestingCluster(userConfiguration: Configuration,
     cfg
   }
 
-  override def startJobManager(actorSystem: ActorSystem): ActorRef = {
+  override def startJobManager(actorSystem: ActorSystem): (ActorRef, Option[WebMonitor]) = {
 
     val (executionContext,
       instanceManager,
@@ -103,7 +104,7 @@ class TestingCluster(userConfiguration: Configuration,
       jobManagerProps
     }
 
-    actorSystem.actorOf(dispatcherJobManagerProps, JobManager.JOB_MANAGER_NAME)
+    (actorSystem.actorOf(dispatcherJobManagerProps, JobManager.JOB_MANAGER_NAME), None)
   }
 
   override def startTaskManager(index: Int, system: ActorSystem) = {
@@ -116,12 +117,14 @@ class TestingCluster(userConfiguration: Configuration,
       None
     }
     
-    TaskManager.startTaskManagerComponentsAndActor(configuration, system,
-                                                   hostname,
-                                                   Some(tmActorName),
-                                                   jobManagerPath,
-                                                   numTaskManagers == 1,
-                                                   streamingMode,
-                                                   classOf[TestingTaskManager])
+    TaskManager.startTaskManagerComponentsAndActor(
+      configuration,
+      system,
+      hostname,
+      Some(tmActorName),
+      jobManagerPath,
+      numTaskManagers == 1,
+      streamingMode,
+      classOf[TestingTaskManager])
   }
 }


### PR DESCRIPTION
Replaces the `ActorRefs` used in the `WebInfoServer`, its servlets and the `WebRuntimeMonitor` with `ActorGateways`. This provides automatic message decoration. E.g. `Cancel` messages sent from the web interface are now correctly wrapped in a `LeaderSessionMessage` and, thus, no longer make the `JobManager` stop upon receiving the undecorated message.

Furthermore, this PR adds support for the new web interface with YARN.

The `FlinkMiniCluster` and its subclasses store now a reference to a possibly started `WebMonitor` which allows the cluster to properly shut it down, when the cluster is stopped.