### PR TITLE
[FLINK-2432] Custom serializer support

### DIFF
--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/types/CustomTypeWrapper.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/types/CustomTypeWrapper.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.flink.python.api.types;
+
+/**
+ * Container for serialized python objects, generally assumed to be custom objects.
+ */
+public class CustomTypeWrapper {
+	private final byte typeID;
+	private final byte[] data;
+
+	public CustomTypeWrapper(byte typeID, byte[] data) {
+		this.typeID = typeID;
+		this.data = data;
+	}
+
+	public byte getType() {
+		return typeID;
+	}
+
+	public byte[] getData() {
+		return data;
+	}
+}

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/CoGroupFunction.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/CoGroupFunction.py
@@ -25,13 +25,13 @@ class CoGroupFunction(Function.Function):
         self._keys1 = None
         self._keys2 = None
 
-    def _configure(self, input_file, output_file, port):
+    def _configure(self, input_file, output_file, port, env):
         self._connection = Connection.TwinBufferingTCPMappedFileConnection(input_file, output_file, port)
-        self._iterator = Iterator.Iterator(self._connection, 0)
-        self._iterator2 = Iterator.Iterator(self._connection, 1)
+        self._iterator = Iterator.Iterator(self._connection, env, 0)
+        self._iterator2 = Iterator.Iterator(self._connection, env, 1)
         self._cgiter = Iterator.CoGroupIterator(self._iterator, self._iterator2, self._keys1, self._keys2)
         self.context = RuntimeContext.RuntimeContext(self._iterator, self._collector)
-        self._configure_chain(Collector.Collector(self._connection))
+        self._configure_chain(Collector.Collector(self._connection, env))
 
     def _run(self):
         collector = self._collector

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/Function.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/Function.py
@@ -32,11 +32,11 @@ class Function(object):
         self.context = None
         self._chain_operator = None
 
-    def _configure(self, input_file, output_file, port):
+    def _configure(self, input_file, output_file, port, env):
         self._connection = Connection.BufferingTCPMappedFileConnection(input_file, output_file, port)
-        self._iterator = Iterator.Iterator(self._connection)
+        self._iterator = Iterator.Iterator(self._connection, env)
         self.context = RuntimeContext.RuntimeContext(self._iterator, self._collector)
-        self._configure_chain(Collector.Collector(self._connection))
+        self._configure_chain(Collector.Collector(self._connection, env))
 
     def _configure_chain(self, collector):
         if self._chain_operator is not None:

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/GroupReduceFunction.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/GroupReduceFunction.py
@@ -29,19 +29,19 @@ class GroupReduceFunction(Function.Function):
         self._combine = False
         self._values = []
 
-    def _configure(self, input_file, output_file, port):
+    def _configure(self, input_file, output_file, port, env):
         if self._combine:
             self._connection = Connection.BufferingTCPMappedFileConnection(input_file, output_file, port)
-            self._iterator = Iterator.Iterator(self._connection)
-            self._collector = Collector.Collector(self._connection)
+            self._iterator = Iterator.Iterator(self._connection, env)
+            self._collector = Collector.Collector(self._connection, env)
             self.context = RuntimeContext.RuntimeContext(self._iterator, self._collector)
             self._run = self._run_combine
         else:
             self._connection = Connection.BufferingTCPMappedFileConnection(input_file, output_file, port)
-            self._iterator = Iterator.Iterator(self._connection)
+            self._iterator = Iterator.Iterator(self._connection, env)
             self._group_iterator = Iterator.GroupIterator(self._iterator, self._keys)
             self.context = RuntimeContext.RuntimeContext(self._iterator, self._collector)
-            self._configure_chain(Collector.Collector(self._connection))
+            self._configure_chain(Collector.Collector(self._connection, env))
         self._open()
 
     def _open(self):

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/ReduceFunction.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/ReduceFunction.py
@@ -27,21 +27,21 @@ class ReduceFunction(Function.Function):
         self._combine = False
         self._values = []
 
-    def _configure(self, input_file, output_file, port):
+    def _configure(self, input_file, output_file, port, env):
         if self._combine:
             self._connection = Connection.BufferingTCPMappedFileConnection(input_file, output_file, port)
-            self._iterator = Iterator.Iterator(self._connection)
-            self._collector = Collector.Collector(self._connection)
+            self._iterator = Iterator.Iterator(self._connection, env)
+            self._collector = Collector.Collector(self._connection, env)
             self.context = RuntimeContext.RuntimeContext(self._iterator, self._collector)
             self._run = self._run_combine
         else:
             self._connection = Connection.BufferingTCPMappedFileConnection(input_file, output_file, port)
-            self._iterator = Iterator.Iterator(self._connection)
+            self._iterator = Iterator.Iterator(self._connection, env)
             if self._keys is None:
                 self._run = self._run_allreduce
             else:
                 self._group_iterator = Iterator.GroupIterator(self._iterator, self._keys)
-            self._configure_chain(Collector.Collector(self._connection))
+            self._configure_chain(Collector.Collector(self._connection, env))
             self.context = RuntimeContext.RuntimeContext(self._iterator, self._collector)
 
     def _set_grouping_keys(self, keys):

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/plan/Constants.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/plan/Constants.py
@@ -91,6 +91,11 @@ import sys
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
+
+class _Dummy(object):
+    pass
+
+
 if PY2:
     BOOL = True
     INT = 1
@@ -98,9 +103,11 @@ if PY2:
     FLOAT = 2.5
     STRING = "type"
     BYTES = bytearray(b"byte")
+    CUSTOM = _Dummy()
 elif PY3:
     BOOL = True
     INT = 1
     FLOAT = 2.5
     STRING = "type"
     BYTES = bytearray(b"byte")
+    CUSTOM = _Dummy()


### PR DESCRIPTION
Users can now  use custom serializers in the Python API.
The registration is done using env.register_custom_type(<type class>,<serializer instance>, <deserializer instnace>)
Objects serialized this way are exist on a java side in serialized form, stored in a CustomTypeWrapper object.

