### PR TITLE
[FLINK-2446]Fix SocketTextStreamFunction has memory leak when reconnect server

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -102,6 +102,7 @@ public class SocketTextStreamFunction extends RichSourceFunction<String> {
 							success = true;
 						} catch (ConnectException ce) {
 							Thread.sleep(CONNECTION_RETRY_SLEEP);
+							socket.close();
 						}
 					}
 


### PR DESCRIPTION
When reconnect server failed, it should call socket.close() to avoid memory leak.