### PR TITLE
[FLINK-2456][fix]add a repository ID for hadoop2 in flink-hbase module

### DIFF
--- a/flink-staging/flink-hbase/pom.xml
+++ b/flink-staging/flink-hbase/pom.xml
@@ -171,6 +171,18 @@ under the License.
 		
 		<profile>
 			<id>hadoop-2</id>
+			<repositories>
+				<repository>
+					<id>hadoop-2-repo2</id>
+					<url>https://repo.maven.apache.org/maven2</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
+			</repositories>
 			<activation>
 				<property>
 					<!-- Please do not remove the 'hadoop2' comment. See ./tools/generate_specific_pom.sh -->


### PR DESCRIPTION
add a repository for hadoop-2 in flink-hbase.
It can be downloaded through a specified mirror like:

<mirror>
        <id>repo2</id>
        <name>Human Readable Name for this Mirror.</name>
        <url>http://repo2.maven.org/maven2/</url>
        <mirrorOf>hadoop-2-repo2</mirrorOf>
    </mirror>

Or it will not affect the normal network environment when default.