### PR TITLE
[FLINK-2465] Fix SocketClientSink closeConnection function memory leak

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/sink/SocketClientSink.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/sink/SocketClientSink.java
@@ -88,7 +88,7 @@ public class SocketClientSink<IN> extends RichSinkFunction<IN> {
 	 */
 	private void closeConnection(){
 		try {
-			dataOutputStream.flush();
+			dataOutputStream.close();
 			client.close();
 		} catch (IOException e) {
 			throw new RuntimeException("Error while closing connection with socket server at "


### PR DESCRIPTION
When closeConnection, should call dataOutputStream.close() instead of dataOutputStream.flush()  because close() will call flush() first and then releases any system resources associated with this stream. Only call dataOutputStream.flush() cause memory leak.