### PR TITLE
User defined communication between parallel instances of tasks at Runtime

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.accumulators.Histogram;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.api.common.messages.TaskMessage;
 import org.apache.flink.api.common.state.OperatorState;
 import org.apache.flink.api.common.state.StateCheckpointer;
 
@@ -230,4 +231,19 @@ public interface RuntimeContext {
 	 */
 	<S extends Serializable> OperatorState<S> getOperatorState(String name, S defaultState,
 			boolean partitioned) throws IOException;
+
+
+	/**
+	 * Send a message to all parallel instances of this task at runtime. This message will also
+	 * be available to this runtime context also via {@link #receive()}
+	 *
+	 * @param message Message to be sent to all parallel instances of task
+	 */
+	void broadcast(TaskMessage message);
+
+	/**
+	 * Fetch all messages received by the task manager from parallel instances of this task in a
+	 * list. If no message has been received, this will be an empty list.
+	 */
+	List<TaskMessage> receive();
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.messages.TaskMessage;
 import org.apache.flink.core.fs.Path;
 
 /**
@@ -114,5 +115,17 @@ public class RuntimeUDFContext extends AbstractRuntimeUDFContext {
 	public void clearAllBroadcastVariables() {
 		this.uninitializedBroadcastVars.clear();
 		this.initializedBroadcastVars.clear();
+	}
+
+	@Override
+	public void broadcast(TaskMessage message){
+		// can't implement this method here. We need the runtime system.
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<TaskMessage> receive(){
+		// can't implement this method here. We need the runtime system.
+		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/messages/HeartBeatMessage.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/messages/HeartBeatMessage.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.messages;
+
+
+/**
+ * An example implementation of a message which tasks can broadcast to parallel instances of themselves.
+ */
+public class HeartBeatMessage implements TaskMessage {}

--- a/flink-core/src/main/java/org/apache/flink/api/common/messages/KeyValueMessage.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/messages/KeyValueMessage.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.messages;
+
+import org.apache.flink.types.Value;
+
+/**
+ * An example implementation of a message which tasks can broadcast to parallel instances of themselves.
+ */
+public class KeyValueMessage implements TaskMessage {
+	private String key;
+	private Value value;
+
+	public KeyValueMessage(String _key, Value _value){
+		key = _key;
+		value = _value;
+	}
+
+	public String getKey(){
+		return key;
+	}
+
+	public Value getValue(){
+		return value;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/messages/TaskMessage.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/messages/TaskMessage.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.messages;
+
+import java.io.Serializable;
+
+/**
+ * An interface for a Task to broadcast messages to all its parallel instances via
+ * {@link org.apache.flink.api.common.functions.RuntimeContext#broadcast}
+ * and receive messages from all its parallel instances via
+ * {@link org.apache.flink.api.common.functions.RuntimeContext#receive}
+ */
+public interface TaskMessage extends Serializable {}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -173,6 +173,11 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_MAX_REGISTRATION_DURATION = "taskmanager.maxRegistrationDuration";
 
 	/**
+	 * Maximum messages a task can receive from its counterparts, i.e., parallel running instances.
+	 */
+	public static final String TASK_MANAGER_MAX_TASK_MESSAGES = "taskmanager.maxTaskMessage";
+
+	/**
 	 * Parameter for the maximum fan for out-of-core algorithms.
 	 * Corresponds to the maximum fan-in for merge-sorts and the maximum fan-out
 	 * for hybrid hash joins. 

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/RichPartitionIteration.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/RichPartitionIteration.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.examples.java.runtime;
+
+import org.apache.flink.api.common.functions.RichMapPartitionFunction;
+import org.apache.flink.api.common.messages.KeyValueMessage;
+import org.apache.flink.api.common.messages.TaskMessage;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.util.Collector;
+
+import java.util.ArrayList;
+
+/**
+ * Implements how to communicate between parallel instances of a task at runtime.
+ * This example shows how, while operating on a Partition of data, you can send and receive data,
+ * and keep operating on this partition without ever leaving the map function.
+ */
+@SuppressWarnings("serial")
+public class RichPartitionIteration {
+	
+	// *************************************************************************
+	//     PROGRAM
+	// *************************************************************************
+	
+	public static void main(String[] args) throws Exception {
+		// set up the execution environment
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.generateSequence(1,20).setParallelism(2).mapPartition(new RichMapPartitionFunction<Long, Long>() {
+			@Override
+			public void mapPartition(Iterable<Long> values, Collector<Long> out) throws Exception {
+				ArrayList<Long> list = new ArrayList<Long>();
+				for(Long j: values){
+					list.add(j);
+				}
+				for(int i = 0; i < 2; i++){
+					for(Long elem: list){
+						getRuntimeContext().broadcast(new KeyValueMessage("", new LongValue(elem)));
+					}
+					// give sufficient time. Generally, we don't want everything since we'll be performing
+					// asynchronous iterations
+					Thread.sleep(2000);
+					long count = 0;
+					for(TaskMessage elem: getRuntimeContext().receive()){
+						count += ((LongValue) ((KeyValueMessage) elem).getValue()).getValue();
+					}
+					if(count != 210){
+						throw new RuntimeException("Invalid sum.");
+					}
+				}
+			}
+		}).output(new DiscardingOutputFormat<Long>());
+		env.execute();
+	}
+}

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/SendOneMessage.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/SendOneMessage.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.examples.java.runtime;
+
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.api.common.messages.KeyValueMessage;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.types.LongValue;
+
+import java.util.List;
+
+/**
+ * Implements how to communicate between parallel instances of a task at runtime.
+ * Verifies that all messages of this one type are sent and received by everyone.
+ *
+ */
+@SuppressWarnings("serial")
+public class SendOneMessage {
+	
+	// *************************************************************************
+	//     PROGRAM
+	// *************************************************************************
+	
+	public static void main(String[] args) throws Exception {
+		// set up the execution environment
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.generateSequence(1,20).filter(new RichFilterFunction<Long>() {
+			@Override
+			public boolean filter(Long value) throws Exception {
+				getRuntimeContext().broadcast(new KeyValueMessage("", new LongValue(value)));
+				return false;
+			}
+
+			@Override
+			public void close() {
+				try {
+					// wait for a while for others to finish to get all messages
+					Thread.sleep(1000);
+				} catch(InterruptedException e){
+
+				}
+				// let's fetch the messages now
+				List messages = getRuntimeContext().receive();
+				if(messages.size() != 20){
+					throw new RuntimeException("Invalid count of messages received");
+				}
+				if(!(messages.get(0) instanceof KeyValueMessage)){
+					throw new RuntimeException("Invalid type of message received");
+				}
+			}
+		}).output(new DiscardingOutputFormat<Long>());
+		env.execute();
+	}
+}

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/SendTooManyMessages.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/SendTooManyMessages.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.examples.java.runtime;
+
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.api.common.messages.KeyValueMessage;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.types.LongValue;
+
+
+/**
+ * Implements how to communicate between parallel instances of a task at runtime.
+ * This program must fail. We're sending messages more than the queue is configured to handle.
+ */
+@SuppressWarnings("serial")
+public class SendTooManyMessages {
+	
+	// *************************************************************************
+	//     PROGRAM
+	// *************************************************************************
+	
+	public static void main(String[] args) throws Exception {
+		// set up the execution environment
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.generateSequence(1,100).filter(new RichFilterFunction<Long>() {
+			@Override
+			public boolean filter(Long value) throws Exception {
+				getRuntimeContext().broadcast(new KeyValueMessage("", new LongValue(value)));
+				return false;
+			}
+		}).output(new DiscardingOutputFormat<Long>());
+		env.execute();
+	}
+}

--- a/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/SendTwoMessages.java
+++ b/flink-examples/flink-java-examples/src/main/java/org/apache/flink/examples/java/runtime/SendTwoMessages.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.examples.java.runtime;
+
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.api.common.messages.HeartBeatMessage;
+import org.apache.flink.api.common.messages.KeyValueMessage;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.types.LongValue;
+
+import java.util.List;
+
+/**
+ * Implements how to communicate between parallel instances of a task at runtime.
+ * Verifies that all messages of two types are sent and received by everyone.
+ */
+@SuppressWarnings("serial")
+public class SendTwoMessages {
+	
+	// *************************************************************************
+	//     PROGRAM
+	// *************************************************************************
+	
+	public static void main(String[] args) throws Exception {
+		// set up the execution environment
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.generateSequence(1,20).filter(new RichFilterFunction<Long>() {
+			@Override
+			public boolean filter(Long value) throws Exception {
+				getRuntimeContext().broadcast(new KeyValueMessage("", new LongValue(value)));
+				return true;
+			}
+		}).filter(new RichFilterFunction<Long>() {
+			@Override
+			public boolean filter(Long value) throws Exception {
+				getRuntimeContext().broadcast(new HeartBeatMessage());
+				return false;
+			}
+
+			@Override
+			public void close(){
+				try {
+					// wait for a while for others to finish to get all messages
+					Thread.sleep(1000);
+				} catch(InterruptedException e){
+
+				}
+				// let's fetch the messages now
+				List messages = getRuntimeContext().receive();
+				if(messages.size() != 40){
+					throw new RuntimeException("Invalid count of messages received.");
+				}
+				int keyValue = 0;
+				int heartBeat = 0;
+				for(int i = 0; i < 40; i++){
+					if(messages.get(i) instanceof KeyValueMessage){
+						keyValue++;
+					} else if(messages.get(i) instanceof HeartBeatMessage){
+						heartBeat++;
+					}
+				}
+				if(keyValue != 20 || heartBeat != 20){
+					throw new RuntimeException("Invalid count of messages received.");
+				}
+			}
+		}).output(new DiscardingOutputFormat<Long>());
+		env.execute();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.runtime.taskmanager.TaskMessageHandler;
 
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -114,6 +115,14 @@ public interface Environment {
 	 * @return the current {@link MemoryManager}.
 	 */
 	MemoryManager getMemoryManager();
+
+	/**
+	 * Returns the {@link org.apache.flink.runtime.taskmanager.TaskMessageHandler} for this task
+	 *
+	 * @return the {@link org.apache.flink.runtime.taskmanager.TaskMessageHandler} for this task
+	 */
+
+	TaskMessageHandler getMessageHandler();
 
 	/**
 	 * Returns the name of the task running in this environment.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativePactTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativePactTask.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.iterative.task;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.runtime.taskmanager.TaskMessageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.aggregators.Aggregator;
@@ -169,7 +170,7 @@ public abstract class AbstractIterativePactTask<S extends Function, OT> extends 
 	public DistributedRuntimeUDFContext createRuntimeContext(String taskName) {
 		Environment env = getEnvironment();
 		return new IterativeRuntimeUdfContext(taskName, env.getNumberOfSubtasks(),
-				env.getIndexInSubtaskGroup(), getUserCodeClassLoader(), getExecutionConfig(), this.accumulatorMap);
+				env.getIndexInSubtaskGroup(), getUserCodeClassLoader(), getExecutionConfig(), this.accumulatorMap, env.getMessageHandler());
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -361,8 +362,8 @@ public abstract class AbstractIterativePactTask<S extends Function, OT> extends 
 
 		public IterativeRuntimeUdfContext(String name, int numParallelSubtasks, int subtaskIndex, ClassLoader userCodeClassLoader,
 										ExecutionConfig executionConfig,
-										Map<String, Accumulator<?,?>> accumulatorMap) {
-			super(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig, accumulatorMap);
+										Map<String, Accumulator<?,?>> accumulatorMap, TaskMessageHandler messageHandler) {
+			super(name, numParallelSubtasks, subtaskIndex, userCodeClassLoader, executionConfig, accumulatorMap, messageHandler);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/RegularPactTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/RegularPactTask.java
@@ -1031,7 +1031,7 @@ public class RegularPactTask<S extends Function, OT> extends AbstractInvokable i
 
 		return new DistributedRuntimeUDFContext(taskName, env.getNumberOfSubtasks(),
 				env.getIndexInSubtaskGroup(), getUserCodeClassLoader(), getExecutionConfig(),
-				env.getDistributedCacheEntries(), this.accumulatorMap);
+				env.getDistributedCacheEntries(), this.accumulatorMap, env.getMessageHandler());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
@@ -68,7 +68,7 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
 		} else {
 			this.udfContext = new DistributedRuntimeUDFContext(taskName, env.getNumberOfSubtasks(),
 					env.getIndexInSubtaskGroup(), userCodeClassLoader, parent.getExecutionConfig(),
-					env.getDistributedCacheEntries(), accumulatorMap
+					env.getDistributedCacheEntries(), accumulatorMap, env.getMessageHandler()
 			);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MessageHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MessageHandler.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+
+import org.apache.flink.api.common.messages.TaskMessage;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import java.util.HashMap;
+
+/**
+ * Message handler for all tasks running under a particular {@link TaskManager}
+ *
+ * {@link TaskManager} has access to this Message Handler and uses it to send and receive message to and
+ * from all tasks running under this {@link TaskManager}
+ */
+public class MessageHandler{
+	/** List of all {@link TaskMessageHandler}s*/
+	private HashMap<JobVertexID, TaskMessageHandler> handlers;
+	private ActorGateway gateway;
+	private boolean isShutDown;
+	private int maxSize;
+
+	/**
+	 * Constructor for this message handler. Initially, everything is shut down.
+	 * Called from {@link TaskManager}startTaskManagerComponentsAndActor(Configuration, ActorSystem, String, Option, Option, boolean, StreamingMode, Class)}
+	 */
+	MessageHandler(){
+		this.gateway = null;
+		this.handlers = null;
+		this.isShutDown = true;
+	}
+
+	/**
+	 * {@link TaskManager} sets this message handler up when it itself registers to a
+	 * {@link org.apache.flink.runtime.jobmanager.JobManager}
+	 *
+	 * Called from {@link TaskManager}#associateWithJobManager(ActorRef, InstanceID, int, UUID)}
+	 *
+	 * @param gateway Gateway to the {@link TaskManager}
+	 * @param maxSize Maximum size of message queue for each task
+	 */
+	void setup(ActorGateway gateway, int maxSize){
+		this.handlers = new HashMap<JobVertexID, TaskMessageHandler>();
+		this.gateway = gateway;
+		this.isShutDown = false;
+		this.maxSize = maxSize;
+	}
+
+	/**
+	 * Called by {@link TaskManager} when it itself is shutting down for what-so-ever-reason.
+	 *
+	 */
+	void shutDown(){
+		synchronized (this){
+			for(TaskMessageHandler handler: this.handlers.values()){
+				handler.shutDown();
+			}
+			this.isShutDown = true;
+			this.handlers.clear();
+		}
+	}
+
+	/**
+	 * Register a particular task with this message handler. If a handler already exists for a particular
+	 * {@link JobVertexID}, then subscribe the corresponding {@link TaskMessageHandler} to serve this
+	 * parallel instance also.
+	 *
+	 * Called from {@link TaskManager}#submitTask(TaskDeploymentDescriptor)}
+	 *
+	 * @param vertexID Job Vertex id of the task being registered
+	 * @param subTaskIndex Sub task index of this task
+	 * @return the {@link TaskMessageHandler} for this task
+	 */
+	TaskMessageHandler registerTask(JobVertexID vertexID, int subTaskIndex) {
+		synchronized (this){
+			error();
+			if(handlers.containsKey(vertexID)){
+				handlers.get(vertexID).subscribe(subTaskIndex);
+			} else{
+				handlers.put(vertexID, new TaskMessageHandler(maxSize, vertexID, gateway));
+				handlers.get(vertexID).subscribe(subTaskIndex);
+			}
+			return handlers.get(vertexID);
+		}
+	}
+
+	/**
+	 * Unregister a particular task from listening and receiving any messages. If all parallel instances
+	 * associated with a particular {@link JobVertexID} have unregistered, the handler for that
+	 * {@link JobVertexID} will be shut down and cleared out of our handler lists.
+	 *
+	 * Called from {@link TaskManager}#unregisterTaskAndNotifyFinalState(ExecutionAttemptID)
+	 *
+	 * @param vertexID Job Vertex id of the task being unregistered
+	 * @param subTaskIndex Sub task index of this task
+	 */
+	void unregisterTask(JobVertexID vertexID, int subTaskIndex){
+		synchronized (this){
+			error();
+			if(handlers.containsKey(vertexID)){
+				boolean unregister = handlers.get(vertexID).unSubscribe(subTaskIndex);
+				if(unregister){
+					handlers.get(vertexID).shutDown();
+					handlers.remove(vertexID);
+				}
+			} else{
+				throw new RuntimeException("Task with vertex id: " + vertexID + " doesn't have any " +
+				" task message handler initialized.");
+			}
+		}
+	}
+
+	/**
+	 * Send a message to all parallel instance of task with {@link JobVertexID}
+	 *
+	 * Called from {@link TaskManager#handleMessage()}
+	 *
+	 * @param vertexID {@link JobVertexID} of the parallel tasks to send message to
+	 * @param message Message to be sent
+	 */
+	void sendToTask(JobVertexID vertexID, TaskMessage message){
+		synchronized (this){
+			if(handlers.containsKey(vertexID)){
+				handlers.get(vertexID).receive(message);
+			}
+			// otherwise just throw this message away. We're not meant to do anything to do with this
+			// message since this task is not registered with us.
+		}
+	}
+
+	private void error(){
+		if(isShutDown){
+			throw new RuntimeException("The Message handler has been shut down by the task manager.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -75,6 +75,8 @@ public class RuntimeEnvironment implements Environment {
 
 	private final AccumulatorRegistry accumulatorRegistry;
 
+	private TaskMessageHandler messageHandler;
+
 	// ------------------------------------------------------------------------
 
 	public RuntimeEnvironment(
@@ -96,7 +98,8 @@ public class RuntimeEnvironment implements Environment {
 			Map<String, Future<Path>> distCacheEntries,
 			ResultPartitionWriter[] writers,
 			InputGate[] inputGates,
-			ActorGateway jobManager) {
+			ActorGateway jobManager,
+			TaskMessageHandler messageHandler) {
 		
 		checkArgument(parallelism > 0 && subtaskIndex >= 0 && subtaskIndex < parallelism);
 
@@ -119,6 +122,7 @@ public class RuntimeEnvironment implements Environment {
 		this.writers = checkNotNull(writers);
 		this.inputGates = checkNotNull(inputGates);
 		this.jobManager = checkNotNull(jobManager);
+		this.messageHandler = checkNotNull(messageHandler);
 	}
 
 
@@ -177,6 +181,11 @@ public class RuntimeEnvironment implements Environment {
 	@Override
 	public MemoryManager getMemoryManager() {
 		return memManager;
+	}
+
+	@Override
+	public TaskMessageHandler getMessageHandler(){
+		return messageHandler;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskMessageHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskMessageHandler.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import org.apache.flink.api.common.messages.TaskMessage;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.messages.TaskMessages;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Message handler for all parallel instances of a {@link Task}
+ *
+ * 1. {@link TaskManager} has access to this handler and uses it to send messages to Tasks.
+ * 2. {@link org.apache.flink.api.common.functions.RuntimeContext} has access to this handler
+ *    and uses it to broadcast to its parallel instances and receive from its parallel instances.
+ */
+public class TaskMessageHandler{
+	// queue related fields
+	private TaskMessage[] data;
+	private HashMap<Integer, Integer> heads;
+	private int tail;
+	private int maxSize;
+
+	// send-receive related fields
+	private JobVertexID vertexID;
+	private ActorGateway gateway;
+	private boolean isShutDown;
+
+	/**-------------------------------------------------------------------------------------------------
+	 * MessageHandler methods
+	 * {@link #TaskMessageHandler(int, JobVertexID, ActorGateway)}} via {@link MessageHandler#registerTask(JobVertexID, int)}
+	 * {@link #receive(TaskMessage)} via {@link MessageHandler#sendToTask(JobVertexID, TaskMessage)}
+	 * {@link #subscribe(int)} via {@link MessageHandler#registerTask(JobVertexID, int)}
+	 * {@link #unSubscribe(int)} via {@link MessageHandler#unregisterTask(JobVertexID, int)}
+	 * {@link #shutDown()} via {@link MessageHandler#shutDown} and {@link MessageHandler#unregisterTask(JobVertexID, int)}
+	 ----------------------------------------------------------------------------------------------------*/
+	/**
+	 * Create a new instance of TaskMessageHandler to handle message for a particular task. This will be created
+	 * by the {@link TaskManager} and passed on to {@link org.apache.flink.api.common.functions.RuntimeContext}.
+	 * All parallel instances of a task running under the parent task manager will send and receive their
+	 * messages via this TaskMessageHandler.
+	 *
+	 * @param maxSize Maximum number of messages allowed to be store
+	 * @param vertexID Vertex ID in the {@link org.apache.flink.runtime.jobgraph.JobGraph} for this task
+	 * @param gateway Gateway to the {@link TaskManager}
+	 *
+	 */
+	public TaskMessageHandler(int maxSize, JobVertexID vertexID, ActorGateway gateway){
+		this.data = new TaskMessage[maxSize];
+		this.heads = new HashMap<Integer, Integer>();
+		this.tail = -1;
+		this.vertexID = vertexID;
+		this.gateway = gateway;
+		this.isShutDown = false;
+		this.maxSize = maxSize;
+	}
+
+	/**
+	 * Receive a message from the {@link MessageHandler}. This message is meant for all parallel running
+	 * instances of task with vertex ID {@link this.vertexID} and must be delivered to everyone.
+	 * Called by {@link MessageHandler}
+	 *
+	 * @param message Message to be provided to tasks with vertexID = {@link this.vertexID}
+	 */
+	void receive(TaskMessage message){
+		synchronized (this){
+			error();
+			if(tail == -1){
+				data[0] = message;
+				tail = 1 % maxSize;
+				return;
+			}
+			for(int head: heads.values()){
+				if(head == tail){
+					throw new RuntimeException("The message queue is full. Try improving your program to " +
+					"consume as fast as it produces. Or set a bigger queue size in your conf file");
+				}
+			}
+			data[tail] = message;
+			tail = (tail + 1) % maxSize;
+		}
+	}
+
+	/**
+	 * Subscribe the task with subTaskIndex to receive messages
+	 */
+	void subscribe(int subTaskIndex){
+		synchronized (this) {
+			if (heads.containsKey(subTaskIndex)) {
+				// maybe we should throw an exception. I'll come back to this.
+			} else {
+				// we'll give this parallel instance any messages we have in store.
+				heads.put(subTaskIndex, -1);
+			}
+		}
+	}
+
+	/**
+	 * Un-subscribe the task with subTaskIndex from receiving anything
+	 */
+	boolean unSubscribe(int subTaskIndex){
+		synchronized (this){
+			if(heads.containsKey(subTaskIndex)){
+				// like I said, maybe we throw an exception
+			} else{
+				heads.remove(subTaskIndex);
+			}
+			// if all tasks have unSubscribed, we can just shut ourselves down.
+			if(heads.size() == 0){
+				return true;
+			} else{
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * Shut down this task message handler. Clear out all resources.
+	 */
+	void shutDown(){
+		synchronized (this){
+			// clear out our heap memory
+			heads.clear();
+			data = null;
+			isShutDown = true;
+			tail = -1;
+		}
+	}
+
+	/** -----------------------------------------------------------------------------------------------------
+	 * User methods:
+	 * {@link #send(TaskMessage)} via {@link org.apache.flink.api.common.functions.RuntimeContext#broadcast}
+	 * {@link #fetch(int)} via {@link org.apache.flink.api.common.functions.RuntimeContext#receive}
+	 --------------------------------------------------------------------------------------------------------*/
+
+	/**
+	 * Broadcast a message to every {@link TaskManager} This will be received by every parallel running
+	 * instance of this task.
+	 *
+	 * @param message Message to be broadcasted
+	 */
+	public void send(TaskMessage message){
+		synchronized (this){
+			error();
+			gateway.tell(new TaskMessages.SelfBroadcast(new TaskMessages.RuntimeMessage(vertexID, message)));
+		}
+	}
+
+	/**
+	 * Make available every message meant for the task with vertex ID {@link this.vertexID} and index subTaskIndex.
+	 * This is on a only once basis, and once provided to a parallel instance, the messages will never be
+	 * provided to the same parallel instance ever again.
+	 *
+	 * @param subTaskIndex index of the task accessing the messages
+	 */
+	public List<TaskMessage> fetch(int subTaskIndex){
+		synchronized (this){
+			if(heads.containsKey(subTaskIndex)){
+				if(tail == -1){
+					return new LinkedList<TaskMessage>();
+				}
+				int head = (heads.get(subTaskIndex) + 1) % maxSize;
+				LinkedList<TaskMessage> result = new LinkedList<TaskMessage>();
+				if(head <= tail){
+					head = head + maxSize;
+				}
+				while(head < tail + maxSize){
+					result.add(data[head % maxSize]);
+					head++;
+				}
+				heads.put(subTaskIndex, head - maxSize - 1);
+				return result;
+			} else{
+				throw new RuntimeException("The sub task index: " + subTaskIndex + " has been unregistered from " +
+				"receiving any messages by the task manager.");
+			}
+		}
+	}
+
+	private void error(){
+		if(isShutDown){
+			throw new RuntimeException("Task Message handler associated with the vertex id: " + vertexID.toString() +
+			" has been shut down.");
+		}
+	}
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -47,6 +47,20 @@ object TaskManagerMessages {
   }
 
   /**
+   * Tells the task manager to fetch the list of current running task managers fromm the job manager
+   */
+  case object FetchTaskManagerList {
+
+    /**
+     * Accessor for the case object instance, to simplify Java interoperability.
+     * @return The FetchTaskManagerList case object instance
+     */
+    def get() : FetchTaskManagerList.type = FetchTaskManagerList
+  }
+
+  case class FetchTaskManagerList()
+
+  /**
    * Reports liveliness of the TaskManager instance with the given instance ID to the
    * This message is sent to the job. This message reports the TaskManagers
    * metrics, as a byte array.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskMessages.scala
@@ -21,9 +21,10 @@ package org.apache.flink.runtime.messages
 import org.apache.flink.runtime.deployment.{InputChannelDeploymentDescriptor, TaskDeploymentDescriptor}
 import org.apache.flink.runtime.execution.ExecutionState
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
-import org.apache.flink.runtime.jobgraph.{IntermediateDataSetID, IntermediateResultPartitionID}
+import org.apache.flink.runtime.jobgraph.{JobVertexID, IntermediateDataSetID, IntermediateResultPartitionID}
 import org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState
 import org.apache.flink.runtime.taskmanager.TaskExecutionState
+import org.apache.flink.api.common.messages.{TaskMessage => RuntimeTaskMessage}
 
 /**
  * A set of messages that control the deployment and the state of Tasks executed
@@ -181,4 +182,18 @@ object TaskMessages {
     new UpdateTaskMultiplePartitionInfos(executionID,
       resultIDs.asScala.zip(partitionInfos.asScala))
   }
+
+  case class RuntimeMessage(jobVertexID: JobVertexID, message: RuntimeTaskMessage){
+    def getVertexID: JobVertexID = jobVertexID
+    def getMessage: RuntimeTaskMessage = message
+  }
+  /**
+   * Message sent from the Message Handler to the Task Manager for broadcasting to everyone
+   */
+  case class SelfBroadcast(runtimeMessage: RuntimeMessage)
+
+  /**
+   * Message broadcasted by a task manager to every task manager.
+   */
+  case class RuntimeBroadcast(runtimeMessage: RuntimeMessage)
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -39,6 +39,7 @@ import grizzled.slf4j.Logger
 import org.apache.flink.configuration.{Configuration, ConfigConstants, GlobalConfiguration, IllegalConfigurationException}
 
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot
+import org.apache.flink.runtime.messages.JobManagerMessages.{RegisteredTaskManagers, RequestRegisteredTaskManagers}
 import org.apache.flink.runtime.messages.checkpoint.{NotifyCheckpointComplete, TriggerCheckpoint, AbstractCheckpointMessage}
 import org.apache.flink.runtime.{FlinkActor, LeaderSessionMessages, LogMessages, StreamingMode}
 import org.apache.flink.runtime.akka.AkkaUtils
@@ -49,7 +50,7 @@ import org.apache.flink.runtime.execution.librarycache.{BlobLibraryCacheManager,
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
 import org.apache.flink.runtime.filecache.FileCache
 import org.apache.flink.runtime.instance.{AkkaActorGateway, HardwareDescription,
-InstanceConnectionInfo, InstanceID}
+InstanceConnectionInfo, InstanceID, Instance}
 import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
 import org.apache.flink.runtime.io.disk.iomanager.{IOManager, IOManagerAsync}
 import org.apache.flink.runtime.io.network.NetworkEnvironment
@@ -124,7 +125,8 @@ class TaskManager(
     protected val memoryManager: MemoryManager,
     protected val ioManager: IOManager,
     protected val network: NetworkEnvironment,
-    protected val numberOfSlots: Int)
+    protected val numberOfSlots: Int,
+    protected val messageHandler: MessageHandler)
   extends FlinkActor
   with LeaderSessionMessages // Mixin order is important: second we want to filter leader messages
   with LogMessages // Mixin order is important: first we want to support message logging
@@ -169,9 +171,13 @@ class TaskManager(
 
   private var heartbeatScheduler: Option[Cancellable] = None
 
+  private var fetchTaskManagerListScheduler: Option[Cancellable] = None
+
   protected var leaderSessionID: Option[UUID] = None
 
   private var currentRegistrationSessionID: UUID = UUID.randomUUID()
+
+  private var taskManagerList: Iterable[Instance] = Iterable.empty
 
   // --------------------------------------------------------------------------
   //  Actor messages and life cycle
@@ -248,6 +254,8 @@ class TaskManager(
       case t: Exception => log.error("FileCache did not shutdown properly.", t)
     }
 
+    messageHandler.shutDown()
+
     log.info(s"Task manager ${self.path} is completely shut down.")
   }
 
@@ -282,6 +290,14 @@ class TaskManager(
         waitForRegistration += sender
       }
 
+    case FetchTaskManagerList =>
+      currentJobManager foreach {
+        jm => jm ! decorateMessage(RequestRegisteredTaskManagers)
+      }
+
+    case taskManagers: RegisteredTaskManagers =>
+      taskManagerList = taskManagers.taskManagers
+
     // this message indicates that some actor watched by this TaskManager has died
     case Terminated(actor: ActorRef) =>
       if (isConnected && actor == currentJobManager.orNull) {
@@ -291,6 +307,14 @@ class TaskManager(
         log.warn(s"Received unrecognized disconnect message " +
           s"from ${if (actor == null) null else actor.path}.")
       }
+
+    case SelfBroadcast(runtimeMessage) =>
+      taskManagerList.iterator.foreach(
+        taskManager => taskManager.getActorGateway.tell(RuntimeBroadcast(runtimeMessage))
+      )
+
+    case RuntimeBroadcast(runtimeMessage) =>
+      messageHandler.sendToTask(runtimeMessage.getVertexID, runtimeMessage.getMessage)
 
     case Disconnect(msg) =>
       handleJobManagerDisconnect(sender(), "JobManager requested disconnect: " + msg)
@@ -703,12 +727,16 @@ class TaskManager(
 
     // start the network stack, now that we have the JobManager actor reference
     try {
+      val tmGateway = new AkkaActorGateway(self, leaderSessionID)
       network.associateWithTaskManagerAndJobManager(
         new AkkaActorGateway(jobManager, leaderSessionID),
-        new AkkaActorGateway(self, leaderSessionID)
+        tmGateway
       )
 
-
+      messageHandler.setup(
+        tmGateway,
+        config.configuration.getInteger(ConfigConstants.TASK_MANAGER_MAX_TASK_MESSAGES, 50)
+      )
     }
     catch {
       case e: Exception =>
@@ -753,6 +781,16 @@ class TaskManager(
       )(context.dispatcher)
     )
 
+    // schedule regular messages to fetch other task manager instances
+    fetchTaskManagerListScheduler = Some(
+      context.system.scheduler.schedule(
+        TaskManager.FETCH_LIST_INITIAL_DELAY,
+        TaskManager.HEARTBEAT_INTERVAL,
+        self,
+        decorateMessage(FetchTaskManagerList)
+      )(context.dispatcher)
+    )
+
     // notify all the actors that listen for a successful registration
     for (listener <- waitForRegistration) {
       listener ! RegisteredAtJobManager
@@ -780,6 +818,11 @@ class TaskManager(
     }
     heartbeatScheduler = None
 
+    fetchTaskManagerListScheduler foreach {
+      _.cancel()
+    }
+    fetchTaskManagerListScheduler = None
+
     // stop the monitoring of the JobManager
     currentJobManager foreach {
       jm => context.unwatch(jm)
@@ -803,6 +846,8 @@ class TaskManager(
       service => service.shutdown()
     }
     blobService = None
+
+    messageHandler.shutDown()
 
     // disassociate the network environment
     network.disassociate()
@@ -892,7 +937,9 @@ class TaskManager(
         jobManagerGateway,
         config.timeout,
         libCache,
-        fileCache)
+        fileCache,
+        messageHandler.registerTask(tdd.getVertexID, tdd.getIndexInSubtaskGroup)
+      )
 
       log.info(s"Received task ${task.getTaskNameWithSubtasks}")
 
@@ -990,6 +1037,7 @@ class TaskManager(
         t.failExternally(cause)
       }
       runningTasks.clear()
+      messageHandler.shutDown()
     }
   }
 
@@ -1015,6 +1063,8 @@ class TaskManager(
         val registry = task.getAccumulatorRegistry
         registry.getSnapshot
       }
+
+      messageHandler.registerTask(task.getJobVertexId, task.getIndexInSubtaskGroup)
 
         self ! decorateMessage(
           UpdateTaskExecutionState(
@@ -1137,6 +1187,8 @@ object TaskManager {
   val DELAY_AFTER_REFUSED_REGISTRATION: FiniteDuration = 10 seconds
 
   val HEARTBEAT_INTERVAL: FiniteDuration = 5000 milliseconds
+
+  val FETCH_LIST_INITIAL_DELAY: FiniteDuration = 0 milliseconds
 
 
   // --------------------------------------------------------------------------
@@ -1596,6 +1648,8 @@ object TaskManager {
       LOG.info("HA mode.")
     }
 
+    val messageHandler = new MessageHandler()
+
     // create the actor properties (which define the actor constructor parameters)
     val tmProps = Props(
       taskManagerClass,
@@ -1605,7 +1659,8 @@ object TaskManager {
       memoryManager,
       ioManager,
       network,
-      taskManagerConfig.numberOfSlots)
+      taskManagerConfig.numberOfSlots,
+      messageHandler)
 
     taskManagerActorName match {
       case Some(actorName) => actorSystem.actorOf(tmProps, actorName)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.partition.consumer.IteratorWrappingTestSingleInputGate;
@@ -42,6 +43,7 @@ import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memorymanager.DefaultMemoryManager;
 import org.apache.flink.runtime.memorymanager.MemoryManager;
 import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.runtime.taskmanager.TaskMessageHandler;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.MutableObjectIterator;
 import org.mockito.invocation.InvocationOnMock;
@@ -276,5 +278,10 @@ public class MockEnvironment implements Environment {
 	@Override
 	public void acknowledgeCheckpoint(long checkpointId, StateHandle<?> state) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TaskMessageHandler getMessageHandler(){
+		return new TaskMessageHandler(0, new JobVertexID(), DummyActorGateway.INSTANCE);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -157,7 +157,8 @@ public class TaskAsyncCallTest {
 				DummyActorGateway.INSTANCE,
 				new FiniteDuration(60, TimeUnit.SECONDS),
 				libCache,
-				mock(FileCache.class));
+				mock(FileCache.class),
+				new TaskMessageHandler(0, new JobVertexID(), DummyActorGateway.INSTANCE));
 	}
 	
 	public static class CheckpointsInOrderInvokable extends AbstractInvokable

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -99,7 +99,7 @@ public class TaskManagerComponentsStartupShutdownTest {
 			// create the task manager
 			final Props tmProps = Props.create(TaskManager.class,
 					tmConfig, connectionInfo, jobManager.path().toString(),
-					memManager, ioManager, network, numberOfSlots);
+					memManager, ioManager, network, numberOfSlots, new MessageHandler());
 
 			final ActorRef taskManager = actorSystem.actorOf(tmProps);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -470,12 +470,20 @@ public class TaskManagerRegistrationTest {
 							message = expectMsgAnyClassOf(
 									TaskManagerMessages.getRegisteredAtJobManagerMessage().getClass(),
 									RegisterTaskManager.class,
-									TaskManagerMessages.Heartbeat.class);
+									TaskManagerMessages.Heartbeat.class,
+									TaskManagerMessages.FetchTaskManagerList.class);
 						}
 
 						tm.tell(JobManagerMessages.getRequestLeaderSessionID(), getTestActor());
 
-						expectMsgEquals(new JobManagerMessages.ResponseLeaderSessionID(Option.apply(trueLeaderSessionID)));
+						JobManagerMessages.ResponseLeaderSessionID expected =
+								new JobManagerMessages.ResponseLeaderSessionID(Option.apply(trueLeaderSessionID));
+
+						while(message == null || !(message.equals(expected))){
+							message = expectMsgAnyClassOf(
+									JobManagerMessages.ResponseLeaderSessionID.class,
+									JobManagerMessages.getRequestRegisteredTaskManagers().getClass());
+						}
 					}
 				};
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -53,10 +53,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.Tasks;
-import org.apache.flink.runtime.messages.Messages;
-import org.apache.flink.runtime.messages.RegistrationMessages;
-import org.apache.flink.runtime.messages.TaskManagerMessages;
-import org.apache.flink.runtime.messages.TaskMessages;
+import org.apache.flink.runtime.messages.*;
 import org.apache.flink.runtime.messages.TaskMessages.CancelTask;
 import org.apache.flink.runtime.messages.TaskMessages.PartitionState;
 import org.apache.flink.runtime.messages.TaskMessages.SubmitTask;
@@ -194,12 +191,14 @@ public class TaskManagerTest {
 										new TaskExecutionState(jid, eid, ExecutionState.FINISHED)));
 						
 						deadline = System.currentTimeMillis() + 10000;
+
 						do {
 							Object message = receiveOne(d);
 							if (message.equals(toRunning)) {
 								break;
 							}
-							else if (!(message instanceof TaskManagerMessages.Heartbeat)) {
+							else if (!(message instanceof TaskManagerMessages.Heartbeat)
+									&& !(message == JobManagerMessages.getRequestRegisteredTaskManagers())) {
 								fail("Unexpected message: " + message);
 							}
 						} while (System.currentTimeMillis() < deadline);
@@ -210,7 +209,8 @@ public class TaskManagerTest {
 							if (message.equals(toFinished)) {
 								break;
 							}
-							else if (!(message instanceof TaskManagerMessages.Heartbeat)) {
+							else if (!(message instanceof TaskManagerMessages.Heartbeat)
+									&& !(message == JobManagerMessages.getRequestRegisteredTaskManagers())) {
 								fail("Unexpected message: " + message);
 							}
 						} while (System.currentTimeMillis() < deadline);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
@@ -725,7 +726,8 @@ public class TaskTest {
 				jobManagerGateway,
 				new FiniteDuration(60, TimeUnit.SECONDS),
 				libCache,
-				mock(FileCache.class));
+				mock(FileCache.class),
+				new TaskMessageHandler(0, new JobVertexID(), DummyActorGateway.INSTANCE));
 	}
 
 	private TaskDeploymentDescriptor createTaskDeploymentDescriptor(Class<? extends AbstractInvokable> invokable) {

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.messages.JobManagerMessages.{ResponseLeaderSessi
 RequestLeaderSessionID}
 import org.apache.flink.runtime.messages.Messages.Disconnect
 import org.apache.flink.runtime.messages.TaskMessages.{UpdateTaskExecutionState, TaskInFinalState}
-import org.apache.flink.runtime.taskmanager.{TaskManagerConfiguration, TaskManager}
+import org.apache.flink.runtime.taskmanager.{MessageHandler, TaskManagerConfiguration, TaskManager}
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobRemoved
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages._
@@ -55,7 +55,8 @@ class TestingTaskManager(
     memoryManager: DefaultMemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
-    numberOfSlots: Int)
+    numberOfSlots: Int,
+    messageHandler: MessageHandler)
   extends TaskManager(
     config,
     connectionInfo,
@@ -63,7 +64,8 @@ class TestingTaskManager(
     memoryManager,
     ioManager,
     network,
-    numberOfSlots) {
+    numberOfSlots,
+    messageHandler) {
 
   import scala.collection.JavaConverters._
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.api.serialization.AdaptiveSpanningRecordDeserializer;
@@ -44,6 +45,7 @@ import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
 import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.runtime.taskmanager.TaskMessageHandler;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -289,6 +291,11 @@ public class StreamMockEnvironment implements Environment {
 
 	@Override
 	public void acknowledgeCheckpoint(long checkpointId, StateHandle<?> state) {
+	}
+
+	@Override
+	public TaskMessageHandler getMessageHandler(){
+		return new TaskMessageHandler(0, new JobVertexID(), DummyActorGateway.INSTANCE);
 	}
 }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/RichPartitionIterationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/RichPartitionIterationITCase.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.exampleJavaPrograms;
+
+import org.apache.flink.examples.java.runtime.RichPartitionIteration;
+import org.apache.flink.test.util.JavaProgramTestBase;
+
+
+public class RichPartitionIterationITCase extends JavaProgramTestBase {
+
+	@Override
+	protected boolean skipCollectionExecution(){
+		return true;
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		RichPartitionIteration.main(new String[]{});
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/SendOneMessageITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/SendOneMessageITCase.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.exampleJavaPrograms;
+
+import org.apache.flink.examples.java.runtime.SendOneMessage;
+import org.apache.flink.test.util.JavaProgramTestBase;
+
+
+
+public class SendOneMessageITCase extends JavaProgramTestBase {
+
+	@Override
+	protected boolean skipCollectionExecution(){
+		return true;
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		SendOneMessage.main(new String[]{});
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/SendTooManyMessagesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/SendTooManyMessagesITCase.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.exampleJavaPrograms;
+
+import org.apache.flink.examples.java.runtime.SendTooManyMessages;
+import org.junit.Test;
+
+
+public class SendTooManyMessagesITCase{
+
+	@Test
+	public void testProgram() throws Exception {
+		try {
+			SendTooManyMessages.main(new String[]{});
+		} catch(Exception e){
+			// expected
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/SendTwoMessagesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/exampleJavaPrograms/SendTwoMessagesITCase.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.exampleJavaPrograms;
+
+import org.apache.flink.examples.java.runtime.SendTwoMessages;
+import org.apache.flink.test.util.JavaProgramTestBase;
+
+
+public class SendTwoMessagesITCase extends JavaProgramTestBase {
+
+	@Override
+	protected boolean skipCollectionExecution(){
+		return true;
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		SendTwoMessages.main(new String[]{});
+	}
+}


### PR DESCRIPTION
This PR implements an interface for allowing users to broadcast messages to parallel running instances of a task, through `RuntimeContext`.
This allows for users to communicate with the parallel instances and share data. This of course lets one instance know the outputs being evaluated by the other instances which can further help with computation.
This can also be used to implement asynchronous iterations, as shown in the example `RichPartitionIteration`. Further, this can also be used to implement better statistics, by sharing data such as time per element, number of elements processed at each slot, etc. 
There are of course a few drawbacks:
1. Uses Akka for sending messages, which leads to an inherent limit on the size of messages being transmitted.
2. Limited number of messages: Tasks will need to consume the messages, not just keep broadcasting them. The message store is managed by the task manager on heap memory, so we need to keep the size in check. I've defined a conservative limit of 50 for now.
3. Some type casting: Users will need to cast the message received back into their intended message type. This can perhaps be solved using reflection. I haven't started working on this yet.

@tillrohrmann can you review this again? This is probably a complete re-design over the previous commit, and I have addressed the issues about too much memory consumption [an efficient multi-consumer queue] and allowing different tasks to set up their own message stores. 