### PR TITLE
Remove unwanted check null of input1 in ConnectedDataStream

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedDataStream.java
@@ -60,9 +60,8 @@ public class ConnectedDataStream<IN1, IN2> {
 	protected ConnectedDataStream(DataStream<IN1> input1, DataStream<IN2> input2) {
 		this.jobGraphBuilder = input1.streamGraph;
 		this.environment = input1.environment;
-		if (input1 != null) {
-			this.dataStream1 = input1.copy();
-		}
+		this.dataStream1 = input1.copy();
+		
 		if (input2 != null) {
 			this.dataStream2 = input2.copy();
 		}


### PR DESCRIPTION
input1 is used in line 61.If input1 is null ,it will throw NullPointException in line 61.So check null of input1  after use input1  is unwanted.