### PR TITLE
[FLINK-2472]Make JobClientActor poll JobManager continuously for updates on submitted job

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/Client.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/Client.java
@@ -370,7 +370,7 @@ public class Client {
 
 			try {
 				if (wait) {
-					return JobClient.submitJobAndWait(actorSystem,
+					return JobClient.submitJobAndWait(configuration, actorSystem,
 						jobManagerGateway, jobGraph, timeout, printStatusDuringExecution, userCodeClassLoader);
 				} else {
 					JobClient.submitJobDetached(jobManagerGateway, jobGraph, timeout, userCodeClassLoader);

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -54,7 +54,27 @@ public final class ConfigConstants {
 	public static final String DEFAULT_EXECUTION_RETRY_DELAY_KEY = "execution-retries.delay";
 	
 	// -------------------------------- Runtime -------------------------------
-	
+
+	/**
+	 * The heartbeat interval for the Job Client to poll Job Manager for status updates
+	 */
+	public static final String JOB_CLIENT_HEARTBEAT_INTERVAL = "client.heartbeat.interval";
+
+	/**
+	 * Initial delay for the Job Client to start checking on the Job Manager for status updates
+	 */
+	public static final String JOB_CLIENT_INITIAL_DELAY = "client.heartbeat.delay";
+
+	/**
+	 * Maximum time the job client waits for the job to go to running state, before failing it.
+	 */
+	public static final String JOB_CLIENT_JOB_STATUS_TIMEOUT = "client.timeout.jobstatus";
+
+	/**
+	 * Maximum time the Job Client waits for a message from Job Manager before considering it dead.
+	 */
+	public static final String JOB_CLIENT_JOB_MANAGER_TIMEOUT= "client.timeout.jobmanager";
+
 	/**
 	 * The config parameter defining the network address to connect to
 	 * for communication with the job manager.
@@ -257,7 +277,6 @@ public final class ConfigConstants {
 	 * for environments sharing a Flink installation between users)
 	 */
 	public static final String YARN_PROPERTIES_FILE_LOCATION = "yarn.properties-file.location";
-
 
 	// ------------------------ Hadoop Configuration ------------------------
 
@@ -600,6 +619,26 @@ public final class ConfigConstants {
 	 * The default timeout for filesystem stream opening: infinite (means max long milliseconds).
 	 */
 	public static final int DEFAULT_FS_STREAM_OPENING_TIMEOUT = 0;
+
+	/**
+	 * Default heartbeat interval for the Job Client to poll Job Manager for status updates
+	 */
+	public static final String DEFAULT_JOB_CLIENT_HEARTBEAT_INTERVAL = "5 s";
+
+	/**
+	 * Default initial delay for the Job Client to start checking on the Job Manager for status updates
+	 */
+	public static final String DEFAULT_JOB_CLIENT_INITIAL_DELAY = "500 ms";
+
+	/**
+	 * Default maximum time the Job Client waits for the job to go to running state, before failing it.
+	 */
+	public static final String DEFAULT_JOB_CLIENT_JOB_STATUS_TIMEOUT = "30 s";
+
+	/**
+	 * Default maximum time Job Client waits for a message from Job Manager before considering it dead.
+	 */
+	public static final String DEFAULT_JOB_CLIENT_JOB_MANAGER_TIMEOUT = "20 s";
 
 	// ------------------------ YARN Configuration ------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -128,6 +128,7 @@ public class JobClient {
 	 *                                                               execution fails.
 	 */
 	public static JobExecutionResult submitJobAndWait(
+			Configuration config,
 			ActorSystem actorSystem,
 			ActorGateway jobManagerGateway,
 			JobGraph jobGraph,
@@ -149,7 +150,8 @@ public class JobClient {
 				jobManagerGateway.actor(),
 				LOG,
 				sysoutLogUpdates,
-				jobManagerGateway.leaderSessionID());
+				jobManagerGateway.leaderSessionID(),
+				config);
 
 		ActorRef jobClientActor = actorSystem.actorOf(jobClientActorProps);
 		

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
@@ -19,17 +19,26 @@
 package org.apache.flink.runtime.client;
 
 import akka.actor.ActorRef;
+import akka.actor.Cancellable;
 import akka.actor.PoisonPill;
+import akka.actor.ReceiveTimeout;
 import akka.actor.Status;
 import akka.actor.Terminated;
 import com.google.common.base.Preconditions;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.ExecutionGraphMessages;
 import org.apache.flink.runtime.messages.JobClientMessages;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.slf4j.Logger;
+
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
 
 import java.util.UUID;
 
@@ -49,25 +58,127 @@ public class JobClientActor extends FlinkUntypedActor {
 	/** Actor which submits a job to the JobManager via this actor */
 	private ActorRef submitter;
 
-	public JobClientActor(ActorRef jobManager, Logger logger, boolean sysoutUpdates,
-			UUID leaderSessionID) {
+	// timeout for a message from the job manager
+	private static FiniteDuration JOB_CLIENT_JOB_MANAGER_TIMEOUT;
 
+	// heartbeat interval for pinging the job manager for job status
+	private static FiniteDuration JOB_CLIENT_HEARTBEAT_INTERVAL;
+
+	// initial time delay before starting pinging job manager over regular intervals
+	private static FiniteDuration JOB_CLIENT_INITIAL_PING_DELAY;
+
+	// maximum waiting time for a job to go to running status (milliseconds)
+	private static long JOB_CLIENT_JOB_STATUS_TIMEOUT;
+
+	// time at which the current job was created
+	private long currentJobCreatedAt;
+
+	// current job id
+	private JobID currentJobId;
+
+	// scheduler to ping JobManager after a time interval
+	private Cancellable scheduler;
+
+	// maintain when we got our last ping from the Job Manager.
+	private long jobManagerPinged = 0;
+
+	// maintain the last time we got a terminal state message
+	private long terminalStateAt = 0;
+
+
+	public JobClientActor(ActorRef jobManager, Logger logger, boolean sysoutUpdates,
+			UUID leaderSessionID, Configuration config) {
 		this.jobManager = Preconditions.checkNotNull(jobManager, "The JobManager ActorRef must not be null.");
 		this.logger = Preconditions.checkNotNull(logger, "The logger must not be null.");
 
 		this.leaderSessionID = leaderSessionID;
 		this.sysoutUpdates = sysoutUpdates;
+		// set this to 0 to indicate the job hasn't been created yet.
+		this.currentJobCreatedAt = 0;
+		this.terminalStateAt = 0;
+		parseTimes(config);
 	}
 	
 	@Override
 	protected void handleMessage(Object message) {
 		
+		// first see if the message was from the Job Manager
+		if (getContext().sender() == jobManager) {
+			this.jobManagerPinged = System.currentTimeMillis();
+		}
+
+		// ======= Job status messages on regular intervals ==============
+		if (message instanceof JobManagerMessages.CurrentJobStatus) {
+			JobStatus statusReport = ((JobManagerMessages.CurrentJobStatus) message).status();
+			long timeDiff;
+			switch (statusReport) {
+				case RUNNING:
+					// Vincent, we happy?
+					resetTimeouts();
+					break;
+				case FINISHED:
+					// Yeah! We happy!
+					resetTimeouts();
+					break;
+				case CREATED:
+					// we're still at Job CREATED. Let's see if we're over the limit.
+					timeDiff = (System.currentTimeMillis() - this.currentJobCreatedAt);
+					if (timeDiff > JOB_CLIENT_JOB_STATUS_TIMEOUT) {
+						failWithTimeout(timeDiff);
+					} // otherwise just wait a bit longer.
+					break;
+				case RESTARTING:
+					if (this.currentJobCreatedAt == 0) {
+						// we effectively have re-created the job
+						this.currentJobCreatedAt = System.currentTimeMillis();
+					}
+					else {
+						// it was already at either CREATED or RESTARTING. See if we're over the limit.
+						timeDiff = (System.currentTimeMillis() - this.currentJobCreatedAt);
+						if (timeDiff > JOB_CLIENT_JOB_STATUS_TIMEOUT) {
+							failWithTimeout(timeDiff);
+						} // otherwise let's wait a bit more.
+					}
+					break;
+				default:
+					if (this.terminalStateAt == 0) {
+						this.terminalStateAt = System.currentTimeMillis();
+					}
+					else {
+						timeDiff = (System.currentTimeMillis() - this.terminalStateAt);
+
+						if (timeDiff > JOB_CLIENT_JOB_STATUS_TIMEOUT) {
+							failWithTimeout(timeDiff);
+						}
+					}
+			}
+
+		}
 		// =========== State Change Messages ===============
 
 		if (message instanceof ExecutionGraphMessages.ExecutionStateChanged) {
 			logAndPrintMessage(message);
+			// if we get SCHEDULED, DEPLOYING, RUNNING OR FINISHED, we're okay :)
+			switch (((ExecutionGraphMessages.ExecutionStateChanged) message).newExecutionState()) {
+				case SCHEDULED:
+					resetTimeouts();
+					break;
+				case DEPLOYING:
+					resetTimeouts();
+					break;
+				case RUNNING:
+					// we don't wanna miss a running state
+					resetTimeouts();
+					break;
+				case FINISHED:
+					resetTimeouts();
+					break;
+				default:
+					// do nothing. This will be handled in the regular RequestJobStatus messages.
+			}
 		}
 		else if (message instanceof ExecutionGraphMessages.JobStatusChanged) {
+			// even though we're polling the Job Manager regularly, this is kept for logging purposes
 			logAndPrintMessage(message);
 		}
 
@@ -97,6 +208,9 @@ public class JobClientActor extends FlinkUntypedActor {
 								ListeningBehaviour.EXECUTION_RESULT_AND_STATE_CHANGES)),
 							getSelf());
 					
+					this.currentJobId = jobGraph.getJobID();
+					this.currentJobCreatedAt = System.currentTimeMillis();
+					getContext().setReceiveTimeout(JOB_CLIENT_JOB_MANAGER_TIMEOUT);
 					// make sure we notify the sender when the connection got lost
 					getContext().watch(jobManager);
 				}
@@ -108,7 +222,9 @@ public class JobClientActor extends FlinkUntypedActor {
 				getSender().tell(
 					decorateMessage(new Status.Failure(new Exception(msg))), ActorRef.noSender());
 
+				// cancel scheduler and inactivity triggered receive messages
 				getContext().unwatch(jobManager);
+				resetContextAndActor();
 				getSelf().tell(decorateMessage(PoisonPill.getInstance()), ActorRef.noSender());
 			}
 		}
@@ -128,11 +244,30 @@ public class JobClientActor extends FlinkUntypedActor {
 			
 			// we are done, stop ourselves
 			getContext().unwatch(jobManager);
+			resetContextAndActor();
 			getSelf().tell(decorateMessage(PoisonPill.getInstance()), ActorRef.noSender());
 		}
 		else if (message instanceof JobManagerMessages.JobSubmitSuccess) {
 			// job was successfully submitted :-)
+			// schedule to receive updates from Job manager after heartbeat interval
+			this.scheduler = getContext().system().scheduler().schedule(
+					JOB_CLIENT_INITIAL_PING_DELAY,
+					JOB_CLIENT_HEARTBEAT_INTERVAL,
+					jobManager,
+					decorateMessage(new JobManagerMessages.RequestJobStatus(currentJobId)),
+					getContext().dispatcher(),
+					self()
+			);
 			logger.info("Job was successfully submitted to the JobManager");
+		}
+
+		else if (message instanceof Status.Failure) {
+			// job execution failed, inform the actor that submitted the job
+			logger.debug("Received failure from JobManager", ((Status.Failure) message).cause());
+			if (submitter != null) {
+				submitter.tell(decorateMessage(message), sender());
+				resetContextAndActor();
+			}
 		}
 
 		// =========== Actor / Communication Failure ===============
@@ -142,16 +277,41 @@ public class JobClientActor extends FlinkUntypedActor {
 			if (jobManager.equals(target)) {
 				String msg = "Lost connection to JobManager " + jobManager.path();
 				logger.info(msg);
-				submitter.tell(decorateMessage(new Status.Failure(new Exception(msg))), getSelf());
-			} else {
+				submitter.tell(decorateMessage(new Status.Failure(new JobExecutionException(currentJobId, msg))), getSelf());
+				resetContextAndActor();
+			}
+			else {
 				logger.error("Received 'Terminated' for unknown actor " + target);
 			}
+		}
+
+		// ============= No messgaes received in the job manager timeout duration ========
+		else if (message instanceof ReceiveTimeout) {
+			double tolerance = 0.1 * JOB_CLIENT_JOB_MANAGER_TIMEOUT.toMillis();
+			if (System.currentTimeMillis() - jobManagerPinged < tolerance) {
+				// do nothing. This is a stray timeout message. It was enqueued but we still had a message just now.
+				// otherwise, this time difference must be close to the actual desired timeout. If not, akka screwed up. :')
+			}
+			String msg = "Connection to JobManager " + jobManager.path() + " timed out";
+			logger.info(msg);
+			submitter.tell(decorateMessage(new Status.Failure(new JobExecutionException(currentJobId, msg))), getSelf());
+			resetContextAndActor();
 		}
 
 		// =========== Unknown Messages ===============
 		
 		else {
 			logger.error("JobClient received unknown message: " + message);
+		}
+	}
+
+	private void failWithTimeout(long timeDiff) {
+		String msg = "Job hasn't been running for more than " + JOB_CLIENT_JOB_STATUS_TIMEOUT / 1.0e+3 + " seconds";
+
+		logger.debug(msg);
+		if (submitter != null) {
+			submitter.tell(decorateMessage(new Status.Failure(new JobExecutionException(currentJobId, msg))), sender());
+			resetContextAndActor();
 		}
 	}
 
@@ -165,5 +325,35 @@ public class JobClientActor extends FlinkUntypedActor {
 		if (sysoutUpdates) {
 			System.out.println(message.toString());
 		}
+	}
+
+	private void resetContextAndActor() {
+		scheduler.cancel();
+		this.currentJobCreatedAt = 0;
+		this.currentJobId = null;
+		getContext().setReceiveTimeout(Duration.Undefined());
+	}
+
+	private void parseTimes(Configuration config) {
+		// parse times from configuration
+		Duration job_client_heartbeat_interval = Duration.apply(config.getString(
+				ConfigConstants.JOB_CLIENT_HEARTBEAT_INTERVAL, ConfigConstants.DEFAULT_JOB_CLIENT_HEARTBEAT_INTERVAL));
+		Duration job_client_initial_delay = Duration.apply(config.getString(
+				ConfigConstants.JOB_CLIENT_INITIAL_DELAY, ConfigConstants.DEFAULT_JOB_CLIENT_INITIAL_DELAY));
+		Duration job_client_timeout_jobmanager = Duration.apply(config.getString(
+				ConfigConstants.JOB_CLIENT_JOB_MANAGER_TIMEOUT, ConfigConstants.DEFAULT_JOB_CLIENT_JOB_MANAGER_TIMEOUT));
+		Duration job_client_timeout_jobstatus = Duration.apply(config.getString(
+				ConfigConstants.JOB_CLIENT_JOB_STATUS_TIMEOUT, ConfigConstants.DEFAULT_JOB_CLIENT_JOB_STATUS_TIMEOUT));
+
+		JOB_CLIENT_HEARTBEAT_INTERVAL = new FiniteDuration(job_client_heartbeat_interval.length(), job_client_heartbeat_interval.unit());
+		JOB_CLIENT_INITIAL_PING_DELAY = new FiniteDuration(job_client_initial_delay.length(), job_client_initial_delay.unit());
+		JOB_CLIENT_JOB_MANAGER_TIMEOUT = new FiniteDuration(job_client_timeout_jobmanager.length(), job_client_timeout_jobmanager.unit());
+		JOB_CLIENT_JOB_STATUS_TIMEOUT = job_client_timeout_jobstatus.toMillis();
+
+	}
+
+	private void resetTimeouts() {
+		this.currentJobCreatedAt = 0;
+		this.terminalStateAt = 0;
 	}
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -412,6 +412,7 @@ abstract class FlinkMiniCluster(
          }
 
      JobClient.submitJobAndWait(
+       configuration,
        clientActorSystem,
        jobManagerGateway,
        jobGraph,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.client;
+
+import akka.actor.ActorSystem;
+import akka.testkit.JavaTestKit;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.client.utils.FakeTestingCluster;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class JobClientTest {
+
+	private static ActorSystem system;
+
+	protected Logger logger = LoggerFactory.getLogger(JobClientTest.class);
+
+	@Before
+	public void setup() {
+		system = AkkaUtils.createLocalActorSystem(new Configuration());
+	}
+
+	@After
+	public void teardown() {
+		JavaTestKit.shutdownActorSystem(system);
+	}
+
+	@Test
+	public void testJobManagerTimeout(){
+		new JavaTestKit(system){{
+			FakeTestingCluster cluster = null;
+			try{
+				cluster = new FakeTestingCluster("idle");
+				try {
+					JobClient.submitJobAndWait(
+							new Configuration(),
+							system,
+							cluster.getJobManagerGateway(),
+							new JobGraph("test graph"),
+							AkkaUtils.INF_TIMEOUT(),
+							false);
+				} catch(JobExecutionException e){
+					assertTrue(e.getMessage().contains("timed out"));
+				}
+			} catch(Exception e){
+				e.printStackTrace();
+				fail(e.getMessage());
+			} finally {
+				if(cluster != null){
+					cluster.stopCluster();
+				}
+			}
+		}};
+	}
+
+	@Test
+	public void testJobStuckCreated(){
+		new JavaTestKit(system){{
+			FakeTestingCluster cluster = null;
+			try{
+				cluster = new FakeTestingCluster("busy");
+				try {
+					JobClient.submitJobAndWait(
+							new Configuration(),
+							system,
+							cluster.getJobManagerGateway(),
+							new JobGraph("test graph"),
+							AkkaUtils.INF_TIMEOUT(),
+							false);
+				} catch(JobExecutionException e){
+					assertTrue(e.getMessage().contains("Job hasn't been running"));
+				}
+			} catch(Exception e){
+				e.printStackTrace();
+				fail(e.getMessage());
+			} finally {
+				if(cluster != null){
+					cluster.stopCluster();
+				}
+			}
+		}};
+	}
+
+	@Test
+	public void testJobStuckRestarting(){
+		new JavaTestKit(system){{
+			FakeTestingCluster cluster = null;
+			try{
+				cluster = new FakeTestingCluster("failed");
+				try {
+					JobClient.submitJobAndWait(
+							new Configuration(),
+							system,
+							cluster.getJobManagerGateway(),
+							new JobGraph("test graph"),
+							AkkaUtils.INF_TIMEOUT(),
+							false);
+				} catch(JobExecutionException e){
+					assertTrue(e.getMessage().contains("Job hasn't been running"));
+				}
+			} catch(Exception e){
+				e.printStackTrace();
+				fail(e.getMessage());
+			} finally {
+				if(cluster != null){
+					cluster.stopCluster();
+				}
+			}
+		}};
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/utils/FakeTestingCluster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/utils/FakeTestingCluster.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.client.utils;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.Status;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.akka.FlinkUntypedActor;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobmanager.JobManager;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import scala.Option;
+
+import java.util.UUID;
+
+/**
+ * A test fake job manager slash cluster which always accepts jobs and handles job status requests
+ * according to how it was constructed, the value of parameter mode.
+ */
+public class FakeTestingCluster{
+
+	private ActorRef jobManager;
+	private ActorSystem system;
+
+	public FakeTestingCluster(String mode){
+		system = AkkaUtils.createLocalActorSystem(new Configuration());
+		jobManager = system.actorOf(Props.create(TestingJobManager.class, mode));
+	}
+
+	public ActorGateway getJobManagerGateway() throws Exception{
+		return JobManager.getJobManagerGateway(jobManager, AkkaUtils.getTimeout(new Configuration()));
+	}
+
+	public void stopCluster(){
+		system.shutdown();
+	}
+}
+class TestingJobManager extends FlinkUntypedActor{
+
+	private final String mode;
+
+	private final Option<UUID> leaderSessionID = Option.apply(UUID.randomUUID());
+
+	private int count;
+
+	public TestingJobManager(String mode) {
+		this.mode = mode;
+		this.count = 0;
+	}
+
+	@Override
+	protected void handleMessage(Object message) {
+
+		// always accept a job :)
+		if(message instanceof JobManagerMessages.SubmitJob){
+			sender().tell(decorateMessage(new Status.Success(new JobID())),self());
+		}
+		// three modes to deal with status request messages
+		else if(message instanceof JobManagerMessages.RequestJobStatus){
+			// now the mode comes in.
+			if(mode.equals("idle")){
+				// do nothing. Let the Client actor think we're dead. :')
+			} else if(mode.equals("busy")){
+				// keep sending out a CREATED message. We're busy. Can't execute your job.
+				sender().tell(decorateMessage(new JobManagerMessages.CurrentJobStatus(new JobID(),JobStatus.CREATED)), self());
+			} else if(mode.equals("failed")){
+				// initially send out one CREATED message, then keep sending out RESTARTING message.
+				if(count == 0){
+					sender().tell(decorateMessage(new JobManagerMessages.CurrentJobStatus(new JobID(),JobStatus.CREATED)), self());
+					count++;
+				} else{
+					sender().tell(decorateMessage(new JobManagerMessages.CurrentJobStatus(new JobID(),JobStatus.RESTARTING)), self());
+				}
+			}
+		}
+		// this has to be done
+		else if(message == JobManagerMessages.getRequestLeaderSessionID()){
+			sender().tell(new JobManagerMessages.ResponseLeaderSessionID(this.leaderSessionID), self());
+		}
+	}
+
+	@Override
+	protected Option<UUID> getLeaderSessionID(){
+		return this.leaderSessionID;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -103,6 +103,7 @@ public class PartialConsumePipelinedResultTest {
 		receiver.setSlotSharingGroup(slotSharingGroup);
 
 		JobClient.submitJobAndWait(
+				new Configuration(),
 				jobClient,
 				flink.getLeaderGateway(TestingUtils.TESTING_DURATION()),
 				jobGraph,


### PR DESCRIPTION
This PR adds functionality for the `JobClientActor` to poll the `JobManager` after a set interval `JOB_CLIENT_HEARTBEAT_INTERVAL`(5s) about the status of submitted job.
Furthermore, there is a inherent timeout on the `JobClientActor` for not receiving any messages(only `JobManager` is likely to send any messages) for `JOB_CLIENT_JOB_MANAGER_TIMEOUT`(10s). This automatically handles the case where if the `JobManager` dies without notifying the actors watching it, we'd still have a way to terminate the `JobClientActor` because of the timeout.

If the job status comes as `CREATED` or `RESTARTING` for more than `JOB_CLIENT_JOB_STATUS_TIMEOUT`(30s), the `JobClient` is sent a `Status.Failure` message, which to equivalent to the idea mentioned in the jira ticket.
This work isn't complete, and I'd love feedback about whether different job status messages are handled properly, and what is the best place to place the time interval configuration. It can be placed in the usual place, i.e., `ConfigConstants` but there is no `Configuration` accessible in the `JobClientActor`.