### PR TITLE
[FLINK-2483]Add default branch of switch(scheduleMode) in scheduleForExecution function

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -666,6 +666,8 @@ public class ExecutionGraph implements Serializable {
 				case BACKTRACKING:
 					// go back from vertices that need computation to the ones we need to run
 					throw new JobException("BACKTRACKING is currently not supported as schedule mode.");
+				default:
+					throw new JobException("Schedule mode is invalid.");
 			}
 		}
 		else {


### PR DESCRIPTION
The scheduleMode in executionGraph is get from JobGraph, and JobGraph has not check the scheduleMode.So the default branch is necessary to avoid invalid scheduleMode.