### PR TITLE
[FLINK-2486]Remove unwanted null check in removeInstance function

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -676,10 +676,6 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener {
 	}
 	
 	private void removeInstance(Instance instance) {
-		if (instance == null) {
-			throw new NullPointerException();
-		}
-
 		allInstances.remove(instance);
 		instancesWithAvailableResources.remove(instance);
 		


### PR DESCRIPTION
removeInstance() is called in getFreeSlotForTask()/getNewSlotForSharingGroup()/handleNewSlot()/instanceDied()/newInstanceAvailable(). 
1.getFreeSlotForTask()/getNewSlotForSharingGroup()/handleNewSlot() only catch InstanceDiedException, if instance is null, removeInstance() will not work.
2.instanceDied()/newInstanceAvailable() has check instance ant the head of function,so the instance parameter of removeInstance() is not null.
So null check of instance  in removeInstance() is unwanted.