### PR TITLE
[FLINK-2307] Drop Java 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ language: java
 #See https://issues.apache.org/jira/browse/FLINK-1072
 matrix:
   include:
-    - jdk: "oraclejdk7"
+    - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.profile=1 -Dscala-2.11"
-    - jdk: "openjdk6" # this will also deploy a uberjar to s3 at some point
+    - jdk: "oraclejdk7" # this will also deploy a uberjar to s3 at some point
       env: PROFILE="-Dhadoop.profile=1"
     - jdk: "openjdk7"
       env: PROFILE="-P!include-yarn -Dhadoop.version=2.0.0-alpha"
-    - jdk: "openjdk6" # we must use openjdk6 here to deploy a java6 compatible uber-jar for YARN
+    - jdk: "oraclejdk7"
       env: PROFILE="-Dhadoop.version=2.2.0"
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.6.0 -Dscala-2.11 -Pinclude-tez -Dmaven.javadoc.skip=true"

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -231,8 +231,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.6</source> <!-- If you want to use Java 8, change this to "1.8" -->
-					<target>1.6</target> <!-- If you want to use Java 8, change this to "1.8" -->
+					<source>1.7</source> <!-- If you want to use Java 8, change this to "1.8" -->
+					<target>1.7</target> <!-- If you want to use Java 8, change this to "1.8" -->
 				</configuration>
 			</plugin>
 		</plugins>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -222,8 +222,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/flink-quickstart/flink-tez-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-tez-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -114,8 +114,8 @@ under the License.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source> <!-- If you want to use Java 8, change this to "1.8" -->
-                    <target>1.6</target> <!-- If you want to use Java 8, change this to "1.8" -->
+                    <source>1.7</source> <!-- If you want to use Java 8, change this to "1.8" -->
+                    <target>1.7</target> <!-- If you want to use Java 8, change this to "1.8" -->
                 </configuration>
             </plugin>
         </plugins>

--- a/flink-staging/flink-avro/pom.xml
+++ b/flink-staging/flink-avro/pom.xml
@@ -189,20 +189,4 @@ under the License.
 		</pluginManagement>
 	</build>
 
-	<profiles>
-		<profile>
-			<!-- A bug with java6 is causing the javadoc generation
-			to fail because the test case contains junit?
-			See https://github.com/stratosphere/stratosphere/pull/405#issuecomment-32591978
-			for further links -->
-			<id>disable-javadocs-in-java6</id>
-			<activation>
-				 <jdk>(,1.6]</jdk> <!-- disable javadocs for java6 or lower. -->
-			</activation>
-			<properties>
-				<maven.javadoc.skip>true</maven.javadoc.skip>
-			</properties>
-		</profile>
-	</profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -813,8 +813,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 					<!-- The output of Xlint is not show by default, but we activate it for the QA bot
 					to be able to get more warnings -->
 					<compilerArgument>-Xlint:all</compilerArgument>


### PR DESCRIPTION
This pull request updates Travis to use only "openjdk7", "oraclejdk7", and "oraclejdk8" for tests.

Root pom and quickstarts poms bump the Java version to 1.7.