### PR TITLE
[FLINK-2286] [streaming] Wrapped ParallelMerge into stream operator

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamFlatMap.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamFlatMap.java
@@ -81,4 +81,8 @@ public class CoStreamFlatMap<IN1, IN2, OUT>
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}
 	}
+
+	protected TimestampedCollector<OUT> getCollector() {
+		return collector;
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/ParallelMerge.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/ParallelMerge.java
@@ -139,4 +139,7 @@ public class ParallelMerge<OUT> extends
 		this.numberOfDiscretizers = getRuntimeContext().getNumberOfParallelSubtasks();
 	}
 
+	Map<Integer, Tuple2<StreamWindow<OUT>, Integer>> getReceivedWindows() {
+		return receivedWindows;
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/ParallelMergeOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/windowing/ParallelMergeOperator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.windowing;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.operators.co.CoStreamFlatMap;
+import org.apache.flink.streaming.api.windowing.StreamWindow;
+
+public class ParallelMergeOperator<OUT> extends CoStreamFlatMap<StreamWindow<OUT>, Tuple2<Integer, Integer>, StreamWindow<OUT>> {
+
+	private ParallelMerge<OUT> parallelMerge;
+
+	public ParallelMergeOperator(ParallelMerge<OUT> parallelMerge) {
+		super(parallelMerge);
+		this.parallelMerge = parallelMerge;
+	}
+
+	@Override
+	public void close() throws Exception {
+		// emit remaining (partial) windows
+
+		for (Tuple2<StreamWindow<OUT>, Integer> receivedWindow : parallelMerge.getReceivedWindows().values()) {
+			getCollector().collect(receivedWindow.f0);
+		}
+
+		super.close();
+	}
+}


### PR DESCRIPTION
Resolved the issue by wrapping the ParallelMerge function into a StreamOperator and emitting the remaining records at the end of the data processing.

This is not tested (automatically), as I could not reproduce the issue in a deterministic way (due to its behaviour depending on time).

It can be reproduced by changing the streaming WordCount to use windows:
```java
final StreamExecutionEnvironment env =
	StreamExecutionEnvironment.getExecutionEnvironment();

DataStreamSource<String> text = env.fromElements(
		"To be, or not to be,--that is the question:--",
		"Whether 'tis nobler in the mind to suffer"
);

DataStream<Tuple2<String, Integer>> counts =
text.flatMap(new Tokenizer())
		.window(Time.of(1000, TimeUnit.MILLISECONDS))
		.groupBy(0)
		.sum(1)
		.flatten();

counts.print();
```

This topology would print nothing before the fix.