### PR TITLE
[FLINK-2494 ]Fix StreamGraph getJobGraph bug

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -572,7 +572,7 @@ public class StreamGraph extends StreamingPlan {
 	public JobGraph getJobGraph(String jobGraphName) {
 		finalizeLoops();
 		// temporarily forbid checkpointing for iterative jobs
-		if (isIterative() && isCheckpointingEnabled() && !forceCheckpoint) {
+		if (isIterative() && isCheckpointingEnabled() && forceCheckpoint) {
 			throw new UnsupportedOperationException(
 					"Checkpointing is currently not supported by default for iterative jobs, as we cannot guarantee exactly once semantics. "
 							+ "State checkpoints happen normally, but records in-transit during the snapshot will be lost upon failure. "


### PR DESCRIPTION
When forceCheckpoint is true,checkpointing will be enabled for iterative jobs.But now temporarily  forbid checkpointing for iterative jobs, so if forceCheckpoint is true, will throw UnsupportedOperationException.
The old code logic is reversed.