### PR TITLE
[FLINK-2500][Streaming]remove a unwanted "if" branch

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -151,10 +151,10 @@ public class DataStream<OUT> {
 		this.iterationWaitTime = dataStream.iterationWaitTime;
 		this.unionedStreams = new ArrayList<DataStream<OUT>>();
 		this.unionedStreams.add(this);
-		if (dataStream.unionedStreams.size() > 1) {
-			for (int i = 1; i < dataStream.unionedStreams.size(); i++) {
-				this.unionedStreams.add(new DataStream<OUT>(dataStream.unionedStreams.get(i)));
-			}
+		
+		int size = dataStream.unionedStreams.size();
+		for (int i = 1; i < size; i++) {
+			this.unionedStreams.add(new DataStream<OUT>(dataStream.unionedStreams.get(i)));
 		}
 
 	}


### PR DESCRIPTION
This "if" is pointless since the "for" will do the same check.
And add a new temporary var(int size)  so that “dataStream.unionedStreams.size()” will just be called once.
Instead "dataStream.unionedStreams.size()" will be called every time when "i++" and it do harm to the performance.