### PR TITLE
[FLINK-2357] Update Node installation instructions

### DIFF
--- a/flink-runtime-web/README.md
+++ b/flink-runtime-web/README.md
@@ -60,14 +60,10 @@ The dashboard files are all pre-built, so one can try it out without building it
 Depending on your version of Linux or MacOS, you may need to manually install *node.js* and *bower*.
 
 
-#### Ubuntu Linux (12.04 and 14.04)
+#### Ubuntu Linux
 
-Install *node.js* via
-```
-sudo add-apt-repository ppa:chris-lea/node.js 
-sudo apt-get update
-sudo apt-get -y install nodejs
-```
+Install *node.js* by following [these instructions](https://github.com/joyent/node/wiki/installing-node.js-via-package-manager).
+
 Verify that the installed version is at least *2.11.3*, via `npm -version`.
 
 


### PR DESCRIPTION
I had some trouble installing Node while following the README. Apparently, from now on they are going to use a different PPA. Maybe it would be best to update the instructions and just point to https://github.com/joyent/node/wiki/installing-node.js-via-package-manager