### PR TITLE
[FLINK-2507]Rename the function tansformAndEmit

### DIFF
--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/AbstractStormCollector.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/AbstractStormCollector.java
@@ -82,7 +82,7 @@ abstract class AbstractStormCollector<OUT> {
 	 * @return the return value of {@link #doEmit(Object)}
 	 */
 	@SuppressWarnings("unchecked")
-	protected final List<Integer> tansformAndEmit(final List<Object> tuple) {
+	protected final List<Integer> transformAndEmit(final List<Object> tuple) {
 		List<Integer> taskIds;
 		if (this.numberOfAttributes > 0) {
 			assert (tuple.size() == this.numberOfAttributes);

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormBoltCollector.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormBoltCollector.java
@@ -72,7 +72,7 @@ class StormBoltCollector<OUT> extends AbstractStormCollector<OUT> implements IOu
 
 	@Override
 	public List<Integer> emit(final String streamId, final Collection<Tuple> anchors, final List<Object> tuple) {
-		return this.tansformAndEmit(tuple);
+		return this.transformAndEmit(tuple);
 	}
 
 	@Override

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormSpoutCollector.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormSpoutCollector.java
@@ -68,7 +68,7 @@ class StormSpoutCollector<OUT> extends AbstractStormCollector<OUT> implements IS
 
 	@Override
 	public List<Integer> emit(final String streamId, final List<Object> tuple, final Object messageId) {
-		return this.tansformAndEmit(tuple);
+		return this.transformAndEmit(tuple);
 	}
 
 


### PR DESCRIPTION
I think the function name "tansformAndEmit" in ' org.apache.flink.stormcompatibility.wrappers.AbstractStormCollector' is a wrong spelling, it should be "transformAndEmit" is more better.