### PR TITLE
[FLINK-2512]Add client.close() before throw RuntimeException

### DIFF
--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkSubmitter.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkSubmitter.java
@@ -99,24 +99,24 @@ public class FlinkSubmitter {
 
 		final String serConf = JSONValue.toJSONString(stormConf);
 
-		final FlinkClient client = FlinkClient.getConfiguredClient(stormConf);
-		if (client.getTopologyJobId(name) != null) {
-			client.close();
-			throw new RuntimeException("Topology with name `" + name + "` already exists on cluster");
-		}
-		String localJar = System.getProperty("storm.jar");
-		if (localJar == null) {
-			try {
-				for (final File file : ((ContextEnvironment) ExecutionEnvironment.getExecutionEnvironment())
-						.getJars()) {
-					// TODO verify that there is onnly one jar
-					localJar = file.getAbsolutePath();
-				}
-			} catch (final ClassCastException e) {
-				// ignore
-			}
-		}
 		try {
+			final FlinkClient client = FlinkClient.getConfiguredClient(stormConf);
+			if (client.getTopologyJobId(name) != null) {
+				throw new RuntimeException("Topology with name `" + name + "` already exists on cluster");
+			}
+			String localJar = System.getProperty("storm.jar");
+			if (localJar == null) {
+				try {
+					for (final File file : ((ContextEnvironment) ExecutionEnvironment.getExecutionEnvironment())
+							.getJars()) {
+						// TODO verify that there is onnly one jar
+						localJar = file.getAbsolutePath();
+					}
+				} catch (final ClassCastException e) {
+					// ignore
+				}
+			}
+
 			logger.info("Submitting topology " + name + " in distributed mode with conf " + serConf);
 			client.submitTopologyWithOpts(name, localJar, topology);
 		} catch (final InvalidTopologyException e) {

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkSubmitter.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkSubmitter.java
@@ -101,6 +101,7 @@ public class FlinkSubmitter {
 
 		final FlinkClient client = FlinkClient.getConfiguredClient(stormConf);
 		if (client.getTopologyJobId(name) != null) {
+			client.close();
 			throw new RuntimeException("Topology with name `" + name + "` already exists on cluster");
 		}
 		String localJar = System.getProperty("storm.jar");

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkSubmitter.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkSubmitter.java
@@ -99,8 +99,8 @@ public class FlinkSubmitter {
 
 		final String serConf = JSONValue.toJSONString(stormConf);
 
+		final FlinkClient client = FlinkClient.getConfiguredClient(stormConf);
 		try {
-			final FlinkClient client = FlinkClient.getConfiguredClient(stormConf);
 			if (client.getTopologyJobId(name) != null) {
 				throw new RuntimeException("Topology with name `" + name + "` already exists on cluster");
 			}


### PR DESCRIPTION
In line 129, it close client in finally{} before throw exception.
But in line 105, it throw exception without close client.
So I think it is better to close client before throw RuntimeException.