### PR TITLE
[CLEANUP] Add space between quotes and plus sign in String concat for readability in flink-yarn module

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnClient.java
@@ -167,8 +167,8 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 	@Override
 	public void setJobManagerMemory(int memoryMb) {
 		if(memoryMb < MIN_JM_MEMORY) {
-			throw new IllegalArgumentException("The JobManager memory ("+memoryMb+") is below the minimum required memory amount "
-					+ "of "+MIN_JM_MEMORY+" MB");
+			throw new IllegalArgumentException("The JobManager memory (" + memoryMb + ") is below the minimum required memory amount "
+					+ "of " + MIN_JM_MEMORY+ " MB");
 		}
 		this.jobManagerMemoryMb = memoryMb;
 	}
@@ -176,8 +176,8 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 	@Override
 	public void setTaskManagerMemory(int memoryMb) {
 		if(memoryMb < MIN_TM_MEMORY) {
-			throw new IllegalArgumentException("The TaskManager memory ("+memoryMb+") is below the minimum required memory amount "
-					+ "of "+MIN_TM_MEMORY+" MB");
+			throw new IllegalArgumentException("The TaskManager memory (" + memoryMb + ") is below the minimum required memory amount "
+					+ "of " + MIN_TM_MEMORY+ " MB");
 		}
 		this.taskManagerMemoryMb = memoryMb;
 	}
@@ -208,7 +208,7 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 	@Override
 	public void setLocalJarPath(Path localJarPath) {
 		if(!localJarPath.toString().endsWith("jar")) {
-			throw new IllegalArgumentException("The passed jar path ('"+localJarPath+"') does not end with the 'jar' extension");
+			throw new IllegalArgumentException("The passed jar path ('" + localJarPath + "') does not end with the 'jar' extension");
 		}
 		this.flinkJarPath = localJarPath;
 	}
@@ -385,7 +385,7 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 				LOG.debug("The YARN cluster does not have any queues configured");
 			}
 		} catch(Throwable e) {
-			LOG.warn("Error while getting queue information from YARN: "+e.getMessage());
+			LOG.warn("Error while getting queue information from YARN: " + e.getMessage());
 			if(LOG.isDebugEnabled()) {
 				LOG.debug("Error details", e);
 			}
@@ -398,7 +398,7 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 		final int yarnMinAllocationMB = conf.getInt("yarn.scheduler.minimum-allocation-mb", 0);
 		if(jobManagerMemoryMb < yarnMinAllocationMB || taskManagerMemoryMb < yarnMinAllocationMB) {
 			LOG.warn("The JobManager or TaskManager memory is below the smallest possible YARN Container size. "
-					+ "The value of 'yarn.scheduler.minimum-allocation-mb' is '"+yarnMinAllocationMB+"'. Please increase the memory size." +
+					+ "The value of 'yarn.scheduler.minimum-allocation-mb' is '" + yarnMinAllocationMB + "'. Please increase the memory size." +
 					"YARN will allocate the smaller containers but the scheduler will account for the minimum-allocation-mb, maybe not all instances " +
 					"you requested will start.");
 		}
@@ -416,13 +416,13 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 		if(jobManagerMemoryMb > maxRes.getMemory() ) {
 			failSessionDuringDeployment();
 			throw new YarnDeploymentException("The cluster does not have the requested resources for the JobManager available!\n"
-					+ "Maximum Memory: "+maxRes.getMemory() + "MB Requested: "+jobManagerMemoryMb+"MB. " + NOTE);
+					+ "Maximum Memory: " + maxRes.getMemory() + "MB Requested: " + jobManagerMemoryMb + "MB. " + NOTE);
 		}
 
 		if(taskManagerMemoryMb > maxRes.getMemory() ) {
 			failSessionDuringDeployment();
 			throw new YarnDeploymentException("The cluster does not have the requested resources for the TaskManagers available!\n"
-					+ "Maximum Memory: " + maxRes.getMemory() + " Requested: "+taskManagerMemoryMb + "MB. " + NOTE);
+					+ "Maximum Memory: " + maxRes.getMemory() + " Requested: " + taskManagerMemoryMb + "MB. " + NOTE);
 		}
 
 		final String NOTE_RSC = "\nThe Flink YARN client will try to allocate the YARN session, but maybe not all TaskManagers are " +
@@ -437,8 +437,8 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 
 		}
 		if(taskManagerMemoryMb > freeClusterMem.containerLimit) {
-			LOG.warn("The requested amount of memory for the TaskManagers ("+taskManagerMemoryMb+"MB) is more than "
-					+ "the largest possible YARN container: "+freeClusterMem.containerLimit + NOTE_RSC);
+			LOG.warn("The requested amount of memory for the TaskManagers (" + taskManagerMemoryMb + "MB) is more than "
+					+ "the largest possible YARN container: " + freeClusterMem.containerLimit + NOTE_RSC);
 		}
 		if(jobManagerMemoryMb > freeClusterMem.containerLimit) {
 			LOG.warn("The requested amount of memory for the JobManager (" + jobManagerMemoryMb + "MB) is more than "
@@ -451,14 +451,15 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 		// first, allocate the jobManager somewhere.
 		if(!allocateResource(nmFree, jobManagerMemoryMb)) {
 			LOG.warn("Unable to find a NodeManager that can fit the JobManager/Application master. " +
-					"The JobManager requires " + jobManagerMemoryMb + "MB. NodeManagers available: "+Arrays.toString(freeClusterMem.nodeManagersFree) + NOTE_RSC);
+					"The JobManager requires " + jobManagerMemoryMb + "MB. NodeManagers available: " +
+					Arrays.toString(freeClusterMem.nodeManagersFree) + NOTE_RSC);
 		}
 		// allocate TaskManagers
 		for(int i = 0; i < taskManagerCount; i++) {
 			if(!allocateResource(nmFree, taskManagerMemoryMb)) {
 				LOG.warn("There is not enough memory available in the YARN cluster. " +
 						"The TaskManager(s) require " + taskManagerMemoryMb + "MB each. " +
-						"NodeManagers available: "+Arrays.toString(freeClusterMem.nodeManagersFree) + "\n" +
+						"NodeManagers available: " + Arrays.toString(freeClusterMem.nodeManagersFree) + "\n" +
 						"After allocating the JobManager (" + jobManagerMemoryMb + "MB) and (" + i + "/" + taskManagerCount + ") TaskManagers, " +
 						"the following NodeManagers are available: " + Arrays.toString(nmFree)  + NOTE_RSC );
 			}
@@ -486,10 +487,10 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 				.newRecord(ContainerLaunchContext.class);
 
 		String amCommand = "$JAVA_HOME/bin/java"
-					+ " -Xmx"+Utils.calculateHeapSize(jobManagerMemoryMb, flinkConfiguration)+"M " +javaOpts;
+					+ " -Xmx" + Utils.calculateHeapSize(jobManagerMemoryMb, flinkConfiguration) + "M " +javaOpts;
 
 		if(hasLogback || hasLog4j) {
-			amCommand += " -Dlog.file=\""+ApplicationConstants.LOG_DIR_EXPANSION_VAR +"/jobmanager-main.log\"";
+			amCommand += " -Dlog.file=\"" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/jobmanager-main.log\"";
 		}
 
 		if(hasLogback) {
@@ -499,13 +500,13 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 			amCommand += " -Dlog4j.configuration=file:" + FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME;
 		}
 
-		amCommand 	+= " "+ApplicationMaster.class.getName()+" "
+		amCommand 	+= " " + ApplicationMaster.class.getName() + " "
 					+ " 1>"
 					+ ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/jobmanager-stdout.log"
 					+ " 2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/jobmanager-stderr.log";
 		amContainer.setCommands(Collections.singletonList(amCommand));
 
-		LOG.debug("Application Master start command: "+amCommand);
+		LOG.debug("Application Master start command: " + amCommand);
 
 		// intialize HDFS
 		// Copy the application master jar to the filesystem
@@ -538,7 +539,7 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 
 		// setup security tokens (code from apache storm)
 		final Path[] paths = new Path[2 + shipFiles.size()];
-		StringBuffer envShipFileList = new StringBuffer();
+		StringBuilder envShipFileList = new StringBuilder();
 		// upload ship files
 		for (int i = 0; i < shipFiles.size(); i++) {
 			File shipFile = shipFiles.get(i);
@@ -594,7 +595,7 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 
 		String name;
 		if(customName == null) {
-			name = "Flink session with "+taskManagerCount+" TaskManagers";
+			name = "Flink session with " + taskManagerCount + " TaskManagers";
 			if(detached) {
 				name += " (detached)";
 			}
@@ -623,16 +624,16 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 				case FINISHED:
 				case KILLED:
 					throw new YarnDeploymentException("The YARN application unexpectedly switched to state "
-							+ appState +" during deployment. \n" +
-							"Diagnostics from YARN: "+report.getDiagnostics() + "\n" +
+							+ appState + " during deployment. \n" +
+							"Diagnostics from YARN: " + report.getDiagnostics() + "\n" +
 							"If log aggregation is enabled on your cluster, use this command to further invesitage the issue:\n" +
-							"yarn logs -applicationId "+appId);
+							"yarn logs -applicationId " + appId);
 					//break ..
 				case RUNNING:
 					LOG.info("YARN application has been deployed successfully.");
 					break loop;
 				default:
-					LOG.info("Deploying cluster, current state "+appState);
+					LOG.info("Deploying cluster, current state " + appState);
 					if(waittime > 60000) {
 						LOG.info("Deployment took more than 60 seconds. Please check if the requested resources are available in the YARN cluster");
 					}
@@ -714,16 +715,17 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 			totalMemory += res.getMemory();
 			totalCores += res.getVirtualCores();
 			ps.format(format, "NodeID", rep.getNodeId());
-			ps.format(format, "Memory", res.getMemory()+" MB");
+			ps.format(format, "Memory", res.getMemory() + " MB");
 			ps.format(format, "vCores", res.getVirtualCores());
 			ps.format(format, "HealthReport", rep.getHealthReport());
 			ps.format(format, "Containers", rep.getNumContainers());
 			ps.println("+---------------------------------------+");
 		}
-		ps.println("Summary: totalMemory "+totalMemory+" totalCores "+totalCores);
+		ps.println("Summary: totalMemory " + totalMemory + " totalCores " + totalCores);
 		List<QueueInfo> qInfo = yarnClient.getAllQueues();
 		for(QueueInfo q : qInfo) {
-			ps.println("Queue: "+q.getQueueName()+", Current Capacity: "+q.getCurrentCapacity()+" Max Capacity: "+q.getMaximumCapacity()+" Applications: "+q.getApplications().size());
+			ps.println("Queue: " + q.getQueueName() + ", Current Capacity: " + q.getCurrentCapacity() + " Max Capacity: " +
+					q.getMaximumCapacity() + " Applications: " + q.getApplications().size());
 		}
 		yarnClient.stop();
 		return baos.toString();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
@@ -282,7 +282,7 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 		} else if(clusterStatus instanceof Some) {
 			return (FlinkYarnClusterStatus) (((Some) clusterStatus).get());
 		} else {
-			throw new RuntimeException("Unexpected type: "+clusterStatus.getClass().getCanonicalName());
+			throw new RuntimeException("Unexpected type: " + clusterStatus.getClass().getCanonicalName());
 		}
 	}
 
@@ -368,9 +368,9 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 
 					if(obj instanceof Messages.YarnMessage) {
 						Messages.YarnMessage msg = (Messages.YarnMessage) obj;
-						ret.add("["+msg.date()+"] "+msg.message());
+						ret.add("[" + msg.date() + "] " + msg.message());
 					} else {
-						LOG.warn("LocalGetYarnMessage returned unexpected type: "+messageOption);
+						LOG.warn("LocalGetYarnMessage returned unexpected type: " + messageOption);
 					}
 				}
 			}
@@ -429,7 +429,7 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 			actorSystem = null;
 		}
 
-		LOG.info("Deleting files in "+sessionFilesDir );
+		LOG.info("Deleting files in " + sessionFilesDir );
 		try {
 			FileSystem shutFS = FileSystem.get(hadoopConfig);
 			shutFS.delete(sessionFilesDir, true); // delete conf and jar file.
@@ -522,7 +522,7 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 			}
 			if(running.get() && !yarnClient.isInState(Service.STATE.STARTED)) {
 				// == if the polling thread is still running but the yarn client is stopped.
-				LOG.warn("YARN client is unexpected in state "+yarnClient.getServiceState());
+				LOG.warn("YARN client is unexpected in state " + yarnClient.getServiceState());
 			}
 		}
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -60,10 +60,10 @@ public class Utils {
 		int minCutoff = conf.getInteger(ConfigConstants.YARN_HEAP_CUTOFF_MIN, ConfigConstants.DEFAULT_YARN_MIN_HEAP_CUTOFF);
 
 		if (memoryCutoffRatio > 1 || memoryCutoffRatio < 0) {
-			throw new IllegalArgumentException("The configuration value '"+ConfigConstants.YARN_HEAP_CUTOFF_RATIO+"' must be between 0 and 1. Value given="+memoryCutoffRatio);
+			throw new IllegalArgumentException("The configuration value '" + ConfigConstants.YARN_HEAP_CUTOFF_RATIO + "' must be between 0 and 1. Value given=" + memoryCutoffRatio);
 		}
 		if (minCutoff > memory) {
-			throw new IllegalArgumentException("The configuration value '"+ConfigConstants.YARN_HEAP_CUTOFF_MIN +"' is higher ("+minCutoff+") than the requested amount of memory "+memory);
+			throw new IllegalArgumentException("The configuration value '" + ConfigConstants.YARN_HEAP_CUTOFF_MIN + "' is higher (" + minCutoff + ") than the requested amount of memory " + memory);
 		}
 
 		int heapLimit = (int)((float)memory * memoryCutoffRatio);
@@ -94,7 +94,7 @@ public class Utils {
 		
 		Path dst = new Path(homedir, suffix);
 		
-		LOG.info("Copying from "+localRsrcPath+" to "+dst );
+		LOG.info("Copying from " + localRsrcPath + " to " + dst );
 		fs.copyFromLocalFile(localRsrcPath, dst);
 		registerLocalResource(fs, dst, appMasterJar);
 		return dst;
@@ -119,7 +119,7 @@ public class Utils {
 		Collection<Token<? extends TokenIdentifier>> usrTok = currUsr.getTokens();
 		for(Token<? extends TokenIdentifier> token : usrTok) {
 			final Text id = new Text(token.getIdentifier());
-			LOG.info("Adding user token "+id+" with "+token);
+			LOG.info("Adding user token " + id + " with " + token);
 			credentials.addToken(id, token);
 		}
 		DataOutputBuffer dob = new DataOutputBuffer();
@@ -138,7 +138,7 @@ public class Utils {
 			
 			@Override
 			public boolean accept(File dir, String name) {
-				logger.info(dir.getAbsolutePath()+"/"+name);
+				logger.info(dir.getAbsolutePath() + "/" + name);
 				return true;
 			}
 		});

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/appMaster/YarnTaskManagerRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/appMaster/YarnTaskManagerRunner.java
@@ -82,8 +82,8 @@ public class YarnTaskManagerRunner {
 					"specified in the Flink config: " + flinkTempDirs);
 		}
 
-		LOG.info("YARN daemon runs as '" + UserGroupInformation.getCurrentUser().getShortUserName()
-				+"' setting user to execute Flink TaskManager to '"+yarnClientUsername+"'");
+		LOG.info("YARN daemon runs as '" + UserGroupInformation.getCurrentUser().getShortUserName() +
+				"' setting user to execute Flink TaskManager to '" + yarnClientUsername + "'");
 
 		// tell akka to die in case of an error
 		configuration.setBoolean(ConfigConstants.AKKA_JVM_EXIT_ON_FATAL_ERROR, true);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -62,7 +62,7 @@ public class FlinkYarnSessionCliTest {
 			cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar", "-n", "15", "-D", "akka.ask.timeout=5 min"});
 		} catch(Exception e) {
 			e.printStackTrace();
-			Assert.fail("Parsing failed with "+e.getMessage());
+			Assert.fail("Parsing failed with " + e.getMessage());
 		}
 
 		AbstractFlinkYarnClient flinkYarnClient = cli.createFlinkYarnClient(cmd);


### PR DESCRIPTION
While working on Flink on YARN, do some simple nit cleanups to add space between quote and plus sign for readability in yarn module for readability.

Use StringBuilder instad of StringBuffer in FlinkYarnClient since the String materializes immediately, so no need synchronize protection.