### PR TITLE
[FLINK-2516]Remove unwanted log.isInfoEnabled check

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -192,9 +192,7 @@ class TaskManager(
     log.info(s"TaskManager has $numberOfSlots task slot(s).")
 
     // log the initial memory utilization
-    if (log.isInfoEnabled) {
-      log.info(MemoryLogger.getMemoryUsageStatsAsString(ManagementFactory.getMemoryMXBean))
-    }
+    log.info(MemoryLogger.getMemoryUsageStatsAsString(ManagementFactory.getMemoryMXBean))
 
     // kick off the registration
     val deadline: Option[Deadline] = config.maxRegistrationDuration.map(_.fromNow)


### PR DESCRIPTION
The function has call log.info() at the head of  it.So i think the check of log.isInfoEnabled after call log.info() is unwanted.