### PR TITLE
[FLINK-2521] [tests] Adds automatic test name and reason of failure logging 

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/io/SequentialFormatTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/SequentialFormatTestBase.java
@@ -33,6 +33,7 @@ import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
+import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,7 +43,7 @@ import org.junit.runners.Parameterized.Parameters;
 /**
  * Test base for {@link org.apache.flink.api.common.io.BinaryInputFormat} and {@link org.apache.flink.api.common.io.BinaryOutputFormat}.
  */
-public abstract class SequentialFormatTestBase<T> {
+public abstract class SequentialFormatTestBase<T> extends TestLogger {
 
 	public class InputSplitSorter implements Comparator<FileInputSplit> {
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ComparatorTestBase.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.*;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ import org.junit.Test;
  *
  * @param <T>
  */
-public abstract class ComparatorTestBase<T> {
+public abstract class ComparatorTestBase<T> extends TestLogger {
 
 	// Same as in the NormalizedKeySorter
 	private static final int DEFAULT_MAX_NORMALIZED_KEY_LEN = 8;

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -31,6 +31,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 
 import org.apache.commons.lang3.SerializationException;
@@ -47,7 +48,7 @@ import org.junit.Test;
  * (JodaTime DataTime) with the default KryoSerializer used to pass this test but the
  * internal state would be corrupt, which becomes evident when toString is called.
  */
-public abstract class SerializerTestBase<T> {
+public abstract class SerializerTestBase<T> extends TestLogger {
 	
 	protected abstract TypeSerializer<T> createSerializer();
 	

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -25,18 +25,18 @@ import static org.junit.Assert.fail;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 /**
  * This class contains test for the configuration package. In particular, the serialization of {@link Configuration}
  * objects is tested.
  */
-public class ConfigurationTest {
+public class ConfigurationTest extends TestLogger {
 	
 	private static final byte[] EMPTY_BYTES = new byte[0];
 	private static final long TOO_LONG = Integer.MAX_VALUE + 10L;
 	private static final double TOO_LONG_DOUBLE = Double.MAX_VALUE;
-	
 
 	/**
 	 * This test checks the serialization/deserialization of configuration objects.

--- a/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
@@ -27,13 +27,14 @@ import java.io.PrintWriter;
 import java.lang.reflect.Field;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.util.TestLogger;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
  * This class contains tests for the global configuration (parsing configuration directory information).
  */
-public class GlobalConfigurationTest {
+public class GlobalConfigurationTest extends TestLogger {
 
 	@Before
 	public void resetSingleton() throws SecurityException, NoSuchFieldException, IllegalArgumentException,

--- a/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -34,7 +35,7 @@ import java.util.Map;
  * This class verifies that the Unmodifiable Configuration class overrides all setter methods in
  * Configuration.
  */
-public class UnmodifiableConfigurationTest {
+public class UnmodifiableConfigurationTest extends TestLogger {
 	
 	@Test
 	public void testOverrideAddMethods() {

--- a/flink-core/src/test/java/org/apache/flink/types/parser/ParserTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/ParserTestBase.java
@@ -26,13 +26,14 @@ import static org.junit.Assert.fail;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 
 /**
  *
  */
-public abstract class ParserTestBase<T> {
+public abstract class ParserTestBase<T> extends TestLogger {
 	
 	public abstract String[] getValidTestValues();
 	

--- a/flink-core/src/test/java/org/apache/flink/util/AbstractIDTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/AbstractIDTest.java
@@ -30,7 +30,7 @@ import java.nio.ByteBuffer;
 /**
  * This class contains tests for the {@link org.apache.flink.util.AbstractID} class.
  */
-public class AbstractIDTest {
+public class AbstractIDTest extends TestLogger {
 	/**
 	 * Tests the serialization/deserialization of an abstract ID.
 	 */

--- a/flink-core/src/test/java/org/apache/flink/util/InstantiationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/InstantiationUtilTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class InstantiationUtilTest {
+public class InstantiationUtilTest extends TestLogger {
 
 	@Test
 	public void testInstantiationOfStringValue() {

--- a/flink-core/src/test/java/org/apache/flink/util/NumberSequenceIteratorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NumberSequenceIteratorTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 
-public class NumberSequenceIteratorTest {
+public class NumberSequenceIteratorTest extends TestLogger {
 
 	@Test
 	public void testSplitRegular() {

--- a/flink-core/src/test/java/org/apache/flink/util/SimpleStringUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/SimpleStringUtilsTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.util.SimpleStringUtils.WhitespaceTokenizer;
 import org.junit.Test;
 
 
-public class SimpleStringUtilsTest {
+public class SimpleStringUtilsTest extends TestLogger {
 
 	@Test
 	public void testToLowerCaseConverting() {

--- a/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 import org.apache.flink.util.StringUtils;
 import org.junit.Test;
 
-public class StringUtilsTest {
+public class StringUtilsTest extends TestLogger {
 
 	@Test
 	public void testControlCharacters() {

--- a/flink-core/src/test/java/org/apache/flink/util/TestLogger.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TestLogger.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adds automatic test name logging. Every test which wants to log which test is currently
+ * executed and why it failed, simply has to extend this class.
+ */
+public class TestLogger {
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+
+	@Rule
+	public TestRule watchman = new TestWatcher() {
+
+		@Override
+		public void starting(Description description) {
+			if (log.isInfoEnabled()) {
+				String logText = "Test " + description + " is running.";
+				String headRuler = org.apache.commons.lang3.StringUtils.repeat("=", logText.length());
+				String bottomRuler = org.apache.commons.lang3.StringUtils.repeat("-", logText.length());
+
+				log.info(headRuler);
+				log.info(logText, description);
+				log.info(bottomRuler);
+			}
+		}
+
+		@Override
+		public void succeeded(Description description) {
+			if (log.isInfoEnabled()) {
+				String logText = "Test " + description + " successfully run.";
+				String bottomRuler = org.apache.commons.lang3.StringUtils.repeat("=", logText.length());
+				String headRuler = org.apache.commons.lang3.StringUtils.repeat("-", logText.length());
+
+				log.info(headRuler);
+				log.info(logText, description);
+				log.info(bottomRuler);
+			}
+		}
+
+		@Override
+		public void failed(Throwable e, Description description) {
+			if (log.isErrorEnabled()) {
+				String testDescription = "Test " + description + " failed with:";
+				String testException = StringUtils.stringifyException(e);
+				String logText = testDescription + "\n" + testException;
+				String bottomRuler = org.apache.commons.lang3.StringUtils.repeat("=", testDescription.length());
+				String headRuler = org.apache.commons.lang3.StringUtils.repeat("-", testDescription.length());
+
+				log.error(headRuler);
+				log.error(logText);
+				log.error(bottomRuler);
+			}
+		}
+	};
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/tuple/base/TuplePairComparatorTestBase.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/tuple/base/TuplePairComparatorTestBase.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 /**
@@ -32,7 +33,7 @@ import org.junit.Test;
  * @param <T>
  * @param <R>
  */
-public abstract class TuplePairComparatorTestBase<T extends Tuple, R extends Tuple> {
+public abstract class TuplePairComparatorTestBase<T extends Tuple, R extends Tuple> extends TestLogger {
 
 	protected abstract TypePairComparator<T, R> createComparator(boolean ascending);
 

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -43,6 +43,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/util/CompilerTestBase.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/util/CompilerTestBase.java
@@ -38,6 +38,7 @@ import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plan.PlanNode;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.Visitor;
 import org.junit.Before;
 
@@ -46,7 +47,7 @@ import org.junit.Before;
  * of a program and to fetch the nodes in an optimizer plan that correspond
  * the the node in the program plan.
  */
-public abstract class CompilerTestBase implements java.io.Serializable {
+public abstract class CompilerTestBase extends TestLogger implements java.io.Serializable {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -47,6 +47,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Basic subpartition behaviour tests.
  */
-public abstract class SubpartitionTestBase {
+public abstract class SubpartitionTestBase extends TestLogger {
 
 	/**
 	 * Return the subpartition to be tested.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
+import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
@@ -53,7 +54,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class DriverTestBase<S extends Function> implements PactTaskContext<S, Record> {
+public class DriverTestBase<S extends Function> extends TestLogger implements PactTaskContext<S, Record> {
 	
 	protected static final long DEFAULT_PER_SORT_MEM = 16 * 1024 * 1024;
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
@@ -36,12 +36,13 @@ import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.MutableObjectIterator;
+import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Assert;
 
 import java.util.List;
 
-public abstract class TaskTestBase {
+public abstract class TaskTestBase extends TestLogger {
 	
 	protected long memorySize = 0;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
@@ -51,7 +52,7 @@ import java.util.Collection;
 import java.util.List;
 
 @RunWith(Parameterized.class)
-public class UnaryOperatorTestBase<S extends Function, IN, OUT> implements PactTaskContext<S, OUT> {
+public class UnaryOperatorTestBase<S extends Function, IN, OUT> extends TestLogger implements PactTaskContext<S, OUT> {
 	
 	protected static final long DEFAULT_PER_SORT_MEM = 16 * 1024 * 1024;
 	

--- a/flink-test-utils/pom.xml
+++ b/flink-test-utils/pom.xml
@@ -52,6 +52,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.StreamingMode;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -66,7 +67,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class TestBaseUtils {
+public class TestBaseUtils extends TestLogger {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TestBaseUtils.class);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancellingTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancellingTestBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobCancellationException;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.test.util.ForkableFlinkMiniCluster;
+import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ import org.junit.Before;
 /**
  * 
  */
-public abstract class CancellingTestBase {
+public abstract class CancellingTestBase extends TestLogger {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(CancellingTestBase.class);
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/completeness/ScalaAPICompletenessTestBase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/completeness/ScalaAPICompletenessTestBase.scala
@@ -19,6 +19,7 @@ package org.apache.flink.api.scala.completeness
 
 import java.lang.reflect.Method
 
+import org.apache.flink.util.TestLogger
 import org.junit.Assert._
 import org.junit.Test
 
@@ -32,7 +33,7 @@ import scala.language.existentials
  *
  * Note: This is inspired by the JavaAPICompletenessChecker from Spark.
  */
-abstract class ScalaAPICompletenessTestBase {
+abstract class ScalaAPICompletenessTestBase extends TestLogger {
 
   /**
    * Determines whether a method is excluded by name.

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/tuple/base/PairComparatorTestBase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/tuple/base/PairComparatorTestBase.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala.runtime.tuple.base
 
+import org.apache.flink.util.TestLogger
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.apache.flink.api.common.typeutils.TypePairComparator
@@ -25,7 +26,7 @@ import org.junit.Test
 /**
  * Abstract test base for PairComparators.
  */
-abstract class PairComparatorTestBase[T, R] {
+abstract class PairComparatorTestBase[T, R] extends TestLogger {
   protected def createComparator(ascending: Boolean): TypePairComparator[T, R]
 
   protected def getSortedTestData: (Array[T], Array[R])

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.flink.client.CliFrontend;
 import org.apache.flink.client.FlinkYarnSessionCli;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.util.TestLogger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
@@ -69,7 +70,7 @@ import java.util.concurrent.ConcurrentMap;
  *
  * The test is not thread-safe. Parallel execution of tests is not possible!
  */
-public abstract class YarnTestBase {
+public abstract class YarnTestBase extends TestLogger {
 	private static final Logger LOG = LoggerFactory.getLogger(YarnTestBase.class);
 
 	protected final static PrintStream originalStdout = System.out;


### PR DESCRIPTION
Adds TestLogger class which automatically logs the currently executed test names and the reasons for a failure. The automatic logging is achieved by specifying a JUnit Rule which executes a `TestWatcher` for every executed test. 

This PR makes all test bases extend the TestLogger. For future tests which don't extend a test base, the test class should extend the TestLogger class to add automatic test name logging.