### PR TITLE
[FLINK-2526]Add try-catch for task when it stop running

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -100,9 +100,27 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			this.isRunning = false;
 			// Cleanup
 			inputProcessor.clearBuffers();
-			inputProcessor.cleanup();
-			outputHandler.flushOutputs();
-			clearBuffers();
+
+			try {
+				inputProcessor.cleanup();
+			}
+			catch (Exception e) {
+				LOG.warn("Clean up input processor failed.");
+			}
+
+			try {
+				outputHandler.flushOutputs();
+			}
+			catch (Exception e) {
+				LOG.warn("Flush outputs failed.");
+			}
+
+			try {
+				clearBuffers();
+			}
+			catch (Exception e) {
+				LOG.warn("Clear buffers failed.");
+			}
 		}
 
 	}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -105,21 +105,21 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 				inputProcessor.cleanup();
 			}
 			catch (Exception e) {
-				LOG.warn("Clean up input processor failed.");
+				LOG.warn("Clean up input processor failed.", e);
 			}
 
 			try {
 				outputHandler.flushOutputs();
 			}
 			catch (Exception e) {
-				LOG.warn("Flush outputs failed.");
+				LOG.warn("Flush outputs failed.", e);
 			}
 
 			try {
 				clearBuffers();
 			}
 			catch (Exception e) {
-				LOG.warn("Clear buffers failed.");
+				LOG.warn("Clear buffers failed.", e);
 			}
 		}
 


### PR DESCRIPTION
inputProcessor cleanup() may throw IOException.If do not catch it, the next line outputHandler .flushOutputs() will not work and cause output data loss.So i think add some try-catch is necessary.