### PR TITLE
[FLINK-2478]fix the array may have out of bounds

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/deltafunction/CosineDistance.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/deltafunction/CosineDistance.java
@@ -53,7 +53,8 @@ public class CosineDistance<DATA> extends ExtractionAwareDeltaFunction<DATA, dou
 		}
 
 		if (oldDataPoint.length != newDataPoint.length) {
-			return 0;
+			throw new IllegalArgumentException(
+					"The size of two input arrays are not same, can not compute cosine distance");
 		}
 
 		double sum1 = 0;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/deltafunction/CosineDistance.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/deltafunction/CosineDistance.java
@@ -52,6 +52,10 @@ public class CosineDistance<DATA> extends ExtractionAwareDeltaFunction<DATA, dou
 			return 0;
 		}
 
+		if (oldDataPoint.length != newDataPoint.length) {
+			return 0;
+		}
+
 		double sum1 = 0;
 		double sum2 = 0;
 		for (int i = 0; i < oldDataPoint.length; i++) {


### PR DESCRIPTION
In getNestedDelta function, the array length of oldDatapoint and the array length of newDatapoint  are not    been ensured same.So add the judgement.And I fixed the problem. Please put this problem to master branch. Thank you.