### PR TITLE
[FLINK-2529][runtime]remove some unused code

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -247,7 +247,7 @@ public class BlobServer extends Thread implements BlobService {
 
 			// Remove shutdown hook to prevent resource leaks, unless this is invoked by the
 			// shutdown hook itself
-			if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
+			if (shutdownHook != Thread.currentThread()) {
 				try {
 					Runtime.getRuntime().removeShutdownHook(shutdownHook);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -497,8 +497,6 @@ public class Execution implements Serializable {
 					@Override
 					public Boolean call() throws Exception {
 						try {
-							final ExecutionGraph consumerGraph = consumerVertex.getExecutionGraph();
-
 							consumerVertex.scheduleForExecution(
 									consumerVertex.getExecutionGraph().getScheduler(),
 									consumerVertex.getExecutionGraph().isQueuedSchedulingAllowed());


### PR DESCRIPTION
There are some reviews:
1.var consumerGraph is never used in public Boolean call() throws Exception.
2.In my learned knowledge, function Thread.currentThread() will never return null.So the code "shutdownHook != null" is unwanted.
And i`m not complete sure.Maybe I`m wrong.