### PR TITLE
[flink-2532]fix the function name and the variable name are the same

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindow.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindow.java
@@ -153,24 +153,24 @@ public class StreamWindow<T> extends ArrayList<T> implements Collector<T> {
 		if (n > numElements) {
 			return split(window, numElements);
 		} else {
-			List<StreamWindow<X>> split = new ArrayList<StreamWindow<X>>();
+			List<StreamWindow<X>> listStreamWindow = new ArrayList<StreamWindow<X>>();
 			int splitSize = numElements / n;
 
 			int index = -1;
 
 			StreamWindow<X> currentSubWindow = new StreamWindow<X>(window.windowID, n);
-			split.add(currentSubWindow);
+			listStreamWindow.add(currentSubWindow);
 
 			for (X element : window) {
 				index++;
-				if (index == splitSize && split.size() < n) {
+				if (index == splitSize && listStreamWindow.size() < n) {
 					currentSubWindow = new StreamWindow<X>(window.windowID, n);
-					split.add(currentSubWindow);
+					listStreamWindow.add(currentSubWindow);
 					index = 0;
 				}
 				currentSubWindow.add(element);
 			}
-			return split;
+			return listStreamWindow;
 		}
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindow.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindow.java
@@ -153,24 +153,24 @@ public class StreamWindow<T> extends ArrayList<T> implements Collector<T> {
 		if (n > numElements) {
 			return split(window, numElements);
 		} else {
-			List<StreamWindow<X>> listStreamWindow = new ArrayList<StreamWindow<X>>();
+			List<StreamWindow<X>> splitsList = new ArrayList<StreamWindow<X>>();
 			int splitSize = numElements / n;
 
 			int index = -1;
 
 			StreamWindow<X> currentSubWindow = new StreamWindow<X>(window.windowID, n);
-			listStreamWindow.add(currentSubWindow);
+			splitsList.add(currentSubWindow);
 
 			for (X element : window) {
 				index++;
-				if (index == splitSize && listStreamWindow.size() < n) {
+				if (index == splitSize && splitsList.size() < n) {
 					currentSubWindow = new StreamWindow<X>(window.windowID, n);
-					listStreamWindow.add(currentSubWindow);
+					splitsList.add(currentSubWindow);
 					index = 0;
 				}
 				currentSubWindow.add(element);
 			}
-			return listStreamWindow;
+			return splitsList;
 		}
 	}
 


### PR DESCRIPTION
In class StreamWindow, in function split, there is a list variable also called split. Two split are confusing , and the readable is poor.