### PR TITLE
[FLINK-2534][RUNTIME]Improve in CompactingHashTable.java

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
@@ -388,7 +388,6 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T> {
 				
 				final int thisCode = bucket.getInt(posInSegment);
 				posInSegment += HASH_CODE_LEN;
-				numInSegment++;
 					
 				// check if the hash code matches
 				if (thisCode == searchHashCode) {
@@ -404,6 +403,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T> {
 						return;
 					}
 				}
+				numInSegment++;
 			}
 			
 			// this segment is done. check if there is another chained bucket

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
@@ -223,7 +223,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T> {
 		// check the size of the first buffer and record it. all further buffers must have the same size.
 		// the size must also be a power of 2
 		this.segmentSize = memorySegments.get(0).size();
-		if ((this.segmentSize & this.segmentSize - 1) != 0) {
+		if ( (this.segmentSize & this.segmentSize - 1) != 0) {
 			throw new IllegalArgumentException("Hash Table requires buffers whose size is a power of 2.");
 		}
 		


### PR DESCRIPTION
1. Remove the var currentForwardPointer is unused in the code since this can reduce little memory cost.
2.Take the numInSegment++ out of the if branch and remove the else branch to decrease the loop complexity.
3.Improve the "while" to a formula:
numBuckets += numPartitions - numBuckets % numPartitions;

Otherwise, I found some places just simply using "for" to find a max or min number like the code following:
'private int getMaxPartition() {
		int maxPartition = 0;
		for(InMemoryPartition<T> p1 : this.partitions) {
			if(p1.getBlockCount() > maxPartition) {
				maxPartition = p1.getBlockCount();
			}
		}
		return maxPartition;
	}'
This does some harm to the performance.
Should we use some algorithm(.i.e RMQ, Segment tree, Heap structure) to take a optimization?
