### PR TITLE
[FLINK-2379][ml]Add column wise statistics for vector Data Sets

### DIFF
--- a/docs/libs/ml/index.md
+++ b/docs/libs/ml/index.md
@@ -52,6 +52,7 @@ FlinkML currently supports the following algorithms:
 ### Utilities
 
 * [Distance Metrics](distance_metrics.html)
+* [Statistics](statistics.html)
 
 ## Getting Started
 

--- a/docs/libs/ml/statistics.md
+++ b/docs/libs/ml/statistics.md
@@ -1,0 +1,68 @@
+---
+mathjax: include
+htmlTitle: FlinkML - Statistics
+title: <a href="../ml">FlinkML</a> - Statistics
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+## Description
+
+ The Statistics package provides methods to evaluate statistics over `DataSet` of `Vector`.
+
+ The following information is available as part of `DataStats`:
+ 1. Number of elements in `X`
+ 2. Dimension of `X`
+ 3. Field-wise statistics:
+   * For Discrete fields: Category wise counts, Entropy, Gini impurity
+   * For Continuous fields: Minimum, Maximum, Mean, Variance
+
+## Methods
+
+ The `dataStats` function operates on a data set `X: DataSet[Vector]` and returns  statistics for
+ `X`. Every field of `X` is allowed to be defined as either *discrete* or *continuous*.
+
+ Statistics can be evaluated by calling `X.dataStats()` or `X.dataStats(discreteFields)`. The
+ latter is used when some fields need to be declared discrete-valued, and is provided as an
+ array of indices of discrete fields.
+
+ `dataStats` also verifies the validity of data by making sure all elements have the exact same
+ dimension.
+
+## Examples
+
+{% highlight scala %}
+
+import org.apache.flink.ml._
+
+// Evaluate Data set statistics
+val dataSet: DataSet[Vector] = ...
+
+// evaluate statistics considering the 0th and 2nd field as discrete
+val stats = dataSet.dataStats(Array(0,2)).collect.head
+
+stats.total                             // total number of elements in dataSet
+stats.dimension                         // dimension of vectors in dataSet
+stats.fields(0).entropy                 // entropy of the 0th attribute
+stats.fields(2).categoryCounts          // hashmap of (category, count) for the 2nd attribute
+stats.fields(3).variance                // variance of the 3rd attribute
+{% endhighlight %}

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/FieldType.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/FieldType.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common
+
+/**
+ * Class to represent the type of a field/attribute of data.
+ * Discrete and Continuous types are supported
+ *
+ */
+object FieldType extends Enumeration {
+  type FieldType = Value
+  val DISCRETE, CONTINUOUS = Value
+}

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/package.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/package.scala
@@ -24,6 +24,8 @@ import org.apache.flink.api.java.operators.DataSink
 import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.ml.common.LabeledVector
+import org.apache.flink.ml.math.Vector
+import org.apache.flink.ml.statistics.DataStats
 
 import scala.reflect.ClassTag
 
@@ -46,6 +48,30 @@ package object ml {
   implicit class RichLabeledDataSet(dataSet: DataSet[LabeledVector]) {
     def writeAsLibSVM(path: String): DataSink[String] = {
       MLUtils.writeLibSVM(path, dataSet)
+    }
+  }
+
+  /** Pimp my [[DataSet]] to directly support `dataStats`
+    *
+    * @param dataSet
+    */
+  implicit class RichVectorDataSet(dataSet: DataSet[Vector]) {
+
+    /** Evaluate statistics for the [[dataSet]]
+      *
+      * @return statistics for the data set
+      */
+    def dataStats(): DataSet[DataStats] = {
+      dataSet.dataStats(Array.ofDim(0))
+    }
+
+    /** Evaluate statistics for the [[dataSet]] when some of the fields are discrete valued.
+      *
+      * @param discreteFields Array of indices of fields which are discrete valued
+      * @return statistics for the data set
+      */
+    def dataStats(discreteFields: Array[Int]): DataSet[DataStats] = {
+      DataStats.dataStats(dataSet, discreteFields)
     }
   }
 

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/statistics/DataStats.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/statistics/DataStats.scala
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.statistics
+
+import org.apache.flink.api.scala.{DataSet, _}
+import org.apache.flink.ml.common.FieldType._
+import org.apache.flink.ml.math.Vector
+
+/**
+ * Class for representing statistics for a DataSet[Vector]
+ *
+ * =Parameters=
+ * -[[total]]:
+ * Total number of elements in the data set
+ *
+ * -[[dimension]]:
+ * Dimensionality of the data set
+ *
+ * -[[fields]]:
+ * Column wise [[FieldStats]] for every field/attribute in the data
+ *
+ */
+class DataStats(val total: Long, val dimension: Int, val fields: Array[FieldStats])
+  extends Serializable
+
+object DataStats {
+
+  /** Evaluate statistics for a [[DataSet]] of [[Vector]]
+    *
+    * @param data Input data set
+    * @param discreteFields Array of indices of discrete valued fields
+    * @return statistics for the data set
+    */
+  def dataStats(data: DataSet[Vector], discreteFields: Array[Int]): DataSet[DataStats] = {
+    data.mapPartition(values => {
+      if (values.isEmpty) {
+        Seq.empty
+      } else {
+        val firstVec = values.next()
+        val dimension = firstVec.size
+        val localStats = new StatisticsCollector(discreteFields, dimension)
+        localStats.add(firstVec)
+        values.foreach(vec => {
+          require(vec.size == dimension, "Dimension mismatch error in data.")
+          localStats.add(vec)
+        })
+        Seq(localStats)
+      }
+    }).reduce(_.merge(_))
+      .map(_.getLocalValue)
+  }
+}
+
+/**
+ * Accumulator for aggregating statistics for data
+ * Min, max, mean, variance are collected for all [[CONTINUOUS]] fields.
+ * Class counts are collected for all [[DISCRETE]] fields.
+ *
+ */
+private final class StatisticsCollector(val categorical: Array[Int], val dimension: Int) {
+
+  private val localFieldStats: Array[FieldStats] = Array.ofDim(dimension)
+  private var localTotal: Long = 0
+
+  localFieldStats.indices.dropWhile(categorical.contains(_)).foreach(
+    localFieldStats(_) = new FieldStats(CONTINUOUS)
+  )
+  categorical.foreach(localFieldStats(_) = new FieldStats(DISCRETE))
+
+  /**
+   * Adds a new vector to this statistics collector
+   *
+   * @param V Vector
+   */
+  def add(V: Vector): Unit = {
+    // increment the total
+    localTotal += 1
+
+    // update the fields accordingly if they are continuous or discrete.
+    localFieldStats.zipWithIndex.foreach(f => {
+      val (field, index) = f
+      val newVal = V(index)
+      field.fieldType match {
+        case CONTINUOUS =>
+          field.setContinuousParameters(
+            math.min(field.min, newVal),
+            math.max(field.max, newVal),
+            // we directly only maintain sums.
+            field.mean + newVal,
+            // similarly, only maintain sum of squares.
+            field.variance + math.pow(newVal, 2)
+          )
+        case DISCRETE =>
+          field.categoryCounts.get(newVal) match {
+            case None => field.categoryCounts.put(newVal, 1)
+            case Some(value) => field.categoryCounts.put(newVal, value + 1)
+          }
+      }
+    })
+  }
+
+  /**
+   * Return the DataStats represented by this Statistics Collector.
+   *
+   * @return DataStats collected so far
+   */
+  def getLocalValue: DataStats = {
+    // this is where we convert the sums and sum of square to mean and variance.
+    new DataStats(
+      localTotal,
+      dimension,
+      localFieldStats.map(field => {
+        field.fieldType match {
+          case CONTINUOUS =>
+            val ret = new FieldStats(CONTINUOUS)
+            ret.setContinuousParameters(field._min, field._max, field._mean / localTotal,
+              field._variance / localTotal - Math.pow(field._mean / localTotal, 2))
+            ret
+          case DISCRETE => field
+        }
+      })
+    )
+  }
+
+  /**
+   * Merge statistics collected by another [[StatisticsCollector]] into this collector
+   *
+   * @param other Statistics collector to be merged
+   * @return itself, after merging
+   */
+  def merge(other: StatisticsCollector): StatisticsCollector = {
+    if (other.localTotal == 0) {
+      this
+    }
+    else if (dimension != other.dimension) {
+      throw new RuntimeException("Dimension mismatch error in data")
+    }
+    else {
+      localTotal += other.localTotal
+
+      localFieldStats.zipWithIndex.foreach(field => {
+        val (field1, field2) = (field._1, other.localFieldStats.apply(field._2))
+        if (field1.fieldType == field2.fieldType) {
+          field1.fieldType match {
+            case CONTINUOUS =>
+              field1.setContinuousParameters(
+                math.min(field1.min, field2.min),
+                math.max(field1.max, field2.max),
+                field1.mean + field2.mean,
+                field1.variance + field2.variance
+              )
+            case DISCRETE =>
+              field2.categoryCounts.iterator.foreach(classCount => {
+                val (key, count) = classCount
+                field1.categoryCounts.get(key) match {
+                  case None => field1.categoryCounts.put(key, count)
+                  case Some(value) => field1.categoryCounts.put(key, value + count)
+                }
+              })
+          }
+        } else {
+          throw new RuntimeException("Invalid merge operation on two different Statistics " +
+            "Collectors.")
+        }
+      })
+    }
+    this
+  }
+}

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/statistics/FieldStats.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/statistics/FieldStats.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.statistics
+
+import org.apache.flink.ml.common.FieldType._
+
+import scala.Double.{MaxValue, MinValue}
+import scala.collection.mutable
+
+/** Class to represent Field statistics.
+  *
+  * =Parameters=
+  * -[[fieldType]]:
+  * Type of this field, [[DISCRETE]] or [[CONTINUOUS]]
+  *
+  * For [[DISCRETE]] fields, [[entropy]], [[gini]] and [[categoryCounts]] are provided.
+  * For [[CONTINUOUS]] fields, [[min]], [[max]], [[mean]] and [[variance]] are provided.
+  *
+  */
+class FieldStats(val fieldType: FieldType) extends Serializable {
+
+  private val logConversion = math.log(2)
+  private[statistics] var _min: Double = MaxValue
+  private[statistics] var _max: Double = MinValue
+  private[statistics] var _mean: Double = 0
+  private[statistics] var _variance: Double = 0
+  private[statistics] var _counts: mutable.HashMap[Double, Int] = null
+
+  if (fieldType == DISCRETE) _counts = new mutable.HashMap[Double, Int]()
+
+  //-------------------- Access methods ----------------------------//
+
+  /**
+   * Returns the entropy value for this [[DISCRETE]] field.
+   *
+   * @return entropy of the field
+   */
+  def entropy: Double = {
+    assume(fieldType == DISCRETE, "Entropy cannot be accessed for continuous fields")
+    val total: Double = _counts.valuesIterator.sum
+    _counts.iterator.map(x => -(x._2 / total) * Math.log(x._2 / total)).sum / logConversion
+  }
+
+  /**
+   * Returns the Gini impurity for this [[DISCRETE]] field.
+   *
+   * @return Gini Impurity of the field
+   */
+  def gini: Double = {
+    assume(fieldType == DISCRETE, "Gini impurity cannot be accessed for continuous fields")
+    val total: Double = _counts.valuesIterator.sum
+    1 - _counts.iterator.map(x => x._2 * x._2).sum / (total * total)
+  }
+
+  override def toString: String = {
+    if (fieldType == DISCRETE) {
+      s"Discrete: " + categoryCounts.toString()
+    } else {
+      s"Continuous: Min: $min, Max: $max, Mean: $mean, Variance: $variance"
+    }
+  }
+
+  /**
+   * Returns the minimum value of this [[CONTINUOUS]] field
+   *
+   * @return minimum value of field
+   */
+  def min: Double = {
+    assume(fieldType == CONTINUOUS, "Calculation of min is not supported on discrete fields")
+    _min
+  }
+
+  /**
+   * Returns the maximum value of this [[CONTINUOUS]] field
+   *
+   * @return maximum value of the field
+   */
+  def max: Double = {
+    assume(fieldType == CONTINUOUS, "Calculation of max is not supported on discrete fields")
+    _max
+  }
+
+  /**
+   * Returns the average value of this [[CONTINUOUS]] field
+   *
+   * @return average value of the field
+   */
+  def mean: Double = {
+    assume(fieldType == CONTINUOUS, "Calculation of mean is not supported on discrete " +
+      "fields")
+    _mean
+  }
+
+  /**
+   * Returns the variance of this [[CONTINUOUS]] field
+   *
+   * @return variance of the field
+   */
+  def variance: Double = {
+    assume(fieldType == CONTINUOUS, "Calculation of variance is not supported on discrete " +
+      "fields")
+    _variance
+  }
+
+  //------------------ Setter methods ------------------//
+
+  /**
+   * Returns the class-wise counts of this [[DISCRETE]] field
+   *
+   * @return class-wise counts of the field
+   */
+  def categoryCounts: mutable.HashMap[Double, Int] = {
+    assume(fieldType == DISCRETE, "Category counts cannot be accessed for continuous fields")
+    _counts
+  }
+
+  /**
+   * Set the statistics for a [[CONTINUOUS]] field
+   *
+   * @param min minimum value of the field
+   * @param max maximum value of the field
+   * @param mean mean value of the field
+   * @param variance variance of the field
+   * @return itself
+   */
+  private[statistics] def setContinuousParameters(
+      min: Double,
+      max: Double,
+      mean: Double,
+      variance: Double)
+    : FieldStats = {
+    assume(fieldType == CONTINUOUS, "Min, max etc. cannot be set for Discrete fields")
+    _min = min
+    _max = max
+    _mean = mean
+    _variance = variance
+    this
+  }
+
+  /**
+   * Sets the statistics for a [[DISCRETE]] field
+   *
+   * @param counts Class-wise counts of the field
+   * @return itself
+   */
+  private[statistics] def setDiscreteParameters(
+      counts: mutable.HashMap[Double, Int])
+    : FieldStats = {
+    assume(fieldType == DISCRETE, "Class counts cannot be set for Continuous fields")
+    _counts = counts
+    this
+  }
+}

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/statistics/DataStatsSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/statistics/DataStatsSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.statistics
+
+import org.apache.flink.api.scala.{ExecutionEnvironment, _}
+import org.apache.flink.ml._
+import org.apache.flink.ml.math.{DenseVector, Vector}
+import org.apache.flink.test.util.FlinkTestBase
+import org.scalatest.{FlatSpec, Matchers}
+
+class DataStatsSuite extends FlatSpec with Matchers with FlinkTestBase {
+
+  behavior of "Flink's Data Statistics Collector"
+
+  it should "succeed in evaluating statistics" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val res = env.fromCollection(Seq[Vector](
+      DenseVector(Array(1, 2)),
+      DenseVector(Array(-1, 1)),
+      DenseVector(Array(4, 0)),
+      DenseVector(Array(8, 1))
+    )).setParallelism(2).dataStats(Array(1)).collect().head
+
+    res.dimension should equal(2)
+    res.total should equal(4)
+    res.fields(0).min should equal(-1)
+    res.fields(0).max should equal(8)
+    res.fields(0).mean should equal(3)
+    res.fields(0).variance should equal(11.5)
+    res.fields(1).categoryCounts.get(0).get should equal(1)
+    res.fields(1).categoryCounts.get(1).get should equal(2)
+    res.fields(1).categoryCounts.get(2).get should equal(1)
+    res.fields(1).entropy should equal(1.5 +- 0.001)
+    res.fields(1).gini should equal(0.625)
+  }
+}


### PR DESCRIPTION
This is because of splitting the work in #861 in two parts.

This PR adds column wise statistics for Vector Data sets.
For discrete fields, category counts, entropy and Gini Impurity are supported.
For continuous fields, min, max, mean, variance are supported.

Note: This needs to be rebased after #861 is merged. Most of the work in this is duplicated from that.
Edit:
Entirely independent of #861 now. A standalone feature in itself now.
