### PR TITLE
Add Scala version of GraphAlgorithm

### DIFF
--- a/flink-staging/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-staging/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -26,6 +26,7 @@ import org.apache.flink.graph._
 import org.apache.flink.graph.gsa.{ApplyFunction, GSAConfiguration, GatherFunction, SumFunction}
 import org.apache.flink.graph.spargel.{MessagingFunction, VertexCentricConfiguration, VertexUpdateFunction}
 import org.apache.flink.{graph => jg}
+import org.apache.flink.graph.{GraphAlgorithm => JGraphAlgorithm}
 
 import _root_.scala.collection.JavaConverters._
 import _root_.scala.reflect.ClassTag
@@ -649,10 +650,13 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
       jtuple.f1))
   }
 
-  def run(algorithm: GraphAlgorithm[K, VV, EV]) = {
+  def run(algorithm: JGraphAlgorithm[K, VV, EV]): Graph[K, VV, EV] = {
     wrapGraph(jgraph.run(algorithm))
   }
 
+  def run(algorithm: GraphAlgorithm[K, VV, EV]): Graph[K, VV, EV] = {
+    algorithm.run(this)
+  }
   /**
    * Runs a Vertex-Centric iteration on the graph.
    * No configuration options are provided.

--- a/flink-staging/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/GraphAlgorithm.scala
+++ b/flink-staging/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/GraphAlgorithm.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.scala
+
+/**
+ * @tparam K key type
+ * @tparam VV vertex value type
+ * @tparam EV edge value type
+ */
+abstract class GraphAlgorithm[K, VV, EV] {
+
+  def run(graph: Graph[K, VV, EV]): Graph[K, VV, EV]
+
+}

--- a/flink-staging/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/MapEdgesITCase.scala
+++ b/flink-staging/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/MapEdgesITCase.scala
@@ -92,6 +92,30 @@ MultipleProgramsTestBase(mode) {
       "5,1,52\n"
   }
 
+  @Test
+  @throws(classOf[Exception])
+  def testWithSameValueAlgorithm {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val graph: Graph[Long, Long, Long] = Graph.fromDataSet(TestGraphUtils
+      .getLongLongVertexData(env), TestGraphUtils.getLongLongEdgeData(env), env)
+
+   class SameValueAlgorithm extends GraphAlgorithm[Long, Long, Long] {
+     override def run(graph: Graph[Long, Long, Long]): Graph[Long, Long, Long] = {
+       graph.mapEdges(edge => edge.getValue + 1)
+     }
+   }
+
+    graph.run(new SameValueAlgorithm).getEdgesAsTuple3().writeAsCsv(resultPath)
+    env.execute
+    expectedResult = "1,2,13\n" +
+      "1,3,14\n" + "" +
+      "2,3,24\n" +
+      "3,4,35\n" +
+      "3,5,36\n" +
+      "4,5,46\n" +
+      "5,1,52\n"
+  }
+
   final class AddOneMapper extends MapFunction[Edge[Long, Long], Long] {
     @throws(classOf[Exception])
     def map(edge: Edge[Long, Long]): Long = {


### PR DESCRIPTION
The Scala Gelly API already has a wrapper for running java-based GraphAlgorithms. It is needed for running pre-built algorithms such as the PageRankAlgorithm. This small addition maintains compatibility with these java-based GraphAlgorithms while giving the user an additional possibility of developing their own GraphAlgorithm that makes use of the syntactic sugar methods that the new Scala Gelly API offers.
