### PR TITLE
[FLINK-2077] [core] Rework Path class and add extend support for Windows paths

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
@@ -78,6 +78,15 @@ public class Path implements IOReadableWritable, Serializable {
 	}
 
 	/**
+	 * Converts the path object to a {@link URI}.
+	 *
+	 * @return the {@link URI} object converted from the path object
+	 */
+	public URI toUri() {
+		return uri;
+	}
+
+	/**
 	 * Resolve a child path against a parent path.
 	 * 
 	 * @param parent
@@ -143,27 +152,6 @@ public class Path implements IOReadableWritable, Serializable {
 	}
 
 	/**
- 	 * Checks if the provided path string is either null or has zero length and throws
-	 * a {@link IllegalArgumentException} if any of the two conditions apply.
-	 * In addition, leading and tailing whitespaces are removed.
-	 *
-	 * @param path
-	 *        the path string to be checked
-	 * @return The checked and trimmed path.
-	 */
-	private String checkAndTrimPathArg(String path) {
-		// disallow construction of a Path from an empty string
-		if (path == null) {
-			throw new IllegalArgumentException("Can not create a Path from a null string");
-		}
-		path = path.trim();
-		if (path.length() == 0) {
-			throw new IllegalArgumentException("Can not create a Path from an empty string");
-		}
-		return path;
-	}
-
-	/**
 	 * Construct a path from a String. Path strings are URIs, but with unescaped
 	 * elements and some additional normalization.
 	 * 
@@ -223,79 +211,6 @@ public class Path implements IOReadableWritable, Serializable {
 	public Path(String scheme, String authority, String path) {
 		path = checkAndTrimPathArg(path);
 		initialize(scheme, authority, path);
-	}
-
-	/**
-	 * Initializes a path object given the scheme, authority and path string.
-	 * 
-	 * @param scheme
-	 *        the scheme string.
-	 * @param authority
-	 *        the authority string.
-	 * @param path
-	 *        the path string.
-	 */
-	private void initialize(String scheme, String authority, String path) {
-		try {
-			this.uri = new URI(scheme, authority, normalizePath(path), null, null).normalize();
-		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException(e);
-		}
-	}
-
-	/**
-	 * Normalizes a path string.
-	 * 
-	 * @param path
-	 *        the path string to normalize
-	 * @return the normalized path string
-	 */
-	private String normalizePath(String path) {
-
-		// remove leading and tailing whitespaces
-		path = path.trim();
-
-		// remove consecutive slashes & backslashes
-		path = path.replace("\\", "/");
-		path = path.replaceAll("/+", "/");
-
-		// remove tailing separator
-		if(!path.equals(SEPARATOR) &&         		// UNIX root path
-				!path.matches("/\\p{Alpha}+:/") &&  // Windows root path
-				path.endsWith(SEPARATOR))
-		{
-			// remove tailing slash
-			path = path.substring(0, path.length() - SEPARATOR.length());
-		}
-
-		return path;
-	}
-
-	/**
-	 * Checks if the provided path string contains a windows drive letter.
-	 * 
-	 * @param path
-	 *        the path to check
-	 * @param slashed
-	 *        <code>true</code> to indicate the first character of the string is a slash, <code>false</code> otherwise
-	 * @return <code>true</code> if the path string contains a windows drive letter, <code>false</code> otherwise
-	 */
-	private boolean hasWindowsDrive(String path, boolean slashed) {
-		final int start = slashed ? 1 : 0;
-		return path.length() >= start + 2
-			&& (!slashed || path.charAt(0) == '/')
-			&& path.charAt(start + 1) == ':'
-			&& ((path.charAt(start) >= 'A' && path.charAt(start) <= 'Z') || (path.charAt(start) >= 'a' && path
-				.charAt(start) <= 'z'));
-	}
-
-	/**
-	 * Converts the path object to a {@link URI}.
-	 * 
-	 * @return the {@link URI} object converted from the path object
-	 */
-	public URI toUri() {
-		return uri;
 	}
 
 	/**
@@ -364,6 +279,118 @@ public class Path implements IOReadableWritable, Serializable {
 		return new Path(getParent(), getName() + suffix);
 	}
 
+	/**
+	 * Returns the number of elements in this path.
+	 *
+	 * @return the number of elements in this path
+	 */
+	public int depth() {
+		String path = uri.getPath();
+		int depth = 0;
+		int slash = path.length() == 1 && path.charAt(0) == '/' ? -1 : 0;
+		while (slash != -1) {
+			depth++;
+			slash = path.indexOf(SEPARATOR, slash + 1);
+		}
+		return depth;
+	}
+
+	/**
+	 * Checks if the provided path string is either null or has zero length and throws
+	 * a {@link IllegalArgumentException} if any of the two conditions apply.
+	 * In addition, leading and tailing whitespaces are removed.
+	 *
+	 * @param path
+	 *        the path string to be checked
+	 * @return The checked and trimmed path.
+	 */
+	private String checkAndTrimPathArg(String path) {
+		// disallow construction of a Path from an empty string
+		if (path == null) {
+			throw new IllegalArgumentException("Can not create a Path from a null string");
+		}
+		path = path.trim();
+		if (path.length() == 0) {
+			throw new IllegalArgumentException("Can not create a Path from an empty string");
+		}
+		return path;
+	}
+
+	/**
+	 * Initializes a path object given the scheme, authority and path string.
+	 *
+	 * @param scheme
+	 *        the scheme string.
+	 * @param authority
+	 *        the authority string.
+	 * @param path
+	 *        the path string.
+	 */
+	private void initialize(String scheme, String authority, String path) {
+		try {
+			this.uri = new URI(scheme, authority, normalizePath(path), null, null).normalize();
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	/**
+	 * Normalizes a path string.
+	 *
+	 * @param path
+	 *        the path string to normalize
+	 * @return the normalized path string
+	 */
+	private String normalizePath(String path) {
+
+		// remove leading and tailing whitespaces
+		path = path.trim();
+
+		// remove consecutive slashes & backslashes
+		path = path.replace("\\", "/");
+		path = path.replaceAll("/+", "/");
+
+		// remove tailing separator
+		if(!path.equals(SEPARATOR) &&         		// UNIX root path
+				!path.matches("/\\p{Alpha}+:/") &&  // Windows root path
+				path.endsWith(SEPARATOR))
+		{
+			// remove tailing slash
+			path = path.substring(0, path.length() - SEPARATOR.length());
+		}
+
+		return path;
+	}
+
+	/**
+	 * Checks if the provided path string contains a windows drive letter.
+	 *
+	 * @param path
+	 *        the path to check
+	 * @param slashed
+	 *        <code>true</code> to indicate the first character of the string is a slash, <code>false</code> otherwise
+	 * @return <code>true</code> if the path string contains a windows drive letter, <code>false</code> otherwise
+	 */
+	private boolean hasWindowsDrive(String path, boolean slashed) {
+		final int start = slashed ? 1 : 0;
+		return path.length() >= start + 2
+				&& (!slashed || path.charAt(0) == '/')
+				&& path.charAt(start + 1) == ':'
+				&& ((path.charAt(start) >= 'A' && path.charAt(start) <= 'Z') || (path.charAt(start) >= 'a' && path
+				.charAt(start) <= 'z'));
+	}
+
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof Path)) {
+			return false;
+		}
+		Path that = (Path) o;
+		return this.uri.equals(that.uri);
+	}
+
+
 	@Override
 	public String toString() {
 		// we can't use uri.toString(), which escapes everything, because we
@@ -390,80 +417,6 @@ public class Path implements IOReadableWritable, Serializable {
 			buffer.append(path);
 		}
 		return buffer.toString();
-	}
-
-
-	@Override
-	public boolean equals(Object o) {
-		if (!(o instanceof Path)) {
-			return false;
-		}
-		Path that = (Path) o;
-		return this.uri.equals(that.uri);
-	}
-
-
-	@Override
-	public int hashCode() {
-		return uri.hashCode();
-	}
-
-	public int compareTo(Object o) {
-		Path that = (Path) o;
-		return this.uri.compareTo(that.uri);
-	}
-
-	/**
-	 * Returns the number of elements in this path.
-	 * 
-	 * @return the number of elements in this path
-	 */
-	public int depth() {
-		String path = uri.getPath();
-		int depth = 0;
-		int slash = path.length() == 1 && path.charAt(0) == '/' ? -1 : 0;
-		while (slash != -1) {
-			depth++;
-			slash = path.indexOf(SEPARATOR, slash + 1);
-		}
-		return depth;
-	}
-
-	/**
-	 * Returns a qualified path object.
-	 * 
-	 * @param fs
-	 *        the FileSystem that should be used to obtain the current working directory
-	 * @return the qualified path object
-	 */
-	public Path makeQualified(FileSystem fs) {
-		Path path = this;
-		if (!isAbsolute()) {
-			path = new Path(fs.getWorkingDirectory(), this);
-		}
-
-		final URI pathUri = path.toUri();
-		final URI fsUri = fs.getUri();
-
-		String scheme = pathUri.getScheme();
-		String authority = pathUri.getAuthority();
-
-		if (scheme != null && (authority != null || fsUri.getAuthority() == null)) {
-			return path;
-		}
-
-		if (scheme == null) {
-			scheme = fsUri.getScheme();
-		}
-
-		if (authority == null) {
-			authority = fsUri.getAuthority();
-			if (authority == null) {
-				authority = "";
-			}
-		}
-
-		return new Path(scheme + ":" + "//" + authority + pathUri.getPath());
 	}
 
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -41,6 +41,7 @@ import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.FileSystemUtil;
 
 /**
  * The class <code>LocalFile</code> provides an implementation of the {@link FileSystem} interface for the local file
@@ -70,7 +71,7 @@ public class LocalFileSystem extends FileSystem {
 	 * Constructs a new <code>LocalFileSystem</code> object.
 	 */
 	public LocalFileSystem() {
-		this.workingDir = new Path(System.getProperty("user.dir")).makeQualified(this);
+		this.workingDir = FileSystemUtil.makeQualified(new Path(System.getProperty("user.dir")), this);
 
 		String tmp = "unknownHost";
 

--- a/flink-core/src/main/java/org/apache/flink/util/FileSystemUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileSystemUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* This file is based on source code from the Hadoop Project (http://hadoop.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+package org.apache.flink.util;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import java.net.URI;
+
+public class FileSystemUtil {
+
+	/**
+	 * Return a qualified path object
+	 *
+	 * @param path the path will be qualified
+	 * @param fs   the FileSystem that should be used to obtain the current working directory
+	 */
+	public static Path makeQualified(Path path, FileSystem fs) {
+		if (!path.isAbsolute()) {
+			path = new Path(fs.getWorkingDirectory(), path);
+		}
+
+		final URI pathUri = path.toUri();
+		final URI fsUri = fs.getUri();
+
+		String scheme = pathUri.getScheme();
+		String authority = pathUri.getAuthority();
+		String fsAuthority = fsUri.getAuthority();
+
+		if (scheme != null && (authority != null || fsAuthority == null)) {
+			return path;
+		}
+
+		if (scheme == null) {
+			scheme = fsUri.getScheme();
+		}
+
+		if (authority == null) {
+			authority = (fsAuthority == null) ? "" : fsAuthority;
+		}
+
+		return new Path(scheme + ":" + "//" + authority + pathUri.getPath());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/PathTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/PathTest.java
@@ -19,6 +19,8 @@ package org.apache.flink.core.fs;
 
 import java.io.IOException;
 import java.net.URI;
+
+import org.apache.flink.util.FileSystemUtil;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -284,7 +286,7 @@ public class PathTest {
 		path = "test/test";
 		p = new Path(path);
 		u = p.toUri();
-		p = p.makeQualified(FileSystem.get(u));
+		p = FileSystemUtil.makeQualified(p, FileSystem.get(u));
 		u = p.toUri();
 		assertEquals("file", u.getScheme());
 		assertEquals(null, u.getAuthority());
@@ -293,7 +295,7 @@ public class PathTest {
 		path = "/test/test";
 		p = new Path(path);
 		u = p.toUri();
-		p = p.makeQualified(FileSystem.get(u));
+		p = FileSystemUtil.makeQualified(p, FileSystem.get(u));
 		u = p.toUri();
 		assertEquals("file", u.getScheme());
 		assertEquals(null, u.getAuthority());

--- a/flink-staging/flink-language-binding/flink-python/src/main/java/org/apache/flink/languagebinding/api/java/python/PythonPlanBinder.java
+++ b/flink-staging/flink-language-binding/flink-python/src/main/java/org/apache/flink/languagebinding/api/java/python/PythonPlanBinder.java
@@ -38,6 +38,7 @@ import org.apache.flink.languagebinding.api.java.python.functions.*;
 import org.apache.flink.languagebinding.api.java.common.streaming.Receiver;
 import org.apache.flink.languagebinding.api.java.common.streaming.StreamPrinter;
 import org.apache.flink.runtime.filecache.FileCache;
+import org.apache.flink.util.FileSystemUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,7 +163,7 @@ public class PythonPlanBinder extends PlanBinder<PythonOperationInfo> {
 		String tmpFilePath = FLINK_PYTHON_FILE_PATH + "/" + identifier;
 		clearPath(tmpFilePath);
 		Path p = new Path(path);
-		FileCache.copy(p.makeQualified(FileSystem.get(p.toUri())), new Path(tmpFilePath), true);
+		FileCache.copy(FileSystemUtil.makeQualified(p, FileSystem.get(p.toUri())), new Path(tmpFilePath), true);
 	}
 
 	private static void distributeFiles(ExecutionEnvironment env) throws IOException, URISyntaxException {


### PR DESCRIPTION
The class org.apache.flink.core.fs.Path handles paths for Flink's FileInputFormat and FileOutputFormat. Over time, this class has become quite hard to read and modify.
This PR does some work on cleaning and refactoring.