### PR TITLE
[FLINK-2560] Flink-Avro Plugin cannot be handled by Eclipse

### DIFF
--- a/flink-staging/flink-avro/pom.xml
+++ b/flink-staging/flink-avro/pom.xml
@@ -181,6 +181,19 @@ under the License.
 										<ignore/>
 									</action>
 								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.avro</groupId>
+										<artifactId>avro-maven-plugin</artifactId>
+										<versionRange>[1.7.7,)</versionRange>
+										<goals>
+											<goal>schema</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore/>
+									</action>
+								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
 					</configuration>


### PR DESCRIPTION
  - disabled avro-maven-plugin within Eclipse via <pluginManagement> ... <lifecyleMappingMetaData>