### PR TITLE
[FLINK-2565] Support primitive Arrays as keys

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
@@ -30,7 +30,7 @@ public class BooleanPrimitiveArrayComparator extends PrimitiveArrayComparator<bo
 	public int hash(boolean[] record) {
 		int result = 0;
 		for (boolean field : record) {
-			result += comparator.hash(field);
+			result += field ? 1231 : 1237;
 		}
 		return result;
 	}
@@ -38,9 +38,9 @@ public class BooleanPrimitiveArrayComparator extends PrimitiveArrayComparator<bo
 	@Override
 	public int compare(boolean[] first, boolean[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = (second[x] == first[x] ? 0 : (first[x] ? 1 : -1));
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.BooleanComparator;
+
+public class BooleanPrimitiveArrayComparator extends PrimitiveArrayComparator<boolean[], BooleanComparator> {
+	public BooleanPrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new BooleanComparator(ascending));
+	}
+
+	@Override
+	public int hash(boolean[] record) {
+		int result = 0;
+		for (boolean field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(boolean[] first, boolean[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<boolean[]> duplicate() {
+		BooleanPrimitiveArrayComparator dupe = new BooleanPrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.ByteComparator;
+
+public class BytePrimitiveArrayComparator extends PrimitiveArrayComparator<byte[], ByteComparator> {
+	public BytePrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new ByteComparator(ascending));
+	}
+
+	@Override
+	public int hash(byte[] record) {
+		int result = 0;
+		for (byte field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(byte[] first, byte[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<byte[]> duplicate() {
+		BytePrimitiveArrayComparator dupe = new BytePrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparator.java
@@ -30,7 +30,7 @@ public class BytePrimitiveArrayComparator extends PrimitiveArrayComparator<byte[
 	public int hash(byte[] record) {
 		int result = 0;
 		for (byte field : record) {
-			result += comparator.hash(field);
+			result += (int) field;
 		}
 		return result;
 	}
@@ -38,9 +38,9 @@ public class BytePrimitiveArrayComparator extends PrimitiveArrayComparator<byte[
 	@Override
 	public int compare(byte[] first, byte[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = first[x] - second[x];
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.CharComparator;
+
+public class CharPrimitiveArrayComparator extends PrimitiveArrayComparator<char[], CharComparator> {
+	public CharPrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new CharComparator(ascending));
+	}
+
+	@Override
+	public int hash(char[] record) {
+		int result = 0;
+		for (char field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(char[] first, char[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<char[]> duplicate() {
+		CharPrimitiveArrayComparator dupe = new CharPrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparator.java
@@ -30,7 +30,7 @@ public class CharPrimitiveArrayComparator extends PrimitiveArrayComparator<char[
 	public int hash(char[] record) {
 		int result = 0;
 		for (char field : record) {
-			result += comparator.hash(field);
+			result += (int) field;
 		}
 		return result;
 	}
@@ -38,9 +38,9 @@ public class CharPrimitiveArrayComparator extends PrimitiveArrayComparator<char[
 	@Override
 	public int compare(char[] first, char[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = first[x] - second[x];
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.DoubleComparator;
+
+public class DoublePrimitiveArrayComparator extends PrimitiveArrayComparator<double[], DoubleComparator> {
+	public DoublePrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new DoubleComparator(ascending));
+	}
+
+	@Override
+	public int hash(double[] record) {
+		int result = 0;
+		for (double field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(double[] first, double[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<double[]> duplicate() {
+		DoublePrimitiveArrayComparator dupe = new DoublePrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparator.java
@@ -30,7 +30,8 @@ public class DoublePrimitiveArrayComparator extends PrimitiveArrayComparator<dou
 	public int hash(double[] record) {
 		int result = 0;
 		for (double field : record) {
-			result += comparator.hash(field);
+			long bits = Double.doubleToLongBits(field);
+			result += (int) (bits ^ (bits >>> 32));
 		}
 		return result;
 	}
@@ -38,9 +39,9 @@ public class DoublePrimitiveArrayComparator extends PrimitiveArrayComparator<dou
 	@Override
 	public int compare(double[] first, double[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = Double.compare(first[x], second[x]);
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
@@ -30,7 +30,7 @@ public class FloatPrimitiveArrayComparator extends PrimitiveArrayComparator<floa
 	public int hash(float[] record) {
 		int result = 0;
 		for (float field : record) {
-			result += comparator.hash(field);
+			result += Float.floatToIntBits(field);
 		}
 		return result;
 	}
@@ -38,9 +38,9 @@ public class FloatPrimitiveArrayComparator extends PrimitiveArrayComparator<floa
 	@Override
 	public int compare(float[] first, float[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = Float.compare(first[x], second[x]);
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.FloatComparator;
+
+public class FloatPrimitiveArrayComparator extends PrimitiveArrayComparator<float[], FloatComparator> {
+	public FloatPrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new FloatComparator(ascending));
+	}
+
+	@Override
+	public int hash(float[] record) {
+		int result = 0;
+		for (float field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(float[] first, float[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<float[]> duplicate() {
+		FloatPrimitiveArrayComparator dupe = new FloatPrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
@@ -30,7 +30,7 @@ public class IntPrimitiveArrayComparator extends PrimitiveArrayComparator<int[],
 	public int hash(int[] record) {
 		int result = 0;
 		for (int field : record) {
-			result += comparator.hash(field);
+			result += field;
 		}
 		return result;
 	}
@@ -38,9 +38,9 @@ public class IntPrimitiveArrayComparator extends PrimitiveArrayComparator<int[],
 	@Override
 	public int compare(int[] first, int[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = first[x] - second[x];
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.IntComparator;
+
+public class IntPrimitiveArrayComparator extends PrimitiveArrayComparator<int[], IntComparator> {
+	public IntPrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new IntComparator(ascending));
+	}
+
+	@Override
+	public int hash(int[] record) {
+		int result = 0;
+		for (int field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(int[] first, int[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<int[]> duplicate() {
+		IntPrimitiveArrayComparator dupe = new IntPrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.LongComparator;
+
+public class LongPrimitiveArrayComparator extends PrimitiveArrayComparator<long[], LongComparator> {
+	public LongPrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new LongComparator(ascending));
+	}
+
+	@Override
+	public int hash(long[] record) {
+		int result = 0;
+		for (long field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(long[] first, long[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<long[]> duplicate() {
+		LongPrimitiveArrayComparator dupe = new LongPrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparator.java
@@ -30,7 +30,7 @@ public class LongPrimitiveArrayComparator extends PrimitiveArrayComparator<long[
 	public int hash(long[] record) {
 		int result = 0;
 		for (long field : record) {
-			result += comparator.hash(field);
+			result += (int) (field ^ (field >>> 32));
 		}
 		return result;
 	}
@@ -38,9 +38,9 @@ public class LongPrimitiveArrayComparator extends PrimitiveArrayComparator<long[
 	@Override
 	public int compare(long[] first, long[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = first[x] < second[x] ? -1 : (first[x] == second[x] ? 0 : 1);
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparator.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import java.io.IOException;
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.BasicTypeComparator;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+
+public abstract class PrimitiveArrayComparator<T, C extends BasicTypeComparator> extends TypeComparator<T> {
+	// For use by getComparators
+	@SuppressWarnings("rawtypes")
+	private final TypeComparator[] comparators = new TypeComparator[]{this};
+
+	protected final boolean ascending;
+	protected transient T reference;
+	protected final C comparator;
+
+	public PrimitiveArrayComparator(boolean ascending, C comparator) {
+		this.ascending = ascending;
+		this.comparator = comparator;
+	}
+
+	@Override
+	public void setReference(T toCompare) {
+		this.reference = toCompare;
+	}
+
+	@Override
+	public boolean equalToReference(T candidate) {
+		return compare(this.reference, candidate) == 0;
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<T> referencedComparator) {
+		return compare(((PrimitiveArrayComparator<T, C>) referencedComparator).reference, this.reference);
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int firstCount = firstSource.readInt();
+		int secondCount = secondSource.readInt();
+		for (int x = 0; x < min(firstCount, secondCount); x++) {
+			int cmp = comparator.compareSerialized(firstSource, secondSource);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = firstCount - secondCount;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator[] getFlatComparators() {
+		return comparators;
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return 0;
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void putNormalizedKey(T record, MemorySegment target, int offset, int numBytes) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void writeWithKeyNormalization(T record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public T readWithKeyDenormalization(T reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return !ascending;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import static java.lang.Math.min;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.base.ShortComparator;
+
+public class ShortPrimitiveArrayComparator extends PrimitiveArrayComparator<short[], ShortComparator> {
+	public ShortPrimitiveArrayComparator(boolean ascending) {
+		super(ascending, new ShortComparator(ascending));
+	}
+
+	@Override
+	public int hash(short[] record) {
+		int result = 0;
+		for (short field : record) {
+			result += comparator.hash(field);
+		}
+		return result;
+	}
+
+	@Override
+	public int compare(short[] first, short[] second) {
+		for (int x = 0; x < min(first.length, second.length); x++) {
+			int cmp = comparator.compare(first[x], second[x]);
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		int cmp = first.length - second.length;
+		return ascending ? cmp : -cmp;
+	}
+
+	@Override
+	public TypeComparator<short[]> duplicate() {
+		ShortPrimitiveArrayComparator dupe = new ShortPrimitiveArrayComparator(this.ascending);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparator.java
@@ -30,7 +30,7 @@ public class ShortPrimitiveArrayComparator extends PrimitiveArrayComparator<shor
 	public int hash(short[] record) {
 		int result = 0;
 		for (short field : record) {
-			result += comparator.hash(field);
+			result += (int) field;
 		}
 		return result;
 	}
@@ -38,9 +38,9 @@ public class ShortPrimitiveArrayComparator extends PrimitiveArrayComparator<shor
 	@Override
 	public int compare(short[] first, short[] second) {
 		for (int x = 0; x < min(first.length, second.length); x++) {
-			int cmp = comparator.compare(first[x], second[x]);
+			int cmp = first[x] - second[x];
 			if (cmp != 0) {
-				return cmp;
+				return ascending ? cmp : -cmp;
 			}
 		}
 		int cmp = first.length - second.length;

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArrayComparatorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class BooleanPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<boolean[]> {
+	public BooleanPrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, boolean[] should, boolean[] is) {
+		Assert.assertTrue(should.length == is.length);
+		for(int x=0; x< should.length; x++) {
+			Assert.assertEquals(should[x], is[x]);
+		}
+	}
+
+	@Override
+	protected boolean[][] getSortedTestData() {
+		return new boolean[][]{
+			new boolean[]{false, false},
+			new boolean[]{false, true},
+			new boolean[]{false, true, true},
+			new boolean[]{true},
+		};
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArrayComparatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class BytePrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<byte[]> {
+	public BytePrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, byte[] should, byte[] is) {
+		Assert.assertArrayEquals(message, should, is);
+	}
+
+	@Override
+	protected byte[][] getSortedTestData() {
+		return new byte[][]{
+			new byte[]{-1, 0},
+			new byte[]{0, -1},
+			new byte[]{0, 0},
+			new byte[]{0, 1},
+			new byte[]{0, 1, 2},
+			new byte[]{2}
+		};
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArrayComparatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class CharPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<char[]> {
+	public CharPrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, char[] should, char[] is) {
+		Assert.assertArrayEquals(message, should, is);
+	}
+
+	@Override
+	protected char[][] getSortedTestData() {
+		return new char[][]{
+			new char[]{0, 0},
+			new char[]{0, 1},
+			new char[]{0, 1, 2},
+			new char[]{2}
+		};
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArrayComparatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class DoublePrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<double[]> {
+	public DoublePrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, double[] should, double[] is) {
+		Assert.assertArrayEquals(message, should, is, 0.00001);
+	}
+
+	@Override
+	protected double[][] getSortedTestData() {
+		return new double[][]{
+			new double[]{-1, 0},
+			new double[]{0, -1},
+			new double[]{0, 0},
+			new double[]{0, 1},
+			new double[]{0, 1, 2},
+			new double[]{2}
+		};
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArrayComparatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class FloatPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<float[]> {
+	public FloatPrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, float[] should, float[] is) {
+		Assert.assertArrayEquals(message, should, is, (float) 0.00001);
+	}
+
+	@Override
+	protected float[][] getSortedTestData() {
+		return new float[][]{
+			new float[]{-1, 0},
+			new float[]{0, -1},
+			new float[]{0, 0},
+			new float[]{0, 1},
+			new float[]{0, 1, 2},
+			new float[]{2}
+		};
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArrayComparatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class IntPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<int[]> {
+	public IntPrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, int[] should, int[] is) {
+		Assert.assertArrayEquals(message, should, is);
+	}
+
+	@Override
+	protected int[][] getSortedTestData() {
+		return new int[][]{
+			new int[]{-1, 0},
+			new int[]{0, -1},
+			new int[]{0, 0},
+			new int[]{0, 1},
+			new int[]{0, 1, 2},
+			new int[]{2}
+		};
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArrayComparatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class LongPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<long[]> {
+	public LongPrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, long[] should, long[] is) {
+		Assert.assertArrayEquals(message, should, is);
+	}
+
+	@Override
+	protected long[][] getSortedTestData() {
+		return new long[][]{
+			new long[]{-1, 0},
+			new long[]{0, -1},
+			new long[]{0, 0},
+			new long[]{0, 1},
+			new long[]{0, 1, 2},
+			new long[]{2}
+		};
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArrayComparatorTestBase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+public abstract class PrimitiveArrayComparatorTestBase<T> extends ComparatorTestBase<T> {
+	private PrimitiveArrayTypeInfo<T> info;
+
+	public PrimitiveArrayComparatorTestBase(PrimitiveArrayTypeInfo<T> info) {
+		this.info = info;
+	}
+
+	@Override
+	protected TypeComparator<T> createComparator(boolean ascending) {
+		return info.createComparator(ascending, null).duplicate();
+	}
+
+	@Override
+	protected TypeSerializer<T> createSerializer() {
+		return info.createSerializer(null);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArrayComparatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.typeutils.base.array;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.junit.Assert;
+
+public class ShortPrimitiveArrayComparatorTest extends PrimitiveArrayComparatorTestBase<short[]> {
+	public ShortPrimitiveArrayComparatorTest() {
+		super(PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO);
+	}
+
+	@Override
+	protected void deepEquals(String message, short[] should, short[] is) {
+		Assert.assertArrayEquals(message, should, is);
+	}
+
+	@Override
+	protected short[][] getSortedTestData() {
+		return new short[][]{
+			new short[]{-1, 0},
+			new short[]{0, -1},
+			new short[]{0, 0},
+			new short[]{0, 1},
+			new short[]{0, 1, 2},
+			new short[]{2}
+		};
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
@@ -128,7 +128,7 @@ public class GroupingTest {
 	}
 
 	@Test
-	public void testGroupByKeyFields6() {
+	public void testGroupByKeyFieldsOnPrimitiveArray() {
 		this.byteArrayData.add(new Tuple2(new byte[]{0}, new byte[]{1}));
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
@@ -67,8 +67,9 @@ public class GroupingTest {
 
 	private final List<Tuple4<Integer, Long, CustomType, Long[]>> tupleWithCustomData =
 			new ArrayList<Tuple4<Integer, Long, CustomType, Long[]>>();
-
 	
+	private final List<Tuple2<byte[], byte[]>> byteArrayData = new ArrayList<Tuple2<byte[], byte[]>>();
+
 	@Test  
 	public void testGroupByKeyFields1() {
 		
@@ -124,6 +125,15 @@ public class GroupingTest {
 
 		// should not work, negative field position
 		tupleDs.groupBy(-1);
+	}
+
+	@Test
+	public void testGroupByKeyFields6() {
+		this.byteArrayData.add(new Tuple2(new byte[]{0}, new byte[]{1}));
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<byte[], byte[]>> tupleDs = env.fromCollection(byteArrayData);
+		tupleDs.groupBy(0);
 	}
 
 	@Test

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/GroupingTest.java
@@ -613,7 +613,7 @@ public class GroupingTest {
 	public static class CustomType2 implements Serializable {
 
 		public int myInt;
-		public int[] myIntArray;
+		public Integer[] myIntArray;
 
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/GroupReduceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/GroupReduceITCase.java
@@ -62,6 +62,37 @@ public class GroupReduceITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
+	public void testCorrectnessofGroupReduceOnTupleContainingPrimitiveByteArrayWithKeyFieldSelectors() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Tuple2<byte[], Integer>> ds = CollectionDataSets.getTuple2WithByteArrayDataSet(env);
+		DataSet<Integer> reduceDs = ds.
+				groupBy(0).reduceGroup(new ByteArrayGroupReduce());
+
+		List<Integer> result = reduceDs.collect();
+
+		String expected = "0\n"
+				+ "1\n"
+				+ "2\n"
+				+ "3\n"
+				+ "4\n";
+
+		compareResultAsText(result, expected);
+
+	}
+
+	public static class ByteArrayGroupReduce implements GroupReduceFunction<Tuple2<byte[], Integer>, Integer> {
+		@Override
+		public void reduce(Iterable<Tuple2<byte[], Integer>> values, Collector<Integer> out) throws Exception {
+			int sum = 0;
+			for (Tuple2<byte[], Integer> value : values) {
+				sum += value.f1;
+			}
+			out.collect(sum);
+		}
+	}
+
+	@Test
 	public void testCorrectnessOfGroupReduceOnTuplesWithKeyFieldSelector() throws Exception{
 		/*
 		 * check correctness of groupReduce on tuples with key field selector

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/util/CollectionDataSets.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/util/CollectionDataSets.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple5;
@@ -203,6 +204,23 @@ public class CollectionDataSets {
 				BasicTypeInfo.INT_TYPE_INFO
 		);
 
+		return env.fromCollection(data, type);
+	}
+	
+	public static DataSet<Tuple2<byte[], Integer>> getTuple2WithByteArrayDataSet(ExecutionEnvironment env) {
+		List<Tuple2<byte[], Integer>> data = new ArrayList<Tuple2<byte[], Integer>>();
+		data.add(new Tuple2<byte[], Integer>(new byte[]{0, 4}, 1));
+		data.add(new Tuple2<byte[], Integer>(new byte[]{2, 0}, 1));
+		data.add(new Tuple2<byte[], Integer>(new byte[]{2, 0, 4}, 4));
+		data.add(new Tuple2<byte[], Integer>(new byte[]{2, 1}, 3));
+		data.add(new Tuple2<byte[], Integer>(new byte[]{0}, 0));
+		data.add(new Tuple2<byte[], Integer>(new byte[]{2, 0}, 1));
+				
+		TupleTypeInfo<Tuple2<byte[], Integer>> type = new TupleTypeInfo<Tuple2<byte[], Integer>>(
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO
+		);
+		
 		return env.fromCollection(data, type);
 	}
 


### PR DESCRIPTION
Adds a comparator and test for every primitive array type.
Modifies the CustomType2 class in GroupingTest to retain a field with an unsupported type.