### PR TITLE
[FLINK-2556] Refactor/Fix pre-flight Key validation

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.operators;
 
-import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
@@ -26,9 +25,7 @@ import org.apache.flink.api.common.operators.SingleInputSemanticProperties;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
 import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase;
 import org.apache.flink.api.common.operators.base.MapOperatorBase;
-import org.apache.flink.api.common.typeinfo.AtomicType;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.java.operators.translation.KeyExtractingMapper;
 import org.apache.flink.api.java.operators.translation.PlanUnwrappingReduceGroupOperator;
@@ -54,10 +51,6 @@ public class DistinctOperator<T> extends SingleInputOperator<T, T, DistinctOpera
 
 		this.distinctLocationName = distinctLocationName;
 
-		if (!(input.getType() instanceof CompositeType) &&
-				!(input.getType() instanceof AtomicType && input.getType().isKeyType())){
-			throw new InvalidProgramException("Distinct only possible on composite or atomic key types.");
-		}
 		// if keys is null distinction is done on all fields
 		if (keys == null) {
 			keys = new Keys.ExpressionKeys<T>(new String[] {Keys.ExpressionKeys.SELECT_ALL_CHAR }, input.getType());

--- a/flink-java/src/test/java/org/apache/flink/api/java/sca/UdfAnalyzerExamplesTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/sca/UdfAnalyzerExamplesTest.java
@@ -529,8 +529,8 @@ public class UdfAnalyzerExamplesTest {
 	@Test
 	public void testLogisticRegressionExamplesSumGradient() {
 		compareAnalyzerResultWithAnnotationsSingleInputWithKeys(ReduceFunction.class, SumGradient.class,
-				"Tuple1<double[]>",
-				"Tuple1<double[]>",
+				"Tuple1<double>",
+				"Tuple1<double>",
 				new String[] { "0" });
 	}
 


### PR DESCRIPTION
Removed redundant key validation in DistinctOperator
Keys constructors now make sure the type of every key is an instance of AtomicType/CompositeType, and that type.isKeyType() is true.
Additionally, the ExpressionKeys int[] constructor explicitly rejects Tuple0
Changes one test that actually tried something that shouldn't work in the first place.