### PR TITLE
[FLINK-2557] TypeExtractor properly returns MissingTypeInfo

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -683,8 +683,8 @@ public class TypeExtractor {
 			return parameter;
 		}
 		
-		throw new IllegalArgumentException("The types of the interface " + baseClass.getName() + " could not be inferred. " + 
-						"Support for synthetic interfaces, lambdas, and generic types is limited at this point.");
+		throw new InvalidTypesException("The types of the interface " + baseClass.getName() + " could not be inferred. " + 
+						"Support for synthetic interfaces, lambdas, and generic or raw types is limited at this point");
 	}
 	
 	private static Type getParameterTypeFromGenericType(Class<?> baseClass, ArrayList<Type> typeHierarchy, Type t, int pos) {
@@ -734,7 +734,7 @@ public class TypeExtractor {
 		try {
 			inType = getParameterType(baseClass, typeHierarchy, clazz, inputParamPos);
 		}
-		catch (IllegalArgumentException e) {
+		catch (InvalidTypesException e) {
 			return; // skip input validation e.g. for raw types
 		}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -854,7 +854,7 @@ public class TypeExtractorTest {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public String map(Object value) throws Exception {
+			public Object map(Object value) throws Exception {
 				return null;
 			}
 		};

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType.FlatFieldDescriptor;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple0;
@@ -844,6 +845,25 @@ public class TypeExtractorTest {
 		catch (InvalidTypesException e) {
 			// expected
 		}
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Test
+	public void testFunctionWithMissingGenericsAndReturns() {
+		RichMapFunction function = new RichMapFunction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String map(Object value) throws Exception {
+				return null;
+			}
+		};
+
+		TypeInformation info = ExecutionEnvironment.getExecutionEnvironment()
+				.fromElements("arbitrary", "data")
+				.map(function).returns("String").getResultType();
+
+		Assert.assertEquals(TypeInfoParser.parse("String"), info);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
This fix is not really obvious so let me explain:

getParameterTye() is called from two different places in the TypeExtractor; to validate the input type and to extract the output type.

Both cases consider the possibility that getParameterType() fails, but check for different exceptions. 

The TypeExtractor only returns a MissingTypeInfo if it encounters an InvalidTypesException; IllegalArgumentExceptions are not catched. This is what @mjsax encountered.
Changing the exception type causes the TypeExtractor to properly return a MissingTypeInfo, which is later overridden by the returns(...) call.

In order for the input validation to still work properly aswell, it now catches InvalidTypesExceptions instead.