### PR TITLE
[FLINK-2525]Add configuration support in Storm-compatibility

### DIFF
--- a/docs/apis/storm_compatibility.md
+++ b/docs/apis/storm_compatibility.md
@@ -169,6 +169,13 @@ The input type is `Tuple1<String>` and `Fields("sentence")` specify that `input.
 
 See [BoltTokenizerWordCountPojo](https://github.com/apache/flink/tree/master/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/wordcount/BoltTokenizerWordCountPojo.java) and [BoltTokenizerWordCountWithNames](https://github.com/apache/flink/tree/master/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/wordcount/BoltTokenizerWordCountWithNames.java) for examples.  
 
+## Configure for embedded Spouts/Bolts
+Embedded Spouts/Bolts can be configure with user defined parameters.
+User defined parameters is stored in a `Map`(as in Storm).
+And this Map is provided as a parameter in the calls `Spout.open(...)` and `Bolt.prepare(...)`.
+Configuration can be used in storm topologies mode or flink mode.
+If a whole topology is executed using `FlinkTopologyBuilder` etc., there is no special attention required &ndash; it works as in regular Storm.
+
 ## Multiple Output Streams
 
 Flink can also handle the declaration of multiple output streams for Spouts and Bolts.

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/README.md
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/README.md
@@ -3,7 +3,6 @@
 The Storm compatibility layer allows to embed spouts or bolt unmodified within a regular Flink streaming program (`StormSpoutWrapper` and `StormBoltWrapper`). Additionally, a whole Storm topology can be submitted to Flink (see `FlinkTopologyBuilder`, `FlinkLocalCluster`, and `FlinkSubmitter`). Only a few minor changes to the original submitting code are required. The code that builds the topology itself, can be reused unmodified. See `flink-storm-examples` for a simple word-count example.
 
 The following Strom features are not (yet/fully) supported by the compatibility layer right now:
-* the spout/bolt configuration within `open()`/`prepare()` is not yet supported (ie, `Map conf` parameter)
 * topology and tuple meta information (ie, `TopologyContext` not fully supported)
 * no fault-tolerance guarantees (ie, calls to `ack()`/`fail()` and anchoring is ignored)
 * for whole Storm topologies the following is not supported by Flink:

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkClient.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkClient.java
@@ -47,6 +47,8 @@ import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
 import org.apache.flink.runtime.messages.JobManagerMessages.RunningJobsStatus;
 
+import org.apache.flink.stormcompatibility.util.StormConfig;
+import org.apache.flink.util.InstantiationUtil;
 import scala.Some;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -66,7 +68,6 @@ import java.util.Map;
 public class FlinkClient {
 
 	/** The client's configuration */
-	@SuppressWarnings("unused")
 	private final Map<?,?> conf;
 	/** The jobmanager's host name */
 	private final String jobManagerHost;
@@ -181,6 +182,15 @@ public class FlinkClient {
 		jobGraph.addJar(new Path(uploadedJarFile.getAbsolutePath()));
 
 		final Configuration configuration = jobGraph.getJobConfiguration();
+
+		/* set storm configuration */
+		if (this.conf != null) {
+			try {
+				InstantiationUtil.writeObjectToConfig(this.conf, configuration, StormConfig.STORM_DEFAULT_CONFIG);
+			} catch (final IOException e) {
+				throw new RuntimeException("Problem with serialize storm configuration", e);
+			}
+		}
 
 		final Client client;
 

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkLocalCluster.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/FlinkLocalCluster.java
@@ -25,7 +25,11 @@ import backtype.storm.generated.RebalanceOptions;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.generated.SubmitOptions;
 import backtype.storm.generated.TopologyInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.stormcompatibility.util.StormConfig;
 import org.apache.flink.streaming.util.ClusterUtil;
+import org.apache.flink.util.InstantiationUtil;
 
 import java.util.Map;
 
@@ -41,7 +45,14 @@ public class FlinkLocalCluster {
 
 	public void submitTopologyWithOpts(final String topologyName, final Map<?, ?> conf, final FlinkTopology topology,
 			final SubmitOptions submitOpts) throws Exception {
-		ClusterUtil.startOnMiniCluster(topology.getStreamGraph().getJobGraph(topologyName), topology.getNumberOfTasks());
+		JobGraph jobGraph = topology.getStreamGraph().getJobGraph(topologyName);
+		Configuration jobConfiguration = jobGraph.getJobConfiguration();
+
+		if (conf != null) {
+			InstantiationUtil.writeObjectToConfig(conf, jobConfiguration, StormConfig.STORM_DEFAULT_CONFIG);
+		}
+
+		ClusterUtil.startOnMiniCluster(jobGraph, topology.getNumberOfTasks());
 	}
 
 	public void killTopology(final String topologyName) {

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/util/StormConfig.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/util/StormConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.stormcompatibility.util;
+
+/**
+ * This class contains all constants for the storm configuration used in storm-compatibility.
+ */
+public final class StormConfig {
+
+	/**
+	 * storm configuration
+	 */
+	public static final String STORM_DEFAULT_CONFIG = "storm.config";
+
+	/**
+	 * Not instantiable.
+	 */
+	private StormConfig() {}
+}

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormBoltWrapper.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormBoltWrapper.java
@@ -18,6 +18,7 @@ package org.apache.flink.stormcompatibility.wrappers;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
@@ -205,7 +206,12 @@ public class StormBoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> imple
 					this.numberOfAttributes, flinkCollector));
 		}
 
-		this.bolt.prepare(null, topologyContext, stormCollector);
+		Map config = new HashMap();
+		Map stormConf = StormWrapperSetupHelper.getStormConfFromContext(super.getRuntimeContext());
+		if (stormConf != null) {
+			config.putAll(stormConf);
+		}
+		this.bolt.prepare(config, topologyContext, stormCollector);
 	}
 
 	@Override

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/test/java/org/apache/flink/stormcompatibility/wrappers/StormSpoutWrapperTest.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/test/java/org/apache/flink/stormcompatibility/wrappers/StormSpoutWrapperTest.java
@@ -17,18 +17,45 @@
 
 package org.apache.flink.stormcompatibility.wrappers;
 
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.IRichSpout;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
+import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.state.StateHandleProvider;
+import org.apache.flink.runtime.taskmanager.RuntimeEnvironment;
+import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.stormcompatibility.util.AbstractTest;
+import org.apache.flink.stormcompatibility.util.StormConfig;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.runtime.tasks.StreamingRuntimeContext;
+import org.apache.flink.util.InstantiationUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -49,6 +76,68 @@ public class StormSpoutWrapperTest extends AbstractTest {
 		spoutWrapper.run(collector);
 
 		Assert.assertEquals(new LinkedList<Tuple1<Integer>>(), collector.result);
+	}
+
+	@Test
+	public void testOpenWithStormConf() throws Exception {
+		final IRichSpout spout = mock(IRichSpout.class);
+		final StormSpoutWrapper<Tuple1<Integer>> spoutWrapper = new StormSpoutWrapper<Tuple1<Integer>>(spout);
+
+		Map stormConf = new HashMap();
+		stormConf.put("path", "/home/user/file.txt");
+		stormConf.put(1, 1024);
+		byte[] bytes = InstantiationUtil.serializeObject(stormConf);
+		Configuration jobConfiguration = new Configuration();
+		jobConfiguration.setBytes(StormConfig.STORM_DEFAULT_CONFIG, bytes);
+		jobConfiguration.setInteger("port", 5566);
+		Environment env = new RuntimeEnvironment(new JobID(), new JobVertexID(), new ExecutionAttemptID(),
+				new String(), new String(), 1, 2, jobConfiguration, mock(Configuration.class), mock(ClassLoader.class),
+				mock(MemoryManager.class), mock(IOManager.class), mock(BroadcastVariableManager.class),
+				mock(AccumulatorRegistry.class), mock(InputSplitProvider.class), mock(Map.class),
+				new ResultPartitionWriter[1], new InputGate[1], mock(ActorGateway.class),
+				mock(TaskManagerRuntimeInfo.class));
+		StreamingRuntimeContext runtimeContext = new StreamingRuntimeContext(env, new ExecutionConfig(),
+				mock(KeySelector.class),
+				mock(StateHandleProvider.class), mock(Map.class));
+
+		spoutWrapper.setRuntimeContext(runtimeContext);
+		spoutWrapper.open(mock(Configuration.class));
+		final SourceFunction.SourceContext ctx = mock(SourceFunction.SourceContext.class);
+		spoutWrapper.cancel();
+		spoutWrapper.run(ctx);
+
+		verify(spout).open(eq(stormConf), any(TopologyContext.class), any(SpoutOutputCollector.class));
+	}
+
+	@Test
+	public void testOpenWithJobConf() throws Exception {
+		final IRichSpout spout = mock(IRichSpout.class);
+		final StormSpoutWrapper<Tuple1<Integer>> spoutWrapper = new StormSpoutWrapper<Tuple1<Integer>>(spout);
+
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		Configuration jobParameters = new Configuration();
+		jobParameters.setString("path", "/home/user/file.txt");
+		executionConfig.setGlobalJobParameters(jobParameters);
+		byte[] bytes = InstantiationUtil.serializeObject(executionConfig);
+		Configuration jobConfiguration = new Configuration();
+		jobConfiguration.setBytes(ExecutionConfig.CONFIG_KEY, bytes);
+		Environment env = new RuntimeEnvironment(new JobID(), new JobVertexID(), new ExecutionAttemptID(),
+				new String(), new String(), 1, 2, jobConfiguration, mock(Configuration.class), mock(ClassLoader.class),
+				mock(MemoryManager.class), mock(IOManager.class), mock(BroadcastVariableManager.class),
+				mock(AccumulatorRegistry.class), mock(InputSplitProvider.class), mock(Map.class),
+				new ResultPartitionWriter[1], new InputGate[1], mock(ActorGateway.class),
+				mock(TaskManagerRuntimeInfo.class));
+		StreamingRuntimeContext runtimeContext = new StreamingRuntimeContext(env, new ExecutionConfig(),
+				mock(KeySelector.class),
+				mock(StateHandleProvider.class), mock(Map.class));
+
+		spoutWrapper.setRuntimeContext(runtimeContext);
+		spoutWrapper.open(mock(Configuration.class));
+		final SourceFunction.SourceContext ctx = mock(SourceFunction.SourceContext.class);
+		spoutWrapper.cancel();
+		spoutWrapper.run(ctx);
+
+		verify(spout).open(eq(jobParameters.toMap()), any(TopologyContext.class), any(SpoutOutputCollector.class));
 	}
 
 	@Test

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/test/java/org/apache/flink/stormcompatibility/wrappers/StormWrapperSetupHelperTest.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/test/java/org/apache/flink/stormcompatibility/wrappers/StormWrapperSetupHelperTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.stormcompatibility.wrappers;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import backtype.storm.topology.IComponent;
 import backtype.storm.topology.IRichBolt;
@@ -25,7 +26,28 @@ import backtype.storm.topology.IRichSpout;
 import backtype.storm.tuple.Fields;
 import backtype.storm.utils.Utils;
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
+import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.state.StateHandleProvider;
+import org.apache.flink.runtime.taskmanager.RuntimeEnvironment;
+import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.stormcompatibility.util.AbstractTest;
+import org.apache.flink.stormcompatibility.util.StormConfig;
+import org.apache.flink.streaming.runtime.tasks.StreamingRuntimeContext;
+import org.apache.flink.util.InstantiationUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -132,4 +154,47 @@ public class StormWrapperSetupHelperTest extends AbstractTest {
 						.newHashSet(new String[] { Utils.DEFAULT_STREAM_ID }) : null));
 	}
 
+	@Test
+	public void testGetConfTopologiesMode() throws Exception {
+		Map stormConf = new HashMap();
+		stormConf.put("path", "/home/user/file.txt");
+		stormConf.put(1, 1024);
+		byte[] bytes = InstantiationUtil.serializeObject(stormConf);
+		Configuration jobConfiguration = new Configuration();
+		jobConfiguration.setBytes(StormConfig.STORM_DEFAULT_CONFIG, bytes);
+		jobConfiguration.setInteger("port", 5566);
+		Environment env = new RuntimeEnvironment(new JobID(), new JobVertexID(), new ExecutionAttemptID(),
+				new String(), new String(), 1, 2, jobConfiguration, mock(Configuration.class), mock(ClassLoader.class),
+				mock(MemoryManager.class), mock(IOManager.class), mock(BroadcastVariableManager.class),
+				mock(AccumulatorRegistry.class), mock(InputSplitProvider.class), mock(Map.class),
+				new ResultPartitionWriter[1], new InputGate[1], mock(ActorGateway.class),
+				mock(TaskManagerRuntimeInfo.class));
+		StreamingRuntimeContext ctx = new StreamingRuntimeContext(env, new ExecutionConfig(),
+				mock(KeySelector.class),
+				mock(StateHandleProvider.class), mock(Map.class));
+
+		Assert.assertEquals(stormConf, StormWrapperSetupHelper.getStormConfFromContext(ctx));
+	}
+
+	@Test
+	public void testGetConfEmbeddedMode() throws Exception {
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		Configuration jobParameters = new Configuration();
+		jobParameters.setString("path", "/home/user/file.txt");
+		executionConfig.setGlobalJobParameters(jobParameters);
+		byte[] bytes = InstantiationUtil.serializeObject(executionConfig);
+		Configuration jobConfiguration = new Configuration();
+		jobConfiguration.setBytes(ExecutionConfig.CONFIG_KEY, bytes);
+		Environment env = new RuntimeEnvironment(new JobID(), new JobVertexID(), new ExecutionAttemptID(),
+				new String(), new String(), 1, 2, jobConfiguration, mock(Configuration.class), mock(ClassLoader.class),
+				mock(MemoryManager.class), mock(IOManager.class), mock(BroadcastVariableManager.class),
+				mock(AccumulatorRegistry.class), mock(InputSplitProvider.class), mock(Map.class),
+				new ResultPartitionWriter[1], new InputGate[1], mock(ActorGateway.class),
+				mock(TaskManagerRuntimeInfo.class));
+		StreamingRuntimeContext ctx = new StreamingRuntimeContext(env, new ExecutionConfig(),
+				mock(KeySelector.class),
+				mock(StateHandleProvider.class), mock(Map.class));
+
+		Assert.assertEquals(jobParameters.toMap(), StormWrapperSetupHelper.getStormConfFromContext(ctx));
+	}
 }

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/excamation/ExclamationWithStormBolt.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/excamation/ExclamationWithStormBolt.java
@@ -36,7 +36,7 @@ import backtype.storm.utils.Utils;
  * The input is a plain text file with lines separated by newline characters.
  * <p/>
  * <p/>
- * Usage: <code>StormExclamationWithStormBolt &lt;text path&gt; &lt;result path&gt;</code><br/>
+ * Usage: <code>StormExclamationWithStormBolt &lt;text path&gt; &lt;result path&gt; &lt;exclamation num&gt;</code><br/>
  * If no parameters are provided, the program is run with default data from
  * {@link WordCountData}.
  * <p/>
@@ -69,7 +69,7 @@ public class ExclamationWithStormBolt {
 						TypeExtractor.getForObject(""),
 				new StormBoltWrapper<String, String>(new ExclamationBolt(),
 						new String[] { Utils.DEFAULT_STREAM_ID }))
-						.map(new ExclamationMap());
+						.map(new ExclamationMap(exclamationNum));
 
 		// emit result
 		if (fileOutput) {
@@ -88,9 +88,23 @@ public class ExclamationWithStormBolt {
 
 	private static class ExclamationMap implements MapFunction<String, String> {
 
+		private String exclamation;
+
+		public ExclamationMap() {
+			exclamation = "!!!";
+		}
+
+		public ExclamationMap(int exclamationNum) {
+			StringBuilder builder = new StringBuilder();
+			for (int index = 0; index < exclamationNum; ++index) {
+				builder.append('!');
+			}
+			exclamation = builder.toString();
+		}
+
 		@Override
 		public String map(String value) throws Exception {
-			return value + "!!!";
+			return value + exclamation;
 		}
 	}
 
@@ -101,23 +115,26 @@ public class ExclamationWithStormBolt {
 	private static boolean fileOutput = false;
 	private static String textPath;
 	private static String outputPath;
+	private static int exclamationNum;
 
 	private static boolean parseParameters(final String[] args) {
 
 		if (args.length > 0) {
 			// parse input arguments
 			fileOutput = true;
-			if (args.length == 2) {
+			if (args.length == 3) {
 				textPath = args[0];
 				outputPath = args[1];
+				exclamationNum = Integer.parseInt(args[2]);
 			} else {
-				System.err.println("Usage: ExclamationWithStormBolt <text path> <result path>");
+				System.err.println("Usage: ExclamationWithStormBolt <text path> <result path> <exclamation num>");
 				return false;
 			}
 		} else {
+			exclamationNum = 3;
 			System.out.println("Executing ExclamationWithStormBolt example with built-in default data");
 			System.out.println("  Provide parameters to read input data from a file");
-			System.out.println("  Usage: ExclamationWithStormBolt <text path> <result path>");
+			System.out.println("  Usage: ExclamationWithStormBolt <text path> <result path> <exclamation num>");
 		}
 		return true;
 	}

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/excamation/stormoperators/ExclamationBolt.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/excamation/stormoperators/ExclamationBolt.java
@@ -31,10 +31,22 @@ import java.util.Map;
 public class ExclamationBolt implements IRichBolt {
 	OutputCollector _collector;
 
+	private String exclamation;
+
 	@SuppressWarnings("rawtypes")
 	@Override
 	public void prepare(Map conf, TopologyContext context, OutputCollector collector) {
 		_collector = collector;
+		exclamation = "!!!";
+
+		if (conf.containsKey("exclamationNum")) {
+			int exclamationNum = (Integer)conf.get("exclamationNum");
+			StringBuilder builder = new StringBuilder();
+			for (int index = 0; index < exclamationNum; ++index) {
+				builder.append('!');
+			}
+			exclamation = builder.toString();
+		}
 	}
 
 	@Override

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/FiniteStormFileSpout.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/FiniteStormFileSpout.java
@@ -35,6 +35,8 @@ public class FiniteStormFileSpout extends StormFileSpout implements FiniteStormS
 	private String line;
 	private boolean newLineRead;
 
+	public FiniteStormFileSpout() {}
+
 	public FiniteStormFileSpout(String path) {
 		super(path);
 	}

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/StormFileSpout.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/main/java/org/apache/flink/stormcompatibility/util/StormFileSpout.java
@@ -33,8 +33,12 @@ import java.util.Map;
 public class StormFileSpout extends AbstractStormSpout {
 	private static final long serialVersionUID = -6996907090003590436L;
 
-	protected final String path;
+	protected String path;
 	protected BufferedReader reader;
+
+	public StormFileSpout() {
+		this.path = null;
+	}
 
 	public StormFileSpout(final String path) {
 		this.path = path;
@@ -45,6 +49,11 @@ public class StormFileSpout extends AbstractStormSpout {
 	public void open(final Map conf, final TopologyContext context, final SpoutOutputCollector collector) {
 		super.open(conf, context, collector);
 		try {
+			/*  If config is given, it should override constructor path  */
+			if (conf.containsKey("textpath")) {
+				this.path = (String)conf.get("textpath");
+			}
+
 			this.reader = new BufferedReader(new FileReader(this.path));
 		} catch (final FileNotFoundException e) {
 			throw new RuntimeException(e);

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/test/java/org/apache/flink/stormcompatibility/exclamation/ExclamationWithStormBoltITCase.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/test/java/org/apache/flink/stormcompatibility/exclamation/ExclamationWithStormBoltITCase.java
@@ -27,11 +27,13 @@ public class ExclamationWithStormBoltITCase extends StreamingProgramTestBase {
 
 	protected String textPath;
 	protected String resultPath;
+	protected String exclamationNum;
 
 	@Override
 	protected void preSubmit() throws Exception {
 		this.textPath = this.createTempFile("text.txt", WordCountData.TEXT);
 		this.resultPath = this.getTempDirPath("result");
+		this.exclamationNum = "3";
 	}
 
 	@Override
@@ -41,7 +43,7 @@ public class ExclamationWithStormBoltITCase extends StreamingProgramTestBase {
 
 	@Override
 	protected void testProgram() throws Exception {
-		ExclamationWithStormBolt.main(new String[]{this.textPath, this.resultPath});
+		ExclamationWithStormBolt.main(new String[]{this.textPath, this.resultPath, this.exclamationNum});
 	}
 
 }

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/test/java/org/apache/flink/stormcompatibility/exclamation/ExclamationWithStormSpoutITCase.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-examples/src/test/java/org/apache/flink/stormcompatibility/exclamation/ExclamationWithStormSpoutITCase.java
@@ -27,11 +27,13 @@ public class ExclamationWithStormSpoutITCase extends StreamingProgramTestBase {
 
 	protected String textPath;
 	protected String resultPath;
+	protected String exclamationNum;
 
 	@Override
 	protected void preSubmit() throws Exception {
 		this.textPath = this.createTempFile("text.txt", WordCountData.TEXT);
 		this.resultPath = this.getTempDirPath("result");
+		this.exclamationNum = "3";
 	}
 
 	@Override
@@ -41,7 +43,7 @@ public class ExclamationWithStormSpoutITCase extends StreamingProgramTestBase {
 
 	@Override
 	protected void testProgram() throws Exception {
-		ExclamationWithStormSpout.main(new String[]{this.textPath, this.resultPath});
+		ExclamationWithStormSpout.main(new String[]{this.textPath, this.resultPath, this.exclamationNum});
 	}
 
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -418,6 +418,17 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 		}
 	}
 
+	/**
+	 * Returns the clone of confData.
+	 *
+	 * @return the clone of confData
+	 */
+	public HashMap<String, Object> getConfDataClone() {
+		synchronized (this.confData) {
+			return new HashMap<String, Object>(this.confData);
+		}
+	}
+
 	public void addAll(Configuration other) {
 		synchronized (this.confData) {
 			synchronized (other.confData) {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamingRuntimeContext.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamingRuntimeContext.java
@@ -91,7 +91,16 @@ public class StreamingRuntimeContext extends RuntimeUDFContext {
 	public Configuration getTaskStubParameters() {
 		return new TaskConfig(env.getTaskConfiguration()).getStubParameters();
 	}
-	
+
+	/**
+	 * Returns the job configuration.
+	 *
+	 * @return The job configuration.
+	 */
+	public Configuration getJobConfiguration() {
+		return new Configuration(env.getJobConfiguration());
+	}
+
 	public StateHandleProvider<Serializable> getStateHandleProvider() {
 		return provider;
 	}


### PR DESCRIPTION
- enable config can used in Spouts.open() and Bout.prepare().

Example like this:
public static void main(final String[] args) {
	String topologyId = "Streaming WordCount";
	final FlinkTopologyBuilder builder = new FlinkTopologyBuilder();
	...
	final Config conf = new Config();
	conf.put("wordsFile", "/home/user/");
	conf.put("delimitSize", 1024);
	final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
	cluster.submitTopology(topologyId, conf, builder.createTopology());
	Utils.sleep(10 * 1000);
	cluster.killTopology(topologyId);
	cluster.shutdown();	
}

public class WordReader implements IRichSpout {
	....
	public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
		try {
			this.context = context;
			this.fileReader = new FileReader(conf.get("wordsFile"));
		} catch (FileNotFoundException e) {
			throw new RuntimeException("Error reading file ["+conf.get("wordFile")+"]");
		}
		this.collector = collector;
	}
}

public final class StormBoltTokenizer implements IRichBolt {
	....
	public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
		this.delimitSize = stormConf.get("delimitSize");
		this.collector = collector;
	}	
}
