### PR TITLE
[FLINK-2089] [runtime] Fix illegal state in RecordWriter after partition write failure

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
-import org.apache.flink.runtime.event.AbstractEvent;
+import  org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.serialization.RecordSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.SpanningRecordSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -86,8 +86,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 					Buffer buffer = serializer.getCurrentBuffer();
 
 					if (buffer != null) {
-						writer.writeBuffer(buffer, targetChannel);
-						serializer.clearCurrentBuffer();
+						writeBuffer(buffer, targetChannel, serializer);
 					}
 
 					buffer = writer.getBufferProvider().requestBufferBlocking();
@@ -112,8 +111,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 					Buffer buffer = serializer.getCurrentBuffer();
 
 					if (buffer != null) {
-						writer.writeBuffer(buffer, targetChannel);
-						serializer.clearCurrentBuffer();
+						writeBuffer(buffer, targetChannel, serializer);
 					}
 
 					buffer = writer.getBufferProvider().requestBufferBlocking();
@@ -135,8 +133,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 						throw new IllegalStateException("Serializer has data but no buffer.");
 					}
 
-					writer.writeBuffer(buffer, targetChannel);
-					serializer.clearCurrentBuffer();
+					writeBuffer(buffer, targetChannel, serializer);
 
 					writer.writeEvent(event, targetChannel);
 
@@ -157,8 +154,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 			synchronized (serializer) {
 				Buffer buffer = serializer.getCurrentBuffer();
 				if (buffer != null) {
-					writer.writeBuffer(buffer, targetChannel);
-					serializer.clearCurrentBuffer();
+					writeBuffer(buffer, targetChannel, serializer);
 
 					buffer = writer.getBufferProvider().requestBufferBlocking();
 					serializer.setNextBuffer(buffer);
@@ -174,26 +170,31 @@ public class RecordWriter<T extends IOReadableWritable> {
 			RecordSerializer<T> serializer = serializers[targetChannel];
 
 			synchronized (serializer) {
-				Buffer buffer = serializer.getCurrentBuffer();
+				try {
+					Buffer buffer = serializer.getCurrentBuffer();
 
-				if (buffer != null) {
-					// Only clear the serializer after the buffer was written out.
-					writer.writeBuffer(buffer, targetChannel);
+					if (buffer != null) {
+						writeBuffer(buffer, targetChannel, serializer);
+					}
+				} finally {
+					serializer.clear();
 				}
-
-				serializer.clear();
 			}
 		}
 	}
 
 	public void clearBuffers() {
-		for (RecordSerializer<?> s : serializers) {
-			synchronized (s) {
-				Buffer b = s.getCurrentBuffer();
-				s.clear();
+		for (RecordSerializer<?> serializer : serializers) {
+			synchronized (serializer) {
+				try {
+					Buffer buffer = serializer.getCurrentBuffer();
 
-				if (b != null) {
-					b.recycle();
+					if (buffer != null) {
+						buffer.recycle();
+					}
+				}
+				finally {
+					serializer.clear();
 				}
 			}
 		}
@@ -205,6 +206,24 @@ public class RecordWriter<T extends IOReadableWritable> {
 	public void setReporter(AccumulatorRegistry.Reporter reporter) {
 		for(RecordSerializer<?> serializer : serializers) {
 			serializer.setReporter(reporter);
+		}
+	}
+
+	/**
+	 * Writes the buffer to the {@link ResultPartitionWriter}.
+	 *
+	 * <p> The buffer is cleared from the serializer state after a call to this method.
+	 */
+	private void writeBuffer(
+			Buffer buffer,
+			int targetChannel,
+			RecordSerializer<T> serializer) throws IOException {
+
+		try {
+			writer.writeBuffer(buffer, targetChannel);
+		}
+		finally {
+			serializer.clearCurrentBuffer();
 		}
 	}
 


### PR DESCRIPTION
I'm waiting for feedback from a user whether this fixes FLINK-2089, but this PR definitely addresses a problem.

Record writers have a `clearBuffers` method, which is called by the task code in a finally block at the end of `invoke` (see `RegularPactTask` for example). This call clears the buffers of the record serializers.

The following illegal state can arise: a buffer has been published to a partition, but the serializers still hold a reference to it. When a serializer tries to clear its current buffer, it might have already been recycled (because it was published to the partition). This will currently happen if there was an Exception during writing the buffer to the partition.

This PR replaces the write-and-clear calls with a try-catch-finally block and tests the expected behaviour in a new test. The removed tests are superseded by this new test.
