### PR TITLE
[FLINK-2577] Fix Stalling Watermarks when Sources Close

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamFlatMap.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamFlatMap.java
@@ -36,8 +36,8 @@ public class CoStreamFlatMap<IN1, IN2, OUT>
 	// We keep track of watermarks from both inputs, the combined input is the minimum
 	// Once the minimum advances we emit a new watermark for downstream operators
 	private long combinedWatermark = Long.MIN_VALUE;
-	private long input1Watermark = Long.MAX_VALUE;
-	private long input2Watermark = Long.MAX_VALUE;
+	private long input1Watermark = Long.MIN_VALUE;
+	private long input2Watermark = Long.MIN_VALUE;
 
 	public CoStreamFlatMap(CoFlatMapFunction<IN1, IN2, OUT> flatMapper) {
 		super(flatMapper);
@@ -66,7 +66,7 @@ public class CoStreamFlatMap<IN1, IN2, OUT>
 	public void processWatermark1(Watermark mark) throws Exception {
 		input1Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}
@@ -76,7 +76,7 @@ public class CoStreamFlatMap<IN1, IN2, OUT>
 	public void processWatermark2(Watermark mark) throws Exception {
 		input2Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamMap.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamMap.java
@@ -32,8 +32,8 @@ public class CoStreamMap<IN1, IN2, OUT>
 	// We keep track of watermarks from both inputs, the combined input is the minimum
 	// Once the minimum advances we emit a new watermark for downstream operators
 	private long combinedWatermark = Long.MIN_VALUE;
-	private long input1Watermark = Long.MAX_VALUE;
-	private long input2Watermark = Long.MAX_VALUE;
+	private long input1Watermark = Long.MIN_VALUE;
+	private long input2Watermark = Long.MIN_VALUE;
 
 	public CoStreamMap(CoMapFunction<IN1, IN2, OUT> mapper) {
 		super(mapper);
@@ -53,7 +53,7 @@ public class CoStreamMap<IN1, IN2, OUT>
 	public void processWatermark1(Watermark mark) throws Exception {
 		input1Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}
@@ -63,7 +63,7 @@ public class CoStreamMap<IN1, IN2, OUT>
 	public void processWatermark2(Watermark mark) throws Exception {
 		input2Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamReduce.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamReduce.java
@@ -35,8 +35,8 @@ public class CoStreamReduce<IN1, IN2, OUT>
 	// We keep track of watermarks from both inputs, the combined input is the minimum
 	// Once the minimum advances we emit a new watermark for downstream operators
 	private long combinedWatermark = Long.MIN_VALUE;
-	private long input1Watermark = Long.MAX_VALUE;
-	private long input2Watermark = Long.MAX_VALUE;
+	private long input1Watermark = Long.MIN_VALUE;
+	private long input2Watermark = Long.MIN_VALUE;
 
 	public CoStreamReduce(CoReduceFunction<IN1, IN2, OUT> coReducer) {
 		super(coReducer);
@@ -68,7 +68,7 @@ public class CoStreamReduce<IN1, IN2, OUT>
 	public void processWatermark1(Watermark mark) throws Exception {
 		input1Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}
@@ -78,7 +78,7 @@ public class CoStreamReduce<IN1, IN2, OUT>
 	public void processWatermark2(Watermark mark) throws Exception {
 		input2Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamWindow.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/operators/co/CoStreamWindow.java
@@ -52,8 +52,8 @@ public class CoStreamWindow<IN1, IN2, OUT>
 	// We keep track of watermarks from both inputs, the combined input is the minimum
 	// Once the minimum advances we emit a new watermark for downstream operators
 	private long combinedWatermark = Long.MIN_VALUE;
-	private long input1Watermark = Long.MAX_VALUE;
-	private long input2Watermark = Long.MAX_VALUE;
+	private long input1Watermark = Long.MIN_VALUE;
+	private long input2Watermark = Long.MIN_VALUE;
 
 	public CoStreamWindow(CoWindowFunction<IN1, IN2, OUT> coWindowFunction, long windowSize,
 			long slideInterval, TimestampWrapper<IN1> timeStamp1, TimestampWrapper<IN2> timeStamp2) {
@@ -105,7 +105,7 @@ public class CoStreamWindow<IN1, IN2, OUT>
 	public void processWatermark1(Watermark mark) throws Exception {
 		input1Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}
@@ -115,7 +115,7 @@ public class CoStreamWindow<IN1, IN2, OUT>
 	public void processWatermark2(Watermark mark) throws Exception {
 		input2Watermark = mark.getTimestamp();
 		long newMin = Math.min(input1Watermark, input2Watermark);
-		if (newMin > combinedWatermark && input1Watermark != Long.MAX_VALUE && input2Watermark != Long.MAX_VALUE) {
+		if (newMin > combinedWatermark) {
 			combinedWatermark = newMin;
 			output.emitWatermark(new Watermark(combinedWatermark));
 		}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/watermark/Watermark.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/watermark/Watermark.java
@@ -33,6 +33,11 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
  * In some cases a watermark is only a heuristic and operators should be able to deal with
  * late elements. They can either discard those or update the result and emit updates/retractions
  * to downstream operations.
+ *
+ * <p>
+ * When a source closes it will emit a final watermark with timestamp {@code Long.MAX_VALUE}. When
+ * an operator receives this it will know that no more input will be arriving in the future.
+ *
  */
 public class Watermark extends StreamElement {
 


### PR DESCRIPTION
Before, when one source closes early it will not emit watermarks
anymore. Downstream operations don't know about this and expect
watermarks to keep on coming. This leads to watermarks not being
forwarded anymore.

Now, when a source closes it will emit a final watermark with timestamp
Long.MAX_VALUE. This will have the effect of allowing the watermarks
from the other operations to propagate though because the watermark is
defined as the minimum over all inputs.

The Long.MAX_VALUE watermark has the added benefit of notifying
operations that no more elements will arrive in the future.