### PR TITLE
[FLINK-2326] Write yarn properties file to temp directory

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -351,6 +351,12 @@ to set the JM host:port manually. It is recommended to leave this option at 1.
 
 - `yarn.heartbeat-delay` (Default: 5 seconds). Time between heartbeats with the ResourceManager.
 
+- `yarn.properties-file.location` (Default: temp directory). When a Flink job is submitted to YARN, 
+the JobManager's host and the number of available processing slots is written into a properties file, 
+so that the Flink client is able to pick those details up. This configuration parameter allows 
+changing the default location of that file (for example for environments sharing a Flink 
+installation between users)
+
 ## Background
 
 ### Configuring the Network Buffers

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -103,7 +103,7 @@ public class CliFrontend {
 	private static final String CONFIG_DIRECTORY_FALLBACK_2 = "conf";
 
 	// YARN-session related constants
-	public static final String YARN_PROPERTIES_FILE = ".yarn-properties";
+	public static final String YARN_PROPERTIES_FILE = ".yarn-properties-";
 	public static final String YARN_PROPERTIES_JOBMANAGER_KEY = "jobManager";
 	public static final String YARN_PROPERTIES_PARALLELISM = "parallelism";
 	public static final String YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING = "dynamicPropertiesString";
@@ -162,7 +162,11 @@ public class CliFrontend {
 		this.config = GlobalConfiguration.getConfiguration();
 
 		// load the YARN properties
-		File propertiesFile = new File(configDirectory, YARN_PROPERTIES_FILE);
+		String defaultPropertiesFileLocation = System.getProperty("java.io.tmpdir");
+		String currentUser = System.getProperty("user.name");
+		String propertiesFileLocation = config.getString(ConfigConstants.YARN_PROPERTIES_FILE_LOCATION, defaultPropertiesFileLocation);
+
+		File propertiesFile = new File(propertiesFileLocation, CliFrontend.YARN_PROPERTIES_FILE + currentUser);
 		if (propertiesFile.exists()) {
 
 			logAndSysout("Found YARN properties file " + propertiesFile.getAbsolutePath());

--- a/flink-clients/src/main/java/org/apache/flink/client/FlinkYarnSessionCli.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/FlinkYarnSessionCli.java
@@ -216,7 +216,8 @@ public class FlinkYarnSessionCli {
 		flinkYarnClient.setDynamicPropertiesEncoded(dynamicPropertiesEncoded);
 
 		if (cmd.hasOption(DETACHED.getOpt())) {
-			flinkYarnClient.setDetachedMode(true);
+			this.detachedMode = true;
+			flinkYarnClient.setDetachedMode(detachedMode);
 		}
 
 		if (cmd.hasOption(STREAMING.getOpt())) {

--- a/flink-clients/src/main/java/org/apache/flink/client/FlinkYarnSessionCli.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/FlinkYarnSessionCli.java
@@ -24,6 +24,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.yarn.AbstractFlinkYarnClient;
@@ -145,13 +146,13 @@ public class FlinkYarnSessionCli {
 
 		flinkYarnClient.setConfigurationFilePath(confPath);
 
-		List<File> shipFiles = new ArrayList<File>();
+		List<File> shipFiles = new ArrayList<>();
 		// path to directory to ship
 		if (cmd.hasOption(SHIP_PATH.getOpt())) {
 			String shipPath = cmd.getOptionValue(SHIP_PATH.getOpt());
 			File shipDir = new File(shipPath);
 			if (shipDir.isDirectory()) {
-				shipFiles = new ArrayList<File>(Arrays.asList(shipDir.listFiles(new FilenameFilter() {
+				shipFiles = new ArrayList<>(Arrays.asList(shipDir.listFiles(new FilenameFilter() {
 					@Override
 					public boolean accept(File dir, String name) {
 						return !(name.equals(".") || name.equals(".."));
@@ -215,8 +216,7 @@ public class FlinkYarnSessionCli {
 		flinkYarnClient.setDynamicPropertiesEncoded(dynamicPropertiesEncoded);
 
 		if (cmd.hasOption(DETACHED.getOpt())) {
-			detachedMode = true;
-			flinkYarnClient.setDetachedMode(detachedMode);
+			flinkYarnClient.setDetachedMode(true);
 		}
 
 		if (cmd.hasOption(STREAMING.getOpt())) {
@@ -254,7 +254,7 @@ public class FlinkYarnSessionCli {
 	}
 
 	public static AbstractFlinkYarnClient getFlinkYarnClient() {
-		AbstractFlinkYarnClient yarnClient = null;
+		AbstractFlinkYarnClient yarnClient;
 		try {
 			Class<? extends AbstractFlinkYarnClient> yarnClientClass =
 					Class.forName("org.apache.flink.yarn.FlinkYarnClient").asSubclass(AbstractFlinkYarnClient.class);
@@ -288,20 +288,21 @@ public class FlinkYarnSessionCli {
 		int numTaskmanagers = 0;
 		try {
 			BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+			label:
 			while (true) {
 				// ------------------ check if there are updates by the cluster -----------
 
 				FlinkYarnClusterStatus status = yarnCluster.getClusterStatus();
 				if (status != null && numTaskmanagers != status.getNumberOfTaskManagers()) {
 					System.err.println("Number of connected TaskManagers changed to " +
-							status.getNumberOfTaskManagers() + ". Slots available: " +  status.getNumberOfSlots());
+							status.getNumberOfTaskManagers() + ". Slots available: " + status.getNumberOfSlots());
 					numTaskmanagers = status.getNumberOfTaskManagers();
 				}
 
 				List<String> messages = yarnCluster.getNewMessages();
 				if (messages != null && messages.size() > 0) {
 					System.err.println("New messages from the YARN cluster: ");
-					for(String msg : messages) {
+					for (String msg : messages) {
 						System.err.println(msg);
 					}
 				}
@@ -321,12 +322,17 @@ public class FlinkYarnSessionCli {
 
 				if (in.ready()) {
 					String command = in.readLine();
-					if (command.equals("quit") || command.equals("stop")) {
-						break; // leave loop, cli will stop cluster.
-					} else if (command.equals("help"))  {
-						System.err.println(HELP);
-					} else {
-						System.err.println("Unknown command '"+command+"'. Showing help: \n"+HELP);
+					switch (command) {
+						case "quit":
+						case "stop":
+							break label;
+
+						case "help":
+							System.err.println(HELP);
+							break;
+						default:
+							System.err.println("Unknown command '" + command + "'. Showing help: \n" + HELP);
+							break;
 					}
 				}
 				if (yarnCluster.hasBeenStopped()) {
@@ -380,7 +386,7 @@ public class FlinkYarnSessionCli {
 		// Query cluster for metrics
 		if (cmd.hasOption(QUERY.getOpt())) {
 			AbstractFlinkYarnClient flinkYarnClient = getFlinkYarnClient();
-			String description = null;
+			String description;
 			try {
 				description = flinkYarnClient.getClusterDescription();
 			} catch (Exception e) {
@@ -415,8 +421,12 @@ public class FlinkYarnSessionCli {
 			System.out.println("Flink JobManager is now running on " + jobManagerAddress);
 			System.out.println("JobManager Web Interface: " + yarnCluster.getWebInterfaceURL());
 			// file that we write into the conf/ dir containing the jobManager address and the dop.
-			String confDirPath = CliFrontend.getConfigurationDirectoryFromEnv();
-			File yarnPropertiesFile = new File(confDirPath + File.separator + CliFrontend.YARN_PROPERTIES_FILE);
+
+			String defaultPropertiesFileLocation = System.getProperty("java.io.tmpdir");
+			String currentUser = System.getProperty("user.name");
+			String propertiesFileLocation = yarnCluster.getFlinkConfiguration().getString(ConfigConstants.YARN_PROPERTIES_FILE_LOCATION, defaultPropertiesFileLocation);
+
+			File yarnPropertiesFile = new File(propertiesFileLocation + File.separator + CliFrontend.YARN_PROPERTIES_FILE + currentUser);
 
 			Properties yarnProps = new Properties();
 			yarnProps.setProperty(CliFrontend.YARN_PROPERTIES_JOBMANAGER_KEY, jobManagerAddress);

--- a/flink-clients/src/test/resources/testconfigwithyarn/flink-conf.yaml
+++ b/flink-clients/src/test/resources/testconfigwithyarn/flink-conf.yaml
@@ -23,4 +23,3 @@
 jobmanager.rpc.address: 192.168.1.33
 
 jobmanager.rpc.port: 55443
-

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -249,6 +249,15 @@ public final class ConfigConstants {
 	 */
 	public static final String YARN_HEARTBEAT_DELAY_SECONDS = "yarn.heartbeat-delay";
 
+	/**
+	 * When a Flink job is submitted to YARN, the JobManager's host and the number of available
+	 * processing slots is written into a properties file, so that the Flink client is able
+	 * to pick those details up.
+	 * This configuration parameter allows changing the default location of that file (for example
+	 * for environments sharing a Flink installation between users)
+	 */
+	public static final String YARN_PROPERTIES_FILE_LOCATION = "yarn.properties-file.location";
+
 
 	// ------------------------ Hadoop Configuration ------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/yarn/AbstractFlinkYarnCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/yarn/AbstractFlinkYarnCluster.java
@@ -75,7 +75,7 @@ public abstract class AbstractFlinkYarnCluster {
 	public abstract List<String> getNewMessages();
 
 	/**
-	 * Retruns a string representation of the ApplicationID assigned by YARN.
+	 * Returns a string representation of the ApplicationID assigned by YARN.
 	 */
 	public abstract String getApplicationId();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/yarn/AbstractFlinkYarnCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/yarn/AbstractFlinkYarnCluster.java
@@ -19,23 +19,48 @@
 package org.apache.flink.runtime.yarn;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 
+/**
+ * Abstract class for interacting with a running Flink cluster within YARN.
+ */
 public abstract class AbstractFlinkYarnCluster {
 
+	/**
+	 * Get hostname and port of the JobManager.
+	 */
 	public abstract InetSocketAddress getJobManagerAddress();
 
+	/**
+	 * Returns an URL (as a string) to the JobManager web interface, running next to the
+	 * ApplicationMaster and JobManager in a YARN container
+	 */
 	public abstract String getWebInterfaceURL();
 
+	/**
+	 * Request the YARN cluster to shut down.
+	 *
+	 * @param failApplication If true, the application will be marked as failed in YARN
+	 */
 	public abstract void shutdown(boolean failApplication);
 
+	/**
+	 * Boolean indicating whether the cluster has been stopped already
+	 */
 	public abstract boolean hasBeenStopped();
 
+	/**
+	 * Returns the latest cluster status, with number of Taskmanagers and slots
+	 */
 	public abstract FlinkYarnClusterStatus getClusterStatus();
 
+	/**
+	 * Boolean indicating whether the Flink YARN cluster is in an erronous state.
+	 */
 	public abstract boolean hasFailed();
 
 	/**
@@ -43,10 +68,24 @@ public abstract class AbstractFlinkYarnCluster {
 	 */
 	public abstract String getDiagnostics();
 
+	/**
+	 * May return new messages from the cluster.
+	 * Messages can be for example about failed containers or container launch requests.
+	 */
 	public abstract List<String> getNewMessages();
 
+	/**
+	 * Retruns a string representation of the ApplicationID assigned by YARN.
+	 */
 	public abstract String getApplicationId();
 
+	/**
+	 * Flink's YARN cluster abstraction has two modes for connecting to the YARN AM.
+	 * In the detached mode, the AM is launched and the Flink YARN client is disconnecting
+	 * afterwards.
+	 * In the non-detached mode, it maintains a connection with the AM to control the cluster.
+	 * @return boolean indicating whether the cluster is a detached cluster
+	 */
 	public abstract boolean isDetached();
 
 	/**
@@ -69,7 +108,13 @@ public abstract class AbstractFlinkYarnCluster {
 	 * Tells the ApplicationMaster to monitor the status of JobId and stop itself once the specified
 	 * job has finished.
 	 *
-	 * @param jobID
+	 * @param jobID Id of the job
 	 */
 	public abstract void stopAfterJob(JobID jobID);
+
+	/**
+	 * Return the Flink configuration object
+	 * @return The Flink configuration object
+	 */
+	public abstract Configuration getFlinkConfiguration();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/yarn/FlinkYarnClusterStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/yarn/FlinkYarnClusterStatus.java
@@ -20,7 +20,12 @@ package org.apache.flink.runtime.yarn;
 import java.io.Serializable;
 
 
+/**
+ * Simple status representation of a running YARN cluster.
+ * It contains the number of available Taskmanagers and processing slots.
+ */
 public class FlinkYarnClusterStatus implements Serializable {
+	private static final long serialVersionUID = 4230348124179245370L;
 	private int numberOfTaskManagers;
 	private int numberOfSlots;
 
@@ -62,11 +67,8 @@ public class FlinkYarnClusterStatus implements Serializable {
 		if (numberOfSlots != that.numberOfSlots) {
 			return false;
 		}
-		if (numberOfTaskManagers != that.numberOfTaskManagers) {
-			return false;
-		}
+		return numberOfTaskManagers == that.numberOfTaskManagers;
 
-		return true;
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
@@ -220,9 +220,8 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 
 	// -------------------------- Interaction with the cluster ------------------------
 
-	/**
+	/*
 	 * This call blocks until the message has been recevied.
-	 * @param jobID
 	 */
 	@Override
 	public void stopAfterJob(JobID jobID) {
@@ -232,6 +231,11 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 		} catch (Exception e) {
 			throw new RuntimeException("Unable to tell application master to stop once the specified job has been finised", e);
 		}
+	}
+
+	@Override
+	public org.apache.flink.configuration.Configuration getFlinkConfiguration() {
+		return flinkConfig;
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
@@ -269,10 +269,10 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 	@Override
 	public FlinkYarnClusterStatus getClusterStatus() {
 		if(!isConnected) {
-			throw new IllegalStateException("The cluster has been connected to the ApplicationMaster.");
+			throw new IllegalStateException("The cluster is not connected to the ApplicationMaster.");
 		}
 		if(hasBeenStopped()) {
-			throw new RuntimeException("The FlinkYarnCluster has alread been stopped");
+			throw new RuntimeException("The FlinkYarnCluster has already been stopped");
 		}
 		Future<Object> clusterStatusOption = ask(applicationClient, Messages.LocalGetYarnClusterStatus$.MODULE$, akkaTimeout);
 		Object clusterStatus;


### PR DESCRIPTION
Flink's YARN client is writing a `.yarn-properties` file to the `conf/` directory containing the JobManager's host and port.
It seems that at least two users were installing Flink into a read only location, thus Flink was unable to write the properties file to `conf/`.

With this change, the file is written into the `/tmp/` directory with the current user's name.
This will allow to use a shared Flink installation with different users at the same time.
I also introduced a configuration value to change the location of the properties file.