### PR TITLE
[FLINK-2493] Simplify names of example program JARs

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -86,7 +86,7 @@ Run the __Word Count example__ to see Flink at work.
 * __Start the example program__:
   
   ~~~bash
-  $ bin/flink run ./examplesWordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
+  $ bin/flink run ./examples/WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
   ~~~
 
 * You will find a file called __wordcount-result.txt__ in your current directory.

--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -86,7 +86,7 @@ Run the __Word Count example__ to see Flink at work.
 * __Start the example program__:
   
   ~~~bash
-  $ bin/flink run ./examples/flink-java-examples-{{site.version}}-WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
+  $ bin/flink run ./examplesWordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
   ~~~
 
 * You will find a file called __wordcount-result.txt__ in your current directory.

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -57,7 +57,7 @@ under the License.
 						</goals>
 
 						<configuration>
-							<classifier>KMeans</classifier>
+							<finalName>KMeans</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -82,14 +82,14 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>TransitiveClosure</classifier>
-				
+							<finalName>TransitiveClosure</finalName>
+
 							<archive>
 								<manifestEntries>
 									<program-class>org.apache.flink.examples.java.graph.TransitiveClosureNaive</program-class>
 								</manifestEntries>
 							</archive>
-				
+
 							<includes>
 								<include>**/java/graph/TransitiveClosureNaive.class</include>
 								<include>**/java/graph/TransitiveClosureNaive$*.class</include>
@@ -106,7 +106,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>ConnectedComponents</classifier>
+							<finalName>ConnectedComponents</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -121,7 +121,7 @@ under the License.
 							</includes>
 						</configuration>
 					</execution>
-					
+
 					<!-- EnumTriangles Basic -->
 					<execution>
 						<id>EnumTrianglesBasic</id>
@@ -130,7 +130,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>EnumTrianglesBasic</classifier>
+							<finalName>EnumTrianglesBasic</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -147,7 +147,7 @@ under the License.
 							</includes>
 						</configuration>
 					</execution>
-					
+
 					<!-- EnumTriangles Opt -->
 					<execution>
 						<id>EnumTrianglesOpt</id>
@@ -156,7 +156,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>EnumTrianglesOpt</classifier>
+							<finalName>EnumTrianglesOpt</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -173,7 +173,7 @@ under the License.
 							</includes>
 						</configuration>
 					</execution>
-					
+
 					<!-- PageRank Basic-->
 					<execution>
 						<id>PageRankBasic</id>
@@ -182,7 +182,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>PageRankBasic</classifier>
+							<finalName>PageRankBasic</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -197,7 +197,7 @@ under the License.
 							</includes>
 						</configuration>
 					</execution>
-					
+
 					<!-- These queries are currently not self-contained -->
 
 					<!-- TPC-H Query 10 -->
@@ -223,7 +223,7 @@ under the License.
 							</includes>
 						</configuration>
 					</execution> -->
-				
+
 					<!-- TPC-H Query 3 -->
 					<!--
 					<execution>
@@ -246,7 +246,7 @@ under the License.
 							</includes>
 						</configuration>
 					</execution> -->
-		
+
 					<!-- WebLogAnalysis -->
 					<execution>
 						<id>WebLogAnalysis</id>
@@ -255,7 +255,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>WebLogAnalysis</classifier>
+							<finalName>WebLogAnalysis</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -280,7 +280,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>WordCount</classifier>
+							<finalName>WordCount</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -304,7 +304,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>WordCountPOJO</classifier>
+							<finalName>WordCountPOJO</finalName>
 
 							<archive>
 								<manifestEntries>

--- a/flink-examples/flink-scala-examples/pom.xml
+++ b/flink-examples/flink-scala-examples/pom.xml
@@ -213,7 +213,7 @@ under the License.
 						</goals>
 
 						<configuration>
-							<classifier>KMeans</classifier>
+							<finalName>KMeans</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -238,7 +238,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>TransitiveClosure</classifier>
+							<finalName>TransitiveClosure</finalName>
 				
 							<archive>
 								<manifestEntries>
@@ -262,7 +262,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>ConnectedComponents</classifier>
+							<finalName>ConnectedComponents</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -286,7 +286,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>EnumTrianglesBasic</classifier>
+							<finalName>EnumTrianglesBasic</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -310,7 +310,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>EnumTrianglesOpt</classifier>
+							<finalName>EnumTrianglesOpt</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -334,7 +334,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>PageRankBasic</classifier>
+							<finalName>PageRankBasic</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -407,7 +407,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>WebLogAnalysis</classifier>
+							<finalName>WebLogAnalysis</finalName>
 
 							<archive>
 								<manifestEntries>
@@ -432,7 +432,7 @@ under the License.
 							<goal>jar</goal>
 						</goals>
 						<configuration>
-							<classifier>WordCount</classifier>
+							<finalName>WordCount</finalName>
 
 							<archive>
 								<manifestEntries>


### PR DESCRIPTION
The names of example JARs have a bit annoying, propose to replace
"examples/flinnk-java-examples-0.10-SNAPSHOT-ConnectedComponents.jar"
with "examples/ConnectedComponents.jar"
1. Changing java and scala examples'  pom.xml, set finalName to replace
default name "artifactId+version+classifer".
2.update quickstart doc which referring to examples