### PR TITLE
[FLINK-2499] [scripts] Warning message for hosts starting multiple da…

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -83,6 +83,12 @@ case $STARTSTOP in
         rotateLogFile $log
         rotateLogFile $out
 
+        # Print a warning if daemons are already running on host
+        if [ -f $pid ]; then
+            count=$(wc -l $pid | awk '{print $1}')
+            echo "[WARNING] $count instance(s) of $DAEMON are already running on $HOSTNAME."
+        fi
+
         echo "Starting $DAEMON daemon on host $HOSTNAME."
         $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} ${ARGS} > "$out" 2>&1 < /dev/null &
         mypid=$!


### PR DESCRIPTION
…emons

As per the discussion on the relevant [ticket](https://issues.apache.org/jira/browse/FLINK-2499) adds a warning message.

I decided against the latest comment of @StephanEwen on the issue, because I have also run into (accidentally) trying to stack multiple JobManagers on the same machine and it is nice to have this warning even in that case. 

This solution is a bit too verbose in test setups with a lot of TaskManagers on the same machine, but keeps the PID related code in the `flink-daemon.sh`.    