### PR TITLE
FLINK-1737: Kronecker product

### DIFF
--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -27,7 +27,7 @@ import breeze.linalg.{SparseVector => BreezeSparseVector, DenseVector => BreezeD
  * @param data Array of doubles to store the vector elements
  */
 case class DenseVector(
-    val data: Array[Double])
+    data: Array[Double])
   extends Vector
   with Serializable {
 
@@ -76,8 +76,8 @@ case class DenseVector(
 
   /** Updates the element at the given index with the provided value
     *
-    * @param index
-    * @param value
+    * @param index Index whose value is updated.
+    * @param value The value used to update the index.
     */
   override def update(index: Int, value: Double): Unit = {
     require(0 <= index && index < data.length, index + " not in [0, " + data.length + ")")
@@ -115,19 +115,19 @@ case class DenseVector(
     val numCols = other.size
 
     other match {
-      case SparseVector(size, indices, data_) =>
-        val entries: Array[(Int, Int, Double)] = for {
-          i <- (0 until numRows).toArray
-          j <- indices
-          value = this(i) * other(j)
+      case sv @ SparseVector(_, _, _) =>
+        val entries = for {
+          i <- 0 until numRows
+          j <- sv.indices
+          value = this(i) * sv.data(sv.indices.indexOf(j))
           if value != 0
         } yield (i, j, value)
 
         SparseMatrix.fromCOO(numRows, numCols, entries)
       case _ =>
         val values = for {
-          i <- (0 until numRows)
-          j <- (0 until numCols)
+          i <- 0 until numRows
+          j <- 0 until numCols
         } yield this(i) * other(j)
 
         DenseMatrix(numRows, numCols, values.toArray)

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -102,15 +102,13 @@ case class DenseVector(
     }
   }
 
-  /** Returns the outer product of the recipient and the argument
+  /** Returns the outer product (a.k.a. Kronecker product) of `this`
+    * with `other`. The result will given in [[org.apache.flink.ml.math.SparseMatrix]]
+    * representation if `other` is sparse and as [[org.apache.flink.ml.math.DenseMatrix]] otherwise.
     *
-    *
-    * @param other
-    * @return
-    *
-    * TODO: Dense x Dense should yield Dense,
-    * Sparse x Sparse should yield Sparse,
-    * Dense x Sparse (and the other way around) should yield Sparse
+    * @param other a Vector
+    * @return the [[org.apache.flink.ml.math.Matrix]] which equals the outer product of `this`
+    *         with `other.`
     */
   override def outer(other: Vector): Matrix = {
     val numRows = size

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -115,11 +115,11 @@ case class DenseVector(
     val numCols = other.size
 
     other match {
-      case sv @ SparseVector(_, _, _) =>
+      case sv: SparseVector =>
         val entries = for {
           i <- 0 until numRows
-          j <- sv.indices
-          value = this(i) * sv.data(sv.indices.indexOf(j))
+          (j, k) <- sv.indices.zipWithIndex
+          value = this(i) * sv.data(k)
           if value != 0
         } yield (i, j, value)
 

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -102,6 +102,40 @@ case class DenseVector(
     }
   }
 
+  /** Returns the outer product of the recipient and the argument
+    *
+    *
+    * @param other
+    * @return
+    *
+    * TODO: Dense x Dense should yield Dense,
+    * Sparse x Sparse should yield Sparse,
+    * Dense x Sparse (and the other way around) should yield Sparse
+    */
+  override def outer(other: Vector): Matrix = {
+    val numRows = size
+    val numCols = other.size
+
+    other match {
+      case SparseVector(size, indices, data_) =>
+        val entries: Array[(Int, Int, Double)] = for {
+          i <- (0 until numRows).toArray
+          j <- indices
+          value = this(i) * other(j)
+          if value != 0
+        } yield (i, j, value)
+
+        SparseMatrix.fromCOO(numRows, numCols, entries)
+      case _ =>
+        val values = for {
+          i <- (0 until numRows)
+          j <- (0 until numCols)
+        } yield this(i) * other(j)
+
+        DenseMatrix(numRows, numCols, values.toArray)
+    }
+  }
+
   /** Magnitude of a vector
     *
     * @return

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -85,17 +85,15 @@ case class SparseVector(
     }
   }
 
-  /** Returns the outer product of the recipient and the argument
+  /** Returns the outer product (a.k.a. Kronecker product) of `this`
+    * with `other`. The result is given in [[org.apache.flink.ml.math.SparseMatrix]]
+    * representation.
     *
-    *
-    * @param other
-    * @return
-    *
-    * TODO: Dense x Dense should yield Dense,
-    * Sparse x Sparse should yield Sparse,
-    * Dense x Sparse (and the other way around) should yield Sparse
+    * @param other a Vector
+    * @return the [[org.apache.flink.ml.math.SparseMatrix]] which equals the outer product of `this`
+    *         with `other.`
     */
-  override def outer(other: Vector): Matrix = {
+  override def outer(other: Vector): SparseMatrix = {
     val numRows = size
     val numCols = other.size
 

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -99,24 +99,19 @@ case class SparseVector(
     val numRows = size
     val numCols = other.size
 
-    other match {
-      case SparseVector(size, indices, data_) =>
-        val entries: Array[(Int, Int, Double)] = for {
-          i <- (0 until numRows).toArray
-          j <- indices
-          value = this(i) * other(j)
-          if value != 0
-        } yield (i, j, value)
-
-        SparseMatrix.fromCOO(numRows, numCols, entries)
-      case _ =>
-        val values = for {
-          i <- (0 until numRows)
-          j <- (0 until numCols)
-        } yield this(i) * other(j)
-
-        DenseMatrix(numRows, numCols, values.toArray)
+    val otherIndices = other match {
+      case sv @ SparseVector(_, _, _) => sv.indices
+      case dv @ DenseVector(_) => (0 until dv.size).toArray
     }
+
+    val entries = for {
+      i <- indices
+      j <- otherIndices
+      value = this(i) * other(j)
+      if value != 0
+    } yield (i, j, value)
+
+    SparseMatrix.fromCOO(numRows, numCols, entries)
   }
 
 

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -85,6 +85,41 @@ case class SparseVector(
     }
   }
 
+  /** Returns the outer product of the recipient and the argument
+    *
+    *
+    * @param other
+    * @return
+    *
+    * TODO: Dense x Dense should yield Dense,
+    * Sparse x Sparse should yield Sparse,
+    * Dense x Sparse (and the other way around) should yield Sparse
+    */
+  override def outer(other: Vector): Matrix = {
+    val numRows = size
+    val numCols = other.size
+
+    other match {
+      case SparseVector(size, indices, data_) =>
+        val entries: Array[(Int, Int, Double)] = for {
+          i <- (0 until numRows).toArray
+          j <- indices
+          value = this(i) * other(j)
+          if value != 0
+        } yield (i, j, value)
+
+        SparseMatrix.fromCOO(numRows, numCols, entries)
+      case _ =>
+        val values = for {
+          i <- (0 until numRows)
+          j <- (0 until numCols)
+        } yield this(i) * other(j)
+
+        DenseMatrix(numRows, numCols, values.toArray)
+    }
+  }
+
+
   /** Magnitude of a vector
     *
     * @return

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -99,11 +99,11 @@ case class SparseVector(
     val numCols = other.size
 
     val entries = other match {
-      case sv @ SparseVector(_, _, _) =>
+      case sv: SparseVector =>
        for {
-          i <- indices
-          j <- sv.indices
-          value = data(indices.indexOf(i)) * sv.data(sv.indices.indexOf(j))
+          (i, k) <- indices.zipWithIndex
+          (j, l) <- sv.indices.zipWithIndex
+          value = data(k) * sv.data(l)
           if value != 0
         } yield (i, j, value)
       case _ =>

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/Vector.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/math/Vector.scala
@@ -58,6 +58,14 @@ trait Vector extends Serializable {
     */
   def dot(other: Vector): Double
 
+  /** Returns the outer product of the recipient and the argument
+    *
+    *
+    * @param other a Vector
+    * @return a matrix
+    */
+  def outer(other: Vector): Matrix
+
   /** Magnitude of a vector
     *
     * @return

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
@@ -79,7 +79,7 @@ class DenseVectorSuite extends FlatSpec with Matchers {
   }
 
   //====================================================================================================================
-  it should "calculate outer product with DenseVectors correctly as DenseMatrix" in {
+  it should "calculate outer product with DenseVector correctly as DenseMatrix" in {
     val vec1 = DenseVector(Array(1, 0, 1))
     val vec2 = DenseVector(Array(0, 1, 0))
 
@@ -97,7 +97,14 @@ class DenseVectorSuite extends FlatSpec with Matchers {
 
   //====================================================================================================================
 
-  it should "calculate outer product of a DenseVector with a SparseVector" in {
+  it should "calculate outer product with a DenseVector correctly as DenseMatrix 2" in {
+    val vec1 = DenseVector(Array(1, 0, 1, 0, 0))
+    val vec2 = DenseVector(Array(0, 0, 1, 0, 1))
+
+    vec1.outer(vec2) should be(DenseMatrix(5, 5, Array(0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
+  }
+
+  it should "calculate outer product with a SparseVector correctly as SparseMatrix 2" in {
     val vec1 = DenseVector(Array(1, 0, 1, 0, 0))
     val vec2 = SparseVector.fromCOO(5, (2, 1), (4, 1))
 

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
@@ -25,13 +25,13 @@ class DenseVectorSuite extends FlatSpec with Matchers {
   behavior of "Flink's DenseVector"
 
   it should "contain the initialization data" in {
-    val data = Array.range(1,10)
+    val data = Array.range(1, 10)
 
     val vector = DenseVector(data)
 
     assertResult(data.length)(vector.size)
 
-    data.zip(vector.map(_._2)).foreach{case (expected, actual) => assertResult(expected)(actual)}
+    data.zip(vector.map(_._2)).foreach { case (expected, actual) => assertResult(expected)(actual) }
   }
 
   it should "fail in case of an illegal element access" in {
@@ -47,7 +47,7 @@ class DenseVectorSuite extends FlatSpec with Matchers {
       vector(size)
     }
   }
-  
+
   it should "calculate dot product with DenseVector" in {
     val vec1 = DenseVector(Array(1, 0, 1))
     val vec2 = DenseVector(Array(0, 1, 0))
@@ -98,52 +98,63 @@ class DenseVectorSuite extends FlatSpec with Matchers {
     val vec1 = DenseVector(Array(1, 0, 1, 0, 0))
     val vec2 = DenseVector(Array(0, 0, 1, 0, 1))
 
-    vec1.outer(vec2) should be(DenseMatrix(5, 5, Array(0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
+    val values = Array(0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    vec1.outer(vec2) should be(DenseMatrix(5, 5, values))
   }
 
   it should "calculate outer product with a SparseVector correctly as SparseMatrix 2" in {
     val vec1 = DenseVector(Array(1, 0, 1, 0, 0))
     val vec2 = SparseVector.fromCOO(5, (2, 1), (4, 1))
 
-    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1), (0, 4, 1), (2, 2, 1), (2, 4, 1)))
+    val entries = Iterable((0, 2, 1.0), (0, 4, 1.0), (2, 2, 1.0), (2, 4, 1.0))
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, entries))
   }
 
-  it should "calculate right outer product with DenseVector with one-dimensional unit DenseVector as identity" in {
+
+
+  it should s"""calculate right outer product with DenseVector
+               |with one-dimensional unit DenseVector as identity""".stripMargin in {
     val vec = DenseVector(Array(1, 0, 1, 0, 0))
     val unit = DenseVector(1)
 
     vec.outer(unit) should equal(DenseMatrix(vec.size, 1, vec.data))
   }
 
-  it should "calculate right outer product with DenseVector with one-dimensional unit SparseVector as identity" in {
+  it should s"""calculate right outer product with DenseVector
+               |with one-dimensional unit SparseVector as identity""".stripMargin in {
     val vec = DenseVector(Array(1, 0, 1, 0, 0))
     val unit = SparseVector(1, Array(0), Array(1))
 
     vec.outer(unit) should equal(SparseMatrix.fromCOO(vec.size, 1, (0, 0, 1), (2, 0, 1)))
   }
 
-  it should "calculate left outer product for DenseVector with one-dimensional unit DenseVector as identity" in {
+  it should s"""calculate left outer product for DenseVector
+               |with one-dimensional unit DenseVector as identity""".stripMargin in {
     val vec = DenseVector(Array(1, 2, 3, 4, 5))
     val unit = DenseVector(1)
 
     unit.outer(vec) should equal(DenseMatrix(1, vec.size, vec.data))
   }
 
-  it should "calculate left outer product for SparseVector with one-dimensional unit DenseVector as identity" in {
+  it should s"""calculate left outer product for SparseVector
+               |with one-dimensional unit DenseVector as identity""".stripMargin in {
     val vec = SparseVector(5, Array(0, 1, 2, 3, 4), Array(1, 2, 3, 4, 5))
     val unit = DenseVector(1)
 
-    unit.outer(vec) should equal(SparseMatrix.fromCOO(1, vec.size, (0, 0, 1), (0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5)))
+    val entries = Iterable((0, 0, 1.0), (0, 1, 2.0), (0, 2, 3.0), (0, 3, 4.0), (0, 4, 5.0))
+    unit.outer(vec) should equal(SparseMatrix.fromCOO(1, vec.size, entries))
   }
 
-  it should "calculate outer product with DenseVector via multiplication if both vectors are one-dimensional" in {
+  it should s"""calculate outer product with DenseVector
+               |via multiplication if both vectors are one-dimensional""".stripMargin in {
     val vec1 = DenseVector(Array(2))
     val vec2 = DenseVector(Array(3))
 
     vec1.outer(vec2) should be(DenseMatrix(1, 1, 2 * 3))
   }
 
-  it should "calculate outer product with SparseVector via multiplication if both vectors are one-dimensioan" in {
+  it should s"""calculate outer product with SparseVector
+               |via multiplication if both vectors are one-dimensional""".stripMargin in {
     val vec1 = DenseVector(Array(2))
     val vec2 = SparseVector(1, Array(0), Array(3))
 

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
@@ -78,6 +78,69 @@ class DenseVectorSuite extends FlatSpec with Matchers {
     }
   }
 
+  //====================================================================================================================
+  it should "calculate outer product with DenseVector" in {
+    val vec1 = DenseVector(Array(1, 0, 1))
+    val vec2 = DenseVector(Array(0, 1, 0))
+
+    vec1.outer(vec2) should be(DenseMatrix(3, 3, Array(0, 1, 0, 0, 0, 0, 0, 1, 0)))
+  }
+
+  it should "calculate outer product with SparseVector" in {
+    val vec1 = DenseVector(Array(1, 0, 1))
+    val vec2 = SparseVector.fromCOO(3, (0, 1), (1, 1))
+
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(3, 3, (0, 0, 1.0), (0, 1, 1.0), (2, 0, 1.0), (2, 1, 1.0)))
+  }
+
+  it should "calculate outer product with SparseVector 2" in {
+    val vec1 = DenseVector(Array(1, 0, 1, 0, 0))
+    val vec2 = SparseVector.fromCOO(5, (2, 1), (4, 1))
+
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1.0), (0, 4, 1.0), (2, 2, 1.0), (2, 4, 1.0)))
+  }
+
+  it should "calculate right outer product with one-dimensional unit vector as identity" in {
+    val vec = DenseVector(Array(1, 0, 1, 0, 0))
+    val unit = DenseVector(1)
+
+    vec.outer(unit) should equal(DenseMatrix(vec.size, 1, vec.data))
+  }
+
+  it should "calculate left outer product with one-dimensional unit vector as identity" in {
+    val vec = DenseVector(Array(1, 2, 3, 4, 5))
+    val unit = DenseVector(1)
+
+    unit.outer(vec) should equal(DenseMatrix(1, vec.size, vec.data))
+  }
+
+  it should "calculate outer product of one-dimensional dense vectors as multiplication" in {
+    val vec1 = DenseVector(Array(2))
+    val vec2 = DenseVector(Array(3))
+
+    vec1.outer(vec2) should be(DenseMatrix(1, 1, 2 * 3))
+  }
+
+  it should "calculate outer product of one-dimensional sparse vectors as multiplication" in {
+    val vec1 = SparseVector(1, Array(0), Array(2))
+    val vec2 = DenseVector(Array(3))
+
+    // TODO: Next line fails due to dummy impl of outer for sparse vectors:
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
+    vec2.outer(vec1) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
+  }
+
+
+//  it should "fail in case of calculation dot product with different size vector" in {
+//    val vec1 = DenseVector(Array(1, 0))
+//    val vec2 = DenseVector(Array(0))
+//
+//    intercept[IllegalArgumentException] {
+//      vec1.dot(vec2)
+//    }
+//  }
+  //====================================================================================================================
+
   it should "calculate magnitude of vector" in {
     val vec = DenseVector(Array(1, 4, 8))
 

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
@@ -78,7 +78,6 @@ class DenseVectorSuite extends FlatSpec with Matchers {
     }
   }
 
-  //====================================================================================================================
   it should "calculate outer product with DenseVector correctly as DenseMatrix" in {
     val vec1 = DenseVector(Array(1, 0, 1))
     val vec2 = DenseVector(Array(0, 1, 0))
@@ -95,8 +94,6 @@ class DenseVectorSuite extends FlatSpec with Matchers {
     vec1.outer(vec2) should be(SparseMatrix.fromCOO(3, 3, (0, 1, 1), (2, 1, 1)))
   }
 
-  //====================================================================================================================
-
   it should "calculate outer product with a DenseVector correctly as DenseMatrix 2" in {
     val vec1 = DenseVector(Array(1, 0, 1, 0, 0))
     val vec2 = DenseVector(Array(0, 0, 1, 0, 1))
@@ -110,8 +107,6 @@ class DenseVectorSuite extends FlatSpec with Matchers {
 
     vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1), (0, 4, 1), (2, 2, 1), (2, 4, 1)))
   }
-
-  //====================================================================================================================
 
   it should "calculate right outer product with DenseVector with one-dimensional unit DenseVector as identity" in {
     val vec = DenseVector(Array(1, 0, 1, 0, 0))
@@ -141,8 +136,6 @@ class DenseVectorSuite extends FlatSpec with Matchers {
     unit.outer(vec) should equal(SparseMatrix.fromCOO(1, vec.size, (0, 0, 1), (0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5)))
   }
 
-  //====================================================================================================================
-
   it should "calculate outer product with DenseVector via multiplication if both vectors are one-dimensional" in {
     val vec1 = DenseVector(Array(2))
     val vec2 = DenseVector(Array(3))
@@ -156,16 +149,6 @@ class DenseVectorSuite extends FlatSpec with Matchers {
 
     vec1.outer(vec2) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
   }
-
-//  it should "fail in case of calculation dot product with different size vector" in {
-//    val vec1 = DenseVector(Array(1, 0))
-//    val vec2 = DenseVector(Array(0))
-//
-//    intercept[IllegalArgumentException] {
-//      vec1.dot(vec2)
-//    }
-//  }
-  //====================================================================================================================
 
   it should "calculate magnitude of vector" in {
     val vec = DenseVector(Array(1, 4, 8))

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/DenseVectorSuite.scala
@@ -79,57 +79,76 @@ class DenseVectorSuite extends FlatSpec with Matchers {
   }
 
   //====================================================================================================================
-  it should "calculate outer product with DenseVector" in {
+  it should "calculate outer product with DenseVectors correctly as DenseMatrix" in {
     val vec1 = DenseVector(Array(1, 0, 1))
     val vec2 = DenseVector(Array(0, 1, 0))
 
+    vec1.outer(vec2) should be(an[DenseMatrix])
     vec1.outer(vec2) should be(DenseMatrix(3, 3, Array(0, 1, 0, 0, 0, 0, 0, 1, 0)))
   }
 
-  it should "calculate outer product with SparseVector" in {
+  it should "calculate outer product with SparseVector correctly as SparseMatrix" in {
     val vec1 = DenseVector(Array(1, 0, 1))
-    val vec2 = SparseVector.fromCOO(3, (0, 1), (1, 1))
+    val vec2 = SparseVector(3, Array(1), Array(1))
 
-    vec1.outer(vec2) should be(SparseMatrix.fromCOO(3, 3, (0, 0, 1.0), (0, 1, 1.0), (2, 0, 1.0), (2, 1, 1.0)))
+    vec1.outer(vec2) should be(an[SparseMatrix])
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(3, 3, (0, 1, 1), (2, 1, 1)))
   }
 
-  it should "calculate outer product with SparseVector 2" in {
+  //====================================================================================================================
+
+  it should "calculate outer product of a DenseVector with a SparseVector" in {
     val vec1 = DenseVector(Array(1, 0, 1, 0, 0))
     val vec2 = SparseVector.fromCOO(5, (2, 1), (4, 1))
 
-    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1.0), (0, 4, 1.0), (2, 2, 1.0), (2, 4, 1.0)))
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1), (0, 4, 1), (2, 2, 1), (2, 4, 1)))
   }
 
-  it should "calculate right outer product with one-dimensional unit vector as identity" in {
+  //====================================================================================================================
+
+  it should "calculate right outer product with DenseVector with one-dimensional unit DenseVector as identity" in {
     val vec = DenseVector(Array(1, 0, 1, 0, 0))
     val unit = DenseVector(1)
 
     vec.outer(unit) should equal(DenseMatrix(vec.size, 1, vec.data))
   }
 
-  it should "calculate left outer product with one-dimensional unit vector as identity" in {
+  it should "calculate right outer product with DenseVector with one-dimensional unit SparseVector as identity" in {
+    val vec = DenseVector(Array(1, 0, 1, 0, 0))
+    val unit = SparseVector(1, Array(0), Array(1))
+
+    vec.outer(unit) should equal(SparseMatrix.fromCOO(vec.size, 1, (0, 0, 1), (2, 0, 1)))
+  }
+
+  it should "calculate left outer product for DenseVector with one-dimensional unit DenseVector as identity" in {
     val vec = DenseVector(Array(1, 2, 3, 4, 5))
     val unit = DenseVector(1)
 
     unit.outer(vec) should equal(DenseMatrix(1, vec.size, vec.data))
   }
 
-  it should "calculate outer product of one-dimensional dense vectors as multiplication" in {
+  it should "calculate left outer product for SparseVector with one-dimensional unit DenseVector as identity" in {
+    val vec = SparseVector(5, Array(0, 1, 2, 3, 4), Array(1, 2, 3, 4, 5))
+    val unit = DenseVector(1)
+
+    unit.outer(vec) should equal(SparseMatrix.fromCOO(1, vec.size, (0, 0, 1), (0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5)))
+  }
+
+  //====================================================================================================================
+
+  it should "calculate outer product with DenseVector via multiplication if both vectors are one-dimensional" in {
     val vec1 = DenseVector(Array(2))
     val vec2 = DenseVector(Array(3))
 
     vec1.outer(vec2) should be(DenseMatrix(1, 1, 2 * 3))
   }
 
-  it should "calculate outer product of one-dimensional sparse vectors as multiplication" in {
-    val vec1 = SparseVector(1, Array(0), Array(2))
-    val vec2 = DenseVector(Array(3))
+  it should "calculate outer product with SparseVector via multiplication if both vectors are one-dimensioan" in {
+    val vec1 = DenseVector(Array(2))
+    val vec2 = SparseVector(1, Array(0), Array(3))
 
-    // TODO: Next line fails due to dummy impl of outer for sparse vectors:
     vec1.outer(vec2) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
-    vec2.outer(vec1) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
   }
-
 
 //  it should "fail in case of calculation dot product with different size vector" in {
 //    val vec1 = DenseVector(Array(1, 0))

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
@@ -119,7 +119,14 @@ class SparseVectorSuite extends FlatSpec with Matchers {
     vec1.dot(vec2) should be(0)
   }
 
-  //====================================================================================================================
+  it should "fail in case of calculation dot product with different size vector" in {
+    val vec1 = SparseVector.fromCOO(4, (0, 1), (2, 1))
+    val vec2 = DenseVector(Array(0, 1, 0))
+
+    intercept[IllegalArgumentException] {
+      vec1.dot(vec2)
+    }
+  }
 
   it should "calculate outer product with SparseVector correctly as SparseMatrix" in {
     val vec1 = SparseVector(3, Array(0, 2), Array(1, 1))
@@ -137,7 +144,43 @@ class SparseVectorSuite extends FlatSpec with Matchers {
     vec1.outer(vec2) should be(SparseMatrix.fromCOO(3, 3, (0, 1, 1), (2, 1, 1)))
   }
 
-  it should "calculate outer product with SparseVector via multiplication if bothe vectors are one-dimensional" in {
+  it should "calculate outer product with a DenseVector correctly as SparseMatrix 2" in {
+    val vec1 = SparseVector(5, Array(0, 2), Array(1, 1))
+    val vec2 = DenseVector(Array(0, 0, 1, 0, 1))
+
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1), (0, 4, 1), (2, 2, 1), (2, 4, 1)))
+  }
+
+  it should "calculate outer product with a SparseVector correctly as SparseMatrix 2" in {
+    val vec1 = SparseVector(5, Array(0, 2), Array(1, 1))
+    val vec2 = SparseVector.fromCOO(5, (2, 1), (4, 1))
+
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1), (0, 4, 1), (2, 2, 1), (2, 4, 1)))
+  }
+
+
+  it should "calculate right outer product with DenseVector with one-dimensional unit DenseVector as identity" in {
+    val vec = SparseVector(5, Array(0, 2), Array(1, 1))
+    val unit = DenseVector(1)
+
+    vec.outer(unit) should equal(SparseMatrix.fromCOO(vec.size, 1, (0, 0, 1), (2, 0, 1)))
+  }
+
+  it should "calculate right outer product with DenseVector with one-dimensional unit SparseVector as identity" in {
+    val vec = SparseVector(5, Array(0, 2), Array(1, 1))
+    val unit = SparseVector(1, Array(0), Array(1))
+
+    vec.outer(unit) should equal(SparseMatrix.fromCOO(vec.size, 1, (0, 0, 1), (2, 0, 1)))
+  }
+
+  it should "calculate left outer product for SparseVector with one-dimensional unit DenseVector as identity" in {
+    val vec = SparseVector(5, Array(0, 1, 2, 3, 4), Array(1, 2, 3, 4, 5))
+    val unit = DenseVector(1)
+
+    unit.outer(vec) should equal(SparseMatrix.fromCOO(1, vec.size, (0, 0, 1), (0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5)))
+  }
+
+  it should "calculate outer product with SparseVector via multiplication if both vectors are one-dimensional" in {
     val vec1 = SparseVector.fromCOO(1, (0, 2))
     val vec2 = SparseVector.fromCOO(1, (0, 3))
 
@@ -149,17 +192,6 @@ class SparseVectorSuite extends FlatSpec with Matchers {
     val vec2 = DenseVector(Array(3))
 
     vec1.outer(vec2) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
-  }
-
-  //====================================================================================================================
-
-  it should "fail in case of calculation dot product with different size vector" in {
-    val vec1 = SparseVector.fromCOO(4, (0, 1), (2, 1))
-    val vec2 = DenseVector(Array(0, 1, 0))
-
-    intercept[IllegalArgumentException] {
-      vec1.dot(vec2)
-    }
   }
 
   it should "calculate magnitude of vector" in {

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
@@ -29,7 +29,7 @@ class SparseVectorSuite extends FlatSpec with Matchers {
 
     sparseVector(0) should equal(1)
 
-    for(index <- 1 until 3) {
+    for (index <- 1 until 3) {
       sparseVector(index) should equal(0)
     }
   }
@@ -53,13 +53,15 @@ class SparseVectorSuite extends FlatSpec with Matchers {
     denseVector should equal(expectedDenseVector)
 
     val dataMap = data.
-      groupBy{_._1}.
-      mapValues{
+      groupBy {
+      _._1
+    }.
+      mapValues {
       entries =>
         entries.map(_._2).reduce(_ + _)
     }
 
-    for(index <- 0 until size) {
+    for (index <- 0 until size) {
       sparseVector(index) should be(dataMap.getOrElse(index, 0))
     }
   }
@@ -82,7 +84,7 @@ class SparseVectorSuite extends FlatSpec with Matchers {
     }
 
     intercept[IllegalArgumentException] {
-      val sparseVector = SparseVector.fromCOO(5, (0, 1), (4,3), (5, 1))
+      val sparseVector = SparseVector.fromCOO(5, (0, 1), (4, 3), (5, 1))
     }
   }
 
@@ -95,7 +97,7 @@ class SparseVectorSuite extends FlatSpec with Matchers {
 
     copy(3) = 3
 
-    sparseVector should not equal(copy)
+    sparseVector should not equal (copy)
   }
 
   it should "calculate dot product with SparseVector" in {
@@ -148,46 +150,54 @@ class SparseVectorSuite extends FlatSpec with Matchers {
     val vec1 = SparseVector(5, Array(0, 2), Array(1, 1))
     val vec2 = DenseVector(Array(0, 0, 1, 0, 1))
 
-    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1), (0, 4, 1), (2, 2, 1), (2, 4, 1)))
+    val entries = Iterable((0, 2, 1.0), (0, 4, 1.0), (2, 2, 1.0), (2, 4, 1.0))
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, entries))
   }
 
   it should "calculate outer product with a SparseVector correctly as SparseMatrix 2" in {
     val vec1 = SparseVector(5, Array(0, 2), Array(1, 1))
     val vec2 = SparseVector.fromCOO(5, (2, 1), (4, 1))
 
-    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, (0, 2, 1), (0, 4, 1), (2, 2, 1), (2, 4, 1)))
+    val entries = Iterable((0, 2, 1.0), (0, 4, 1.0), (2, 2, 1.0), (2, 4, 1.0))
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(5, 5, entries))
   }
 
 
-  it should "calculate right outer product with DenseVector with one-dimensional unit DenseVector as identity" in {
+  it should s"""calculate right outer product with DenseVector
+               |with one-dimensional unit DenseVector as identity""".stripMargin in {
     val vec = SparseVector(5, Array(0, 2), Array(1, 1))
     val unit = DenseVector(1)
 
     vec.outer(unit) should equal(SparseMatrix.fromCOO(vec.size, 1, (0, 0, 1), (2, 0, 1)))
   }
 
-  it should "calculate right outer product with DenseVector with one-dimensional unit SparseVector as identity" in {
+  it should s"""calculate right outer product with DenseVector
+               |with one-dimensional unit SparseVector as identity""".stripMargin in {
     val vec = SparseVector(5, Array(0, 2), Array(1, 1))
     val unit = SparseVector(1, Array(0), Array(1))
 
     vec.outer(unit) should equal(SparseMatrix.fromCOO(vec.size, 1, (0, 0, 1), (2, 0, 1)))
   }
 
-  it should "calculate left outer product for SparseVector with one-dimensional unit DenseVector as identity" in {
+  it should s"""calculate left outer product for SparseVector
+               |with one-dimensional unit DenseVector as identity""".stripMargin in {
     val vec = SparseVector(5, Array(0, 1, 2, 3, 4), Array(1, 2, 3, 4, 5))
     val unit = DenseVector(1)
 
-    unit.outer(vec) should equal(SparseMatrix.fromCOO(1, vec.size, (0, 0, 1), (0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5)))
+    val entries = Iterable((0, 0, 1.0), (0, 1, 2.0), (0, 2, 3.0), (0, 3, 4.0), (0, 4, 5.0))
+    unit.outer(vec) should equal(SparseMatrix.fromCOO(1, vec.size, entries))
   }
 
-  it should "calculate outer product with SparseVector via multiplication if both vectors are one-dimensional" in {
+  it should s"""calculate outer product with SparseVector
+               |via multiplication if both vectors are one-dimensional""".stripMargin in {
     val vec1 = SparseVector.fromCOO(1, (0, 2))
     val vec2 = SparseVector.fromCOO(1, (0, 3))
 
     vec1.outer(vec2) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
   }
 
-  it should "calculate outer product with DenseVector via multiplication if both vectors are one-dimensional" in {
+  it should s"""calculate outer product with DenseVector
+               |via multiplication if both vectors are one-dimensional""".stripMargin in {
     val vec1 = SparseVector(1, Array(0), Array(2))
     val vec2 = DenseVector(Array(3))
 

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/math/SparseVectorSuite.scala
@@ -119,6 +119,40 @@ class SparseVectorSuite extends FlatSpec with Matchers {
     vec1.dot(vec2) should be(0)
   }
 
+  //====================================================================================================================
+
+  it should "calculate outer product with SparseVector correctly as SparseMatrix" in {
+    val vec1 = SparseVector(3, Array(0, 2), Array(1, 1))
+    val vec2 = SparseVector(3, Array(1), Array(1))
+
+    vec1.outer(vec2) should be(an[SparseMatrix])
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(3, 3, (0, 1, 1), (2, 1, 1)))
+  }
+
+  it should "calculate outer product with DenseVector correctly as SparseMatrix" in {
+    val vec1 = SparseVector(3, Array(0, 2), Array(1, 1))
+    val vec2 = DenseVector(Array(0, 1, 0))
+
+    vec1.outer(vec2) should be(an[SparseMatrix])
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(3, 3, (0, 1, 1), (2, 1, 1)))
+  }
+
+  it should "calculate outer product with SparseVector via multiplication if bothe vectors are one-dimensional" in {
+    val vec1 = SparseVector.fromCOO(1, (0, 2))
+    val vec2 = SparseVector.fromCOO(1, (0, 3))
+
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
+  }
+
+  it should "calculate outer product with DenseVector via multiplication if both vectors are one-dimensional" in {
+    val vec1 = SparseVector(1, Array(0), Array(2))
+    val vec2 = DenseVector(Array(3))
+
+    vec1.outer(vec2) should be(SparseMatrix.fromCOO(1, 1, (0, 0, 2 * 3)))
+  }
+
+  //====================================================================================================================
+
   it should "fail in case of calculation dot product with different size vector" in {
     val vec1 = SparseVector.fromCOO(4, (0, 1), (2, 1))
     val vec2 = DenseVector(Array(0, 1, 0))


### PR DESCRIPTION
This is preparational work related to FLINK-1737: Adds an implementation of outer/Kronecker product which can subsequently be used to compute the sample covariance matrix.