### PR TITLE
[FLINK1919] add HCatOutputFormat

### DIFF
--- a/flink-staging/flink-hcatalog/pom.xml
+++ b/flink-staging/flink-hcatalog/pom.xml
@@ -34,17 +34,70 @@ under the License.
 
 	<packaging>jar</packaging>
 
+
 	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>${shading-artifact.name}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-scala</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hive.hcatalog</groupId>
-			<artifactId>hcatalog-core</artifactId>
-			<version>0.12.0</version>
+			<artifactId>hive-hcatalog-core</artifactId>
+			<version>1.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hive.hcatalog</groupId>
+			<artifactId>hive-hcatalog-server-extensions</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hive.hcatalog</groupId>
+			<artifactId>hive-webhcat-java-client</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-cli</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-common</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-metastore</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-exec</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+			<type>jar</type>
 		</dependency>
 
 	</dependencies>
@@ -170,6 +223,22 @@ under the License.
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 					<outputFile>${project.basedir}/scalastyle-output.xml</outputFile>
 					<outputEncoding>UTF-8</outputEncoding>
+				</configuration>
+			</plugin>
+
+
+			<plugin>
+				<!--The testing hive metastore is not thread safe, throttle the parallelisim for testing-->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.17</version><!--$NO-MVN-MAN-VER$-->
+				<configuration combine.self="override">
+					<forkCount>1</forkCount>
+					<reuseForks>false</reuseForks>
+					<systemPropertyVariables>
+						<forkNumber>0</forkNumber>
+					</systemPropertyVariables>
+					<argLine>-Xms256m -Xmx800m -Dlog4j.configuration=${log4j.configuration} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 			</plugin>
 

--- a/flink-staging/flink-hcatalog/src/main/java/org/apache/flink/hcatalog/HCatOutputFormatBase.java
+++ b/flink-staging/flink-hcatalog/src/main/java/org/apache/flink/hcatalog/HCatOutputFormatBase.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hcatalog;
+
+import org.apache.flink.api.common.io.FinalizeOnMaster;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.hadoop.mapreduce.utils.HadoopUtils;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobConfigurable;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hive.hcatalog.common.HCatUtil;
+import org.apache.hive.hcatalog.data.HCatRecord;
+import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
+import org.apache.hive.hcatalog.data.schema.HCatSchema;
+import org.apache.hive.hcatalog.mapreduce.OutputJobInfo;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import java.util.Map;
+
+public abstract class HCatOutputFormatBase<T> implements OutputFormat<T>, FinalizeOnMaster {
+	private static final long serialVersionUID = 1L;
+
+	private Configuration configuration;
+	//a Job is used to create OutputJobInfo
+	private Job job;
+
+	private org.apache.hive.hcatalog.mapreduce.HCatOutputFormat hCatOutputFormat;
+	private RecordWriter<WritableComparable<?>, HCatRecord> recordWriter;
+
+	//required data type by the table
+	protected TypeInformation<T> reqType;
+
+	protected String[] fieldNames = new String[0];
+	protected HCatSchema outputSchema;
+	private transient TaskAttemptContext context;
+
+
+	@Override
+	public void configure(org.apache.flink.configuration.Configuration parameters) {
+		// configure MR OutputFormat if necessary
+		if (this.hCatOutputFormat instanceof Configurable) {
+			((Configurable) this.hCatOutputFormat).setConf(configuration);
+		} else if (this.hCatOutputFormat instanceof JobConfigurable) {
+			((JobConfigurable) this.hCatOutputFormat).configure(new JobConf(configuration));
+		}
+	}
+
+	/**
+	 * Creates a HCatOutputFormat for the given database and table and a Map of PartitionValues
+	 * By default. The RecordWriter of
+	 * {@link HCatInputFormatBase#asFlinkTuples()}.
+	 *
+	 * @param database The name of the database to read from.
+	 * @param table    The name of the table to read.
+	 * @param partitionValues the map of partition values. if null, the job writes to unpartitioned
+	 *                        table
+	 * @throws java.io.IOException
+	 */
+	public HCatOutputFormatBase(String database, String table, Map<String, String> partitionValues)
+			throws IOException {
+		this(database, table, partitionValues, new Configuration());
+	}
+
+	protected abstract HCatRecord TupleToHCatRecord(T record) throws IOException;
+
+	protected abstract int getMaxFlinkTupleSize();
+
+	/**
+	 * Creates a HCatOutputFormat for the given database, table, partitionValues
+	 * {@link org.apache.hadoop.conf.Configuration}.
+	 * if
+	 *
+	 * @param database        The name of the database to read from.
+	 * @param table           The name of the table to read.
+	 * @param partitionValues the map of partition values. if null, the job writes to unpartitioned
+	 *                        table
+	 * @param config          The Configuration for the InputFormat.
+	 * @throws java.io.IOException
+	 */
+	public HCatOutputFormatBase(String database, String table, Map<String, String> partitionValues,
+								Configuration config) throws IOException {
+		super();
+		this.configuration = config;
+		HadoopUtils.mergeHadoopConf(this.configuration);
+		this.job = Job.getInstance(this.configuration);
+
+
+		OutputJobInfo jobInfo = OutputJobInfo.create(database, table, partitionValues);
+
+		org.apache.hive.hcatalog.mapreduce.HCatOutputFormat.setOutput(job, jobInfo);
+
+		this.hCatOutputFormat = new org.apache.hive.hcatalog.mapreduce.HCatOutputFormat();
+
+		this.configuration.set("mapreduce.lib.hcatoutput.info", HCatUtil.serialize(jobInfo));
+		this.outputSchema = jobInfo.getOutputSchema();
+		org.apache.hive.hcatalog.mapreduce.HCatOutputFormat.
+				setSchema(this.configuration, this.outputSchema);
+		int numFields = outputSchema.getFields().size();
+		if (numFields > this.getMaxFlinkTupleSize()) {
+			throw new IllegalArgumentException("Only up to " + this.getMaxFlinkTupleSize() +
+					" fields can be accepted as Flink tuples target table.");
+		}
+		TypeInformation[] fieldTypes = new TypeInformation[numFields];
+		fieldNames = new String[numFields];
+		for (String fieldName : outputSchema.getFieldNames()) {
+			HCatFieldSchema field = outputSchema.get(fieldName);
+
+			int fieldPos = outputSchema.getPosition(fieldName);
+			TypeInformation fieldType = getFieldType(field);
+
+			fieldTypes[fieldPos] = fieldType;
+			fieldNames[fieldPos] = fieldName;
+
+		}
+		this.reqType = new TupleTypeInfo(fieldTypes);
+	}
+
+
+	private TypeInformation getFieldType(HCatFieldSchema fieldSchema) {
+
+		switch (fieldSchema.getType()) {
+			case INT:
+				return BasicTypeInfo.INT_TYPE_INFO;
+			case TINYINT:
+				return BasicTypeInfo.BYTE_TYPE_INFO;
+			case SMALLINT:
+				return BasicTypeInfo.SHORT_TYPE_INFO;
+			case BIGINT:
+				return BasicTypeInfo.LONG_TYPE_INFO;
+			case BOOLEAN:
+				return BasicTypeInfo.BOOLEAN_TYPE_INFO;
+			case FLOAT:
+				return BasicTypeInfo.FLOAT_TYPE_INFO;
+			case DOUBLE:
+				return BasicTypeInfo.DOUBLE_TYPE_INFO;
+			case STRING:
+				return BasicTypeInfo.STRING_TYPE_INFO;
+			case BINARY:
+				return PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO;
+			case ARRAY:
+				return new GenericTypeInfo(List.class);
+			case MAP:
+				return new GenericTypeInfo(Map.class);
+			case STRUCT:
+				return new GenericTypeInfo(List.class);
+			default:
+				throw new IllegalArgumentException("Unknown data type \"" +
+						fieldSchema.getType() + "\" encountered.");
+		}
+	}
+
+	@Override
+	public void open(int taskNumber, int numTasks) throws IOException {
+
+		/*code adapted from
+		 *{@link org.apache.flink.api.java.hadoop.mapreduce.HadoopOutputFormatBase}
+		 */
+		if (Integer.toString(taskNumber + 1).length() > 6) {
+			throw new IOException("Task id too large.");
+		}
+
+		TaskAttemptID taskAttemptID = TaskAttemptID.forName("attempt__0000_r_"
+				+ String.format("%" + (6 - Integer.toString(taskNumber + 1).length()) + "s", " ")
+				.replace(" ", "0")
+				+ Integer.toString(taskNumber + 1)
+				+ "_0");
+
+		try {
+			this.context = HadoopUtils.instantiateTaskAttemptContext(this.configuration,
+					taskAttemptID);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		// for mapred api
+		this.context.getConfiguration().set("mapred.task.id", taskAttemptID.toString());
+		this.context.getConfiguration().setInt("mapred.task.partition", taskNumber + 1);
+		// for mapreduce api
+		this.context.getConfiguration().set("mapreduce.task.attempt.id", taskAttemptID.toString());
+		this.context.getConfiguration().setInt("mapreduce.task.partition", taskNumber + 1);
+
+
+		//set output explicitly, needed for hadoop1
+		try {
+			OutputCommitter committer = this.hCatOutputFormat.getOutputCommitter(this.context);
+			committer.setupJob(this.context);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		try {
+			this.recordWriter = this.hCatOutputFormat.getRecordWriter(this.context);
+		} catch (InterruptedException e) {
+			throw new IOException("Could not create RecordReader.", e);
+		}
+	}
+
+
+	@Override
+	public void writeRecord(T record) throws IOException {
+		try {
+			this.recordWriter.write(NullWritable.get(), TupleToHCatRecord(record));
+		} catch (InterruptedException e) {
+			throw new IOException("Could not write Record.", e);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			this.recordWriter.close(this.context);
+		} catch (InterruptedException e) {
+			throw new IOException("Could not close RecordReader.", e);
+		}
+		try {
+			OutputCommitter committer = this.hCatOutputFormat.getOutputCommitter(this.context);
+			if (committer.needsTaskCommit(this.context)) {
+				committer.commitTask(this.context);
+			}
+		} catch (InterruptedException e) {
+			throw new IOException("Could not commit task " + this.context.getTaskAttemptID(), e);
+		}
+
+	}
+
+
+	@Override
+	public void finalizeGlobal(int parallelism) throws IOException {
+		// finalize the job
+		try {
+			OutputCommitter committer = this.hCatOutputFormat.getOutputCommitter(this.context);
+			committer.commitJob(context);
+		} catch (InterruptedException e) {
+			throw new IOException("Could not commit job " + context.getJobID(), e);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Custom serialization methods
+	// --------------------------------------------------------------------------------------------
+	private void writeObject(ObjectOutputStream out) throws IOException {
+		out.writeInt(this.fieldNames.length);
+		for (String fieldName : this.fieldNames) {
+			out.writeUTF(fieldName);
+		}
+		this.configuration.write(out);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		this.fieldNames = new String[in.readInt()];
+		for (int i = 0; i < this.fieldNames.length; i++) {
+			this.fieldNames[i] = in.readUTF();
+		}
+
+		Configuration config = new Configuration();
+		config.readFields(in);
+
+		if (this.configuration == null) {
+			this.configuration = config;
+		}
+
+		this.hCatOutputFormat = new org.apache.hive.hcatalog.mapreduce.HCatOutputFormat();
+		this.outputSchema = (HCatSchema) HCatUtil.deserialize(
+				this.configuration.get("mapreduce.lib.hcat.output.schema"));
+		org.apache.hive.hcatalog.mapreduce.HCatOutputFormat.
+				setSchema(this.configuration, this.outputSchema);
+	}
+}

--- a/flink-staging/flink-hcatalog/src/main/java/org/apache/flink/hcatalog/java/HCatOutputFormat.java
+++ b/flink-staging/flink-hcatalog/src/main/java/org/apache/flink/hcatalog/java/HCatOutputFormat.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.hcatalog.java;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.hcatalog.HCatOutputFormatBase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hive.hcatalog.data.DefaultHCatRecord;
+import org.apache.hive.hcatalog.data.HCatRecord;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/*
+ * A OutputFormat to write to HCatalog tables
+ * The outputFormat supports write to table and partitions through partitionValue map.
+ *
+ * Flink {@link org.apache.flink.api.java.tuple.Tuple} and {@link HCatRecord} are accepted
+ * as data source. If user want to write other type of data to HCatalog, a preceding Map function
+ * is required to convert the user data type to {@link HCatRecord}
+ *
+ * The constructor provides type checking if the user also pass a typeinfo object for the tuple type
+ */
+public class HCatOutputFormat<T> extends HCatOutputFormatBase<T> {
+
+
+	/**
+	 * Create HCatOutputFormat with default conf
+	 * @param database The database schema for the hcatalog table
+	 * @param table the name of the table
+	 * @param partitionValues Map of partition values, if null, whole table is used
+	 * @throws IOException
+	 */
+	public HCatOutputFormat(String database, String table, Map<String, String> partitionValues
+							) throws IOException
+	{
+		super(database, table, partitionValues);
+	}
+
+	/**
+	 * Create HCatOutputFormat with given conf
+	 * @param database The database schema for the hcatalog table
+	 * @param table the name of the table
+	 * @param partitionValues Map of partition values, if null, whole table is used
+	 * @param conf a hadoop configuration
+	 * @throws IOException
+	 */
+	public HCatOutputFormat(String database, String table, Map<String, String> partitionValues,
+							Configuration conf) throws IOException
+	{
+		super(database, table, partitionValues, conf);
+	}
+
+	/**
+	 * Create HCatOutputFormat with type checking
+	 * @param database The database schema for the hcatalog table
+	 * @param table the name of the table
+	 * @param partitionValues Map of partition values, if null, whole table is used
+	 * @param conf a hadoop configuration
+	 * @param typeInfo a typeInfo to be matched by the HCatSchema
+	 * @throws IOException
+	 */
+	public HCatOutputFormat(String database, String table, Map<String, String> partitionValues,
+							Configuration conf, TypeInformation<T> typeInfo) throws IOException
+	{
+		super(database, table, partitionValues, conf);
+		if(!typeInfo.equals(this.reqType))
+		{
+			throw new IOException("tuple has different types from the table's columns");
+		}
+
+	}
+
+	@Override
+	protected HCatRecord TupleToHCatRecord(T record) throws IOException{
+		if(record instanceof  Tuple) {
+			Tuple tuple = (Tuple) record;
+			if (tuple.getArity() != this.reqType.getArity()) {
+				throw new IOException("tuple has different arity from the table's column numbers");
+			}
+			List<Object> fieldList = new ArrayList<>();
+			for (int i = 0; i < this.reqType.getArity(); i++) {
+				Object o = tuple.getField(i);
+
+				if (((TupleTypeInfo<Tuple>) reqType).getTypeAt(i).getTypeClass().isInstance(o)) {
+					fieldList.add(tuple.getField(i));
+				} else {
+					throw new IOException("field has different type from required");
+				}
+
+			}
+			return new DefaultHCatRecord(fieldList);
+		}
+		else if(record instanceof HCatRecord){
+			//assume the user has done the conversion in previous map step
+			return (HCatRecord)record;
+		}
+		else {
+			throw new IOException("the record should be either Tuple or HCatRecord");
+		}
+	}
+
+	@Override
+	protected int getMaxFlinkTupleSize() {
+		return Tuple.MAX_ARITY;
+	}
+}

--- a/flink-staging/flink-hcatalog/src/main/scala/org/apache/flink/hcatalog/scala/HCatInputFormat.scala
+++ b/flink-staging/flink-hcatalog/src/main/scala/org/apache/flink/hcatalog/scala/HCatInputFormat.scala
@@ -23,6 +23,7 @@ import org.apache.flink.hcatalog.HCatInputFormatBase
 import org.apache.hadoop.conf.Configuration
 import org.apache.hive.hcatalog.data.HCatRecord
 import org.apache.hive.hcatalog.data.schema.HCatFieldSchema
+import scala.collection.JavaConverters._
 
 /**
  * A InputFormat to read from HCatalog tables.
@@ -125,21 +126,21 @@ class HCatInputFormat[T](
               throw new RuntimeException("Cannot handle partition keys of type ARRAY.")
             }
             else {
-              vals(i) = o.asInstanceOf[List[Object]]
+              vals(i) = o.asInstanceOf[java.util.List[_]].asScala
             }
           case HCatFieldSchema.Type.MAP =>
             if (o.isInstanceOf[String]) {
               throw new RuntimeException("Cannot handle partition keys of type MAP.")
             }
             else {
-              vals(i) = o.asInstanceOf[Map[Object, Object]]
+              vals(i) = o.asInstanceOf[java.util.Map[_,_]].asScala
             }
           case HCatFieldSchema.Type.STRUCT =>
             if (o.isInstanceOf[String]) {
               throw new RuntimeException("Cannot handle partition keys of type STRUCT.")
             }
             else {
-              vals(i) = o.asInstanceOf[List[Object]]
+              vals(i) = o.asInstanceOf[java.util.List[_]].asScala
             }
           case _ =>
             throw new RuntimeException("Invalid type " + this.outputSchema.get(i).getType +

--- a/flink-staging/flink-hcatalog/src/main/scala/org/apache/flink/hcatalog/scala/HCatOutputFormat.scala
+++ b/flink-staging/flink-hcatalog/src/main/scala/org/apache/flink/hcatalog/scala/HCatOutputFormat.scala
@@ -1,0 +1,449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hcatalog.scala
+
+import java.io.IOException
+import java.util
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.TupleTypeInfo
+import org.apache.flink.api.scala.createTypeInformation
+import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
+import org.apache.flink.hcatalog.HCatOutputFormatBase
+import org.apache.hadoop.conf.Configuration
+import org.apache.hive.hcatalog.data.{DefaultHCatRecord, HCatRecord}
+
+import scala.collection.JavaConversions.mapAsJavaMap
+import scala.collection.JavaConverters._
+
+/*
+ * A OutputFormat to write to HCatalog tables for scala api
+ * The outputFormat supports write to table and partitions through partitionValue map.
+ *
+ * scala tuple types and {@link HCatRecord} are accepted
+ * as data source. If user want to write other type of data to HCatalog, a preceding Map function
+ * is required to convert the user data type to {@link HCatRecord}
+ *
+ * The constructor provides type checking and requires import org.apache.flink.api.scala._ in the
+ * import statement of the user's program when compiling to allow scala macro to extract type info
+ */
+/**
+ *
+ * @param database hive database name, if null, default database is used
+ * @param table hive table name
+ * @param partitionValues Map of partition values, if null, whole table is used
+ * @param config the configuration
+ * @tparam T
+ */
+class HCatOutputFormat[T: TypeInformation](
+                                            database: String,
+                                            table: String,
+                                            partitionValues: Map[String, String],
+                                            config: Configuration
+                                            ) extends
+HCatOutputFormatBase[T](database, table, mapAsJavaMap(partitionValues), config) {
+
+  //get the TypeInformation
+  val ti: TypeInformation[T] = createTypeInformation[T]
+
+
+  //check the types of columns if the input is tuple(case class) type
+  if (ti.isInstanceOf[CaseClassTypeInfo[_]]) {
+    //check the number of columns
+    if (ti.asInstanceOf[CaseClassTypeInfo[_]].getArity != this.reqType.getArity) {
+      throw new IOException("tuple has different arity from the table's column numbers")
+    }
+
+    for (i <- 0 until this.reqType.getArity) {
+      val it = ti.asInstanceOf[CaseClassTypeInfo[_]].getTypeAt(i)
+      val ot = reqType.asInstanceOf[TupleTypeInfo[_]].getTypeAt(i)
+
+      if (!isCompatibleType(it, ot)) {
+        throw new IOException("field has different type from required")
+      }
+    }
+  }
+
+  /**
+   *
+   * @param database hive database name, if null, default database is used
+   * @param table hive table name
+   * @param partitionValues Map of partition values, if null, whole table is used
+   */
+  def this(database: String, table: String, partitionValues: Map[String, String]) {
+    this(database, table, partitionValues, new Configuration)
+  }
+
+  //convert the type T to HCatRecord, if T is already HCatRecord, do nothing
+  override protected def TupleToHCatRecord(record: T): HCatRecord = {
+    if (ti.isInstanceOf[CaseClassTypeInfo[_]]) {
+
+      val fieldList: util.List[AnyRef] = new util.ArrayList[AnyRef]
+      //we've checked the type of the scala tuple matches the table, so fill the list now
+      fillList(fieldList, record.asInstanceOf[AnyRef])
+      new DefaultHCatRecord(fieldList)
+    }
+    else if (record.isInstanceOf[HCatRecord]) {
+      record.asInstanceOf[HCatRecord]
+    }
+    else {
+      throw new IOException("the record should be either scala Tuple or HCatRecord")
+    }
+  }
+
+  //scala tuple max arity 22.
+  override protected def getMaxFlinkTupleSize: Int = 22
+
+  //THe HCatalog expects Java types for complex types
+  private def toJava(i: AnyRef): Object = {
+    if (i.isInstanceOf[Map[_, _]]) i.asInstanceOf[Map[_, _]].asJava
+    else if (i.isInstanceOf[List[_]]) i.asInstanceOf[List[_]].asJava
+    else i
+  }
+
+  private def isCompatibleType(scalaT: TypeInformation[_], javaT: TypeInformation[_]): Boolean = {
+    if (scalaT.equals(javaT)) true
+    else if (scalaT.getTypeClass == classOf[List[_]]) {
+      javaT.getTypeClass == classOf[java.util.List[_]]
+    }
+    else if (scalaT.getTypeClass == classOf[Map[_, _]]) {
+      javaT.getTypeClass == classOf[java.util.Map[_, _]]
+    }
+    else false
+  }
+
+  //fill an empty java list with the content of a scala tuple, with conversion for complex types
+  private def fillList(list: util.List[AnyRef], o: AnyRef) = {
+    o match {
+      case Tuple1(i1: AnyRef) => list.add(toJava(i1))
+      case Tuple2(i1: AnyRef, i2: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+      }
+      case Tuple3(i1: AnyRef, i2: AnyRef, i3: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+      }
+      case Tuple4(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+      }
+      case Tuple5(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+      }
+      case Tuple6(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+      }
+      case Tuple7(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+      }
+      case Tuple8(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+      }
+      case Tuple9(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+      }
+      case Tuple10(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+      }
+      case Tuple11(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+      }
+      case Tuple12(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+      }
+      case Tuple13(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+      }
+      case Tuple14(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+      }
+      case Tuple15(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+      };
+      case Tuple16(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef, i16: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+        list.add(toJava(i16))
+      };
+      case Tuple17(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef, i16: AnyRef, i17: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+        list.add(toJava(i16))
+        list.add(toJava(i17))
+      };
+      case Tuple18(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef, i16: AnyRef, i17: AnyRef, i18: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+        list.add(toJava(i16))
+        list.add(toJava(i17))
+        list.add(toJava(i18))
+      };
+      case Tuple19(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef, i16: AnyRef, i17: AnyRef, i18: AnyRef, i19: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+        list.add(toJava(i16))
+        list.add(toJava(i17))
+        list.add(toJava(i18))
+        list.add(toJava(i19))
+      };
+      case Tuple20(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef, i16: AnyRef, i17: AnyRef, i18: AnyRef, i19: AnyRef, i20: AnyRef)
+      => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+        list.add(toJava(i16))
+        list.add(toJava(i17))
+        list.add(toJava(i18))
+        list.add(toJava(i19))
+        list.add(toJava(i20))
+      };
+      case Tuple21(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef, i16: AnyRef, i17: AnyRef, i18: AnyRef, i19: AnyRef, i20: AnyRef,
+      i21: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+        list.add(toJava(i16))
+        list.add(toJava(i17))
+        list.add(toJava(i18))
+        list.add(toJava(i19))
+        list.add(toJava(i20))
+        list.add(toJava(i21))
+      };
+      case Tuple22(i1: AnyRef, i2: AnyRef, i3: AnyRef, i4: AnyRef, i5: AnyRef, i6: AnyRef,
+      i7: AnyRef, i8: AnyRef, i9: AnyRef, i10: AnyRef, i11: AnyRef, i12: AnyRef, i13: AnyRef,
+      i14: AnyRef, i15: AnyRef, i16: AnyRef, i17: AnyRef, i18: AnyRef, i19: AnyRef, i20: AnyRef,
+      i21: AnyRef, i22: AnyRef) => {
+        list.add(toJava(i1))
+        list.add(toJava(i2))
+        list.add(toJava(i3))
+        list.add(toJava(i4))
+        list.add(toJava(i5))
+        list.add(toJava(i6))
+        list.add(toJava(i7))
+        list.add(toJava(i8))
+        list.add(toJava(i9))
+        list.add(toJava(i11))
+        list.add(toJava(i12))
+        list.add(toJava(i13))
+        list.add(toJava(i14))
+        list.add(toJava(i15))
+        list.add(toJava(i16))
+        list.add(toJava(i17))
+        list.add(toJava(i18))
+        list.add(toJava(i19))
+        list.add(toJava(i20))
+        list.add(toJava(i21))
+        list.add(toJava(i22))
+      };
+      case _ =>
+        throw new IOException("Only scala tuple is allowed")
+
+    }
+  }
+}

--- a/flink-staging/flink-hcatalog/src/test/java/org/apache/flink/hcatalog/java/test/HcatInputOutputFormatITest.java
+++ b/flink-staging/flink-hcatalog/src/test/java/org/apache/flink/hcatalog/java/test/HcatInputOutputFormatITest.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hcatalog.java.test;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.DataSource;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.hcatalog.java.HCatInputFormat;
+import org.apache.flink.hcatalog.java.HCatOutputFormat;
+import org.apache.hadoop.hive.cli.CliSessionState;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class HcatInputOutputFormatITest {
+
+    private File dataDir;
+    private String warehouseDir;
+    private String inputFileName;
+    private Driver driver;
+    private String[] input;
+    private HiveConf hiveConf;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setup() throws Exception {
+        dataDir = new File(System.getProperty("java.io.tmpdir") + File.separator +
+                HcatInputOutputFormatITest.class.getCanonicalName() + "-" +
+                System.currentTimeMillis());
+        hiveConf = new HiveConf();
+        warehouseDir = makePathASafeFileName(dataDir + File.separator + "warehouse");
+
+        hiveConf.set(HiveConf.ConfVars.PREEXECHOOKS.varname, "");
+        hiveConf.set(HiveConf.ConfVars.POSTEXECHOOKS.varname, "");
+        hiveConf.set(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY.varname, "false");
+        hiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, warehouseDir);
+        driver = new Driver(hiveConf);
+        SessionState.start(new CliSessionState(hiveConf));
+
+        if(!(new File(warehouseDir).mkdirs())) {
+            throw new RuntimeException("Could not create " + warehouseDir);
+        }
+
+
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if(dataDir != null) {
+            FileUtils.deleteDirectory(dataDir);
+        }
+    }
+
+    @Test
+    public void testReadTextFile() throws Exception {
+        //create input
+        inputFileName = makePathASafeFileName(dataDir + File.separator + "input1.data");
+        int numRows = 3;
+        input = new String[numRows];
+        for (int i = 0; i < numRows; i++) {
+            String col1 = "a" + i;
+            String col2 = "b" + i;
+            input[i] = i + "\t" + col1 + "\t" + col2;
+        }
+        createTestDataFile(inputFileName, input);
+
+        String createTable = "CREATE TABLE test_table1(a0 int, a1 String, a2 String)row format " +
+                "delimited fields terminated by '\t' STORED AS TEXTFILE";
+        driver.run("drop table test_table1");
+        int retCode1 = driver.run(createTable).getResponseCode();
+        assertTrue("table created", retCode1 == 0);
+
+        String loadTable = "load data inpath '" + inputFileName + "' into table test_table1";
+        int retCode2 = driver.run(loadTable).getResponseCode();
+        assertTrue("table data loaded", retCode2 == 0);
+
+        ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+        HCatInputFormat<Tuple3> ipf = (HCatInputFormat<Tuple3>)
+        new HCatInputFormat<Tuple3>(null, "test_table1", hiveConf).asFlinkTuples();
+        DataSet<Tuple3> d = env.createInput(ipf);
+        List<Tuple3> l = d.collect();
+        Integer i = 0;
+        for(Tuple3 t: l)
+        {
+            assertEquals(t.f0, i);
+            assertEquals(t.f1, "a"+ i);
+            assertEquals(t.f2, "b" + i);
+            i++;
+        }
+
+    }
+
+    @Test
+    public void testReadComplexType() throws Exception {
+        //create input
+        inputFileName = makePathASafeFileName(dataDir + File.separator + "input2.data");
+        int numRows = 2;
+        input = new String[numRows];
+        input[0] = "a1/b1/c1\t1:v11/2:v12\td/1";
+        input[1] = "a2/b2/c2\t1:v21/2:v22\td/2";
+        createTestDataFile(inputFileName, input);
+
+        String createTable = "CREATE TABLE test_table2(c1 array<string>,\n" +
+                "c2 map<int,string>,\n" +
+                "c3 struct<name:string,score:int>)row format delimited " +
+                "fields terminated by '\t' " +
+                "COLLECTION ITEMS TERMINATED BY '/' " +
+                "MAP KEYS TERMINATED BY ':' " +
+                "STORED AS TEXTFILE";
+        driver.run("drop table test_table2");
+        int retCode1 = driver.run(createTable).getResponseCode();
+        assertTrue("table created", retCode1 == 0);
+
+        String loadTable = "load data inpath '" + inputFileName + "' into table test_table2";
+        int retCode2 = driver.run(loadTable).getResponseCode();
+        assertTrue("table data loaded", retCode2 == 0);
+
+        ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+        HCatInputFormat<Tuple3> ipf = (HCatInputFormat<Tuple3>)
+                new HCatInputFormat<Tuple3>(null, "test_table2", hiveConf).asFlinkTuples();
+        DataSet<Tuple3> d = env.createInput(ipf);
+        List<Tuple3> l = d.collect();
+
+        //just check the first row
+        Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>> t= l.get(0);
+        assertEquals(t.f0.get(0), "a1");
+        assertEquals(t.f0.get(1), "b1");
+        assertEquals(t.f0.get(2), "c1");
+        assertEquals(t.f1.get(1), "v11");
+        assertEquals(t.f1.get(2), "v12");
+        assertEquals(t.f2.get(0), "d");
+        assertEquals(t.f2.get(1), 1);
+    }
+
+    @Test
+    public void testWriteComplexType() throws Exception {
+
+        String createTable = "CREATE TABLE test_table3(c1 array<string>,\n" +
+                "c2 map<int,string>,\n" +
+                "c3 struct<name:string,score:int>)row format delimited " +
+                "fields terminated by '\t' " +
+                "COLLECTION ITEMS TERMINATED BY '/' " +
+                "MAP KEYS TERMINATED BY ':' " +
+                "STORED AS TEXTFILE";
+        driver.run("drop table test_table3");
+        int retCode1 = driver.run(createTable).getResponseCode();
+        assertTrue("table created", retCode1 == 0);
+
+        HCatOutputFormat<Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>>> opf
+                = new HCatOutputFormat<>(null, "test_table3",null, hiveConf);
+
+
+        List<Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>>> l =
+                new ArrayList<>(2);
+        Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>> t1 = new Tuple3<>();
+        t1.f0 = new ArrayList<>();
+        t1.f0.add("a1");
+        t1.f0.add("b1");
+        t1.f0.add("c1");
+        t1.f1 = new HashMap<>();
+        t1.f1.put(1, "v11");
+        t1.f1.put(2, "v12");
+        t1.f2 = new ArrayList<>();
+        t1.f2.add("d");
+        t1.f2.add(1);
+        Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>> t2 = new Tuple3<>();
+        t2.f0 = new ArrayList<>();
+        t2.f0.add("a2");
+        t2.f0.add("b2");
+        t2.f0.add("c2");
+        t2.f1 = new HashMap<>();
+        t2.f1.put(1, "v21");
+        t2.f1.put(2, "v22");
+        t2.f2 = new ArrayList<>();
+        t2.f2.add("d");
+        t2.f2.add(2);
+        l.add(t1);
+        l.add(t2);
+
+        ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+
+        DataSource<Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>>> d =
+                env.fromCollection(l);
+        d.output(opf);
+        env.execute();
+
+        //verify the result has been writen to the table, we don't want to depend on flink test
+        String outputFileName = makePathASafeFileName(warehouseDir + File.separator +
+                "test_table3/part-m-00001");
+        BufferedReader reader = new BufferedReader(new FileReader(outputFileName));
+        try {
+            String line = reader.readLine();
+            assertEquals("1st row", line, "a1/b1/c1\t1:v11/2:v12\td/1");
+            line = reader.readLine();
+            assertEquals("2nd row", line, "a2/b2/c2\t1:v21/2:v22\td/2");
+            reader.close();
+        } catch(Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testWriteComplexTypeParition() throws Exception {
+
+        String createTable = "CREATE TABLE test_table4(" +
+                "c1 array<string>,\n" +
+                "c2 map<int,string>,\n" +
+                "c3 struct<name:string,score:int>)\n" +
+                "partitioned by (c0 string)\n" +
+                "row format delimited " +
+                "fields terminated by '\t' " +
+                "COLLECTION ITEMS TERMINATED BY '/' " +
+                "MAP KEYS TERMINATED BY ':' " +
+                "STORED AS TEXTFILE";
+        driver.run("drop table test_table4");
+        int retCode1 = driver.run(createTable).getResponseCode();
+        assertTrue("table created", retCode1 == 0);
+
+        Map<String, String> partitionValues = new HashMap<>();
+        partitionValues.put("c0", "part0");
+        HCatOutputFormat<Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>>> opf
+                = new HCatOutputFormat<>(null, "test_table4",partitionValues, hiveConf);
+
+
+        List<Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>>> l =
+                new ArrayList<>(2);
+        Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>> t1 = new Tuple3<>();
+        t1.f0 = new ArrayList<>();
+        t1.f0.add("a1");
+        t1.f0.add("b1");
+        t1.f0.add("c1");
+        t1.f1 = new HashMap<>();
+        t1.f1.put(1, "v11");
+        t1.f1.put(2, "v12");
+        t1.f2 = new ArrayList<>();
+        t1.f2.add("d");
+        t1.f2.add(1);
+        Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>> t2 = new Tuple3<>();
+        t2.f0 = new ArrayList<>();
+        t2.f0.add("a2");
+        t2.f0.add("b2");
+        t2.f0.add("c2");
+        t2.f1 = new HashMap<>();
+        t2.f1.put(1, "v21");
+        t2.f1.put(2, "v22");
+        t2.f2 = new ArrayList<>();
+        t2.f2.add("d");
+        t2.f2.add(2);
+        l.add(t1);
+        l.add(t2);
+
+        ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
+
+        DataSource<Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>>> d =
+                env.fromCollection(l);
+        d.output(opf);
+        env.execute();
+
+        //verify the result has been written to the table
+        String outputFileName = makePathASafeFileName(warehouseDir + File.separator +
+                "test_table4/c0=part0/part-m-00001");
+        BufferedReader reader = new BufferedReader(new FileReader(outputFileName));
+        try {
+            String line = reader.readLine();
+            assertEquals("1st row", line, "a1/b1/c1\t1:v11/2:v12\td/1");
+            line = reader.readLine();
+            assertEquals("2nd row", line, "a2/b2/c2\t1:v21/2:v22\td/2");
+            reader.close();
+        } catch(Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testTypeInfoCheck() throws Exception {
+
+        String createTable = "CREATE TABLE test_table4(" +
+                "c1 array<string>,\n" +
+                "c2 map<int,string>,\n" +
+                "c3 struct<name:string,score:int>)\n" +
+                "partitioned by (c0 string)\n" +
+                "row format delimited " +
+                "fields terminated by '\t' " +
+                "COLLECTION ITEMS TERMINATED BY '/' " +
+                "MAP KEYS TERMINATED BY ':' " +
+                "STORED AS TEXTFILE";
+        driver.run("drop table test_table4");
+        int retCode1 = driver.run(createTable).getResponseCode();
+        assertTrue(retCode1 == 0);
+
+        Map<String, String> partitionValues = new HashMap<>();
+        partitionValues.put("c0", "part0");
+        //should not be able to create a HCatOutputFormat of
+        // Tuple3<ArrayList<String>, HashMap<Integer, String>, String>
+        //when the hcat schema requires
+        //Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList>
+
+        exception.expect(IOException.class);
+        @SuppressWarnings("unchecked")
+        HCatOutputFormat<Tuple3<ArrayList<String>, HashMap<Integer, String>, String>> opf
+                = new HCatOutputFormat<>(null, "test_table4", partitionValues, hiveConf,
+                new TupleTypeInfo(new GenericTypeInfo(List.class),
+                        new GenericTypeInfo(Map.class),
+                        BasicTypeInfo.STRING_TYPE_INFO));
+
+
+        //this should succeed!
+        try {
+            @SuppressWarnings("unchecked")
+            HCatOutputFormat<Tuple3<ArrayList<String>, HashMap<Integer, String>, ArrayList<Object>>>
+                    opf1
+                    = new HCatOutputFormat<>(null, "test_table4", partitionValues, hiveConf,
+                    new TupleTypeInfo(new GenericTypeInfo(List.class),
+                            new GenericTypeInfo(Map.class),
+                            new GenericTypeInfo(List.class)));
+        } catch (IOException e) {
+            fail("should be able to construct HCatOutputFormat for correct types");
+        }
+
+
+    }
+    public static void createTestDataFile(String filename, String[] lines) throws IOException {
+        FileWriter writer = null;
+        try {
+            File file = new File(filename);
+            file.deleteOnExit();
+            writer = new FileWriter(file);
+            for (String line : lines) {
+                writer.write(line + "\n");
+            }
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+    public static String makePathASafeFileName(String filePath) {
+        return new File(filePath).getPath().replaceAll("\\\\", "/");
+    }
+}

--- a/flink-staging/flink-hcatalog/src/test/scala/org/apache/flink/hcatalog/scala/test/HCatInputOutputFormatITest.scala
+++ b/flink-staging/flink-hcatalog/src/test/scala/org/apache/flink/hcatalog/scala/test/HCatInputOutputFormatITest.scala
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.hcatalog.scala.test
+
+
+import java.io.{FileWriter, FileReader, BufferedReader, IOException, File}
+
+import org.apache.commons.io.FileUtils
+import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment, _}
+import org.apache.flink.hcatalog.scala.{HCatInputFormat, HCatOutputFormat}
+import org.apache.hadoop.hive.cli.CliSessionState
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.Driver
+import org.apache.hadoop.hive.ql.session.SessionState
+import org.junit.Assert._
+import org.junit.rules.ExpectedException
+import org.junit.{Rule, After, Before, Test}
+
+class HCatInputOutputFormatITest {
+  private var dataDir: File = null
+  private var warehouseDir: String = null
+  private var inputFileName: String = null
+  private var driver: Driver = null
+  private var input: Array[String] = null
+  private var hiveConf: HiveConf = null
+
+  @Before
+  @throws(classOf[Exception])
+  def setup {
+    dataDir = new File(System.getProperty("java.io.tmpdir") + File.separator +
+      this.getClass.getCanonicalName + "-" + System.currentTimeMillis)
+    hiveConf = new HiveConf
+    warehouseDir = makePathASafeFileName(dataDir + File.separator + "warehouse")
+    hiveConf.set(HiveConf.ConfVars.PREEXECHOOKS.varname, "")
+    hiveConf.set(HiveConf.ConfVars.POSTEXECHOOKS.varname, "")
+    hiveConf.set(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY.varname, "false")
+    hiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, warehouseDir)
+    driver = new Driver(hiveConf)
+    SessionState.start(new CliSessionState(hiveConf))
+    if (!(new File(warehouseDir).mkdirs)) {
+      throw new RuntimeException("Could not create " + warehouseDir)
+    }
+  }
+
+  @After
+  @throws(classOf[IOException])
+  def teardown {
+    if (dataDir != null) {
+      FileUtils.deleteDirectory(dataDir)
+    }
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testReadTextFile {
+    inputFileName = makePathASafeFileName(dataDir + File.separator + "input1.data")
+
+    input = Array[String]("a1/b1/c1\t1:v11/2:v12\td/1\te1\t0.1",
+      "a2/b2/c2\t1:v21/2:v22\td/2\te2\t0.2")
+
+    createTestDataFile(inputFileName, input)
+
+    val createTable: String = "CREATE TABLE test_table(" +
+      "c1 array<string>,\n" +
+      "c2 map<int,string>,\n" +
+      "c3 struct<name:string,score:int>,\n" +
+      "c4 string,\n" +
+      "c5 float)\n" +
+      "row format delimited " +
+      "fields terminated by '\t' " +
+      "COLLECTION ITEMS TERMINATED BY '/' " +
+      "MAP KEYS TERMINATED BY ':' " +
+      "STORED AS TEXTFILE"
+    driver.run("drop table test_table")
+    val retCode1: Int = driver.run(createTable).getResponseCode
+    assertTrue("table created", retCode1 == 0)
+    val loadTable: String = "load data inpath '" + inputFileName + "' into table test_table"
+    val retCode2: Int = driver.run(loadTable).getResponseCode
+    assertTrue("table data loaded", retCode2 == 0)
+
+    val env: ExecutionEnvironment = ExecutionEnvironment.createCollectionsEnvironment
+    val ipf: HCatInputFormat[(List[String], Map[Int, String], List[Any], String, Float)] =
+      new HCatInputFormat(null, "test_table", hiveConf).asFlinkTuples().
+        asInstanceOf[HCatInputFormat[(List[String], Map[Int, String], List[Any], String, Float)]]
+    val d: DataSet[(List[String], Map[Int, String], List[Any], String, Float)] =
+      env.createInput(ipf)
+    val l = d.collect
+
+    //verify the first row
+    l.head match {
+      case Tuple5(List("a1","b1","c1"), _, List("d", 1), "e1", 0.1f) => //Map is not case class
+      case _ => fail()
+    }
+    //verify the Map item ignored in the pattern matching above
+    assertEquals(l.head._2(1), "v11")
+    assertEquals(l.head._2(2), "v12")
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testWriteComplexTypeParition {
+    val createTable: String = "CREATE TABLE test_table(" +
+      "c1 array<string>,\n" +
+      "c2 map<int,string>,\n" +
+      "c3 struct<name:string,score:int>,\n" +
+      "c4 string,\n" +
+      "c5 float)\n" +
+      "partitioned by (c0 string)\n" +
+      "row format delimited " +
+      "fields terminated by '\t' " +
+      "COLLECTION ITEMS TERMINATED BY '/' " +
+      "MAP KEYS TERMINATED BY ':' " +
+      "STORED AS TEXTFILE"
+    driver.run("drop table test_table")
+    val retCode1: Int = driver.run(createTable).getResponseCode
+    assertTrue("Table created", retCode1 == 0)
+    val partitionValues: Map[String, String] = Map("c0" -> "part0")
+    val opf: HCatOutputFormat[(List[String], Map[Int, String], List[Any], String, Float)] =
+      new HCatOutputFormat[(List[String], Map[Int, String], List[Any], String, Float)](null,
+        "test_table", partitionValues, hiveConf)
+
+    val t1 = (List[String]("a1","b1","c1"), Map[Int, String](1 -> "v11", 2 -> "v12"),
+      List[Any]("d", 1), "e1", 0.1f)
+    val t2 = (List[String]("a2","b2","c2"), Map[Int, String](1 -> "v21", 2 -> "v22"),
+      List[Any]("d", 2), "e2", 0.2f)
+    val l: List[(List[String], Map[Int, String], List[Any], String, Float)]=
+      List[(List[String], Map[Int, String], List[Any], String, Float)](t1, t2)
+    val env: ExecutionEnvironment = ExecutionEnvironment.createCollectionsEnvironment
+    val d: DataSet[(List[String], Map[Int, String], List[Any], String, Float)] =
+      env.fromCollection(l)
+    d.output(opf)
+    env.execute
+    val outputFileName: String = makePathASafeFileName(warehouseDir +
+      File.separator + "test_table/c0=part0/part-m-00001")
+    val reader: BufferedReader = new BufferedReader(new FileReader(outputFileName))
+    try {
+      var line: String = reader.readLine
+      assertEquals("1st row", line, "a1/b1/c1\t1:v11/2:v12\td/1\te1\t0.1")
+      line = reader.readLine
+      assertEquals("2nd row", line, "a2/b2/c2\t1:v21/2:v22\td/2\te2\t0.2")
+      reader.close
+    }
+    catch {
+      case e: Exception => {
+        e.printStackTrace
+      }
+    }
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testTypeInfoCheck {
+    val createTable: String = "CREATE TABLE test_table(" +
+      "c1 array<string>,\n" +
+      "c2 map<int,string>,\n" +
+      "c3 struct<name:string,score:int>,\n" +
+      "c4 string,\n" +
+      "c5 float)\n" +
+      "partitioned by (c0 string)\n" +
+      "row format delimited " +
+      "fields terminated by '\t' " +
+      "COLLECTION ITEMS TERMINATED BY '/' " +
+      "MAP KEYS TERMINATED BY ':' " +
+      "STORED AS TEXTFILE"
+    driver.run("drop table test_table")
+    val retCode1: Int = driver.run(createTable).getResponseCode
+    assertTrue("Table created", retCode1 == 0)
+    val partitionValues: Map[String, String] = Map("c0" -> "part0")
+
+    //wrong type, should throw exception
+    try{
+      val opf =
+        new HCatOutputFormat[(List[String], Map[Int, String], List[Any], Float, Float)](null,
+          "test_table", partitionValues, hiveConf)
+    } catch{
+      case ioe: IOException => //succeeded!
+      case _ => fail("expecting IOException!")
+    }
+  }
+
+  @throws(classOf[IOException])
+  def createTestDataFile(filename: String, lines: Array[String]) {
+    var writer: FileWriter = null
+    try {
+      val file: File = new File(filename)
+      file.deleteOnExit
+      writer = new FileWriter(file)
+      for (line <- lines) {
+        writer.write(line + "\n")
+      }
+    } finally {
+      if (writer != null) {
+        writer.close
+      }
+    }
+  }
+
+  def makePathASafeFileName(filePath: String): String = {
+    return new File(filePath).getPath.replaceAll("\\\\", "/")
+  }
+}

--- a/flink-staging/pom.xml
+++ b/flink-staging/pom.xml
@@ -42,7 +42,6 @@ under the License.
 		<module>flink-streaming</module>
 		<module>flink-hbase</module>
 		<module>flink-gelly</module>
-		<module>flink-hcatalog</module>
 		<module>flink-table</module>
 		<module>flink-ml</module>
 		<module>flink-language-binding</module>
@@ -64,6 +63,21 @@ under the License.
 				 	The HDFS minicluster interfaces changed between the two versions.
 				 -->
 				<module>flink-fs-tests</module>
+			</modules>
+		</profile>
+		<profile>
+			<id>hadoop-1</id>
+			<activation>
+				<property>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop1--><name>hadoop.profile</name><value>1</value>
+				</property>
+			</activation>
+			<modules>
+				<!-- Include the flink-hcatalog project only for HD1.
+				 	The maven hcatalog jar is compiled against hadoop1
+				 -->
+				<module>flink-hcatalog</module>
 			</modules>
 		</profile>
 		<profile>


### PR DESCRIPTION
[FLINK1919]
Add `HCatOutputFormat` for Tuple data types for java and scala api also fix a bug for the scala api's `HCatInputFormat` for hive complex types.
Java api includes check for whether the schema of the HCatalog table and the Flink tuples match if the user provides a `TypeInformation` in the constructor. For data types other than tuples, the OutputFormat requires a preceding Map function that converts to `HCatRecords`
scala api includes check if the schema of the HCatalog table and the Scala tuples match. For data types other than scala Tuple, the `OutputFormat` requires a preceding Map function that converts to HCatRecords scala api requires user to import `org.apache.flink.api.scala`._ to allow the type be captured by the scala macro.
The Hcatalog jar in maven central is compiled using hadoop1, which is not compatible with hive jars for testing, so a cloudera hcatalog jar is pulled into the pom for testing purpose. It can be removed if not required.
java List and Map can not be cast to scala `List` and `Map`, `JavaConverters` is used to fix a bug in HcatInputFormat scala api

@chiwanpark @rmetzger 
I have changed the hcatalog jar to the apache version. That requires that I move the hcatalog module to hadoop1 profile. 
@chiwanpark 
I had made changes to most of your comment. Except for your comment regarding the verification of Exception in the tests. I feel that it's better to verify the exception at the point it's expected to be thrown. If we use method-wide annotation, we are not sure where the exception is thrown from the test method, this is not safe especially for common exception types such as IOException. I did remove the test dependency on exception error message.