### PR TITLE
[FLINK-1730]Persist operator on Data Sets

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/base/PersistOperatorBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/base/PersistOperatorBase.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators.base;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.NoOpFunction;
+import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.api.common.operators.SingleInputOperator;
+import org.apache.flink.api.common.operators.UnaryOperatorInformation;
+import org.apache.flink.api.common.operators.util.UserCodeObjectWrapper;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Persists the input of the operator in memory.
+ *
+ * @param <T> The input type.
+ */
+public class PersistOperatorBase<T> extends SingleInputOperator<T, T, NoOpFunction> {
+
+	public PersistOperatorBase(NoOpFunction udf, UnaryOperatorInformation<T, T> operatorInfo, String name) {
+		super(new UserCodeObjectWrapper<NoOpFunction>(udf), operatorInfo, name);
+	}
+
+	@Override
+	protected List<T> executeOnCollections(List<T> inputData, RuntimeContext ctx, ExecutionConfig executionConfig) throws Exception {
+		ArrayList<T> result = new ArrayList<T>(inputData.size());
+
+		TypeSerializer<T> inSerializer = getOperatorInfo().getInputType().createSerializer(executionConfig);
+		TypeSerializer<T> outSerializer = getOperatorInfo().getOutputType().createSerializer(executionConfig);
+
+		for (T element : inputData) {
+			T out = inSerializer.copy(element);
+			result.add(outSerializer.copy(out));
+		}
+
+		return result;
+	}
+
+	// ----------  Disallow some functions --------------------------------------------------------
+
+	@Override
+	public Map<String, Operator<?>> getBroadcastInputs() {
+		return this.broadcastInputs;
+	}
+
+	@Override
+	public void setBroadcastVariable(String name, Operator<?> root) {
+		throw new UnsupportedOperationException("Persist operator doesn't allow broadcast inputs");
+	}
+
+	@Override
+	public <BC> void setBroadcastVariables(Map<String, Operator<BC>> inputs) {
+		throw new UnsupportedOperationException("Persist operator doesn't allow broadcast inputs");
+	}
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -68,6 +68,7 @@ import org.apache.flink.api.java.operators.Keys;
 import org.apache.flink.api.java.operators.MapOperator;
 import org.apache.flink.api.java.operators.MapPartitionOperator;
 import org.apache.flink.api.java.operators.PartitionOperator;
+import org.apache.flink.api.java.operators.PersistOperator;
 import org.apache.flink.api.java.operators.ProjectOperator;
 import org.apache.flink.api.java.operators.ProjectOperator.Projection;
 import org.apache.flink.api.java.operators.ReduceOperator;
@@ -190,6 +191,19 @@ public abstract class DataSet<T> {
 	//  Filter & Transformations
 	// --------------------------------------------------------------------------------------------
 	
+	/**
+	 * Persists this DataSet in memory and returns a PersistOperator which emits its output from
+	 * memory if available. Otherwise, this DataSet is persisted in memory the first time it is
+	 * executed.
+	 *
+	 * @return A PersistOperator which represents the Persisted DataSet
+	 */
+	public PersistOperator<T> persist() {
+		String callLocation = Utils.getCallLocationName();
+		TypeInformation<T> resultType = this.getType();
+		return new PersistOperator<>(this, resultType, callLocation);
+	}
+
 	/**
 	 * Applies a Map transformation on this DataSet.<br/>
 	 * The transformation calls a {@link org.apache.flink.api.common.functions.MapFunction} for each element of the DataSet.

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/PersistOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/PersistOperator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.operators;
+
+import org.apache.flink.api.common.functions.util.NoOpFunction;
+import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.api.common.operators.UnaryOperatorInformation;
+import org.apache.flink.api.common.operators.base.PersistOperatorBase;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+
+/**
+ * This operator represents the application of a "persist" function on a data set. It persists
+ * the input of the operator in memory and directly serves from there when accessed again.
+ *
+ * @param <T> The type of the data set consumed by the operator.
+ */
+public class PersistOperator<T> extends SingleInputUdfOperator<T, T, PersistOperator<T>> {
+
+	protected final NoOpFunction function;
+
+	protected final String defaultName;
+
+	public PersistOperator(DataSet<T> input, TypeInformation<T> resultType, String defaultName) {
+		super(input, resultType);
+
+		this.defaultName = defaultName;
+		this.function = new NoOpFunction();
+
+		UdfOperatorUtils.analyzeSingleInputUdf(this, NoOpFunction.class, defaultName, function, null);
+	}
+
+	@Override
+	protected NoOpFunction getFunction() {
+		return function;
+	}
+
+	@Override
+	protected PersistOperatorBase<T> translateToDataFlow(Operator<T> input) {
+
+		String name = getName() != null ? getName() : "Persist at " + defaultName;
+		// create operator
+		PersistOperatorBase<T> po = new PersistOperatorBase<>(function, new UnaryOperatorInformation<T, T>(getInputType(), getResultType()), name);
+		// set input
+		po.setInput(input);
+		// set parallelism
+		po.setParallelism(input.getParallelism());
+
+		return po;
+	}
+
+	@Override
+	public PersistOperator<T> setParallelism(int parallelism) {
+		throw new UnsupportedOperationException("Parallelism of Persist operator is exactly the same as its input");
+	}
+
+	// ------------------- disallow some functions -----------------------------------------------
+	@Override
+	public PersistOperator<T> withBroadcastSet(DataSet<?> data, String name) {
+		throw new UnsupportedOperationException("Persist operator doesn't allow broadcast inputs");
+	}
+}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/costs/CostEstimator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/costs/CostEstimator.java
@@ -172,6 +172,7 @@ public abstract class CostEstimator {
 		case BINARY_NO_OP:	
 		case COLLECTOR_MAP:
 		case MAP:
+		case PERSIST:
 		case MAP_PARTITION:
 		case FLAT_MAP:
 			

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/PersistNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/PersistNode.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.optimizer.dag;
+
+import org.apache.flink.api.common.operators.SemanticProperties;
+import org.apache.flink.api.common.operators.SingleInputOperator;
+import org.apache.flink.api.common.operators.SingleInputSemanticProperties;
+import org.apache.flink.optimizer.DataStatistics;
+import org.apache.flink.optimizer.operators.OperatorDescriptorSingle;
+import org.apache.flink.optimizer.operators.PersistDescriptor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The optimizer's internal representation of a <i>Persist</i> node.
+ */
+public class PersistNode extends SingleInputNode {
+
+	private final List<OperatorDescriptorSingle> possibleProperties;
+
+	/**
+	 * Creates a new PersistNode for the given operator.
+	 *
+	 * @param operator The persist operator.
+	 */
+	public PersistNode(SingleInputOperator<?, ?, ?> operator) {
+		super(operator);
+
+		this.possibleProperties = Collections.<OperatorDescriptorSingle>singletonList(new PersistDescriptor());
+	}
+
+	@Override
+	public String getName() {
+		return "Persist";
+	}
+
+	@Override
+	protected List<OperatorDescriptorSingle> getPossibleProperties() {
+		return this.possibleProperties;
+	}
+
+	@Override
+	public SemanticProperties getSemanticProperties() {
+		return new SingleInputSemanticProperties.AllFieldsForwardedProperties();
+	}
+
+	/**
+	 * Computes the estimates for the Persist operator.
+	 */
+	@Override
+	protected void computeOperatorSpecificDefaultEstimates(DataStatistics statistics) {
+		this.estimatedNumRecords = getPredecessorNode().getEstimatedNumRecords();
+		this.estimatedOutputSize = getPredecessorNode().getEstimatedOutputSize();
+	}
+}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/PersistDescriptor.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/PersistDescriptor.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.optimizer.operators;
+
+import org.apache.flink.optimizer.dag.SingleInputNode;
+import org.apache.flink.optimizer.plan.Channel;
+import org.apache.flink.optimizer.plan.SingleInputPlanNode;
+import org.apache.flink.runtime.operators.DriverStrategy;
+
+
+public class PersistDescriptor extends NoOpDescriptor {
+
+	@Override
+	public DriverStrategy getStrategy() {
+		return DriverStrategy.PERSIST;
+	}
+
+	@Override
+	public SingleInputPlanNode instantiate(Channel in, SingleInputNode node) {
+		return new SingleInputPlanNode(node, "Persist", in, DriverStrategy.PERSIST);
+	}
+}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -812,6 +812,11 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 			
 			config = new TaskConfig(vertex.getConfiguration());
 			config.setDriver(ds.getDriverClass());
+
+			// set persist node
+			if (ds == DriverStrategy.PERSIST) {
+				config.setPersistTask();
+			}
 		}
 		
 		// set user code

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/GraphCreatingVisitor.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/GraphCreatingVisitor.java
@@ -36,6 +36,7 @@ import org.apache.flink.api.common.operators.base.JoinOperatorBase;
 import org.apache.flink.api.common.operators.base.MapOperatorBase;
 import org.apache.flink.api.common.operators.base.MapPartitionOperatorBase;
 import org.apache.flink.api.common.operators.base.PartitionOperatorBase;
+import org.apache.flink.api.common.operators.base.PersistOperatorBase;
 import org.apache.flink.api.common.operators.base.ReduceOperatorBase;
 import org.apache.flink.api.common.operators.base.SortPartitionOperatorBase;
 import org.apache.flink.optimizer.CompilerException;
@@ -58,6 +59,7 @@ import org.apache.flink.optimizer.dag.MapNode;
 import org.apache.flink.optimizer.dag.MapPartitionNode;
 import org.apache.flink.optimizer.dag.OptimizerNode;
 import org.apache.flink.optimizer.dag.PartitionNode;
+import org.apache.flink.optimizer.dag.PersistNode;
 import org.apache.flink.optimizer.dag.ReduceNode;
 import org.apache.flink.optimizer.dag.SolutionSetNode;
 import org.apache.flink.optimizer.dag.SortPartitionNode;
@@ -135,6 +137,9 @@ public class GraphCreatingVisitor implements Visitor<Operator<?>> {
 		}
 		else if (c instanceof GenericDataSourceBase) {
 			n = new DataSourceNode((GenericDataSourceBase<?, ?>) c);
+		}
+		else if (c instanceof PersistOperatorBase) {
+			n = new PersistNode((PersistOperatorBase) c);
 		}
 		else if (c instanceof MapOperatorBase) {
 			n = new MapNode((MapOperatorBase<?, ?, ?>) c);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memorymanager/MemoryManager.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.operators.resettable.SpillingResettableMutableObjectIterator;
 
 /**
  * Interface for a memory manager that assigns portions of memory to different tasks. Each allocated segment of
@@ -131,4 +132,20 @@ public interface MemoryManager {
 	 * @return True, if the memory manager is empty and valid, false if it is not empty or corrupted.
 	 */
 	boolean verifyEmpty();
+
+	/**
+	 * Get the persistent iterator stored in the memory manager under the given key
+	 *
+	 * @param key Key
+	 * @return The persistent iterator for the given key.
+	 */
+	SpillingResettableMutableObjectIterator getPersistedInput(String key);
+
+	/**
+	 * Put the persistent iterator for a given key in the memory manager
+	 *
+	 * @param key Key
+	 * @param iterator Iterator to be stored
+	 */
+	void putPersistedInput(String key, SpillingResettableMutableObjectIterator iterator);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DriverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DriverStrategy.java
@@ -40,6 +40,9 @@ public enum DriverStrategy {
 	// a binary no-op operator. non implementation available
 	BINARY_NO_OP(null, null, PIPELINED, PIPELINED, 0),
 
+	// persist
+	PERSIST(NoOpDriver.class, null, PIPELINED, 0),
+
 	// the old mapper
 	COLLECTOR_MAP(CollectorMapDriver.class, ChainedCollectorMapDriver.class, PIPELINED, 0),
 	// the proper mapper

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DummyPersistInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DummyPersistInvokable.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.util;
+
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+
+/**
+ * A Dummy Invokable class.
+ */
+public class DummyPersistInvokable extends AbstractInvokable {
+
+	public static DummyPersistInvokable INSTANCE = new DummyPersistInvokable();
+
+	@Override
+	public void registerInputOutput() {}
+
+	@Override
+	public void invoke() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
@@ -123,6 +123,8 @@ public class TaskConfig implements Serializable {
 	private static final String INPUT_DAM_MEMORY_PREFIX = "in.dam.mem.";
 	
 	private static final String BROADCAST_INPUT_NAME_PREFIX = "in.broadcast.name.";
+
+	private static final String INPUT_PERSIST = "in.input.persist";
 	
 	
 	// -------------------------------------- Outputs ---------------------------------------------
@@ -228,6 +230,9 @@ public class TaskConfig implements Serializable {
 	// --------------------------------------------------------------------------------------------
 	//                         Members, Constructors, and Accessors
 	// --------------------------------------------------------------------------------------------
+
+	/** Whether this task config corresponds to a Persist task. */
+	protected boolean isPersistent = false;
 	
 	protected final Configuration config;			// the actual configuration holding the values
 	
@@ -252,6 +257,14 @@ public class TaskConfig implements Serializable {
 	// --------------------------------------------------------------------------------------------
 	//                                       User Code
 	// --------------------------------------------------------------------------------------------
+
+	public void setPersistTask() {
+		this.config.setBoolean(INPUT_PERSIST, true);
+	}
+
+	public boolean isPersistTask() {
+		return this.config.getBoolean(INPUT_PERSIST, false);
+	}
 	
 	public void setTaskName(String name) {
 		if (name != null) {
@@ -487,7 +500,11 @@ public class TaskConfig implements Serializable {
 	}
 	
 	public double getRelativeInputMaterializationMemory(int inputNum) {
-		return this.config.getDouble(INPUT_DAM_MEMORY_PREFIX + inputNum, 0);
+		if (this.isPersistTask()) {
+			return 1.0;
+		} else {
+			return this.config.getDouble(INPUT_DAM_MEMORY_PREFIX + inputNum, 0);
+		}
 	}
 	
 	public void setBroadcastInputName(String name, int groupIndex) {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -268,6 +268,17 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   // --------------------------------------------------------------------------------------------
 
   /**
+   * Persists this DataSet in memory and returns a PersistOperator which emits its output from
+   * memory if available. Otherwise, this DataSet is persisted in memory the first time it is
+   * executed.
+   *
+   * @return A PersistOperator which represents the Persisted DataSet
+   */
+  def persist: DataSet[T] = {
+    wrap(new PersistOperator[T](javaSet, javaSet.getType, getCallLocationName()))
+  }
+
+  /**
    * Creates a new DataSet by applying the given function to every element of this DataSet.
    */
   def map[R: TypeInformation: ClassTag](mapper: MapFunction[T, R]): DataSet[R] = {

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
@@ -19,6 +19,8 @@
 package org.apache.flink.test.util;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.operators.CollectionExecutor;
 import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
@@ -27,12 +29,20 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 
 	private CollectionTestEnvironment lastEnv = null;
 
+	CollectionExecutor executor = null;
+
+	public CollectionTestEnvironment() {
+	}
+
+	public CollectionTestEnvironment(CollectionExecutor executor) {
+		this.executor = executor;
+	}
+
 	@Override
 	public JobExecutionResult getLastJobExecutionResult() {
 		if (lastEnv == null) {
 			return this.lastJobExecutionResult;
-		}
-		else {
+		} else {
 			return lastEnv.getLastJobExecutionResult();
 		}
 	}
@@ -44,16 +54,22 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		JobExecutionResult result = super.execute(jobName);
-		this.lastJobExecutionResult = result;
-		return result;
+		if (executor == null) {
+			JobExecutionResult result = super.execute(jobName);
+			this.lastJobExecutionResult = result;
+			return result;
+		} else {
+			Plan p = createProgramPlan(jobName);
+			this.lastJobExecutionResult = executor.execute(p);
+			return this.lastJobExecutionResult;
+		}
 	}
 
 	protected void setAsContext() {
 		ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 			@Override
 			public ExecutionEnvironment createExecutionEnvironment() {
-				lastEnv = new CollectionTestEnvironment();
+				lastEnv = new CollectionTestEnvironment(executor);
 				return lastEnv;
 			}
 		};

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.test.util;
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.operators.CollectionExecutor;
 import org.apache.flink.runtime.StreamingMode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -74,6 +76,8 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	protected static boolean startWebServer = false;
 
 	protected static ForkableFlinkMiniCluster cluster = null;
+
+	protected static CollectionExecutor executor = null;
 	
 	// ------------------------------------------------------------------------
 	
@@ -89,7 +93,7 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 				clusterEnv.setAsContext();
 				break;
 			case COLLECTION:
-				CollectionTestEnvironment collectionEnv = new CollectionTestEnvironment();
+				CollectionTestEnvironment collectionEnv = new CollectionTestEnvironment(executor);
 				collectionEnv.setAsContext();
 				break;
 		}
@@ -108,11 +112,13 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 			startWebServer,
 			false,
 			true);
+		executor = new CollectionExecutor(new ExecutionConfig());
 	}
 
 	@AfterClass
 	public static void teardown() throws Exception {
 		stopCluster(cluster, TestBaseUtils.DEFAULT_TIMEOUT);
+		executor = null;
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/PersistITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/PersistITCase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.javaApiOperators;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class PersistITCase extends MultipleProgramsTestBase {
+
+	public PersistITCase(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testPersist() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Long> data = env.generateSequence(1, 100).map(new MapFunction<Long, Long>() {
+			@Override
+			public Long map(Long value) throws Exception {
+				return new Random().nextLong();
+			}
+		}).persist();
+
+		// if the input was indeed persisted, the result on all collects will be the same.
+		List<Long> exec1 = data.collect();
+		List<Long> exec2 = data.collect();
+		Collections.sort(exec1);
+		Collections.sort(exec2);
+		assertEquals(exec1, exec2);
+	}
+}


### PR DESCRIPTION
This PR introduces a `persist` operation on `DataSet` which allows persisting the data set in memory, allowing for direct access if this data set is operated on again and again.
The idea behind the implementation is this:
1. A `PersistOperator` extending a `SingleInputUdfOperator` for common api and Java API.
2. A `Persist` driver strategy which allows the Job Graph to generate a `PersistNode`, which just uses a `NoOpDriver` to forward results from input to output.
3. `RegularPactTask` determines whether it is a Persist task and accordingly uses a `SpillingResettableMutableObjectIterator` to read the input and persist them.
4. To make the results truly persistent, the `MemorySegment`s must not be freed when the `Task` ends. To this end, I have created a `DummyPersistInvokable` which does nothing. It just prevents freeing of memory.
5. All persisted memory segments are cleared out when the `MemoryManager` is shutting down. There is a possibility of writing some kind of Cache clearing strategy here.

For testing the functionality, I have written a test `PersistITCase` which generates 100 random Long values inside a Map function and persists the output. Then, triggering the execution twice must provide the same results.