### PR TITLE
[Flink 2493] Simplify names of example program JARs

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -86,7 +86,7 @@ Run the __Word Count example__ to see Flink at work.
 * __Start the example program__:
   
   ~~~bash
-  $ bin/flink run ./examples/flink-java-examples-{{site.version}}-WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
+  $ bin/flink run ./examples/WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
   ~~~
 
 * You will find a file called __wordcount-result.txt__ in your current directory.

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -160,6 +160,7 @@ under the License.
 				<exclude>flink-java-examples-${project.version}-sources.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-tests.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-javadoc.jar</exclude>
+				<exclude>flink-java-examples-${project.version}-*.jar</exclude>
 			</excludes>
 		</fileSet>
 

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -160,7 +160,6 @@ under the License.
 				<exclude>flink-java-examples-${project.version}-sources.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-tests.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-javadoc.jar</exclude>
-				<exclude>flink-java-examples-${project.version}-*.jar</exclude>
 			</excludes>
 		</fileSet>
 

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -322,6 +322,32 @@ under the License.
 					
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>all</id>
+						<phase>package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" tofile="${project.basedir}/target/KMeans.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-TransitiveClosure.jar" tofile="${project.basedir}/target/TransitiveClosure.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" tofile="${project.basedir}/target/ConnectedComponents.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesBasic.jar" tofile="${project.basedir}/target/EnumTrianglesBasic.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesOpt.jar" tofile="${project.basedir}/target/EnumTrianglesOpt.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-PageRankBasic.jar" tofile="${project.basedir}/target/PageRankBasic.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WebLogAnalysis.jar" tofile="${project.basedir}/target/WebLogAnalysis.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WordCountPOJO.jar" tofile="${project.basedir}/target/WordCountPOJO.jar" />
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -322,6 +322,7 @@ under the License.
 					
 				</executions>
 			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
@@ -334,15 +335,15 @@ under the License.
 						</goals>
 						<configuration>
 							<target>
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" tofile="${project.basedir}/target/KMeans.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-TransitiveClosure.jar" tofile="${project.basedir}/target/TransitiveClosure.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" tofile="${project.basedir}/target/ConnectedComponents.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesBasic.jar" tofile="${project.basedir}/target/EnumTrianglesBasic.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesOpt.jar" tofile="${project.basedir}/target/EnumTrianglesOpt.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-PageRankBasic.jar" tofile="${project.basedir}/target/PageRankBasic.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WebLogAnalysis.jar" tofile="${project.basedir}/target/WebLogAnalysis.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
-								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WordCountPOJO.jar" tofile="${project.basedir}/target/WordCountPOJO.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" dest="${project.basedir}/target/KMeans.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" dest="${project.basedir}/target/ConnectedComponents.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesBasic.jar" dest="${project.basedir}/target/EnumTrianglesBasic.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesOpt.jar" dest="${project.basedir}/target/EnumTrianglesOpt.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-PageRankBasic.jar" dest="${project.basedir}/target/PageRankBasic.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-TransitiveClosure.jar" dest="${project.basedir}/target/TransitiveClosure.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WebLogAnalysis.jar" dest="${project.basedir}/target/WebLogAnalysis.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WordCount.jar" dest="${project.basedir}/target/WordCount.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WordCountPOJO.jar" dest="${project.basedir}/target/WordCountPOJO.jar" />
 							</target>
 						</configuration>
 					</execution>


### PR DESCRIPTION
The names of the example JARs under build-target/examples have some confusion, the version number might stop users from submitting examples to incompatible versions of Flink

Propose to name the file examples/ConnectedComponents.jar rather than examples/flink-java-examples-0.10-SNAPSHOT-ConnectedComponents.jar.
