### PR TITLE
[FLINK-2493] Simplify names of example program JARs

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -86,7 +86,7 @@ Run the __Word Count example__ to see Flink at work.
 * __Start the example program__:
   
   ~~~bash
-  $ bin/flink run ./examples/flink-java-examples-{{site.version}}-WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
+  $ bin/flink run ./examples/WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
   ~~~
 
 * You will find a file called __wordcount-result.txt__ in your current directory.

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -326,10 +326,11 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.7</version>
 				<executions>
 					<execution>
 						<id>rename</id>
-						<phase>package</phase>
+						<phase>install</phase>
 						<goals>
 							<goal>run</goal>
 						</goals>

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -335,15 +335,15 @@ under the License.
 						</goals>
 						<configuration>
 							<target>
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" dest="${project.basedir}/target/KMeans.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" dest="${project.basedir}/target/ConnectedComponents.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesBasic.jar" dest="${project.basedir}/target/EnumTrianglesBasic.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesOpt.jar" dest="${project.basedir}/target/EnumTrianglesOpt.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-PageRankBasic.jar" dest="${project.basedir}/target/PageRankBasic.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-TransitiveClosure.jar" dest="${project.basedir}/target/TransitiveClosure.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WebLogAnalysis.jar" dest="${project.basedir}/target/WebLogAnalysis.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WordCount.jar" dest="${project.basedir}/target/WordCount.jar" />
-								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WordCountPOJO.jar" dest="${project.basedir}/target/WordCountPOJO.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" tofile="${project.basedir}/target/KMeans.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" tofile="${project.basedir}/target/ConnectedComponents.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesBasic.jar" tofile="${project.basedir}/target/EnumTrianglesBasic.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesOpt.jar" tofile="${project.basedir}/target/EnumTrianglesOpt.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-PageRankBasic.jar" tofile="${project.basedir}/target/PageRankBasic.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-TransitiveClosure.jar" tofile="${project.basedir}/target/TransitiveClosure.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-WebLogAnalysis.jar" tofile="${project.basedir}/target/WebLogAnalysis.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
+								<move file="${project.basedir}/target/flink-java-examples-${project.version}-WordCountPOJO.jar" tofile="${project.basedir}/target/WordCountPOJO.jar" />
 							</target>
 						</configuration>
 					</execution>

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -334,7 +334,7 @@ under the License.
 						<goals>
 							<goal>run</goal>
 						</goals>
-						<configuration>
+						<configuration> 
 							<target>
 								<move file="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" tofile="${project.basedir}/target/KMeans.jar" />
 								<move file="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" tofile="${project.basedir}/target/ConnectedComponents.jar" />

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -328,7 +328,7 @@ under the License.
 				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>all</id>
+						<id>rename</id>
 						<phase>package</phase>
 						<goals>
 							<goal>run</goal>

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -322,6 +322,33 @@ under the License.
 					
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>all</id>
+						<phase>package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" dest="${project.basedir}/target/KMeans.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" dest="${project.basedir}/target/ConnectedComponents.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesBasic.jar" dest="${project.basedir}/target/EnumTrianglesBasic.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesOpt.jar" dest="${project.basedir}/target/EnumTrianglesOpt.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-PageRankBasic.jar" dest="${project.basedir}/target/PageRankBasic.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-TransitiveClosure.jar" dest="${project.basedir}/target/TransitiveClosure.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WebLogAnalysis.jar" dest="${project.basedir}/target/WebLogAnalysis.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WordCount.jar" dest="${project.basedir}/target/WordCount.jar" />
+								<rename src="${project.basedir}/target/flink-java-examples-${project.version}-WordCountPOJO.jar" dest="${project.basedir}/target/WordCountPOJO.jar" />
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -326,7 +326,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.7</version>
+				<version>1.7</version> 
 				<executions>
 					<execution>
 						<id>rename</id>


### PR DESCRIPTION
The names of the example JARs under build-target/examples have some confusion, the version number might stop users from submitting examples to incompatible versions of Flink
Propose to name the file examples/ConnectedComponents.jar rather than examples/flink-java-examples-0.10-SNAPSHOT-ConnectedComponents.jar.