### PR TITLE
[FLINK-2615]Preserve executors for the entire run of program.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -26,8 +26,9 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A PlanExecutor runs a plan. The specific implementation (such as the org.apache.flink.client.LocalExecutor
- * and org.apache.flink.client.RemoteExecutor) determines where and how to run the plan.
+ * A PlanExecutor runs a plan. The specific implementation (such as the org.apache.flink.client.LocalExecutor,
+ * org.apache.flink.client.RemoteExecutor, org.apache.flink.api.common.operators.CollectionExecutor)
+ * determines where and how to run the plan.
  * 
  * The concrete implementations are loaded dynamically, because they depend on the full set of
  * dependencies of all runtime classes.
@@ -36,6 +37,7 @@ public abstract class PlanExecutor {
 	
 	private static final String LOCAL_EXECUTOR_CLASS = "org.apache.flink.client.LocalExecutor";
 	private static final String REMOTE_EXECUTOR_CLASS = "org.apache.flink.client.RemoteExecutor";
+	private static final String COLLECTOR_EXECUTOR_CLASS = "org.apache.flink.api.common.operators.CollectionExecutor";
 
 	// ------------------------------------------------------------------------
 	//  Config Options
@@ -82,6 +84,23 @@ public abstract class PlanExecutor {
 	//  Executor Factories
 	// ------------------------------------------------------------------------
 	
+	/**
+	 * Creates an executor that runs the plan locally in a collection environment.
+	 *
+	 * @return A collection executor
+	 */
+	public static PlanExecutor createCollectionExecutor() {
+		Class<? extends PlanExecutor> leClass = loadExecutorClass(COLLECTOR_EXECUTOR_CLASS);
+
+		try {
+			return leClass.newInstance();
+		}
+		catch (Throwable t) {
+			throw new RuntimeException("An error occurred while loading the collection executor ("
+					+ COLLECTOR_EXECUTOR_CLASS + ").", t);
+		}
+	}
+
 	/**
 	 * Creates an executor that runs the plan locally in a multi-threaded environment.
 	 * 

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -20,17 +20,21 @@ package org.apache.flink.api.java;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
-import org.apache.flink.api.common.operators.CollectionExecutor;
+import org.apache.flink.api.common.PlanExecutor;
 
 public class CollectionEnvironment extends ExecutionEnvironment {
+
+	private PlanExecutor executor;
+
+	public CollectionEnvironment() {
+		executor = PlanExecutor.createCollectionExecutor();
+	}
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
 
-		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.
-		CollectionExecutor exec = new CollectionExecutor(getConfig());
-		this.lastJobExecutionResult = exec.execute(p);
+		this.lastJobExecutionResult = executor.executePlan(p);
 		return this.lastJobExecutionResult;
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -33,7 +33,9 @@ import org.apache.flink.configuration.Configuration;
  * machine.
  */
 public class LocalEnvironment extends ExecutionEnvironment {
-	private Configuration configuration;
+
+	private PlanExecutor executor;
+
 	/**
 	 * Creates a new local environment.
 	 */
@@ -41,6 +43,8 @@ public class LocalEnvironment extends ExecutionEnvironment {
 		if(!ExecutionEnvironment.localExecutionIsAllowed()) {
 			throw new InvalidProgramException("The LocalEnvironment cannot be used when submitting a program through a client.");
 		}
+		// in case no custom configuration is provided ever.
+		setConfiguration(null);
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -48,8 +52,6 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
-		
-		PlanExecutor executor = PlanExecutor.createLocalExecutor(configuration);
 		executor.setPrintStatusDuringExecution(p.getExecutionConfig().isSysoutLoggingEnabled());
 		this.lastJobExecutionResult = executor.executePlan(p);
 		return this.lastJobExecutionResult;
@@ -58,8 +60,6 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	@Override
 	public String getExecutionPlan() throws Exception {
 		Plan p = createProgramPlan(null, false);
-		
-		PlanExecutor executor = PlanExecutor.createLocalExecutor(configuration);
 		return executor.getOptimizerPlanAsJSON(p);
 	}
 	// --------------------------------------------------------------------------------------------
@@ -71,6 +71,6 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	}
 
 	public void setConfiguration(Configuration customConfiguration) {
-		this.configuration = customConfiguration;
+		executor = PlanExecutor.createLocalExecutor(customConfiguration);
 	}
 }


### PR DESCRIPTION
1. Prevents re-starts of local cluster several times on multiple executions.
2. Preserves the executor states for the entire run of the program.