### PR TITLE
[FLINK-2493] Simplify names of example program JARs

### DIFF
--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -46,43 +46,43 @@ The command line can be used to
 
 -   Run example program with no arguments.
 
-        ./bin/flink run ./examples/flink-java-examples-{{ site.version }}-WordCount.jar
+        ./bin/flink run ./examples/WordCount.jar
 
 -   Run example program with arguments for input and result files
 
-        ./bin/flink run ./examples/flink-java-examples-{{ site.version }}-WordCount.jar \
+        ./bin/flink run ./examples/WordCount.jar \
                                file:///home/user/hamlet.txt file:///home/user/wordcount_out
 
 -   Run example program with parallelism 16 and arguments for input and result files
 
-        ./bin/flink run -p 16 ./examples/flink-java-examples-{{ site.version }}-WordCount.jar \
+        ./bin/flink run -p 16 ./examples/WordCount.jar \
                                 file:///home/user/hamlet.txt file:///home/user/wordcount_out
 
 -   Run example program with flink log output disabled
 
-            ./bin/flink run -q ./examples/flink-java-examples-{{ site.version }}-WordCount.jar
+            ./bin/flink run -q ./examples/WordCount.jar
 
 -   Run example program on a specific JobManager:
 
         ./bin/flink run -m myJMHost:6123 \
-                               ./examples/flink-java-examples-{{ site.version }}-WordCount.jar \
+                               ./examples/WordCount.jar \
                                file:///home/user/hamlet.txt file:///home/user/wordcount_out
 
 -   Run example program with a specific class as an entry point:
 
         ./bin/flink run -c org.apache.flink.examples.java.wordcount.WordCount \
-                               ./examples/flink-java-examples-{{ site.version }}-WordCount.jar \
+                               ./examples/WordCount.jar \
                                file:///home/user/hamlet.txt file:///home/user/wordcount_out
 
 -   Run example program using a [per-job YARN cluster]({{site.baseurl}}/setup/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn) with 2 TaskManagers:
 
         ./bin/flink run -m yarn-cluster -yn 2 \
-                               ./examples/flink-java-examples-{{ site.version }}-WordCount.jar \
+                               ./examples/WordCount.jar \
                                hdfs:///user/hamlet.txt hdfs:///user/wordcount_out
 
 -   Display the optimized execution plan for the WordCount example program as JSON:
 
-        ./bin/flink info ./examples/flink-java-examples-{{ site.version }}-WordCount.jar \
+        ./bin/flink info ./examples/WordCount.jar \
                                 file:///home/user/hamlet.txt file:///home/user/wordcount_out
 
 -   List scheduled and running jobs (including their JobIDs):

--- a/docs/apis/examples.md
+++ b/docs/apis/examples.md
@@ -42,7 +42,7 @@ Each binary release of Flink contains an `examples` directory with jar files for
 To run the WordCount example, issue the following command:
 
 ~~~bash
-./bin/flink run ./examples/flink-java-examples-{{site.version}}-WordCount.jar
+./bin/flink run ./examples/WordCount.jar
 ~~~
 
 The other examples can be started in a similar way.
@@ -50,7 +50,7 @@ The other examples can be started in a similar way.
 Note that many examples run without passing any arguments for them, by using build-in data. To run WordCount with real data, you have to pass the path to the data:
 
 ~~~bash
-./bin/flink run ./examples/flink-java-examples-{{site.version}}-WordCount.jar /path/to/some/text/data /path/to/result
+./bin/flink run ./examples/WordCount.jar /path/to/some/text/data /path/to/result
 ~~~
 
 Note that non-local file systems require a schema prefix, such as `hdfs://`.

--- a/docs/quickstart/run_example_quickstart.md
+++ b/docs/quickstart/run_example_quickstart.md
@@ -36,7 +36,7 @@ Flink contains a data generator for K-Means.
 mkdir kmeans
 cd kmeans
 # Run data generator
-java -cp ../examples/flink-java-examples-{{ site.version }}-KMeans.jar:../lib/flink-dist-{{ site.version }}.jar \
+java -cp ../examples/KMeans.jar:../lib/flink-dist-{{ site.version }}.jar \
   org.apache.flink.examples.java.clustering.util.KMeansDataGenerator \
   -points 500 -k 10 -stddev 0.08 -output `pwd`
 ~~~
@@ -93,7 +93,7 @@ The Flink web client allows to submit Flink programs using a graphical user inte
 		1. Open web client on  <a href="http://localhost:8080/launch.html">localhost:8080</a> <br>
 		2. Upload the K-Mean job JAR file. 
 			{% highlight bash %}
-			./examples/flink-java-examples-*-KMeans.jar
+			./examples/KMeans.jar
 			{% endhighlight %} </br>
 		3. Select it in the left box to see how the operators in the plan are connected to each other. <br>
 		4. Enter the arguments and options in the lower left box: <br>

--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -86,7 +86,7 @@ Run the __Word Count example__ to see Flink at work.
 * __Start the example program__:
   
   ~~~bash
-  $ bin/flink run ./examples/flink-java-examples-{{site.version}}-WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
+  $ bin/flink run ./examples/WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
   ~~~
 
 * You will find a file called __wordcount-result.txt__ in your current directory.

--- a/docs/setup/gce_setup.md
+++ b/docs/setup/gce_setup.md
@@ -95,7 +95,7 @@ To bring up the Flink cluster on Google Compute Engine, execute:
 
     ./bdutil shell
     cd /home/hadoop/flink-install/bin
-    ./flink run ../examples/flink-java-examples-*-WordCount.jar gs://dataflow-samples/shakespeare/othello.txt gs://<bucket_name>/output
+    ./flink run ../examples/WordCount.jar gs://dataflow-samples/shakespeare/othello.txt gs://<bucket_name>/output
 
 ## Shut down your cluster
 

--- a/docs/setup/yarn_setup.md
+++ b/docs/setup/yarn_setup.md
@@ -48,7 +48,7 @@ Once the session has been started, you can submit jobs to the cluster using the 
 curl -O <flink_hadoop2_download_url>
 tar xvzf flink-{{ site.version }}-bin-hadoop2.tgz
 cd flink-{{ site.version }}/
-./bin/flink run -m yarn-cluster -yn 4 -yjm 1024 -ytm 4096 ./examples/flink-java-examples-{{ site.version }}-WordCount.jar
+./bin/flink run -m yarn-cluster -yn 4 -yjm 1024 -ytm 4096 ./examples/WordCount.jar
 ~~~
 
 ## Apache Flink on Hadoop YARN using a YARN Session
@@ -180,7 +180,7 @@ Use the *run* action to submit a job to YARN. The client is able to determine th
 ~~~bash
 wget -O LICENSE-2.0.txt http://www.apache.org/licenses/LICENSE-2.0.txt
 hadoop fs -copyFromLocal LICENSE-2.0.txt hdfs:/// ...
-./bin/flink run ./examples/flink-java-examples-{{site.version }}-WordCount.jar \
+./bin/flink run ./examples/WordCount.jar \
         hdfs:///..../LICENSE-2.0.txt hdfs:///.../wordcount-result.txt
 ~~~
 
@@ -206,7 +206,7 @@ Please note that the client then expects the `-yn` value to be set (number of Ta
 ***Example:***
 
 ~~~bash
-./bin/flink run -m yarn-cluster -yn 2 ./examples/flink-java-examples-{{site.version }}-WordCount.jar 
+./bin/flink run -m yarn-cluster -yn 2 ./examples/WordCount.jar 
 ~~~
 
 The command line options of the YARN session are also available with the `./bin/flink` tool. 

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -160,6 +160,7 @@ under the License.
 				<exclude>flink-java-examples-${project.version}-sources.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-tests.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-javadoc.jar</exclude>
+				<exclude>flink-java-examples-${project.version}-*.jar</exclude>
 			</excludes>
 		</fileSet>
 

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -323,7 +323,7 @@ under the License.
 				</executions>
 			</plugin>
 
-			<!--simplify the name of example JARs for build-target/examples-->
+			<!--simplify the name of example JARs for build-target/examples -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -322,6 +322,34 @@ under the License.
 					
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<execution>
+						<id>rename</id>
+						<phase>package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration> 
+							<target>
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-KMeans.jar" tofile="${project.basedir}/target/KMeans.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-ConnectedComponents.jar" tofile="${project.basedir}/target/ConnectedComponents.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesBasic.jar" tofile="${project.basedir}/target/EnumTrianglesBasic.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-EnumTrianglesOpt.jar" tofile="${project.basedir}/target/EnumTrianglesOpt.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-PageRankBasic.jar" tofile="${project.basedir}/target/PageRankBasic.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-TransitiveClosure.jar" tofile="${project.basedir}/target/TransitiveClosure.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WebLogAnalysis.jar" tofile="${project.basedir}/target/WebLogAnalysis.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
+								<copy file="${project.basedir}/target/flink-java-examples-${project.version}-WordCountPOJO.jar" tofile="${project.basedir}/target/WordCountPOJO.jar" />
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-examples/flink-java-examples/pom.xml
+++ b/flink-examples/flink-java-examples/pom.xml
@@ -323,6 +323,7 @@ under the License.
 				</executions>
 			</plugin>
 
+			<!--simplify the name of example JARs for build-target/examples-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
The names of the example JARs under build-target/examples have some confusion, the version number might stop users from submitting examples to incompatible versions of Flink
Propose to name the file examples/ConnectedComponents.jar rather than examples/flink-java-examples-0.10-SNAPSHOT-ConnectedComponents.jar.
The result as below:
build-target
  --examples
    --ConnectedComponents.jar
    --EnumTrianglesBasic.jar
    --EnumTrianglesOpt.jar
    ......
    