### PR TITLE
[FLINK-2533] [core] Gap based random sample optimization.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/sampling/BernoulliSampler.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/sampling/BernoulliSampler.java
@@ -28,11 +28,15 @@ import java.util.Random;
  * Bernoulli experiment.
  *
  * @param <T> The type of sample.
+ * @see <a href="http://erikerlandson.github.io/blog/2014/09/11/faster-random-samples-with-gap-sampling/">Gap Sampling</a>
  */
 public class BernoulliSampler<T> extends RandomSampler<T> {
 	
 	private final double fraction;
 	private final Random random;
+	
+	//THRESHOLD	 is a tuning parameter for choosing sampling method according to the fraction
+	private final static double THRESHOLD = 0.33;
 	
 	/**
 	 * Create a Bernoulli sampler with sample fraction and default random number generator.
@@ -102,15 +106,31 @@ public class BernoulliSampler<T> extends RandomSampler<T> {
 			}
 
 			private T getNextSampledElement() {
-				while (input.hasNext()) {
-					T element = input.next();
-
-					if (random.nextDouble() <= fraction) {
+				if (fraction <= THRESHOLD) {
+					double rand = random.nextDouble();
+					double u = Math.max(rand, EPSILON);
+					int gap = (int) (Math.log(u) / Math.log(1 - fraction));
+					int elementCount = 0;
+					if (input.hasNext()) {
+						T element = input.next();
+						while (input.hasNext() && elementCount < gap) {
+							element = input.next();
+							elementCount++;
+						}
 						return element;
+					} else {
+						return null;
 					}
-				}
+				}else {
+					while (input.hasNext()){
+						T element = input.next();
 
-				return null;
+						if (random.nextDouble() <= fraction) {
+							return element;
+						}
+					}
+					return null;
+				}
 			}
 		};
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/sampling/BernoulliSampler.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/sampling/BernoulliSampler.java
@@ -35,7 +35,7 @@ public class BernoulliSampler<T> extends RandomSampler<T> {
 	private final double fraction;
 	private final Random random;
 	
-	//THRESHOLD	 is a tuning parameter for choosing sampling method according to the fraction
+	// THRESHOLD is a tuning parameter for choosing sampling method according to the fraction.
 	private final static double THRESHOLD = 0.33;
 	
 	/**
@@ -117,12 +117,16 @@ public class BernoulliSampler<T> extends RandomSampler<T> {
 							element = input.next();
 							elementCount++;
 						}
-						return element;
+						if (elementCount < gap) {
+							return null;
+						} else {
+							return element;
+						}
 					} else {
 						return null;
 					}
-				}else {
-					while (input.hasNext()){
+				} else {
+					while (input.hasNext()) {
 						T element = input.next();
 
 						if (random.nextDouble() <= fraction) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/sampling/PoissonSampler.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/sampling/PoissonSampler.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.math3.distribution.PoissonDistribution;
 
 import java.util.Iterator;
+import java.util.Random;
 
 /**
  * A sampler implementation based on the Poisson Distribution. While sampling elements with fraction
@@ -28,11 +29,16 @@ import java.util.Iterator;
  *
  * @param <T> The type of sample.
  * @see <a href="https://en.wikipedia.org/wiki/Poisson_distribution">https://en.wikipedia.org/wiki/Poisson_distribution</a>
+ * @see <a href="http://erikerlandson.github.io/blog/2014/09/11/faster-random-samples-with-gap-sampling/">Gap Sampling</a>
  */
 public class PoissonSampler<T> extends RandomSampler<T> {
 	
 	private PoissonDistribution poissonDistribution;
 	private final double fraction;
+	private final Random random = new Random();
+	
+	//THRESHOLD	 is a tuning parameter for choosing sampling method according to the fraction
+	private final static double THRESHOLD = 0.4;
 	
 	/**
 	 * Create a poisson sampler which can sample elements with replacement.
@@ -84,8 +90,7 @@ public class PoissonSampler<T> extends RandomSampler<T> {
 				if (currentCount > 0) {
 					return true;
 				} else {
-					moveToNextElement();
-
+					samplingProcess();
 					if (currentCount > 0) {
 						return true;
 					} else {
@@ -93,29 +98,59 @@ public class PoissonSampler<T> extends RandomSampler<T> {
 					}
 				}
 			}
-
-			private void moveToNextElement() {
-				while (input.hasNext()) {
+			
+			public int poisson_ge1(double p){
+				// sample 'k' from Poisson(p), conditioned to k >= 1
+				double q = Math.pow(Math.E, -p);
+				// simulate a poisson trial such that k >= 1
+				double t = q + (1 - q)*random.nextDouble();
+				int k = 1;
+				// continue standard poisson generation trials
+				t = t * random.nextDouble();
+				while (t > q) {
+					k++;
+					t = t * random.nextDouble();
+				}
+				return k;
+			}
+			
+			private void moveToNextElement(int num) {
+				// skip elements with replication factor zero
+				int elementCount = 0;
+				while (input.hasNext() && elementCount < num){
 					currentElement = input.next();
-					currentCount = poissonDistribution.sample();
-					if (currentCount > 0) {
-						break;
+					elementCount++;
+				}
+			}
+			
+			private void samplingProcess(){
+				if (fraction <= THRESHOLD) {
+					double u = Math.max(random.nextDouble(), EPSILON);
+					int gap = (int) (Math.log(u) / -fraction);
+					moveToNextElement(gap);
+					if (input.hasNext()) {
+						currentElement = input.next();
+						currentCount = poisson_ge1(fraction);
+					}
+				}
+				else {
+					while (input.hasNext()){
+						currentElement = input.next();
+						currentCount = poissonDistribution.sample();
+						if (currentCount > 0) {
+							break;
+						}
 					}
 				}
 			}
 			
 			@Override
 			public T next() {
-				if (currentCount == 0) {
-					moveToNextElement();
+				if (currentCount <= 0) {
+					samplingProcess();
 				}
-
-				if (currentCount == 0) {
-					return null;
-				} else {
-					currentCount--;
-					return currentElement;
-				}
+				currentCount--;
+				return currentElement;
 			}
 		};
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/sampling/RandomSampler.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/sampling/RandomSampler.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
  * @param <T> The type of sampler data.
  */
 public abstract class RandomSampler<T> {
+
+	protected final static double EPSILON = 1e-5;
 	
 	protected final Iterator<T> EMPTY_ITERABLE = new SampledIterator<T>() {
 		@Override


### PR DESCRIPTION
For random sampler with fraction, like BernoulliSampler and PoissonSampler, Gap based random sampler could exploit O(np) sample implementation instead of previous O(n) sample implementation, it should perform better while sample fraction is very small.When deal with large fraction, it's better to use previous sample implementation. So we add a threshold to control the sampling method according to the fraction.(threshold_Bernoulli = 0.33, threshold_Poisson = 0.4)
![bernoullisampler](https://cloud.githubusercontent.com/assets/12931563/9751893/fd4195a2-56dc-11e5-8937-30ebfa927960.PNG)
![poissonsampler](https://cloud.githubusercontent.com/assets/12931563/9751894/fd4c35a2-56dc-11e5-9d71-e7b62e5dcc05.PNG)