### PR TITLE
[FLINK-2639] Add repository for hdp specific jetty to 'vendor-repos' profile

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -322,6 +322,9 @@ under the License.
 									<excludes>
 										<exclude>log4j.properties</exclude>
 										<exclude>log4j-test.properties</exclude>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -73,6 +73,15 @@ under the License.
 							<createDependencyReducedPom>true</createDependencyReducedPom>
 							<dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
 							<filters>
+								<!-- Exclude signatures -->
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
 								<filter>
 									<artifact>org.slf4j:*</artifact>
 									<excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -447,20 +447,18 @@ under the License.
 				</repository>
 				<!-- Hortonworks -->
 				<repository>
-					<releases>
-						<enabled>true</enabled>
-						<updatePolicy>always</updatePolicy>
-						<checksumPolicy>warn</checksumPolicy>
-					</releases>
-					<snapshots>
-						<enabled>false</enabled>
-						<updatePolicy>never</updatePolicy>
-						<checksumPolicy>fail</checksumPolicy>
-					</snapshots>
 					<id>HDPReleases</id>
 					<name>HDP Releases</name>
 					<url>http://repo.hortonworks.com/content/repositories/releases/</url>
-					<layout>default</layout>
+					<snapshots><enabled>false</enabled></snapshots>
+					<releases><enabled>true</enabled></releases>
+				</repository>
+				<repository>
+					<id>HortonworksJettyHadoop</id>
+					<name>HDP Jetty</name>
+					<url>http://repo.hortonworks.com/content/repositories/jetty-hadoop</url>
+					<snapshots><enabled>false</enabled></snapshots>
+					<releases><enabled>true</enabled></releases>
 				</repository>
 				<!-- MapR -->
 				<repository>


### PR DESCRIPTION
This adds a second hortonworks repository to the `vendor-repos` profile.
Certain HDP-specific Hadoop releases depend on 
```
[INFO] |  +- org.mortbay.jetty:jetty:jar:6.1.26.hwx:compile
[INFO] |  +- org.mortbay.jetty:jetty-util:jar:6.1.26.hwx:compile
```
Which is only available in a special Hortonworks repository.

The dependency comes from `org.apache.hadoop:hadoop-common:jar:2.6.0.2.2.6.0-2800:compile`.
Usually, we exclude jetty and other libraries which are only needed for Hadoop's web interfaces.
In this case, the dependency comes from the `flink-shaded-include-yarn-tests`: The module builds a full shaded Hadoop package. For the `flink-yarn-tests` we need to also have jetty in the dependencies, because the YarnMiniCluster is also starting web servers (and we actually use these to test that Flink's web interface proxy is properly working).

This change does not affect the regular builds, because the additional repository is "hidden" by the maven build profile.