### PR TITLE
[FLINK-2656] Fix behavior of FlinkKafkaConsumer for out of range offsets

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -67,6 +67,11 @@ public class KafkaITCase extends KafkaConsumerTestBase {
 		runFailOnDeployTest();
 	}
 
+	@Test
+	public void testInvalidOffset() throws Exception {
+		runInvalidOffsetTest();
+	}
+
 	// --- source to partition mappings and exactly once ---
 	
 	@Test


### PR DESCRIPTION
The FlinkKafkaConsumer is failing with an OutOfRangeException. 
Flink users are expecting Flink's Kafka Source to behave similar to Kafka's own high level kafka consumer. The Kafka consumer has a configuration parameter for controlling the behavior in case of invalid or unknown offsets (where to start).

In this pull request, I've changed the behavior of the FlinkKafkaConsumer to now throw the OutOfRangeException. I'll set the offset according to the configuration parameter.

I've also added a test case to verify the fix.