### PR TITLE
Getter for wrapped StreamExecutionEnvironment by scala api

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -506,7 +506,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Getter of the wrapped [[org.apache.flink.streaming.api.environment.StreamExecutionEnvironment]]
    * @return The encased ExecutionEnvironment
    */
-  def getWrappedExecutionEnvironment = javaEnv
+  def getWrappedStreamExecutionEnvironment = javaEnv
 
   /**
    * Returns a "closure-cleaned" version of the given function. Cleans only if closure cleaning

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -503,6 +503,12 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def getStreamGraph = javaEnv.getStreamGraph
 
   /**
+   * Getter of the wrapped [[org.apache.flink.streaming.api.environment.StreamExecutionEnvironment]]
+   * @return The encased ExecutionEnvironment
+   */
+  def getWrappedExecutionEnvironment = javaEnv
+
+  /**
    * Returns a "closure-cleaned" version of the given function. Cleans only if closure cleaning
    * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]]
    */


### PR DESCRIPTION
Currently it is not possible to pass an ExecutionEnvironment defined with the scala api to a method working with the org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.
Added a getter to the scala api StreamExecutionEnvironment for java scala interoperability.