### PR TITLE
[FLINK-2537] Add scala examples.jar to build-target/examples

### DIFF
--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -149,7 +149,7 @@ under the License.
 		<!-- copy jar files of java examples -->
 		<fileSet>
 			<directory>../flink-examples/flink-java-examples/target</directory>
-			<outputDirectory>examples</outputDirectory>
+			<outputDirectory>examples/java</outputDirectory>
 			<fileMode>0644</fileMode>
 			<includes>
 				<include>*.jar</include>
@@ -161,6 +161,24 @@ under the License.
 				<exclude>flink-java-examples-${project.version}-tests.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-javadoc.jar</exclude>
 				<exclude>flink-java-examples-${project.version}-*.jar</exclude>
+			</excludes>
+		</fileSet>
+
+		<!-- copy jar files of scala examples -->
+		<fileSet>
+			<directory>../flink-examples/flink-scala-examples/target</directory>
+			<outputDirectory>examples/scala</outputDirectory>
+			<fileMode>0644</fileMode>
+			<includes>
+				<include>*.jar</include>
+			</includes>
+			<excludes>
+				<exclude>flink-scala-examples-${project.version}.jar</exclude>
+				<exclude>original-flink-scala-examples-${project.version}.jar</exclude>
+				<exclude>flink-scala-examples-${project.version}-sources.jar</exclude>
+				<exclude>flink-scala-examples-${project.version}-tests.jar</exclude>
+				<exclude>flink-scala-examples-${project.version}-javadoc.jar</exclude>
+				<exclude>flink-scala-examples-${project.version}-*.jar</exclude>
 			</excludes>
 		</fileSet>
 

--- a/flink-examples/flink-scala-examples/pom.xml
+++ b/flink-examples/flink-scala-examples/pom.xml
@@ -450,6 +450,34 @@ under the License.
 					
 				</executions>
 			</plugin>
+
+			<!--simplify the name of scala example JARs for build-target/examples-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<execution>
+						<id>rename-scala</id>
+						<phase>package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-KMeans.jar" tofile="${project.basedir}/target/KMeans.jar" />
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-ConnectedComponents.jar" tofile="${project.basedir}/target/ConnectedComponents.jar" />
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-EnumTrianglesBasic.jar" tofile="${project.basedir}/target/EnumTrianglesBasic.jar" />
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-EnumTrianglesOpt.jar" tofile="${project.basedir}/target/EnumTrianglesOpt.jar" />
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-PageRankBasic.jar" tofile="${project.basedir}/target/PageRankBasic.jar" />
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-TransitiveClosure.jar" tofile="${project.basedir}/target/TransitiveClosure.jar" />
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-WebLogAnalysis.jar" tofile="${project.basedir}/target/WebLogAnalysis.jar" />
+								<copy file="${project.basedir}/target/flink-scala-examples-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		
 		<pluginManagement>


### PR DESCRIPTION
Currently Scala as functional programming language has been acknowledged by more and more developers, some starters may want to modify scala examples' code for further understanding flink mechanism. After changing scala code,they may select the below steps to check result: 
1.go to "build-target/bin" start server
2.use web UI to upload scala examples' jar
3.this time they would get confusion, why changes would be not updated.
Because build-target/examples only copy java examples, suggest adding scala examples also.
The new directory would like this :
build-target/examples/java
build-target/examples/scala