### PR TITLE
[FLINK-2664] [streaming] Allow partitioned state removal

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/OperatorState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/OperatorState.java
@@ -55,7 +55,9 @@ public interface OperatorState<T> {
 	/**
 	 * Updates the operator state accessible by {@link #value()} to the given
 	 * value. The next time {@link #value()} is called (for the same state
-	 * partition) the returned state will represent the updated value.
+	 * partition) the returned state will represent the updated value. When a
+	 * partitioned state is updated with null, the state for the current key 
+	 * will be removed and the default value is returned on the next access.
 	 * 
 	 * @param state
 	 *            The new value for the state.

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/PartitionedStateStore.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/PartitionedStateStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.state;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -35,13 +36,15 @@ import org.apache.flink.runtime.state.StateHandle;
  */
 public interface PartitionedStateStore<S, C extends Serializable> {
 
-	S getStateForKey(Serializable key) throws Exception;
+	S getStateForKey(Serializable key) throws IOException;
 
 	void setStateForKey(Serializable key, S state);
+	
+	void removeStateForKey(Serializable key);
 
-	Map<Serializable, S> getPartitionedState() throws Exception;
+	Map<Serializable, S> getPartitionedState() throws IOException;
 
-	StateHandle<Serializable> snapshotStates(long checkpointId, long checkpointTimestamp) throws Exception;
+	StateHandle<Serializable> snapshotStates(long checkpointId, long checkpointTimestamp) throws IOException;
 
 	void restoreStates(StateHandle<Serializable> snapshot, ClassLoader userCodeClassLoader) throws Exception;
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/state/StatefulOperatorTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/state/StatefulOperatorTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.streaming.api.state;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -101,25 +103,28 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 		assertEquals((Integer) 7, ((StatefulMapper) restoredMap.getUserFunction()).checkpointedCounter);
 
 	}
-	
+
 	@Test
 	public void apiTest() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(3);
 
 		KeyedDataStream<Integer> keyedStream = env.fromCollection(Arrays.asList(0, 1, 2, 3, 4, 5, 6)).keyBy(new ModKey(4));
-		
+
 		keyedStream.map(new StatefulMapper()).addSink(new SinkFunction<String>() {
 			private static final long serialVersionUID = 1L;
+
 			public void invoke(String value) throws Exception {
 			}
 		});
-		
+
 		keyedStream.map(new StatefulMapper2()).setParallelism(1).addSink(new SinkFunction<String>() {
 			private static final long serialVersionUID = 1L;
-			public void invoke(String value) throws Exception {}
+
+			public void invoke(String value) throws Exception {
+			}
 		});
-		
+
 		try {
 			keyedStream.shuffle();
 			fail();
@@ -127,6 +132,21 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 
 		}
 		
+		env.fromElements(0, 1, 2, 2, 2, 3, 4, 3, 4).keyBy(new KeySelector<Integer, Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Integer getKey(Integer value) throws Exception {
+				return value;
+			}
+
+		}).map(new PStateKeyRemovalTestMapper()).setParallelism(1).addSink(new SinkFunction<String>() {
+			private static final long serialVersionUID = 1L;
+
+			public void invoke(String value) throws Exception {
+			}
+		});
+
 		env.execute();
 	}
 
@@ -143,7 +163,7 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 		final List<String> outputList = output;
 
 		StreamingRuntimeContext context = new StreamingRuntimeContext(
-				new MockEnvironment("MockTask", 3 * 1024 * 1024, new MockInputSplitProvider(), 1024), 
+				new MockEnvironment("MockTask", 3 * 1024 * 1024, new MockInputSplitProvider(), 1024),
 				new ExecutionConfig(),
 				partitioner,
 				new LocalStateHandleProvider<Serializable>(),
@@ -181,11 +201,11 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 
 	public static class StatefulMapper extends RichMapFunction<Integer, String> implements
 			Checkpointed<Integer> {
-	private static final long serialVersionUID = -9007873655253339356L;
+		private static final long serialVersionUID = -9007873655253339356L;
 		OperatorState<Integer> counter;
 		OperatorState<MutableInt> groupCounter;
 		OperatorState<String> concat;
-		
+
 		Integer checkpointedCounter = 0;
 
 		@Override
@@ -199,7 +219,7 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 			try {
 				counter.update(null);
 				fail();
-			} catch (RuntimeException e){
+			} catch (RuntimeException e) {
 			}
 			return value.toString();
 		}
@@ -212,15 +232,15 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 			try {
 				getRuntimeContext().getOperatorState("test", null, true);
 				fail();
-			} catch (RuntimeException e){
+			} catch (RuntimeException e) {
 			}
 			try {
 				getRuntimeContext().getOperatorState("test", null, true, null);
 				fail();
-			} catch (RuntimeException e){
+			} catch (RuntimeException e) {
 			}
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public void close() throws Exception {
@@ -229,14 +249,13 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 			for (Entry<Serializable, Integer> count : groupCounter.getPartitionedState().entrySet()) {
 				Integer key = (Integer) count.getKey();
 				Integer expected = key < 3 ? 2 : 1;
-				
+
 				assertEquals(new MutableInt(expected), count.getValue());
 			}
 		}
 
 		@Override
-		public Integer snapshotState(long checkpointId, long checkpointTimestamp)
-				throws Exception {
+		public Integer snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
 			return checkpointedCounter;
 		}
 
@@ -245,23 +264,23 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 			this.checkpointedCounter = (Integer) state;
 		}
 	}
-	
+
 	public static class StatefulMapper2 extends RichMapFunction<Integer, String> {
 		private static final long serialVersionUID = 1L;
 		OperatorState<Integer> groupCounter;
-		
+
 		@Override
 		public String map(Integer value) throws Exception {
 			groupCounter.update(groupCounter.value() + 1);
-			
+
 			return value.toString();
 		}
 
 		@Override
-		public void open(Configuration conf) throws IOException {		
+		public void open(Configuration conf) throws IOException {
 			groupCounter = getRuntimeContext().getOperatorState("groupCounter", 0, true);
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public void close() throws Exception {
@@ -274,9 +293,48 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 				assertEquals(expected, count.getValue());
 			}
 		}
-		
+
 	}
-	
+
+	public static class PStateKeyRemovalTestMapper extends RichMapFunction<Integer, String> {
+
+		private static final long serialVersionUID = 1L;
+		OperatorState<Boolean> seen;
+
+		@Override
+		public String map(Integer value) throws Exception {
+			if (value == 0) {
+				seen.update(null);
+			}else{
+				Boolean s = seen.value();
+				if (s) {
+					seen.update(null);
+				} else {
+					seen.update(true);
+				}
+			}
+
+			return value.toString();
+		}
+
+		public void open(Configuration c) throws IOException {
+			seen = getRuntimeContext().getOperatorState("seen", false, true);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void close() throws Exception {
+			Map<String, StreamOperatorState<?, ?>> states = ((StreamingRuntimeContext) getRuntimeContext()).getOperatorStates();
+			PartitionedStreamOperatorState<Integer, Boolean, Boolean> seen = (PartitionedStreamOperatorState<Integer, Boolean, Boolean>) states.get("seen");
+			assertFalse(seen.getPartitionedState().containsKey(0));
+			assertEquals(2,seen.getPartitionedState().size());
+			for (Entry<Serializable, Boolean> s : seen.getPartitionedState().entrySet()) {
+					assertTrue(s.getValue());
+			}
+		}
+
+	}
+
 	public static class ModKey implements KeySelector<Integer, Serializable> {
 
 		private static final long serialVersionUID = 4193026742083046736L;


### PR DESCRIPTION
This PR changes the way Partitioned states handle null values.

Before this PR the user was not allowed to put null values in a partitioned state and an exception was thrown. This did not allow the user to remove the state for the current key (so the default value will be retreived next time).

Now whenever a user updates a partitioned state with a null value, the system will remove the state for the respective key from that map containing all the <key,state> pairs allowing for the garbage collection of unwanted user state.

The StatefulOperatorTest has also been modified to test for the changed behavior.