### PR TITLE
[FLINK-2167] [table] Add fromHCat() to TableEnvironment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/AbstractExecutionEnvironment.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/AbstractExecutionEnvironment.java
@@ -15,27 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.expressions.analysis
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.plan.PlanNode
-import org.apache.flink.api.table.trees.Analyzer
+package org.apache.flink.api.common;
 
 /**
- * This analyzes selection expressions.
+ * The AbstractExecutionEnvironment is the context in which a program is executed. The context can be a
+ * ExecutionEnvironment for working with DataSets or a StreamExecutionEnvironment for working
+ * with DataStreams.
  */
-class SelectionAnalyzer(inputFields: Seq[(String, TypeInformation[_])], inputOperation: PlanNode)
-  extends Analyzer[Expression] {
+public interface AbstractExecutionEnvironment {
 
-  def this(inputOperation: PlanNode) = this(inputOperation.outputFields, inputOperation)
-
-  def this(inputFields: Seq[(String, TypeInformation[_])]) = this(inputFields, null)
-
-  def rules = Seq(
-    new ResolveFieldReferences(inputFields, inputOperation, false),
-    new VerifyNoNestedAggregates,
-    new InsertAutoCasts,
-    new TypeCheck)
-
+	/**
+	 * Gets the config object.
+	 */
+	public ExecutionConfig getConfig();
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.flink.api.common.AbstractExecutionEnvironment;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -74,7 +75,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 
 /**
- * The ExecutionEnviroment is the context in which a program is executed. A
+ * The ExecutionEnvironment is the context in which a program is executed. A
  * {@link LocalEnvironment} will cause execution in the current JVM, a
  * {@link RemoteEnvironment} will cause execution on a remote setup.
  * <p>
@@ -91,7 +92,7 @@ import com.google.common.base.Preconditions;
  * @see LocalEnvironment
  * @see RemoteEnvironment
  */
-public abstract class ExecutionEnvironment {
+public abstract class ExecutionEnvironment implements AbstractExecutionEnvironment {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ExecutionEnvironment.class);
 	

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -22,7 +22,7 @@ import java.util.UUID
 import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult}
+import org.apache.flink.api.common.{AbstractExecutionEnvironment, ExecutionConfig, JobExecutionResult}
 import org.apache.flink.api.java.io._
 import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -44,7 +44,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 /**
- * The ExecutionEnviroment is the context in which a program is executed. A local environment will
+ * The ExecutionEnvironment is the context in which a program is executed. A local environment will
  * cause execution in the current JVM, a remote environment will cause execution on a remote
  * cluster installation.
  *
@@ -58,16 +58,19 @@ import scala.reflect.ClassTag
  *  - [[ExecutionEnvironment.createRemoteEnvironment]]
  *
  *  Use [[ExecutionEnvironment.getExecutionEnvironment]] to get the correct environment depending
- *  on where the program is executed. If it is run inside an IDE a loca environment will be
+ *  on where the program is executed. If it is run inside an IDE a local environment will be
  *  created. If the program is submitted to a cluster a remote execution environment will
  *  be created.
  */
-class ExecutionEnvironment(javaEnv: JavaEnv) {
+class ExecutionEnvironment(val javaEnv: JavaEnv) extends AbstractExecutionEnvironment {
 
   /**
-   * @return the Java Execution environment.
+   * Returns the enclosed Java ExecutionEnvironment for special use cases.
+   *
+   * @return reference to the ExecutionEnvironment of the Java API
    */
   def getJavaEnv: JavaEnv = javaEnv
+
   /**
    * Gets the config object.
    */

--- a/flink-staging/flink-hcatalog/pom.xml
+++ b/flink-staging/flink-hcatalog/pom.xml
@@ -43,8 +43,8 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.hive.hcatalog</groupId>
-			<artifactId>hcatalog-core</artifactId>
-			<version>0.12.0</version>
+			<artifactId>hive-hcatalog-core</artifactId>
+			<version>1.2.1</version>
 		</dependency>
 
 	</dependencies>

--- a/flink-staging/flink-hcatalog/src/main/java/org/apache/flink/hcatalog/HCatInputFormatBase.java
+++ b/flink-staging/flink-hcatalog/src/main/java/org/apache/flink/hcatalog/HCatInputFormatBase.java
@@ -248,6 +248,13 @@ public abstract class HCatInputFormatBase<T> extends RichInputFormat<T, HadoopIn
 		return this.outputSchema;
 	}
 
+	/**
+	 * Returns the partitioning columns as {@link org.apache.hive.hcatalog.data.schema.HCatSchema}.
+	 */
+	public HCatSchema getPartitionColumns() throws IOException {
+		return org.apache.hive.hcatalog.mapreduce.HCatInputFormat.getPartitionColumns(this.configuration);
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  InputFormat
 	// --------------------------------------------------------------------------------------------

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.environment;
 import com.esotericsoftware.kryo.Serializer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import org.apache.flink.api.common.AbstractExecutionEnvironment;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -79,7 +80,7 @@ import java.util.List;
  * {@link org.apache.flink.api.java.ExecutionEnvironment} for streaming jobs. An instance of it is
  * necessary to construct streaming topologies.
  */
-public abstract class StreamExecutionEnvironment {
+public abstract class StreamExecutionEnvironment implements AbstractExecutionEnvironment {
 
 	public final static String DEFAULT_JOB_NAME = "Flink Streaming Job";
 

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.scala
 
 import com.esotericsoftware.kryo.Serializer
+import org.apache.flink.api.common.AbstractExecutionEnvironment
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -37,7 +38,14 @@ import scala.reflect.ClassTag
 
 import _root_.scala.language.implicitConversions
 
-class StreamExecutionEnvironment(javaEnv: JavaEnv) {
+class StreamExecutionEnvironment(javaEnv: JavaEnv) extends AbstractExecutionEnvironment {
+
+  /**
+   * Returns the enclosed Java StreamExecutionEnvironment for special use cases.
+   *
+   * @return reference to the StreamExecutionEnvironment of the Java API
+   */
+  def getJavaEnv(): JavaEnv = javaEnv
 
   /**
    * Gets the config object.

--- a/flink-staging/flink-table/pom.xml
+++ b/flink-staging/flink-table/pom.xml
@@ -37,7 +37,7 @@ under the License.
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
+			<version>14.0.1</version>
 		</dependency>
 
 		<dependency>
@@ -55,6 +55,12 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-scala-examples</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hcatalog</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 

--- a/flink-staging/flink-table/src/main/java/org/apache/flink/examples/java/JavaTableExample.java
+++ b/flink-staging/flink-table/src/main/java/org/apache/flink/examples/java/JavaTableExample.java
@@ -50,7 +50,7 @@ public class JavaTableExample {
 
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<WC> input = env.fromElements(
 				new WC("Hello", 1),

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataSetConversions.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataSetConversions.scala
@@ -41,7 +41,8 @@ class DataSetConversions[T](set: DataSet[T], inputType: CompositeType[T]) {
    * of type `Int`.
    */
   def as(fields: Expression*): Table = {
-     new ScalaBatchTranslator().createTable(set, fields.toArray)
+     new ScalaBatchTranslator(set.getExecutionEnvironment.getJavaEnv)
+       .createTable(set, fields.toArray)
   }
 
   /**

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
@@ -19,14 +19,16 @@
 package org.apache.flink.api.scala.table
 
 
-import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.api.java.table.JavaBatchTranslator
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.scala.wrap
-import org.apache.flink.api.table.plan._
-import org.apache.flink.api.table.Table
+import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.scala.DataSet
+import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.java.ExecutionEnvironment
+import org.apache.flink.api.java.table.JavaBatchTranslator
+import org.apache.flink.api.scala.{DataSet, wrap}
+import org.apache.flink.api.table.Table
+import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.input.TableSource
+import org.apache.flink.api.table.plan._
 
 import scala.reflect.ClassTag
 
@@ -35,9 +37,9 @@ import scala.reflect.ClassTag
  * [[PlanTranslator]] for creating [[Table]]s from Scala [[DataSet]]s and
  * translating them back to Scala [[DataSet]]s.
  */
-class ScalaBatchTranslator extends PlanTranslator {
+class ScalaBatchTranslator(val javaEnv: ExecutionEnvironment = null) extends PlanTranslator {
 
-  private val javaTranslator = new JavaBatchTranslator
+  private val javaTranslator = new JavaBatchTranslator(javaEnv)
 
   type Representation[A] = DataSet[A]
 
@@ -64,5 +66,16 @@ class ScalaBatchTranslator extends PlanTranslator {
     val result = javaTranslator.createTable(repr.javaSet, inputType, expressions, resultFields)
 
     Table(result.operation)
+  }
+
+  override def createTable(tableSource: TableSource): Table = {
+    // a TableSource requires an ExecutionEnvironment
+    if (javaEnv == null) {
+      throw new InvalidProgramException("This operation requires an ExecutionEnvironment." +
+        "Scala implicit conversions can not be used in this case. Use a TableEnvironment instead.")
+    }
+    val result = javaTranslator.createTable(tableSource)
+
+    new Table(result.operation)
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
@@ -18,12 +18,15 @@
 
 package org.apache.flink.api.scala.table
 
+import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.java.table.JavaStreamingTranslator
 import org.apache.flink.api.table.Table
-import org.apache.flink.api.table.plan._
 import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.input.TableSource
+import org.apache.flink.api.table.plan._
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.scala.{DataStream, javaToScalaStream}
 
 /**
@@ -33,9 +36,10 @@ import org.apache.flink.streaming.api.scala.{DataStream, javaToScalaStream}
  * This is very limited right now. Only select and filter are implemented. Also, the expression
  * operations must be extended to allow windowing operations.
  */
-class ScalaStreamingTranslator extends PlanTranslator {
+class ScalaStreamingTranslator(val javaEnv: StreamExecutionEnvironment = null)
+  extends PlanTranslator {
 
-  private val javaTranslator = new JavaStreamingTranslator
+  private val javaTranslator = new JavaStreamingTranslator(javaEnv)
 
   override type Representation[A] = DataStream[A]
 
@@ -52,6 +56,17 @@ class ScalaStreamingTranslator extends PlanTranslator {
 
     val result =
       javaTranslator.createTable(repr.getJavaStream, inputType, expressions, resultFields)
+
+    new Table(result.operation)
+  }
+
+  override def createTable(tableSource: TableSource): Table = {
+    // a TableSource requires an StreamExecutionEnvironment
+    if (javaEnv == null) {
+      throw new InvalidProgramException("This operation requires a StreamExecutionEnvironment." +
+        "Scala implicit conversions can not be used in this case. Use a TableEnvironment instead.")
+    }
+    val result = javaTranslator.createTable(tableSource)
 
     new Table(result.operation)
   }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.table
+
+import org.apache.flink.api.common.AbstractExecutionEnvironment
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.table.JavaBatchTranslator
+import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.table.Table
+import org.apache.flink.api.table.input.HCatTableSource
+import org.apache.flink.api.table.plan.PlanTranslator
+import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+
+/**
+ * Environment for working with the Table API.
+ *
+ * Conversion from [[DataSet]] or [[DataStream]] to a [[Table]] happen implicitly in Scala.
+ */
+class TableEnvironment(private[flink] val environment: AbstractExecutionEnvironment) {
+
+  private def translatorFromEnv: PlanTranslator = {
+    if (environment.isInstanceOf[ExecutionEnvironment]) {
+      new ScalaBatchTranslator(environment.asInstanceOf[ExecutionEnvironment]
+        .getJavaEnv)
+    }
+    else if (environment.isInstanceOf[StreamExecutionEnvironment]) {
+      new ScalaStreamingTranslator(environment.asInstanceOf[StreamExecutionEnvironment]
+        .getJavaEnv)
+    }
+    else {
+      throw new IllegalArgumentException("ExecutionEnvironment is invalid for the " +
+        "Scala TableEnvironment.")
+    }
+  }
+
+  /**
+   * Reads a [[org.apache.flink.api.table.Table]] from a HCatalog data source.
+   *
+   * Make sure that the hive-site.xml is included in your class path.
+   */
+  def fromHCat[T](database: String, table: String): Table = {
+    translatorFromEnv.createTable(new HCatTableSource(database, table))
+  }
+
+  /**
+   * Converts the [[Table]] to a [[DataSet]].
+   */
+  def toDataSet[T: TypeInformation](table: Table): DataSet[T] = {
+    val translator = translatorFromEnv
+    if (!translator.isInstanceOf[ScalaBatchTranslator]) {
+      throw new IllegalArgumentException("ExecutionEnvironment does not support Scala DataSets.")
+    }
+    translator.asInstanceOf[ScalaBatchTranslator].translate[T](table.operation)
+  }
+
+  /**
+   * Converts the [[Table]] to a [[DataStream]].
+   */
+  def toDataStream[T: TypeInformation](table: Table): DataStream[T] = {
+    val translator = translatorFromEnv
+    if (!translator.isInstanceOf[ScalaStreamingTranslator]) {
+      throw new IllegalArgumentException("ExecutionEnvironment does not support Scala DataStreams.")
+    }
+    translator.asInstanceOf[ScalaStreamingTranslator].translate[T](table.operation)
+  }
+}
+

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
@@ -55,7 +55,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def select(fields: Expression*): Table = {
-    val analyzer = new SelectionAnalyzer(operation.outputFields)
+    val analyzer = new SelectionAnalyzer(operation)
     val analyzedFields = fields.map(analyzer.analyze)
     val fieldNames = analyzedFields map(_.name)
     if (fieldNames.toSet.size != fieldNames.size) {
@@ -126,7 +126,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def filter(predicate: Expression): Table = {
-    val analyzer = new PredicateAnalyzer(operation.outputFields)
+    val analyzer = new PredicateAnalyzer(operation)
     val analyzedPredicate = analyzer.analyze(predicate)
     this.copy(operation = Filter(operation, analyzedPredicate))
   }
@@ -185,7 +185,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def groupBy(fields: Expression*): Table = {
-    val analyzer = new GroupByAnalyzer(operation.outputFields)
+    val analyzer = new GroupByAnalyzer(operation)
     val analyzedFields = fields.map(analyzer.analyze)
 
     val illegalKeys = analyzedFields filter {

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions.analysis
+
+import org.apache.flink.api.table.expressions.{Naming, ResolvedFieldReference}
+import org.apache.flink.api.table.input.{AdaptiveTableSource, TableSource}
+import org.apache.flink.api.table.plan._
+
+object FieldBacktracker {
+
+  /**
+   * Tracks a field back to its Root and returns its original name and AdaptiveTableSource
+   * if possible.
+   * This only happens if the field is forwarded unmodified. Renaming operations are reverted.
+   *
+   * @param op start operator
+   * @param fieldName field name at start operator
+   * @return original field name with corresponding AdaptiveTableSource or null
+   */
+  def resolveFieldNameAndTableSource(op: PlanNode, fieldName: String)
+    : (AdaptiveTableSource, String) = {
+    op match {
+      case s@Select(input, selection) =>
+        var resolvedField: (AdaptiveTableSource, String) = null
+        // only follow unmodified fields
+        selection.foreach {
+          case ResolvedFieldReference(name, _) if name == fieldName =>
+            resolvedField = resolveFieldNameAndTableSource(input, fieldName)
+          case n@Naming(ResolvedFieldReference(oldName,_), newName) if newName == fieldName =>
+            resolvedField = resolveFieldNameAndTableSource(input, oldName)
+          case _ => // do nothing
+        }
+        resolvedField
+      case Filter(input, _) =>
+        resolveFieldNameAndTableSource(input, fieldName)
+      case Join(leftPlanNode, rightPlanNode) =>
+        if (leftPlanNode.outputFields.map(_._1).contains(fieldName)) {
+          resolveFieldNameAndTableSource(leftPlanNode, fieldName)
+        }
+        else if (rightPlanNode.outputFields.map(_._1).contains(fieldName)) {
+          resolveFieldNameAndTableSource(rightPlanNode, fieldName)
+        }
+        else {
+          null
+        }
+      case As(input, newFieldNames) =>
+        val oldName = input.outputFields(newFieldNames.indexOf(fieldName))._1
+        resolveFieldNameAndTableSource(input, oldName)
+      case GroupBy(input, fields) if fields.filter(_.isInstanceOf[ResolvedFieldReference])
+        .map(_.name).contains(fieldName) =>
+        resolveFieldNameAndTableSource(input, fieldName)
+      // original AdaptiveTableSource name can be resolved
+      case r@Root(tableSource: AdaptiveTableSource, outputFields) if outputFields.map(_._1)
+        .contains(fieldName) =>
+        (tableSource, fieldName)
+      case _ => null
+    }
+  }
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/GroupByAnalyzer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/GroupByAnalyzer.scala
@@ -19,7 +19,7 @@ package org.apache.flink.api.table.expressions.analysis
 
 import org.apache.flink.api.table._
 import org.apache.flink.api.table.expressions.{ResolvedFieldReference, Expression}
-import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.table.plan.PlanNode
 
 import scala.collection.mutable
 
@@ -29,10 +29,10 @@ import org.apache.flink.api.table.trees.{Rule, Analyzer}
 /**
  * Analyzer for grouping expressions. Only field expressions are allowed as grouping expressions.
  */
-class GroupByAnalyzer(inputFields: Seq[(String, TypeInformation[_])])
+class GroupByAnalyzer(inputOperation: PlanNode)
   extends Analyzer[Expression] {
 
-  def rules = Seq(new ResolveFieldReferences(inputFields), CheckGroupExpression)
+  def rules = Seq(new ResolveFieldReferences(inputOperation, false), CheckGroupExpression)
 
   object CheckGroupExpression extends Rule[Expression] {
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicateAnalyzer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicateAnalyzer.scala
@@ -17,19 +17,20 @@
  */
 package org.apache.flink.api.table.expressions.analysis
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.plan.PlanNode
 import org.apache.flink.api.table.trees.Analyzer
 
 /**
  * Analyzer for predicates, i.e. filter operations and where clauses of joins.
  */
-class PredicateAnalyzer(inputFields: Seq[(String, TypeInformation[_])])
+class PredicateAnalyzer(inputOperation: PlanNode)
   extends Analyzer[Expression] {
   def rules = Seq(
-    new ResolveFieldReferences(inputFields),
+    new ResolveFieldReferences(inputOperation, true),
     new InsertAutoCasts,
     new TypeCheck,
     new VerifyNoAggregates,
-    new VerifyBoolean)
+    new VerifyBoolean,
+    new PredicatePushdown(inputOperation))
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicateFilter.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicateFilter.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions.analysis
+
+import org.apache.flink.api.table.expressions._
+
+object PredicateFilter {
+
+  /**
+   * Prunes an expression according to the given filter.
+   * One part of a conjunction remains if the other part is filtered out.
+   * A disjunction is removed if one part is filtered out.
+   *
+   * @param filter filter function
+   * @param expr expression to be copied and pruned
+   * @return new pruned expression
+   */
+  def pruneExpr(filter: (Expression) => Boolean, expr: Expression): Expression = {
+    expr match {
+      case And(left, right) =>
+        val prunedLeft = pruneExpr(filter, left)
+        val prunedRight = pruneExpr(filter, right)
+
+        if (prunedLeft.isInstanceOf[NopExpression]) {
+          prunedRight
+        }
+        else if (prunedRight.isInstanceOf[NopExpression]) {
+          prunedLeft
+        }
+        else {
+          And(prunedLeft, prunedRight)
+        }
+      case Or(left, right) =>
+        if (filter(left) && filter(right)) {
+          val prunedLeft = pruneExpr(filter, left)
+          val prunedRight = pruneExpr(filter, right)
+
+          if (prunedLeft.isInstanceOf[NopExpression] || prunedRight.isInstanceOf[NopExpression]) {
+            NopExpression()
+          }
+          else {
+            Or(prunedLeft, prunedRight)
+          }
+        }
+        else {
+          NopExpression()
+        }
+      case Not(e) =>
+        if (filter(e)) {
+          val prunedE = pruneExpr(filter, e)
+          if (prunedE.isInstanceOf[NopExpression]){
+            NopExpression()
+          }
+          else {
+            Not(e)
+          }
+        }
+        else {
+          NopExpression()
+        }
+      case e: Expression =>
+        if (filter(e)) {
+          e
+        }
+        else {
+          NopExpression()
+        }
+      case _ => NopExpression()
+    }
+  }
+
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePushdown.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePushdown.scala
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions.analysis
+
+import org.apache.flink.api.table.expressions._
+import org.apache.flink.api.table.expressions.analysis.FieldBacktracker
+.resolveFieldNameAndTableSource
+import org.apache.flink.api.table.expressions.analysis.PredicateFilter.pruneExpr
+import org.apache.flink.api.table.input.{AdaptiveTableSource, TableSource}
+import org.apache.flink.api.table.plan._
+import org.apache.flink.api.table.trees.Rule
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Pushes constant predicates (e.g. a===12 && b.isNotNull) to each corresponding
+ * AdaptiveTableSource that support predicates.
+ */
+class PredicatePushdown(val inputOperation: PlanNode) extends Rule[Expression] {
+
+  def apply(expr: Expression) = {
+    // get all table sources where predicates can be push into
+    val tableSources = getPushableTableSources(inputOperation)
+
+    // prune expression tree such that it only contains constant predicates
+    // such as a=1,a="Hello World", isNull(a) but not a=b
+    val constantExpr = pruneExpr(isResolvedAndConstant, expr)
+
+    // push predicates to each table source respectively
+    for (ts <- tableSources) {
+      // prune expression tree such that it only contains field references of ts
+      val tsExpr = pruneExpr((e) => isSameTableSource(e, ts), constantExpr)
+
+      // resolve field names to field names of the table source
+      val result = tsExpr.transformPost {
+        case rfr@ResolvedFieldReference(fieldName, typeInfo) =>
+          ResolvedFieldReference(
+            resolveFieldNameAndTableSource(inputOperation, fieldName)._2,
+            typeInfo
+          )
+      }
+      // push down predicates
+      if (result != NopExpression()) {
+        ts.notifyPredicates(result)
+      }
+    }
+    expr
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+   * @return all AdaptiveTableSources the given PlanNode contains
+   */
+  def getPushableTableSources(tree: PlanNode): Seq[AdaptiveTableSource] = tree match {
+    case Root(ts: AdaptiveTableSource, _) if ts.supportsPredicatePushdown() => Seq(ts)
+    case pn:PlanNode =>
+      val res = new ArrayBuffer[AdaptiveTableSource]()
+      for (child <- pn.children) res ++= getPushableTableSources(child)
+      res
+    case _ => Seq() // add nothing
+  }
+
+  /**
+   * 
+   * @return true if the given expression is a predicate that consists of a
+   *         ResolvedFieldReference and a constant/literal
+   *         e.g. a=1, 2<c
+   */
+  def isResolvedAndConstant(expr: Expression) : Boolean = {
+    expr match {
+      case bc: BinaryComparison if bc.left.isInstanceOf[Literal]
+        && bc.right.isInstanceOf[ResolvedFieldReference] =>
+        true
+      case bc: BinaryComparison if bc.right.isInstanceOf[Literal]
+        && bc.left.isInstanceOf[ResolvedFieldReference] =>
+        true
+      case ue@(IsNotNull(_) | IsNull(_) | NumericIsNotNull(_)) =>
+        val child = ue.asInstanceOf[UnaryExpression].child
+        child.isInstanceOf[ResolvedFieldReference]
+      case And(_,_) | Or(_,_) | Not(_) =>
+        true
+      case _ => false
+    }
+  }
+
+  /**
+   * @return true if the given expression only consists of ResolvedFieldReference of
+   *         the same given AdaptiveTableSource
+   */
+  def isSameTableSource(expr: Expression, ts: AdaptiveTableSource) : Boolean = {
+    expr match {
+      case bc: BinaryComparison if bc.right.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.right.asInstanceOf[ResolvedFieldReference]
+        val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
+        resolvedField != null && resolvedField._1 == ts
+      case bc: BinaryComparison if bc.left.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.left.asInstanceOf[ResolvedFieldReference]
+        val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
+        resolvedField != null && resolvedField._1 == ts
+      case ue@(IsNotNull(_) | IsNull(_) | NumericIsNotNull(_)) =>
+        val fieldRef = ue.asInstanceOf[UnaryExpression].child.asInstanceOf[ResolvedFieldReference]
+        val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
+        resolvedField != null && resolvedField._1 == ts
+      case _ => false
+    }
+  }
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/ResolveFieldReferences.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/ResolveFieldReferences.scala
@@ -17,10 +17,13 @@
  */
 package org.apache.flink.api.table.expressions.analysis
 
+import org.apache.flink.api.table.expressions.analysis.FieldBacktracker
+.resolveFieldNameAndTableSource
 import org.apache.flink.api.table.expressions.{ResolvedFieldReference,
 UnresolvedFieldReference, Expression}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.table._
+import org.apache.flink.api.table.plan.PlanNode
 
 import scala.collection.mutable
 
@@ -30,21 +33,43 @@ import org.apache.flink.api.table.trees.Rule
  * Rule that resolved field references. This rule verifies that field references point to existing
  * fields of the input operation and creates [[ResolvedFieldReference]]s that hold the field
  * [[TypeInformation]] in addition to the field name.
+ * 
+ * @param inputOperation is optional but required if resolved fields should be pushed to underlying
+ *                       table sources.
+ * @param filtering defines if the field is resolved as a part of filtering operation or not
  */
-class ResolveFieldReferences(inputFields: Seq[(String, TypeInformation[_])])
+class ResolveFieldReferences(inputFields: Seq[(String, TypeInformation[_])],
+                             inputOperation: PlanNode,
+                             filtering: Boolean)
   extends Rule[Expression] {
+
+  def this(inputOperation: PlanNode, filtering: Boolean) = this(inputOperation.outputFields,
+    inputOperation, filtering)
+
+  def this(inputFields: Seq[(String, TypeInformation[_])], filtering: Boolean) = this(inputFields,
+    null, filtering)
 
   def apply(expr: Expression) = {
     val errors = mutable.MutableList[String]()
 
     val result = expr.transformPost {
       case fe@UnresolvedFieldReference(fieldName) =>
-        inputFields.find { _._1 == fieldName } match {
-          case Some((_, tpe)) => ResolvedFieldReference(fieldName, tpe)
+        inputOperation.outputFields.find { _._1 == fieldName } match {
+          case Some((_, tpe)) =>
+
+            val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldName)
+
+            // notify about field access if fields origin is an AdaptiveTableSource
+            if (resolvedField != null && resolvedField._1.supportsResolvedFieldPushdown()) {
+              resolvedField._1.notifyResolvedField(resolvedField._2, filtering)
+            }
+
+            ResolvedFieldReference(fieldName, tpe)
 
           case None =>
             errors +=
-              s"Field '$fieldName' is not valid for input fields ${inputFields.mkString(",")}"
+              s"Field '$fieldName' is not valid for input " +
+                s"fields ${inputOperation.outputFields.mkString(",")}"
             fe
         }
     }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/AdaptiveTableSource.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/AdaptiveTableSource.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.table.Row
+import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+/**
+ * AdaptiveTableSources can adapt their output to the requirements of the plan.
+ * Although the output schema stays the same, the TableSource can react on
+ * field resolution and/or predicates internally and can return adapted DataSet/DataStream
+ * versions in the "translate" step.
+ */
+trait AdaptiveTableSource extends TableSource {
+
+  /**
+   * Returns the schema of the resulting rows. The schema remains constant even if the
+   * TableSource adapts to information passed in notify-methods.
+   *
+   * @return schema of the result rows
+   */
+  def getOutputFields(): Seq[(String, TypeInformation[_])]
+
+  /**
+   * Returns whether the TableSource supports adaption to resolved fields.
+   *
+   * @return `true` if TableSource supports adaption to resolved fields.
+   *         `notifyResolvedField()` needs to be implemented.
+   */
+  def supportsResolvedFieldPushdown(): Boolean
+
+  /**
+   * Returns whether the TableSource supports adaption to predicates.
+   *
+   * @return `true` if TableSource supports adaption to predicates.
+   *         `notifyResolvedField()` needs to be implemented.
+   */
+  def supportsPredicatePushdown(): Boolean
+
+  /**
+   * Notifies the TableSource about a resolved field.
+   *
+   * @param field resolved field name
+   * @param filtering `true` if field has been resolved as part of a filter
+   *                  operation. At least one `false` indicates that a wildcard
+   *                  selection does not take place.
+   */
+  def notifyResolvedField(field: String, filtering: Boolean)
+
+  /**
+   * Notifies the TableSource about predicates that apply to its fields. The
+   * predicates are already cleaned such that they only contain comparisons
+   * with literals `a===5 or b==='10'` or `a.notNull and c.isNull`.
+   *
+   * @param expression expression tree only consisting of predicates relevant for this
+   *                   TableSource with literal comparisons
+   */
+  def notifyPredicates(expression: Expression)
+
+  /**
+   * Returns the [[DataSet]] of [[Row]]s that sticks to schema defined in `getOutputFields()`.
+   * The TableSource may has modified unresolved fields (e.g. has set fields to `null`) and
+   * added pre-filters.
+   *
+   * @param env execution environment
+   * @return adapted data set
+   */
+  def createAdaptiveDataSet(env: ExecutionEnvironment) : DataSet[Row]
+
+  /**
+   * Returns the [[DataStream]] of [[Row]]s that sticks to schema defined in `getOutputFields()`.
+   * The TableSource may has modified unresolved fields (e.g. has set fields to `null`) and
+   * added pre-filters.
+   *
+   * @param env stream execution environment
+   * @return adapted data stream
+   */
+  def createAdaptiveDataStream(env: StreamExecutionEnvironment) : DataStream[Row]
+
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/HCatTableSource.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/HCatTableSource.scala
@@ -1,0 +1,381 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import java.util.{Map, List}
+
+import org.apache.flink.api.common.functions.MapFunction
+import org.apache.flink.api.common.typeinfo.{PrimitiveArrayTypeInfo, BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.java.operators.MapOperator
+import org.apache.flink.api.java.typeutils.GenericTypeInfo
+import org.apache.flink.api.table.expressions._
+import org.apache.flink.api.table.typeinfo.RowTypeInfo
+import org.apache.flink.api.table.Row
+import org.apache.flink.hcatalog.java.HCatInputFormat
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.hive.hcatalog.data.DefaultHCatRecord
+import org.apache.hive.hcatalog.data.schema.{HCatSchema, HCatFieldSchema}
+import org.apache.hive.hcatalog.data.schema.HCatFieldSchema.Type._
+import scala.collection.mutable.ArraySeq
+import scala.collection.mutable.Set
+
+class HCatTableSource(private[flink] val database: String,
+                      private[flink] val table: String) extends AdaptiveTableSource {
+
+  val inputFormat = new HCatInputFormat[DefaultHCatRecord](database, table)
+  val outputFields = generateFieldsFromSchema(inputFormat.getOutputSchema)
+  val partitionColumns = generatePartitionColumns(inputFormat)
+
+  var resolvedFields: Set[String] = null
+  val resolvedPredicateFields: Set[String] = Set[String]()
+
+  val predicates = Set[String]()
+
+  override def getOutputFields(): Seq[(String, TypeInformation[_])] = {
+    outputFields
+  }
+
+  override def supportsResolvedFieldPushdown(): Boolean = true
+
+  override def supportsPredicatePushdown(): Boolean = true
+
+  override def notifyResolvedField(field: String, filtering: Boolean) = {
+    // selection: from '*' to reduced field set
+    if (!filtering && resolvedFields == null) {
+      resolvedFields = Set[String]()
+      resolvedFields ++= resolvedPredicateFields
+      resolvedFields.add(field)
+    }
+    // filtering: add field to separate field set in case
+    // the field set will be reduced later
+    else if (filtering && resolvedFields == null) {
+      resolvedPredicateFields.add(field)
+    }
+    // selection or filtering: add field to reduced field set
+    else {
+      resolvedFields.add(field)
+    }
+  }
+
+  def notifyPredicates(expr: Expression) = {
+    // input format does not support "not" and only supports partitioned columns
+    val cleanedExpr = removeNotAndUnpartitionedPredicates(expr)
+
+    // convert non-empty predicate expressions to string and add
+    if (!cleanedExpr.isInstanceOf[NopExpression]) {
+      predicates.add(exprToFilterString(cleanedExpr))
+    }
+  }
+
+  override def createAdaptiveDataSet(env: ExecutionEnvironment) : DataSet[Row] = {
+    val adaptiveInputFormat = new HCatInputFormat[DefaultHCatRecord](database, table)
+
+    // projection pushdown to input format
+    if (resolvedFields != null) {
+      val resolvedOrderedOutputNames = outputFields
+        .filter(field => resolvedFields.contains(field._1))
+        .map(_._1)
+      adaptiveInputFormat.getFields(resolvedOrderedOutputNames:_*)
+    }
+
+    // predicate pushdown to input format
+    if (predicates.size > 0) {
+      adaptiveInputFormat.withFilter(predicates.mkString(" and"))
+    }
+
+    val inputDs = env.createInput(adaptiveInputFormat)
+    val function = new HCatTableSource.HCatRecord2RowMapper(
+      adaptiveInputFormat.getOutputSchema,
+      outputFields)
+
+    val outputNames = outputFields.map(_._1)
+    val outputTypes = outputFields.map(_._2)
+
+    val resultType = new RowTypeInfo(outputTypes, outputNames)
+    new MapOperator(inputDs, resultType, function,
+      s"HCatTableSource(${outputNames.mkString(",")})")
+  }
+
+  override def createAdaptiveDataStream(env: StreamExecutionEnvironment) : DataStream[Row] =
+    throw new UnsupportedOperationException("HCatTableSource currently only supports " +
+      "batch executions.")
+
+  // ----------------------------------------------------------------------------------------------
+
+  def generatePartitionColumns(inputFormat: HCatInputFormat[DefaultHCatRecord]): Seq[String] = {
+    val schema = inputFormat.getPartitionColumns
+    val resultFields: Array[String] = new Array(schema.size)
+    for (i <- 0 until schema.size) {
+      resultFields(i) = schema.get(i).getName
+    }
+    resultFields
+  }
+
+  def generateFieldsFromSchema(schema: HCatSchema): Seq[(String, TypeInformation[_])] = {
+    val numFields = schema.getFields.size
+    val resultFields: ArraySeq[(String, TypeInformation[_])] = new ArraySeq(numFields)
+
+    for (i <- 0 until schema.size()) {
+      val fieldName: String = schema.get(i).getName()
+
+      val fieldSchema: HCatFieldSchema = schema.get(fieldName)
+      val fieldPos: Int = schema.getPosition(fieldName)
+      val fieldType: TypeInformation[_] = getFieldType(fieldSchema)
+      resultFields.update(fieldPos, (fieldName, fieldType))
+    }
+    resultFields
+  }
+
+  def getFieldType(fieldSchema: HCatFieldSchema): TypeInformation[_] = {
+    fieldSchema.getType match {
+      case INT =>
+        BasicTypeInfo.INT_TYPE_INFO
+      case TINYINT =>
+        BasicTypeInfo.BYTE_TYPE_INFO
+      case SMALLINT =>
+        BasicTypeInfo.SHORT_TYPE_INFO
+      case BIGINT =>
+        BasicTypeInfo.LONG_TYPE_INFO
+      case BOOLEAN =>
+        BasicTypeInfo.BOOLEAN_TYPE_INFO
+      case FLOAT =>
+        BasicTypeInfo.FLOAT_TYPE_INFO
+      case DOUBLE =>
+        BasicTypeInfo.DOUBLE_TYPE_INFO
+      case STRING =>
+        BasicTypeInfo.STRING_TYPE_INFO
+      case BINARY =>
+        PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
+      case ARRAY =>
+        new GenericTypeInfo[List[_]](classOf[List[_]])
+      case MAP =>
+        new GenericTypeInfo[Map[_,_]](classOf[Map[_,_]])
+      case STRUCT =>
+        new GenericTypeInfo[List[_]](classOf[List[_]])
+      case unknownType =>
+        throw new IllegalArgumentException("Unknown data type \"" + unknownType
+          + "\" encountered.")
+    }
+  }
+
+  def removeNotAndUnpartitionedPredicates(expr: Expression): Expression = {
+    expr match {
+      case And(left, right) =>
+        val prunedLeft = removeNotAndUnpartitionedPredicates(left)
+        val prunedRight = removeNotAndUnpartitionedPredicates(right)
+
+        if (prunedLeft.isInstanceOf[NopExpression]) {
+          prunedRight
+        }
+        else if (prunedRight.isInstanceOf[NopExpression]) {
+          prunedLeft
+        }
+        else {
+          And(prunedLeft, prunedRight)
+        }
+      case Or(left, right) =>
+        if (!left.isInstanceOf[Not] && !right.isInstanceOf[Not]) {
+          val prunedLeft = removeNotAndUnpartitionedPredicates(left)
+          val prunedRight = removeNotAndUnpartitionedPredicates(right)
+
+          if (prunedLeft.isInstanceOf[NopExpression] || prunedRight.isInstanceOf[NopExpression]) {
+            NopExpression()
+          }
+          else {
+            Or(prunedLeft, prunedRight)
+          }
+        }
+        else {
+          NopExpression()
+        }
+      case Not(e) =>
+          NopExpression()
+      case bc: BinaryComparison if bc.right.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.right.asInstanceOf[ResolvedFieldReference]
+        if (partitionColumns.contains(fieldRef.name)) {
+          bc
+        }
+        NopExpression()
+      case bc: BinaryComparison if bc.left.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.left.asInstanceOf[ResolvedFieldReference]
+        if (partitionColumns.contains(fieldRef.name)) {
+          bc
+        }
+        else {
+          NopExpression()
+        }
+      case ue@(IsNotNull(_) | IsNull(_) | NumericIsNotNull(_)) =>
+        val fieldRef = ue.asInstanceOf[UnaryExpression].child.asInstanceOf[ResolvedFieldReference]
+        if (partitionColumns.contains(fieldRef.name)) {
+          ue
+        }
+        else {
+          NopExpression()
+        }
+      case e: Expression => if (!e.isInstanceOf[Not]) e else NopExpression()
+      case _ => NopExpression()
+    }
+  }
+
+  def exprToFilterString(expr: Expression): String = {
+    expr match {
+      case And(left, right) =>
+        "((" + exprToFilterString(left) + ") and (" + exprToFilterString(right) + "))"
+      case Or(left, right) =>
+        "((" + exprToFilterString(left) + ") or (" + exprToFilterString(right) + "))"
+      case bc: BinaryComparison if bc.right.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.right.asInstanceOf[ResolvedFieldReference]
+        val literal = bc.left.asInstanceOf[Literal]
+        comparisonToString(bc, fieldRef.name, literal)
+      case bc: BinaryComparison if bc.left.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.left.asInstanceOf[ResolvedFieldReference]
+        val literal = bc.right.asInstanceOf[Literal]
+        comparisonToString(bc, fieldRef.name, literal)
+      case ue@(IsNotNull(_) | IsNull(_) | NumericIsNotNull(_)) =>
+        comparisonToString(ue, ue.asInstanceOf[UnaryExpression].child
+          .asInstanceOf[ResolvedFieldReference].name)
+      case _ => throw new IllegalArgumentException("Should not happen. This is a bug.")
+    }
+  }
+
+  def comparisonToString(expr: Expression, fieldName: String, literal: Literal = null): String = {
+    expr match {
+      case EqualTo(_,_) => fieldName + "=" + "\"" + literal + "\""
+      case GreaterThan(_,_) => fieldName + ">" + "\"" + literal + "\""
+      case GreaterThanOrEqual(_,_) => fieldName + ">=" + "\"" + literal + "\""
+      case LessThan(_,_) => fieldName + "<" + "\"" + literal + "\""
+      case LessThanOrEqual(_,_) => fieldName + "<=" + "\"" + literal + "\""
+      case NotEqualTo(_,_) => fieldName + "<>" + "\"" + literal + "\""
+      case IsNotNull(_) => fieldName + "<> \"\""
+      case IsNull(_) => fieldName + "= \"\""
+      case NumericIsNotNull(_) => fieldName + "<> \"\""
+      case _ => throw new IllegalArgumentException("Should not happen. This is a bug.")
+    }
+  }
+}
+
+object HCatTableSource {
+
+  class HCatRecord2RowMapper(inputSchema: HCatSchema,
+                             outputFields: Seq[(String, TypeInformation[_])])
+    extends MapFunction[DefaultHCatRecord, Row] {
+
+    override def map(input: DefaultHCatRecord): Row = {
+      val row = new Row(outputFields.size)
+      for (i <- 0 until input.size()){
+        val field = input.get(i)
+        val fieldSchema = inputSchema.get(i)
+        row.setField(outputFields.indexWhere(_._1 == fieldSchema.getName),
+          convertField(fieldSchema.getType, field))
+      }
+      row
+    }
+
+    def convertField(schemaType: HCatFieldSchema.Type, o: AnyRef): Any = {
+      // partition columns are returned as String
+      //   Check and convert to actual type.
+      schemaType match {
+        case HCatFieldSchema.Type.INT =>
+          if (o.isInstanceOf[String]) {
+            o.asInstanceOf[String].toInt
+          }
+          else {
+            o.asInstanceOf[Int]
+          }
+        case HCatFieldSchema.Type.TINYINT =>
+          if (o.isInstanceOf[String]) {
+            o.asInstanceOf[String].toInt.toByte
+          }
+          else {
+            o.asInstanceOf[Byte]
+          }
+        case HCatFieldSchema.Type.SMALLINT =>
+          if (o.isInstanceOf[String]) {
+            o.asInstanceOf[String].toInt.toShort
+          }
+          else {
+            o.asInstanceOf[Short]
+          }
+        case HCatFieldSchema.Type.BIGINT =>
+          if (o.isInstanceOf[String]) {
+            o.asInstanceOf[String].toLong
+          }
+          else {
+            o.asInstanceOf[Long]
+          }
+        case HCatFieldSchema.Type.BOOLEAN =>
+          if (o.isInstanceOf[String]) {
+            o.asInstanceOf[String].toBoolean
+          }
+          else {
+            o.asInstanceOf[Boolean]
+          }
+        case HCatFieldSchema.Type.FLOAT =>
+          if (o.isInstanceOf[String]) {
+            o.asInstanceOf[String].toFloat
+          }
+          else {
+            o.asInstanceOf[Float]
+          }
+        case HCatFieldSchema.Type.DOUBLE =>
+          if (o.isInstanceOf[String]) {
+            o.asInstanceOf[String].toDouble
+          }
+          else {
+            o.asInstanceOf[Double]
+          }
+        case HCatFieldSchema.Type.STRING =>
+          o
+        case HCatFieldSchema.Type.BINARY =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type BINARY.")
+          }
+          else {
+            o.asInstanceOf[Array[Byte]]
+          }
+        case HCatFieldSchema.Type.ARRAY =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type ARRAY.")
+          }
+          else {
+            o.asInstanceOf[List[Object]]
+          }
+        case HCatFieldSchema.Type.MAP =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type MAP.")
+          }
+          else {
+            o.asInstanceOf[Map[Object, Object]]
+          }
+        case HCatFieldSchema.Type.STRUCT =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type STRUCT.")
+          }
+          else {
+            o.asInstanceOf[List[Object]]
+          }
+        case unknownType =>
+          throw new RuntimeException("Invalid type " + unknownType +
+            " encountered.")
+      }
+    }
+  }
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/StaticTableSource.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/StaticTableSource.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+/**
+ * StaticTableSources are an easy way to provide the Table API with additional input formats.
+ * For more advanced TableSources that also adapt to field accesses and
+ * predicates see [[AdaptiveTableSource]].
+ */
+trait StaticTableSource extends TableSource {
+
+  /**
+   * Define name and order of output fields.
+   *
+   * @return output field names
+   */
+  def getOutputFieldNames(): Seq[String]
+
+  /**
+   * Returns a [[DataSet]] of a [[org.apache.flink.api.common.typeutils.CompositeType]].
+   *
+   * @param env execution environment
+   * @return data set
+   */
+  def createStaticDataSet(env: ExecutionEnvironment) : DataSet[_]
+
+  /**
+   * Returns a [[DataStream]] of a [[org.apache.flink.api.common.typeutils.CompositeType]].
+   *
+   * @param env execution environment
+   * @return data stream
+   */
+  def createStaticDataStream(env: StreamExecutionEnvironment) : DataStream[_]
+
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/TableSource.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/TableSource.scala
@@ -15,27 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.expressions.analysis
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.plan.PlanNode
-import org.apache.flink.api.table.trees.Analyzer
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.table.Table
 
 /**
- * This analyzes selection expressions.
+ * Base class for input formats of [[Table]]s.
+ *
+ * See also [[AdaptiveTableSource]] and [[StaticTableSource]].
  */
-class SelectionAnalyzer(inputFields: Seq[(String, TypeInformation[_])], inputOperation: PlanNode)
-  extends Analyzer[Expression] {
-
-  def this(inputOperation: PlanNode) = this(inputOperation.outputFields, inputOperation)
-
-  def this(inputFields: Seq[(String, TypeInformation[_])]) = this(inputFields, null)
-
-  def rules = Seq(
-    new ResolveFieldReferences(inputFields, inputOperation, false),
-    new VerifyNoNestedAggregates,
-    new InsertAutoCasts,
-    new TypeCheck)
+trait TableSource {
 
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/ExpandAggregations.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/ExpandAggregations.scala
@@ -111,7 +111,7 @@ object ExpandAggregations {
         }
       }
 
-      val intermediateAnalyzer = new SelectionAnalyzer(input.outputFields)
+      val intermediateAnalyzer = new SelectionAnalyzer(input)
       val analyzedIntermediates = intermediateFields.toSeq.map(intermediateAnalyzer.analyze)
 
       val finalAnalyzer =

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/PlanTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/PlanTranslator.scala
@@ -21,6 +21,7 @@ import java.lang.reflect.Modifier
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.table.input.TableSource
 import org.apache.flink.api.table.parser.ExpressionParser
 import org.apache.flink.api.table.expressions.{Expression, Naming, ResolvedFieldReference, UnresolvedFieldReference}
 import org.apache.flink.api.table.typeinfo.RowTypeInfo
@@ -50,6 +51,11 @@ abstract class PlanTranslator {
       inputType: CompositeType[A],
       expressions: Array[Expression],
       resultFields: Seq[(String, TypeInformation[_])]): Table
+
+  /**
+   * Creates a [[Table]] from a given table source.
+   */
+  def createTable(tableSource: TableSource): Table
 
   /**
    * Creates a [[Table]] from the given DataSet or DataStream.
@@ -101,7 +107,7 @@ abstract class PlanTranslator {
         new Table(
           Root(repr, expressions))
 
-      case c: CompositeType[A] => // us ok
+      case c: CompositeType[A] => // is ok
 
       case tpe => throw new ExpressionException("Only DataSets or DataStreams of composite type" +
         "can be transformed to a Table. These would be tuples, case classes and " +

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
@@ -20,6 +20,7 @@ package org.apache.flink.api.table.plan
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.aggregation.Aggregations
 import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.input.TableSource
 import org.apache.flink.api.table.trees.TreeNode
 
 /**
@@ -32,6 +33,8 @@ sealed abstract class PlanNode extends TreeNode[PlanNode] { self: Product =>
 /**
  * Operation that transforms a [[org.apache.flink.api.scala.DataSet]] or
  * [[org.apache.flink.streaming.api.scala.DataStream]] into a [[org.apache.flink.api.table.Table]].
+ * The input can also be a [[org.apache.flink.api.table.input.AdaptiveTableSource]] that provides
+ * both a DataSet or a DataStream.
  */
 case class Root[T](input: T, outputFields: Seq[(String, TypeInformation[_])]) extends PlanNode {
   val children = Nil
@@ -92,7 +95,7 @@ case class As(input: PlanNode, names: Seq[String]) extends PlanNode {
 }
 
 /**
- * Grouping operation. Keys are specified using field references. A group by operation os only
+ * Grouping operation. Keys are specified using field references. A group by operation is only
  * useful when performing a select with aggregates afterwards.
  * @param input
  * @param fields

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
@@ -82,7 +82,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAggregationTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table = tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env));
 
@@ -99,7 +99,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAggregationOnNonExistingField() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env));
@@ -118,7 +118,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testWorkingAggregationDataTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(
@@ -142,7 +142,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAggregationWithArithmetic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, String>> input =
 				env.fromElements(
@@ -167,7 +167,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNonWorkingDataTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, String>> input = env.fromElements(new Tuple2<Float, String>(1f,
 				"Hello"));
@@ -190,7 +190,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNoNestedAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, String>> input = env.fromElements(new Tuple2<Float, String>(1f, "Hello"));
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AsITCase.java
@@ -62,7 +62,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAs() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c");
@@ -83,7 +83,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToFewFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b");
@@ -99,7 +99,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToManyFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c, d");
@@ -115,7 +115,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithAmbiguousFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, b");
@@ -131,7 +131,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithNonFieldReference1() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a + 1, b, c");
@@ -147,7 +147,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithNonFieldReference2() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a as foo, b," +

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
@@ -62,7 +62,7 @@ public class CastingITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAutoCastToString() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(new Tuple7<Byte, Short, Integer, Long, Float, Double, String>(
@@ -85,7 +85,7 @@ public class CastingITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testNumericAutocastInArithmetic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(new Tuple7<Byte, Short, Integer, Long, Float, Double, String>(
@@ -108,7 +108,7 @@ public class CastingITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testNumericAutocastInComparison() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
@@ -64,7 +64,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testArithmetic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Integer, Integer>> input =
 				env.fromElements(new Tuple2<Integer, Integer>(5, 10));
@@ -86,7 +86,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testLogic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Integer, Boolean>> input =
 				env.fromElements(new Tuple2<Integer, Boolean>(5, true));
@@ -108,7 +108,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testComparisons() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple3<Integer, Integer, Integer>> input =
 				env.fromElements(new Tuple3<Integer, Integer, Integer>(5, 5, 4));
@@ -130,7 +130,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testBitwiseOperation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Byte, Byte>> input =
 				env.fromElements(new Tuple2<Byte, Byte>((byte) 3, (byte) 5));
@@ -152,7 +152,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testBitwiseWithAutocast() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Integer, Byte>> input =
 				env.fromElements(new Tuple2<Integer, Byte>(3, (byte) 5));
@@ -174,7 +174,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testBitwiseWithNonWorkingAutocast() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, Byte>> input =
 				env.fromElements(new Tuple2<Float, Byte>(3.0f, (byte) 5));

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FilterITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FilterITCase.java
@@ -62,7 +62,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAllRejectingFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -83,7 +83,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAllPassingFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -109,7 +109,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testFilterOnIntegerTupleField() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -132,7 +132,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testNotEquals() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -155,7 +155,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testIntegerBiggerThan128() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = env.fromElements(new Tuple3<Integer, Long, String>(300, 1L, "Hello"));
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
@@ -63,7 +63,7 @@ public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testGroupingOnNonExistentField() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -84,7 +84,7 @@ public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testGroupedAggregate() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -109,7 +109,7 @@ public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 		// if we don't want the key in the output
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/JoinITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/JoinITCase.java
@@ -64,7 +64,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoin() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -85,7 +85,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoinWithFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -106,7 +106,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoinWithMultipleKeys() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.get3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -128,7 +128,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testJoinNonExistingKey() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -149,7 +149,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testJoinWithNonMatchingKeyTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -171,7 +171,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testJoinWithAmbiguousFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -193,7 +193,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoinWithAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/SelectITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/SelectITCase.java
@@ -63,7 +63,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSimpleSelectAllWithAs() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -89,7 +89,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSimpleSelectWithNaming() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -112,7 +112,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToFewFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -129,7 +129,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToManyFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -146,7 +146,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithAmbiguousFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -163,7 +163,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testOnlyFieldRefInAs() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/StringExpressionsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/StringExpressionsITCase.java
@@ -62,7 +62,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSubstring() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, Integer>> ds = env.fromElements(
 				new Tuple2<String, Integer>("AAAA", 2),
@@ -84,7 +84,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSubstringWithMaxEnd() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, Integer>> ds = env.fromElements(
 				new Tuple2<String, Integer>("ABCD", 2),
@@ -106,7 +106,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNonWorkingSubstring1() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, Float>> ds = env.fromElements(
 				new Tuple2<String, Float>("ABCD", 2.0f),
@@ -128,7 +128,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNonWorkingSubstring2() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, String>> ds = env.fromElements(
 				new Tuple2<String, String>("ABCD", "a"),

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithPushdown.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithPushdown.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.table.Row
+import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.Set
+
+class DummyTableSourceWithPushdown extends AdaptiveTableSource {
+
+  val resolvedFields = Set[(String, Boolean)]()
+  val predicates = ListBuffer[Expression]()
+
+  override def getOutputFields(): Seq[(String, TypeInformation[_])] = {
+    List(("a", BasicTypeInfo.INT_TYPE_INFO),
+      ("b", BasicTypeInfo.INT_TYPE_INFO),
+      ("c", BasicTypeInfo.STRING_TYPE_INFO))
+  }
+
+  override def supportsResolvedFieldPushdown(): Boolean = true
+
+  override def supportsPredicatePushdown(): Boolean = true
+
+  override def notifyResolvedField(field: String, filtering: Boolean): Unit = {
+    resolvedFields += ((field, filtering))
+  }
+
+  override def notifyPredicates(expression: Expression): Unit = {
+    predicates += expression
+  }
+
+  override def createAdaptiveDataStream(env: StreamExecutionEnvironment): DataStream[Row] = null
+
+  override def createAdaptiveDataSet(env: ExecutionEnvironment): DataSet[Row] = null
+
+}

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithoutPushdown.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithoutPushdown.scala
@@ -15,27 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.expressions.analysis
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.plan.PlanNode
-import org.apache.flink.api.table.trees.Analyzer
+package org.apache.flink.api.table.input
 
-/**
- * This analyzes selection expressions.
- */
-class SelectionAnalyzer(inputFields: Seq[(String, TypeInformation[_])], inputOperation: PlanNode)
-  extends Analyzer[Expression] {
+import org.apache.flink.api.java.tuple.Tuple1
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 
-  def this(inputOperation: PlanNode) = this(inputOperation.outputFields, inputOperation)
+class DummyTableSourceWithoutPushdown extends StaticTableSource {
 
-  def this(inputFields: Seq[(String, TypeInformation[_])]) = this(inputFields, null)
+  override def getOutputFieldNames(): Seq[String] = Seq("field")
 
-  def rules = Seq(
-    new ResolveFieldReferences(inputFields, inputOperation, false),
-    new VerifyNoNestedAggregates,
-    new InsertAutoCasts,
-    new TypeCheck)
+  override def createStaticDataStream(env: StreamExecutionEnvironment): DataStream[_] = null
+
+  override def createStaticDataSet(env: ExecutionEnvironment): DataSet[_] = {
+    env.fromElements(
+      new Tuple1[String]("A"),
+      new Tuple1[String]("B"),
+      new Tuple1[String]("C"),
+      new Tuple1[String]("D"))
+  }
 
 }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.java.{ExecutionEnvironment => JavaEnv}
+import org.apache.flink.api.java.table.JavaBatchTranslator
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.table._
+import org.apache.flink.api.table.Table
+import org.apache.flink.api.table.expressions._
+import org.apache.flink.api.table.input.TableSourceTest.MyResult
+import org.apache.flink.api.table.parser.ExpressionParser
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TableSourceTest {
+
+  @Test
+  def testResolvedFieldPushDown() = {
+    val tableSource1 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource1)
+      .filter("a===10")
+    assertEquals(Set(("a", true)), tableSource1.resolvedFields)
+
+    val tableSource2 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource2)
+      .filter("a===b")
+    assertEquals(Set(("a", true), ("b", true)), tableSource2.resolvedFields)
+
+    val tableSource3 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource3)
+      .select("a, b")
+    assertEquals(Set(("a", false), ("b", false)), tableSource3.resolvedFields)
+
+    val tableSource4 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource4)
+      .filter("a===b")
+      .select("a")
+    assertEquals(Set(("a", true), ("b", true), ("a", false)), tableSource4.resolvedFields)
+
+    val tableSource5 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource5)
+      .filter("a===b")
+      .select("b")
+    assertEquals(Set(("a", true), ("b", true), ("b", false)), tableSource5.resolvedFields)
+
+    val tableSource6 = new DummyTableSourceWithPushdown
+    val tableSource7 = new DummyTableSourceWithPushdown
+    val t6 = getTableJava(tableSource6)
+      .filter("a===b")
+      .select("a as a6")
+    val t7 = getTableJava(tableSource7)
+      .filter("a===b")
+      .select("a as a7")
+    t6.join(t7).where("a6===a7");
+    assertEquals(Set(("a", true), ("b", true), ("a", false)), tableSource6.resolvedFields)
+    assertEquals(Set(("a", true), ("b", true), ("a", false)), tableSource7.resolvedFields)
+
+    val tableSource8 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource8)
+      .select("c.substring(0,2) as X")
+    assertEquals(Set(("c", false)), tableSource8.resolvedFields)
+
+    val tableSource9 = new DummyTableSourceWithPushdown
+    val tableSource10 = new DummyTableSourceWithPushdown
+    val t9 = getTableJava(tableSource9)
+      .select("a as a9, b as b9, c as c9");
+    getTableJava(tableSource10)
+      .join(t9)
+      .where("a9===a")
+      .groupBy("b")
+    assertEquals(Set(("a", true), ("a", false), ("b", false), ("c", false)),
+      tableSource9.resolvedFields)
+    assertEquals(Set(("a", true), ("b", false)), tableSource10.resolvedFields)
+
+    val tableSource11 = new DummyTableSourceWithPushdown
+    val tableSource12 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource11)
+      .filter("a===5 || a===6")
+      .select("a as a4, b as b4, c as c4")
+      .filter("b4===7")
+      .join(getTableJava(tableSource12))
+      .where("a===a4 && c==='Test' && c4==='Test2'")
+    assertEquals(Set(("a", true), ("a", false), ("b", true), ("b", false), ("c", false),
+      ("c", true)), tableSource11.resolvedFields)
+    assertEquals(Set(("a", true), ("c", true)), tableSource12.resolvedFields)
+  }
+
+  @Test
+  def testPredicatePushDown() = {
+    val tableSource1 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource1)
+      .filter("a===10")
+    comparePredicateList(List("a===10"), tableSource1)
+
+    val tableSource2 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource2)
+      .filter("a===10 && b===a")
+    comparePredicateList(List("a===10"), tableSource2)
+
+    val tableSource3 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource3)
+      .filter("(a===10 || b===a) && b===15")
+    comparePredicateList(List("b===15"), tableSource3)
+
+    val tableSource4 = new DummyTableSourceWithPushdown
+    val tableSource5 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource4)
+      .filter("a===5 || a===6")
+      .select("a as a4, b as b4, c as c4")
+      .filter("b4===7")
+      .join(getTableJava(tableSource5))
+      .where("a===a4 && c==='Test' && c4==='Test2'")
+    comparePredicateList(List("a===5 || a===6", "b===7", "c==='Test2'"), tableSource4)
+    comparePredicateList(List("c==='Test'"), tableSource5)
+
+    val tableSource6 = new DummyTableSourceWithPushdown
+    val tableSource7 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource6)
+      .filter("a===5 || a===6")
+      .select("b, c")
+      .as("X, Y")
+      .filter("X===34")
+      .join(getTableJava(tableSource7))
+      .where("X===b && Y==='Test2' && c==='Test'")
+    comparePredicateList(List("a===5 || a===6", "b===34", "c==='Test2'"), tableSource6)
+    comparePredicateList(List("c==='Test'"), tableSource7)
+
+    val tableSource8 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource8)
+      .select("a, b")
+      .groupBy("a")
+      .select("a, b.avg as b")
+      .filter("a===5 && b>6")
+      .select("b, a.max as c")
+      .filter("c<4")
+    comparePredicateList(List("a===5"), tableSource8)
+  }
+
+  @Test
+  def testStaticTableSource() = {
+    val ds = getTableJava(new DummyTableSourceWithoutPushdown)
+      .filter("field!=='D'")
+      .toDataSet[MyResult]
+      .collect()
+    assertEquals(Seq(MyResult("A"), MyResult("B"), MyResult("C")), ds)
+  }
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testScalaImplicitConversions(): Unit = {
+    getTableJava(new DummyTableSourceWithPushdown())
+        .toDataSet[MyResult]
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  def getTableJava(tableSource: TableSource): Table = {
+    val translator = new JavaBatchTranslator(JavaEnv.getExecutionEnvironment)
+    translator.createTable(tableSource)
+  }
+
+  def getTableScala(tableSource: TableSource): Table = {
+    val translator = new JavaBatchTranslator(JavaEnv.getExecutionEnvironment)
+    translator.createTable(tableSource)
+  }
+
+  def comparePredicateList(expected: List[String], ts: DummyTableSourceWithPushdown) = {
+    val expectedExpr: List[Expression] = expected.map(ExpressionParser.parseExpression(_))
+    val actual = ts.predicates.map( _.transformPost {
+      case rfr@ResolvedFieldReference(fieldName, typeInfo) =>
+        UnresolvedFieldReference(fieldName)
+    })
+    assertEquals(expectedExpr, actual)
+  }
+}
+
+object TableSourceTest {
+  case class MyResult(field: String)
+}


### PR DESCRIPTION
This PR introduces input format interfaces (so-called `TableSource`s) for the Table API. There are two types of TableSources:

- `AdaptiveTableSource`s can adapt their output to the requirements of the plan. Although the output schema stays the same, the TableSource can react on field resolution and/or predicates internally and can return adapted DataSet/DataStream versions in the "translate" step.
- `StaticTableSource`s are an easy way to provide the Table API with additional input formats without much implementation effort (e.g. for fromCsvFile())

TableSource have been deeply integrated into the Table API. 

The TableEnvironment now requires the newly introduced `AbstractExecutionEnvironment` (common super class of all ExecutionEnvironments for DataSets and DataStreams).

An example of an AdaptiveTableSources can be found in `HCatTableSource`. HCatTableSource supports predicate pushdown as well as selection pushdown to HCatalog. Only those predicates are pushed to HCatalog that are partioned columns. Unresolved fields will not be read from HCatalog and remain `null` within the Table APIs rows.

A an easy example looks like:
```
TableEnironment t = new TableEnvironment(env);
t.fromHCat("database", "table")
  .select("col1, col2")
  .filter("partCol==='5'");
```

Here's what a TableSource can see from more complicated queries:

```
getTableJava(tableSource1)
  .filter("a===5 || a===6")
  .select("a as a4, b as b4, c as c4")
  .filter("b4===7")
  .join(getTableJava(tableSource2))
  .where("a===a4 && c==='Test' && c4==='Test2'")

// Result predicates for tableSource1:
// 	List("a===5 || a===6", "b===7", "c==='Test2'")
// Result predicates for tableSource2:
//	List("c==='Test'")
// Result resolved fields for tableSource1 (true = filtering, false=selection):
// 	Set(("a", true), ("a", false), ("b", true), ("b", false), ("c", false), ("c", true))
// Result resolved fields for tableSource2 (true = filtering, false=selection):
// 	Set(("a", true), ("c", true))
```


HCatTableSource has no tests yet, but I will implement it them soon. First I would be happy about some general feedback.