### PR TITLE
[FLINK-2665] [api-breaking] [runtime] Makes ExecutionConfig serializable by forcing Kryo serializers to be Serializable

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -21,9 +21,8 @@ package org.apache.flink.api.common;
 import com.esotericsoftware.kryo.Serializer;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -94,19 +93,15 @@ public class ExecutionConfig implements Serializable {
 	private boolean timestampsEnabled = false;
 
 	// Serializers and types registered with Kryo and the PojoSerializer
-	// we store them in lists to ensure they are registered in order in all kryo instances.
+	// we store them in linked maps/sets to ensure they are registered in order in all kryo instances.
 
-	private final List<Entry<Class<?>, Serializer<?>>> registeredTypesWithKryoSerializers =
-			new ArrayList<Entry<Class<?>, Serializer<?>>>();
+	private final LinkedHashMap<Class<?>, SerializableSerializer<?>> registeredTypesWithKryoSerializers = new LinkedHashMap<Class<?>, SerializableSerializer<?>>();
 
-	private final List<Entry<Class<?>, Class<? extends Serializer<?>>>> registeredTypesWithKryoSerializerClasses =
-			new ArrayList<Entry<Class<?>, Class<? extends Serializer<?>>>>();
+	private final LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> registeredTypesWithKryoSerializerClasses = new LinkedHashMap<Class<?>, Class<? extends Serializer<?>>>();
 
-	private final List<Entry<Class<?>, Serializer<?>>> defaultKryoSerializers =
-			new ArrayList<Entry<Class<?>, Serializer<?>>>();
+	private final LinkedHashMap<Class<?>, SerializableSerializer<?>> defaultKryoSerializers = new LinkedHashMap<Class<?>, SerializableSerializer<?>>();
 
-	private final List<Entry<Class<?>, Class<? extends Serializer<?>>>> defaultKryoSerializerClasses =
-			new ArrayList<Entry<Class<?>, Class<? extends Serializer<?>>>>();
+	private final LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> defaultKryoSerializerClasses = new LinkedHashMap<Class<?>, Class<? extends Serializer<?>>>();
 
 	private final LinkedHashSet<Class<?>> registeredKryoTypes = new LinkedHashSet<Class<?>>();
 
@@ -457,19 +452,12 @@ public class ExecutionConfig implements Serializable {
 	 * @param type The class of the types serialized with the given serializer.
 	 * @param serializer The serializer to use.
 	 */
-	public void addDefaultKryoSerializer(Class<?> type, Serializer<?> serializer) {
+	public <T extends Serializer<?> & Serializable>void addDefaultKryoSerializer(Class<?> type, T serializer) {
 		if (type == null || serializer == null) {
 			throw new NullPointerException("Cannot register null class or serializer.");
 		}
-		if (!(serializer instanceof java.io.Serializable)) {
-			throw new IllegalArgumentException("The serializer instance must be serializable, (for distributing it in the cluster), "
-					+ "as defined by java.io.Serializable. For stateless serializers, you can use the "
-					+ "'registerSerializer(Class, Class)' method to register the serializer via its class.");
-		}
-		Entry<Class<?>, Serializer<?>> e = new Entry<Class<?>, Serializer<?>>(type, serializer);
-		if(!defaultKryoSerializers.contains(e)) {
-			defaultKryoSerializers.add(e);
-		}
+
+		defaultKryoSerializers.put(type, new SerializableSerializer<T>(serializer));
 	}
 
 	/**
@@ -482,10 +470,7 @@ public class ExecutionConfig implements Serializable {
 		if (type == null || serializerClass == null) {
 			throw new NullPointerException("Cannot register null class or serializer.");
 		}
-		Entry<Class<?>, Class<? extends Serializer<?>>> e = new Entry<Class<?>, Class<? extends Serializer<?>>>(type, serializerClass);
-		if(!defaultKryoSerializerClasses.contains(e)) {
-			defaultKryoSerializerClasses.add(e);
-		}
+		defaultKryoSerializerClasses.put(type, serializerClass);
 	}
 
 	/**
@@ -497,19 +482,12 @@ public class ExecutionConfig implements Serializable {
 	 * @param type The class of the types serialized with the given serializer.
 	 * @param serializer The serializer to use.
 	 */
-	public void registerTypeWithKryoSerializer(Class<?> type, Serializer<?> serializer) {
+	public <T extends Serializer<?> & Serializable>void registerTypeWithKryoSerializer(Class<?> type, T serializer) {
 		if (type == null || serializer == null) {
 			throw new NullPointerException("Cannot register null class or serializer.");
 		}
-		if (!(serializer instanceof java.io.Serializable)) {
-			throw new IllegalArgumentException("The serializer instance must be serializable, (for distributing it in the cluster), "
-					+ "as defined by java.io.Serializable. For stateless serializers, you can use the "
-					+ "'registerSerializer(Class, Class)' method to register the serializer via its class.");
-		}
-		Entry<Class<?>, Serializer<?>> e = new Entry<Class<?>, Serializer<?>>(type, serializer);
-		if(!registeredTypesWithKryoSerializers.contains(e)) {
-			registeredTypesWithKryoSerializers.add(e);
-		}
+
+		registeredTypesWithKryoSerializers.put(type, new SerializableSerializer<T>(serializer));
 	}
 
 	/**
@@ -522,10 +500,7 @@ public class ExecutionConfig implements Serializable {
 		if (type == null || serializerClass == null) {
 			throw new NullPointerException("Cannot register null class or serializer.");
 		}
-		Entry<Class<?>, Class<? extends Serializer<?>>> e = new Entry<Class<?>, Class<? extends Serializer<?>>>(type, serializerClass);
-		if(!registeredTypesWithKryoSerializerClasses.contains(e)) {
-			registeredTypesWithKryoSerializerClasses.add(e);
-		}
+		registeredTypesWithKryoSerializerClasses.put(type, serializerClass);
 	}
 
 	/**
@@ -563,14 +538,14 @@ public class ExecutionConfig implements Serializable {
 	/**
 	 * Returns the registered types with Kryo Serializers.
 	 */
-	public List<Entry<Class<?>, Serializer<?>>> getRegisteredTypesWithKryoSerializers() {
+	public LinkedHashMap<Class<?>, SerializableSerializer<?>> getRegisteredTypesWithKryoSerializers() {
 		return registeredTypesWithKryoSerializers;
 	}
 
 	/**
 	 * Returns the registered types with their Kryo Serializer classes.
 	 */
-	public List<Entry<Class<?>, Class<? extends Serializer<?>>>> getRegisteredTypesWithKryoSerializerClasses() {
+	public LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> getRegisteredTypesWithKryoSerializerClasses() {
 		return registeredTypesWithKryoSerializerClasses;
 	}
 
@@ -578,14 +553,14 @@ public class ExecutionConfig implements Serializable {
 	/**
 	 * Returns the registered default Kryo Serializers.
 	 */
-	public List<Entry<Class<?>, Serializer<?>>> getDefaultKryoSerializers() {
+	public LinkedHashMap<Class<?>, SerializableSerializer<?>> getDefaultKryoSerializers() {
 		return defaultKryoSerializers;
 	}
 
 	/**
 	 * Returns the registered default Kryo Serializer classes.
 	 */
-	public List<Entry<Class<?>, Class<? extends Serializer<?>>>> getDefaultKryoSerializerClasses() {
+	public LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> getDefaultKryoSerializerClasses() {
 		return defaultKryoSerializerClasses;
 	}
 
@@ -633,60 +608,17 @@ public class ExecutionConfig implements Serializable {
 
 	// ------------------------------ Utilities  ----------------------------------
 
-	public static class Entry<K, V> implements Serializable {
+	public static class SerializableSerializer<T extends Serializer<?> & Serializable> implements Serializable {
+		private static final long serialVersionUID = 4687893502781067189L;
 
-		private static final long serialVersionUID = 1L;
+		private T serializer;
 
-		private final K k;
-		private final V v;
-
-		public Entry(K k, V v) {
-			this.k = k;
-			this.v = v;
+		public SerializableSerializer(T serializer) {
+			this.serializer = serializer;
 		}
 
-		public K getKey() {
-			return k;
-		}
-
-		public V getValue() {
-			return v;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-
-			Entry entry = (Entry) o;
-
-			if (k != null ? !k.equals(entry.k) : entry.k != null) {
-				return false;
-			}
-			if (v != null ? !v.equals(entry.v) : entry.v != null) {
-				return false;
-			}
-
-			return true;
-		}
-
-		@Override
-		public int hashCode() {
-			int result = k != null ? k.hashCode() : 0;
-			result = 31 * result + (v != null ? v.hashCode() : 0);
-			return result;
-		}
-
-		@Override
-		public String toString() {
-			return "Entry{" +
-					"k=" + k +
-					", v=" + v +
-					'}';
+		public T getSerializer() {
+			return serializer;
 		}
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -271,7 +272,7 @@ public abstract class ExecutionEnvironment {
 	 * @param type The class of the types serialized with the given serializer.
 	 * @param serializer The serializer to use.
 	 */
-	public void addDefaultKryoSerializer(Class<?> type, Serializer<?> serializer) {
+	public <T extends Serializer<?> & Serializable>void addDefaultKryoSerializer(Class<?> type, T serializer) {
 		config.addDefaultKryoSerializer(type, serializer);
 	}
 
@@ -294,7 +295,7 @@ public abstract class ExecutionEnvironment {
 	 * @param type The class of the types serialized with the given serializer.
 	 * @param serializer The serializer to use.
 	 */
-	public void registerTypeWithKryoSerializer(Class<?> type, Serializer<?> serializer) {
+	public <T extends Serializer<?> & Serializable>void registerTypeWithKryoSerializer(Class<?> type, T serializer) {
 		config.registerTypeWithKryoSerializer(type, serializer);
 	}
 
@@ -987,10 +988,10 @@ public abstract class ExecutionEnvironment {
 
 		if(LOG.isDebugEnabled()) {
 			LOG.debug("Registered Kryo types: {}", Joiner.on(',').join(config.getRegisteredKryoTypes()));
-			LOG.debug("Registered Kryo with Serializers types: {}", Joiner.on(',').join(config.getRegisteredTypesWithKryoSerializers()));
-			LOG.debug("Registered Kryo with Serializer Classes types: {}", Joiner.on(',').join(config.getRegisteredTypesWithKryoSerializerClasses()));
-			LOG.debug("Registered Kryo default Serializers: {}", Joiner.on(',').join(config.getDefaultKryoSerializers()));
-			LOG.debug("Registered Kryo default Serializers Classes {}", Joiner.on(',').join(config.getDefaultKryoSerializerClasses()));
+			LOG.debug("Registered Kryo with Serializers types: {}", Joiner.on(',').join(config.getRegisteredTypesWithKryoSerializers().entrySet()));
+			LOG.debug("Registered Kryo with Serializer Classes types: {}", Joiner.on(',').join(config.getRegisteredTypesWithKryoSerializerClasses().entrySet()));
+			LOG.debug("Registered Kryo default Serializers: {}", Joiner.on(',').join(config.getDefaultKryoSerializers().entrySet()));
+			LOG.debug("Registered Kryo default Serializers Classes {}", Joiner.on(',').join(config.getDefaultKryoSerializerClasses().entrySet()));
 			LOG.debug("Registered POJO types: {}", Joiner.on(',').join(config.getRegisteredPojoTypes()));
 
 			// print information about static code analysis

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -153,7 +153,10 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * Note that the serializer instance must be serializable (as defined by java.io.Serializable),
    * because it may be distributed to the worker nodes by java serialization.
    */
-  def registerTypeWithKryoSerializer(clazz: Class[_], serializer: Serializer[_]): Unit = {
+  def registerTypeWithKryoSerializer[T <: Serializer[_] with Serializable](
+      clazz: Class[_],
+      serializer: T)
+    : Unit = {
     javaEnv.registerTypeWithKryoSerializer(clazz, serializer)
   }
 
@@ -178,7 +181,10 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * Note that the serializer instance must be serializable (as defined by java.io.Serializable),
    * because it may be distributed to the worker nodes by java serialization.
    */
-  def addDefaultKryoSerializer(clazz: Class[_], serializer: Serializer[_]): Unit = {
+  def addDefaultKryoSerializer[T <: Serializer[_] with Serializable](
+      clazz: Class[_],
+      serializer: T)
+    : Unit = {
     javaEnv.addDefaultKryoSerializer(clazz, serializer)
   }
   

--- a/flink-staging/flink-avro/src/test/java/org/apache/flink/api/io/avro/AvroRecordInputFormatTest.java
+++ b/flink-staging/flink-avro/src/test/java/org/apache/flink/api/io/avro/AvroRecordInputFormatTest.java
@@ -242,7 +242,9 @@ public class AvroRecordInputFormatTest {
 
 		TypeSerializer<GenericData.Record> tser = te.createSerializer(ec);
 		Assert.assertEquals(1, ec.getDefaultKryoSerializerClasses().size());
-		Assert.assertEquals(new ExecutionConfig.Entry<Class<?>, Class<? extends Serializer<?>>>(Schema.class, Serializers.AvroSchemaSerializer.class), ec.getDefaultKryoSerializerClasses().get(0));
+		Assert.assertTrue(
+			ec.getDefaultKryoSerializerClasses().containsKey(Schema.class) &&
+			ec.getDefaultKryoSerializerClasses().get(Schema.class).equals(Serializers.AvroSchemaSerializer.class));
 		ComparatorTestBase.TestOutputView target = new ComparatorTestBase.TestOutputView();
 		tser.serialize(rec, target);
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -70,6 +70,7 @@ import org.apache.flink.util.SplittableIterator;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -443,7 +444,7 @@ public abstract class StreamExecutionEnvironment {
 	 * @param serializer
 	 * 		The serializer to use.
 	 */
-	public void addDefaultKryoSerializer(Class<?> type, Serializer<?> serializer) {
+	public <T extends Serializer<?> & Serializable>void addDefaultKryoSerializer(Class<?> type, T serializer) {
 		config.addDefaultKryoSerializer(type, serializer);
 	}
 
@@ -472,7 +473,7 @@ public abstract class StreamExecutionEnvironment {
 	 * @param serializer
 	 * 		The serializer to use.
 	 */
-	public void registerTypeWithKryoSerializer(Class<?> type, Serializer<?> serializer) {
+	public <T extends Serializer<?> & Serializable>void registerTypeWithKryoSerializer(Class<?> type, T serializer) {
 		config.registerTypeWithKryoSerializer(type, serializer);
 	}
 

--- a/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-staging/flink-streaming/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -243,7 +243,10 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @param serializer
    * The serializer to use.
    */
-  def addDefaultKryoSerializer(`type`: Class[_], serializer: Serializer[_]) {
+  def addDefaultKryoSerializer[T <: Serializer[_] with Serializable](
+      `type`: Class[_],
+      serializer: T)
+    : Unit = {
     javaEnv.addDefaultKryoSerializer(`type`, serializer)
   }
 
@@ -265,7 +268,10 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Note that the serializer instance must be serializable (as defined by java.io.Serializable),
    * because it may be distributed to the worker nodes by java serialization.
    */
-  def registerTypeWithKryoSerializer(clazz: Class[_], serializer: Serializer[_]): Unit = {
+  def registerTypeWithKryoSerializer[T <: Serializer[_] with Serializable](
+      clazz: Class[_],
+      serializer: T)
+    : Unit = {
     javaEnv.registerTypeWithKryoSerializer(clazz, serializer)
   }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/RegisterTypeWithKryoSerializerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/RegisterTypeWithKryoSerializerITCase.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class RegisterTypeWithKryoSerializerITCase extends MultipleProgramsTestBase {
+
+	public RegisterTypeWithKryoSerializerITCase(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	/**
+	 * Tests whether the kryo serializer is forwarded via the ExecutionConfig.
+	 * @throws Exception
+	 */
+	@Test
+	public void testRegisterTypeWithKryoSerializer() throws Exception {
+		int numElements = 10;
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.registerTypeWithKryoSerializer(TestClass.class, new TestClassSerializer());
+
+		DataSet<Long> input = env.generateSequence(0, numElements - 1);
+
+		DataSet<TestClass> mapped = input.map(new MapFunction<Long, TestClass>() {
+			private static final long serialVersionUID = -529116076312998262L;
+
+			@Override
+			public TestClass map(Long value) throws Exception {
+				return new TestClass(value);
+			}
+		});
+
+		List<TestClass> expected = new ArrayList<>(numElements);
+
+		for (int i = 0; i < numElements; i++) {
+			expected.add(new TestClass(42));
+		}
+
+		compareResultCollections(expected, mapped.collect(), new Comparator<TestClass>() {
+			@Override
+			public int compare(TestClass o1, TestClass o2) {
+				return (int)(o1.getValue() - o2.getValue());
+			}
+		});
+	}
+
+	static class TestClass {
+		private final long value;
+		private Object obj = new Object();
+
+		public TestClass(long value) {
+			this.value = value;
+		}
+
+		public long getValue() {
+			return value;
+		}
+
+		@Override
+		public String toString() {
+			return "TestClass(" + value + ")";
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof TestClass) {
+				TestClass other = (TestClass) obj;
+
+				return value == other.value;
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			return (int)value;
+		}
+	}
+
+	static class TestClassSerializer extends Serializer<TestClass> implements Serializable {
+
+		private static final long serialVersionUID = -3585880741695717533L;
+
+		@Override
+		public void write(Kryo kryo, Output output, TestClass testClass) {
+			output.writeLong(42);
+		}
+
+		@Override
+		public TestClass read(Kryo kryo, Input input, Class<TestClass> aClass) {
+			return new TestClass(input.readLong());
+		}
+	}
+}


### PR DESCRIPTION
Adding an explicit type constraint for the Kryo serializers to be `Serializable`. This allows to make the `ExecutionConfig` serializable.

This PR is **API breaking**.