### PR TITLE
[FLINK-2641] integrate off-heap memory configuration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -125,11 +125,6 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_MEMORY_FRACTION_KEY = "taskmanager.memory.fraction";
 
 	/**
-	 * The fraction of off-heap memory relative to the heap size.
-	 */
-	public static final String TASK_MANAGER_MEMORY_OFF_HEAP_RATIO_KEY = "taskmanager.memory.off-heap-ratio";
-	
-	/**
 	 * The config parameter defining the memory allocation method (JVM heap or off-heap).
 	*/
 	public static final String TASK_MANAGER_MEMORY_OFF_HEAP_KEY = "taskmanager.memory.off-heap";
@@ -546,11 +541,6 @@ public final class ConfigConstants {
 	 * The default fraction of the free memory allocated by the task manager's memory manager.
 	 */
 	public static final float DEFAULT_MEMORY_MANAGER_MEMORY_FRACTION = 0.7f;
-
-	/**
-	 * The default ratio of heap to off-heap memory, when the TaskManager is started with off-heap memory.
-	 */
-	public static final float DEFAULT_MEMORY_MANAGER_MEMORY_OFF_HEAP_RATIO = 3.0f;
 	
 	/**
 	 * Default number of buffers used in the network stack.

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -43,21 +43,21 @@ if [[ $STARTSTOP == "start" ]]; then
         STREAMINGMODE="batch"
     fi
 
-    if [[ ! ${FLINK_JM_HEAP} =~ $IS_NUMBER ]]; then
-        echo "[ERROR] Configured JobManager JVM heap size is not a number. Please set '$KEY_JOBM_HEAP_MB' in $FLINK_CONF_FILE."
+    if [[ ! ${FLINK_JM_HEAP} =~ $IS_NUMBER ]] || [[ "${FLINK_JM_HEAP}" -lt "0" ]]; then
+        echo "[ERROR] Configured JobManager memory size is not a valid value. Please set '${KEY_JOBM_MEM_SIZE}' in ${FLINK_CONF_FILE}."
         exit 1
     fi
 
     if [ "$EXECUTIONMODE" = "local" ]; then
-        if [[ ! ${FLINK_TM_HEAP} =~ $IS_NUMBER ]]; then
-            echo "[ERROR] Configured JobManager JVM heap size is not a number. Please set '$KEY_TASKM_HEAP_MB' in $FLINK_CONF_FILE."
+        if [[ ! ${FLINK_TM_HEAP} =~ $IS_NUMBER ]] || [[ "${FLINK_TM_HEAP}" -lt "0" ]]; then
+            echo "[ERROR] Configured TaskManager memory size is not a valid value. Please set ${KEY_TASKM_MEM_SIZE} in ${FLINK_CONF_FILE}."
             exit 1
         fi
 
         FLINK_JM_HEAP=`expr $FLINK_JM_HEAP + $FLINK_TM_HEAP`
     fi
 
-    if [ "$FLINK_JM_HEAP" -gt 0 ]; then
+    if [ "${FLINK_JM_HEAP}" -gt "0" ]; then
         export JVM_ARGS="$JVM_ARGS -Xms"$FLINK_JM_HEAP"m -Xmx"$FLINK_JM_HEAP"m"
     fi
 

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -51,13 +51,43 @@ if [[ $STARTSTOP == "start" ]]; then
         fi
     fi
 
-    if [[ ! ${FLINK_TM_HEAP} =~ ${IS_NUMBER} ]]; then
-        echo "[ERROR] Configured TaskManager JVM heap size is not a number. Please set '$KEY_TASKM_HEAP_MB' in $FLINK_CONF_FILE."
+    if [[ ! ${FLINK_TM_HEAP} =~ ${IS_NUMBER} ]] || [[ "${FLINK_TM_HEAP}" -lt "0" ]]; then
+        echo "[ERROR] Configured TaskManager JVM heap size is not a number. Please set '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE}."
         exit 1
     fi
 
-    if [ "$FLINK_TM_HEAP" -gt 0 ]; then
-        export JVM_ARGS="$JVM_ARGS -Xms"$FLINK_TM_HEAP"m -Xmx"$FLINK_TM_HEAP"m"
+    if [ "${FLINK_TM_HEAP}" -gt "0" ]; then
+
+        TM_HEAP_SIZE=${FLINK_TM_HEAP}
+        TM_OFFHEAP_SIZE=0
+        # some space for Netty initialization
+        NETTY_BUFFERS=1
+
+        if [[ "${STREAMINGMODE}" == "batch" ]] && useOffHeapMemory; then
+            if [[ "${FLINK_TM_MEM_MANAGED_SIZE}" -gt "0" ]]; then
+                # We split up the total memory in heap and off-heap memory
+                if [[ "${FLINK_TM_HEAP}" -le "${FLINK_TM_MEM_MANAGED_SIZE}" ]]; then
+                    echo "[ERROR] Configured TaskManager memory size ('${KEY_TASKM_MEM_SIZE}') must be larger than the managed memory size ('${KEY_TASKM_MEM_MANAGED_SIZE}')."
+                    exit 1
+                fi
+                TM_OFFHEAP_SIZE=${FLINK_TM_MEM_MANAGED_SIZE}
+                TM_HEAP_SIZE=$((FLINK_TM_HEAP - FLINK_TM_MEM_MANAGED_SIZE))
+            else
+                # We calculate the memory using a fraction of the total memory
+                if [[ `bc -l <<< "${FLINK_TM_MEM_MANAGED_FRACTION} >= 1.0"` != "0" ]] || [[ `bc -l <<< "${FLINK_TM_MEM_MANAGED_FRACTION} <= 0.0"` != "0" ]]; then
+                    echo "[ERROR] Configured TaskManager managed memory fraction is not a valid value. Please set '${KEY_TASKM_MEM_MANAGED_FRACTION}' in ${FLINK_CONF_FILE}"
+                    exit 1
+                fi
+                # recalculate the JVM heap memory by taking the off-heap ratio into account
+                TM_OFFHEAP_SIZE=`printf '%.0f\n' $(bc -l <<< "${FLINK_TM_HEAP} * ${FLINK_TM_MEM_MANAGED_FRACTION}")`
+                TM_HEAP_SIZE=$((FLINK_TM_HEAP - TM_OFFHEAP_SIZE))
+            fi
+        fi
+
+        TM_HEAP_SIZE=$((TM_HEAP_SIZE - FLINK_TM_MEM_NETWORK_SIZE - NETTY_BUFFERS))
+        echo export JVM_ARGS="${JVM_ARGS} -Xms${TM_HEAP_SIZE}M -Xmx${TM_HEAP_SIZE}M -XX:MaxDirectMemorySize=$((TM_OFFHEAP_SIZE + FLINK_TM_MEM_NETWORK_SIZE + NETTY_BUFFERS))M"
+        export JVM_ARGS="${JVM_ARGS} -Xms${TM_HEAP_SIZE}M -Xmx${TM_HEAP_SIZE}M -XX:MaxDirectMemorySize=$((TM_OFFHEAP_SIZE + FLINK_TM_MEM_NETWORK_SIZE + NETTY_BUFFERS))M"
+
     fi
 
     # Startup parameters

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -196,10 +196,11 @@ public class NetworkBufferPool implements BufferPoolFactory {
 				throw new IOException(String.format("Insufficient number of network buffers: " +
 								"required %d, but only %d available. The total number of network " +
 								"buffers is currently set to %d. You can increase this " +
-								"number by setting the configuration key '" +
-								ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY +  "'.",
-						numRequiredBuffers, totalNumberOfMemorySegments - numTotalRequiredBuffers,
-						totalNumberOfMemorySegments));
+								"number by setting the configuration key '%s'.",
+						numRequiredBuffers,
+						totalNumberOfMemorySegments - numTotalRequiredBuffers,
+						totalNumberOfMemorySegments,
+						ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY));
 			}
 
 			this.numTotalRequiredBuffers += numRequiredBuffers;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1578,7 +1578,7 @@ object TaskManager {
       LOG.info(s"Using $configuredMemory MB for Flink managed memory.")
       configuredMemory << 20 // megabytes to bytes
     }
-    else if (memType == MemoryType.HEAP) {
+    else {
       val fraction = configuration.getFloat(
         ConfigConstants.TASK_MANAGER_MEMORY_FRACTION_KEY,
         ConfigConstants.DEFAULT_MEMORY_MANAGER_MEMORY_FRACTION)
@@ -1586,32 +1586,53 @@ object TaskManager {
                            ConfigConstants.TASK_MANAGER_MEMORY_FRACTION_KEY,
                            "MemoryManager fraction of the free memory must be between 0.0 and 1.0")
 
-      val relativeMemSize = (EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag() *
-        fraction).toLong
+      if (memType == MemoryType.HEAP) {
+        val relativeMemSize = (EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag() *
+          fraction).toLong
 
-      LOG.info(s"Using $fraction of the currently free heap space for Flink managed " +
-        s" heap memory (${relativeMemSize >> 20} MB).")
+        LOG.info(s"Using $fraction of the currently free heap space for Flink managed " +
+          s" heap memory (${relativeMemSize >> 20} MB).")
 
-      relativeMemSize
+        relativeMemSize
+      }
+      else if (memType == MemoryType.OFF_HEAP) {
+
+        val networkBufferSizeNew = configuration.getLong(
+          ConfigConstants.TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY,
+          ConfigConstants.DEFAULT_TASK_MANAGER_MEMORY_SEGMENT_SIZE)
+
+        val networkBufferSizeOld = configuration.getLong(
+          ConfigConstants.TASK_MANAGER_NETWORK_BUFFER_SIZE_KEY, -1)
+        val networkBufferSize =
+          if (networkBufferSizeNew != -1) {
+            networkBufferSizeNew
+          } else if (networkBufferSizeOld == -1) {
+            ConfigConstants.DEFAULT_TASK_MANAGER_MEMORY_SEGMENT_SIZE
+          } else {
+            networkBufferSizeOld
+          }
+
+        val numNetworkBuffers = configuration.getLong(
+          ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY,
+          ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_NUM_BUFFERS)
+
+        // direct memory for Netty's off-heap buffers
+        val networkMemory = (numNetworkBuffers * networkBufferSize) + (1 << 20)
+
+        // The maximum heap memory has been adjusted according to the fraction
+        val maxMemory = EnvironmentInformation.getMaxJvmHeapMemory() + networkMemory
+        val directMemorySize = (maxMemory / (1.0 - fraction) * fraction).toLong
+
+        LOG.info(s"Using $fraction of the maximum memory size for " +
+          s"Flink managed off-heap memory (${directMemorySize >> 20} MB).")
+
+        directMemorySize
+      }
+      else {
+        throw new RuntimeException("No supported memory type detected.")
+      }
     }
-    else {
-      val ratio = configuration.getFloat(
-        ConfigConstants.TASK_MANAGER_MEMORY_OFF_HEAP_RATIO_KEY,
-        ConfigConstants.DEFAULT_MEMORY_MANAGER_MEMORY_OFF_HEAP_RATIO)
-      
-      checkConfigParameter(ratio > 0.0f,
-        ConfigConstants.TASK_MANAGER_MEMORY_OFF_HEAP_RATIO_KEY,
-        "MemoryManager ratio (off-heap memory / heap size) must be larger than zero")
-      
-      val maxHeapSize = EnvironmentInformation.getMaxJvmHeapMemory()
-      val relativeMemSize = (maxHeapSize * ratio).toLong
 
-      LOG.info(s"Using $ratio time the heap size (${maxHeapSize} bytes) for Flink " +
-        s"managed off-heap memory (${relativeMemSize >> 20} MB).")
-
-      relativeMemSize
-    }
-    
     val preAllocateMemory: Boolean = streamingMode == StreamingMode.BATCH_ONLY
 
     // now start the memory manager


### PR DESCRIPTION
Following the discussion in #1125, this pull request introduces a less "invasive" change to make the off-heap memory configurable.

- add offheap configuration parameter taskmanager.memory.off-heap

- remove offheap ratio parameter and reuse memory fraction parameter

- set JVM -XX:MaxDirectMemorySize parameter correctly