### PR TITLE
[FLINK-2637] [api-breaking] [scala, types] Adds equals and hashCode method to TypeInformations and TypeSerializers

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A config to define the behavior of the program execution. It allows to define (among other
@@ -603,6 +604,61 @@ public class ExecutionConfig implements Serializable {
 	 */
 	public void disableAutoTypeRegistration() {
 		this.autoTypeRegistrationEnabled = false;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof ExecutionConfig) {
+			ExecutionConfig other = (ExecutionConfig) obj;
+
+			return other.canEqual(this) &&
+				Objects.equals(executionMode, other.executionMode) &&
+				useClosureCleaner == other.useClosureCleaner &&
+				parallelism == other.parallelism &&
+				numberOfExecutionRetries == other.numberOfExecutionRetries &&
+				forceKryo == other.forceKryo &&
+				objectReuse == other.objectReuse &&
+				autoTypeRegistrationEnabled == other.autoTypeRegistrationEnabled &&
+				forceAvro == other.forceAvro &&
+				Objects.equals(codeAnalysisMode, other.codeAnalysisMode) &&
+				printProgressDuringExecution == other.printProgressDuringExecution &&
+				Objects.equals(globalJobParameters, other.globalJobParameters) &&
+				autoWatermarkInterval == other.autoWatermarkInterval &&
+				timestampsEnabled == other.timestampsEnabled &&
+				registeredTypesWithKryoSerializerClasses.equals(other.registeredTypesWithKryoSerializerClasses) &&
+				defaultKryoSerializerClasses.equals(other.defaultKryoSerializerClasses) &&
+				registeredKryoTypes.equals(other.registeredKryoTypes) &&
+				registeredPojoTypes.equals(other.registeredPojoTypes);
+
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+			executionMode,
+			useClosureCleaner,
+			parallelism,
+			numberOfExecutionRetries,
+			forceKryo,
+			objectReuse,
+			autoTypeRegistrationEnabled,
+			forceAvro,
+			codeAnalysisMode,
+			printProgressDuringExecution,
+			globalJobParameters,
+			autoWatermarkInterval,
+			timestampsEnabled,
+			registeredTypesWithKryoSerializerClasses,
+			defaultKryoSerializerClasses,
+			registeredKryoTypes,
+			registeredPojoTypes);
+	}
+
+	public boolean canEqual(Object obj) {
+		return obj instanceof ExecutionConfig;
 	}
 
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfo.java
@@ -20,14 +20,16 @@ package org.apache.flink.api.common.typeinfo;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.StringArraySerializer;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
 
-public class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
+public final class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -45,14 +47,12 @@ public class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
 	// --------------------------------------------------------------------------------------------
 
 	private final Class<T> arrayClass;
-	private final Class<C> componentClass;
 	private final TypeInformation<C> componentInfo;
 
 	@SuppressWarnings("unchecked")
 	private BasicArrayTypeInfo(Class<T> arrayClass, BasicTypeInfo<C> componentInfo) {
-		this.arrayClass = arrayClass;
-		this.componentClass = (Class<C>) arrayClass.getComponentType();
-		this.componentInfo = componentInfo;
+		this.arrayClass = Preconditions.checkNotNull(arrayClass);
+		this.componentInfo = Preconditions.checkNotNull(componentInfo);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -83,7 +83,7 @@ public class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
 	}
 
 	public Class<C> getComponentTypeClass() {
-		return this.componentClass;
+		return this.componentInfo.getTypeClass();
 	}
 	
 	public TypeInformation<C> getComponentInfo() {
@@ -99,13 +99,39 @@ public class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
 	@SuppressWarnings("unchecked")
 	public TypeSerializer<T> createSerializer(ExecutionConfig executionConfig) {
 		// special case the string array
-		if (componentClass.equals(String.class)) {
+		if (componentInfo.getTypeClass().equals(String.class)) {
 			return (TypeSerializer<T>) StringArraySerializer.INSTANCE;
 		} else {
-			return (TypeSerializer<T>) new GenericArraySerializer<C>(this.componentClass, this.componentInfo.createSerializer(executionConfig));
+			return (TypeSerializer<T>) new GenericArraySerializer<C>(
+				this.componentInfo.getTypeClass(),
+				this.componentInfo.createSerializer(executionConfig));
 		}
 	}
-	
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof BasicArrayTypeInfo) {
+			BasicArrayTypeInfo<?, ?> other = (BasicArrayTypeInfo<?, ?>) obj;
+
+			return other.canEqual(this) &&
+				arrayClass == other.arrayClass &&
+				componentInfo.equals(other.componentInfo);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(arrayClass, componentInfo);
+	}
+
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof BasicArrayTypeInfo;
+	}
+
 	@Override
 	public String toString() {
 		return this.getClass().getSimpleName()+"<"+this.componentInfo+">";

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/FractionalTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/FractionalTypeInfo.java
@@ -18,15 +18,29 @@
 
 package org.apache.flink.api.common.typeinfo;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+import java.util.Set;
+
 /**
- * Type information for numeric primitive types (int, long, double, byte, ...).
+ * Type information for numeric fractional primitive types (double, float).
  */
 public class FractionalTypeInfo<T> extends NumericTypeInfo<T> {
 
+	private static final long serialVersionUID = 554334260950199994L;
+
+	private static final Set<Class<?>> fractionalTypes = Sets.<Class<?>>newHashSet(
+			Double.class,
+			Float.class
+	);
+
 	protected FractionalTypeInfo(Class<T> clazz, Class<?>[] possibleCastTargetTypes, TypeSerializer<T> serializer, Class<? extends TypeComparator<T>> comparatorClass) {
 		super(clazz, possibleCastTargetTypes, serializer, comparatorClass);
+
+		Preconditions.checkArgument(fractionalTypes.contains(clazz), "The given class " +
+			clazz.getSimpleName() + " is not a fractional type.");
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/IntegerTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/IntegerTypeInfo.java
@@ -18,15 +18,32 @@
 
 package org.apache.flink.api.common.typeinfo;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+import java.util.Set;
+
 /**
- * Type information for numeric primitive types (int, long, double, byte, ...).
+ * Type information for numeric integer primitive types: int, long, byte, short, character.
  */
 public class IntegerTypeInfo<T> extends NumericTypeInfo<T> {
 
+	private static final long serialVersionUID = -8068827354966766955L;
+
+	private static final Set<Class<?>> integerTypes = Sets.<Class<?>>newHashSet(
+			Integer.class,
+			Long.class,
+			Byte.class,
+			Short.class,
+			Character.class
+	);
+
 	protected IntegerTypeInfo(Class<T> clazz, Class<?>[] possibleCastTargetTypes, TypeSerializer<T> serializer, Class<? extends TypeComparator<T>> comparatorClass) {
 		super(clazz, possibleCastTargetTypes, serializer, comparatorClass);
+
+		Preconditions.checkArgument(integerTypes.contains(clazz), "The given class " +
+		clazz.getSimpleName() + " is not a integer type.");
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NothingTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NothingTypeInfo.java
@@ -63,4 +63,30 @@ public class NothingTypeInfo extends TypeInformation<Nothing> {
 	public TypeSerializer<Nothing> createSerializer(ExecutionConfig executionConfig) {
 		throw new RuntimeException("The Nothing type cannot have a serializer.");
 	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof NothingTypeInfo) {
+			NothingTypeInfo nothingTypeInfo = (NothingTypeInfo) obj;
+
+			return nothingTypeInfo.canEqual(this);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return NothingTypeInfo.class.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof NothingTypeInfo;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NumericTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NumericTypeInfo.java
@@ -18,16 +18,35 @@
 
 package org.apache.flink.api.common.typeinfo;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+import java.util.Set;
+
 /**
- * Type information for numeric primitive types (int, long, double, byte, ...).
+ * Type information for numeric primitive types: int, long, double, byte, short, float, char.
  */
-public class NumericTypeInfo<T> extends BasicTypeInfo<T> {
+public abstract class NumericTypeInfo<T> extends BasicTypeInfo<T> {
+
+	private static final long serialVersionUID = -5937777910658986986L;
+
+	private static final Set<Class<?>> numericalTypes = Sets.<Class<?>>newHashSet(
+			Integer.class,
+			Long.class,
+			Double.class,
+			Byte.class,
+			Short.class,
+			Float.class,
+			Character.class
+	);
 
 	protected NumericTypeInfo(Class<T> clazz, Class<?>[] possibleCastTargetTypes, TypeSerializer<T> serializer, Class<? extends
 			TypeComparator<T>> comparatorClass) {
 		super(clazz, possibleCastTargetTypes, serializer, comparatorClass);
+
+		Preconditions.checkArgument(numericalTypes.contains(clazz), "The given class " +
+				clazz.getSimpleName() + " is not a numerical type.");
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -146,4 +146,21 @@ public abstract class TypeInformation<T> implements Serializable {
 	 * @return A serializer for this type.
 	 */
 	public abstract TypeSerializer<T> createSerializer(ExecutionConfig config);
+
+	@Override
+	public abstract String toString();
+
+	@Override
+	public abstract boolean equals(Object obj);
+
+	@Override
+	public abstract int hashCode();
+
+	/**
+	 * Returns true if the given object can be equaled with this object. If not, it returns false.
+	 *
+	 * @param obj Object which wants to take part in the equality relation
+	 * @return true if obj can be equaled with this, otherwise false
+	 */
+	public abstract boolean canEqual(Object obj);
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -146,4 +146,16 @@ public abstract class TypeSerializer<T> implements Serializable {
 	 * @throws IOException Thrown if any of the two views raises an exception.
 	 */
 	public abstract void copy(DataInputView source, DataOutputView target) throws IOException;
+
+	public abstract boolean equals(Object obj);
+
+	/**
+	 * Returns true if the given object can be equaled with this object. If not, it returns false.
+	 *
+	 * @param obj Object which wants to take part in the equality relation
+	 * @return true if obj can be equaled with this, otherwise false
+	 */
+	public abstract boolean canEqual(Object obj);
+
+	public abstract int hashCode();
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanSerializer.java
@@ -75,4 +75,9 @@ public final class BooleanSerializer extends TypeSerializerSingleton<Boolean> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeBoolean(source.readBoolean());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof BooleanSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializer.java
@@ -80,4 +80,9 @@ public final class BooleanValueSerializer extends TypeSerializerSingleton<Boolea
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeBoolean(source.readBoolean());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof BooleanValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteSerializer.java
@@ -77,4 +77,9 @@ public final class ByteSerializer extends TypeSerializerSingleton<Byte> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeByte(source.readByte());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof ByteSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializer.java
@@ -78,4 +78,9 @@ public final class ByteValueSerializer extends TypeSerializerSingleton<ByteValue
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeByte(source.readByte());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof ByteValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharSerializer.java
@@ -77,4 +77,9 @@ public final class CharSerializer extends TypeSerializerSingleton<Character> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeChar(source.readChar());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof CharSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharValueSerializer.java
@@ -77,4 +77,9 @@ public class CharValueSerializer extends TypeSerializerSingleton<CharValue> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeChar(source.readChar());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof CharValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DateSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DateSerializer.java
@@ -97,4 +97,9 @@ public final class DateSerializer extends TypeSerializerSingleton<Date> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeLong(source.readLong());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof DateSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleSerializer.java
@@ -76,4 +76,9 @@ public final class DoubleSerializer extends TypeSerializerSingleton<Double> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeDouble(source.readDouble());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof DoubleSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializer.java
@@ -78,4 +78,9 @@ public final class DoubleValueSerializer extends TypeSerializerSingleton<DoubleV
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeDouble(source.readDouble());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof DoubleValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.reflect.Method;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -36,7 +37,7 @@ public final class EnumSerializer<T extends Enum<T>> extends TypeSerializer<T> {
 	private final Class<T> enumClass;
 
 	public EnumSerializer(Class<T> enumClass) {
-		this.enumClass = enumClass;
+		this.enumClass = Preconditions.checkNotNull(enumClass);
 		this.values = createValues(enumClass);
 	}
 
@@ -94,10 +95,21 @@ public final class EnumSerializer<T extends Enum<T>> extends TypeSerializer<T> {
 	public boolean equals(Object obj) {
 		if(obj instanceof EnumSerializer) {
 			EnumSerializer<?> other = (EnumSerializer<?>) obj;
-			return other.enumClass == this.enumClass;
+
+			return other.canEqual(this) && other.enumClass == this.enumClass;
 		} else {
 			return false;
 		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof EnumSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return enumClass.hashCode();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatSerializer.java
@@ -76,4 +76,9 @@ public final class FloatSerializer extends TypeSerializerSingleton<Float> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeFloat(source.readFloat());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof FloatSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializer.java
@@ -78,4 +78,9 @@ public class FloatValueSerializer extends TypeSerializerSingleton<FloatValue> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeFloat(source.readFloat());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof FloatValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntSerializer.java
@@ -77,4 +77,9 @@ public final class IntSerializer extends TypeSerializerSingleton<Integer> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeInt(source.readInt());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof IntSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntValueSerializer.java
@@ -78,4 +78,9 @@ public final class IntValueSerializer extends TypeSerializerSingleton<IntValue> 
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeInt(source.readInt());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof IntValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongSerializer.java
@@ -77,4 +77,9 @@ public final class LongSerializer extends TypeSerializerSingleton<Long> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeLong(source.readLong());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof LongSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongValueSerializer.java
@@ -78,4 +78,9 @@ public final class LongValueSerializer extends TypeSerializerSingleton<LongValue
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeLong(source.readLong());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof LongValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortSerializer.java
@@ -77,4 +77,9 @@ public final class ShortSerializer extends TypeSerializerSingleton<Short> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeShort(source.readShort());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof ShortSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializer.java
@@ -78,4 +78,9 @@ public final class ShortValueSerializer extends TypeSerializerSingleton<ShortVal
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeShort(source.readShort());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof ShortValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringSerializer.java
@@ -77,4 +77,9 @@ public final class StringSerializer extends TypeSerializerSingleton<String> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		StringValue.copyString(source, target);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof StringSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringValueSerializer.java
@@ -103,4 +103,9 @@ public final class StringValueSerializer extends TypeSerializerSingleton<StringV
 			}
 		}
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof StringValueSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
@@ -33,11 +33,17 @@ public abstract class TypeSerializerSingleton<T> extends TypeSerializer<T>{
 
 	@Override
 	public int hashCode() {
-		return super.hashCode();
+		return TypeSerializerSingleton.class.hashCode();
 	}
 	
 	@Override
 	public boolean equals(Object obj) {
-		return obj != null && obj.getClass() == this.getClass();
+		if (obj instanceof TypeSerializerSingleton) {
+			TypeSerializerSingleton<?> other = (TypeSerializerSingleton<?>) obj;
+
+			return other.canEqual(this);
+		} else {
+			return false;
+		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/VoidSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/VoidSerializer.java
@@ -77,4 +77,9 @@ public final class VoidSerializer extends TypeSerializerSingleton<Void> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.write(source.readByte());
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof VoidSerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
@@ -101,4 +101,9 @@ public final class BooleanPrimitiveArraySerializer extends TypeSerializerSinglet
 		target.writeInt(len);
 		target.write(source, len);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof BooleanPrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
@@ -93,4 +93,9 @@ public final class BytePrimitiveArraySerializer extends TypeSerializerSingleton<
 		target.writeInt(len);
 		target.write(source, len);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof BytePrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
@@ -100,4 +100,9 @@ public final class CharPrimitiveArraySerializer extends TypeSerializerSingleton<
 		target.writeInt(len);
 		target.write(source, len * 2);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof CharPrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
@@ -100,4 +100,9 @@ public final class DoublePrimitiveArraySerializer extends TypeSerializerSingleto
 		target.writeInt(len);
 		target.write(source, len * 8);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof DoublePrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
@@ -100,4 +100,9 @@ public final class FloatPrimitiveArraySerializer extends TypeSerializerSingleton
 		target.writeInt(len);
 		target.write(source, len * 4);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof FloatPrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
@@ -100,4 +100,9 @@ public class IntPrimitiveArraySerializer extends TypeSerializerSingleton<int[]>{
 		target.writeInt(len);
 		target.write(source, len * 4);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof IntPrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
@@ -100,4 +100,9 @@ public final class LongPrimitiveArraySerializer extends TypeSerializerSingleton<
 		target.writeInt(len);
 		target.write(source, len * 8);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof LongPrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
@@ -100,4 +100,9 @@ public final class ShortPrimitiveArraySerializer extends TypeSerializerSingleton
 		target.writeInt(len);
 		target.write(source, len * 2);
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof ShortPrimitiveArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
@@ -104,4 +104,9 @@ public final class StringArraySerializer extends TypeSerializerSingleton<String[
 			StringValue.copyString(source, target);
 		}
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof StringArraySerializer;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/record/RecordSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/record/RecordSerializer.java
@@ -40,7 +40,7 @@ public final class RecordSerializer extends TypeSerializer<Record> {
 	
 	// --------------------------------------------------------------------------------------------
 
-	public static final RecordSerializer get() {
+	public static RecordSerializer get() {
 		return INSTANCE;
 	}
 	
@@ -120,5 +120,25 @@ public final class RecordSerializer extends TypeSerializer<Record> {
 		}
 		
 		target.write(source, val);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof RecordSerializer) {
+			RecordSerializer other = (RecordSerializer) obj;
+			return other.canEqual(this);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof RecordSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return RecordSerializer.class.hashCode();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/types/BasicArrayTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/BasicArrayTypeInfoTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types;
+
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class BasicArrayTypeInfoTest extends TestLogger {
+
+	static Class<?>[] classes = {String[].class, Integer[].class, Boolean[].class, Byte[].class,
+		Short[].class, Long[].class, Float[].class, Double[].class, Character[].class};
+
+	@Test
+	public void testBasicArrayTypeInfoEquality() {
+		for (Class<?> clazz: classes) {
+			BasicArrayTypeInfo<?, ?> tpeInfo1 = BasicArrayTypeInfo.getInfoFor(clazz);
+			BasicArrayTypeInfo<?, ?> tpeInfo2 = BasicArrayTypeInfo.getInfoFor(clazz);
+
+			assertEquals(tpeInfo1, tpeInfo2);
+			assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+		}
+	}
+
+	@Test
+	public void testBasicArrayTypeInfoInequality() {
+		for (Class<?> clazz1: classes) {
+			for (Class<?> clazz2: classes) {
+				if (!clazz1.equals(clazz2)) {
+					BasicArrayTypeInfo<?, ?> tpeInfo1 = BasicArrayTypeInfo.getInfoFor(clazz1);
+					BasicArrayTypeInfo<?, ?> tpeInfo2 = BasicArrayTypeInfo.getInfoFor(clazz2);
+					assertNotEquals(tpeInfo1, tpeInfo2);
+				}
+			}
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/types/BasicTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/BasicTypeInfoTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WNTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class BasicTypeInfoTest extends TestLogger {
+
+	static Class<?>[] classes = {String.class, Integer.class, Boolean.class, Byte.class,
+		Short.class, Long.class, Float.class, Double.class, Character.class, Date.class,
+		Void.class};
+
+	@Test
+	public void testBasicTypeInfoEquality() {
+		for (Class<?> clazz: classes) {
+			BasicTypeInfo<?> tpeInfo1 = BasicTypeInfo.getInfoFor(clazz);
+			BasicTypeInfo<?> tpeInfo2 = BasicTypeInfo.getInfoFor(clazz);
+
+			assertEquals(tpeInfo1, tpeInfo2);
+			assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+		}
+	}
+
+	@Test
+	public void testBasicTypeInfoInequality() {
+		for (Class<?> clazz1: classes) {
+			for (Class<?> clazz2: classes) {
+				if (!clazz1.equals(clazz2)) {
+					BasicTypeInfo<?> tpeInfo1 = BasicTypeInfo.getInfoFor(clazz1);
+					BasicTypeInfo<?> tpeInfo2 = BasicTypeInfo.getInfoFor(clazz2);
+					assertNotEquals(tpeInfo1, tpeInfo2);
+				}
+			}
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/types/NothingTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/NothingTypeInfoTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.NothingTypeInfo;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NothingTypeInfoTest extends TestLogger {
+
+	@Test
+	public void testNothingTypeInfoEquality() {
+		NothingTypeInfo tpeInfo1 = new NothingTypeInfo();
+		NothingTypeInfo tpeInfo2 = new NothingTypeInfo();
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testNothingTypeInfoInequality() {
+		NothingTypeInfo tpeInfo1 = new NothingTypeInfo();
+		BasicTypeInfo<Integer> tpeInfo2 = BasicTypeInfo.getInfoFor(Integer.class);
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+		assertNotEquals(tpeInfo2, tpeInfo1);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/types/PrimitiveArrayTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/PrimitiveArrayTypeInfoTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types;
+
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class PrimitiveArrayTypeInfoTest extends TestLogger {
+
+	static Class<?>[] classes = {int[].class, boolean[].class, byte[].class,
+		short[].class, long[].class, float[].class, double[].class, char[].class};
+
+	@Test
+	public void testPrimitiveArrayTypeInfoEquality() {
+		for (Class<?> clazz: classes) {
+			PrimitiveArrayTypeInfo<?> tpeInfo1 = PrimitiveArrayTypeInfo.getInfoFor(clazz);
+			PrimitiveArrayTypeInfo<?> tpeInfo2 = PrimitiveArrayTypeInfo.getInfoFor(clazz);
+
+			assertEquals(tpeInfo1, tpeInfo2);
+			assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+		}
+	}
+
+	@Test
+	public void testBasicArrayTypeInfoInequality() {
+		for (Class<?> clazz1: classes) {
+			for (Class<?> clazz2: classes) {
+				if (!clazz1.equals(clazz2)) {
+					PrimitiveArrayTypeInfo<?> tpeInfo1 = PrimitiveArrayTypeInfo.getInfoFor(clazz1);
+					PrimitiveArrayTypeInfo<?> tpeInfo2 = PrimitiveArrayTypeInfo.getInfoFor(clazz2);
+					assertNotEquals(tpeInfo1, tpeInfo2);
+				}
+			}
+		}
+	}
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -300,7 +300,7 @@ public class CsvReader {
 			if(pos < 0) {
 				throw new IllegalArgumentException("Field \""+pojoFields[i]+"\" not part of POJO type "+pojoType.getCanonicalName());
 			}
-			classes[i] = typeInfo.getPojoFieldAt(pos).type.getTypeClass();
+			classes[i] = typeInfo.getPojoFieldAt(pos).getTypeInformation().getTypeClass();
 		}
 
 		configureInputFormat(inputFormat, classes);

--- a/flink-java/src/main/java/org/apache/flink/api/java/sca/UdfAnalyzerUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/sca/UdfAnalyzerUtils.java
@@ -75,7 +75,7 @@ public final class UdfAnalyzerUtils {
 			final PojoTypeInfo<?> pojoTypeInfo = (PojoTypeInfo<?>) typeInfo;
 			HashMap<String, TaggedValue> containerMapping = new HashMap<String, TaggedValue>();
 			for (int i = 0; i < pojoTypeInfo.getArity(); i++) {
-				final String fieldName = pojoTypeInfo.getPojoFieldAt(i).field.getName();
+				final String fieldName = pojoTypeInfo.getPojoFieldAt(i).getField().getName();
 				containerMapping.put(fieldName,
 						convertTypeInfoToTaggedValue(input,
 								pojoTypeInfo.getTypeAt(i),

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/AvroTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/AvroTypeInfo.java
@@ -56,7 +56,7 @@ public class AvroTypeInfo<T extends SpecificRecordBase> extends PojoTypeInfo<T> 
 
 		for(int i = 0; i < pti.getArity(); i++) {
 			PojoField f = pti.getPojoFieldAt(i);
-			TypeInformation newType = f.type;
+			TypeInformation newType = f.getTypeInformation();
 			// check if type is a CharSequence
 			if(newType instanceof GenericTypeInfo) {
 				if((newType).getTypeClass().equals(CharSequence.class)) {
@@ -64,7 +64,7 @@ public class AvroTypeInfo<T extends SpecificRecordBase> extends PojoTypeInfo<T> 
 					newType = new GenericTypeInfo(org.apache.avro.util.Utf8.class);
 				}
 			}
-			PojoField newField = new PojoField(f.field, newType);
+			PojoField newField = new PojoField(f.getField(), newType);
 			newFields.add(newField);
 		}
 		return newFields;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.AtomicType;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -38,12 +39,12 @@ public class EnumTypeInfo<T extends Enum<T>> extends TypeInformation<T> implemen
 	private final Class<T> typeClass;
 
 	public EnumTypeInfo(Class<T> typeClass) {
-		if (typeClass == null) {
-			throw new NullPointerException();
-		}
+		Preconditions.checkNotNull(typeClass, "Enum type class must not be null.");
+
 		if (!Enum.class.isAssignableFrom(typeClass) ) {
 			throw new IllegalArgumentException("EnumTypeInfo can only be used for subclasses of " + Enum.class.getName());
 		}
+
 		this.typeClass = typeClass;
 	}
 
@@ -98,13 +99,22 @@ public class EnumTypeInfo<T extends Enum<T>> extends TypeInformation<T> implemen
 	
 	@Override
 	public int hashCode() {
-		return typeClass.hashCode() ^ 0xd3a2646c;
+		return typeClass.hashCode();
 	}
-	
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof EnumTypeInfo;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof EnumTypeInfo) {
-			return typeClass == ((EnumTypeInfo<?>) obj).typeClass;
+			@SuppressWarnings("unchecked")
+			EnumTypeInfo<T> enumTypeInfo = (EnumTypeInfo<T>) obj;
+
+			return enumTypeInfo.canEqual(this) &&
+				typeClass == enumTypeInfo.typeClass;
 		} else {
 			return false;
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.AtomicType;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -34,7 +35,7 @@ public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType
 	private final Class<T> typeClass;
 
 	public GenericTypeInfo(Class<T> typeClass) {
-		this.typeClass = typeClass;
+		this.typeClass = Preconditions.checkNotNull(typeClass);
 	}
 
 	@Override
@@ -88,13 +89,21 @@ public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType
 
 	@Override
 	public int hashCode() {
-		return typeClass.hashCode() ^ 0x165667b1;
+		return typeClass.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof GenericTypeInfo;
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj.getClass() == GenericTypeInfo.class) {
-			return typeClass == ((GenericTypeInfo<?>) obj).typeClass;
+		if (obj instanceof GenericTypeInfo) {
+			@SuppressWarnings("unchecked")
+			GenericTypeInfo<T> genericTypeInfo = (GenericTypeInfo<T>) obj;
+
+			return typeClass == genericTypeInfo.typeClass;
 		} else {
 			return false;
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
@@ -31,8 +31,8 @@ public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
 
 	private static final long serialVersionUID = -4212082837126702723L;
 	
-	private String functionName;
-	private InvalidTypesException typeException;
+	private final String functionName;
+	private final InvalidTypesException typeException;
 
 	
 	public MissingTypeInfo(String functionName) {
@@ -84,6 +84,34 @@ public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
 	@Override
 	public TypeSerializer<InvalidTypesException> createSerializer(ExecutionConfig executionConfig) {
 		throw new UnsupportedOperationException("The missing type information cannot be used as a type information.");
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "<" + functionName + ", " + typeException.getMessage() + ">";
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof MissingTypeInfo) {
+			MissingTypeInfo missingTypeInfo = (MissingTypeInfo) obj;
+
+			return missingTypeInfo.canEqual(this) &&
+				functionName.equals(missingTypeInfo.functionName) &&
+				typeException.equals(missingTypeInfo.typeException);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return 31 * functionName.hashCode() + typeException.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof MissingTypeInfo;
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoField.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoField.java
@@ -23,16 +23,29 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.util.Objects;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 public class PojoField implements Serializable {
-	public transient Field field;
-	public TypeInformation<?> type;
+
+	private static final long serialVersionUID = 1975295846436559363L;
+
+	private transient Field field;
+	private final TypeInformation<?> type;
 
 	public PojoField(Field field, TypeInformation<?> type) {
-		this.field = field;
-		this.type = type;
+		this.field = Preconditions.checkNotNull(field);
+		this.type = Preconditions.checkNotNull(type);
+	}
+
+	public Field getField() {
+		return field;
+	}
+
+	public TypeInformation<?> getTypeInformation() {
+		return type;
 	}
 
 	private void writeObject(ObjectOutputStream out)
@@ -67,5 +80,26 @@ public class PojoField implements Serializable {
 	@Override
 	public String toString() {
 		return "PojoField " + field.getDeclaringClass() + "." + field.getName() + " (" + type + ")";
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof PojoField) {
+			PojoField other = (PojoField) obj;
+
+			return other.canEqual(this) && type.equals(other.type) &&
+				Objects.equals(field, other.field);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(field, type);
+	}
+
+	public boolean canEqual(Object obj) {
+		return obj instanceof PojoField;
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/RecordTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/RecordTypeInfo.java
@@ -70,12 +70,22 @@ public class RecordTypeInfo extends TypeInformation<Record> {
 	
 	@Override
 	public int hashCode() {
-		return Record.class.hashCode() ^ 0x165667b1;
+		return Record.class.hashCode();
 	}
-	
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof RecordTypeInfo;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
-		return obj.getClass() == RecordTypeInfo.class;
+		if (obj instanceof RecordTypeInfo) {
+			RecordTypeInfo recordTypeInfo = (RecordTypeInfo) obj;
+			return recordTypeInfo.canEqual(this);
+		} else {
+			return false;
+		}
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -18,8 +18,12 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Ints;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -52,10 +56,13 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 
 	public TupleTypeInfo(Class<T> tupleType, TypeInformation<?>... types) {
 		super(tupleType, types);
-		if (types == null || types.length > Tuple.MAX_ARITY) {
-			throw new IllegalArgumentException();
-		}
+
+		Preconditions.checkArgument(
+			types.length <= Tuple.MAX_ARITY,
+			"The tuple type exceeds the maximum supported arity.");
+
 		this.fieldNames = new String[types.length];
+
 		for (int i = 0; i < types.length; i++) {
 			fieldNames[i] = "f" + i;
 		}
@@ -78,7 +85,7 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public TupleSerializer<T> createSerializer(ExecutionConfig executionConfig) {
-		if (this.tupleType == Tuple0.class) {
+		if (getTypeClass() == Tuple0.class) {
 			return (TupleSerializer<T>) Tuple0Serializer.INSTANCE;
 		}
 
@@ -91,48 +98,65 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 		
 		return new TupleSerializer<T>(tupleClass, fieldSerializers);
 	}
-	
-	/**
-	 * Comparator creation
-	 */
-	private TypeComparator<?>[] fieldComparators;
-	private int[] logicalKeyFields;
-	private int comparatorHelperIndex = 0;
-	
-	@Override
-	protected void initializeNewComparator(int localKeyCount) {
-		fieldComparators = new TypeComparator<?>[localKeyCount];
-		logicalKeyFields = new int[localKeyCount];
-		comparatorHelperIndex = 0;
-	}
 
 	@Override
-	protected void addCompareField(int fieldId, TypeComparator<?> comparator) {
-		fieldComparators[comparatorHelperIndex] = comparator;
-		logicalKeyFields[comparatorHelperIndex] = fieldId;
-		comparatorHelperIndex++;
+	protected TypeComparatorBuilder<T> createTypeComparatorBuilder() {
+		return new TupleTypeComparatorBuilder();
 	}
 
-	@Override
-	protected TypeComparator<T> getNewComparator(ExecutionConfig executionConfig) {
-		@SuppressWarnings("rawtypes")
-		final TypeComparator[] finalFieldComparators = Arrays.copyOf(fieldComparators, comparatorHelperIndex);
-		final int[] finalLogicalKeyFields = Arrays.copyOf(logicalKeyFields, comparatorHelperIndex);
-		//final TypeSerializer[] finalFieldSerializers = Arrays.copyOf(fieldSerializers, comparatorHelperIndex);
-		// create the serializers for the prefix up to highest key position
-		int maxKey = 0;
-		for(int key : finalLogicalKeyFields) {
-			maxKey = Math.max(maxKey, key);
+	private class TupleTypeComparatorBuilder implements TypeComparatorBuilder<T> {
+
+		private final ArrayList<TypeComparator> fieldComparators = new ArrayList<TypeComparator>();
+		private final ArrayList<Integer> logicalKeyFields = new ArrayList<Integer>();
+
+		@Override
+		public void initializeTypeComparatorBuilder(int size) {
+			fieldComparators.ensureCapacity(size);
+			logicalKeyFields.ensureCapacity(size);
 		}
-		TypeSerializer<?>[] fieldSerializers = new TypeSerializer<?>[maxKey + 1];
-		for (int i = 0; i <= maxKey; i++) {
-			fieldSerializers[i] = types[i].createSerializer(executionConfig);
+
+		@Override
+		public void addComparatorField(int fieldId, TypeComparator<?> comparator) {
+			fieldComparators.add(comparator);
+			logicalKeyFields.add(fieldId);
 		}
-		if(finalFieldComparators.length == 0 || finalLogicalKeyFields.length == 0 || fieldSerializers.length == 0 
-				|| finalFieldComparators.length != finalLogicalKeyFields.length) {
-			throw new IllegalArgumentException("Tuple comparator creation has a bug");
+
+		@Override
+		public TypeComparator<T> createTypeComparator(ExecutionConfig config) {
+			Preconditions.checkState(
+				fieldComparators.size() > 0,
+				"No field comparators were defined for the TupleTypeComparatorBuilder."
+			);
+
+			Preconditions.checkState(
+				logicalKeyFields.size() > 0,
+				"No key fields were defined for the TupleTypeComparatorBuilder."
+			);
+
+			Preconditions.checkState(
+				fieldComparators.size() == logicalKeyFields.size(),
+				"The number of field comparators and key fields is not equal."
+			);
+
+			final int maxKey = Collections.max(logicalKeyFields);
+
+			Preconditions.checkState(
+				maxKey >= 0,
+				"The maximum key field must be greater or equal than 0."
+			);
+
+			TypeSerializer<?>[] fieldSerializers = new TypeSerializer<?>[maxKey + 1];
+
+			for (int i = 0; i <= maxKey; i++) {
+				fieldSerializers[i] = types[i].createSerializer(config);
+			}
+
+			return new TupleComparator<T>(
+				Ints.toArray(logicalKeyFields),
+				fieldComparators.toArray(new TypeComparator[fieldComparators.size()]),
+				fieldSerializers
+			);
 		}
-		return new TupleComparator<T>(finalLogicalKeyFields, finalFieldComparators, fieldSerializers);
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -142,17 +166,22 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 		if (obj instanceof TupleTypeInfo) {
 			@SuppressWarnings("unchecked")
 			TupleTypeInfo<T> other = (TupleTypeInfo<T>) obj;
-			return ((this.tupleType == null && other.tupleType == null) || this.tupleType.equals(other.tupleType)) &&
-					Arrays.deepEquals(this.types, other.types);
-			
+			return other.canEqual(this) &&
+				super.equals(other) &&
+				Arrays.equals(fieldNames, other.fieldNames);
 		} else {
 			return false;
 		}
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof TupleTypeInfo;
+	}
 	
 	@Override
 	public int hashCode() {
-		return this.types.hashCode() ^ Arrays.deepHashCode(this.types);
+		return 31 * super.hashCode() + Arrays.hashCode(fieldNames);
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.operators.Keys.ExpressionKeys;
@@ -45,17 +46,20 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	
 	protected final TypeInformation<?>[] types;
 	
-	protected final Class<T> tupleType;
-
-	private int totalFields;
+	private final int totalFields;
 
 	public TupleTypeInfoBase(Class<T> tupleType, TypeInformation<?>... types) {
 		super(tupleType);
-		this.tupleType = tupleType;
-		this.types = types;
+
+		this.types = Preconditions.checkNotNull(types);
+
+		int fieldCounter = 0;
+
 		for(TypeInformation<?> type : types) {
-			totalFields += type.getTotalFields();
+			fieldCounter += type.getTotalFields();
 		}
+
+		totalFields = fieldCounter;
 	}
 
 	@Override
@@ -83,11 +87,6 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	}
 
 	@Override
-	public Class<T> getTypeClass() {
-		return tupleType;
-	}
-
-	@Override
 	public void getFlatFields(String fieldExpression, int offset, List<FlatFieldDescriptor> result) {
 
 		Matcher matcher = PATTERN_NESTED_FIELDS_WILDCARD.matcher(fieldExpression);
@@ -109,53 +108,49 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 				}
 				keyPosition++;
 			}
-			return;
-		}
-
-		String fieldStr = matcher.group(1);
-		Matcher fieldMatcher = PATTERN_FIELD.matcher(fieldStr);
-		if (!fieldMatcher.matches()) {
-			throw new RuntimeException("Invalid matcher pattern");
-		}
-		field = fieldMatcher.group(2);
-		int fieldPos = Integer.valueOf(field);
-
-		if (fieldPos >= this.getArity()) {
-			throw new InvalidFieldReferenceException("Tuple field expression \"" + fieldStr + "\" out of bounds of " + this.toString() + ".");
-		}
-		TypeInformation<?> fieldType = this.getTypeAt(fieldPos);
-		String tail = matcher.group(5);
-		if(tail == null) {
-			if(fieldType instanceof CompositeType) {
-				// forward offsets
-				for(int i=0; i<fieldPos; i++) {
-					offset += this.getTypeAt(i).getTotalFields();
-				}
-				// add all fields of composite type
-				((CompositeType<?>) fieldType).getFlatFields("*", offset, result);
-				return;
-			} else {
-				// we found the field to add
-				// compute flat field position by adding skipped fields
-				int flatFieldPos = offset;
-				for(int i=0; i<fieldPos; i++) {
-					flatFieldPos += this.getTypeAt(i).getTotalFields();
-				}
-				result.add(new FlatFieldDescriptor(flatFieldPos, fieldType));
-				// nothing left to do
-				return;
-			}
 		} else {
-			if(fieldType instanceof CompositeType<?>) {
-				// forward offset
-				for(int i=0; i<fieldPos; i++) {
-					offset += this.getTypeAt(i).getTotalFields();
+			String fieldStr = matcher.group(1);
+			Matcher fieldMatcher = PATTERN_FIELD.matcher(fieldStr);
+
+			if (!fieldMatcher.matches()) {
+				throw new RuntimeException("Invalid matcher pattern");
+			}
+
+			field = fieldMatcher.group(2);
+			int fieldPos = Integer.valueOf(field);
+
+			if (fieldPos >= this.getArity()) {
+				throw new InvalidFieldReferenceException("Tuple field expression \"" + fieldStr + "\" out of bounds of " + this.toString() + ".");
+			}
+			TypeInformation<?> fieldType = this.getTypeAt(fieldPos);
+			String tail = matcher.group(5);
+			if (tail == null) {
+				if (fieldType instanceof CompositeType) {
+					// forward offsets
+					for (int i = 0; i < fieldPos; i++) {
+						offset += this.getTypeAt(i).getTotalFields();
+					}
+					// add all fields of composite type
+					((CompositeType<?>) fieldType).getFlatFields("*", offset, result);
+				} else {
+					// we found the field to add
+					// compute flat field position by adding skipped fields
+					int flatFieldPos = offset;
+					for (int i = 0; i < fieldPos; i++) {
+						flatFieldPos += this.getTypeAt(i).getTotalFields();
+					}
+					result.add(new FlatFieldDescriptor(flatFieldPos, fieldType));
 				}
-				((CompositeType<?>) fieldType).getFlatFields(tail, offset, result);
-				// nothing left to do
-				return;
 			} else {
-				throw new InvalidFieldReferenceException("Nested field expression \""+tail+"\" not possible on atomic type "+fieldType+".");
+				if (fieldType instanceof CompositeType<?>) {
+					// forward offset
+					for (int i = 0; i < fieldPos; i++) {
+						offset += this.getTypeAt(i).getTotalFields();
+					}
+					((CompositeType<?>) fieldType).getFlatFields(tail, offset, result);
+				} else {
+					throw new InvalidFieldReferenceException("Nested field expression \"" + tail + "\" not possible on atomic type " + fieldType + ".");
+				}
 			}
 		}
 	}
@@ -213,17 +208,24 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 		if (obj instanceof TupleTypeInfoBase) {
 			@SuppressWarnings("unchecked")
 			TupleTypeInfoBase<T> other = (TupleTypeInfoBase<T>) obj;
-			return ((this.tupleType == null && other.tupleType == null) || this.tupleType.equals(other.tupleType)) &&
-					Arrays.deepEquals(this.types, other.types);
-			
+
+			return other.canEqual(this) &&
+				super.equals(other) &&
+				Arrays.equals(types, other.types) &&
+				totalFields == other.totalFields;
 		} else {
 			return false;
 		}
 	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof TupleTypeInfoBase;
+	}
 	
 	@Override
 	public int hashCode() {
-		return this.types.hashCode() ^ Arrays.deepHashCode(this.types);
+		return 31 * (31 * super.hashCode() + Arrays.hashCode(types)) + totalFields;
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -526,12 +526,33 @@ public class TypeExtractor {
 				} catch (ClassNotFoundException e) {
 					throw new InvalidTypesException("Could not convert GenericArrayType to Class.");
 				}
+
 				return getForClass(classArray);
+			} else {
+				TypeInformation<?> componentInfo = createTypeInfoWithTypeHierarchy(
+					typeHierarchy,
+					genericArray.getGenericComponentType(),
+					in1Type,
+					in2Type);
+
+				Class<OUT> classArray;
+
+				try {
+					String componentClassName = componentInfo.getTypeClass().getName();
+					String resultingClassName;
+
+					if (componentClassName.startsWith("[")) {
+						resultingClassName = "[" + componentClassName;
+					} else {
+						resultingClassName = "[L" + componentClassName + ";";
+					}
+					classArray = (Class<OUT>) Class.forName(resultingClassName);
+				} catch (ClassNotFoundException e) {
+					throw new InvalidTypesException("Could not convert GenericArrayType to Class.");
+				}
+
+				return ObjectArrayTypeInfo.getInfoFor(classArray, componentInfo);
 			}
-			
-			TypeInformation<?> componentInfo = createTypeInfoWithTypeHierarchy(typeHierarchy, genericArray.getGenericComponentType(),
-					in1Type, in2Type);
-			return ObjectArrayTypeInfo.getInfoFor(t, componentInfo);
 		}
 		// objects with generics are treated as Class first
 		else if (t instanceof ParameterizedType) {
@@ -1188,7 +1209,13 @@ public class TypeExtractor {
 			
 			// object arrays
 			else {
-				return ObjectArrayTypeInfo.getInfoFor(clazz);
+				TypeInformation<?> componentTypeInfo = createTypeInfoWithTypeHierarchy(
+					typeHierarchy,
+					clazz.getComponentType(),
+					in1Type,
+					in2Type);
+
+				return ObjectArrayTypeInfo.getInfoFor(clazz, componentTypeInfo);
 			}
 		}
 		
@@ -1481,8 +1508,8 @@ public class TypeExtractor {
 	private static TypeInformation<?> getTypeOfPojoField(TypeInformation<?> pojoInfo, Field field) {
 		for (int j = 0; j < pojoInfo.getArity(); j++) {
 			PojoField pf = ((PojoTypeInfo<?>) pojoInfo).getPojoFieldAt(j);
-			if (pf.field.getName().equals(field.getName())) {
-				return pf.type;
+			if (pf.getField().getName().equals(field.getName())) {
+				return pf.getTypeInformation();
 			}
 		}
 		return null;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -38,7 +39,7 @@ public class CopyableValueSerializer<T extends CopyableValue<T>> extends TypeSer
 	
 	
 	public CopyableValueSerializer(Class<T> valueClass) {
-		this.valueClass = valueClass;
+		this.valueClass = Preconditions.checkNotNull(valueClass);
 	}
 
 	@Override
@@ -105,16 +106,24 @@ public class CopyableValueSerializer<T extends CopyableValue<T>> extends TypeSer
 	
 	@Override
 	public int hashCode() {
-		return this.valueClass.hashCode() + 9231;
+		return this.valueClass.hashCode();
 	}
 	
 	@Override
 	public boolean equals(Object obj) {
-		if (obj.getClass() == CopyableValueSerializer.class) {
-			CopyableValueSerializer<?> other = (CopyableValueSerializer<?>) obj;
-			return this.valueClass == other.valueClass;
+		if (obj instanceof CopyableValueSerializer) {
+			@SuppressWarnings("unchecked")
+			CopyableValueSerializer<T> copyableValueSerializer = (CopyableValueSerializer<T>) obj;
+
+			return copyableValueSerializer.canEqual(this) &&
+				valueClass == copyableValueSerializer.valueClass;
 		} else {
 			return false;
 		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof CopyableValueSerializer;
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/Tuple0Serializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/Tuple0Serializer.java
@@ -13,6 +13,7 @@
 package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
+
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple0;
 import org.apache.flink.core.memory.DataInputView;
@@ -94,12 +95,23 @@ public class Tuple0Serializer extends TupleSerializer<Tuple0> {
 
 	@Override
 	public int hashCode() {
-		return 1837461876;
+		return Tuple0Serializer.class.hashCode();
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		return obj == this || obj instanceof Tuple0Serializer;
+		if (obj instanceof Tuple0Serializer) {
+			Tuple0Serializer other = (Tuple0Serializer) obj;
+
+			return other.canEqual(this);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof Tuple0Serializer;
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -47,11 +48,7 @@ public class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 	// --------------------------------------------------------------------------------------------
 	
 	public ValueSerializer(Class<T> type) {
-		if (type == null) {
-			throw new NullPointerException();
-		}
-		
-		this.type = type;
+		this.type = Preconditions.checkNotNull(type);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -126,16 +123,22 @@ public class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 	
 	@Override
 	public int hashCode() {
-		return this.type.hashCode() + 17;
+		return this.type.hashCode();
 	}
 	
 	@Override
 	public boolean equals(Object obj) {
-		if (obj.getClass() == ValueSerializer.class) {
+		if (obj instanceof ValueSerializer) {
 			ValueSerializer<?> other = (ValueSerializer<?>) obj;
-			return this.type == other.type;
+
+			return other.canEqual(this) && type == other.type;
 		} else {
 			return false;
 		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof ValueSerializer;
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
@@ -121,16 +121,22 @@ public class WritableSerializer<T extends Writable> extends TypeSerializer<T> {
 	
 	@Override
 	public int hashCode() {
-		return this.typeClass.hashCode() + 177;
+		return this.typeClass.hashCode();
 	}
 	
 	@Override
 	public boolean equals(Object obj) {
-		if (obj.getClass() == WritableSerializer.class) {
+		if (obj instanceof WritableSerializer) {
 			WritableSerializer<?> other = (WritableSerializer<?>) obj;
-			return this.typeClass == other.typeClass;
+
+			return other.canEqual(this) && typeClass == other.typeClass;
 		} else {
 			return false;
 		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof WritableSerializer;
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class CollectionInputFormatTest {
 	
@@ -265,8 +266,8 @@ public class CollectionInputFormatTest {
 
 		private static final long serialVersionUID = 1L;
 		
-		private boolean failOnRead;
-		private boolean failOnWrite;
+		private final boolean failOnRead;
+		private final boolean failOnWrite;
 		
 		public TestSerializer(boolean failOnRead, boolean failOnWrite) {
 			this.failOnRead = failOnRead;
@@ -330,6 +331,27 @@ public class CollectionInputFormatTest {
 		@Override
 		public void copy(DataInputView source, DataOutputView target) throws IOException {
 			target.writeInt(source.readInt());
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof TestSerializer) {
+				TestSerializer other = (TestSerializer) obj;
+
+				return other.canEqual(this) && failOnRead == other.failOnRead && failOnWrite == other.failOnWrite;
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return obj instanceof TestSerializer;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(failOnRead, failOnWrite);
 		}
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/PojoTypeExtractionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/PojoTypeExtractionTest.java
@@ -336,37 +336,37 @@ public class PojoTypeExtractionTest {
 				tupleSeen = false, objectSeen = false, writableSeen = false, collectionSeen = false;
 		for(int i = 0; i < pojoTypeComplexNested.getArity(); i++) {
 			PojoField field = pojoTypeComplexNested.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("date")) {
 				if(dateSeen) {
 					Assert.fail("already seen");
 				}
 				dateSeen = true;
-				Assert.assertEquals(BasicTypeInfo.DATE_TYPE_INFO, field.type);
-				Assert.assertEquals(Date.class, field.type.getTypeClass());
+				Assert.assertEquals(BasicTypeInfo.DATE_TYPE_INFO, field.getTypeInformation());
+				Assert.assertEquals(Date.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("someNumberWithÜnicödeNäme")) {
 				if(intSeen) {
 					Assert.fail("already seen");
 				}
 				intSeen = true;
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.type);
-				Assert.assertEquals(Integer.class, field.type.getTypeClass());
+				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+				Assert.assertEquals(Integer.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("someFloat")) {
 				if(floatSeen) {
 					Assert.fail("already seen");
 				}
 				floatSeen = true;
-				Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, field.type);
-				Assert.assertEquals(Float.class, field.type.getTypeClass());
+				Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, field.getTypeInformation());
+				Assert.assertEquals(Float.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("word")) {
 				if(tupleSeen) {
 					Assert.fail("already seen");
 				}
 				tupleSeen = true;
-				Assert.assertTrue(field.type instanceof TupleTypeInfo<?>);
-				Assert.assertEquals(Tuple3.class, field.type.getTypeClass());
+				Assert.assertTrue(field.getTypeInformation() instanceof TupleTypeInfo<?>);
+				Assert.assertEquals(Tuple3.class, field.getTypeInformation().getTypeClass());
 				// do some more advanced checks on the tuple
-				TupleTypeInfo<?> tupleTypeFromComplexNested = (TupleTypeInfo<?>) field.type;
+				TupleTypeInfo<?> tupleTypeFromComplexNested = (TupleTypeInfo<?>) field.getTypeInformation();
 				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(0));
 				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(1));
 				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(2));
@@ -375,21 +375,21 @@ public class PojoTypeExtractionTest {
 					Assert.fail("already seen");
 				}
 				objectSeen = true;
-				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.type);
-				Assert.assertEquals(Object.class, field.type.getTypeClass());
+				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.getTypeInformation());
+				Assert.assertEquals(Object.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("hadoopCitizen")) {
 				if(writableSeen) {
 					Assert.fail("already seen");
 				}
 				writableSeen = true;
-				Assert.assertEquals(new WritableTypeInfo<MyWritable>(MyWritable.class), field.type);
-				Assert.assertEquals(MyWritable.class, field.type.getTypeClass());
+				Assert.assertEquals(new WritableTypeInfo<MyWritable>(MyWritable.class), field.getTypeInformation());
+				Assert.assertEquals(MyWritable.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("collection")) {
 				if(collectionSeen) {
 					Assert.fail("already seen");
 				}
 				collectionSeen = true;
-				Assert.assertEquals(new GenericTypeInfo(List.class), field.type);
+				Assert.assertEquals(new GenericTypeInfo(List.class), field.getTypeInformation());
 
 			} else {
 				Assert.fail("field "+field+" is not expected");
@@ -428,28 +428,28 @@ public class PojoTypeExtractionTest {
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeInformation;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("somethingFancy")) {
 				if(arrayListSeen) {
 					Assert.fail("already seen");
 				}
 				arrayListSeen = true;
-				Assert.assertTrue(field.type instanceof GenericTypeInfo);
-				Assert.assertEquals(ArrayList.class, field.type.getTypeClass());
+				Assert.assertTrue(field.getTypeInformation() instanceof GenericTypeInfo);
+				Assert.assertEquals(ArrayList.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("fancyIds")) {
 				if(multisetSeen) {
 					Assert.fail("already seen");
 				}
 				multisetSeen = true;
-				Assert.assertTrue(field.type instanceof GenericTypeInfo);
-				Assert.assertEquals(HashMultiset.class, field.type.getTypeClass());
+				Assert.assertTrue(field.getTypeInformation() instanceof GenericTypeInfo);
+				Assert.assertEquals(HashMultiset.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("fancyArray")) {
 				if(strArraySeen) {
 					Assert.fail("already seen");
 				}
 				strArraySeen = true;
-				Assert.assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, field.type);
-				Assert.assertEquals(String[].class, field.type.getTypeClass());
+				Assert.assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, field.getTypeInformation());
+				Assert.assertEquals(String[].class, field.getTypeInformation().getTypeClass());
 			} else if(Arrays.asList("date", "someNumberWithÜnicödeNäme", "someFloat", "word", "nothing", "hadoopCitizen", "collection").contains(name)) {
 				// ignore these, they are inherited from the ComplexNestedClass
 			}
@@ -479,13 +479,13 @@ public class PojoTypeExtractionTest {
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeInformation;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("special")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
 			} else if(name.equals("f0") || name.equals("f1")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
 			} else if(name.equals("f2")) {
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
 			} else {
 				Assert.fail("unexpected field");
 			}
@@ -499,15 +499,15 @@ public class PojoTypeExtractionTest {
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeForClass;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("field1")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("field2")) {
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("field3")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
 			} else {
 				Assert.fail("Unexpected field "+field);
 			}
@@ -525,13 +525,13 @@ public class PojoTypeExtractionTest {
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeForClass;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("field1")) {
-				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.type);
+				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.getTypeInformation());
 			} else if (name.equals("field2")) {
-				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.type);
+				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.getTypeInformation());
 			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
 			} else {
 				Assert.fail("Unexpected field "+field);
 			}
@@ -546,14 +546,14 @@ public class PojoTypeExtractionTest {
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeForClass;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("field1")) {
-				Assert.assertTrue(field.type instanceof PojoTypeInfo<?>); // From tuple is pojo (not tuple type!)
+				Assert.assertTrue(field.getTypeInformation() instanceof PojoTypeInfo<?>); // From tuple is pojo (not tuple type!)
 			} else if (name.equals("field2")) {
-				Assert.assertTrue(field.type instanceof TupleTypeInfo<?>);
-				Assert.assertTrue( ((TupleTypeInfo<?>)field.type).getTypeAt(0).equals(BasicTypeInfo.STRING_TYPE_INFO) );
+				Assert.assertTrue(field.getTypeInformation() instanceof TupleTypeInfo<?>);
+				Assert.assertTrue( ((TupleTypeInfo<?>)field.getTypeInformation()).getTypeAt(0).equals(BasicTypeInfo.STRING_TYPE_INFO) );
 			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
 			} else {
 				Assert.fail("Unexpected field "+field);
 			}
@@ -641,13 +641,13 @@ public class PojoTypeExtractionTest {
 		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
 		for(int i = 0; i < pti.getArity(); i++) {
 			PojoField field = pti.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("field1")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("field2")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
 			} else {
 				Assert.fail("Unexpected field "+field);
 			}
@@ -680,15 +680,15 @@ public class PojoTypeExtractionTest {
 		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
 		for(int i = 0; i < pti.getArity(); i++) {
 			PojoField field = pti.getPojoFieldAt(i);
-			String name = field.field.getName();
+			String name = field.getField().getName();
 			if(name.equals("extraField")) {
-				Assert.assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("f0")) {
-				Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("f1")) {
-				Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.getTypeInformation());
 			} else if (name.equals("f2")) {
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.type);
+				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
 			} else {
 				Assert.fail("Unexpected field "+field);
 			}
@@ -831,7 +831,7 @@ public class PojoTypeExtractionTest {
 	public void testRecursivePojo1() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(RecursivePojo1.class);
 		Assert.assertTrue(ti instanceof PojoTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).type.getClass());
+		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
 	@Test
@@ -839,8 +839,8 @@ public class PojoTypeExtractionTest {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(RecursivePojo2.class);
 		Assert.assertTrue(ti instanceof PojoTypeInfo);
 		PojoField pf = ((PojoTypeInfo) ti).getPojoFieldAt(0);
-		Assert.assertTrue(pf.type instanceof TupleTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((TupleTypeInfo) pf.type).getTypeAt(0).getClass());
+		Assert.assertTrue(pf.getTypeInformation() instanceof TupleTypeInfo);
+		Assert.assertEquals(GenericTypeInfo.class, ((TupleTypeInfo) pf.getTypeInformation()).getTypeAt(0).getClass());
 	}
 
 	@Test
@@ -848,8 +848,8 @@ public class PojoTypeExtractionTest {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(RecursivePojo3.class);
 		Assert.assertTrue(ti instanceof PojoTypeInfo);
 		PojoField pf = ((PojoTypeInfo) ti).getPojoFieldAt(0);
-		Assert.assertTrue(pf.type instanceof PojoTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pf.type).getPojoFieldAt(0).type.getClass());
+		Assert.assertTrue(pf.getTypeInformation() instanceof PojoTypeInfo);
+		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pf.getTypeInformation()).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
 	public static class FooBarPojo {

--- a/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/type/extractor/TypeExtractorTest.java
@@ -66,6 +66,8 @@ import org.apache.hadoop.io.Writable;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.xml.bind.TypeConstraintException;
+
 
 public class TypeExtractorTest {
 
@@ -1237,7 +1239,7 @@ public class TypeExtractorTest {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("org.apache.flink.api.java.type.extractor.TypeExtractorTest$CustomArrayObject[]"));
 
 		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
-		Assert.assertEquals(CustomArrayObject.class, ((ObjectArrayTypeInfo<?, ?>) ti).getComponentType());
+		Assert.assertEquals(CustomArrayObject.class, ((ObjectArrayTypeInfo<?, ?>) ti).getComponentInfo().getTypeClass());
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/EnumTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/EnumTypeInfoTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class EnumTypeInfoTest extends TestLogger {
+
+	enum TestEnum {
+		ONE, TWO
+	}
+
+	enum AlternativeEnum {
+		ONE, TWO
+	}
+
+	@Test
+	public void testEnumTypeEquality() {
+		EnumTypeInfo<TestEnum> enumTypeInfo1 = new EnumTypeInfo<TestEnum>(TestEnum.class);
+		EnumTypeInfo<TestEnum> enumTypeInfo2 = new EnumTypeInfo<TestEnum>(TestEnum.class);
+
+		assertEquals(enumTypeInfo1, enumTypeInfo2);
+		assertEquals(enumTypeInfo1.hashCode(), enumTypeInfo2.hashCode());
+	}
+
+	@Test
+	public void testEnumTypeInequality() {
+		EnumTypeInfo<TestEnum> enumTypeInfo1 = new EnumTypeInfo<TestEnum>(TestEnum.class);
+		EnumTypeInfo<AlternativeEnum> enumTypeInfo2 = new EnumTypeInfo<AlternativeEnum>(AlternativeEnum.class);
+
+		assertNotEquals(enumTypeInfo1, enumTypeInfo2);
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/GenericTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/GenericTypeInfoTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class GenericTypeInfoTest extends TestLogger {
+
+	static class TestClass {}
+	static class AlternativeClass {}
+
+	@Test
+	public void testGenericTypeInfoEquality() {
+		GenericTypeInfo<TestClass> tpeInfo1 = new GenericTypeInfo<>(TestClass.class);
+		GenericTypeInfo<TestClass> tpeInfo2 = new GenericTypeInfo<>(TestClass.class);
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testGenericTypeInfoInequality() {
+		GenericTypeInfo<TestClass> tpeInfo1 = new GenericTypeInfo<>(TestClass.class);
+		GenericTypeInfo<AlternativeClass> tpeInfo2 = new GenericTypeInfo<>(AlternativeClass.class);
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+	}
+
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/MissingTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/MissingTypeInfoTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MissingTypeInfoTest extends TestLogger {
+	static final String functionName = "foobar";
+	static final InvalidTypesException testException = new InvalidTypesException("Test exception.");
+
+	@Test
+	public void testMissingTypeInfoEquality() {
+		MissingTypeInfo tpeInfo1 = new MissingTypeInfo(functionName, testException);
+		MissingTypeInfo tpeInfo2 = new MissingTypeInfo(functionName, testException);
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testMissingTypeInfoInequality() {
+		MissingTypeInfo tpeInfo1 = new MissingTypeInfo(functionName, testException);
+		MissingTypeInfo tpeInfo2 = new MissingTypeInfo("alt" + functionName, testException);
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfoTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class ObjectArrayTypeInfoTest extends TestLogger {
+
+	public static class TestClass{}
+
+	@Test
+	public void testObjectArrayTypeInfoEquality() {
+		ObjectArrayTypeInfo<TestClass[], TestClass> tpeInfo1 = ObjectArrayTypeInfo.getInfoFor(
+			TestClass[].class,
+			new GenericTypeInfo<TestClass>(TestClass.class));
+
+		ObjectArrayTypeInfo<TestClass[], TestClass> tpeInfo2 = ObjectArrayTypeInfo.getInfoFor(
+			TestClass[].class,
+			new GenericTypeInfo<TestClass>(TestClass.class));
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testObjectArrayTypeInfoInequality() {
+		ObjectArrayTypeInfo<TestClass[], TestClass> tpeInfo1 = ObjectArrayTypeInfo.getInfoFor(
+			TestClass[].class,
+			new GenericTypeInfo<TestClass>(TestClass.class));
+
+		ObjectArrayTypeInfo<TestClass[], TestClass> tpeInfo2 = ObjectArrayTypeInfo.getInfoFor(
+			TestClass[].class,
+			new PojoTypeInfo<TestClass>(TestClass.class, new ArrayList<PojoField>()));
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
@@ -21,12 +21,15 @@ package org.apache.flink.api.java.typeutils;
 import static org.junit.Assert.*;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.InstantiationUtil;
 import org.junit.Test;
+
+import java.io.IOException;
 
 public class PojoTypeInfoTest {
 
 	@Test
-	public void testEquals() {
+	public void testPojoTypeInfoEquality() {
 		try {
 			TypeInformation<TestPojo> info1 = TypeExtractor.getForClass(TestPojo.class);
 			TypeInformation<TestPojo> info2 = TypeExtractor.getForClass(TestPojo.class);
@@ -42,6 +45,35 @@ public class PojoTypeInfoTest {
 			fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testPojoTypeInfoInequality() {
+		try {
+			TypeInformation<TestPojo> info1 = TypeExtractor.getForClass(TestPojo.class);
+			TypeInformation<AlternatePojo> info2 = TypeExtractor.getForClass(AlternatePojo.class);
+
+			assertTrue(info1 instanceof PojoTypeInfo);
+			assertTrue(info2 instanceof PojoTypeInfo);
+
+			assertFalse(info1.equals(info2));
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSerializabilityOfPojoTypeInfo() throws IOException, ClassNotFoundException {
+		PojoTypeInfo<TestPojo> pojoTypeInfo = (PojoTypeInfo<TestPojo>)TypeExtractor.getForClass(TestPojo.class);
+
+		byte[] serializedPojoTypeInfo = InstantiationUtil.serializeObject(pojoTypeInfo);
+		PojoTypeInfo<TestPojo> deserializedPojoTypeInfo = (PojoTypeInfo<TestPojo>)InstantiationUtil.deserializeObject(
+			serializedPojoTypeInfo,
+			getClass().getClassLoader());
+
+		assertEquals(pojoTypeInfo, deserializedPojoTypeInfo);
+	}
 	
 	public static final class TestPojo {
 		
@@ -56,6 +88,24 @@ public class PojoTypeInfoTest {
 			this.aString = aString;
 		}
 		
+		public String getaString() {
+			return aString;
+		}
+	}
+
+	public static final class AlternatePojo {
+
+		public int someInt;
+
+		private String aString;
+
+		public Double[] doubleArray;
+
+
+		public void setaString(String aString) {
+			this.aString = aString;
+		}
+
 		public String getaString() {
 			return aString;
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/RecordTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/RecordTypeInfoTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RecordTypeInfoTest extends TestLogger {
+
+	@Test
+	public void testRecordTypeInfoEquality() {
+		RecordTypeInfo tpeInfo1 = new RecordTypeInfo();
+		RecordTypeInfo tpeInfo2 = new RecordTypeInfo();
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testRecordTypeInfoInequality() {
+		RecordTypeInfo tpeInfo1 = new RecordTypeInfo();
+		MissingTypeInfo tpeInfo2 = new MissingTypeInfo("foobar");
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/TupleTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/TupleTypeInfoTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.TestLogger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TupleTypeInfoTest extends TestLogger {
+
+	@Test
+	public void testTupleTypeInfoSymmetricEqualityRelation() {
+		TupleTypeInfo<Tuple1<Integer>> tupleTypeInfo = new TupleTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO);
+
+		TupleTypeInfoBase<Tuple1> anonymousTupleTypeInfo = new TupleTypeInfoBase<Tuple1>(
+			(Class<Tuple1>)Tuple1.class,
+			(TypeInformation<?>)BasicTypeInfo.INT_TYPE_INFO) {
+
+			private static final long serialVersionUID = -7985593598027660836L;
+
+			@Override
+			public TypeSerializer<Tuple1> createSerializer(ExecutionConfig config) {
+				return null;
+			}
+
+			@Override
+			protected TypeComparatorBuilder<Tuple1> createTypeComparatorBuilder() {
+				return null;
+			}
+
+			@Override
+			public String[] getFieldNames() {
+				return new String[0];
+			}
+
+			@Override
+			public int getFieldIndex(String fieldName) {
+				return 0;
+			}
+		};
+
+		boolean tupleVsAnonymous = tupleTypeInfo.equals(anonymousTupleTypeInfo);
+		boolean anonymousVsTuple = anonymousTupleTypeInfo.equals(tupleTypeInfo);
+
+		Assert.assertTrue("Equality relation should be symmetric", tupleVsAnonymous == anonymousVsTuple);
+	}
+
+	@Test
+	public void testTupleTypeInfoEquality() {
+		TupleTypeInfo<Tuple2<Integer, String>> tupleTypeInfo1 = new TupleTypeInfo<>(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		TupleTypeInfo<Tuple2<Integer, String>> tupleTypeInfo2 = new TupleTypeInfo<>(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		Assert.assertEquals(tupleTypeInfo1, tupleTypeInfo2);
+		Assert.assertEquals(tupleTypeInfo1.hashCode(), tupleTypeInfo2.hashCode());
+	}
+
+	@Test
+	public void testTupleTypeInfoInequality() {
+		TupleTypeInfo<Tuple2<Integer, String>> tupleTypeInfo1 = new TupleTypeInfo<>(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO);
+
+		TupleTypeInfo<Tuple2<Integer, Boolean>> tupleTypeInfo2 = new TupleTypeInfo<>(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.BOOLEAN_TYPE_INFO);
+
+		Assert.assertNotEquals(tupleTypeInfo1, tupleTypeInfo2);
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoParserTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoParserTest.java
@@ -181,14 +181,14 @@ public class TypeInfoParserTest {
 				+ ">");
 		Assert.assertTrue(ti instanceof PojoTypeInfo);
 		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
-		Assert.assertEquals("array", pti.getPojoFieldAt(0).field.getName());
-		Assert.assertTrue(pti.getPojoFieldAt(0).type instanceof BasicArrayTypeInfo);
-		Assert.assertEquals("basic", pti.getPojoFieldAt(1).field.getName());
-		Assert.assertTrue(pti.getPojoFieldAt(1).type instanceof BasicTypeInfo);
-		Assert.assertEquals("hadoopCitizen", pti.getPojoFieldAt(2).field.getName());
-		Assert.assertTrue(pti.getPojoFieldAt(2).type instanceof WritableTypeInfo);
-		Assert.assertEquals("tuple", pti.getPojoFieldAt(3).field.getName());
-		Assert.assertTrue(pti.getPojoFieldAt(3).type instanceof TupleTypeInfo);
+		Assert.assertEquals("array", pti.getPojoFieldAt(0).getField().getName());
+		Assert.assertTrue(pti.getPojoFieldAt(0).getTypeInformation() instanceof BasicArrayTypeInfo);
+		Assert.assertEquals("basic", pti.getPojoFieldAt(1).getField().getName());
+		Assert.assertTrue(pti.getPojoFieldAt(1).getTypeInformation() instanceof BasicTypeInfo);
+		Assert.assertEquals("hadoopCitizen", pti.getPojoFieldAt(2).getField().getName());
+		Assert.assertTrue(pti.getPojoFieldAt(2).getTypeInformation() instanceof WritableTypeInfo);
+		Assert.assertEquals("tuple", pti.getPojoFieldAt(3).getField().getName());
+		Assert.assertTrue(pti.getPojoFieldAt(3).getTypeInformation() instanceof TupleTypeInfo);
 	}
 	
 	@Test
@@ -198,12 +198,12 @@ public class TypeInfoParserTest {
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
 		Assert.assertTrue(tti.getTypeAt(0) instanceof BasicTypeInfo);
 		Assert.assertTrue(tti.getTypeAt(1) instanceof TupleTypeInfo);
-		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>) tti.getTypeAt(1);
+		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>)(Object)tti.getTypeAt(1);
 		Assert.assertTrue(tti2.getTypeAt(0) instanceof BasicTypeInfo);
 		Assert.assertTrue(tti2.getTypeAt(1) instanceof PojoTypeInfo);
 		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) tti2.getTypeAt(1);
-		Assert.assertEquals("basic", pti.getPojoFieldAt(0).field.getName());
-		Assert.assertTrue(pti.getPojoFieldAt(0).type instanceof BasicTypeInfo);
+		Assert.assertEquals("basic", pti.getPojoFieldAt(0).getField().getName());
+		Assert.assertTrue(pti.getPojoFieldAt(0).getTypeInformation() instanceof BasicTypeInfo);
 	}
 	
 	public static class MyWritable implements Writable {
@@ -232,7 +232,7 @@ public class TypeInfoParserTest {
 		TypeInformation<?> ti = TypeInfoParser.parse("java.lang.Class[]");
 
 		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
-		Assert.assertEquals(Class.class, ((ObjectArrayTypeInfo<?, ?>) ti).getComponentType());
+		Assert.assertEquals(Class.class, ((ObjectArrayTypeInfo<?, ?>) ti).getComponentInfo().getTypeClass());
 		
 		TypeInformation<?> ti2 = TypeInfoParser.parse("Tuple2<Integer,Double>[]");
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/ValueTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/ValueTypeInfoTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.types.Record;
+import org.apache.flink.types.Value;
+import org.apache.flink.util.TestLogger;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class ValueTypeInfoTest extends TestLogger {
+
+	public static class TestClass implements Value {
+		private static final long serialVersionUID = -492760806806568285L;
+
+		@Override
+		public void write(DataOutputView out) throws IOException {
+
+		}
+
+		@Override
+		public void read(DataInputView in) throws IOException {
+
+		}
+	}
+
+	public static class AlternativeClass implements Value {
+
+		private static final long serialVersionUID = -163437084575260172L;
+
+		@Override
+		public void write(DataOutputView out) throws IOException {
+
+		}
+
+		@Override
+		public void read(DataInputView in) throws IOException {
+
+		}
+	}
+
+	@Test
+	public void testValueTypeInfoEquality() {
+		ValueTypeInfo<TestClass> tpeInfo1 = new ValueTypeInfo<>(TestClass.class);
+		ValueTypeInfo<TestClass> tpeInfo2 = new ValueTypeInfo<>(TestClass.class);
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testValueTyepInfoInequality() {
+		ValueTypeInfo<TestClass> tpeInfo1 = new ValueTypeInfo<>(TestClass.class);
+		ValueTypeInfo<AlternativeClass> tpeInfo2 = new ValueTypeInfo<>(AlternativeClass.class);
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+	}
+
+	@Test
+	public void testValueTypeEqualsWithNull() throws Exception {
+		ValueTypeInfo<Record> tpeInfo = new ValueTypeInfo<>(Record.class);
+
+		Assert.assertFalse(tpeInfo.equals(null));
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/WritableTypeInfoTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/WritableTypeInfoTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.util.TestLogger;
+import org.apache.hadoop.io.Writable;
+import org.junit.Test;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class WritableTypeInfoTest extends TestLogger {
+
+	public static class TestClass implements Writable {
+		@Override
+		public void write(DataOutput dataOutput) throws IOException {
+
+		}
+
+		@Override
+		public void readFields(DataInput dataInput) throws IOException {
+
+		}
+	}
+
+	public static class AlternateClass implements Writable {
+		@Override
+		public void write(DataOutput dataOutput) throws IOException {
+
+		}
+
+		@Override
+		public void readFields(DataInput dataInput) throws IOException {
+
+		}
+	}
+
+
+	@Test
+	public void testWritableTypeInfoEquality() {
+		WritableTypeInfo<TestClass> tpeInfo1 = new WritableTypeInfo<>(TestClass.class);
+		WritableTypeInfo<TestClass> tpeInfo2 = new WritableTypeInfo<>(TestClass.class);
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testWritableTypeInfoInequality() {
+		WritableTypeInfo<TestClass> tpeInfo1 = new WritableTypeInfo<>(TestClass.class);
+		WritableTypeInfo<AlternateClass> tpeInfo2 = new WritableTypeInfo<>(AlternateClass.class);
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
@@ -106,4 +106,25 @@ public class IntListSerializer extends TypeSerializer<IntList> {
 			target.writeInt(source.readInt());
 		}
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof IntListSerializer) {
+			IntListSerializer other = (IntListSerializer) obj;
+
+			return other.canEqual(this);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof IntListSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return IntListSerializer.class.hashCode();
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
@@ -88,6 +88,27 @@ public class IntPairSerializer extends TypeSerializer<IntPair> {
 		target.write(source, 8);
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof IntPairSerializer) {
+			IntPairSerializer other = (IntPairSerializer) obj;
+
+			return other.canEqual(this);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof IntPairSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return IntPairSerializer.class.hashCode();
+	}
+
 	public static final class IntPairSerializerFactory implements TypeSerializerFactory<IntPair> {
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
@@ -83,4 +83,25 @@ public class StringPairSerializer extends TypeSerializer<StringPair> {
 		StringValue.writeString(StringValue.readString(source), target);
 		StringValue.writeString(StringValue.readString(source), target);
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof StringPairSerializer) {
+			StringPairSerializer other = (StringPairSerializer) obj;
+
+			return other.canEqual(this);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof StringPairSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return StringPairSerializer.class.hashCode();
+	}
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -296,7 +296,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
                 "Field \"" + pojoFields(i) + "\" not part of POJO type " +
                   info.getTypeClass.getCanonicalName);
             }
-            classesBuf += info.getPojoFieldAt(pos).`type`.getTypeClass
+            classesBuf += info.getPojoFieldAt(pos).getTypeInformation().getTypeClass
           }
         }
       case _ => throw new IllegalArgumentException("Type information is not valid.")

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
@@ -121,7 +121,7 @@ private[flink] trait TypeInformationGen[C <: Context] {
             fieldSerializers(i) = types(i).createSerializer(executionConfig)
           }
 
-          new CaseClassSerializer[T](tupleType, fieldSerializers) {
+          new CaseClassSerializer[T](getTypeClass(), fieldSerializers) {
             override def createInstance(fields: Array[AnyRef]): T = {
               instance.splice
             }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
@@ -86,11 +86,20 @@ class EitherSerializer[A, B, T <: Either[A, B]](
   }
 
   override def equals(obj: Any): Boolean = {
-    if (obj != null && obj.isInstanceOf[EitherSerializer[_, _, _]]) {
-      val other = obj.asInstanceOf[EitherSerializer[_, _, _]]
-      other.leftSerializer.equals(leftSerializer) && other.rightSerializer.equals(rightSerializer)
-    } else {
-      false
+    obj match {
+      case eitherSerializer: EitherSerializer[_, _, _] =>
+        eitherSerializer.canEqual(this) &&
+        leftSerializer.equals(eitherSerializer.leftSerializer) &&
+        rightSerializer.equals(eitherSerializer.rightSerializer)
+      case _ => false
     }
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[EitherSerializer[_, _, _]]
+  }
+
+  override def hashCode(): Int = {
+    31 * leftSerializer.hashCode() + rightSerializer.hashCode()
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
@@ -27,9 +27,9 @@ import scala.collection.JavaConverters._
  * TypeInformation [[Either]].
  */
 class EitherTypeInfo[A, B, T <: Either[A, B]](
-    clazz: Class[T],
-    leftTypeInfo: TypeInformation[A],
-    rightTypeInfo: TypeInformation[B])
+    val clazz: Class[T],
+    val leftTypeInfo: TypeInformation[A],
+    val rightTypeInfo: TypeInformation[B])
   extends TypeInformation[T] {
 
   override def isBasicType: Boolean = false
@@ -53,6 +53,25 @@ class EitherTypeInfo[A, B, T <: Either[A, B]](
       new NothingSerializer
     }
     new EitherSerializer(leftSerializer, rightSerializer)
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case eitherTypeInfo: EitherTypeInfo[_, _, _] =>
+        eitherTypeInfo.canEqual(this) &&
+        clazz.equals(eitherTypeInfo.clazz) &&
+        leftTypeInfo.equals(eitherTypeInfo.leftTypeInfo) &&
+        rightTypeInfo.equals(eitherTypeInfo.rightTypeInfo)
+      case _ => false
+    }
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[EitherTypeInfo[_, _, _]]
+  }
+
+  override def hashCode(): Int = {
+    31 * (31 * clazz.hashCode() + leftTypeInfo.hashCode()) + rightTypeInfo.hashCode()
   }
 
   override def toString = s"Either[$leftTypeInfo, $rightTypeInfo]"

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
@@ -51,15 +51,18 @@ class EnumValueSerializer[E <: Enumeration](val enum: E) extends TypeSerializer[
   override def deserialize(reuse: T, source: DataInputView): T = deserialize(source)
 
   override def equals(obj: Any): Boolean = {
-    if (obj != null && obj.isInstanceOf[EnumValueSerializer[_]]) {
-      val other = obj.asInstanceOf[EnumValueSerializer[_]]
-      this.enum == other.enum
-    } else {
-      false
+    obj match {
+      case enumValueSerializer: EnumValueSerializer[_] =>
+        enumValueSerializer.canEqual(this) && enum == enumValueSerializer.enum
+      case _ => false
     }
   }
 
   override def hashCode(): Int = {
     enum.hashCode()
+  }
+
+  override def canEqual(obj: scala.Any): Boolean = {
+    obj.isInstanceOf[EnumValueSerializer[_]]
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 /**
  * TypeInformation for [[Enumeration]] values.
  */
-class EnumValueTypeInfo[E <: Enumeration](enum: E, clazz: Class[E#Value])
+class EnumValueTypeInfo[E <: Enumeration](val enum: E, val clazz: Class[E#Value])
   extends TypeInformation[E#Value] with AtomicType[E#Value] {
 
   type T = E#Value
@@ -49,4 +49,22 @@ class EnumValueTypeInfo[E <: Enumeration](enum: E, clazz: Class[E#Value])
   }
 
   override def toString = clazz.getCanonicalName
+
+  override def hashCode(): Int = {
+    31 * enum.hashCode() + clazz.hashCode()
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case enumValueTypeInfo: EnumValueTypeInfo[E] =>
+        enumValueTypeInfo.canEqual(this) &&
+          enum.equals(enumValueTypeInfo.enum) &&
+          clazz.equals(enumValueTypeInfo.clazz)
+      case _ => false
+    }
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[EnumValueTypeInfo[E]]
+  }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/NothingSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/NothingSerializer.scala
@@ -56,6 +56,17 @@ class NothingSerializer extends TypeSerializer[Any] {
     throw new RuntimeException("This must not be used. You encountered a bug.")
 
   override def equals(obj: Any): Boolean = {
-    obj != null && obj.isInstanceOf[NothingSerializer]
+    obj match {
+      case nothingSerializer: NothingSerializer => nothingSerializer.canEqual(this)
+      case _ => false
+    }
+  }
+
+  override def canEqual(obj: scala.Any): Boolean = {
+    obj.isInstanceOf[NothingSerializer]
+  }
+
+  override def hashCode(): Int = {
+    classOf[NothingSerializer].hashCode()
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
@@ -71,11 +71,18 @@ class OptionSerializer[A](val elemSerializer: TypeSerializer[A])
   override def deserialize(reuse: Option[A], source: DataInputView): Option[A] = deserialize(source)
 
   override def equals(obj: Any): Boolean = {
-    if (obj != null && obj.isInstanceOf[OptionSerializer[_]]) {
-      val other = obj.asInstanceOf[OptionSerializer[_]]
-      other.elemSerializer.equals(elemSerializer)
-    } else {
-      false
+    obj match {
+      case optionSerializer: OptionSerializer[_] =>
+        optionSerializer.canEqual(this) && elemSerializer.equals(optionSerializer.elemSerializer)
+      case _ => false
     }
+  }
+
+  override def canEqual(obj: scala.Any): Boolean = {
+    obj.isInstanceOf[OptionSerializer[_]]
+  }
+
+  override def hashCode(): Int = {
+    elemSerializer.hashCode()
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 /**
  * TypeInformation for [[Option]].
  */
-class OptionTypeInfo[A, T <: Option[A]](elemTypeInfo: TypeInformation[A])
+class OptionTypeInfo[A, T <: Option[A]](private val elemTypeInfo: TypeInformation[A])
   extends TypeInformation[T] {
 
   override def isBasicType: Boolean = false
@@ -49,4 +49,20 @@ class OptionTypeInfo[A, T <: Option[A]](elemTypeInfo: TypeInformation[A])
   }
 
   override def toString = s"Option[$elemTypeInfo]"
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case optTpe: OptionTypeInfo[_, _] =>
+        optTpe.canEqual(this) && elemTypeInfo.equals(optTpe.elemTypeInfo)
+      case _ => false
+    }
+  }
+
+  def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[OptionTypeInfo[_, _]]
+  }
+
+  override def hashCode: Int = {
+    elemTypeInfo.hashCode()
+  }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
@@ -134,11 +134,18 @@ abstract class TraversableSerializer[T <: TraversableOnce[E], E](
   }
 
   override def equals(obj: Any): Boolean = {
-    if (obj != null && obj.isInstanceOf[TraversableSerializer[_, _]]) {
-      val other = obj.asInstanceOf[TraversableSerializer[_, _]]
-      other.elementSerializer.equals(elementSerializer)
-    } else {
-      false
+    obj match {
+      case other: TraversableSerializer[_, _] =>
+        other.canEqual(this) && elementSerializer.equals(other.elementSerializer)
+      case _ => false
     }
+  }
+
+  override def hashCode(): Int = {
+    elementSerializer.hashCode()
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[TraversableSerializer[_, _]]
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
@@ -27,7 +27,9 @@ import scala.util.{Success, Try, Failure}
 /**
  * Serializer for [[scala.util.Try]].
  */
-class TrySerializer[A](val elemSerializer: TypeSerializer[A], executionConfig: ExecutionConfig)
+class TrySerializer[A](
+    private val elemSerializer: TypeSerializer[A],
+    private val executionConfig: ExecutionConfig)
   extends TypeSerializer[Try[A]] {
 
   override def duplicate: TrySerializer[A] = this
@@ -80,11 +82,18 @@ class TrySerializer[A](val elemSerializer: TypeSerializer[A], executionConfig: E
   override def deserialize(reuse: Try[A], source: DataInputView): Try[A] = deserialize(source)
 
   override def equals(obj: Any): Boolean = {
-    if (obj != null && obj.isInstanceOf[TrySerializer[_]]) {
-      val other = obj.asInstanceOf[TrySerializer[_]]
-      other.elemSerializer.equals(elemSerializer)
-    } else {
-      false
+    obj match {
+      case other: TrySerializer[_] =>
+        other.canEqual(this) && elemSerializer.equals(other.elemSerializer)
+      case _ => false
     }
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[TrySerializer[_]]
+  }
+
+  override def hashCode(): Int = {
+    31 * elemSerializer.hashCode() + executionConfig.hashCode()
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
@@ -28,7 +28,7 @@ import scala.util.Try
 /**
  * TypeInformation for [[scala.util.Try]].
  */
-class TryTypeInfo[A, T <: Try[A]](elemTypeInfo: TypeInformation[A])
+class TryTypeInfo[A, T <: Try[A]](val elemTypeInfo: TypeInformation[A])
   extends TypeInformation[T] {
 
   override def isBasicType: Boolean = false
@@ -47,6 +47,23 @@ class TryTypeInfo[A, T <: Try[A]](elemTypeInfo: TypeInformation[A])
       new TrySerializer(elemTypeInfo.createSerializer(executionConfig), executionConfig)
         .asInstanceOf[TypeSerializer[T]]
     }
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case tryTypeInfo: TryTypeInfo[_, _] =>
+        tryTypeInfo.canEqual(this) &&
+        elemTypeInfo.equals(tryTypeInfo.elemTypeInfo)
+      case _ => false
+    }
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[TryTypeInfo[_, _]]
+  }
+
+  override def hashCode(): Int = {
+    elemTypeInfo.hashCode()
   }
 
   override def toString = s"Try[$elemTypeInfo]"

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfoTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.util.TestLogger
+import org.junit.Test
+import org.scalatest.junit.JUnitSuiteLike
+
+class CaseClassTypeInfoTest extends TestLogger with JUnitSuiteLike {
+
+  @Test
+  def testCaseClassTypeInfoEquality(): Unit = {
+    val tpeInfo1 = new CaseClassTypeInfo[Tuple2[Int, String]](
+      classOf[Tuple2[Int, String]],
+      Array(),
+      Array(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO),
+      Array("_1", "_2")) {
+      override def createSerializer(config: ExecutionConfig): TypeSerializer[(Int, String)] = ???
+    }
+
+    val tpeInfo2 = new CaseClassTypeInfo[Tuple2[Int, String]](
+      classOf[Tuple2[Int, String]],
+      Array(),
+      Array(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO),
+      Array("_1", "_2")) {
+      override def createSerializer(config: ExecutionConfig): TypeSerializer[(Int, String)] = ???
+    }
+
+    assert(tpeInfo1.equals(tpeInfo2))
+    assert(tpeInfo1.hashCode() == tpeInfo2.hashCode())
+  }
+
+  @Test
+  def testCaseClassTypeInfoInequality(): Unit = {
+    val tpeInfo1 = new CaseClassTypeInfo[Tuple2[Int, String]](
+      classOf[Tuple2[Int, String]],
+      Array(),
+      Array(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO),
+      Array("_1", "_2")) {
+      override def createSerializer(config: ExecutionConfig): TypeSerializer[(Int, String)] = ???
+    }
+
+    val tpeInfo2 = new CaseClassTypeInfo[Tuple2[Int, Boolean]](
+      classOf[Tuple2[Int, Boolean]],
+      Array(),
+      Array(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.BOOLEAN_TYPE_INFO),
+      Array("_1", "_2")) {
+      override def createSerializer(config: ExecutionConfig): TypeSerializer[(Int, Boolean)] = ???
+    }
+
+    assert(!tpeInfo1.equals(tpeInfo2))
+  }
+
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfoTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.util.TestLogger
+import org.junit.Test
+import org.scalatest.junit.JUnitSuiteLike
+
+class EitherTypeInfoTest extends TestLogger with JUnitSuiteLike {
+
+  @Test
+  def testEitherTypeEquality(): Unit = {
+    val eitherTypeInfo1 = new EitherTypeInfo[Integer, String, Either[Integer, String]](
+      classOf[Either[Integer,String]],
+      BasicTypeInfo.INT_TYPE_INFO,
+      BasicTypeInfo.STRING_TYPE_INFO
+    )
+    val eitherTypeInfo2 = new EitherTypeInfo[Integer, String, Either[Integer, String]](
+      classOf[Either[Integer,String]],
+      BasicTypeInfo.INT_TYPE_INFO,
+      BasicTypeInfo.STRING_TYPE_INFO
+    )
+
+    assert(eitherTypeInfo1.equals(eitherTypeInfo2))
+    assert(eitherTypeInfo1.hashCode() == eitherTypeInfo2.hashCode())
+  }
+
+  @Test
+  def testEitherTypeInequality(): Unit = {
+    val eitherTypeInfo1 = new EitherTypeInfo[Integer, Integer, Either[Integer, Integer]](
+      classOf[Either[Integer,Integer]],
+      BasicTypeInfo.INT_TYPE_INFO,
+      BasicTypeInfo.INT_TYPE_INFO
+    )
+    val eitherTypeInfo2 = new EitherTypeInfo[Integer, String, Either[Integer, String]](
+      classOf[Either[Integer,String]],
+      BasicTypeInfo.INT_TYPE_INFO,
+      BasicTypeInfo.STRING_TYPE_INFO
+    )
+    assert(!eitherTypeInfo1.equals(eitherTypeInfo2))
+  }
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfoTest.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.scala.typeutils.AlternateEnumeration.AlternateEnumeration
+import org.apache.flink.api.scala.typeutils.TestEnumeration.TestEnumeration
+import org.apache.flink.util.TestLogger
+import org.junit.Test
+import org.scalatest.junit.JUnitSuiteLike
+
+class EnumValueTypeInfoTest extends TestLogger with JUnitSuiteLike {
+
+  @Test
+  def testEnumValueTypeInfoEquality(): Unit = {
+    val enumTypeInfo1 = new EnumValueTypeInfo[TestEnumeration.type](
+      TestEnumeration,
+      classOf[TestEnumeration])
+    val enumTypeInfo2 = new EnumValueTypeInfo[TestEnumeration.type](
+      TestEnumeration,
+      classOf[TestEnumeration])
+
+    assert(enumTypeInfo1.equals(enumTypeInfo2))
+    assert(enumTypeInfo1.hashCode() == enumTypeInfo2.hashCode())
+  }
+
+  @Test
+  def testEnumValueTypeInfoInequality(): Unit = {
+    val enumTypeInfo1 = new EnumValueTypeInfo[TestEnumeration.type](
+      TestEnumeration,
+      classOf[TestEnumeration])
+    val enumTypeInfo2 = new EnumValueTypeInfo[AlternateEnumeration.type](
+      AlternateEnumeration,
+      classOf[AlternateEnumeration])
+
+    assert(!enumTypeInfo1.equals(enumTypeInfo2))
+  }
+
+}
+
+object TestEnumeration extends Enumeration {
+  type TestEnumeration = Value
+  val ONE = this.Value
+}
+
+object AlternateEnumeration extends Enumeration {
+  type AlternateEnumeration = Value
+  val TWO = this.Value
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfoTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.java.typeutils.GenericTypeInfo
+import org.apache.flink.util.TestLogger
+import org.junit.Test
+import org.scalatest.junit.{JUnitSuiteLike, JUnitSuite}
+
+class OptionTypeInfoTest extends TestLogger with JUnitSuiteLike {
+
+  @Test
+  def testOptionTypeEquality: Unit = {
+    val optionTypeInfo1 = new OptionTypeInfo[Integer, Option[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+    val optionTypeInfo2 = new OptionTypeInfo[Integer, Option[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+
+    assert(optionTypeInfo1.equals(optionTypeInfo2))
+    assert(optionTypeInfo1.hashCode == optionTypeInfo2.hashCode)
+  }
+
+  @Test
+  def testOptionTypeInequality: Unit = {
+    val optionTypeInfo1 = new OptionTypeInfo[Integer, Option[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+    val optionTypeInfo2 = new OptionTypeInfo[String, Option[String]](BasicTypeInfo.STRING_TYPE_INFO)
+
+    assert(!optionTypeInfo1.equals(optionTypeInfo2))
+  }
+
+  @Test
+  def testOptionTypeInequalityWithDifferentType: Unit = {
+    val optionTypeInfo = new OptionTypeInfo[Integer, Option[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+    val genericTypeInfo = new GenericTypeInfo[Double](Double.getClass.asInstanceOf[Class[Double]])
+
+    assert(!optionTypeInfo.equals(genericTypeInfo))
+  }
+}
+

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfoTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.{TypeInformation, BasicTypeInfo}
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.util.TestLogger
+import org.junit.Test
+import org.scalatest.junit.JUnitSuiteLike
+
+class TraversableTypeInfoTest extends TestLogger with JUnitSuiteLike {
+
+  @Test
+  def testTraversableTypeInfoEquality(): Unit = {
+    val tpeInfo1 = new TraversableTypeInfo[Seq[Int], Int](
+      classOf[Seq[Int]],
+      BasicTypeInfo.INT_TYPE_INFO.asInstanceOf[TypeInformation[Int]]) {
+      override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[Seq[Int]] =
+        ???
+    }
+
+    val tpeInfo2 = new TraversableTypeInfo[Seq[Int], Int](
+      classOf[Seq[Int]],
+      BasicTypeInfo.INT_TYPE_INFO.asInstanceOf[TypeInformation[Int]]) {
+      override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[Seq[Int]] =
+        ???
+    }
+
+    assert(tpeInfo1.equals(tpeInfo2))
+  }
+
+  @Test
+  def testTraversableTypeInfoInequality(): Unit = {
+    val tpeInfo1 = new TraversableTypeInfo[Seq[Int], Int](
+      classOf[Seq[Int]],
+      BasicTypeInfo.INT_TYPE_INFO.asInstanceOf[TypeInformation[Int]]) {
+      override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[Seq[Int]] =
+        ???
+    }
+
+    val tpeInfo2 = new TraversableTypeInfo[List[Int], Int](
+      classOf[List[Int]],
+      BasicTypeInfo.INT_TYPE_INFO.asInstanceOf[TypeInformation[Int]]) {
+      override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[List[Int]] =
+        ???
+    }
+
+    assert(!tpeInfo1.equals(tpeInfo2))
+  }
+
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TryTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TryTypeInfoTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.java.typeutils.GenericTypeInfo
+import org.apache.flink.util.TestLogger
+import org.junit.Test
+import org.scalatest.junit.JUnitSuiteLike
+
+import scala.util.Try
+
+class TryTypeInfoTest extends TestLogger with JUnitSuiteLike {
+
+  @Test
+  def testTryTypeEquality: Unit = {
+    val TryTypeInfo1 = new TryTypeInfo[Integer, Try[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+    val TryTypeInfo2 = new TryTypeInfo[Integer, Try[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+
+    assert(TryTypeInfo1.equals(TryTypeInfo2))
+    assert(TryTypeInfo1.hashCode == TryTypeInfo2.hashCode)
+  }
+
+  @Test
+  def testTryTypeInequality: Unit = {
+    val TryTypeInfo1 = new TryTypeInfo[Integer, Try[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+    val TryTypeInfo2 = new TryTypeInfo[String, Try[String]](BasicTypeInfo.STRING_TYPE_INFO)
+
+    assert(!TryTypeInfo1.equals(TryTypeInfo2))
+  }
+
+  @Test
+  def testTryTypeInequalityWithDifferentType: Unit = {
+    val TryTypeInfo = new TryTypeInfo[Integer, Try[Integer]](BasicTypeInfo.INT_TYPE_INFO)
+    val genericTypeInfo = new GenericTypeInfo[Double](Double.getClass.asInstanceOf[Class[Double]])
+
+    assert(!TryTypeInfo.equals(genericTypeInfo))
+  }
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindowSerializer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindowSerializer.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.windowing;
 
 import java.io.IOException;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -37,6 +38,8 @@ public final class StreamWindowSerializer<T> extends TypeSerializer<StreamWindow
 	TypeSerializer<Boolean> boolSerializer = BooleanSerializer.INSTANCE;
 
 	public StreamWindowSerializer(TypeInformation<T> typeInfo, ExecutionConfig conf) {
+		Preconditions.checkNotNull(typeInfo);
+
 		this.typeSerializer = typeInfo.createSerializer(conf);
 	}
 
@@ -115,6 +118,27 @@ public final class StreamWindowSerializer<T> extends TypeSerializer<StreamWindow
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		serialize(deserialize(source), target);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof StreamWindowSerializer) {
+			StreamWindowSerializer<?> other = (StreamWindowSerializer<?>) obj;
+
+			return other.canEqual(this) && typeSerializer.equals(other.typeSerializer);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof StreamWindowSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return typeSerializer.hashCode();
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindowTypeInfo.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/windowing/StreamWindowTypeInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.windowing;
 
+import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -25,10 +26,11 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 public class StreamWindowTypeInfo<T> extends TypeInformation<StreamWindow<T>> {
 
 	private static final long serialVersionUID = 1L;
-	TypeInformation<T> innerType;
+
+	final TypeInformation<T> innerType;
 
 	public StreamWindowTypeInfo(TypeInformation<T> innerType) {
-		this.innerType = innerType;
+		this.innerType = Preconditions.checkNotNull(innerType);
 	}
 
 	public TypeInformation<T> getInnerType() {
@@ -50,10 +52,10 @@ public class StreamWindowTypeInfo<T> extends TypeInformation<StreamWindow<T>> {
 		return innerType.getArity();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public Class<StreamWindow<T>> getTypeClass() {
-		// TODO Auto-generated method stub
-		return null;
+		return (Class<StreamWindow<T>>)(Object)StreamWindow.class;
 	}
 
 	@Override
@@ -64,6 +66,34 @@ public class StreamWindowTypeInfo<T> extends TypeInformation<StreamWindow<T>> {
 	@Override
 	public TypeSerializer<StreamWindow<T>> createSerializer(ExecutionConfig conf) {
 		return new StreamWindowSerializer<T>(innerType, conf);
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "<" + innerType + ">";
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof StreamWindowTypeInfo) {
+			@SuppressWarnings("unchecked")
+			StreamWindowTypeInfo<T> streamWindowTypeInfo = (StreamWindowTypeInfo<T>) obj;
+
+			return streamWindowTypeInfo.canEqual(this) &&
+				innerType.equals(streamWindowTypeInfo.innerType);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return innerType.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof StreamWindowTypeInfo;
 	}
 
 	@Override

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/streamrecord/MultiplexingStreamRecordSerializer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/streamrecord/MultiplexingStreamRecordSerializer.java
@@ -164,4 +164,25 @@ public final class MultiplexingStreamRecordSerializer<T> extends TypeSerializer<
 			typeSerializer.copy(source, target);
 		}
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof MultiplexingStreamRecordSerializer) {
+			MultiplexingStreamRecordSerializer<?> other = (MultiplexingStreamRecordSerializer<?>) obj;
+
+			return other.canEqual(this) && typeSerializer.equals(other.typeSerializer);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof MultiplexingStreamRecordSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return typeSerializer.hashCode();
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecordSerializer.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecordSerializer.java
@@ -122,4 +122,25 @@ public final class StreamRecordSerializer<T> extends TypeSerializer<StreamRecord
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		typeSerializer.copy(source, target);
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof StreamRecordSerializer) {
+			StreamRecordSerializer<?> other = (StreamRecordSerializer<?>) obj;
+
+			return other.canEqual(this) && typeSerializer.equals(other.typeSerializer);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof StreamRecordSerializer;
+	}
+
+	@Override
+	public int hashCode() {
+		return typeSerializer.hashCode();
+	}
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/StreamWindowTypeInfoTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/windowing/StreamWindowTypeInfoTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing;
+
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.java.typeutils.PojoField;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class StreamWindowTypeInfoTest extends TestLogger {
+
+	public static class TestClass{}
+
+	@Test
+	public void testStreamWindowTypeInfoEquality() {
+		StreamWindowTypeInfo<TestClass> tpeInfo1 = new StreamWindowTypeInfo<>(new GenericTypeInfo<>(TestClass.class));
+		StreamWindowTypeInfo<TestClass> tpeInfo2 = new StreamWindowTypeInfo<>(new GenericTypeInfo<>(TestClass.class));
+
+		assertEquals(tpeInfo1, tpeInfo2);
+		assertEquals(tpeInfo1.hashCode(), tpeInfo2.hashCode());
+	}
+
+	@Test
+	public void testStreamWindowTypeInfoInequality() {
+		StreamWindowTypeInfo<TestClass> tpeInfo1 = new StreamWindowTypeInfo<>(new GenericTypeInfo<>(TestClass.class));
+		StreamWindowTypeInfo<TestClass> tpeInfo2 = new StreamWindowTypeInfo<>(new PojoTypeInfo<>(TestClass.class, new ArrayList<PojoField>()));
+
+		assertNotEquals(tpeInfo1, tpeInfo2);
+	}
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/typeinfo/RowSerializer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/typeinfo/RowSerializer.scala
@@ -28,7 +28,7 @@ import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 /**
  * Serializer for [[Row]].
  */
-class RowSerializer(fieldSerializers: Array[TypeSerializer[Any]])
+class RowSerializer(val fieldSerializers: Array[TypeSerializer[Any]])
   extends TypeSerializer[Row] {
 
   private def getFieldSerializers = fieldSerializers
@@ -150,9 +150,17 @@ class RowSerializer(fieldSerializers: Array[TypeSerializer[Any]])
   override def equals(any: scala.Any): Boolean = {
     any match {
       case otherRS: RowSerializer =>
-        val otherFieldSerializers = otherRS.getFieldSerializers.asInstanceOf[Array[AnyRef]]
-        util.Arrays.deepEquals(fieldSerializers.asInstanceOf[Array[AnyRef]], otherFieldSerializers)
+        otherRS.canEqual(this) &&
+        fieldSerializers.sameElements(otherRS.fieldSerializers)
       case _ => false
     }
+  }
+
+  override def canEqual(obj: scala.Any): Boolean = {
+    obj.isInstanceOf[RowSerializer]
+  }
+
+  override def hashCode(): Int = {
+    util.Arrays.hashCode(fieldSerializers.asInstanceOf[Array[AnyRef]])
   }
 }

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/PojoGroupingITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/PojoGroupingITCase.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.table.test;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.table.TableEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.table.Table;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class PojoGroupingITCase extends MultipleProgramsTestBase {
+
+	public PojoGroupingITCase(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testPojoGrouping() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Tuple3<String, Double, String>> data = env.fromElements(
+			new Tuple3<String, Double, String>("A", 23.0, "Z"),
+			new Tuple3<String, Double, String>("A", 24.0, "Y"),
+			new Tuple3<String, Double, String>("B", 1.0, "Z"));
+
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		Table table = tableEnv
+			.fromDataSet(data, "groupMe, value, name")
+			.select("groupMe, value, name")
+			.where("groupMe != 'B'");
+
+		DataSet<MyPojo> myPojos = tableEnv.toDataSet(table, MyPojo.class);
+
+		DataSet<MyPojo> result = myPojos.groupBy("groupMe")
+			.sortGroup("value", Order.DESCENDING)
+			.first(1);
+		List<MyPojo> resultList = result.collect();
+
+		compareResultAsText(resultList, "A,24.0,Y");
+	}
+
+	public static class MyPojo implements Serializable {
+		private static final long serialVersionUID = 8741918940120107213L;
+
+		public String groupMe;
+		public double value;
+		public String name;
+
+		public MyPojo() {
+			// for serialization
+		}
+
+		public MyPojo(String groupMe, double value, String name) {
+			this.groupMe = groupMe;
+			this.value = value;
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return groupMe + "," + value + "," + name;
+		}
+	}
+}

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RenamingProxyTypeInfoTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/typeinfo/RenamingProxyTypeInfoTest.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.typeinfo
+
+import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.util.TestLogger
+import org.junit.Test
+import org.scalatest.junit.JUnitSuiteLike
+
+class RenamingProxyTypeInfoTest extends TestLogger with JUnitSuiteLike {
+
+  @Test
+  def testRenamingProxyTypeEquality(): Unit = {
+    val pojoTypeInfo1 = TypeExtractor.createTypeInfo(classOf[TestPojo])
+      .asInstanceOf[CompositeType[TestPojo]]
+
+    val tpeInfo1 = new RenamingProxyTypeInfo[TestPojo](
+      pojoTypeInfo1,
+      Array("someInt", "aString", "doubleArray"))
+
+    val tpeInfo2 = new RenamingProxyTypeInfo[TestPojo](
+      pojoTypeInfo1,
+      Array("someInt", "aString", "doubleArray"))
+
+    assert(tpeInfo1.equals(tpeInfo2))
+    assert(tpeInfo1.hashCode() == tpeInfo2.hashCode())
+  }
+
+  @Test
+  def testRenamingProxyTypeInequality(): Unit = {
+    val pojoTypeInfo1 = TypeExtractor.createTypeInfo(classOf[TestPojo])
+      .asInstanceOf[CompositeType[TestPojo]]
+
+    val tpeInfo1 = new RenamingProxyTypeInfo[TestPojo](
+      pojoTypeInfo1,
+      Array("someInt", "aString", "doubleArray"))
+
+    val tpeInfo2 = new RenamingProxyTypeInfo[TestPojo](
+      pojoTypeInfo1,
+      Array("foobar", "aString", "doubleArray"))
+
+    assert(!tpeInfo1.equals(tpeInfo2))
+  }
+}
+
+final class TestPojo {
+  var someInt: Int = 0
+  private var aString: String = null
+  var doubleArray: Array[Double] = null
+
+  def setaString(aString: String) {
+    this.aString = aString
+  }
+
+  def getaString: String = {
+    return aString
+  }
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
@@ -340,7 +340,7 @@ class TypeInformationGenTest {
     Assert.assertTrue(ti.isInstanceOf[ObjectArrayTypeInfo[_, _]])
     Assert.assertEquals(
       classOf[CustomType],
-      ti.asInstanceOf[ObjectArrayTypeInfo[_, _]].getComponentType)
+      ti.asInstanceOf[ObjectArrayTypeInfo[_, _]].getComponentInfo.getTypeClass)
   }
 
   @Test


### PR DESCRIPTION
Adds abstract `equals`, `hashCode`, `canEqual` and `toString` methods to `TypeInformation`. Adds missing implementations to subtypes. The `canEqual(Object obj)` method returns true iff the `obj` can be equaled with the called instance.

Adds abstract `equals`, `hashCode` and `canEqual` methods to `TypeSerializer`.

Makes `CompositeType` subtypes serializable by removing non-serializable fields which were only used for the comparator construction. The comparator construction is now realized within a builder object which keeps the intermediate state. Consequently, the PR #943 is now obsolete and can be closed.  

Refactors the `ObjectArrayTypeInfo` so that the type extraction logic now happens within the `TypeExtractor` and no longer in the `TypeInformation` subtype.