### PR TITLE
[FLINK-2616] [test-stability] Hardens ZooKeeperLeaderElectionTest

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -89,6 +89,8 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 	@Override
 	public void nodeChanged() throws Exception {
 		try {
+			LOG.debug("Leader node has changed.");
+
 			ChildData childData = cache.getCurrentData();
 
 			String leaderAddress;
@@ -114,6 +116,11 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 
 			if(!(Objects.equals(leaderAddress, lastLeaderAddress) &&
 					Objects.equals(leaderSessionID, lastLeaderSessionID))) {
+				LOG.debug(
+					"New leader information: Leader={}, session ID={}.",
+					leaderAddress,
+					leaderSessionID);
+
 				lastLeaderAddress = leaderAddress;
 				lastLeaderSessionID = leaderSessionID;
 				leaderListener.notifyLeaderAddress(leaderAddress, leaderSessionID);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -25,7 +25,7 @@ import akka.actor.Props;
 import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
 import akka.util.Timeout;
-import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.TestingServer;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.StreamingMode;
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 public class JobManagerLeaderElectionTest extends TestLogger {
 
 	private static ActorSystem actorSystem;
-	private static TestingCluster testingCluster;
+	private static TestingServer testingServer;
 	private static Timeout timeout = new Timeout(TestingUtils.TESTING_DURATION());
 	private static FiniteDuration duration = new FiniteDuration(5, TimeUnit.MINUTES);
 
@@ -59,8 +59,7 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 	public static void setup() throws Exception {
 		actorSystem = ActorSystem.create("TestingActorSystem");
 
-		testingCluster = new TestingCluster(3);
-		testingCluster.start();
+		testingServer = new TestingServer();
 	}
 
 	@AfterClass
@@ -69,8 +68,8 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 			JavaTestKit.shutdownActorSystem(actorSystem);
 		}
 
-		if(testingCluster != null) {
-			testingCluster.stop();
+		if(testingServer != null) {
+			testingServer.stop();
 		}
 	}
 
@@ -83,8 +82,8 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 		configuration.setString(
-				ConfigConstants.ZOOKEEPER_QUORUM_KEY,
-				testingCluster.getConnectString());
+			ConfigConstants.ZOOKEEPER_QUORUM_KEY,
+			testingServer.getConnectString());
 
 		ActorRef jm = null;
 
@@ -114,8 +113,8 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 		configuration.setString(
-				ConfigConstants.ZOOKEEPER_QUORUM_KEY,
-				testingCluster.getConnectString());
+			ConfigConstants.ZOOKEEPER_QUORUM_KEY,
+			testingServer.getConnectString());
 
 		ActorRef jm;
 		ActorRef jm2 = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -24,7 +24,7 @@ import org.apache.curator.framework.api.ProtectACLCreateModePathAndBytesable;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.NodeCache;
 import org.apache.curator.framework.recipes.cache.NodeCacheListener;
-import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.TestingServer;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalService;
@@ -54,16 +54,14 @@ import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
 
 public class ZooKeeperLeaderElectionTest extends TestLogger {
-	private TestingCluster testingCluster;
+	private TestingServer testingServer;
 	private static final String TEST_URL = "akka//user/jobmanager";
-	private static final FiniteDuration timeout = new FiniteDuration(60000, TimeUnit.MILLISECONDS);
+	private static final FiniteDuration timeout = new FiniteDuration(200, TimeUnit.SECONDS);
 
 	@Before
 	public void before() {
-		testingCluster = new TestingCluster(3);
-
 		try {
-			testingCluster.start();
+			testingServer = new TestingServer();
 		} catch (Exception e) {
 			throw new RuntimeException("Could not start ZooKeeper testing cluster.", e);
 		}
@@ -72,12 +70,12 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 	@After
 	public void after() {
 		try {
-			testingCluster.stop();
+			testingServer.stop();
 		} catch (Exception e) {
 			throw new RuntimeException("Could not stop ZooKeeper testing cluster.", e);
 		}
 
-		testingCluster = null;
+		testingServer = null;
 	}
 
 	/**
@@ -86,7 +84,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 	@Test
 	public void testZooKeeperLeaderElectionRetrieval() throws Exception {
 		Configuration configuration = new Configuration();
-		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 
 		ZooKeeperLeaderElectionService leaderElectionService = null;
@@ -131,10 +129,10 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 	@Test
 	public void testZooKeeperReelection() throws Exception {
 		Configuration configuration = new Configuration();
-		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 
-		int num = 100;
+		int num = 50;
 
 		ZooKeeperLeaderElectionService[] leaderElectionService = new ZooKeeperLeaderElectionService[num];
 		TestingContender[] contenders = new TestingContender[num];
@@ -200,7 +198,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 	@Test
 	public void testZooKeeperReelectionWithReplacement() throws Exception {
 		Configuration configuration = new Configuration();
-		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 
 		int num = 3;
@@ -281,7 +279,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 		final String leaderPath = "/leader";
 
 		Configuration configuration = new Configuration();
-		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 		configuration.setString(ConfigConstants.ZOOKEEPER_LEADER_PATH, leaderPath);
 
@@ -359,7 +357,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 	@Test
 	public void testExceptionForwarding() throws Exception {
 		Configuration configuration = new Configuration();
-		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 
 		ZooKeeperLeaderElectionService leaderElectionService = null;
@@ -428,7 +426,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 	@Test
 	public void testEphemeralZooKeeperNodes() throws Exception {
 		Configuration configuration = new Configuration();
-		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		configuration.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 		configuration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
 
 		ZooKeeperLeaderElectionService leaderElectionService;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.TestingServer;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobmanager.JobManager;
@@ -45,13 +45,12 @@ import static org.junit.Assert.*;
 
 public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 
-	private TestingCluster testingCluster;
+	private TestingServer testingServer;
 
 	@Before
 	public void before() {
-		testingCluster = new TestingCluster(3);
 		try {
-			testingCluster.start();
+			testingServer = new TestingServer();
 		} catch (Exception e) {
 			throw new RuntimeException("Could not start ZooKeeper testing cluster.", e);
 		}
@@ -59,13 +58,13 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 
 	@After
 	public void after() {
-		if(testingCluster != null) {
+		if(testingServer != null) {
 			try {
-				testingCluster.stop();
+				testingServer.stop();
 			} catch (IOException e) {
 				throw new RuntimeException("Could not stop ZooKeeper testing cluster.", e);
 			}
-			testingCluster = null;
+			testingServer = null;
 		}
 	}
 
@@ -83,7 +82,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 		long sleepingTime = 1000;
 
 		config.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
-		config.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		config.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 
 		LeaderElectionService leaderElectionService = null;
 		LeaderElectionService faultyLeaderElectionService;
@@ -168,7 +167,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 	public void testTimeoutOfFindConnectingAddress() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
-		config.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingCluster.getConnectString());
+		config.setString(ConfigConstants.ZOOKEEPER_QUORUM_KEY, testingServer.getConnectString());
 
 		FiniteDuration timeout = new FiniteDuration(10, TimeUnit.SECONDS);
 

--- a/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
+++ b/flink-test-utils/src/main/scala/org/apache/flink/test/util/ForkableFlinkMiniCluster.scala
@@ -34,9 +34,8 @@ import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages
 .NotifyWhenRegisteredAtJobManager
 import org.apache.flink.runtime.testingUtils.{TestingUtils, TestingTaskManager,
 TestingJobManager, TestingMemoryArchivist}
-import org.apache.flink.runtime.webmonitor.WebMonitor
 
-import scala.concurrent.{Future, Promise, Await}
+import scala.concurrent.{Future, Await}
 
 /**
  * A forkable mini cluster is a special case of the mini cluster, used for parallel test execution

--- a/tools/log4j-travis.properties
+++ b/tools/log4j-travis.properties
@@ -37,3 +37,4 @@ log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m
 # suppress the irrelevant (wrong) warnings from the netty channel handler
 log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file
 log4j.logger.org.apache.zookeeper=ERROR, file
+log4j.logger.org.apache.zookeeper.server.quorum.QuorumCnxManager=OFF, file


### PR DESCRIPTION
Replaces Curator's TestingCluster with TestingServer in ZooKeeperElection/RetrievalTests. This should be more lightweight. Increased the timeout to 200s in ZooKeeperLeaderElectionTest.

Adds logging statements to ZooKeeperLeaderElection/RetrievalService.