### PR TITLE
[FLINK-2696] [test-stability] Hardens ZookeeperOffsetHandlerTest.runOffsetManipulationinZooKeeperTest

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -127,18 +127,15 @@ public abstract class KafkaTestBase extends TestLogger {
 			assertTrue("cannot create kafka temp dir", tmpDir.mkdir());
 			tmpKafkaDirs.add(tmpDir);
 		}
-
-
-		int zkPort = NetUtils.getAvailablePort();
-		zookeeperConnectionString = "localhost:" + zkPort;
-
+		
 		zookeeper = null;
 		brokers = null;
 
 		try {
 			LOG.info("Starting Zookeeper");
-			zookeeper = new TestingServer(zkPort, tmpZkDir);
-			
+			zookeeper = new TestingServer(-1, tmpZkDir);
+			zookeeperConnectionString = zookeeper.getConnectString();
+
 			LOG.info("Starting KafkaServer");
 			brokers = new ArrayList<>(NUMBER_OF_KAFKA_SERVERS);
 			


### PR DESCRIPTION
The test case `ZookeeperOffsetHandlerTest.runOffsetManipulationinZooKeeperTest` failed, because the ZooKeeper client could not connect to the ZooKeeper server. I suspect that this might be caused by contention of multiple test cases for the same port to bind to. Internally, Curator's `TestingServer` is started with a port which has been determined using `NetUtils.getAvailablePort`. Since the port is not directly bound, it is possible that another process uses the determined port and, thus, preventing the `TestingServer` from starting. 