### PR TITLE
[FLINK-2713] [streaming] Include custom StateCheckpointers in the snapshots

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateCheckpointer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateCheckpointer.java
@@ -40,7 +40,7 @@ import java.io.Serializable;
  * @param <C>
  *            Type of the snapshot that will be persisted.
  */
-public interface StateCheckpointer<S, C extends Serializable> {
+public interface StateCheckpointer<S, C extends Serializable> extends Serializable {
 
 	/**
 	 * Takes a snapshot of a given operator state. The snapshot returned will be

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/OperatorStateHandle.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/OperatorStateHandle.java
@@ -27,10 +27,12 @@ public class OperatorStateHandle implements StateHandle<Serializable> {
 	
 	private final StateHandle<Serializable> handle;
 	private final boolean isPartitioned;
+	private final byte[] serializedCheckpointer;
 	
-	public OperatorStateHandle(StateHandle<Serializable> handle, boolean isPartitioned){
+	public OperatorStateHandle(StateHandle<Serializable> handle, boolean isPartitioned, byte[] serializedCheckpointer){
 		this.handle = handle;
 		this.isPartitioned = isPartitioned;
+		this.serializedCheckpointer = serializedCheckpointer;
 	}
 	
 	public boolean isPartitioned(){
@@ -49,6 +51,10 @@ public class OperatorStateHandle implements StateHandle<Serializable> {
 	
 	public StateHandle<Serializable> getHandle() {
 		return handle;
+	}
+	
+	public byte[] getSerializedCheckpointer() {
+		return serializedCheckpointer;
 	}
 
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/PartitionedStreamOperatorState.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/PartitionedStreamOperatorState.java
@@ -143,6 +143,12 @@ public class PartitionedStreamOperatorState<IN, S, C extends Serializable> exten
 	public Map<Serializable, S> getPartitionedState() throws Exception {
 		return stateStore.getPartitionedState();
 	}
+	
+	@Override
+	public void setCheckpointer(StateCheckpointer<S, C> checkpointer) {
+		super.setCheckpointer(checkpointer);
+		stateStore.setCheckPointer(checkpointer);
+	}
 
 	@Override
 	public String toString() {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/state/StateHandleTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/state/StateHandleTest.java
@@ -44,7 +44,7 @@ public class StateHandleTest {
 
 		MockHandle<Serializable> h1 = new MockHandle<Serializable>(1);
 
-		OperatorStateHandle opHandle = new OperatorStateHandle(h1, true);
+		OperatorStateHandle opHandle = new OperatorStateHandle(h1, true, null);
 		assertEquals(1, opHandle.getState(this.getClass().getClassLoader()));
 
 		OperatorStateHandle dsHandle = serializeDeserialize(opHandle);
@@ -66,8 +66,8 @@ public class StateHandleTest {
 		MockHandle<Serializable> h2 = new MockHandle<Serializable>(2);
 		StateHandle<Serializable> h3 = new MockHandle<Serializable>(3);
 
-		OperatorStateHandle opH1 = new OperatorStateHandle(h1, true);
-		OperatorStateHandle opH2 = new OperatorStateHandle(h2, false);
+		OperatorStateHandle opH1 = new OperatorStateHandle(h1, true, null);
+		OperatorStateHandle opH2 = new OperatorStateHandle(h2, false, null);
 
 		Map<String, OperatorStateHandle> opHandles = ImmutableMap.of("h1", opH1, "h2", opH2);
 

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/state/StatefulOperatorTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/state/StatefulOperatorTest.java
@@ -227,7 +227,7 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 
 		@Override
 		public void open(Configuration conf) throws IOException {
-			counter = getRuntimeContext().getOperatorState("counter", 0, false);
+			counter = getRuntimeContext().getOperatorState("counter", 0, false, intCheckpointer);
 			groupCounter = getRuntimeContext().getOperatorState("groupCounter", new MutableInt(0), true);
 			concat = getRuntimeContext().getOperatorState("concat", "", false);
 			try {
@@ -279,19 +279,7 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 
 		@Override
 		public void open(Configuration conf) throws IOException {
-			groupCounter = getRuntimeContext().getOperatorState("groupCounter", 0, true,
-					new StateCheckpointer<Integer, String>() {
-
-						@Override
-						public String snapshotState(Integer state, long checkpointId, long checkpointTimestamp) {
-							return state.toString();
-						}
-
-						@Override
-						public Integer restoreState(String stateSnapshot) {
-							return Integer.parseInt(stateSnapshot);
-						}
-					});
+			groupCounter = getRuntimeContext().getOperatorState("groupCounter", 0, true, intCheckpointer);
 		}
 
 		@SuppressWarnings("unchecked")
@@ -308,6 +296,21 @@ public class StatefulOperatorTest extends StreamingMultipleProgramsTestBase {
 		}
 
 	}
+	
+	public static StateCheckpointer<Integer, String> intCheckpointer = new StateCheckpointer<Integer, String>() {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String snapshotState(Integer state, long checkpointId, long checkpointTimestamp) {
+			return state.toString();
+		}
+
+		@Override
+		public Integer restoreState(String stateSnapshot) {
+			return Integer.parseInt(stateSnapshot);
+		}
+	};
 
 	public static class PStateKeyRemovalTestMapper extends RichMapFunction<Integer, String> {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.checkpointing;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.StateCheckpointer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -308,7 +309,20 @@ public class StreamCheckpointingITCase extends StreamFaultToleranceTestBase {
 		
 		@Override
 		public void open(Configuration conf) throws IOException {
-			this.count = getRuntimeContext().getOperatorState("count", 0L, false);
+			this.count = getRuntimeContext().getOperatorState("count", 0L, false,
+					new StateCheckpointer<Long, String>() {
+
+						@Override
+						public String snapshotState(Long state, long id, long ts) {
+							return state.toString();
+						}
+
+						@Override
+						public Long restoreState(String stateSnapshot) {
+							return Long.parseLong(stateSnapshot);
+						}
+
+					});
 		}
 
 		@Override


### PR DESCRIPTION
Currently failure recovery fails when using custom StateCheckpointers because they are not correctly set before trying to restore the operator initial state. This PR solves this issue by including custom StateCheckpointers in the snapshot.

The current order of events and the problem:
 1. Create StreamTask
 2. Call restoreInitialState(snapshot) -> default java-serialization StateCheckpointer is used
 3. Open UDF and run computation. -> This is the point when custom StateCheckpointers are set
 4. Take snapshots....

We can see while the custom StateCheckpointers are available and work for taking snapshots they are not set set yet when call restore which obviously leads to error.

This PR now includes the custom StateCheckpointer in the snapshot so we can set it in step 2. before calling restore. An optimization is that we include only the serialized version as a byte array in the buffer so we don't need to serialize it over and over again.

The PR also extends the StreamCheckpointingITCase and the PartitionedStateCheckpointingITCase to include a case for custom StateCheckpointers for both local and partitioned OperatorStates.