### PR TITLE
[FLINK-2713] [streaming] Set state restore to lazy to avoid StateCheckpointer issues and reduce checkpoint overhead

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.checkpointing;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.StateCheckpointer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -308,7 +309,20 @@ public class StreamCheckpointingITCase extends StreamFaultToleranceTestBase {
 		
 		@Override
 		public void open(Configuration conf) throws IOException {
-			this.count = getRuntimeContext().getOperatorState("count", 0L, false);
+			this.count = getRuntimeContext().getOperatorState("count", 0L, false,
+					new StateCheckpointer<Long, String>() {
+
+						@Override
+						public String snapshotState(Long state, long id, long ts) {
+							return state.toString();
+						}
+
+						@Override
+						public Long restoreState(String stateSnapshot) {
+							return Long.parseLong(stateSnapshot);
+						}
+
+					});
 		}
 
 		@Override


### PR DESCRIPTION
Currently failure recovery fails when using custom StateCheckpointers because they are not correctly set before trying to restore the operator initial state. This PR solves this issue by making state restore lazy (only happens if the user wants to access the value of the state)

The current order of events and the problem:
 1. Create StreamTask
 2. Call restoreInitialState(snapshot) -> default java-serialization StateCheckpointer is used
 2. Open UDF and run computation. -> This is the point when custom StateCheckpointers are set
 2. Take snapshots....
We can see while the custom StateCheckpointers are available and work for taking snapshots they are not set set yet when call restore which obviously leads to error.

The change is:
 1. Create StreamTask
 2. Call restoreInitialState(snapshot) -> state is not restored yet, but a flag is set
 3. Open UDF and run computation. -> This is the point when custom StateCheckpointers are set
 4. The state is restored when the user accesses the value
 5. Take snapshots... (just return the last checkpoint if not restored yet)

The PR also extends the StreamCheckpointingITCase and the PartitionedStateCheckpointingITCase to include a case for custom StateCheckpointers for both local and partitioned OperatorStates.