### PR TITLE
[FLINK-2720][storm-compatibility]Add Storm-CountMetric for storm metrics

### DIFF
--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/metrics/FlinkCountMetric.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/api/metrics/FlinkCountMetric.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.stormcompatibility.api.metrics;
+
+import backtype.storm.metric.api.CountMetric;
+import org.apache.flink.api.common.accumulators.LongCounter;
+
+/**
+ * The wrapper for using {@link backtype.storm.metric.api.CountMetric}
+ */
+public class FlinkCountMetric extends CountMetric {
+
+	private LongCounter longCounter;
+
+	public FlinkCountMetric () {
+	}
+
+	public void setCounter (LongCounter longCounter) {
+		this.longCounter = longCounter;
+	}
+
+	@Override
+	public void incr() {
+		incrBy(1);
+	}
+
+	@Override
+	public void incrBy(long incrementBy) {
+		this.longCounter.add(incrementBy);
+	}
+
+	@Override
+	public Object getValueAndReset() {
+		long ret = this.longCounter.getLocalValue();
+		this.longCounter.resetLocal();
+		return ret;
+	}
+}

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormWrapperSetupHelper.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/main/java/org/apache/flink/stormcompatibility/wrappers/StormWrapperSetupHelper.java
@@ -104,7 +104,10 @@ class StormWrapperSetupHelper {
 			bolts.put(context.getTaskName(), new Bolt(null, common));
 		}
 
-		return new FlinkTopologyContext(new StormTopology(spoutSpecs, bolts, null), taskToComponents, taskId);
+		FlinkTopologyContext flinkContext = new FlinkTopologyContext(new StormTopology(spoutSpecs, bolts, null), taskToComponents, taskId);
+
+		flinkContext.setContext(context);
+		return flinkContext;
 	}
 
 }

--- a/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/test/java/org/apache/flink/stormcompatibility/api/metrics/FlinkCountMetricTest.java
+++ b/flink-contrib/flink-storm-compatibility/flink-storm-compatibility-core/src/test/java/org/apache/flink/stormcompatibility/api/metrics/FlinkCountMetricTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.stormcompatibility.api.metrics;
+
+import org.apache.flink.api.common.accumulators.LongCounter;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class FlinkCountMetricTest {
+
+	@Test
+	public void testAll() {
+		LongCounter longCounter = new LongCounter();
+		FlinkCountMetric flinkCount = new FlinkCountMetric();
+		flinkCount.setCounter(longCounter);
+		flinkCount.incr();
+		assertEquals(1L, flinkCount.getValueAndReset());
+		flinkCount.incrBy(1);
+		assertEquals(1L, flinkCount.getValueAndReset());
+		assertEquals(0L, flinkCount.getValueAndReset());
+	}
+}


### PR DESCRIPTION
I added the Storm-CountMetric for the first step about storm metrics.
1.Do a wrapper `FlinkCountMetric` for the CountMetric.
2.There is a real metric LongCounter in FlinkCountMetric class.
3.Push the RuntimeContext in `FlinkTopologyContext` for registering the metric.
4.Add a simple ut for the  `FlinkCountMetric` .