### PR TITLE
[FLINK-2722] Use InetAddress.getLocalHost() as first approach when detecting the TMs own ip/hostname

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/NetUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/NetUtils.java
@@ -193,6 +193,8 @@ public class NetUtils {
 			if(tryToConnect(localhostName, targetAddress, strategy.getTimeout(), logging)) {
 				LOG.debug("Using InetAddress.getLocalHost() immediately for the connecting address");
 				return localhostName;
+			} else {
+				return null;
 			}
 		}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnCluster.java
@@ -140,7 +140,9 @@ public class FlinkYarnCluster extends AbstractFlinkYarnCluster {
 
 		// start actor system
 		LOG.info("Start actor system.");
-		InetAddress ownHostname = NetUtils.resolveAddress(jobManagerAddress); // find name of own public interface, able to connect to the JM
+		// find name of own public interface, able to connect to the JM
+		// try to find address for 2 seconds. log after 400 ms.
+		InetAddress ownHostname = NetUtils.findConnectingAddress(jobManagerAddress, 2000, 400);
 		actorSystem = AkkaUtils.createActorSystem(flinkConfig,
 				new Some(new Tuple2<String, Integer>(ownHostname.getCanonicalHostName(), 0)));
 


### PR DESCRIPTION
A user reported a connection issue with Netty being unable to connect to a TaskManager to subscribe to an intermediate result.
The problem occurred when the TaskManager and JobManager were running on the same host (something that can easily happen on YARN).
In that case, the TaskManager was reporting a host-local ip address to the JobManager when connecting.

To avoid the issue in the future, the TaskManager first tries to use the hostname returned by InetAddress.getLocalHost(). In a properly set-up environment, this will return a connection which is accessible by all machines in a cluster.

I tested this implementation on a cluster in GCE using YARN (note that I was not able to reproduce the issue originally reported, but the user reported that the issue has been fixed)

I would really like to include this fix into the **0.10-milestone-1** release!