### PR TITLE
[FLINK-2479] Refactor runtime.operators.* tests

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
@@ -84,10 +84,10 @@ public class NonReusingHashMatchIteratorITCase {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.recordSerializer = TestData.getTupleSerializer();
+		this.recordSerializer = TestData.getIntStringTupleSerializer();
 		
-		this.record1Comparator = TestData.getTupleComparator();
-		this.record2Comparator = TestData.getTupleComparator();
+		this.record1Comparator = TestData.getIntStringTupleComparator();
+		this.record2Comparator = TestData.getIntStringTupleComparator();
 		
 		this.recordPairComparator = new GenericPairComparator(record1Comparator, record2Comparator);
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
@@ -19,15 +19,10 @@
 
 package org.apache.flink.runtime.operators.hash;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializer;
-import org.apache.flink.api.java.record.functions.JoinFunction;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -35,18 +30,14 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.runtime.operators.testutils.UniformIntPairGenerator;
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.runtime.operators.testutils.types.IntPair;
-import org.apache.flink.runtime.operators.testutils.types.IntPairComparator;
 import org.apache.flink.runtime.operators.testutils.types.IntPairSerializer;
-import org.apache.flink.types.IntValue;
 import org.apache.flink.types.NullKeyFieldException;
-import org.apache.flink.types.Record;
-import org.apache.flink.types.Value;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.After;
@@ -60,6 +51,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.apache.flink.api.common.typeutils.GenericPairComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
 
 @SuppressWarnings({"serial", "deprecation"})
 public class NonReusingHashMatchIteratorITCase {
@@ -77,29 +70,29 @@ public class NonReusingHashMatchIteratorITCase {
 	private IOManager ioManager;
 	private MemoryManager memoryManager;
 	
-	private TypeSerializer<Record> recordSerializer;
-	private TypeComparator<Record> record1Comparator;
-	private TypeComparator<Record> record2Comparator;
-	private TypePairComparator<Record, Record> recordPairComparator;
+	private TypeSerializer<Tuple2<Integer, String>> recordSerializer;
+	private TypeComparator<Tuple2<Integer, String>> record1Comparator;
+	private TypeComparator<Tuple2<Integer, String>> record2Comparator;
+	private TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> recordPairComparator;
 	
 	private TypeSerializer<IntPair> pairSerializer;
 	private TypeComparator<IntPair> pairComparator;
-	private TypePairComparator<IntPair, Record> pairRecordPairComparator;
-	private TypePairComparator<Record, IntPair> recordPairPairComparator;
+	private TypePairComparator<IntPair, Tuple2<Integer, String>> pairRecordPairComparator;
+	private TypePairComparator<Tuple2<Integer, String>, IntPair> recordPairPairComparator;
 
 
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.recordSerializer = RecordSerializer.get();
+		this.recordSerializer = TestData.getTupleSerializer();
 		
-		this.record1Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
-		this.record2Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
+		this.record1Comparator = TestData.getTupleComparator();
+		this.record2Comparator = TestData.getTupleComparator();
 		
-		this.recordPairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {TestData.Key.class});
+		this.recordPairComparator = new GenericPairComparator(record1Comparator, record2Comparator);
 		
 		this.pairSerializer = new IntPairSerializer();
-		this.pairComparator = new IntPairComparator();
+		this.pairComparator = new TestData.IntPairComparator();
 		this.pairRecordPairComparator = new IntPairRecordPairComparator();
 		this.recordPairPairComparator = new RecordIntPairPairComparator();
 		
@@ -129,19 +122,19 @@ public class NonReusingHashMatchIteratorITCase {
 	@Test
 	public void testBuildFirst() {
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator1 = new TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<Tuple2<Integer, String>>();
 	
 			// reset the generators
 			generator1.reset();
@@ -150,8 +143,8 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			NonReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
-					new NonReusingBuildFirstHashMatchIterator<Record, Record, Record>(
+			NonReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildFirstHashMatchIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 						this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -163,7 +156,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -187,29 +180,29 @@ public class NonReusingHashMatchIteratorITCase {
 		final int DUPLICATE_KEY = 13;
 		
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator1 = new TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator gen1Iter = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator gen2Iter = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator gen1Iter = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator gen2Iter = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
-			final TestData.ConstantValueIterator const1Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
-			final TestData.ConstantValueIterator const2Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
+			final TestData.TupleConstantValueIterator const1Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
+			final TestData.TupleConstantValueIterator const2Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
 			
-			final List<MutableObjectIterator<Record>> inList1 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList1 = new ArrayList<>();
 			inList1.add(gen1Iter);
 			inList1.add(const1Iter);
 			
-			final List<MutableObjectIterator<Record>> inList2 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList2 = new ArrayList<>();
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 			
-			MutableObjectIterator<Record> input1 = new UnionIterator<Record>(inList1);
-			MutableObjectIterator<Record> input2 = new UnionIterator<Record>(inList2);
+			MutableObjectIterator<Tuple2<Integer, String>> input1 = new UnionIterator<>(inList1);
+			MutableObjectIterator<Tuple2<Integer, String>> input2 = new UnionIterator<>(inList2);
 			
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
@@ -231,14 +224,14 @@ public class NonReusingHashMatchIteratorITCase {
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 	
-			input1 = new UnionIterator<Record>(inList1);
-			input2 = new UnionIterator<Record>(inList2);
+			input1 = new UnionIterator<>(inList1);
+			input2 = new UnionIterator<>(inList2);
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
-			NonReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
-					new NonReusingBuildFirstHashMatchIterator<Record, Record, Record>(
+			NonReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildFirstHashMatchIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 						this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -250,7 +243,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -265,19 +258,19 @@ public class NonReusingHashMatchIteratorITCase {
 	@Test
 	public void testBuildSecond() {
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator1 = new TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
 			generator1.reset();
@@ -286,8 +279,8 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values			
-			NonReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
-				new NonReusingBuildSecondHashMatchIterator<Record, Record, Record>(
+			NonReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new NonReusingBuildSecondHashMatchIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -299,7 +292,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -323,29 +316,29 @@ public class NonReusingHashMatchIteratorITCase {
 		final int DUPLICATE_KEY = 13;
 		
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator1 = new TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator gen1Iter = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator gen2Iter = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator gen1Iter = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator gen2Iter = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
-			final TestData.ConstantValueIterator const1Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
-			final TestData.ConstantValueIterator const2Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
+			final TestData.TupleConstantValueIterator const1Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
+			final TestData.TupleConstantValueIterator const2Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
 			
-			final List<MutableObjectIterator<Record>> inList1 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList1 = new ArrayList<>();
 			inList1.add(gen1Iter);
 			inList1.add(const1Iter);
 			
-			final List<MutableObjectIterator<Record>> inList2 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList2 = new ArrayList<>();
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 			
-			MutableObjectIterator<Record> input1 = new UnionIterator<Record>(inList1);
-			MutableObjectIterator<Record> input2 = new UnionIterator<Record>(inList2);
+			MutableObjectIterator<Tuple2<Integer, String>> input1 = new UnionIterator<>(inList1);
+			MutableObjectIterator<Tuple2<Integer, String>> input2 = new UnionIterator<>(inList2);
 			
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
@@ -367,14 +360,14 @@ public class NonReusingHashMatchIteratorITCase {
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 	
-			input1 = new UnionIterator<Record>(inList1);
-			input2 = new UnionIterator<Record>(inList2);
+			input1 = new UnionIterator<>(inList1);
+			input2 = new UnionIterator<>(inList2);
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 
-			NonReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
-				new NonReusingBuildSecondHashMatchIterator<Record, Record, Record>(
+			NonReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new NonReusingBuildSecondHashMatchIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -386,7 +379,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -403,16 +396,16 @@ public class NonReusingHashMatchIteratorITCase {
 		try {
 			MutableObjectIterator<IntPair> input1 = new UniformIntPairGenerator(500, 40, false);
 			
-			final Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TupleGenerator generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
 				collectIntPairData(input1),
 				collectRecordData(input2));
 			
-			final FlatJoinFunction<IntPair, Record, Record> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<Tuple2<Integer, String>>();
 	
 			// reset the generators
 			input1 = new UniformIntPairGenerator(500, 40, false);
@@ -420,8 +413,8 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			NonReusingBuildSecondHashMatchIterator<IntPair, Record, Record> iterator =
-					new NonReusingBuildSecondHashMatchIterator<IntPair, Record, Record>(
+			NonReusingBuildSecondHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildSecondHashMatchIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator,
 						this.recordSerializer, this.record2Comparator, this.pairRecordPairComparator,
 						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
@@ -433,7 +426,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -450,16 +443,16 @@ public class NonReusingHashMatchIteratorITCase {
 		try {
 			MutableObjectIterator<IntPair> input1 = new UniformIntPairGenerator(500, 40, false);
 			
-			final Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TupleGenerator generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
 				collectIntPairData(input1),
 				collectRecordData(input2));
 			
-			final FlatJoinFunction<IntPair, Record, Record> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
 			input1 = new UniformIntPairGenerator(500, 40, false);
@@ -467,8 +460,8 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			NonReusingBuildFirstHashMatchIterator<IntPair, Record, Record> iterator =
-					new NonReusingBuildFirstHashMatchIterator<IntPair, Record, Record>(
+			NonReusingBuildFirstHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildFirstHashMatchIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairPairComparator,
 						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
@@ -480,7 +473,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -498,15 +491,15 @@ public class NonReusingHashMatchIteratorITCase {
 
 	
 	
-	static Map<TestData.Key, Collection<RecordMatch>> matchRecordValues(
-			Map<TestData.Key, Collection<TestData.Value>> leftMap,
-			Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	static Map<Integer, Collection<RecordMatch>> matchRecordValues(
+			Map<Integer, Collection<String>> leftMap,
+			Map<Integer, Collection<String>> rightMap)
 	{
-		Map<TestData.Key, Collection<RecordMatch>> map = new HashMap<TestData.Key, Collection<RecordMatch>>();
+		Map<Integer, Collection<RecordMatch>> map = new HashMap<>();
 
-		for (TestData.Key key : leftMap.keySet()) {
-			Collection<TestData.Value> leftValues = leftMap.get(key);
-			Collection<TestData.Value> rightValues = rightMap.get(key);
+		for (Integer key : leftMap.keySet()) {
+			Collection<String> leftValues = leftMap.get(key);
+			Collection<String> rightValues = rightMap.get(key);
 
 			if (rightValues == null) {
 				continue;
@@ -518,8 +511,8 @@ public class NonReusingHashMatchIteratorITCase {
 
 			Collection<RecordMatch> matchedValues = map.get(key);
 
-			for (TestData.Value leftValue : leftValues) {
-				for (TestData.Value rightValue : rightValues) {
+			for (String leftValue : leftValues) {
+				for (String rightValue : rightValues) {
 					matchedValues.add(new RecordMatch(leftValue, rightValue));
 				}
 			}
@@ -528,31 +521,29 @@ public class NonReusingHashMatchIteratorITCase {
 		return map;
 	}
 	
-	static Map<TestData.Key, Collection<RecordIntPairMatch>> matchRecordIntPairValues(
+	static Map<Integer, Collection<RecordIntPairMatch>> matchRecordIntPairValues(
 		Map<Integer, Collection<Integer>> leftMap,
-		Map<TestData.Key, Collection<TestData.Value>> rightMap)
+		Map<Integer, Collection<String>> rightMap)
 	{
-		final Map<TestData.Key, Collection<RecordIntPairMatch>> map = new HashMap<TestData.Key, Collection<RecordIntPairMatch>>();
+		final Map<Integer, Collection<RecordIntPairMatch>> map = new HashMap<>();
 	
 		for (Integer i : leftMap.keySet()) {
 			
-			final TestData.Key key = new TestData.Key(i.intValue());
-			
 			final Collection<Integer> leftValues = leftMap.get(i);
-			final Collection<TestData.Value> rightValues = rightMap.get(key);
+			final Collection<String> rightValues = rightMap.get(i);
 	
 			if (rightValues == null) {
 				continue;
 			}
 	
-			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<RecordIntPairMatch>());
+			if (!map.containsKey(i)) {
+				map.put(i, new ArrayList<RecordIntPairMatch>());
 			}
 	
-			final Collection<RecordIntPairMatch> matchedValues = map.get(key);
+			final Collection<RecordIntPairMatch> matchedValues = map.get(i);
 	
 			for (Integer v : leftValues) {
-				for (TestData.Value val : rightValues) {
+				for (String val : rightValues) {
 					matchedValues.add(new RecordIntPairMatch(v, val));
 				}
 			}
@@ -562,21 +553,21 @@ public class NonReusingHashMatchIteratorITCase {
 	}
 
 	
-	static Map<TestData.Key, Collection<TestData.Value>> collectRecordData(MutableObjectIterator<Record> iter)
+	static Map<Integer, Collection<String>> collectRecordData(MutableObjectIterator<Tuple2<Integer, String>> iter)
 	throws Exception
 	{
-		Map<TestData.Key, Collection<TestData.Value>> map = new HashMap<TestData.Key, Collection<TestData.Value>>();
-		Record pair = new Record();
+		Map<Integer, Collection<String>> map = new HashMap<>();
+		Tuple2<Integer, String> pair = new Tuple2<>();
 		
 		while ((pair = iter.next(pair)) != null) {
 
-			TestData.Key key = pair.getField(0, TestData.Key.class);
+			Integer key = pair.f0;
 			if (!map.containsKey(key)) {
-				map.put(new TestData.Key(key.getKey()), new ArrayList<TestData.Value>());
+				map.put(key, new ArrayList<String>());
 			}
 
-			Collection<TestData.Value> values = map.get(key);
-			values.add(new TestData.Value(pair.getField(1, TestData.Value.class).getValue()));
+			Collection<String> values = map.get(key);
+			values.add(pair.f1);
 		}
 
 		return map;
@@ -608,10 +599,10 @@ public class NonReusingHashMatchIteratorITCase {
 	 */
 	static class RecordMatch {
 		
-		private final Value left;
-		private final Value right;
+		private final String left;
+		private final String right;
 
-		public RecordMatch(Value left, Value right) {
+		public RecordMatch(String left, String right) {
 			this.left = left;
 			this.right = right;
 		}
@@ -639,11 +630,11 @@ public class NonReusingHashMatchIteratorITCase {
 	static class RecordIntPairMatch
 	{
 		private final int left;
-		private final Value right;
+		private final String right;
 
-		public RecordIntPairMatch(int left, Value right) {
+		public RecordIntPairMatch(int left, String right) {
 			this.left = left;
-			this.right = right;
+			this.right = new String(right);
 		}
 
 		@Override
@@ -663,21 +654,21 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordMatchRemovingJoin extends JoinFunction
+	static final class RecordMatchRemovingJoin implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<TestData.Key, Collection<RecordMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<RecordMatch>> toRemoveFrom;
 		
-		protected RecordMatchRemovingJoin(Map<TestData.Key, Collection<RecordMatch>> map) {
+		protected RecordMatchRemovingJoin(Map<Integer, Collection<RecordMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
 		@Override
-		public void join(Record rec1, Record rec2, Collector<Record> out) throws Exception
+		public void join(Tuple2<Integer, String> rec1, Tuple2<Integer, String> rec2, Collector<Tuple2<Integer, String>> out) throws Exception
 		{
-			TestData.Key key = rec1.getField(0, TestData.Key.class);
-			TestData.Value value1 = rec1.getField(1, TestData.Value.class);
-			TestData.Value value2 = rec2.getField(1, TestData.Value.class);
-			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.getField(0, TestData.Key.class));
+			int key = rec1.f0;
+			String value1 = rec1.f1;
+			String value2 = rec2.f1;
+			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.f0);
 			Collection<RecordMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
 				Assert.fail("Match " + key + " - " + value1 + ":" + value2 + " is unexpected.");
@@ -692,24 +683,24 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordIntPairMatchRemovingMatcher extends AbstractRichFunction implements FlatJoinFunction<IntPair, Record, Record>
+	static final class RecordIntPairMatchRemovingMatcher implements FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<TestData.Key, Collection<RecordIntPairMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<RecordIntPairMatch>> toRemoveFrom;
 		
-		protected RecordIntPairMatchRemovingMatcher(Map<TestData.Key, Collection<RecordIntPairMatch>> map) {
+		protected RecordIntPairMatchRemovingMatcher(Map<Integer, Collection<RecordIntPairMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
 		@Override
-		public void join(IntPair rec1, Record rec2, Collector<Record> out) throws Exception
+		public void join(IntPair rec1, Tuple2<Integer, String> rec2, Collector<Tuple2<Integer, String>> out) throws Exception
 		{
 			final int k = rec1.getKey();
 			final int v = rec1.getValue(); 
 			
-			final TestData.Key key = rec2.getField(0, TestData.Key.class);
-			final TestData.Value value = rec2.getField(1, TestData.Value.class);
-			
-			Assert.assertTrue("Key does not match for matching IntPair Record combination.", k == key.getKey()); 
+			final Integer key = rec2.f0;
+			final String value = rec2.f1;
+
+			Assert.assertTrue("Key does not match for matching IntPair Record combination.", k == key);
 			
 			Collection<RecordIntPairMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
@@ -725,7 +716,7 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class IntPairRecordPairComparator extends TypePairComparator<IntPair, Record>
+	static final class IntPairRecordPairComparator extends TypePairComparator<IntPair, Tuple2<Integer, String>>
 	{
 		private int reference;
 		
@@ -735,33 +726,31 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 
 		@Override
-		public boolean equalToReference(Record candidate) {
+		public boolean equalToReference(Tuple2<Integer, String> candidate) {
 			try {
-				final IntValue i = candidate.getField(0, IntValue.class);
-				return i.getValue() == this.reference;
+				return candidate.f0 == this.reference;
 			} catch (NullPointerException npex) {
 				throw new NullKeyFieldException();
 			}
 		}
 
 		@Override
-		public int compareToReference(Record candidate) {
+		public int compareToReference(Tuple2<Integer, String> candidate) {
 			try {
-				final IntValue i = candidate.getField(0, IntValue.class);
-				return i.getValue() - this.reference;
+				return candidate.f0 - this.reference;
 			} catch (NullPointerException npex) {
 				throw new NullKeyFieldException();
 			}
 		}
 	}
 	
-	static final class RecordIntPairPairComparator extends TypePairComparator<Record, IntPair>
+	static final class RecordIntPairPairComparator extends TypePairComparator<Tuple2<Integer, String>, IntPair>
 	{
 		private int reference;
 		
 		@Override
-		public void setReference(Record reference) {
-			this.reference = reference.getField(0, IntValue.class).getValue();
+		public void setReference(Tuple2<Integer, String> reference) {
+			this.reference = reference.f0;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashMatchIteratorITCase.java
@@ -93,8 +93,8 @@ public class NonReusingHashMatchIteratorITCase {
 		
 		this.pairSerializer = new IntPairSerializer();
 		this.pairComparator = new TestData.IntPairComparator();
-		this.pairRecordPairComparator = new IntPairRecordPairComparator();
-		this.recordPairPairComparator = new RecordIntPairPairComparator();
+		this.pairRecordPairComparator = new IntPairTuplePairComparator();
+		this.recordPairPairComparator = new TupleIntPairPairComparator();
 		
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
@@ -129,11 +129,11 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<Tuple2<Integer, String>>();
 	
 			// reset the generators
@@ -156,7 +156,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -202,9 +202,9 @@ public class NonReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -227,7 +227,7 @@ public class NonReusingHashMatchIteratorITCase {
 			input1 = new UnionIterator<>(inList1);
 			input2 = new UnionIterator<>(inList2);
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			NonReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
@@ -243,7 +243,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -265,11 +265,11 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
@@ -292,7 +292,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -338,9 +338,9 @@ public class NonReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -363,7 +363,7 @@ public class NonReusingHashMatchIteratorITCase {
 			input1 = new UnionIterator<>(inList1);
 			input2 = new UnionIterator<>(inList2);
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 
 			NonReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
@@ -379,7 +379,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -400,11 +400,11 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
 				collectIntPairData(input1),
-				collectRecordData(input2));
+				collectTupleData(input2));
 			
-			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<Tuple2<Integer, String>>();
 	
 			// reset the generators
@@ -426,7 +426,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -447,11 +447,11 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
 				collectIntPairData(input1),
-				collectRecordData(input2));
+				collectTupleData(input2));
 			
-			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
@@ -473,7 +473,7 @@ public class NonReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -491,11 +491,11 @@ public class NonReusingHashMatchIteratorITCase {
 
 	
 	
-	static Map<Integer, Collection<RecordMatch>> matchRecordValues(
+	static Map<Integer, Collection<TupleMatch>> matchSecondTupleFields(
 			Map<Integer, Collection<String>> leftMap,
 			Map<Integer, Collection<String>> rightMap)
 	{
-		Map<Integer, Collection<RecordMatch>> map = new HashMap<>();
+		Map<Integer, Collection<TupleMatch>> map = new HashMap<>();
 
 		for (Integer key : leftMap.keySet()) {
 			Collection<String> leftValues = leftMap.get(key);
@@ -506,14 +506,14 @@ public class NonReusingHashMatchIteratorITCase {
 			}
 
 			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<RecordMatch>());
+				map.put(key, new ArrayList<TupleMatch>());
 			}
 
-			Collection<RecordMatch> matchedValues = map.get(key);
+			Collection<TupleMatch> matchedValues = map.get(key);
 
 			for (String leftValue : leftValues) {
 				for (String rightValue : rightValues) {
-					matchedValues.add(new RecordMatch(leftValue, rightValue));
+					matchedValues.add(new TupleMatch(leftValue, rightValue));
 				}
 			}
 		}
@@ -521,11 +521,11 @@ public class NonReusingHashMatchIteratorITCase {
 		return map;
 	}
 	
-	static Map<Integer, Collection<RecordIntPairMatch>> matchRecordIntPairValues(
+	static Map<Integer, Collection<TupleIntPairMatch>> matchTupleIntPairValues(
 		Map<Integer, Collection<Integer>> leftMap,
 		Map<Integer, Collection<String>> rightMap)
 	{
-		final Map<Integer, Collection<RecordIntPairMatch>> map = new HashMap<>();
+		final Map<Integer, Collection<TupleIntPairMatch>> map = new HashMap<>();
 	
 		for (Integer i : leftMap.keySet()) {
 			
@@ -537,14 +537,14 @@ public class NonReusingHashMatchIteratorITCase {
 			}
 	
 			if (!map.containsKey(i)) {
-				map.put(i, new ArrayList<RecordIntPairMatch>());
+				map.put(i, new ArrayList<TupleIntPairMatch>());
 			}
 	
-			final Collection<RecordIntPairMatch> matchedValues = map.get(i);
+			final Collection<TupleIntPairMatch> matchedValues = map.get(i);
 	
 			for (Integer v : leftValues) {
 				for (String val : rightValues) {
-					matchedValues.add(new RecordIntPairMatch(v, val));
+					matchedValues.add(new TupleIntPairMatch(v, val));
 				}
 			}
 		}
@@ -553,7 +553,7 @@ public class NonReusingHashMatchIteratorITCase {
 	}
 
 	
-	static Map<Integer, Collection<String>> collectRecordData(MutableObjectIterator<Tuple2<Integer, String>> iter)
+	static Map<Integer, Collection<String>> collectTupleData(MutableObjectIterator<Tuple2<Integer, String>> iter)
 	throws Exception
 	{
 		Map<Integer, Collection<String>> map = new HashMap<>();
@@ -597,19 +597,19 @@ public class NonReusingHashMatchIteratorITCase {
 	/**
 	 * Private class used for storage of the expected matches in a hash-map.
 	 */
-	static class RecordMatch {
+	static class TupleMatch {
 		
 		private final String left;
 		private final String right;
 
-		public RecordMatch(String left, String right) {
+		public TupleMatch(String left, String right) {
 			this.left = left;
 			this.right = right;
 		}
 
 		@Override
 		public boolean equals(Object obj) {
-			RecordMatch o = (RecordMatch) obj;
+			TupleMatch o = (TupleMatch) obj;
 			return this.left.equals(o.left) && this.right.equals(o.right);
 		}
 		
@@ -627,19 +627,19 @@ public class NonReusingHashMatchIteratorITCase {
 	/**
 	 * Private class used for storage of the expected matches in a hash-map.
 	 */
-	static class RecordIntPairMatch
+	static class TupleIntPairMatch
 	{
 		private final int left;
 		private final String right;
 
-		public RecordIntPairMatch(int left, String right) {
+		public TupleIntPairMatch(int left, String right) {
 			this.left = left;
 			this.right = new String(right);
 		}
 
 		@Override
 		public boolean equals(Object obj) {
-			RecordIntPairMatch o = (RecordIntPairMatch) obj;
+			TupleIntPairMatch o = (TupleIntPairMatch) obj;
 			return this.left == o.left && this.right.equals(o.right);
 		}
 		
@@ -654,11 +654,11 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordMatchRemovingJoin implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>
+	static final class TupleMatchRemovingJoin implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<Integer, Collection<RecordMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<TupleMatch>> toRemoveFrom;
 		
-		protected RecordMatchRemovingJoin(Map<Integer, Collection<RecordMatch>> map) {
+		protected TupleMatchRemovingJoin(Map<Integer, Collection<TupleMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
@@ -669,13 +669,13 @@ public class NonReusingHashMatchIteratorITCase {
 			String value1 = rec1.f1;
 			String value2 = rec2.f1;
 			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.f0);
-			Collection<RecordMatch> matches = this.toRemoveFrom.get(key);
+			Collection<TupleMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
 				Assert.fail("Match " + key + " - " + value1 + ":" + value2 + " is unexpected.");
 			}
 			
 			Assert.assertTrue("Produced match was not contained: " + key + " - " + value1 + ":" + value2,
-				matches.remove(new RecordMatch(value1, value2)));
+				matches.remove(new TupleMatch(value1, value2)));
 			
 			if (matches.isEmpty()) {
 				this.toRemoveFrom.remove(key);
@@ -683,11 +683,11 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordIntPairMatchRemovingMatcher implements FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>>
+	static final class TupleIntPairMatchRemovingMatcher implements FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<Integer, Collection<RecordIntPairMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<TupleIntPairMatch>> toRemoveFrom;
 		
-		protected RecordIntPairMatchRemovingMatcher(Map<Integer, Collection<RecordIntPairMatch>> map) {
+		protected TupleIntPairMatchRemovingMatcher(Map<Integer, Collection<TupleIntPairMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
@@ -700,15 +700,15 @@ public class NonReusingHashMatchIteratorITCase {
 			final Integer key = rec2.f0;
 			final String value = rec2.f1;
 
-			Assert.assertTrue("Key does not match for matching IntPair Record combination.", k == key);
+			Assert.assertTrue("Key does not match for matching IntPair Tuple combination.", k == key);
 			
-			Collection<RecordIntPairMatch> matches = this.toRemoveFrom.get(key);
+			Collection<TupleIntPairMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
 				Assert.fail("Match " + key + " - " + v + ":" + value + " is unexpected.");
 			}
 			
 			Assert.assertTrue("Produced match was not contained: " + key + " - " + v + ":" + value,
-				matches.remove(new RecordIntPairMatch(v, value)));
+				matches.remove(new TupleIntPairMatch(v, value)));
 			
 			if (matches.isEmpty()) {
 				this.toRemoveFrom.remove(key);
@@ -716,7 +716,7 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class IntPairRecordPairComparator extends TypePairComparator<IntPair, Tuple2<Integer, String>>
+	static final class IntPairTuplePairComparator extends TypePairComparator<IntPair, Tuple2<Integer, String>>
 	{
 		private int reference;
 		
@@ -744,7 +744,7 @@ public class NonReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordIntPairPairComparator extends TypePairComparator<Tuple2<Integer, String>, IntPair>
+	static final class TupleIntPairPairComparator extends TypePairComparator<Tuple2<Integer, String>, IntPair>
 	{
 		private int reference;
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
@@ -22,8 +22,6 @@ package org.apache.flink.runtime.operators.hash;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -31,7 +29,6 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.operators.hash.HashTableITCase.ConstantsKeyValuePairsIterator;
 import org.apache.flink.runtime.operators.hash.MutableHashTable.HashBucketIterator;
 import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase.RecordMatch;
 import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase
@@ -42,10 +39,7 @@ import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Key;
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
-import org.apache.flink.types.IntValue;
-import org.apache.flink.types.Record;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.After;
@@ -63,7 +57,7 @@ import java.util.Map.Entry;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.GenericPairComparator;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
+import org.apache.flink.runtime.operators.testutils.UniformIntTupleGenerator;
 
 import static org.junit.Assert.fail;
 
@@ -96,30 +90,26 @@ public class NonReusingReOpenableHashTableITCase {
 
 
 	private static final AbstractInvokable MEM_OWNER = new DummyInvokable();
-	private TypeSerializer<Record> recordBuildSideAccesssor;
-	private TypeSerializer<Record> recordProbeSideAccesssor;
-	private TypeComparator<Record> recordBuildSideComparator;
-	private TypeComparator<Record> recordProbeSideComparator;
-	private TypePairComparator<Record, Record> pactRecordComparator;
+	private TypeSerializer<Tuple2<Integer, Integer>> recordBuildSideAccesssor;
+	private TypeSerializer<Tuple2<Integer, Integer>> recordProbeSideAccesssor;
+	private TypeComparator<Tuple2<Integer, Integer>> recordBuildSideComparator;
+	private TypeComparator<Tuple2<Integer, Integer>> recordProbeSideComparator;
+	private TypePairComparator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> pactRecordComparator;
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Before
 	public void beforeTest() {
-		this.recordSerializer = TestData.getTupleSerializer();
+		this.recordSerializer = TestData.getIntStringTupleSerializer();
 
-		this.record1Comparator = TestData.getTupleComparator();
-		this.record2Comparator = TestData.getTupleComparator();
+		this.record1Comparator = TestData.getIntStringTupleComparator();
+		this.record2Comparator = TestData.getIntStringTupleComparator();
 		this.recordPairComparator = new GenericPairComparator(this.record1Comparator, this.record2Comparator);
 
-
-		final int[] keyPos = new int[] {0};
-		final Class<? extends Key>[] keyType = (Class<? extends Key>[]) new Class[] { IntValue.class };
-
-		this.recordBuildSideAccesssor = RecordSerializer.get();
-		this.recordProbeSideAccesssor = RecordSerializer.get();
-		this.recordBuildSideComparator = new RecordComparator(keyPos, keyType);
-		this.recordProbeSideComparator = new RecordComparator(keyPos, keyType);
-		this.pactRecordComparator = new HashTableITCase.RecordPairComparatorFirstInt();
+		this.recordBuildSideAccesssor = TestData.getIntIntTupleSerializer();
+		this.recordProbeSideAccesssor = TestData.getIntIntTupleSerializer();
+		this.recordBuildSideComparator = TestData.getIntIntTupleComparator();
+		this.recordProbeSideComparator = TestData.getIntIntTupleComparator();
+		this.pactRecordComparator = new GenericPairComparator(this.recordBuildSideComparator, this.recordProbeSideComparator);
 
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
 		this.ioManager = new IOManagerAsync();
@@ -237,7 +227,7 @@ public class NonReusingReOpenableHashTableITCase {
 
 		// compare with iterator values
 		NonReusingBuildFirstReOpenableHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-				new NonReusingBuildFirstReOpenableHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>(
+				new NonReusingBuildFirstReOpenableHashMatchIterator<>(
 						buildInput, probeInput, this.recordSerializer, this.record1Comparator,
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -278,16 +268,16 @@ public class NonReusingReOpenableHashTableITCase {
 	//
 	//
 
-	private MutableObjectIterator<Record> getProbeInput(final int numKeys,
+	private MutableObjectIterator<Tuple2<Integer, Integer>> getProbeInput(final int numKeys,
 			final int probeValsPerKey, final int repeatedValue1, final int repeatedValue2) {
-		MutableObjectIterator<Record> probe1 = new UniformRecordGenerator(numKeys, probeValsPerKey, true);
-		MutableObjectIterator<Record> probe2 = new ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
-		MutableObjectIterator<Record> probe3 = new ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
-		List<MutableObjectIterator<Record>> probes = new ArrayList<MutableObjectIterator<Record>>();
+		MutableObjectIterator<Tuple2<Integer, Integer>> probe1 = new UniformIntTupleGenerator(numKeys, probeValsPerKey, true);
+		MutableObjectIterator<Tuple2<Integer, Integer>> probe2 = new TestData.ConstantIntIntTuplesIterator(repeatedValue1, 17, 5);
+		MutableObjectIterator<Tuple2<Integer, Integer>> probe3 = new TestData.ConstantIntIntTuplesIterator(repeatedValue2, 23, 5);
+		List<MutableObjectIterator<Tuple2<Integer, Integer>>> probes = new ArrayList<>();
 		probes.add(probe1);
 		probes.add(probe2);
 		probes.add(probe3);
-		return new UnionIterator<Record>(probes);
+		return new UnionIterator<>(probes);
 	}
 
 	@Test
@@ -305,14 +295,14 @@ public class NonReusingReOpenableHashTableITCase {
 		final int PROBE_VALS_PER_KEY = 10;
 
 		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
-		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
-		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
-		MutableObjectIterator<Record> build3 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
-		List<MutableObjectIterator<Record>> builds = new ArrayList<MutableObjectIterator<Record>>();
+		MutableObjectIterator<Tuple2<Integer, Integer>> build1 = new UniformIntTupleGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build2 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build3 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
+		List<MutableObjectIterator<Tuple2<Integer, Integer>>> builds = new ArrayList<>();
 		builds.add(build1);
 		builds.add(build2);
 		builds.add(build3);
-		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
+		MutableObjectIterator<Tuple2<Integer, Integer>> buildInput = new UnionIterator<>(builds);
 
 
 
@@ -332,40 +322,40 @@ public class NonReusingReOpenableHashTableITCase {
 
 		// ----------------------------------------------------------------------------------------
 
-		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
+		final ReOpenableMutableHashTable<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> join = new ReOpenableMutableHashTable<>(
 				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager, true);
 
 		for (int probe = 0; probe < NUM_PROBES; probe++) {
 			// create a probe input that gives 10 million pairs with 10 values sharing a key
-			MutableObjectIterator<Record> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
+			MutableObjectIterator<Tuple2<Integer, Integer>> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
 			if(probe == 0) {
 				join.open(buildInput, probeInput);
 			} else {
 				join.reopenProbe(probeInput);
 			}
 
-			Record record;
-			final Record recordReuse = new Record();
+			Tuple2<Integer, Integer> record;
+			final Tuple2<Integer, Integer> recordReuse = new Tuple2<>();
 
 			while (join.nextRecord()) {
 				long numBuildValues = 0;
 
-				final Record probeRec = join.getCurrentProbeRecord();
-				int key = probeRec.getField(0, IntValue.class).getValue();
+				final Tuple2<Integer, Integer> probeRec = join.getCurrentProbeRecord();
+				Integer key = probeRec.f0;
 
-				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
+				HashBucketIterator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> buildSide = join.getBuildSideIterator();
 				if ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues = 1;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0);
 				}
 				else {
 					fail("No build side values found for a probe key.");
 				}
 				while ((record = buildSide.next(record)) != null) {
 					numBuildValues++;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0);
 				}
 
 				Long contained = map.get(key);
@@ -422,14 +412,14 @@ public class NonReusingReOpenableHashTableITCase {
 		final int PROBE_VALS_PER_KEY = 10;
 
 		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
-		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
-		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
-		MutableObjectIterator<Record> build3 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
-		List<MutableObjectIterator<Record>> builds = new ArrayList<MutableObjectIterator<Record>>();
+		MutableObjectIterator<Tuple2<Integer, Integer>> build1 = new UniformIntTupleGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build2 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build3 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
+		List<MutableObjectIterator<Tuple2<Integer, Integer>>> builds = new ArrayList<>();
 		builds.add(build1);
 		builds.add(build2);
 		builds.add(build3);
-		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
+		MutableObjectIterator<Tuple2<Integer, Integer>> buildInput = new UnionIterator<>(builds);
 
 
 		// allocate the memory for the HashTable
@@ -447,39 +437,39 @@ public class NonReusingReOpenableHashTableITCase {
 
 		// ----------------------------------------------------------------------------------------
 
-		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
+		final ReOpenableMutableHashTable<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> join = new ReOpenableMutableHashTable<>(
 				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor,
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager, true);
 		
 		for (int probe = 0; probe < NUM_PROBES; probe++) {
 			// create a probe input that gives 10 million pairs with 10 values sharing a key
-			MutableObjectIterator<Record> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
+			MutableObjectIterator<Tuple2<Integer, Integer>> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
 			if (probe == 0) {
 				join.open(buildInput, probeInput);
 			} else {
 				join.reopenProbe(probeInput);
 			}
-			Record record;
-			final Record recordReuse = new Record();
+			Tuple2<Integer, Integer> record;
+			final Tuple2<Integer, Integer> recordReuse = new Tuple2<>();
 
 			while (join.nextRecord()) {
 				long numBuildValues = 0;
 
-				final Record probeRec = join.getCurrentProbeRecord();
-				int key = probeRec.getField(0, IntValue.class).getValue();
+				final Tuple2<Integer, Integer> probeRec = join.getCurrentProbeRecord();
+				Integer key = probeRec.f0;
 
-				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
+				HashBucketIterator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> buildSide = join.getBuildSideIterator();
 				if ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues = 1;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0);
 				}
 				else {
 					fail("No build side values found for a probe key.");
 				}
 				while ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues++;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0);
 				}
 
 				Long contained = map.get(key);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
@@ -23,9 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
 import org.apache.flink.api.common.typeutils.record.RecordSerializer;
-import org.apache.flink.api.java.record.functions.JoinFunction;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -41,11 +39,10 @@ import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.runtime.operators.testutils.TestData.Key;
-import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.Record;
@@ -63,6 +60,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.GenericPairComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
 
 import static org.junit.Assert.fail;
 
@@ -86,10 +87,10 @@ public class NonReusingReOpenableHashTableITCase {
 	private IOManager ioManager;
 	private MemoryManager memoryManager;
 
-	private TypeSerializer<Record> recordSerializer;
-	private TypeComparator<Record> record1Comparator;
-	private TypeComparator<Record> record2Comparator;
-	private TypePairComparator<Record, Record> recordPairComparator;
+	private TypeSerializer<Tuple2<Integer, String>> recordSerializer;
+	private TypeComparator<Tuple2<Integer, String>> record1Comparator;
+	private TypeComparator<Tuple2<Integer, String>> record2Comparator;
+	private TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> recordPairComparator;
 
 
 
@@ -104,11 +105,11 @@ public class NonReusingReOpenableHashTableITCase {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Before
 	public void beforeTest() {
-		this.recordSerializer = RecordSerializer.get();
+		this.recordSerializer = TestData.getTupleSerializer();
 
-		this.record1Comparator = new RecordComparator(new int[] {0}, new Class[] {Key.class});
-		this.record2Comparator = new RecordComparator(new int[] {0}, new Class[] {Key.class});
-		this.recordPairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {Key.class});
+		this.record1Comparator = TestData.getTupleComparator();
+		this.record2Comparator = TestData.getTupleComparator();
+		this.recordPairComparator = new GenericPairComparator(this.record1Comparator, this.record2Comparator);
 
 
 		final int[] keyPos = new int[] {0};
@@ -153,11 +154,11 @@ public class NonReusingReOpenableHashTableITCase {
 		int buildSize = 1000;
 		int probeSize = 1000;
 		try {
-			Generator bgen = new Generator(SEED1, 200, 1024, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
-			Generator pgen = new Generator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			TupleGenerator bgen = new TupleGenerator(SEED1, 200, 1024, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
+			TupleGenerator pgen = new TupleGenerator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
 
-			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
-			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
+			final TestData.TupleGeneratorIterator buildInput = new TestData.TupleGeneratorIterator(bgen, buildSize);
+			final TestData.TupleGeneratorIterator probeInput = new TestData.TupleGeneratorIterator(pgen, probeSize);
 			doTest(buildInput,probeInput, bgen, pgen);
 		}
 		catch (Exception e) {
@@ -175,11 +176,11 @@ public class NonReusingReOpenableHashTableITCase {
 		int buildSize = 1000;
 		int probeSize = 1000;
 		try {
-			Generator bgen = new Generator(SEED1, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
-			Generator pgen = new Generator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			TupleGenerator bgen = new TupleGenerator(SEED1, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			TupleGenerator pgen = new TupleGenerator(SEED2, 0, 1024, KeyMode.SORTED, ValueMode.FIX_LENGTH);
 
-			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
-			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
+			final TestData.TupleGeneratorIterator buildInput = new TestData.TupleGeneratorIterator(bgen, buildSize);
+			final TestData.TupleGeneratorIterator probeInput = new TestData.TupleGeneratorIterator(pgen, probeSize);
 			doTest(buildInput,probeInput, bgen, pgen);
 		}
 		catch (Exception e) {
@@ -198,11 +199,11 @@ public class NonReusingReOpenableHashTableITCase {
 		int buildSize = 1000;
 		int probeSize = 1000;
 		try {
-			Generator bgen = new Generator(SEED1, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
-			Generator pgen = new Generator(SEED2, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			TupleGenerator bgen = new TupleGenerator(SEED1, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
+			TupleGenerator pgen = new TupleGenerator(SEED2, 0, 28, KeyMode.SORTED, ValueMode.FIX_LENGTH);
 
-			final TestData.GeneratorIterator buildInput = new TestData.GeneratorIterator(bgen, buildSize);
-			final TestData.GeneratorIterator probeInput = new TestData.GeneratorIterator(pgen, probeSize);
+			final TestData.TupleGeneratorIterator buildInput = new TestData.TupleGeneratorIterator(bgen, buildSize);
+			final TestData.TupleGeneratorIterator probeInput = new TestData.TupleGeneratorIterator(pgen, probeSize);
 
 			doTest(buildInput,probeInput, bgen, pgen);
 		}
@@ -212,21 +213,21 @@ public class NonReusingReOpenableHashTableITCase {
 		}
 	}
 
-	private void doTest(TestData.GeneratorIterator buildInput, TestData.GeneratorIterator probeInput, Generator bgen, Generator pgen) throws Exception {
+	private void doTest(TestData.TupleGeneratorIterator buildInput, TestData.TupleGeneratorIterator probeInput, TupleGenerator bgen, TupleGenerator pgen) throws Exception {
 		// collect expected data
-		final Map<Key, Collection<RecordMatch>> expectedFirstMatchesMap = NonReusingHashMatchIteratorITCase.matchRecordValues(NonReusingHashMatchIteratorITCase.collectRecordData(buildInput), NonReusingHashMatchIteratorITCase.collectRecordData(probeInput));
+		final Map<Integer, Collection<RecordMatch>> expectedFirstMatchesMap = NonReusingHashMatchIteratorITCase.matchRecordValues(NonReusingHashMatchIteratorITCase.collectRecordData(buildInput), NonReusingHashMatchIteratorITCase.collectRecordData(probeInput));
 
-		final List<Map<Key, Collection<RecordMatch>>> expectedNMatchesMapList = new ArrayList<Map<Key,Collection<RecordMatch>>>(NUM_PROBES);
-		final JoinFunction[] nMatcher = new RecordMatchRemovingJoin[NUM_PROBES];
+		final List<Map<Integer, Collection<RecordMatch>>> expectedNMatchesMapList = new ArrayList<>(NUM_PROBES);
+		final FlatJoinFunction[] nMatcher = new RecordMatchRemovingJoin[NUM_PROBES];
 		for(int i = 0; i < NUM_PROBES; i++) {
-			Map<Key, Collection<RecordMatch>> tmp;
+			Map<Integer, Collection<RecordMatch>> tmp;
 			expectedNMatchesMapList.add(tmp = deepCopy(expectedFirstMatchesMap));
 			nMatcher[i] = new RecordMatchRemovingJoin(tmp);
 		}
 
-		final JoinFunction firstMatcher = new RecordMatchRemovingJoin(expectedFirstMatchesMap);
+		final FlatJoinFunction firstMatcher = new RecordMatchRemovingJoin(expectedFirstMatchesMap);
 
-		final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+		final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 
 		// reset the generators
 		bgen.reset();
@@ -235,8 +236,8 @@ public class NonReusingReOpenableHashTableITCase {
 		probeInput.reset();
 
 		// compare with iterator values
-		NonReusingBuildFirstReOpenableHashMatchIterator<Record, Record, Record> iterator =
-				new NonReusingBuildFirstReOpenableHashMatchIterator<Record, Record, Record>(
+		NonReusingBuildFirstReOpenableHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new NonReusingBuildFirstReOpenableHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>(
 						buildInput, probeInput, this.recordSerializer, this.record1Comparator,
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -246,7 +247,7 @@ public class NonReusingReOpenableHashTableITCase {
 		while (iterator.callWithNextKey(firstMatcher, collector));
 
 		// assert that each expected match was seen for the first input
-		for (Entry<Key, Collection<RecordMatch>> entry : expectedFirstMatchesMap.entrySet()) {
+		for (Entry<Integer, Collection<RecordMatch>> entry : expectedFirstMatchesMap.entrySet()) {
 			if (!entry.getValue().isEmpty()) {
 				Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 			}
@@ -261,7 +262,7 @@ public class NonReusingReOpenableHashTableITCase {
 			while (iterator.callWithNextKey(nMatcher[i], collector));
 
 			// assert that each expected match was seen for the second input
-			for (Entry<Key, Collection<RecordMatch>> entry : expectedNMatchesMapList.get(i).entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedNMatchesMapList.get(i).entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -515,9 +516,9 @@ public class NonReusingReOpenableHashTableITCase {
 	}
 
 
-	static Map<Key, Collection<RecordMatch>> deepCopy(Map<Key, Collection<RecordMatch>> expectedSecondMatchesMap) {
-		Map<Key, Collection<RecordMatch>> copy = new HashMap<Key, Collection<RecordMatch>>(expectedSecondMatchesMap.size());
-		for(Entry<Key, Collection<RecordMatch>> entry : expectedSecondMatchesMap.entrySet()) {
+	static Map<Integer, Collection<RecordMatch>> deepCopy(Map<Integer, Collection<RecordMatch>> expectedSecondMatchesMap) {
+		Map<Integer, Collection<RecordMatch>> copy = new HashMap<>(expectedSecondMatchesMap.size());
+		for(Entry<Integer, Collection<RecordMatch>> entry : expectedSecondMatchesMap.entrySet()) {
 			List<RecordMatch> matches = new ArrayList<RecordMatch>(entry.getValue().size());
 			for(RecordMatch m : entry.getValue()) {
 				matches.add(m);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
@@ -30,9 +30,8 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.hash.MutableHashTable.HashBucketIterator;
-import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase.RecordMatch;
-import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase
-		.RecordMatchRemovingJoin;
+import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase.TupleMatch;
+import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase.TupleMatchRemovingJoin;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -205,17 +204,17 @@ public class NonReusingReOpenableHashTableITCase {
 
 	private void doTest(TestData.TupleGeneratorIterator buildInput, TestData.TupleGeneratorIterator probeInput, TupleGenerator bgen, TupleGenerator pgen) throws Exception {
 		// collect expected data
-		final Map<Integer, Collection<RecordMatch>> expectedFirstMatchesMap = NonReusingHashMatchIteratorITCase.matchRecordValues(NonReusingHashMatchIteratorITCase.collectRecordData(buildInput), NonReusingHashMatchIteratorITCase.collectRecordData(probeInput));
+		final Map<Integer, Collection<TupleMatch>> expectedFirstMatchesMap = NonReusingHashMatchIteratorITCase.matchSecondTupleFields(NonReusingHashMatchIteratorITCase.collectTupleData(buildInput), NonReusingHashMatchIteratorITCase.collectTupleData(probeInput));
 
-		final List<Map<Integer, Collection<RecordMatch>>> expectedNMatchesMapList = new ArrayList<>(NUM_PROBES);
-		final FlatJoinFunction[] nMatcher = new RecordMatchRemovingJoin[NUM_PROBES];
+		final List<Map<Integer, Collection<TupleMatch>>> expectedNMatchesMapList = new ArrayList<>(NUM_PROBES);
+		final FlatJoinFunction[] nMatcher = new TupleMatchRemovingJoin[NUM_PROBES];
 		for(int i = 0; i < NUM_PROBES; i++) {
-			Map<Integer, Collection<RecordMatch>> tmp;
+			Map<Integer, Collection<TupleMatch>> tmp;
 			expectedNMatchesMapList.add(tmp = deepCopy(expectedFirstMatchesMap));
-			nMatcher[i] = new RecordMatchRemovingJoin(tmp);
+			nMatcher[i] = new TupleMatchRemovingJoin(tmp);
 		}
 
-		final FlatJoinFunction firstMatcher = new RecordMatchRemovingJoin(expectedFirstMatchesMap);
+		final FlatJoinFunction firstMatcher = new TupleMatchRemovingJoin(expectedFirstMatchesMap);
 
 		final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 
@@ -237,7 +236,7 @@ public class NonReusingReOpenableHashTableITCase {
 		while (iterator.callWithNextKey(firstMatcher, collector));
 
 		// assert that each expected match was seen for the first input
-		for (Entry<Integer, Collection<RecordMatch>> entry : expectedFirstMatchesMap.entrySet()) {
+		for (Entry<Integer, Collection<TupleMatch>> entry : expectedFirstMatchesMap.entrySet()) {
 			if (!entry.getValue().isEmpty()) {
 				Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 			}
@@ -252,7 +251,7 @@ public class NonReusingReOpenableHashTableITCase {
 			while (iterator.callWithNextKey(nMatcher[i], collector));
 
 			// assert that each expected match was seen for the second input
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedNMatchesMapList.get(i).entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedNMatchesMapList.get(i).entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -506,11 +505,11 @@ public class NonReusingReOpenableHashTableITCase {
 	}
 
 
-	static Map<Integer, Collection<RecordMatch>> deepCopy(Map<Integer, Collection<RecordMatch>> expectedSecondMatchesMap) {
-		Map<Integer, Collection<RecordMatch>> copy = new HashMap<>(expectedSecondMatchesMap.size());
-		for(Entry<Integer, Collection<RecordMatch>> entry : expectedSecondMatchesMap.entrySet()) {
-			List<RecordMatch> matches = new ArrayList<RecordMatch>(entry.getValue().size());
-			for(RecordMatch m : entry.getValue()) {
+	static Map<Integer, Collection<TupleMatch>> deepCopy(Map<Integer, Collection<TupleMatch>> expectedSecondMatchesMap) {
+		Map<Integer, Collection<TupleMatch>> copy = new HashMap<>(expectedSecondMatchesMap.size());
+		for(Entry<Integer, Collection<TupleMatch>> entry : expectedSecondMatchesMap.entrySet()) {
+			List<TupleMatch> matches = new ArrayList<TupleMatch>(entry.getValue().size());
+			for(TupleMatch m : entry.getValue()) {
 				matches.add(m);
 			}
 			copy.put(entry.getKey(), matches);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
@@ -28,13 +28,11 @@ import java.util.Map.Entry;
 
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.GenericPairComparator;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializer;
-import org.apache.flink.api.java.record.functions.JoinFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -44,16 +42,11 @@ import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
 import org.apache.flink.runtime.operators.testutils.UniformIntPairGenerator;
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.runtime.operators.testutils.types.IntPair;
-import org.apache.flink.runtime.operators.testutils.types.IntPairComparator;
 import org.apache.flink.runtime.operators.testutils.types.IntPairSerializer;
-import org.apache.flink.types.IntValue;
 import org.apache.flink.types.NullKeyFieldException;
-import org.apache.flink.types.Record;
-import org.apache.flink.types.Value;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.After;
@@ -77,29 +70,29 @@ public class ReusingHashMatchIteratorITCase {
 	private IOManager ioManager;
 	private MemoryManager memoryManager;
 	
-	private TypeSerializer<Record> recordSerializer;
-	private TypeComparator<Record> record1Comparator;
-	private TypeComparator<Record> record2Comparator;
-	private TypePairComparator<Record, Record> recordPairComparator;
+	private TypeSerializer<Tuple2<Integer, String>> recordSerializer;
+	private TypeComparator<Tuple2<Integer, String>> record1Comparator;
+	private TypeComparator<Tuple2<Integer, String>> record2Comparator;
+	private TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> recordPairComparator;
 	
 	private TypeSerializer<IntPair> pairSerializer;
 	private TypeComparator<IntPair> pairComparator;
-	private TypePairComparator<IntPair, Record> pairRecordPairComparator;
-	private TypePairComparator<Record, IntPair> recordPairPairComparator;
+	private TypePairComparator<IntPair, Tuple2<Integer, String>> pairRecordPairComparator;
+	private TypePairComparator<Tuple2<Integer, String>, IntPair> recordPairPairComparator;
 
 
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.recordSerializer = RecordSerializer.get();
+		this.recordSerializer = TestData.getTupleSerializer();
 		
-		this.record1Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
-		this.record2Comparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
+		this.record1Comparator = TestData.getTupleComparator();
+		this.record2Comparator = TestData.getTupleComparator();
 		
-		this.recordPairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {TestData.Key.class});
+		this.recordPairComparator = new GenericPairComparator(this.record1Comparator, this.record2Comparator);
 		
 		this.pairSerializer = new IntPairSerializer();
-		this.pairComparator = new IntPairComparator();
+		this.pairComparator = new TestData.IntPairComparator();
 		this.pairRecordPairComparator = new IntPairRecordPairComparator();
 		this.recordPairPairComparator = new RecordIntPairPairComparator();
 		
@@ -129,19 +122,19 @@ public class ReusingHashMatchIteratorITCase {
 	@Test
 	public void testBuildFirst() {
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
 			generator1.reset();
@@ -150,8 +143,8 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			ReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
-					new ReusingBuildFirstHashMatchIterator<Record, Record, Record>(
+			ReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashMatchIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 						this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -163,7 +156,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -187,29 +180,29 @@ public class ReusingHashMatchIteratorITCase {
 		final int DUPLICATE_KEY = 13;
 		
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator gen1Iter = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator gen2Iter = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator gen1Iter = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator gen2Iter = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
-			final TestData.ConstantValueIterator const1Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
-			final TestData.ConstantValueIterator const2Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
+			final TestData.TupleConstantValueIterator const1Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
+			final TestData.TupleConstantValueIterator const2Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
 			
-			final List<MutableObjectIterator<Record>> inList1 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList1 = new ArrayList<>();
 			inList1.add(gen1Iter);
 			inList1.add(const1Iter);
 			
-			final List<MutableObjectIterator<Record>> inList2 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList2 = new ArrayList<>();
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 			
-			MutableObjectIterator<Record> input1 = new UnionIterator<Record>(inList1);
-			MutableObjectIterator<Record> input2 = new UnionIterator<Record>(inList2);
+			MutableObjectIterator<Tuple2<Integer, String>> input1 = new UnionIterator<>(inList1);
+			MutableObjectIterator<Tuple2<Integer, String>> input2 = new UnionIterator<>(inList2);
 			
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
@@ -231,14 +224,14 @@ public class ReusingHashMatchIteratorITCase {
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 	
-			input1 = new UnionIterator<Record>(inList1);
-			input2 = new UnionIterator<Record>(inList2);
+			input1 = new UnionIterator<Tuple2<Integer, String>>(inList1);
+			input2 = new UnionIterator<Tuple2<Integer, String>>(inList2);
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
-			ReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
-					new ReusingBuildFirstHashMatchIterator<Record, Record, Record>(
+			ReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashMatchIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 						this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -250,7 +243,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -265,19 +258,19 @@ public class ReusingHashMatchIteratorITCase {
 	@Test
 	public void testBuildSecond() {
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
 			generator1.reset();
@@ -286,8 +279,8 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values			
-			ReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
-				new ReusingBuildSecondHashMatchIterator<Record, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>,Tuple2<Integer, String> ,Tuple2<Integer, String> > iterator =
+				new ReusingBuildSecondHashMatchIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -299,7 +292,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -323,29 +316,29 @@ public class ReusingHashMatchIteratorITCase {
 		final int DUPLICATE_KEY = 13;
 		
 		try {
-			Generator generator1 = new Generator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator gen1Iter = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator gen2Iter = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator gen1Iter = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator gen2Iter = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
-			final TestData.ConstantValueIterator const1Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
-			final TestData.ConstantValueIterator const2Iter = new TestData.ConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
+			final TestData.TupleConstantValueIterator const1Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "LEFT String for Duplicate Keys", INPUT_1_DUPLICATES);
+			final TestData.TupleConstantValueIterator const2Iter = new TestData.TupleConstantValueIterator(DUPLICATE_KEY, "RIGHT String for Duplicate Keys", INPUT_2_DUPLICATES);
 			
-			final List<MutableObjectIterator<Record>> inList1 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList1 = new ArrayList<>();
 			inList1.add(gen1Iter);
 			inList1.add(const1Iter);
 			
-			final List<MutableObjectIterator<Record>> inList2 = new ArrayList<MutableObjectIterator<Record>>();
+			final List<MutableObjectIterator<Tuple2<Integer, String>>> inList2 = new ArrayList<>();
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 			
-			MutableObjectIterator<Record> input1 = new UnionIterator<Record>(inList1);
-			MutableObjectIterator<Record> input2 = new UnionIterator<Record>(inList2);
+			MutableObjectIterator<Tuple2<Integer, String>> input1 = new UnionIterator<>(inList1);
+			MutableObjectIterator<Tuple2<Integer, String>> input2 = new UnionIterator<>(inList2);
 			
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
+			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
 				collectRecordData(input1),
 				collectRecordData(input2));
 			
@@ -367,14 +360,14 @@ public class ReusingHashMatchIteratorITCase {
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 	
-			input1 = new UnionIterator<Record>(inList1);
-			input2 = new UnionIterator<Record>(inList2);
+			input1 = new UnionIterator<>(inList1);
+			input2 = new UnionIterator<>(inList2);
 			
-			final JoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
-			ReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
-				new ReusingBuildSecondHashMatchIterator<Record, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new ReusingBuildSecondHashMatchIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
 					this.memoryManager, ioManager, this.parentTask, 1.0, true);
@@ -386,7 +379,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -403,16 +396,16 @@ public class ReusingHashMatchIteratorITCase {
 		try {
 			MutableObjectIterator<IntPair> input1 = new UniformIntPairGenerator(500, 40, false);
 			
-			final Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
 				collectIntPairData(input1),
 				collectRecordData(input2));
 			
-			final FlatJoinFunction<IntPair, Record, Record> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
 			input1 = new UniformIntPairGenerator(500, 40, false);
@@ -420,8 +413,8 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			ReusingBuildSecondHashMatchIterator<IntPair, Record, Record> iterator =
-					new ReusingBuildSecondHashMatchIterator<IntPair, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildSecondHashMatchIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator,
 						this.recordSerializer, this.record2Comparator, this.pairRecordPairComparator,
 						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
@@ -433,7 +426,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -450,16 +443,16 @@ public class ReusingHashMatchIteratorITCase {
 		try {
 			MutableObjectIterator<IntPair> input1 = new UniformIntPairGenerator(500, 40, false);
 			
-			final Generator generator2 = new Generator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<TestData.Key, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
 				collectIntPairData(input1),
 				collectRecordData(input2));
 			
-			final FlatJoinFunction<IntPair, Record, Record> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
 			input1 = new UniformIntPairGenerator(500, 40, false);
@@ -467,8 +460,8 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			ReusingBuildFirstHashMatchIterator<IntPair, Record, Record> iterator =
-					new ReusingBuildFirstHashMatchIterator<IntPair, Record, Record>(
+			ReusingBuildFirstHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashMatchIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairPairComparator,
 						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
@@ -480,7 +473,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<TestData.Key, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -498,15 +491,15 @@ public class ReusingHashMatchIteratorITCase {
 
 	
 	
-	static Map<TestData.Key, Collection<RecordMatch>> matchRecordValues(
-			Map<TestData.Key, Collection<TestData.Value>> leftMap,
-			Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	static Map<Integer, Collection<RecordMatch>> matchRecordValues(
+			Map<Integer, Collection<String>> leftMap,
+			Map<Integer, Collection<String>> rightMap)
 	{
-		Map<TestData.Key, Collection<RecordMatch>> map = new HashMap<TestData.Key, Collection<RecordMatch>>();
+		Map<Integer, Collection<RecordMatch>> map = new HashMap<>();
 
-		for (TestData.Key key : leftMap.keySet()) {
-			Collection<TestData.Value> leftValues = leftMap.get(key);
-			Collection<TestData.Value> rightValues = rightMap.get(key);
+		for (Integer key : leftMap.keySet()) {
+			Collection<String> leftValues = leftMap.get(key);
+			Collection<String> rightValues = rightMap.get(key);
 
 			if (rightValues == null) {
 				continue;
@@ -518,8 +511,8 @@ public class ReusingHashMatchIteratorITCase {
 
 			Collection<RecordMatch> matchedValues = map.get(key);
 
-			for (TestData.Value leftValue : leftValues) {
-				for (TestData.Value rightValue : rightValues) {
+			for (String leftValue : leftValues) {
+				for (String rightValue : rightValues) {
 					matchedValues.add(new RecordMatch(leftValue, rightValue));
 				}
 			}
@@ -528,18 +521,18 @@ public class ReusingHashMatchIteratorITCase {
 		return map;
 	}
 	
-	static Map<TestData.Key, Collection<RecordIntPairMatch>> matchRecordIntPairValues(
+	static Map<Integer, Collection<RecordIntPairMatch>> matchRecordIntPairValues(
 		Map<Integer, Collection<Integer>> leftMap,
-		Map<TestData.Key, Collection<TestData.Value>> rightMap)
+		Map<Integer, Collection<String>> rightMap)
 	{
-		final Map<TestData.Key, Collection<RecordIntPairMatch>> map = new HashMap<TestData.Key, Collection<RecordIntPairMatch>>();
+		final Map<Integer, Collection<RecordIntPairMatch>> map = new HashMap<>();
 	
 		for (Integer i : leftMap.keySet()) {
 			
-			final TestData.Key key = new TestData.Key(i.intValue());
+			final Integer key = new Integer(i.intValue());
 			
 			final Collection<Integer> leftValues = leftMap.get(i);
-			final Collection<TestData.Value> rightValues = rightMap.get(key);
+			final Collection<String> rightValues = rightMap.get(key);
 	
 			if (rightValues == null) {
 				continue;
@@ -552,7 +545,7 @@ public class ReusingHashMatchIteratorITCase {
 			final Collection<RecordIntPairMatch> matchedValues = map.get(key);
 	
 			for (Integer v : leftValues) {
-				for (TestData.Value val : rightValues) {
+				for (String val : rightValues) {
 					matchedValues.add(new RecordIntPairMatch(v, val));
 				}
 			}
@@ -562,21 +555,21 @@ public class ReusingHashMatchIteratorITCase {
 	}
 
 	
-	static Map<TestData.Key, Collection<TestData.Value>> collectRecordData(MutableObjectIterator<Record> iter)
+	static Map<Integer, Collection<String>> collectRecordData(MutableObjectIterator<Tuple2<Integer, String>> iter)
 	throws Exception
 	{
-		Map<TestData.Key, Collection<TestData.Value>> map = new HashMap<TestData.Key, Collection<TestData.Value>>();
-		Record pair = new Record();
+		Map<Integer, Collection<String>> map = new HashMap<>();
+		Tuple2<Integer, String> pair = new Tuple2<>();
 		
 		while ((pair = iter.next(pair)) != null) {
 
-			TestData.Key key = pair.getField(0, TestData.Key.class);
+			Integer key = pair.f0;
 			if (!map.containsKey(key)) {
-				map.put(new TestData.Key(key.getKey()), new ArrayList<TestData.Value>());
+				map.put(key, new ArrayList<String>());
 			}
 
-			Collection<TestData.Value> values = map.get(key);
-			values.add(new TestData.Value(pair.getField(1, TestData.Value.class).getValue()));
+			Collection<String> values = map.get(key);
+			values.add(pair.f1);
 		}
 
 		return map;
@@ -585,7 +578,7 @@ public class ReusingHashMatchIteratorITCase {
 	static Map<Integer, Collection<Integer>> collectIntPairData(MutableObjectIterator<IntPair> iter)
 	throws Exception
 	{
-		Map<Integer, Collection<Integer>> map = new HashMap<Integer, Collection<Integer>>();
+		Map<Integer, Collection<Integer>> map = new HashMap<>();
 		IntPair pair = new IntPair();
 		
 		while ((pair = iter.next(pair)) != null) {
@@ -608,10 +601,10 @@ public class ReusingHashMatchIteratorITCase {
 	 */
 	static class RecordMatch {
 		
-		private final Value left;
-		private final Value right;
+		private final String left;
+		private final String right;
 
-		public RecordMatch(Value left, Value right) {
+		public RecordMatch(String left, String right) {
 			this.left = left;
 			this.right = right;
 		}
@@ -639,9 +632,9 @@ public class ReusingHashMatchIteratorITCase {
 	static class RecordIntPairMatch
 	{
 		private final int left;
-		private final Value right;
+		private final String right;
 
-		public RecordIntPairMatch(int left, Value right) {
+		public RecordIntPairMatch(int left, String right) {
 			this.left = left;
 			this.right = right;
 		}
@@ -663,20 +656,20 @@ public class ReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordMatchRemovingJoin extends JoinFunction
+	static final class RecordMatchRemovingJoin implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<TestData.Key, Collection<RecordMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<RecordMatch>> toRemoveFrom;
 		
-		protected RecordMatchRemovingJoin(Map<TestData.Key, Collection<RecordMatch>> map) {
+		protected RecordMatchRemovingJoin(Map<Integer, Collection<RecordMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
 		@Override
-		public void join(Record rec1, Record rec2, Collector<Record> out) throws Exception
+		public void join(Tuple2<Integer, String> rec1, Tuple2<Integer, String> rec2, Collector<Tuple2<Integer, String>> out) throws Exception
 		{
-			TestData.Key key = rec1.getField(0, TestData.Key.class);
-			TestData.Value value1 = rec1.getField(1, TestData.Value.class);
-			TestData.Value value2 = rec2.getField(1, TestData.Value.class);
+			Integer key = rec1.f0;
+			String value1 = rec1.f1;
+			String value2 = rec2.f1;
 			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.getField(0, TestData.Key.class));
 			Collection<RecordMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
@@ -692,24 +685,24 @@ public class ReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordIntPairMatchRemovingMatcher extends AbstractRichFunction implements FlatJoinFunction<IntPair, Record, Record>
+	static final class RecordIntPairMatchRemovingMatcher extends AbstractRichFunction implements FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<TestData.Key, Collection<RecordIntPairMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<RecordIntPairMatch>> toRemoveFrom;
 		
-		protected RecordIntPairMatchRemovingMatcher(Map<TestData.Key, Collection<RecordIntPairMatch>> map) {
+		protected RecordIntPairMatchRemovingMatcher(Map<Integer, Collection<RecordIntPairMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
 		@Override
-		public void join(IntPair rec1, Record rec2, Collector<Record> out) throws Exception
+		public void join(IntPair rec1, Tuple2<Integer, String> rec2, Collector<Tuple2<Integer, String>> out) throws Exception
 		{
 			final int k = rec1.getKey();
 			final int v = rec1.getValue(); 
 			
-			final TestData.Key key = rec2.getField(0, TestData.Key.class);
-			final TestData.Value value = rec2.getField(1, TestData.Value.class);
+			final Integer key = rec2.f0;
+			final String value = rec2.f1;
 			
-			Assert.assertTrue("Key does not match for matching IntPair Record combination.", k == key.getKey()); 
+			Assert.assertTrue("Key does not match for matching IntPair Record combination.", k == key); 
 			
 			Collection<RecordIntPairMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
@@ -725,7 +718,7 @@ public class ReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class IntPairRecordPairComparator extends TypePairComparator<IntPair, Record>
+	static final class IntPairRecordPairComparator extends TypePairComparator<IntPair, Tuple2<Integer, String>>
 	{
 		private int reference;
 		
@@ -735,33 +728,31 @@ public class ReusingHashMatchIteratorITCase {
 		}
 
 		@Override
-		public boolean equalToReference(Record candidate) {
+		public boolean equalToReference(Tuple2<Integer, String> candidate) {
 			try {
-				final IntValue i = candidate.getField(0, IntValue.class);
-				return i.getValue() == this.reference;
+				return candidate.f0 == this.reference;
 			} catch (NullPointerException npex) {
 				throw new NullKeyFieldException();
 			}
 		}
 
 		@Override
-		public int compareToReference(Record candidate) {
+		public int compareToReference(Tuple2<Integer, String> candidate) {
 			try {
-				final IntValue i = candidate.getField(0, IntValue.class);
-				return i.getValue() - this.reference;
+				return candidate.f0 - this.reference;
 			} catch (NullPointerException npex) {
 				throw new NullKeyFieldException();
 			}
 		}
 	}
 	
-	static final class RecordIntPairPairComparator extends TypePairComparator<Record, IntPair>
+	static final class RecordIntPairPairComparator extends TypePairComparator<Tuple2<Integer, String>, IntPair>
 	{
 		private int reference;
 		
 		@Override
-		public void setReference(Record reference) {
-			this.reference = reference.getField(0, IntValue.class).getValue();
+		public void setReference(Tuple2<Integer, String> reference) {
+			this.reference = reference.f0;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
@@ -84,10 +84,10 @@ public class ReusingHashMatchIteratorITCase {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.recordSerializer = TestData.getTupleSerializer();
+		this.recordSerializer = TestData.getIntStringTupleSerializer();
 		
-		this.record1Comparator = TestData.getTupleComparator();
-		this.record2Comparator = TestData.getTupleComparator();
+		this.record1Comparator = TestData.getIntStringTupleComparator();
+		this.record2Comparator = TestData.getIntStringTupleComparator();
 		
 		this.recordPairComparator = new GenericPairComparator(this.record1Comparator, this.record2Comparator);
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashMatchIteratorITCase.java
@@ -93,8 +93,8 @@ public class ReusingHashMatchIteratorITCase {
 		
 		this.pairSerializer = new IntPairSerializer();
 		this.pairComparator = new TestData.IntPairComparator();
-		this.pairRecordPairComparator = new IntPairRecordPairComparator();
-		this.recordPairPairComparator = new RecordIntPairPairComparator();
+		this.pairRecordPairComparator = new IntPairTuplePairComparator();
+		this.recordPairPairComparator = new TupleIntPairPairComparator();
 		
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
@@ -129,11 +129,11 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
@@ -156,7 +156,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -202,9 +202,9 @@ public class ReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -227,7 +227,7 @@ public class ReusingHashMatchIteratorITCase {
 			input1 = new UnionIterator<Tuple2<Integer, String>>(inList1);
 			input2 = new UnionIterator<Tuple2<Integer, String>>(inList2);
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			ReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
@@ -243,7 +243,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -265,11 +265,11 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
@@ -292,7 +292,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -338,9 +338,9 @@ public class ReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordMatch>> expectedMatchesMap = matchRecordValues(
-				collectRecordData(input1),
-				collectRecordData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
+				collectTupleData(input1),
+				collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -363,7 +363,7 @@ public class ReusingHashMatchIteratorITCase {
 			input1 = new UnionIterator<>(inList1);
 			input2 = new UnionIterator<>(inList2);
 			
-			final FlatJoinFunction matcher = new RecordMatchRemovingJoin(expectedMatchesMap);
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			ReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
@@ -379,7 +379,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -400,11 +400,11 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
 				collectIntPairData(input1),
-				collectRecordData(input2));
+				collectTupleData(input2));
 			
-			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
@@ -426,7 +426,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -447,11 +447,11 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<RecordIntPairMatch>> expectedMatchesMap = matchRecordIntPairValues(
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
 				collectIntPairData(input1),
-				collectRecordData(input2));
+				collectTupleData(input2));
 			
-			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new RecordIntPairMatchRemovingMatcher(expectedMatchesMap);
+			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
@@ -473,7 +473,7 @@ public class ReusingHashMatchIteratorITCase {
 			iterator.close();
 	
 			// assert that each expected match was seen
-			for (Entry<Integer, Collection<RecordIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
+			for (Entry<Integer, Collection<TupleIntPairMatch>> entry : expectedMatchesMap.entrySet()) {
 				if (!entry.getValue().isEmpty()) {
 					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
 				}
@@ -491,11 +491,11 @@ public class ReusingHashMatchIteratorITCase {
 
 	
 	
-	static Map<Integer, Collection<RecordMatch>> matchRecordValues(
+	static Map<Integer, Collection<TupleMatch>> matchSecondTupleFields(
 			Map<Integer, Collection<String>> leftMap,
 			Map<Integer, Collection<String>> rightMap)
 	{
-		Map<Integer, Collection<RecordMatch>> map = new HashMap<>();
+		Map<Integer, Collection<TupleMatch>> map = new HashMap<>();
 
 		for (Integer key : leftMap.keySet()) {
 			Collection<String> leftValues = leftMap.get(key);
@@ -506,14 +506,14 @@ public class ReusingHashMatchIteratorITCase {
 			}
 
 			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<RecordMatch>());
+				map.put(key, new ArrayList<TupleMatch>());
 			}
 
-			Collection<RecordMatch> matchedValues = map.get(key);
+			Collection<TupleMatch> matchedValues = map.get(key);
 
 			for (String leftValue : leftValues) {
 				for (String rightValue : rightValues) {
-					matchedValues.add(new RecordMatch(leftValue, rightValue));
+					matchedValues.add(new TupleMatch(leftValue, rightValue));
 				}
 			}
 		}
@@ -521,11 +521,11 @@ public class ReusingHashMatchIteratorITCase {
 		return map;
 	}
 	
-	static Map<Integer, Collection<RecordIntPairMatch>> matchRecordIntPairValues(
+	static Map<Integer, Collection<TupleIntPairMatch>> matchTupleIntPairValues(
 		Map<Integer, Collection<Integer>> leftMap,
 		Map<Integer, Collection<String>> rightMap)
 	{
-		final Map<Integer, Collection<RecordIntPairMatch>> map = new HashMap<>();
+		final Map<Integer, Collection<TupleIntPairMatch>> map = new HashMap<>();
 	
 		for (Integer i : leftMap.keySet()) {
 			
@@ -539,14 +539,14 @@ public class ReusingHashMatchIteratorITCase {
 			}
 	
 			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<RecordIntPairMatch>());
+				map.put(key, new ArrayList<TupleIntPairMatch>());
 			}
 	
-			final Collection<RecordIntPairMatch> matchedValues = map.get(key);
+			final Collection<TupleIntPairMatch> matchedValues = map.get(key);
 	
 			for (Integer v : leftValues) {
 				for (String val : rightValues) {
-					matchedValues.add(new RecordIntPairMatch(v, val));
+					matchedValues.add(new TupleIntPairMatch(v, val));
 				}
 			}
 		}
@@ -555,7 +555,7 @@ public class ReusingHashMatchIteratorITCase {
 	}
 
 	
-	static Map<Integer, Collection<String>> collectRecordData(MutableObjectIterator<Tuple2<Integer, String>> iter)
+	static Map<Integer, Collection<String>> collectTupleData(MutableObjectIterator<Tuple2<Integer, String>> iter)
 	throws Exception
 	{
 		Map<Integer, Collection<String>> map = new HashMap<>();
@@ -599,19 +599,19 @@ public class ReusingHashMatchIteratorITCase {
 	/**
 	 * Private class used for storage of the expected matches in a hash-map.
 	 */
-	static class RecordMatch {
+	static class TupleMatch {
 		
 		private final String left;
 		private final String right;
 
-		public RecordMatch(String left, String right) {
+		public TupleMatch(String left, String right) {
 			this.left = left;
 			this.right = right;
 		}
 
 		@Override
 		public boolean equals(Object obj) {
-			RecordMatch o = (RecordMatch) obj;
+			TupleMatch o = (TupleMatch) obj;
 			return this.left.equals(o.left) && this.right.equals(o.right);
 		}
 		
@@ -629,19 +629,19 @@ public class ReusingHashMatchIteratorITCase {
 	/**
 	 * Private class used for storage of the expected matches in a hash-map.
 	 */
-	static class RecordIntPairMatch
+	static class TupleIntPairMatch
 	{
 		private final int left;
 		private final String right;
 
-		public RecordIntPairMatch(int left, String right) {
+		public TupleIntPairMatch(int left, String right) {
 			this.left = left;
 			this.right = right;
 		}
 
 		@Override
 		public boolean equals(Object obj) {
-			RecordIntPairMatch o = (RecordIntPairMatch) obj;
+			TupleIntPairMatch o = (TupleIntPairMatch) obj;
 			return this.left == o.left && this.right.equals(o.right);
 		}
 		
@@ -656,11 +656,11 @@ public class ReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordMatchRemovingJoin implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>
+	static final class TupleMatchRemovingJoin implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<Integer, Collection<RecordMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<TupleMatch>> toRemoveFrom;
 		
-		protected RecordMatchRemovingJoin(Map<Integer, Collection<RecordMatch>> map) {
+		protected TupleMatchRemovingJoin(Map<Integer, Collection<TupleMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
@@ -671,13 +671,13 @@ public class ReusingHashMatchIteratorITCase {
 			String value1 = rec1.f1;
 			String value2 = rec2.f1;
 			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.getField(0, TestData.Key.class));
-			Collection<RecordMatch> matches = this.toRemoveFrom.get(key);
+			Collection<TupleMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
 				Assert.fail("Match " + key + " - " + value1 + ":" + value2 + " is unexpected.");
 			}
 			
 			Assert.assertTrue("Produced match was not contained: " + key + " - " + value1 + ":" + value2,
-				matches.remove(new RecordMatch(value1, value2)));
+				matches.remove(new TupleMatch(value1, value2)));
 			
 			if (matches.isEmpty()) {
 				this.toRemoveFrom.remove(key);
@@ -685,11 +685,11 @@ public class ReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordIntPairMatchRemovingMatcher extends AbstractRichFunction implements FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>>
+	static final class TupleIntPairMatchRemovingMatcher extends AbstractRichFunction implements FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
-		private final Map<Integer, Collection<RecordIntPairMatch>> toRemoveFrom;
+		private final Map<Integer, Collection<TupleIntPairMatch>> toRemoveFrom;
 		
-		protected RecordIntPairMatchRemovingMatcher(Map<Integer, Collection<RecordIntPairMatch>> map) {
+		protected TupleIntPairMatchRemovingMatcher(Map<Integer, Collection<TupleIntPairMatch>> map) {
 			this.toRemoveFrom = map;
 		}
 		
@@ -702,15 +702,15 @@ public class ReusingHashMatchIteratorITCase {
 			final Integer key = rec2.f0;
 			final String value = rec2.f1;
 			
-			Assert.assertTrue("Key does not match for matching IntPair Record combination.", k == key); 
+			Assert.assertTrue("Key does not match for matching IntPair Tuple combination.", k == key); 
 			
-			Collection<RecordIntPairMatch> matches = this.toRemoveFrom.get(key);
+			Collection<TupleIntPairMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {
 				Assert.fail("Match " + key + " - " + v + ":" + value + " is unexpected.");
 			}
 			
 			Assert.assertTrue("Produced match was not contained: " + key + " - " + v + ":" + value,
-				matches.remove(new RecordIntPairMatch(v, value)));
+				matches.remove(new TupleIntPairMatch(v, value)));
 			
 			if (matches.isEmpty()) {
 				this.toRemoveFrom.remove(key);
@@ -718,7 +718,7 @@ public class ReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class IntPairRecordPairComparator extends TypePairComparator<IntPair, Tuple2<Integer, String>>
+	static final class IntPairTuplePairComparator extends TypePairComparator<IntPair, Tuple2<Integer, String>>
 	{
 		private int reference;
 		
@@ -746,7 +746,7 @@ public class ReusingHashMatchIteratorITCase {
 		}
 	}
 	
-	static final class RecordIntPairPairComparator extends TypePairComparator<Tuple2<Integer, String>, IntPair>
+	static final class TupleIntPairPairComparator extends TypePairComparator<Tuple2<Integer, String>, IntPair>
 	{
 		private int reference;
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingReOpenableHashTableITCase.java
@@ -34,8 +34,6 @@ import org.apache.flink.api.common.typeutils.GenericPairComparator;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
@@ -46,18 +44,14 @@ import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.hash.ReusingHashMatchIteratorITCase.RecordMatch;
 import org.apache.flink.runtime.operators.hash.ReusingHashMatchIteratorITCase.RecordMatchRemovingJoin;
-import org.apache.flink.runtime.operators.hash.HashTableITCase.ConstantsKeyValuePairsIterator;
 import org.apache.flink.runtime.operators.hash.MutableHashTable.HashBucketIterator;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
 import org.apache.flink.runtime.operators.testutils.UnionIterator;
-import org.apache.flink.runtime.operators.testutils.TestData.Key;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
-import org.apache.flink.types.IntValue;
-import org.apache.flink.types.Record;
+import org.apache.flink.runtime.operators.testutils.UniformIntTupleGenerator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.After;
@@ -94,30 +88,26 @@ public class ReusingReOpenableHashTableITCase {
 	
 	
 	private static final AbstractInvokable MEM_OWNER = new DummyInvokable();
-	private TypeSerializer<Record> recordBuildSideAccesssor;
-	private TypeSerializer<Record> recordProbeSideAccesssor;
-	private TypeComparator<Record> recordBuildSideComparator;
-	private TypeComparator<Record> recordProbeSideComparator;
-	private TypePairComparator<Record, Record> pactRecordComparator;
+	private TypeSerializer<Tuple2<Integer, Integer>> recordBuildSideAccesssor;
+	private TypeSerializer<Tuple2<Integer, Integer>> recordProbeSideAccesssor;
+	private TypeComparator<Tuple2<Integer, Integer>> recordBuildSideComparator;
+	private TypeComparator<Tuple2<Integer, Integer>> recordProbeSideComparator;
+	private TypePairComparator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> pactRecordComparator;
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Before
 	public void beforeTest() {
-		this.recordSerializer = TestData.getTupleSerializer();
+		this.recordSerializer = TestData.getIntStringTupleSerializer();
 		
-		this.record1Comparator = TestData.getTupleComparator();
-		this.record2Comparator = TestData.getTupleComparator();
+		this.record1Comparator = TestData.getIntStringTupleComparator();
+		this.record2Comparator = TestData.getIntStringTupleComparator();
 		this.recordPairComparator = new GenericPairComparator(this.record1Comparator, this.record2Comparator);
 		
-		
-		final int[] keyPos = new int[] {0};
-		final Class<? extends Key>[] keyType = (Class<? extends Key>[]) new Class[] { IntValue.class };
-		
-		this.recordBuildSideAccesssor = RecordSerializer.get();
-		this.recordProbeSideAccesssor = RecordSerializer.get();
-		this.recordBuildSideComparator = new RecordComparator(keyPos, keyType);
-		this.recordProbeSideComparator = new RecordComparator(keyPos, keyType);
-		this.pactRecordComparator = new HashTableITCase.RecordPairComparatorFirstInt();
+		this.recordBuildSideAccesssor = TestData.getIntIntTupleSerializer();
+		this.recordProbeSideAccesssor = TestData.getIntIntTupleSerializer();
+		this.recordBuildSideComparator = TestData.getIntIntTupleComparator();
+		this.recordProbeSideComparator = TestData.getIntIntTupleComparator();
+		this.pactRecordComparator = new GenericPairComparator(this.recordBuildSideComparator, this.recordProbeSideComparator);
 		
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
 		this.ioManager = new IOManagerAsync();
@@ -276,16 +266,16 @@ public class ReusingReOpenableHashTableITCase {
 	//
 	//
 	
-	private MutableObjectIterator<Record> getProbeInput(final int numKeys,
+	private MutableObjectIterator<Tuple2<Integer, Integer>> getProbeInput(final int numKeys,
 			final int probeValsPerKey, final int repeatedValue1, final int repeatedValue2) {
-		MutableObjectIterator<Record> probe1 = new UniformRecordGenerator(numKeys, probeValsPerKey, true);
-		MutableObjectIterator<Record> probe2 = new ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
-		MutableObjectIterator<Record> probe3 = new ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
-		List<MutableObjectIterator<Record>> probes = new ArrayList<MutableObjectIterator<Record>>();
+		MutableObjectIterator<Tuple2<Integer, Integer>> probe1 = new UniformIntTupleGenerator(numKeys, probeValsPerKey, true);
+		MutableObjectIterator<Tuple2<Integer, Integer>> probe2 = new TestData.ConstantIntIntTuplesIterator(repeatedValue1, 17, 5);
+		MutableObjectIterator<Tuple2<Integer, Integer>> probe3 = new TestData.ConstantIntIntTuplesIterator(repeatedValue2, 23, 5);
+		List<MutableObjectIterator<Tuple2<Integer, Integer>>> probes = new ArrayList<>();
 		probes.add(probe1);
 		probes.add(probe2);
 		probes.add(probe3);
-		return new UnionIterator<Record>(probes);
+		return new UnionIterator<>(probes);
 	}
 	
 	@Test
@@ -302,14 +292,14 @@ public class ReusingReOpenableHashTableITCase {
 		final int PROBE_VALS_PER_KEY = 10;
 		
 		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
-		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
-		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
-		MutableObjectIterator<Record> build3 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
-		List<MutableObjectIterator<Record>> builds = new ArrayList<MutableObjectIterator<Record>>();
+		MutableObjectIterator<Tuple2<Integer, Integer>> build1 = new UniformIntTupleGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build2 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build3 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
+		List<MutableObjectIterator<Tuple2<Integer, Integer>>> builds = new ArrayList<>();
 		builds.add(build1);
 		builds.add(build2);
 		builds.add(build3);
-		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
+		MutableObjectIterator<Tuple2<Integer, Integer>> buildInput = new UnionIterator<>(builds);
 
 		// allocate the memory for the HashTable
 		List<MemorySegment> memSegments;
@@ -326,40 +316,40 @@ public class ReusingReOpenableHashTableITCase {
 		
 		// ----------------------------------------------------------------------------------------
 		
-		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
+		final ReOpenableMutableHashTable<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> join = new ReOpenableMutableHashTable<>(
 				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager, true);
 		
 		for(int probe = 0; probe < NUM_PROBES; probe++) {
 			// create a probe input that gives 10 million pairs with 10 values sharing a key
-			MutableObjectIterator<Record> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
+			MutableObjectIterator<Tuple2<Integer, Integer>> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
 			if(probe == 0) {
 				join.open(buildInput, probeInput);
 			} else {
 				join.reopenProbe(probeInput);
 			}
 		
-			Record record;
-			final Record recordReuse = new Record();
+			Tuple2<Integer, Integer> record;
+			final Tuple2<Integer, Integer> recordReuse = new Tuple2<>();
 
 			while (join.nextRecord()) {
 				long numBuildValues = 0;
 		
-				final Record probeRec = join.getCurrentProbeRecord();
-				int key = probeRec.getField(0, IntValue.class).getValue();
+				final Tuple2<Integer, Integer> probeRec = join.getCurrentProbeRecord();
+				Integer key = probeRec.f0;
 				
-				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
+				HashBucketIterator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> buildSide = join.getBuildSideIterator();
 				if ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues = 1;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue()); 
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0); 
 				}
 				else {
 					fail("No build side values found for a probe key.");
 				}
 				while ((record = buildSide.next(record)) != null) {
 					numBuildValues++;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0);
 				}
 				
 				Long contained = map.get(key);
@@ -416,14 +406,14 @@ public class ReusingReOpenableHashTableITCase {
 		final int PROBE_VALS_PER_KEY = 10;
 		
 		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
-		MutableObjectIterator<Record> build1 = new UniformRecordGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
-		MutableObjectIterator<Record> build2 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
-		MutableObjectIterator<Record> build3 = new ConstantsKeyValuePairsIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
-		List<MutableObjectIterator<Record>> builds = new ArrayList<MutableObjectIterator<Record>>();
+		MutableObjectIterator<Tuple2<Integer, Integer>> build1 = new UniformIntTupleGenerator(NUM_KEYS, BUILD_VALS_PER_KEY, false);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build2 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_1, 17, REPEATED_VALUE_COUNT_BUILD);
+		MutableObjectIterator<Tuple2<Integer, Integer>> build3 = new TestData.ConstantIntIntTuplesIterator(REPEATED_VALUE_2, 23, REPEATED_VALUE_COUNT_BUILD);
+		List<MutableObjectIterator<Tuple2<Integer, Integer>>> builds = new ArrayList<>();
 		builds.add(build1);
 		builds.add(build2);
 		builds.add(build3);
-		MutableObjectIterator<Record> buildInput = new UnionIterator<Record>(builds);
+		MutableObjectIterator<Tuple2<Integer, Integer>> buildInput = new UnionIterator<>(builds);
 	
 
 		// allocate the memory for the HashTable
@@ -441,40 +431,40 @@ public class ReusingReOpenableHashTableITCase {
 		
 		// ----------------------------------------------------------------------------------------
 		
-		final ReOpenableMutableHashTable<Record, Record> join = new ReOpenableMutableHashTable<Record, Record>(
+		final ReOpenableMutableHashTable<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> join = new ReOpenableMutableHashTable<>(
 				this.recordBuildSideAccesssor, this.recordProbeSideAccesssor, 
 				this.recordBuildSideComparator, this.recordProbeSideComparator, this.pactRecordComparator,
 				memSegments, ioManager, true);
 		
 		for (int probe = 0; probe < NUM_PROBES; probe++) {
 			// create a probe input that gives 10 million pairs with 10 values sharing a key
-			MutableObjectIterator<Record> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
+			MutableObjectIterator<Tuple2<Integer, Integer>> probeInput = getProbeInput(NUM_KEYS, PROBE_VALS_PER_KEY, REPEATED_VALUE_1, REPEATED_VALUE_2);
 			if(probe == 0) {
 				join.open(buildInput, probeInput);
 			} else {
 				join.reopenProbe(probeInput);
 			}
-			Record record;
-			final Record recordReuse = new Record();
+			Tuple2<Integer, Integer> record;
+			final Tuple2<Integer, Integer> recordReuse = new Tuple2<>();
 
 			while (join.nextRecord())
 			{	
 				long numBuildValues = 0;
 				
-				final Record probeRec = join.getCurrentProbeRecord();
-				int key = probeRec.getField(0, IntValue.class).getValue();
+				final Tuple2<Integer, Integer> probeRec = join.getCurrentProbeRecord();
+				Integer key = probeRec.f0;
 				
-				HashBucketIterator<Record, Record> buildSide = join.getBuildSideIterator();
+				HashBucketIterator<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> buildSide = join.getBuildSideIterator();
 				if ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues = 1;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue()); 
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0); 
 				}
 				else {
 					fail("No build side values found for a probe key.");
 				}
 				while ((record = buildSide.next(recordReuse)) != null) {
 					numBuildValues++;
-					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.getField(0, IntValue.class).getValue());
+					Assert.assertEquals("Probe-side key was different than build-side key.", key, record.f0);
 				}
 				
 				Long contained = map.get(key);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import org.apache.flink.api.common.ExecutionConfig;
 
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -33,7 +32,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.common.typeutils.base.IntComparator;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -41,8 +39,6 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.MockTuple2Reader;
-import org.apache.flink.runtime.operators.testutils.TestData.MockTupleSerializerFactory;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
 import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.runtime.util.ReusingKeyGroupedIterator;
@@ -84,12 +80,11 @@ public class CombiningUnilateralSortMergerITCase {
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 		
-		this.serializerFactory1 = TestData.getTupleSerializerFactory();
-		this.comparator1 = TestData.getTupleComparator();
+		this.serializerFactory1 = TestData.getIntStringTupleSerializerFactory();
+		this.comparator1 = TestData.getIntStringTupleComparator();
 
-		TupleTypeInfo<Tuple2<Integer, Integer>> typeInfo2 = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, Integer.class);
-		this.serializerFactory2 = new MockTupleSerializerFactory(typeInfo2);
-		this.comparator2 = typeInfo2.createComparator(new int[]{0}, new boolean[]{true}, 0, new ExecutionConfig());
+		this.serializerFactory2 = TestData.getIntIntTupleSerializerFactory();
+		this.comparator2 = TestData.getIntIntTupleComparator();
 	}
 
 	@After
@@ -113,7 +108,7 @@ public class CombiningUnilateralSortMergerITCase {
 		int noKeys = 100;
 		int noKeyCnt = 10000;
 
-		MockTuple2Reader<Tuple2<Integer, Integer>> reader = new MockTuple2Reader<>();
+		TestData.MockTuple2Reader<Tuple2<Integer, Integer>> reader = TestData.getIntIntTupleReader();
 
 		LOG.debug("initializing sortmerger");
 		
@@ -152,7 +147,7 @@ public class CombiningUnilateralSortMergerITCase {
 		int noKeys = 100;
 		int noKeyCnt = 10000;
 
-		MockTuple2Reader<Tuple2<Integer, Integer>> reader = new MockTuple2Reader<>();
+		TestData.MockTuple2Reader<Tuple2<Integer, Integer>> reader = TestData.getIntIntTupleReader();
 
 		LOG.debug("initializing sortmerger");
 		
@@ -198,7 +193,7 @@ public class CombiningUnilateralSortMergerITCase {
 		final TypeComparator<Integer> keyComparator = new IntComparator(true);
 
 		// reader
-		MockTuple2Reader<Tuple2<Integer, String>> reader = new MockTuple2Reader<>();
+		TestData.MockTuple2Reader<Tuple2<Integer, String>> reader = TestData.getIntStringTupleReader();
 
 		// merge iterator
 		LOG.debug("initializing sortmerger");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
@@ -79,8 +79,8 @@ public class ExternalSortITCase {
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 		
-		this.pactRecordSerializer = TestData.getTupleSerializerFactory();
-		this.pactRecordComparator = TestData.getTupleComparator();
+		this.pactRecordSerializer = TestData.getIntStringTupleSerializerFactory();
+		this.pactRecordComparator = TestData.getIntStringTupleComparator();
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
@@ -18,12 +18,11 @@
 
 package org.apache.flink.runtime.operators.sort;
 
-import java.util.Comparator;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializerFactory;
+import org.apache.flink.api.common.typeutils.base.IntComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -31,14 +30,10 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.RandomIntPairGenerator;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Key;
-import org.apache.flink.runtime.operators.testutils.TestData.Value;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.runtime.operators.testutils.types.IntPair;
-import org.apache.flink.runtime.operators.testutils.types.IntPairComparator;
 import org.apache.flink.runtime.operators.testutils.types.IntPairSerializer;
-import org.apache.flink.types.Record;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.After;
 import org.junit.Assert;
@@ -58,7 +53,7 @@ public class ExternalSortITCase {
 
 	private static final int VALUE_LENGTH = 114;
 	
-	private static final Value VAL = new Value("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+	private static final String VAL = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 	private static final int NUM_PAIRS = 200000;
 
@@ -70,9 +65,9 @@ public class ExternalSortITCase {
 
 	private MemoryManager memoryManager;
 	
-	private TypeSerializerFactory<Record> pactRecordSerializer;
+	private TypeSerializerFactory<Tuple2<Integer, String>> pactRecordSerializer;
 	
-	private TypeComparator<Record> pactRecordComparator;
+	private TypeComparator<Tuple2<Integer, String>> pactRecordComparator;
 	
 	private boolean testSuccess;
 
@@ -84,8 +79,8 @@ public class ExternalSortITCase {
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
 		this.ioManager = new IOManagerAsync();
 		
-		this.pactRecordSerializer = RecordSerializerFactory.get();
-		this.pactRecordComparator = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
+		this.pactRecordSerializer = TestData.getTupleSerializerFactory();
+		this.pactRecordComparator = TestData.getTupleComparator();
 	}
 
 	@After
@@ -109,15 +104,15 @@ public class ExternalSortITCase {
 	public void testInMemorySort() {
 		try {
 			// comparator
-			final Comparator<TestData.Key> keyComparator = new TestData.KeyComparator();
+			final TypeComparator<Integer> keyComparator = new IntComparator(true);
 			
-			final TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.CONSTANT, VAL);
-			final MutableObjectIterator<Record> source = new TestData.GeneratorIterator(generator, NUM_PAIRS);
+			final TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.CONSTANT, VAL);
+			final MutableObjectIterator<Tuple2<Integer, String>> source = new TestData.TupleGeneratorIterator(generator, NUM_PAIRS);
 	
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
 			
-			Sorter<Record> merger = new UnilateralSortMerger<Record>(this.memoryManager, this.ioManager, 
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
 				source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
 					(double)64/78, 2, 0.9f, true);
 	
@@ -125,27 +120,21 @@ public class ExternalSortITCase {
 			LOG.debug("Reading and sorting data...");
 	
 			// check order
-			MutableObjectIterator<Record> iterator = merger.getIterator();
+			MutableObjectIterator<Tuple2<Integer, String>> iterator = merger.getIterator();
 			
 			LOG.debug("Checking results...");
 			int pairsEmitted = 1;
 	
-			Record rec1 = new Record();
-			Record rec2 = new Record();
+			Tuple2<Integer, String> rec1 = new Tuple2<>();
+			Tuple2<Integer, String> rec2 = new Tuple2<>();
 			
 			Assert.assertTrue((rec1 = iterator.next(rec1)) != null);
 			while ((rec2 = iterator.next(rec2)) != null) {
-				final Key k1 = rec1.getField(0, TestData.Key.class);
-				final Key k2 = rec2.getField(0, TestData.Key.class);
 				pairsEmitted++;
 				
-				Assert.assertTrue(keyComparator.compare(k1, k2) <= 0); 
+				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
 				
-				Record tmp = rec1;
 				rec1 = rec2;
-				k1.setKey(k2.getKey());
-				
-				rec2 = tmp;
 			}
 			Assert.assertTrue(NUM_PAIRS == pairsEmitted);
 			
@@ -162,15 +151,15 @@ public class ExternalSortITCase {
 	public void testInMemorySortUsing10Buffers() {
 		try {
 			// comparator
-			final Comparator<TestData.Key> keyComparator = new TestData.KeyComparator();
+			final TypeComparator<Integer> keyComparator = new IntComparator(true);
 			
-			final TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.CONSTANT, VAL);
-			final MutableObjectIterator<Record> source = new TestData.GeneratorIterator(generator, NUM_PAIRS);
+			final TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.CONSTANT, VAL);
+			final MutableObjectIterator<Tuple2<Integer, String>> source = new TestData.TupleGeneratorIterator(generator, NUM_PAIRS);
 	
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
 			
-			Sorter<Record> merger = new UnilateralSortMerger<Record>(this.memoryManager, this.ioManager, 
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
 					source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
 					(double)64/78, 10, 2, 0.9f, false);
 	
@@ -178,27 +167,21 @@ public class ExternalSortITCase {
 			LOG.debug("Reading and sorting data...");
 	
 			// check order
-			MutableObjectIterator<Record> iterator = merger.getIterator();
+			MutableObjectIterator<Tuple2<Integer, String>> iterator = merger.getIterator();
 			
 			LOG.debug("Checking results...");
 			int pairsEmitted = 1;
 	
-			Record rec1 = new Record();
-			Record rec2 = new Record();
+			Tuple2<Integer, String> rec1 = new Tuple2<>();
+			Tuple2<Integer, String> rec2 = new Tuple2<>();
 			
 			Assert.assertTrue((rec1 = iterator.next(rec1)) != null);
 			while ((rec2 = iterator.next(rec2)) != null) {
-				final Key k1 = rec1.getField(0, TestData.Key.class);
-				final Key k2 = rec2.getField(0, TestData.Key.class);
 				pairsEmitted++;
 				
-				Assert.assertTrue(keyComparator.compare(k1, k2) <= 0); 
+				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
 				
-				Record tmp = rec1;
 				rec1 = rec2;
-				k1.setKey(k2.getKey());
-				
-				rec2 = tmp;
 			}
 			Assert.assertTrue(NUM_PAIRS == pairsEmitted);
 			
@@ -215,15 +198,15 @@ public class ExternalSortITCase {
 	public void testSpillingSort() {
 		try {
 			// comparator
-			final Comparator<TestData.Key> keyComparator = new TestData.KeyComparator();
+			final TypeComparator<Integer> keyComparator = new IntComparator(true);
 			
-			final TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.CONSTANT, VAL);
-			final MutableObjectIterator<Record> source = new TestData.GeneratorIterator(generator, NUM_PAIRS);
+			final TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.CONSTANT, VAL);
+			final MutableObjectIterator<Tuple2<Integer, String>> source = new TestData.TupleGeneratorIterator(generator, NUM_PAIRS);
 	
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
 			
-			Sorter<Record> merger = new UnilateralSortMerger<Record>(this.memoryManager, this.ioManager, 
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
 					source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
 					(double)16/78, 64, 0.7f, true);
 	
@@ -231,27 +214,20 @@ public class ExternalSortITCase {
 			LOG.debug("Reading and sorting data...");
 	
 			// check order
-			MutableObjectIterator<Record> iterator = merger.getIterator();
+			MutableObjectIterator<Tuple2<Integer, String>> iterator = merger.getIterator();
 			
 			LOG.debug("Checking results...");
 			int pairsEmitted = 1;
 	
-			Record rec1 = new Record();
-			Record rec2 = new Record();
+			Tuple2<Integer, String> rec1 = new Tuple2<>();
+			Tuple2<Integer, String> rec2 = new Tuple2<>();
 			
 			Assert.assertTrue((rec1 = iterator.next(rec1)) != null);
 			while ((rec2 = iterator.next(rec2)) != null) {
-				final Key k1 = rec1.getField(0, TestData.Key.class);
-				final Key k2 = rec2.getField(0, TestData.Key.class);
 				pairsEmitted++;
 				
-				Assert.assertTrue(keyComparator.compare(k1, k2) <= 0); 
-				
-				Record tmp = rec1;
+				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
 				rec1 = rec2;
-				k1.setKey(k2.getKey());
-				
-				rec2 = tmp;
 			}
 			Assert.assertTrue(NUM_PAIRS == pairsEmitted);
 			
@@ -271,15 +247,15 @@ public class ExternalSortITCase {
 			final int PAIRS = 10000000;
 	
 			// comparator
-			final Comparator<TestData.Key> keyComparator = new TestData.KeyComparator();
+			final TypeComparator<Integer> keyComparator = new IntComparator(true);
 	
-			final TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
-			final MutableObjectIterator<Record> source = new TestData.GeneratorIterator(generator, PAIRS);
+			final TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
+			final MutableObjectIterator<Tuple2<Integer, String>> source = new TestData.TupleGeneratorIterator(generator, PAIRS);
 			
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
 			
-			Sorter<Record> merger = new UnilateralSortMerger<Record>(this.memoryManager, this.ioManager, 
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
 					source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
 					(double)64/78, 16, 0.7f, false);
 			
@@ -287,27 +263,21 @@ public class ExternalSortITCase {
 			LOG.debug("Emitting data...");
 	
 			// check order
-			MutableObjectIterator<Record> iterator = merger.getIterator();
+			MutableObjectIterator<Tuple2<Integer, String>> iterator = merger.getIterator();
 			
 			LOG.debug("Checking results...");
 			int pairsRead = 1;
 			int nextStep = PAIRS / 20;
 	
-			Record rec1 = new Record();
-			Record rec2 = new Record();
+			Tuple2<Integer, String> rec1 = new Tuple2<>();
+			Tuple2<Integer, String> rec2 = new Tuple2<>();
 			
 			Assert.assertTrue((rec1 = iterator.next(rec1)) != null);
 			while ((rec2 = iterator.next(rec2)) != null) {
-				final Key k1 = rec1.getField(0, TestData.Key.class);
-				final Key k2 = rec2.getField(0, TestData.Key.class);
 				pairsRead++;
 				
-				Assert.assertTrue(keyComparator.compare(k1, k2) <= 0); 
-				
-				Record tmp = rec1;
+				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
 				rec1 = rec2;
-				k1.setKey(k2.getKey());
-				rec2 = tmp;
 				
 				// log
 				if (pairsRead == nextStep) {
@@ -335,7 +305,7 @@ public class ExternalSortITCase {
 			final RandomIntPairGenerator generator = new RandomIntPairGenerator(12345678, PAIRS);
 			
 			final TypeSerializerFactory<IntPair> serializerFactory = new IntPairSerializer.IntPairSerializerFactory();
-			final TypeComparator<IntPair> comparator = new IntPairComparator();
+			final TypeComparator<IntPair> comparator = new TestData.IntPairComparator();
 			
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
@@ -133,8 +133,10 @@ public class ExternalSortITCase {
 				pairsEmitted++;
 				
 				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
-				
+
+				Tuple2<Integer, String> tmp = rec1;
 				rec1 = rec2;
+				rec2 = tmp;
 			}
 			Assert.assertTrue(NUM_PAIRS == pairsEmitted);
 			
@@ -180,8 +182,10 @@ public class ExternalSortITCase {
 				pairsEmitted++;
 				
 				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
-				
+
+				Tuple2<Integer, String> tmp = rec1;
 				rec1 = rec2;
+				rec2 = tmp;
 			}
 			Assert.assertTrue(NUM_PAIRS == pairsEmitted);
 			
@@ -227,7 +231,10 @@ public class ExternalSortITCase {
 				pairsEmitted++;
 				
 				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
+
+				Tuple2<Integer, String> tmp = rec1;
 				rec1 = rec2;
+				rec2 = tmp;
 			}
 			Assert.assertTrue(NUM_PAIRS == pairsEmitted);
 			
@@ -277,7 +284,10 @@ public class ExternalSortITCase {
 				pairsRead++;
 				
 				Assert.assertTrue(keyComparator.compare(rec1.f0, rec2.f0) <= 0);
+
+				Tuple2<Integer, String> tmp = rec1;
 				rec1 = rec2;
+				rec2 = tmp;
 				
 				// log
 				if (pairsRead == nextStep) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
@@ -38,7 +38,7 @@ public class MergeIteratorTest {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void setup() {
-		this.comparator = TestData.getTupleComparator();
+		this.comparator = TestData.getIntStringTupleComparator();
 	}
 	
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
@@ -114,7 +114,9 @@ public class MergeIteratorTest {
 			Assert.assertTrue(comparator.compare(k1, k2) <= 0);
 			Assert.assertEquals(expected[pos++], k2); 
 			
+			Tuple2<Integer, String> tmp = rec1;
 			rec1 = rec2;
+			rec2 = tmp;
 		}
 	}
 	
@@ -151,7 +153,9 @@ public class MergeIteratorTest {
 
 			Assert.assertTrue(comparator.compare(rec1.f0, rec2.f0) <= 0);
 			
+			Tuple2<Integer, String> tmp = rec1;
 			rec1 = rec2;
+			rec2 = tmp;
 		}
 		
 		Assert.assertEquals("Too few elements returned from stream.", 50, elementsFound);
@@ -193,7 +197,9 @@ public class MergeIteratorTest {
 				break;
 			}
 			
+			Tuple2<Integer, String> tmp = rec1;
 			rec1 = rec2;
+			rec2 = tmp;
 		}
 		
 		Assert.assertTrue("Merge must have returned a wrong result", violationFound);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/MergeIteratorTest.java
@@ -19,16 +19,12 @@
 package org.apache.flink.runtime.operators.sort;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.runtime.operators.sort.MergeIterator;
+import org.apache.flink.api.common.typeutils.base.IntComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Key;
-import org.apache.flink.runtime.operators.testutils.TestData.Value;
-import org.apache.flink.types.Record;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,33 +32,33 @@ import org.junit.Test;
 
 public class MergeIteratorTest {
 	
-	private TypeComparator<Record> comparator;
+	private TypeComparator<Tuple2<Integer, String>> comparator;
 	
 	
 	@SuppressWarnings("unchecked")
 	@Before
 	public void setup() {
-		this.comparator = new RecordComparator(new int[] {0}, new Class[] { TestData.Key.class});
+		this.comparator = TestData.getTupleComparator();
 	}
 	
 	
-	private MutableObjectIterator<Record> newIterator(final int[] keys, final String[] values) {
+	private MutableObjectIterator<Tuple2<Integer, String>> newIterator(final int[] keys, final String[] values) {
 		
-		return new MutableObjectIterator<Record>() {
+		return new MutableObjectIterator<Tuple2<Integer, String>>() {
 			
-			private Key key = new Key();
-			private Value value = new Value();
+			private int key = 0;
+			private String value = new String();
 			
 			private int current = 0;
 
 			@Override
-			public Record next(Record reuse) {
+			public Tuple2<Integer, String> next(Tuple2<Integer, String> reuse) {
 				if (current < keys.length) {
-					key.setKey(keys[current]);
-					value.setValue(values[current]);
+					key = keys[current];
+					value = values[current];
 					current++;
-					reuse.setField(0, key);
-					reuse.setField(1, value);
+					reuse.setField(key, 0);
+					reuse.setField(value, 1);
 					return reuse;
 				}
 				else {
@@ -71,9 +67,9 @@ public class MergeIteratorTest {
 			}
 
 			@Override
-			public Record next() {
+			public Tuple2<Integer, String> next() {
 				if (current < keys.length) {
-					Record result = new Record(new Key(keys[current]), new Value(values[current]));
+					Tuple2<Integer, String> result = new Tuple2<>(keys[current], values[current]);
 					current++;
 					return result;
 				}
@@ -88,39 +84,37 @@ public class MergeIteratorTest {
 	public void testMergeOfTwoStreams() throws Exception
 	{
 		// iterators
-		List<MutableObjectIterator<Record>> iterators = new ArrayList<MutableObjectIterator<Record>>();
+		List<MutableObjectIterator<Tuple2<Integer, String>>> iterators = new ArrayList<>();
 		iterators.add(newIterator(new int[] { 1, 2, 4, 5, 10 }, new String[] { "1", "2", "4", "5", "10" }));
 		iterators.add(newIterator(new int[] { 3, 6, 7, 10, 12 }, new String[] { "3", "6", "7", "10", "12" }));
 		
 		final int[] expected = new int[] {1, 2, 3, 4, 5, 6, 7, 10, 10, 12};
 
 		// comparator
-		Comparator<TestData.Key> comparator = new TestData.KeyComparator();
+		TypeComparator<Integer> comparator = new IntComparator(true);
 
 		// merge iterator
-		MutableObjectIterator<Record> iterator = new MergeIterator<Record>(iterators, this.comparator);
+		MutableObjectIterator<Tuple2<Integer, String>> iterator = new MergeIterator<>(iterators, this.comparator);
 
 		// check expected order
-		Record rec1 = new Record();
-		Record rec2 = new Record();
-		final Key k1 = new Key();
-		final Key k2 = new Key();
+		Tuple2<Integer, String> rec1 = new Tuple2<>();
+		Tuple2<Integer, String> rec2 = new Tuple2<>();
+		int k1 = 0;
+		int k2 = 0;
 		
 		int pos = 1;
 		
 		Assert.assertTrue((rec1 = iterator.next(rec1)) != null);
-		Assert.assertEquals(expected[0], rec1.getField(0, TestData.Key.class).getKey());
+		Assert.assertEquals(expected[0], rec1.f0.intValue());
 		
 		while ((rec2 = iterator.next(rec2)) != null) {
-			k1.setKey(rec1.getField(0, TestData.Key.class).getKey());
-			k2.setKey(rec2.getField(0, TestData.Key.class).getKey());
+			k1 = rec1.f0;
+			k2 = rec2.f0;
 			
 			Assert.assertTrue(comparator.compare(k1, k2) <= 0);
-			Assert.assertEquals(expected[pos++], k2.getKey()); 
+			Assert.assertEquals(expected[pos++], k2); 
 			
-			Record tmp = rec1;
 			rec1 = rec2;
-			rec2 = tmp;
 		}
 	}
 	
@@ -128,7 +122,7 @@ public class MergeIteratorTest {
 	public void testMergeOfTenStreams() throws Exception
 	{
 		// iterators
-		List<MutableObjectIterator<Record>> iterators = new ArrayList<MutableObjectIterator<Record>>();
+		List<MutableObjectIterator<Tuple2<Integer, String>>> iterators = new ArrayList<>();
 		iterators.add(newIterator(new int[] { 1, 2, 17, 23, 23 }, new String[] { "A", "B", "C", "D", "E" }));
 		iterators.add(newIterator(new int[] { 2, 6, 7, 8, 9 }, new String[] { "A", "B", "C", "D", "E" }));
 		iterators.add(newIterator(new int[] { 4, 10, 11, 11, 12 }, new String[] { "A", "B", "C", "D", "E" }));
@@ -141,28 +135,23 @@ public class MergeIteratorTest {
 		iterators.add(newIterator(new int[] { 8, 8, 14, 14, 15 }, new String[] { "A", "B", "C", "D", "E" }));
 
 		// comparator
-		Comparator<TestData.Key> comparator = new TestData.KeyComparator();
+		TypeComparator<Integer> comparator = new IntComparator(true);
 
 		// merge iterator
-		MutableObjectIterator<Record> iterator = new MergeIterator<Record>(iterators, this.comparator);
+		MutableObjectIterator<Tuple2<Integer, String>> iterator = new MergeIterator<>(iterators, this.comparator);
 
 		int elementsFound = 1;
 		// check expected order
-		Record rec1 = new Record();
-		Record rec2 = new Record();
-		final Key k1 = new Key();
-		final Key k2 = new Key();
+		Tuple2<Integer, String> rec1 = new Tuple2<>();
+		Tuple2<Integer, String> rec2 = new Tuple2<>();
 		
 		Assert.assertTrue((rec1 = iterator.next(rec1)) != null);
 		while ((rec2 = iterator.next(rec2)) != null) {
 			elementsFound++;
-			k1.setKey(rec1.getField(0, TestData.Key.class).getKey());
-			k2.setKey(rec2.getField(0, TestData.Key.class).getKey());
-			Assert.assertTrue(comparator.compare(k1, k2) <= 0);
+
+			Assert.assertTrue(comparator.compare(rec1.f0, rec2.f0) <= 0);
 			
-			Record tmp = rec1;
 			rec1 = rec2;
-			rec2 = tmp;
 		}
 		
 		Assert.assertEquals("Too few elements returned from stream.", 50, elementsFound);
@@ -172,7 +161,7 @@ public class MergeIteratorTest {
 	public void testInvalidMerge() throws Exception
 	{
 		// iterators
-		List<MutableObjectIterator<Record>> iterators = new ArrayList<MutableObjectIterator<Record>>();
+		List<MutableObjectIterator<Tuple2<Integer, String>>> iterators = new ArrayList<>();
 		iterators.add(newIterator(new int[] { 1, 2, 17, 23, 23 }, new String[] { "A", "B", "C", "D", "E" }));
 		iterators.add(newIterator(new int[] { 2, 6, 7, 8, 9 }, new String[] { "A", "B", "C", "D", "E" }));
 		iterators.add(newIterator(new int[] { 4, 10, 11, 11, 12 }, new String[] { "A", "B", "C", "D", "E" }));
@@ -185,33 +174,26 @@ public class MergeIteratorTest {
 		iterators.add(newIterator(new int[] { 8, 8, 14, 14, 15 }, new String[] { "A", "B", "C", "D", "E" }));
 
 		// comparator
-		Comparator<TestData.Key> comparator = new TestData.KeyComparator();
+		TypeComparator<Integer> comparator = new IntComparator(true);
 
 		// merge iterator
-		MutableObjectIterator<Record> iterator = new MergeIterator<Record>(iterators, this.comparator);
+		MutableObjectIterator<Tuple2<Integer, String>> iterator = new MergeIterator<>(iterators, this.comparator);
 
 		boolean violationFound = false;
 		
 		// check expected order
-		Record rec1 = new Record();
-		Record rec2 = new Record();
+		Tuple2<Integer, String> rec1 = new Tuple2<>();
+		Tuple2<Integer, String> rec2 = new Tuple2<>();
 		
 		Assert.assertTrue((rec1 = iterator.next(rec1)) != null);
 		while ((rec2 = iterator.next(rec2)) != null)
-		{
-			final Key k1 = new Key();
-			final Key k2 = new Key();
-			k1.setKey(rec1.getField(0, TestData.Key.class).getKey());
-			k2.setKey(rec2.getField(0, TestData.Key.class).getKey());
-			
-			if (comparator.compare(k1, k2) > 0) {
+		{			
+			if (comparator.compare(rec1.f0, rec2.f0) > 0) {
 				violationFound = true;
 				break;
 			}
 			
-			Record tmp = rec1;
 			rec1 = rec2;
-			rec2 = tmp;
 		}
 		
 		Assert.assertTrue("Merge must have returned a wrong result", violationFound);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
@@ -77,10 +77,10 @@ public class NonReusingSortMergeCoGroupIteratorITCase
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.serializer1 = TestData.getTupleSerializer();
-		this.serializer2 = TestData.getTupleSerializer();
-		this.comparator1 = TestData.getTupleComparator();
-		this.comparator2 = TestData.getTupleComparator();
+		this.serializer1 = TestData.getIntStringTupleSerializer();
+		this.serializer2 = TestData.getIntStringTupleSerializer();
+		this.comparator1 = TestData.getIntStringTupleComparator();
+		this.comparator2 = TestData.getIntStringTupleComparator();
 		this.pairComparator = new GenericPairComparator(this.comparator1, this.comparator2);
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
@@ -22,14 +22,10 @@ package org.apache.flink.runtime.operators.sort;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializer;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
-import org.apache.flink.types.Record;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,6 +39,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.flink.api.common.typeutils.GenericPairComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
 
 /**
  */
@@ -59,77 +57,77 @@ public class NonReusingSortMergeCoGroupIteratorITCase
 	private static final long SEED2 = 231434613412342L;
 
 	// left and right input data generators
-	private Generator generator1;
+	private TupleGenerator generator1;
 
-	private Generator generator2;
+	private TupleGenerator generator2;
 
 	// left and right input RecordReader mocks
-	private MutableObjectIterator<Record> reader1;
+	private MutableObjectIterator<Tuple2<Integer, String>> reader1;
 
-	private MutableObjectIterator<Record> reader2;
+	private MutableObjectIterator<Tuple2<Integer, String>> reader2;
 	
 	
-	private TypeSerializer<Record> serializer1;
-	private TypeSerializer<Record> serializer2;
-	private TypeComparator<Record> comparator1;
-	private TypeComparator<Record> comparator2;
-	private TypePairComparator<Record, Record> pairComparator;
+	private TypeSerializer<Tuple2<Integer, String>> serializer1;
+	private TypeSerializer<Tuple2<Integer, String>> serializer2;
+	private TypeComparator<Tuple2<Integer, String>> comparator1;
+	private TypeComparator<Tuple2<Integer, String>> comparator2;
+	private TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> pairComparator;
 
 
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.serializer1 = RecordSerializer.get();
-		this.serializer2 = RecordSerializer.get();
-		this.comparator1 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
-		this.comparator2 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
-		this.pairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[]{TestData.Key.class});
+		this.serializer1 = TestData.getTupleSerializer();
+		this.serializer2 = TestData.getTupleSerializer();
+		this.comparator1 = TestData.getTupleComparator();
+		this.comparator2 = TestData.getTupleComparator();
+		this.pairComparator = new GenericPairComparator(this.comparator1, this.comparator2);
 	}
 	
 	@Test
 	public void testMerge() {
 		try {
 			
-			generator1 = new Generator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
-			generator2 = new Generator(SEED2, 500, 2048, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			generator1 = new TupleGenerator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
 
-			reader1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			reader2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			reader1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			reader2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 
 			// collect expected data
-			Map<TestData.Key, Collection<TestData.Value>> expectedValuesMap1 = collectData(generator1, INPUT_1_SIZE);
-			Map<TestData.Key, Collection<TestData.Value>> expectedValuesMap2 = collectData(generator2, INPUT_2_SIZE);
-			Map<TestData.Key, List<Collection<TestData.Value>>> expectedCoGroupsMap = coGroupValues(expectedValuesMap1, expectedValuesMap2);
+			Map<Integer, Collection<String>> expectedValuesMap1 = collectData(generator1, INPUT_1_SIZE);
+			Map<Integer, Collection<String>> expectedValuesMap2 = collectData(generator2, INPUT_2_SIZE);
+			Map<Integer, List<Collection<String>>> expectedCoGroupsMap = coGroupValues(expectedValuesMap1, expectedValuesMap2);
 	
 			// reset the generators
 			generator1.reset();
 			generator2.reset();
 	
 			// compare with iterator values
-			NonReusingSortMergeCoGroupIterator<Record, Record> iterator =	new NonReusingSortMergeCoGroupIterator<Record, Record>(
+			NonReusingSortMergeCoGroupIterator<Tuple2<Integer, String>,Tuple2<Integer, String>> iterator =	new NonReusingSortMergeCoGroupIterator<>(
 					this.reader1, this.reader2, this.serializer1, this.comparator1, this.serializer2, this.comparator2,
 					this.pairComparator);
 	
 			iterator.open();
 			
-			final TestData.Key key = new TestData.Key();
+			int key = 0;
 			while (iterator.next())
 			{
-				Iterator<Record> iter1 = iterator.getValues1().iterator();
-				Iterator<Record> iter2 = iterator.getValues2().iterator();
+				Iterator<Tuple2<Integer, String>> iter1 = iterator.getValues1().iterator();
+				Iterator<Tuple2<Integer, String>> iter2 = iterator.getValues2().iterator();
 				
-				TestData.Value v1 = null;
-				TestData.Value v2 = null;
+				String v1 = null;
+				String v2 = null;
 				
 				if (iter1.hasNext()) {
-					Record rec = iter1.next();
-					rec.getFieldInto(0, key);
-					v1 = rec.getField(1, TestData.Value.class);
+					Tuple2<Integer, String> rec = iter1.next();
+					key = rec.f0;
+					v1 = rec.f1;
 				}
 				else if (iter2.hasNext()) {
-					Record rec = iter2.next();
-					rec.getFieldInto(0, key);
-					v2 = rec.getField(1, TestData.Value.class);
+					Tuple2<Integer, String> rec = iter2.next();
+					key = rec.f0;
+					v2 = rec.f1;
 				}
 				else {
 					Assert.fail("No input on both sides.");
@@ -138,8 +136,8 @@ public class NonReusingSortMergeCoGroupIteratorITCase
 				// assert that matches for this key exist
 				Assert.assertTrue("No matches for key " + key, expectedCoGroupsMap.containsKey(key));
 				
-				Collection<TestData.Value> expValues1 = expectedCoGroupsMap.get(key).get(0);
-				Collection<TestData.Value> expValues2 = expectedCoGroupsMap.get(key).get(1);
+				Collection<String> expValues1 = expectedCoGroupsMap.get(key).get(0);
+				Collection<String> expValues2 = expectedCoGroupsMap.get(key).get(1);
 				
 				if (v1 != null) {
 					expValues1.remove(v1);
@@ -149,14 +147,14 @@ public class NonReusingSortMergeCoGroupIteratorITCase
 				}
 				
 				while(iter1.hasNext()) {
-					Record rec = iter1.next();
-					Assert.assertTrue("Value not in expected set of first input", expValues1.remove(rec.getField(1, TestData.Value.class)));
+					Tuple2<Integer, String> rec = iter1.next();
+					Assert.assertTrue("Value not in expected set of first input", expValues1.remove(rec.f1));
 				}
 				Assert.assertTrue("Expected set of first input not empty", expValues1.isEmpty());
 				
 				while(iter2.hasNext()) {
-					Record rec = iter2.next();
-					Assert.assertTrue("Value not in expected set of second input", expValues2.remove(rec.getField(1, TestData.Value.class)));
+					Tuple2<Integer, String> rec = iter2.next();
+					Assert.assertTrue("Value not in expected set of second input", expValues2.remove(rec.f1));
 				}
 				Assert.assertTrue("Expected set of second input not empty", expValues2.isEmpty());
 	
@@ -174,28 +172,28 @@ public class NonReusingSortMergeCoGroupIteratorITCase
 
 	// --------------------------------------------------------------------------------------------
 	
-	private Map<TestData.Key, List<Collection<TestData.Value>>> coGroupValues(
-			Map<TestData.Key, Collection<TestData.Value>> leftMap,
-			Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	private Map<Integer, List<Collection<String>>> coGroupValues(
+			Map<Integer, Collection<String>> leftMap,
+			Map<Integer, Collection<String>> rightMap)
 	{
-		Map<TestData.Key, List<Collection<TestData.Value>>> map = new HashMap<TestData.Key, List<Collection<TestData.Value>>>(1000);
+		Map<Integer, List<Collection<String>>> map = new HashMap<>(1000);
 
-		Set<TestData.Key> keySet = new HashSet<TestData.Key>(leftMap.keySet());
+		Set<Integer> keySet = new HashSet<>(leftMap.keySet());
 		keySet.addAll(rightMap.keySet());
 		
-		for (TestData.Key key : keySet) {
-			Collection<TestData.Value> leftValues = leftMap.get(key);
-			Collection<TestData.Value> rightValues = rightMap.get(key);
-			ArrayList<Collection<TestData.Value>> list = new ArrayList<Collection<TestData.Value>>(2);
+		for (Integer key : keySet) {
+			Collection<String> leftValues = leftMap.get(key);
+			Collection<String> rightValues = rightMap.get(key);
+			ArrayList<Collection<String>> list = new ArrayList<>(2);
 			
 			if (leftValues == null) {
-				list.add(new ArrayList<TestData.Value>(0));
+				list.add(new ArrayList<String>(0));
 			} else {
 				list.add(leftValues);
 			}
 			
 			if (rightValues == null) {
-				list.add(new ArrayList<TestData.Value>(0));
+				list.add(new ArrayList<String>(0));
 			} else {
 				list.add(rightValues);
 			}
@@ -205,22 +203,22 @@ public class NonReusingSortMergeCoGroupIteratorITCase
 		return map;
 	}
 
-	private Map<TestData.Key, Collection<TestData.Value>> collectData(Generator iter, int num)
+	private Map<Integer, Collection<String>> collectData(TupleGenerator iter, int num)
 	throws Exception
 	{
-		Map<TestData.Key, Collection<TestData.Value>> map = new HashMap<TestData.Key, Collection<TestData.Value>>();
-		Record pair = new Record();
+		Map<Integer, Collection<String>> map = new HashMap<>();
+		Tuple2<Integer, String> pair = new Tuple2<>();
 		
 		for (int i = 0; i < num; i++) {
 			iter.next(pair);
-			TestData.Key key = pair.getField(0, TestData.Key.class);
+			Integer key = pair.f0;
 			
 			if (!map.containsKey(key)) {
-				map.put(new TestData.Key(key.getKey()), new ArrayList<TestData.Value>());
+				map.put(key, new ArrayList<String>());
 			}
 
-			Collection<TestData.Value> values = map.get(key);
-			values.add(new TestData.Value(pair.getField(1, TestData.Value.class).getValue()));
+			Collection<String> values = map.get(key);
+			values.add(pair.f1);
 		}
 		return map;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NonReusingSortMergeCoGroupIteratorITCase.java
@@ -61,7 +61,7 @@ public class NonReusingSortMergeCoGroupIteratorITCase
 
 	private TupleGenerator generator2;
 
-	// left and right input RecordReader mocks
+	// left and right input TupleReader mocks
 	private MutableObjectIterator<Tuple2<Integer, String>> reader1;
 
 	private MutableObjectIterator<Tuple2<Integer, String>> reader2;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
@@ -75,7 +75,7 @@ public class NormalizedKeySorterTest {
 
 	private NormalizedKeySorter<Tuple2<Integer, String>> newSortBuffer(List<MemorySegment> memory) throws Exception
 	{
-		return new NormalizedKeySorter<>(TestData.getTupleSerializer(), TestData.getTupleComparator(), memory);
+		return new NormalizedKeySorter<>(TestData.getIntStringTupleSerializer(), TestData.getIntStringTupleComparator(), memory);
 	}
 
 	@Test
@@ -363,8 +363,8 @@ public class NormalizedKeySorterTest {
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
 		@SuppressWarnings("unchecked")
-		TypeComparator<Tuple2<Integer, String>> accessors = TestData.getTupleTypeInfo().createComparator(new int[]{1}, new boolean[]{true}, 0, null);
-		NormalizedKeySorter<Tuple2<Integer, String>> sorter = new NormalizedKeySorter<>(TestData.getTupleSerializer(), accessors, memory);
+		TypeComparator<Tuple2<Integer, String>> accessors = TestData.getIntStringTupleTypeInfo().createComparator(new int[]{1}, new boolean[]{true}, 0, null);
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = new NormalizedKeySorter<>(TestData.getIntStringTupleSerializer(), accessors, memory);
 		
 		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, 5, KeyMode.RANDOM,
 			ValueMode.FIX_LENGTH);
@@ -407,8 +407,8 @@ public class NormalizedKeySorterTest {
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
 		@SuppressWarnings("unchecked")
-		TypeComparator<Tuple2<Integer, String>> accessors = TestData.getTupleTypeInfo().createComparator(new int[]{1}, new boolean[]{true}, 0, null);
-		NormalizedKeySorter<Tuple2<Integer, String>> sorter = new NormalizedKeySorter<>(TestData.getTupleSerializer(), accessors, memory);
+		TypeComparator<Tuple2<Integer, String>> accessors = TestData.getIntStringTupleTypeInfo().createComparator(new int[]{1}, new boolean[]{true}, 0, null);
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = new NormalizedKeySorter<>(TestData.getIntStringTupleSerializer(), accessors, memory);
 		
 		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
 			ValueMode.FIX_LENGTH);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorterTest.java
@@ -21,19 +21,16 @@ package org.apache.flink.runtime.operators.sort;
 
 import java.util.List;
 import java.util.Random;
+import org.apache.flink.api.common.typeutils.TypeComparator;
 
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Key;
-import org.apache.flink.runtime.operators.testutils.TestData.Value;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
-import org.apache.flink.types.Record;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.util.MutableObjectIterator;
 
 import org.junit.After;
@@ -76,10 +73,9 @@ public class NormalizedKeySorterTest {
 		}
 	}
 
-	private NormalizedKeySorter<Record> newSortBuffer(List<MemorySegment> memory) throws Exception {
-		@SuppressWarnings({"unchecked", "rawtypes"})
-		RecordComparator accessors = new RecordComparator(new int[] {0}, new Class[]{ Key.class });
-		return new NormalizedKeySorter<Record>(RecordSerializer.get(), accessors, memory);
+	private NormalizedKeySorter<Tuple2<Integer, String>> newSortBuffer(List<MemorySegment> memory) throws Exception
+	{
+		return new NormalizedKeySorter<>(TestData.getTupleSerializer(), TestData.getTupleComparator(), memory);
 	}
 
 	@Test
@@ -87,12 +83,12 @@ public class NormalizedKeySorterTest {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
-		NormalizedKeySorter<Record> sorter = newSortBuffer(memory);
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = newSortBuffer(memory);
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
 			ValueMode.RANDOM_LENGTH);
 		
 		// write the records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		int num = -1;
 		do {
 			generator.next(record);
@@ -102,18 +98,18 @@ public class NormalizedKeySorterTest {
 		
 		// re-read the records
 		generator.reset();
-		Record readTarget = new Record();
+		Tuple2<Integer, String> readTarget = new Tuple2<>();
 		
 		int i = 0;
 		while (i < num) {
 			generator.next(record);
 			readTarget = sorter.getRecord(readTarget, i++);
 			
-			Key rk = readTarget.getField(0, Key.class);
-			Key gk = record.getField(0, Key.class);
+			int rk = readTarget.f0;
+			int gk = record.f0;
 			
-			Value rv = readTarget.getField(1, Value.class);
-			Value gv = record.getField(1, Value.class);
+			String rv = readTarget.f1;
+			String gv = record.f1;
 			
 			Assert.assertEquals("The re-read key is wrong", gk, rk);
 			Assert.assertEquals("The re-read value is wrong", gv, rv);
@@ -129,12 +125,12 @@ public class NormalizedKeySorterTest {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
-		NormalizedKeySorter<Record> sorter = newSortBuffer(memory);
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = newSortBuffer(memory);
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
 			ValueMode.RANDOM_LENGTH);
 		
 		// write the records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		do {
 			generator.next(record);
 		}
@@ -142,17 +138,17 @@ public class NormalizedKeySorterTest {
 		
 		// re-read the records
 		generator.reset();
-		MutableObjectIterator<Record> iter = sorter.getIterator();
-		Record readTarget = new Record();
+		MutableObjectIterator<Tuple2<Integer, String>> iter = sorter.getIterator();
+		Tuple2<Integer, String> readTarget = new Tuple2<>();
 		
 		while ((readTarget = iter.next(readTarget)) != null) {
 			generator.next(record);
 			
-			Key rk = readTarget.getField(0, Key.class);
-			Key gk = record.getField(0, Key.class);
+			int rk = readTarget.f0;
+			int gk = record.f0;
 			
-			Value rv = readTarget.getField(1, Value.class);
-			Value gv = record.getField(1, Value.class);
+			String rv = readTarget.f1;
+			String gv = record.f1;
 			
 			Assert.assertEquals("The re-read key is wrong", gk, rk);
 			Assert.assertEquals("The re-read value is wrong", gv, rv);
@@ -168,11 +164,11 @@ public class NormalizedKeySorterTest {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
-		NormalizedKeySorter<Record> sorter = newSortBuffer(memory);
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = newSortBuffer(memory);
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
 		
 		// write the buffer full with the first set of records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		int num = -1;
 		do {
 			generator.next(record);
@@ -183,7 +179,7 @@ public class NormalizedKeySorterTest {
 		sorter.reset();
 		
 		// write a second sequence of records. since the values are of fixed length, we must be able to write an equal number
-		generator = new TestData.Generator(SEED2, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
+		generator = new TestData.TupleGenerator(SEED2, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
 		
 		// write the buffer full with the first set of records
 		int num2 = -1;
@@ -197,18 +193,18 @@ public class NormalizedKeySorterTest {
 		
 		// re-read the records
 		generator.reset();
-		Record readTarget = new Record();
+		Tuple2<Integer, String> readTarget = new Tuple2<>();
 		
 		int i = 0;
 		while (i < num) {
 			generator.next(record);
 			readTarget = sorter.getRecord(readTarget, i++);
 			
-			Key rk = readTarget.getField(0, Key.class);
-			Key gk = record.getField(0, Key.class);
+			int rk = readTarget.f0;
+			int gk = record.f0;
 			
-			Value rv = readTarget.getField(1, Value.class);
-			Value gv = record.getField(1, Value.class);
+			String rv = readTarget.f1;
+			String gv = record.f1;
 			
 			Assert.assertEquals("The re-read key is wrong", gk, rk);
 			Assert.assertEquals("The re-read value is wrong", gv, rv);
@@ -229,12 +225,12 @@ public class NormalizedKeySorterTest {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
-		NormalizedKeySorter<Record> sorter = newSortBuffer(memory);
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = newSortBuffer(memory);
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
 			ValueMode.RANDOM_LENGTH);
 		
 		// write the records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		int num = -1;
 		do {
 			generator.next(record);
@@ -250,18 +246,18 @@ public class NormalizedKeySorterTest {
 		
 		// re-read the records
 		generator.reset();
-		Record readTarget = new Record();
+		Tuple2<Integer, String> readTarget = new Tuple2<>();
 		
 		int i = num - 1;
 		while (i >= 0) {
 			generator.next(record);
 			readTarget = sorter.getRecord(readTarget, i--);
 			
-			Key rk = readTarget.getField(0, Key.class);
-			Key gk = record.getField(0, Key.class);
+			int rk = readTarget.f0;
+			int gk = record.f0;
 			
-			Value rv = readTarget.getField(1, Value.class);
-			Value gv = record.getField(1, Value.class);
+			String rv = readTarget.f1;
+			String gv = record.f1;
 			
 			Assert.assertEquals("The re-read key is wrong", gk, rk);
 			Assert.assertEquals("The re-read value is wrong", gv, rv);
@@ -282,12 +278,12 @@ public class NormalizedKeySorterTest {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
-		NormalizedKeySorter<Record> sorter = newSortBuffer(memory);
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.SORTED,
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = newSortBuffer(memory);
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.SORTED,
 			ValueMode.RANDOM_LENGTH);
 		
 		// write the records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		int num = -1;
 		do {
 			generator.next(record);
@@ -323,12 +319,12 @@ public class NormalizedKeySorterTest {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
-		NormalizedKeySorter<Record> sorter = newSortBuffer(memory);
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = newSortBuffer(memory);
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
 			ValueMode.RANDOM_LENGTH);
 		
 		// write the records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		int num = 0;
 		do {
 			generator.next(record);
@@ -339,26 +335,21 @@ public class NormalizedKeySorterTest {
 		QuickSort qs = new QuickSort();
 		qs.sort(sorter);
 		
-		MutableObjectIterator<Record> iter = sorter.getIterator();
-		Record readTarget = new Record();
-		
-		Key current = new Key();
-		Key last = new Key();
-		
+		MutableObjectIterator<Tuple2<Integer, String>> iter = sorter.getIterator();
+		Tuple2<Integer, String> readTarget = new Tuple2<>();
+
 		iter.next(readTarget);
-		readTarget.getFieldInto(0, last);
+		int last = readTarget.f0;
 		
 		while ((readTarget = iter.next(readTarget)) != null) {
-			readTarget.getFieldInto(0, current);
+			int current = readTarget.f0;
 			
-			final int cmp = last.compareTo(current);
+			final int cmp = last - current;
 			if (cmp > 0) {
 				Assert.fail("Next key is not larger or equal to previous key.");
 			}
 			
-			Key tmp = current;
-			current = last;
-			last = tmp;
+			last = current;
 		}
 		
 		// release the memory occupied by the buffers
@@ -370,16 +361,16 @@ public class NormalizedKeySorterTest {
 	public void testSortShortStringKeys() throws Exception {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
-
-		@SuppressWarnings({"unchecked", "rawtypes"})
-		RecordComparator accessors = new RecordComparator(new int[] {1}, new Class[]{Value.class});
-		NormalizedKeySorter<Record> sorter = new NormalizedKeySorter<Record>(RecordSerializer.get(), accessors, memory);
 		
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, 5, KeyMode.RANDOM,
+		@SuppressWarnings("unchecked")
+		TypeComparator<Tuple2<Integer, String>> accessors = TestData.getTupleTypeInfo().createComparator(new int[]{1}, new boolean[]{true}, 0, null);
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = new NormalizedKeySorter<>(TestData.getTupleSerializer(), accessors, memory);
+		
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, 5, KeyMode.RANDOM,
 			ValueMode.FIX_LENGTH);
 		
 		// write the records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		do {
 			generator.next(record);
 		}
@@ -388,26 +379,21 @@ public class NormalizedKeySorterTest {
 		QuickSort qs = new QuickSort();
 		qs.sort(sorter);
 		
-		MutableObjectIterator<Record> iter = sorter.getIterator();
-		Record readTarget = new Record();
-		
-		Value current = new Value();
-		Value last = new Value();
-		
+		MutableObjectIterator<Tuple2<Integer, String>> iter = sorter.getIterator();
+		Tuple2<Integer, String> readTarget = new Tuple2<>();
+	
 		iter.next(readTarget);
-		readTarget.getFieldInto(1, last);
+		String last = readTarget.f1;
 		
 		while ((readTarget = iter.next(readTarget)) != null) {
-			readTarget.getFieldInto(1, current);
+			String current = readTarget.f1;
 			
 			final int cmp = last.compareTo(current);
 			if (cmp > 0) {
 				Assert.fail("Next value is not larger or equal to previous value.");
 			}
 			
-			Value tmp = current;
-			current = last;
-			last = tmp;
+			last = current;
 		}
 		
 		// release the memory occupied by the buffers
@@ -420,15 +406,15 @@ public class NormalizedKeySorterTest {
 		final int numSegments = MEMORY_SIZE / MEMORY_PAGE_SIZE;
 		final List<MemorySegment> memory = this.memoryManager.allocatePages(new DummyInvokable(), numSegments);
 		
-		@SuppressWarnings({"unchecked", "rawtypes"})
-		RecordComparator accessors = new RecordComparator(new int[] {1}, new Class[]{Value.class});
-		NormalizedKeySorter<Record> sorter = new NormalizedKeySorter<Record>(RecordSerializer.get(), accessors, memory);
+		@SuppressWarnings("unchecked")
+		TypeComparator<Tuple2<Integer, String>> accessors = TestData.getTupleTypeInfo().createComparator(new int[]{1}, new boolean[]{true}, 0, null);
+		NormalizedKeySorter<Tuple2<Integer, String>> sorter = new NormalizedKeySorter<>(TestData.getTupleSerializer(), accessors, memory);
 		
-		TestData.Generator generator = new TestData.Generator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
+		TestData.TupleGenerator generator = new TestData.TupleGenerator(SEED, KEY_MAX, VALUE_LENGTH, KeyMode.RANDOM,
 			ValueMode.FIX_LENGTH);
 		
 		// write the records
-		Record record = new Record();
+		Tuple2<Integer, String> record = new Tuple2<>();
 		do {
 			generator.next(record);
 		}
@@ -437,26 +423,21 @@ public class NormalizedKeySorterTest {
 		QuickSort qs = new QuickSort();
 		qs.sort(sorter);
 		
-		MutableObjectIterator<Record> iter = sorter.getIterator();
-		Record readTarget = new Record();
-		
-		Value current = new Value();
-		Value last = new Value();
+		MutableObjectIterator<Tuple2<Integer, String>> iter = sorter.getIterator();
+		Tuple2<Integer, String> readTarget = new Tuple2<>();
 		
 		iter.next(readTarget);
-		readTarget.getFieldInto(1, last);
+		String last = readTarget.f1;
 		
 		while ((readTarget = iter.next(readTarget)) != null) {
-			readTarget.getFieldInto(1, current);
+			String current = readTarget.f1;
 			
 			final int cmp = last.compareTo(current);
 			if (cmp > 0) {
 				Assert.fail("Next value is not larger or equal to previous value.");
 			}
 			
-			Value tmp = current;
-			current = last;
-			last = tmp;
+			last = current;
 		}
 		
 		// release the memory occupied by the buffers

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIteratorITCase.java
@@ -76,10 +76,10 @@ public class ReusingSortMergeCoGroupIteratorITCase
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.serializer1 = TestData.getTupleSerializer();
-		this.serializer2 = TestData.getTupleSerializer();
-		this.comparator1 = TestData.getTupleComparator();
-		this.comparator2 = TestData.getTupleComparator();
+		this.serializer1 = TestData.getIntStringTupleSerializer();
+		this.serializer2 = TestData.getIntStringTupleSerializer();
+		this.comparator1 = TestData.getIntStringTupleComparator();
+		this.comparator2 = TestData.getIntStringTupleComparator();
 		this.pairComparator = new GenericPairComparator(comparator1, comparator2);
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ReusingSortMergeCoGroupIteratorITCase.java
@@ -27,18 +27,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.flink.api.common.typeutils.GenericPairComparator;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
-import org.apache.flink.types.Record;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.Assert;
 import org.junit.Before;
@@ -59,77 +57,76 @@ public class ReusingSortMergeCoGroupIteratorITCase
 	private static final long SEED2 = 231434613412342L;
 
 	// left and right input data generators
-	private Generator generator1;
+	private TupleGenerator generator1;
 
-	private Generator generator2;
+	private TupleGenerator generator2;
 
-	// left and right input RecordReader mocks
-	private MutableObjectIterator<Record> reader1;
+	// left and right input Tuple2<Integer, String>Reader mocks
+	private MutableObjectIterator<Tuple2<Integer, String>> reader1;
 
-	private MutableObjectIterator<Record> reader2;
+	private MutableObjectIterator<Tuple2<Integer, String>> reader2;
 	
-	
-	private TypeSerializer<Record> serializer1;
-	private TypeSerializer<Record> serializer2;
-	private TypeComparator<Record> comparator1;
-	private TypeComparator<Record> comparator2;
-	private TypePairComparator<Record, Record> pairComparator;
+	private TypeSerializer<Tuple2<Integer, String>> serializer1;
+	private TypeSerializer<Tuple2<Integer, String>> serializer2;
+	private TypeComparator<Tuple2<Integer, String>> comparator1;
+	private TypeComparator<Tuple2<Integer, String>> comparator2;
+	private TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> pairComparator;
 
 
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.serializer1 = RecordSerializer.get();
-		this.serializer2 = RecordSerializer.get();
-		this.comparator1 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
-		this.comparator2 = new RecordComparator(new int[] {0}, new Class[]{TestData.Key.class});
-		this.pairComparator = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[]{TestData.Key.class});
+		this.serializer1 = TestData.getTupleSerializer();
+		this.serializer2 = TestData.getTupleSerializer();
+		this.comparator1 = TestData.getTupleComparator();
+		this.comparator2 = TestData.getTupleComparator();
+		this.pairComparator = new GenericPairComparator(comparator1, comparator2);
 	}
 	
 	@Test
 	public void testMerge() {
 		try {
 			
-			generator1 = new Generator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
-			generator2 = new Generator(SEED2, 500, 2048, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			generator1 = new TupleGenerator(SEED1, 500, 4096, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
+			generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.SORTED, ValueMode.RANDOM_LENGTH);
 
-			reader1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			reader2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			reader1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			reader2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 
 			// collect expected data
-			Map<TestData.Key, Collection<TestData.Value>> expectedValuesMap1 = collectData(generator1, INPUT_1_SIZE);
-			Map<TestData.Key, Collection<TestData.Value>> expectedValuesMap2 = collectData(generator2, INPUT_2_SIZE);
-			Map<TestData.Key, List<Collection<TestData.Value>>> expectedCoGroupsMap = coGroupValues(expectedValuesMap1, expectedValuesMap2);
+			Map<Integer, Collection<String>> expectedStringsMap1 = collectData(generator1, INPUT_1_SIZE);
+			Map<Integer, Collection<String>> expectedStringsMap2 = collectData(generator2, INPUT_2_SIZE);
+			Map<Integer, List<Collection<String>>> expectedCoGroupsMap = coGroupValues(expectedStringsMap1, expectedStringsMap2);
 	
 			// reset the generators
 			generator1.reset();
 			generator2.reset();
 	
 			// compare with iterator values
-			ReusingSortMergeCoGroupIterator<Record, Record> iterator =	new ReusingSortMergeCoGroupIterator<Record, Record>(
+			ReusingSortMergeCoGroupIterator<Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =	new ReusingSortMergeCoGroupIterator<>(
 					this.reader1, this.reader2, this.serializer1, this.comparator1, this.serializer2, this.comparator2,
 					this.pairComparator);
 	
 			iterator.open();
 			
-			final TestData.Key key = new TestData.Key();
+			int key = 0;
 			while (iterator.next())
 			{
-				Iterator<Record> iter1 = iterator.getValues1().iterator();
-				Iterator<Record> iter2 = iterator.getValues2().iterator();
+				Iterator<Tuple2<Integer, String>> iter1 = iterator.getValues1().iterator();
+				Iterator<Tuple2<Integer, String>> iter2 = iterator.getValues2().iterator();
 				
-				TestData.Value v1 = null;
-				TestData.Value v2 = null;
+				String v1 = null;
+				String v2 = null;
 				
 				if (iter1.hasNext()) {
-					Record rec = iter1.next();
-					rec.getFieldInto(0, key);
-					v1 = rec.getField(1, TestData.Value.class);
+					Tuple2<Integer, String> rec = iter1.next();
+					key = rec.f0;
+					v1 = rec.f1;
 				}
 				else if (iter2.hasNext()) {
-					Record rec = iter2.next();
-					rec.getFieldInto(0, key);
-					v2 = rec.getField(1, TestData.Value.class);
+					Tuple2<Integer, String> rec = iter2.next();
+					key = rec.f0;
+					v2 = rec.f1;
 				}
 				else {
 					Assert.fail("No input on both sides.");
@@ -138,8 +135,8 @@ public class ReusingSortMergeCoGroupIteratorITCase
 				// assert that matches for this key exist
 				Assert.assertTrue("No matches for key " + key, expectedCoGroupsMap.containsKey(key));
 				
-				Collection<TestData.Value> expValues1 = expectedCoGroupsMap.get(key).get(0);
-				Collection<TestData.Value> expValues2 = expectedCoGroupsMap.get(key).get(1);
+				Collection<String> expValues1 = expectedCoGroupsMap.get(key).get(0);
+				Collection<String> expValues2 = expectedCoGroupsMap.get(key).get(1);
 				
 				if (v1 != null) {
 					expValues1.remove(v1);
@@ -149,14 +146,14 @@ public class ReusingSortMergeCoGroupIteratorITCase
 				}
 				
 				while(iter1.hasNext()) {
-					Record rec = iter1.next();
-					Assert.assertTrue("Value not in expected set of first input", expValues1.remove(rec.getField(1, TestData.Value.class)));
+					Tuple2<Integer, String> rec = iter1.next();
+					Assert.assertTrue("String not in expected set of first input", expValues1.remove(rec.f1));
 				}
 				Assert.assertTrue("Expected set of first input not empty", expValues1.isEmpty());
 				
 				while(iter2.hasNext()) {
-					Record rec = iter2.next();
-					Assert.assertTrue("Value not in expected set of second input", expValues2.remove(rec.getField(1, TestData.Value.class)));
+					Tuple2<Integer, String> rec = iter2.next();
+					Assert.assertTrue("String not in expected set of second input", expValues2.remove(rec.f1));
 				}
 				Assert.assertTrue("Expected set of second input not empty", expValues2.isEmpty());
 	
@@ -174,28 +171,28 @@ public class ReusingSortMergeCoGroupIteratorITCase
 
 	// --------------------------------------------------------------------------------------------
 	
-	private Map<TestData.Key, List<Collection<TestData.Value>>> coGroupValues(
-			Map<TestData.Key, Collection<TestData.Value>> leftMap,
-			Map<TestData.Key, Collection<TestData.Value>> rightMap)
+	private Map<Integer, List<Collection<String>>> coGroupValues(
+			Map<Integer, Collection<String>> leftMap,
+			Map<Integer, Collection<String>> rightMap)
 	{
-		Map<TestData.Key, List<Collection<TestData.Value>>> map = new HashMap<TestData.Key, List<Collection<TestData.Value>>>(1000);
+		Map<Integer, List<Collection<String>>> map = new HashMap<>(1000);
 
-		Set<TestData.Key> keySet = new HashSet<TestData.Key>(leftMap.keySet());
+		Set<Integer> keySet = new HashSet<>(leftMap.keySet());
 		keySet.addAll(rightMap.keySet());
 		
-		for (TestData.Key key : keySet) {
-			Collection<TestData.Value> leftValues = leftMap.get(key);
-			Collection<TestData.Value> rightValues = rightMap.get(key);
-			ArrayList<Collection<TestData.Value>> list = new ArrayList<Collection<TestData.Value>>(2);
+		for (Integer key : keySet) {
+			Collection<String> leftValues = leftMap.get(key);
+			Collection<String> rightValues = rightMap.get(key);
+			ArrayList<Collection<String>> list = new ArrayList<>(2);
 			
 			if (leftValues == null) {
-				list.add(new ArrayList<TestData.Value>(0));
+				list.add(new ArrayList<String>(0));
 			} else {
 				list.add(leftValues);
 			}
 			
 			if (rightValues == null) {
-				list.add(new ArrayList<TestData.Value>(0));
+				list.add(new ArrayList<String>(0));
 			} else {
 				list.add(rightValues);
 			}
@@ -205,22 +202,22 @@ public class ReusingSortMergeCoGroupIteratorITCase
 		return map;
 	}
 
-	private Map<TestData.Key, Collection<TestData.Value>> collectData(Generator iter, int num)
+	private Map<Integer, Collection<String>> collectData(TupleGenerator iter, int num)
 	throws Exception
 	{
-		Map<TestData.Key, Collection<TestData.Value>> map = new HashMap<TestData.Key, Collection<TestData.Value>>();
-		Record pair = new Record();
+		Map<Integer, Collection<String>> map = new HashMap<>();
+		Tuple2<Integer, String> pair = new Tuple2<>();
 		
 		for (int i = 0; i < num; i++) {
 			iter.next(pair);
-			TestData.Key key = pair.getField(0, TestData.Key.class);
+			int key = pair.f0;
 			
 			if (!map.containsKey(key)) {
-				map.put(new TestData.Key(key.getKey()), new ArrayList<TestData.Value>());
+				map.put(key, new ArrayList<String>());
 			}
 
-			Collection<TestData.Value> values = map.get(key);
-			values.add(new TestData.Value(pair.getField(1, TestData.Value.class).getValue()));
+			Collection<String> values = map.get(key);
+			values.add(pair.f1);
 		}
 		return map;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TestData.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TestData.java
@@ -166,7 +166,7 @@ public final class TestData {
 	}
 
 	/**
-	 * Record reader mock.
+	 * Tuple reader mock.
 	 */
 	public static class TupleGeneratorIterator implements MutableObjectIterator<Tuple2<Integer, String>> {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TestData.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TestData.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.operators.testutils;
 
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -37,8 +36,6 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.operators.testutils.types.IntPair;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.Record;
-import org.apache.flink.types.StringValue;
 import org.apache.flink.util.MutableObjectIterator;
 
 /**
@@ -50,250 +47,6 @@ public final class TestData {
 	 * Private constructor (container class should not be instantiated)
 	 */
 	private TestData() {}
-
-	/**
-	 * Key comparator.
-	 */
-	public static class KeyComparator implements Comparator<Key> {
-		@Override
-		public int compare(Key k1, Key k2) {
-			return k1.compareTo(k2);
-		}
-	};
-
-	/**
-	 * Key implementation.
-	 */
-	public static class Key extends IntValue {
-		private static final long serialVersionUID = 1L;
-		
-		public Key() {
-			super();
-		}
-
-		public Key(int k) {
-			super(k);
-		}
-
-		public int getKey() {
-			return getValue();
-		}
-		
-		public void setKey(int key) {
-			setValue(key);
-		}
-	}
-
-	/**
-	 * Value implementation.
-	 */
-	public static class Value extends StringValue {
-		
-		private static final long serialVersionUID = 1L;
-
-		public Value() {
-			super();
-		}
-
-		public Value(String v) {
-			super(v);
-		}
-		
-		@Override
-		public boolean equals(final Object obj) {
-			if (this == obj) {
-				return true;
-			}
-			
-			if (obj.getClass() == TestData.Value.class) {
-				final StringValue other = (StringValue) obj;
-				int len = this.length();
-				
-				if (len == other.length()) {
-					final char[] tc = this.getCharArray();
-					final char[] oc = other.getCharArray();
-					int i = 0, j = 0;
-					
-					while (len-- != 0) {
-						if (tc[i++] != oc[j++]) {
-							return false;
-						}
-					}
-					return true;
-				}
-			}
-			return false;
-		}
-	}
-
-	/**
-	 * Pair generator.
-	 */
-	public static class Generator implements MutableObjectIterator<Record> {
-		
-		public enum KeyMode {
-			SORTED, RANDOM
-		};
-
-		public enum ValueMode {
-			FIX_LENGTH, RANDOM_LENGTH, CONSTANT
-		};
-
-		private static char[] alpha = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'a', 'b', 'c',
-			'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm' };
-
-		private final long seed;
-
-		private final int keyMax;
-
-		private final int valueLength;
-
-		private final KeyMode keyMode;
-
-		private final ValueMode valueMode;
-
-		private Random random;
-
-		private int counter;
-
-		private Key key;
-		private Value value;
-
-		public Generator(long seed, int keyMax, int valueLength) {
-			this(seed, keyMax, valueLength, KeyMode.RANDOM, ValueMode.FIX_LENGTH);
-		}
-
-		public Generator(long seed, int keyMax, int valueLength, KeyMode keyMode, ValueMode valueMode) {
-			this(seed, keyMax, valueLength, keyMode, valueMode, null);
-		}
-		
-		public Generator(long seed, int keyMax, int valueLength, KeyMode keyMode, ValueMode valueMode, Value constant) {
-			this.seed = seed;
-			this.keyMax = keyMax;
-			this.valueLength = valueLength;
-			this.keyMode = keyMode;
-			this.valueMode = valueMode;
-
-			this.random = new Random(seed);
-			this.counter = 0;
-			
-			this.key = new Key();
-			this.value = constant == null ? new Value() : constant;
-		}
-
-		public Record next(Record reuse) {
-			this.key.setKey(keyMode == KeyMode.SORTED ? ++counter : Math.abs(random.nextInt() % keyMax) + 1);
-			if (this.valueMode != ValueMode.CONSTANT) {
-				this.value.setValue(randomString());
-			}
-			reuse.setField(0, this.key);
-			reuse.setField(1, this.value);
-			return reuse;
-		}
-
-		public Record next() {
-			return next(new Record(2));
-		}
-
-		public boolean next(org.apache.flink.types.Value[] target) {
-			this.key.setKey(keyMode == KeyMode.SORTED ? ++counter : Math.abs(random.nextInt() % keyMax) + 1);
-			// TODO change this to something proper
-			((IntValue)target[0]).setValue(this.key.getValue());
-			((IntValue)target[1]).setValue(random.nextInt());
-			return true;
-		}
-
-		public int sizeOf(Record rec) {
-			// key
-			int valueLength = Integer.SIZE / 8;
-
-			// value
-			String text = rec.getField(1, Value.class).getValue();
-			int strlen = text.length();
-			int utflen = 0;
-			int c;
-			for (int i = 0; i < strlen; i++) {
-				c = text.charAt(i);
-				if ((c >= 0x0001) && (c <= 0x007F)) {
-					utflen++;
-				} else if (c > 0x07FF) {
-					utflen += 3;
-				} else {
-					utflen += 2;
-				}
-			}
-			valueLength += 2 + utflen;
-
-			return valueLength;
-		}
-
-		public void reset() {
-			this.random = new Random(seed);
-			this.counter = 0;
-		}
-
-		private String randomString() {
-			int length;
-
-			if (valueMode == ValueMode.FIX_LENGTH) {
-				length = valueLength;
-			} else {
-				length = valueLength - random.nextInt(valueLength / 3);
-			}
-
-			StringBuilder sb = new StringBuilder();
-			for (int i = 0; i < length; i++) {
-				sb.append(alpha[random.nextInt(alpha.length)]);
-			}
-			return sb.toString();
-		}
-
-	}
-	
-	/**
-	 * Record reader mock.
-	 */
-	public static class GeneratorIterator implements MutableObjectIterator<Record> {
-		
-		private final Generator generator;
-
-		private final int numberOfRecords;
-
-		private int counter;
-
-		public GeneratorIterator(Generator generator, int numberOfRecords) {
-			this.generator = generator;
-			this.generator.reset();
-			this.numberOfRecords = numberOfRecords;
-			this.counter = 0;
-		}
-
-		@Override
-		public Record next(Record target) {
-			if (counter < numberOfRecords) {
-				counter++;
-				return generator.next(target);
-			}
-			else {
-				return null;
-			}
-		}
-
-		@Override
-		public Record next() {
-			if (counter < numberOfRecords) {
-				counter++;
-				return generator.next();
-			}
-			else {
-				return null;
-			}
-		}
-		
-		public void reset() {
-			this.counter = 0;
-		}
-	}
 
 	/**
 	 * Tuple2<Integer, String> generator.
@@ -412,7 +165,6 @@ public final class TestData {
 
 	}
 
-
 	/**
 	 * Record reader mock.
 	 */
@@ -457,52 +209,6 @@ public final class TestData {
 			this.counter = 0;
 		}
 	}
-	
-	// --------------------------------------------------------------------------------------------
-	
-	public static class ConstantValueIterator implements MutableObjectIterator<Record> {
-		
-		private final Key key;
-		private final Value value;
-		
-		private final String valueValue;
-		
-		
-		private final int numPairs;
-		
-		private int pos;
-		
-		
-		public ConstantValueIterator(int keyValue, String valueValue, int numPairs) {
-			this.key = new Key(keyValue);
-			this.value = new Value();
-			this.valueValue = valueValue;
-			this.numPairs = numPairs;
-		}
-		
-		@Override
-		public Record next(Record reuse) {
-			if (pos < this.numPairs) {
-				this.value.setValue(this.valueValue + ' ' + pos);
-				reuse.setField(0, this.key);
-				reuse.setField(1, this.value);
-				pos++;
-				return reuse;
-			}
-			else {
-				return null;
-			}
-		}
-
-		@Override
-		public Record next() {
-			return next(new Record(2));
-		}
-
-		public void reset() {
-			this.pos = 0;
-		}
-	}
 
 	public static class TupleConstantValueIterator implements MutableObjectIterator<Tuple2<Integer, String>> {
 
@@ -545,32 +251,93 @@ public final class TestData {
 			this.pos = 0;
 		}
 	}
-	
-	private static TupleTypeInfo<Tuple2<Integer, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, String.class);
-	
-	private static TypeSerializerFactory<Tuple2<Integer, String>> serializerFactory = new MockTupleSerializerFactory(typeInfo);
-	
-	public static TupleTypeInfo<Tuple2<Integer, String>> getTupleTypeInfo() {
-		return typeInfo;
+
+	/**
+	 * An iterator that returns the Key/Value pairs with identical value a given number of times.
+	 */
+	public static final class ConstantIntIntTuplesIterator implements MutableObjectIterator<Tuple2<Integer, Integer>> {
+
+		private final int key;
+		private final int value;
+
+		private int numLeft;
+
+		public ConstantIntIntTuplesIterator(int key, int value, int count) {
+			this.key = key;
+			this.value = value;
+			this.numLeft = count;
+		}
+
+		@Override
+		public Tuple2<Integer, Integer> next(Tuple2<Integer, Integer> reuse) {
+			if (this.numLeft > 0) {
+				this.numLeft--;
+				reuse.setField(this.key, 0);
+				reuse.setField(this.value, 1);
+				return reuse;
+			} else {
+				return null;
+			}
+		}
+
+		@Override
+		public Tuple2<Integer, Integer> next() {
+			return next(new Tuple2<>(0, 0));
+		}
 	}
 
-	public static TypeSerializerFactory<Tuple2<Integer, String>> getTupleSerializerFactory() {
-		return serializerFactory;
-	}
-	
-	public static TypeSerializer<Tuple2<Integer, String>> getTupleSerializer(){
-		return serializerFactory.getSerializer();
+	//----Tuple2<Integer, String>
+	private static final TupleTypeInfo<Tuple2<Integer, String>> typeInfoIntString = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, String.class);
+
+	private static final TypeSerializerFactory<Tuple2<Integer, String>> serializerFactoryIntString = new MockTupleSerializerFactory(typeInfoIntString);
+
+	public static TupleTypeInfo<Tuple2<Integer, String>> getIntStringTupleTypeInfo() {
+		return typeInfoIntString;
 	}
 
-	public static TypeComparator<Tuple2<Integer, String>> getTupleComparator() {
-		return getTupleTypeInfo().createComparator(new int[]{0}, new boolean[]{true}, 0, null);
+	public static TypeSerializerFactory<Tuple2<Integer, String>> getIntStringTupleSerializerFactory() {
+		return serializerFactoryIntString;
 	}
 
-	public static MutableObjectIterator<Tuple2<Integer, String>> getTupleReader() {
+	public static TypeSerializer<Tuple2<Integer, String>> getIntStringTupleSerializer() {
+		return serializerFactoryIntString.getSerializer();
+	}
+
+	public static TypeComparator<Tuple2<Integer, String>> getIntStringTupleComparator() {
+		return getIntStringTupleTypeInfo().createComparator(new int[]{0}, new boolean[]{true}, 0, null);
+	}
+
+	public static MockTuple2Reader<Tuple2<Integer, String>> getIntStringTupleReader() {
 		return new MockTuple2Reader<Tuple2<Integer, String>>();
 	}
 
-	public static class MockTupleSerializerFactory<T extends Tuple> implements TypeSerializerFactory<T> {
+	//----Tuple2<Integer, Integer>
+	private static final TupleTypeInfo<Tuple2<Integer, Integer>> typeInfoIntInt = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, Integer.class);
+
+	private static final TypeSerializerFactory<Tuple2<Integer, Integer>> serializerFactoryIntInt = new MockTupleSerializerFactory(typeInfoIntInt);
+
+	public static TupleTypeInfo<Tuple2<Integer, Integer>> getIntIntTupleTypeInfo() {
+		return typeInfoIntInt;
+	}
+
+	public static TypeSerializerFactory<Tuple2<Integer, Integer>> getIntIntTupleSerializerFactory() {
+		return serializerFactoryIntInt;
+	}
+
+	public static TypeSerializer<Tuple2<Integer, Integer>> getIntIntTupleSerializer() {
+		return getIntIntTupleSerializerFactory().getSerializer();
+	}
+
+	public static TypeComparator<Tuple2<Integer, Integer>> getIntIntTupleComparator() {
+		return getIntIntTupleTypeInfo().createComparator(new int[]{0}, new boolean[]{true}, 0, null);
+	}
+
+	public static MockTuple2Reader<Tuple2<Integer, Integer>> getIntIntTupleReader() {
+		return new MockTuple2Reader<>();
+	}
+
+	//----Tuple2<?, ?>
+	private static class MockTupleSerializerFactory<T extends Tuple> implements TypeSerializerFactory<T> {
 		private final TupleTypeInfo<T> info;
 
 		public MockTupleSerializerFactory(TupleTypeInfo<T> info) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
@@ -18,13 +18,12 @@
 
 package org.apache.flink.runtime.operators.util;
 
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.GenericPairComparator;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
-import org.apache.flink.api.common.typeutils.record.RecordComparator;
-import org.apache.flink.api.common.typeutils.record.RecordPairComparator;
-import org.apache.flink.api.common.typeutils.record.RecordSerializerFactory;
-import org.apache.flink.api.java.record.functions.JoinFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -37,10 +36,8 @@ import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.KeyMode;
-import org.apache.flink.runtime.operators.testutils.TestData.Generator.ValueMode;
-import org.apache.flink.types.Record;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.KeyMode;
+import org.apache.flink.runtime.operators.testutils.TestData.TupleGenerator.ValueMode;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 import org.junit.After;
@@ -78,21 +75,21 @@ public class HashVsSortMiniBenchmark {
 	private IOManager ioManager;
 	private MemoryManager memoryManager;
 	
-	private TypeSerializerFactory<Record> serializer1;
-	private TypeSerializerFactory<Record> serializer2;
-	private TypeComparator<Record> comparator1;
-	private TypeComparator<Record> comparator2;
-	private TypePairComparator<Record, Record> pairComparator11;
+	private TypeSerializerFactory<Tuple2<Integer, String>> serializer1;
+	private TypeSerializerFactory<Tuple2<Integer, String>> serializer2;
+	private TypeComparator<Tuple2<Integer, String>> comparator1;
+	private TypeComparator<Tuple2<Integer, String>> comparator2;
+	private TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> pairComparator11;
 
 
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.serializer1 = RecordSerializerFactory.get();
-		this.serializer2 = RecordSerializerFactory.get();
-		this.comparator1 = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
-		this.comparator2 = new RecordComparator(new int[] {0}, new Class[] {TestData.Key.class});
-		this.pairComparator11 = new RecordPairComparator(new int[] {0}, new int[] {0}, new Class[] {TestData.Key.class});
+		this.serializer1 = TestData.getTupleSerializerFactory();
+		this.serializer2 = TestData.getTupleSerializerFactory();
+		this.comparator1 = TestData.getTupleComparator();
+		this.comparator2 = TestData.getTupleComparator();
+		this.pairComparator11 = new GenericPairComparator(this.comparator1, this.comparator2);
 		
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);
 		this.ioManager = new IOManagerAsync();
@@ -120,31 +117,31 @@ public class HashVsSortMiniBenchmark {
 	public void testSortBothMerge() {
 		try {
 			
-			Generator generator1 = new Generator(SEED1, INPUT_1_SIZE / 10, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, INPUT_2_SIZE, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, INPUT_1_SIZE / 10, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, INPUT_2_SIZE, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 
-			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
-			final JoinFunction matcher = new NoOpMatcher();
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final FlatJoinFunction matcher = new NoOpMatcher();
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 			
 			long start = System.nanoTime();
 			
-			final UnilateralSortMerger<Record> sorter1 = new UnilateralSortMerger<Record>(
+			final UnilateralSortMerger<Tuple2<Integer, String>> sorter1 = new UnilateralSortMerger<>(
 					this.memoryManager, this.ioManager, input1, this.parentTask, this.serializer1, 
 					this.comparator1.duplicate(), MEMORY_FOR_SORTER, 128, 0.8f, true);
 			
-			final UnilateralSortMerger<Record> sorter2 = new UnilateralSortMerger<Record>(
+			final UnilateralSortMerger<Tuple2<Integer, String>> sorter2 = new UnilateralSortMerger<>(
 					this.memoryManager, this.ioManager, input2, this.parentTask, this.serializer2, 
 					this.comparator2.duplicate(), MEMORY_FOR_SORTER, 128, 0.8f, true);
 			
-			final MutableObjectIterator<Record> sortedInput1 = sorter1.getIterator();
-			final MutableObjectIterator<Record> sortedInput2 = sorter2.getIterator();
+			final MutableObjectIterator<Tuple2<Integer, String>> sortedInput1 = sorter1.getIterator();
+			final MutableObjectIterator<Tuple2<Integer, String>> sortedInput2 = sorter2.getIterator();
 			
 			// compare with iterator values
-			ReusingMergeInnerJoinIterator<Record, Record, Record> iterator =
-				new ReusingMergeInnerJoinIterator<Record, Record, Record>(sortedInput1, sortedInput2,
+			ReusingMergeInnerJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new ReusingMergeInnerJoinIterator<>(sortedInput1, sortedInput2,
 						this.serializer1.getSerializer(), this.comparator1, this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
 						this.memoryManager, this.ioManager, MEMORY_PAGES_FOR_MERGE, this.parentTask);
 			
@@ -170,21 +167,21 @@ public class HashVsSortMiniBenchmark {
 	@Test
 	public void testBuildFirst() {
 		try {
-			Generator generator1 = new Generator(SEED1, INPUT_1_SIZE / 10, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, INPUT_2_SIZE, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, INPUT_1_SIZE / 10, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, INPUT_2_SIZE, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
-			final JoinFunction matcher = new NoOpMatcher();
+			final FlatJoinFunction matcher = new NoOpMatcher();
 			
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 			
 			long start = System.nanoTime();
 			
 			// compare with iterator values
-			final ReusingBuildFirstHashMatchIterator<Record, Record, Record> iterator =
-					new ReusingBuildFirstHashMatchIterator<Record, Record, Record>(
+			final ReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashMatchIterator<>(
 						input1, input2, this.serializer1.getSerializer(), this.comparator1, 
 							this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
 							this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE, true);
@@ -209,21 +206,21 @@ public class HashVsSortMiniBenchmark {
 	@Test
 	public void testBuildSecond() {
 		try {
-			Generator generator1 = new Generator(SEED1, INPUT_1_SIZE / 10, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
-			Generator generator2 = new Generator(SEED2, INPUT_2_SIZE, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, INPUT_1_SIZE / 10, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, INPUT_2_SIZE, 100, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
 			
-			final TestData.GeneratorIterator input1 = new TestData.GeneratorIterator(generator1, INPUT_1_SIZE);
-			final TestData.GeneratorIterator input2 = new TestData.GeneratorIterator(generator2, INPUT_2_SIZE);
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
-			final JoinFunction matcher = new NoOpMatcher();
+			final FlatJoinFunction matcher = new NoOpMatcher();
 			
-			final Collector<Record> collector = new DiscardingOutputCollector<Record>();
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 			
 			long start = System.nanoTime();
 			
 			// compare with iterator values
-			ReusingBuildSecondHashMatchIterator<Record, Record, Record> iterator =
-					new ReusingBuildSecondHashMatchIterator<Record, Record, Record>(
+			ReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildSecondHashMatchIterator<>(
 						input1, input2, this.serializer1.getSerializer(), this.comparator1, 
 						this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
 						this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE, true);
@@ -246,11 +243,11 @@ public class HashVsSortMiniBenchmark {
 	}
 	
 	
-	private static final class NoOpMatcher extends JoinFunction {
+	private static final class NoOpMatcher implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> {
 		private static final long serialVersionUID = 1L;
 		
 		@Override
-		public void join(Record rec1, Record rec2, Collector<Record> out) throws Exception {
+		public void join(Tuple2<Integer, String> rec1, Tuple2<Integer, String> rec2, Collector<Tuple2<Integer, String>> out) throws Exception {
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
@@ -85,10 +85,10 @@ public class HashVsSortMiniBenchmark {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void beforeTest() {
-		this.serializer1 = TestData.getTupleSerializerFactory();
-		this.serializer2 = TestData.getTupleSerializerFactory();
-		this.comparator1 = TestData.getTupleComparator();
-		this.comparator2 = TestData.getTupleComparator();
+		this.serializer1 = TestData.getIntStringTupleSerializerFactory();
+		this.serializer2 = TestData.getIntStringTupleSerializerFactory();
+		this.comparator1 = TestData.getIntStringTupleComparator();
+		this.comparator2 = TestData.getIntStringTupleComparator();
 		this.pairComparator11 = new GenericPairComparator(this.comparator1, this.comparator2);
 		
 		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1, PAGE_SIZE, MemoryType.HEAP, true);


### PR DESCRIPTION
This PR refactors most runtime.operators tests to use the TupleGenerator introduced in FLINK-2105.

The changes made can generally be summed up as replacing usages of Records with Tuple2\<Integer, String\> and adjusting serializers/comparators accordingly. I've added a few static helper methods to the TestData class to simplify comparator/serializer(factory) creation.

One oddball change is the introduction of a separate IntPairComparator whose hash() implementation uses the underlying IntComparators hash() method, to be in line with the TupleComparators implementation.