### PR TITLE
[FLINK-2705] [test-stability] Fixes Yarn crash when running with DEBUG log level

### DIFF
--- a/flink-dist/src/main/flink-bin/LICENSE
+++ b/flink-dist/src/main/flink-bin/LICENSE
@@ -219,7 +219,7 @@ The Apache Flink project bundles the following components
 under the Apache License (v 2.0):
 
  - Apache Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/proper/commons-logging/)
- - Apache Commons Codec (commons-codec:commons-codec:1.3 - http://commons.apache.org/proper/commons-codec/)
+ - Apache Commons Codec (commons-codec:commons-codec:1.4 - http://commons.apache.org/proper/commons-codec/)
  - Apache Commons Collections (commons-collections:commons-collections:3.2.1 - http://commons.apache.org/collections/)
  - Apache Commons CLI (commons-cli:commons-cli:1.2 - http://commons.apache.org/cli/)
  - Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.3.1 - http://commons.apache.org/fileupload/)

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -91,6 +91,12 @@ under the License.
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk</artifactId>
 			<version>1.8.1</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-codec</artifactId>
+					<groupId>commons-codec</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/fs/s3/S3FileSystemTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/fs/s3/S3FileSystemTest.java
@@ -39,7 +39,6 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.fs.s3.S3FileSystem;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Excludes commons-codec:1.3 from aws-java-jdk dependency to resolve dependency ambiguity between hadoop-commons and aws-java-jdk. Now the included version of commons-codec is 1.4