### PR TITLE
[FLINK-2727] [streaming] Add a base class for Message Queue Sources that acknowledge messages by ID

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/DataOutputSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/DataOutputSerializer.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.UTFDataFormatException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
  * A simple and efficient serializer for the {@link java.io.DataOutput} interface.
@@ -65,6 +66,10 @@ public class DataOutputSerializer implements DataOutputView {
 
 	public byte[] getByteArray() {
 		return buffer;
+	}
+	
+	public byte[] getCopyOfBuffer() {
+		return Arrays.copyOf(buffer, position);
 	}
 
 	public void clear() {

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/Checkpointed.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/checkpoint/Checkpointed.java
@@ -61,5 +61,5 @@ public interface Checkpointed<T extends Serializable> {
 	 *
 	 * @param state The state to be restored. 
 	 */
-	void restoreState(T state);
+	void restoreState(T state) throws Exception;
 }

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledingSourceBase.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledingSourceBase.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.checkpoint.CheckpointNotifier;
+import org.apache.flink.streaming.api.checkpoint.Checkpointed;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.streaming.api.state.SerializedCheckpointData;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Abstract base class for data sources that receive elements from a message queue and
+ * acknowledge them back by IDs.
+ * <p>
+ * The mechanism for this source assumes that messages are identified by a unique ID.
+ * When messages are taken from the message queue, the message must not be dropped immediately,
+ * but must be retained until acknowledged. Messages that are not acknowledged within a certain
+ * time interval will be served again (to a different connection, established by the recovered source).
+ * <p>
+ * Note that this source can give no guarantees about message order in teh case of failures,
+ * because messages that were retrieved but not yet acknowledged will be returned later again, after
+ * a set of messages that was not retrieved before the failure.
+ * <p>
+ * Internally, this source gathers the IDs of elements it emits. Per checkpoint, the IDs are stored and
+ * acknowledged when the checkpoint is complete. That way, no message is acknowledged unless it is certain
+ * that it has been successfully processed throughout the topology and the updates to any state caused by
+ * that message are persistent.
+ * <p>
+ * All messages that are emitted and successfully processed by the streaming program will eventually be
+ * acknowledged. In corner cases, the source may acknowledge certain IDs multiple times, if a
+ * failure occurs while acknowledging.
+ * <p>
+ * A typical way to use this base in a source function is by implementing a run() method as follows:
+ * <pre>{@code
+ * public void run(SourceContext<Type> ctx) throws Exception {
+ *     while (running) {
+ *         Message msg = queue.retrieve();
+ *         synchronized (ctx.getCheckpointLock()) {
+ *             ctx.collect(msg.getMessageData());
+ *             addId(msg.getMessageId());
+ *         }
+ *     }
+ * }
+ * }</pre>
+ * 
+ * @param <Type> The type of the messages created by the source.
+ * @param <Id> The type of the IDs that are used for acknowledging elements.
+ */
+public abstract class MessageAcknowledingSourceBase<Type, Id> extends RichSourceFunction<Type> 
+	implements Checkpointed<SerializedCheckpointData[]>, CheckpointNotifier {
+	
+	private static final long serialVersionUID = -8689291992192955579L;
+	
+	/** Serializer used to serialize the IDs for checkpoints */
+	private final TypeSerializer<Id> idSerializer;
+	
+	/** The list gathering the IDs of messages emitted during the current checkpoint */
+	private transient List<Id> idsForCurrentCheckpoint;
+
+	/** The list with IDs from checkpoints that were triggered, but not yet completed or notified of completion */
+	private transient ArrayDeque<Tuple2<Long, List<Id>>> pendingCheckpoints;
+
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new MessageAcknowledingSourceBase for IDs of teh given type.
+	 * 
+	 * @param idClass The class of the message ID type, used to create a serializer for the message IDs.
+	 */
+	protected MessageAcknowledingSourceBase(Class<Id> idClass) {
+		this(TypeExtractor.getForClass(idClass));
+	}
+
+	/**
+	 * Creates a new MessageAcknowledingSourceBase for IDs of teh given type.
+	 * 
+	 * @param idTypeInfo The type information of the message ID type, used to create a serializer for the message IDs.
+	 */
+	protected MessageAcknowledingSourceBase(TypeInformation<Id> idTypeInfo) {
+		this.idSerializer = idTypeInfo.createSerializer(new ExecutionConfig());
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		idsForCurrentCheckpoint = new ArrayList<>(64);
+		pendingCheckpoints = new ArrayDeque<>();
+	}
+
+	@Override
+	public void close() throws Exception {
+		idsForCurrentCheckpoint.clear();
+		pendingCheckpoints.clear();
+	}
+
+
+	// ------------------------------------------------------------------------
+	//  ID Checkpointing
+	// ------------------------------------------------------------------------
+
+	/**
+	 * This method must be implemented to acknowledge the given set of IDs back to the message queue.
+	 * @param ids The list od IDs to acknowledge.
+	 */
+	protected abstract void acknowledgeIDs(List<Id> ids);
+
+	/**
+	 * Adds an ID to be stored with the current checkpoint.
+	 * @param id The ID to add.
+	 */
+	protected void addId(Id id) {
+		idsForCurrentCheckpoint.add(id);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Checkpointing the data
+	// ------------------------------------------------------------------------
+	
+	@Override
+	public SerializedCheckpointData[] snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
+		pendingCheckpoints.addLast(new Tuple2<Long, List<Id>>(checkpointId, idsForCurrentCheckpoint));
+		idsForCurrentCheckpoint = new ArrayList<>(64);
+		
+		return SerializedCheckpointData.fromDeque(pendingCheckpoints, idSerializer);
+	}
+
+	@Override
+	public void restoreState(SerializedCheckpointData[] state) throws Exception {
+		pendingCheckpoints = SerializedCheckpointData.toDeque(state, idSerializer);
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		for (Iterator<Tuple2<Long, List<Id>>> iter = pendingCheckpoints.iterator(); iter.hasNext();) {
+			Tuple2<Long, List<Id>> checkpoint = iter.next();
+			long id = checkpoint.f0;
+			
+			if (id <= checkpointId) {
+				acknowledgeIDs(checkpoint.f1);
+				iter.remove();
+			}
+			else {
+				break;
+			}
+		}
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/SerializedCheckpointData.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/state/SerializedCheckpointData.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.util.DataInputDeserializer;
+import org.apache.flink.runtime.util.DataOutputSerializer;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class represents serialized checkpoint data for a collection of elements.
+ */
+public class SerializedCheckpointData implements java.io.Serializable {
+
+	private static final long serialVersionUID = -8783744683896503488L;
+	
+	/** ID of the checkpoint for which the IDs are stored */
+	private final long checkpointId;
+
+	/** The serialized elements */
+	private final byte[] serializedData;
+
+	/** The number of elements in the checkpoint */
+	private final int numIds;
+
+	/**
+	 * Creates a SerializedCheckpointData object for the given serialized data.
+	 * 
+	 * @param checkpointId The checkpointId of the checkpoint.
+	 * @param serializedData The serialized IDs in this checkpoint.
+	 * @param numIds The number of IDs in the checkpoint.
+	 */
+	public SerializedCheckpointData(long checkpointId, byte[] serializedData, int numIds) {
+		this.checkpointId = checkpointId;
+		this.serializedData = serializedData;
+		this.numIds = numIds;
+	}
+
+	/**
+	 * Gets the checkpointId of the checkpoint.
+	 * @return The checkpointId of the checkpoint.
+	 */
+	public long getCheckpointId() {
+		return checkpointId;
+	}
+
+	/**
+	 * Gets the binary data for the serialized elements.
+	 * @return The binary data for the serialized elements.
+	 */
+	public byte[] getSerializedData() {
+		return serializedData;
+	}
+
+	/**
+	 * Gets the number of IDs in the checkpoint.
+	 * @return The number of IDs in the checkpoint.
+	 */
+	public int getNumIds() {
+		return numIds;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Serialize to Checkpoint
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Converts a list of checkpoints with elements into an array of SerializedCheckpointData.
+	 * 
+	 * @param checkpoints The checkpoints to be converted into IdsCheckpointData.
+	 * @param serializer The serializer to serialize the IDs.
+	 * @param <T> The type of the ID.
+	 * @return An array of serializable SerializedCheckpointData, one per entry in the 
+	 * 
+	 * @throws IOException Thrown, if the serialization fails.
+	 */
+	public static <T> SerializedCheckpointData[] fromDeque(ArrayDeque<Tuple2<Long, List<T>>> checkpoints,
+												TypeSerializer<T> serializer) throws IOException {
+		return fromDeque(checkpoints, serializer, new DataOutputSerializer(128));
+	}
+
+	/**
+	 * Converts a list of checkpoints into an array of SerializedCheckpointData.
+	 *
+	 * @param checkpoints The checkpoints to be converted into IdsCheckpointData.
+	 * @param serializer The serializer to serialize the IDs.
+	 * @param outputBuffer The reusable serialization buffer.
+	 * @param <T> The type of the ID.
+	 * @return An array of serializable SerializedCheckpointData, one per entry in the 
+	 *
+	 * @throws IOException Thrown, if the serialization fails.
+	 */
+	public static <T> SerializedCheckpointData[] fromDeque(ArrayDeque<Tuple2<Long, List<T>>> checkpoints,
+												TypeSerializer<T> serializer,
+												DataOutputSerializer outputBuffer) throws IOException {
+		SerializedCheckpointData[] serializedCheckpoints = new SerializedCheckpointData[checkpoints.size()];
+		
+		int pos = 0;
+		for (Tuple2<Long, List<T>> checkpoint : checkpoints) {
+			outputBuffer.clear();
+			List<T> checkpointIds = checkpoint.f1;
+			
+			for (T id : checkpointIds) {
+				serializer.serialize(id, outputBuffer);
+			}
+
+			serializedCheckpoints[pos++] = new SerializedCheckpointData(
+					checkpoint.f0, outputBuffer.getCopyOfBuffer(), checkpointIds.size());
+		}
+		
+		return serializedCheckpoints;
+	}
+
+	// ------------------------------------------------------------------------
+	//  De-Serialize from Checkpoint
+	// ------------------------------------------------------------------------
+
+	/**
+	 * De-serializes an array of SerializedCheckpointData back into an ArrayDeque of element checkpoints.
+	 * 
+	 * @param data The data to be deserialized.
+	 * @param serializer The serializer used to deserialize the data.
+	 * @param <T> The type of the elements.
+	 * @return An ArrayDeque of element checkpoints.
+	 * 
+	 * @throws IOException Thrown, if the serialization fails.
+	 */
+	public static <T> ArrayDeque<Tuple2<Long, List<T>>> toDeque(
+			SerializedCheckpointData[] data, TypeSerializer<T> serializer) throws IOException
+	{
+		ArrayDeque<Tuple2<Long, List<T>>> deque = new ArrayDeque<>(data.length);
+		DataInputDeserializer deser = null;
+		
+		for (SerializedCheckpointData checkpoint : data) {
+			byte[] serializedData = checkpoint.getSerializedData();
+			if (deser == null) {
+				deser = new DataInputDeserializer(serializedData, 0, serializedData.length);
+			}
+			else {
+				deser.setBuffer(serializedData, 0, serializedData.length);
+			}
+			
+			final List<T> ids = new ArrayList<>(checkpoint.getNumIds());
+			final int numIds = checkpoint.getNumIds();
+			
+			for (int i = 0; i < numIds; i++) {
+				ids.add(serializer.deserialize(deser));
+			}
+
+			deque.addLast(new Tuple2<Long, List<T>>(checkpoint.checkpointId, ids));
+		}
+		
+		return deque;
+	}
+}


### PR DESCRIPTION
Several message queues (RabbitMQ, Amazon SQS) have the pattern that you retrieve messages and acknowledge them back by ID. This pull request adds a simple base non-parallel source that provides tooling for:

  - Collecting the IDs of elements emitted between two checkpoints
  - Persisting them with the checkpoint, respecting proper serialization
  - Acknowledging them when a checkpoint is notified of completion.

This assumes that the Message Queues retain unacknowledged messages and re-emit them after the acknowledgement period expired.

### Form the class header

The mechanism for this source assumes that messages are identified by a unique ID.
When messages are taken from the message queue, the message must not be dropped immediately, but must be retained until acknowledged. Messages that are not acknowledged within a certain time interval will be served again (to a different connection, established by the recovered source).

Note that this source can give no guarantees about message order in the case of failures, because messages that were retrieved but not yet acknowledged will be returned later again, after a set of messages that was not retrieved before the failure.

Internally, this source gathers the IDs of elements it emits. Per checkpoint, the IDs are stored and acknowledged when the checkpoint is complete. That way, no message is acknowledged unless it is certain that it has been successfully processed throughout the topology and the updates to any state caused by that message are persistent.

All messages that are emitted and successfully processed by the streaming program will eventually be acknowledged. In corner cases, the source may acknowledge certain IDs multiple times, if a failure occurs while acknowledging.

A typical way to use this base in a source function is by implementing a run() method as follows:
```java
public void run(SourceContext<Type> ctx) throws Exception {
    while (running) {
        Message msg = queue.retrieve();
        synchronized (ctx.getCheckpointLock()) {
            ctx.collect(msg.getMessageData());
            addId(msg.getMessageId());
        }
    }
}
```