### PR TITLE
[utils] Missing getters for ParameterTool

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -365,6 +365,84 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 		}
 	}
 
+	// -------------- BOOLEAN
+
+	/**
+	 * Returns the Boolean value for the given key.
+	 * The method fails if the key does not exist.
+	 */
+	public boolean getBoolean(String key) {
+		addToDefaults(key, null);
+		String value = getRequired(key);
+		return Boolean.valueOf(value);
+	}
+
+	/**
+	 * Returns the Boolean value for the given key. If the key does not exists it will return the default value given.
+	 * The method returns whether the string of the value is "true" ignoring cases.
+	 */
+	public boolean getBoolean(String key, boolean defaultValue) {
+		addToDefaults(key, Boolean.toString(defaultValue));
+		String value = get(key);
+		if(value == null) {
+			return defaultValue;
+		} else {
+			return Boolean.valueOf(value);
+		}
+	}
+
+	// -------------- SHORT
+
+	/**
+	 * Returns the Short value for the given key.
+	 * The method fails if the key does not exist.
+	 */
+	public short getShort(String key) {
+		addToDefaults(key, null);
+		String value = getRequired(key);
+		return Short.valueOf(value);
+	}
+
+	/**
+	 * Returns the Short value for the given key. If the key does not exists it will return the default value given.
+	 * The method fails if the value is not a Short.
+	 */
+	public short getShort(String key, short defaultValue) {
+		addToDefaults(key, Short.toString(defaultValue));
+		String value = get(key);
+		if(value == null) {
+			return defaultValue;
+		} else {
+			return Short.valueOf(value);
+		}
+	}
+
+	// -------------- BYTE
+
+	/**
+	 * Returns the Byte value for the given key.
+	 * The method fails if the key does not exist.
+	 */
+	public byte getByte(String key) {
+		addToDefaults(key, null);
+		String value = getRequired(key);
+		return Byte.valueOf(value);
+	}
+
+	/**
+	 * Returns the Byte value for the given key. If the key does not exists it will return the default value given.
+	 * The method fails if the value is not a Byte.
+	 */
+	public byte getByte(String key, byte defaultValue) {
+		addToDefaults(key, Byte.toString(defaultValue));
+		String value = get(key);
+		if(value == null) {
+			return defaultValue;
+		} else {
+			return Byte.valueOf(value);
+		}
+	}
+
 	// --------------- Internals
 
 	protected void addToDefaults(String key, String value) {

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -101,11 +101,15 @@ public class ParameterToolTest {
 
 	@Test
 	public void testFromCliArgs() {
-		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--input", "myInput", "-expectedCount", "15", "--withoutValues", "--negativeFloat", "-0.58"});
-		Assert.assertEquals(4, parameter.getNumberOfParameters());
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--input", "myInput", "-expectedCount", "15", "--withoutValues",
+				"--negativeFloat", "-0.58", "-isWorking", "true", "--maxByte", "127", "-negativeShort", "-1024"});
+		Assert.assertEquals(7, parameter.getNumberOfParameters());
 		validate(parameter);
 		Assert.assertTrue(parameter.has("withoutValues"));
 		Assert.assertEquals(-0.58, parameter.getFloat("negativeFloat"), 0.1);
+		Assert.assertTrue(parameter.getBoolean("isWorking"));
+		Assert.assertEquals(127, parameter.getByte("maxByte"));
+		Assert.assertEquals(-1024, parameter.getShort("negativeShort"));
 	}
 
 	@Test
@@ -162,6 +166,9 @@ public class ParameterToolTest {
 		Assert.assertEquals("myDefaultValue", parameter.get("output", "myDefaultValue"));
 		Assert.assertEquals(null, parameter.get("whatever"));
 		Assert.assertEquals(15L, parameter.getLong("expectedCount", -1L));
+		Assert.assertTrue(parameter.getBoolean("thisIsUseful", true));
+		Assert.assertEquals(42, parameter.getByte("myDefaultByte", (byte) 42));
+		Assert.assertEquals(42, parameter.getShort("myDefaultShort", (short) 42));
 
 		Configuration config = parameter.getConfiguration();
 		Assert.assertEquals(15L, config.getLong("expectedCount", -1L));


### PR DESCRIPTION
When using the `ParameterTool` I have found the `Boolean` getter missing, so added the missing functions.