### PR TITLE
[FLINK-2746] [tests] Add RetryOnException annotation for tests

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/junit/RetryOnException.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/junit/RetryOnException.java
@@ -23,9 +23,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to use with {@link RetryRule}.
+ * Annotation to use with {@link org.apache.flink.testutils.junit.RetryRule}.
  *
- * <p>Add the {@link RetryRule} to your test and annotate tests with {@link RetryOnFailure}.
+ * <p>Add the {@link org.apache.flink.testutils.junit.RetryRule} to your test and
+ * annotate tests with {@link org.apache.flink.testutils.junit.RetryOnException}.
  *
  * <pre>
  * public class YourTest {
@@ -34,16 +35,26 @@ import java.lang.annotation.Target;
  *     public RetryRule retryRule = new RetryRule();
  *
  *     {@literal @}Test
- *     {@literal @}RetryOnFailure(times=1)
- *     public void yourTest() {
+ *     {@literal @}RetryOnException(times=1, exception=IOException.class)
+ *     public void yourTest() throws Exception {
  *         // This will be retried 1 time (total runs 2) before failing the test.
- *         throw new Exception("Failing test");
+ *         throw new IOException("Failing test");
+ *     }
+ *     
+ *     {@literal @}Test
+ *     {@literal @}RetryOnException(times=1, exception=IOException.class)
+ *     public void yourTest() throws Exception {
+ *         // This will not be retried, because it throws the wrong exception
+ *         throw new IllegalStateException("Failing test");
  *     }
  * }
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ java.lang.annotation.ElementType.METHOD })
-public @interface RetryOnFailure {
+@Target(java.lang.annotation.ElementType.METHOD)
+public @interface RetryOnException {
+
 	int times();
+	
+	Class<? extends Throwable> exception();
 }

--- a/flink-core/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit;
+
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RetryOnExceptionTest {
+
+	@Rule
+	public RetryRule retryRule = new RetryRule();
+
+	private static final int NUMBER_OF_RUNS = 3;
+	
+	private static int runsForSuccessfulTest = 0;
+
+	private static int runsForTestWithMatchingException = 0;
+
+	private static int runsForTestWithSubclassException = 0;
+	
+	private static int runsForPassAfterOneFailure = 0;
+
+	
+	@AfterClass
+	public static void verify() {
+		assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithMatchingException);
+		assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithSubclassException);
+		assertEquals(1, runsForSuccessfulTest);
+		assertEquals(2, runsForPassAfterOneFailure);
+	}
+
+	@Test
+	@RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
+	public void testSuccessfulTest() {
+		runsForSuccessfulTest++;
+	}
+
+	@Test
+	@RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
+	public void testMatchingException() {
+		runsForTestWithMatchingException++;
+		if (runsForTestWithMatchingException <= NUMBER_OF_RUNS) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	@Test
+	@RetryOnException(times = NUMBER_OF_RUNS, exception = RuntimeException.class)
+	public void testSubclassException() {
+		runsForTestWithSubclassException++;
+		if (runsForTestWithSubclassException <= NUMBER_OF_RUNS) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	@Test
+	@RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
+	public void testPassAfterOneFailure() {
+		runsForPassAfterOneFailure++;
+		if (runsForPassAfterOneFailure == 1) {
+			throw new IllegalArgumentException();
+		}
+	}
+}


### PR DESCRIPTION
This follows the same pattern as `RetryOnFailure`, but does it only for specific exceptions.