### PR TITLE
[FLINK-2616] [test-stability] Fixes ZooKeeperLeaderElectionTest.testMultipleLeaders by introducing second retrieval service

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
@@ -48,7 +48,7 @@ public class StandaloneLeaderElectionTest extends TestLogger {
 			assertTrue(contender.isLeader());
 			assertEquals(null, contender.getLeaderSessionID());
 
-			testingListener.waitForLeader(1000l);
+			testingListener.waitForNewLeader(1000l);
 
 			assertEquals(TEST_URL, testingListener.getAddress());
 			assertEquals(null, testingListener.getLeaderSessionID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingListener.java
@@ -47,33 +47,6 @@ public class TestingListener implements LeaderRetrievalListener {
 		return leaderSessionID;
 	}
 
-	public void clear() {
-		address = null;
-		leaderSessionID = null;
-	}
-
-	public void waitForLeader(long timeout) throws Exception {
-		long start = System.currentTimeMillis();
-		long curTimeout;
-
-		while (exception == null && address == null && (curTimeout = timeout - System.currentTimeMillis() + start) > 0) {
-			synchronized (lock) {
-				try {
-					lock.wait(curTimeout);
-				} catch (InterruptedException e) {
-					// we got interrupted so check again for the condition
-				}
-			}
-		}
-
-		if (exception != null) {
-			throw exception;
-		} else if (address == null) {
-			throw new TimeoutException("Listener was not notified about a leader within " +
-					timeout + "ms");
-		}
-	}
-
 	public void waitForNewLeader(long timeout) throws Exception {
 		long start = System.currentTimeMillis();
 		long curTimeout;

--- a/tools/log4j-travis.properties
+++ b/tools/log4j-travis.properties
@@ -35,11 +35,12 @@ log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 
 # suppress the irrelevant (wrong) warnings from the netty channel handler
-log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file
-log4j.logger.org.apache.zookeeper=ERROR, file
-log4j.logger.org.apache.zookeeper.server.quorum.QuorumCnxManager=OFF, file
-log4j.logger.org.apache.flink.runtime.leaderelection=DEBUG,file
-log4j.logger.org.apache.flink.runtime.leaderretrieval=DEBUG,file
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.apache.zookeeper.server.quorum.QuorumCnxManager=OFF
+log4j.logger.org.apache.flink.runtime.leaderelection=DEBUG
+log4j.logger.org.apache.flink.runtime.leaderretrieval=DEBUG
+
 # Log a bit when running the flink-yarn-tests to avoid running into the 5 minutes timeout for
 # the tests
 log4j.logger.org.apache.flink.yarn.YARNSessionFIFOITCase=INFO, console


### PR DESCRIPTION
I think this time I've figured out why the `ZooKeeperLeaderElectionTest.testMultipleLeaders` test case sometimes failed. Apparently, Curator's `NodeCache` does not receive all node changes. If for example, the node's data has been changed twice, the `NodeCache` eventually sees only the most recent state. This led to problems in the test case, because the `LeaderRetrievalListener` did not see the firstly changed leader address. The `ZooKeeperLeaderRetrievalService` only notifies the `LeaderRetrievalListener` about a new leader if the read address from the ZooKeeper nodes is different to the last read information. If the node cache misses the firstly changed leader address and only sees the overwritten (corrected) address, then it won't notify the listener, because for him nothing has changed. Therefore, the test failed because it waited for a changing leader address.

I resolved the test failure by using a second `LeaderRetrievalService` which is just started after the faulty leader information has been written to ZooKeeper. That way we can be sure that it will see any leader information, the false or the corrected data, for the first time.