### PR TITLE
[FLINK-2651] Add Netty to dependency management

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -102,7 +102,7 @@ under the License.
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.0.27.Final</version>
+			<!-- Version is set in root POM -->
 		</dependency>
 
 		<!-- See: https://groups.google.com/forum/#!msg/netty/-aAPDBNUnDg/SkGOXL2Ma2QJ -->

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,12 @@ under the License.
 				<artifactId>zookeeper</artifactId>
 				<version>${zookeeper.version}</version>
 			</dependency>
+
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-all</artifactId>
+				<version>4.0.27.Final</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@ under the License.
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-all</artifactId>
-				<version>4.0.27.Final</version>
+				<version>4.0.31.Final</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Hadoop 2.7.0 pulls in an older Netty version, which clashes with our version. This makes sure to only pull in our version.

To test this, you have to build it with `-Dhadoop.version=2.7.0` set.

I've checked that this is respected in the fat jar.

Additionally, I've bumped the Netty version to the most recent 4.0.31 (from 4.0.27). There is no particular reason for this, but the release notes mention many improvements and fixes. In general, I think it's a good idea to have the most recent version.