### PR TITLE
[FLINK-2754] FixedLengthRecordSorter can not write to output cross MemorySegments.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorter.java
@@ -447,11 +447,13 @@ public final class FixedLengthRecordSorter<T> implements InMemorySorter<T> {
 				num -= recordsPerSegment;
 			} else {
 				// partially filled segment
-				for (; num > 0; num--) {
+				for (; num > 0 && offset <= this.lastEntryOffset; num--, offset += this.recordSize) {
 					record = comparator.readWithKeyDenormalization(record, inView);
 					serializer.serialize(record, output);
 				}
 			}
+
+			offset = 0;
 		}
 	}
 	


### PR DESCRIPTION
The issue happens while call FixedLengthRecordSorter::WriteToOutput with non-zero offset and write record across multi memory pages. Fix the issue and add more unit test.