### PR TITLE
[FLINK-2756] Fix start/stop scripts for paths with spaces

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -22,7 +22,7 @@ USAGE="Usage: flink-daemon.sh (start|stop|stop-all) (jobmanager|taskmanager|zook
 
 STARTSTOP=$1
 DAEMON=$2
-ARGS=$3
+ARGS=("${@:3}") # get remaining arguments as array
 
 case $DAEMON in
     (jobmanager)
@@ -62,12 +62,12 @@ mkdir -p "$FLINK_PID_DIR"
 # This allows us to start multiple daemon of each type.
 id=$([ -f "$pid" ] && echo $(wc -l < $pid) || echo "0")
 
-log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-$DAEMON-$id-$HOSTNAME.log
-out=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-$DAEMON-$id-$HOSTNAME.out
+log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}.log"
+out="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}.out"
 
-log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml)
+log_setting=("-Dlog.file=${log}" "-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback.xml")
 
-JAVA_VERSION=$($JAVA_RUN -version 2>&1 | sed 's/.*version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VERSION=$(${JAVA_RUN} -version 2>&1 | sed 's/.*version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 
 # Only set JVM 8 arguments if we have correctly extracted the version
 if [[ ${JAVA_VERSION} =~ ${IS_NUMBER} ]]; then
@@ -90,7 +90,8 @@ case $STARTSTOP in
         fi
 
         echo "Starting $DAEMON daemon on host $HOSTNAME."
-        $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} ${ARGS} > "$out" 2>&1 < /dev/null &
+        $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}" > "$out" 2>&1 < /dev/null &
+
         mypid=$!
 
         # Add to pid file if successful start

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -62,14 +62,16 @@ if [[ $STARTSTOP == "start" ]]; then
     fi
 
     # Startup parameters
-    args="--configDir ${FLINK_CONF_DIR} --executionMode ${EXECUTIONMODE} --streamingMode ${STREAMINGMODE}"
+    args=("--configDir" "${FLINK_CONF_DIR}" "--executionMode" "${EXECUTIONMODE}" "--streamingMode" "${STREAMINGMODE}")
     if [ ! -z $HOST ]; then
-        args="${args} --host $HOST"
+        args+=("--host")
+        args+=("${HOST}")
     fi
 
     if [ ! -z $WEBUIPORT ]; then
-        args="${args} --webui-port $WEBUIPORT"
+        args+=("--webui-port")
+        args+=("${WEBUIPORT}")
     fi
 fi
 
-${FLINK_BIN_DIR}/flink-daemon.sh $STARTSTOP jobmanager "${args}"
+"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP jobmanager "${args[@]}"

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -42,7 +42,7 @@ if [[ $RECOVERY_MODE == "zookeeper" ]]; then
     for ((i=0;i<${#MASTERS[@]};++i)); do
         master=${MASTERS[i]}
         webuiport=${WEBUIPORTS[i]}
-        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l $FLINK_BIN_DIR/jobmanager.sh start cluster ${STREAMING_MODE} ${master} ${webuiport} &"
+        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" start cluster ${STREAMING_MODE} ${master} ${webuiport} &"
     done
 
 else
@@ -57,5 +57,5 @@ shopt -u nocasematch
 readSlaves
 
 for slave in ${SLAVES[@]}; do
-    ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l $FLINK_BIN_DIR/taskmanager.sh start ${STREAMING_MODE} &"
+    ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" start ${STREAMING_MODE} &"
 done

--- a/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
@@ -26,7 +26,7 @@ bin=`cd "$bin"; pwd`
 readSlaves
 
 for slave in ${SLAVES[@]}; do
-    ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l $FLINK_BIN_DIR/taskmanager.sh stop &"
+    ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" stop &"
 done
 
 # Stop JobManager instance(s)
@@ -36,7 +36,7 @@ if [[ $RECOVERY_MODE == "zookeeper" ]]; then
     readMasters
 
     for master in ${MASTERS[@]}; do
-        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l $FLINK_BIN_DIR/jobmanager.sh stop &"
+        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" stop &"
     done
 
 else

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -85,13 +85,12 @@ if [[ $STARTSTOP == "start" ]]; then
         fi
 
         TM_HEAP_SIZE=$((TM_HEAP_SIZE - FLINK_TM_MEM_NETWORK_SIZE - NETTY_BUFFERS))
-        echo export JVM_ARGS="${JVM_ARGS} -Xms${TM_HEAP_SIZE}M -Xmx${TM_HEAP_SIZE}M -XX:MaxDirectMemorySize=$((TM_OFFHEAP_SIZE + FLINK_TM_MEM_NETWORK_SIZE + NETTY_BUFFERS))M"
         export JVM_ARGS="${JVM_ARGS} -Xms${TM_HEAP_SIZE}M -Xmx${TM_HEAP_SIZE}M -XX:MaxDirectMemorySize=$((TM_OFFHEAP_SIZE + FLINK_TM_MEM_NETWORK_SIZE + NETTY_BUFFERS))M"
 
     fi
 
     # Startup parameters
-    args="--configDir ${FLINK_CONF_DIR} --streamingMode ${STREAMINGMODE}"
+    args=("--configDir" "${FLINK_CONF_DIR}" "--streamingMode" "${STREAMINGMODE}")
 fi
 
-${FLINK_BIN_DIR}/flink-daemon.sh $STARTSTOP taskmanager "${args}"
+"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP taskmanager "${args[@]}"

--- a/flink-dist/src/main/flink-bin/bin/zookeeper.sh
+++ b/flink-dist/src/main/flink-bin/bin/zookeeper.sh
@@ -50,7 +50,7 @@ if [[ $STARTSTOP == "start" ]]; then
     fi
 
     # Startup parameters
-    args="--zkConfigFile $ZK_CONF --peerId $PEER_ID"
+    args=("--zkConfigFile" "${ZK_CONF}" "--peerId" "${PEER_ID}")
 fi
 
-${FLINK_BIN_DIR}/flink-daemon.sh $STARTSTOP zookeeper "${args}"
+"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP zookeeper "${args[@]}"


### PR DESCRIPTION
Checked the following scripts:

- `start-local.sh`
- `stop-local.sh`
- `start-cluster.sh`
- `stop-cluster.sh` 

with default setting.
@uce, can you check if the script still work for the HA setup (zookeeper, multiple JMs, etc.)?