### PR TITLE
[FLINK-1966][ml]Add support for Predictive Model Markup Language

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -268,6 +268,7 @@ The Apache Flink project bundles the following files under BSD licenses:
 (3-clause BSD license)
  - D3 v3.4.6 (http://d3js.org/) - Copyright (c) 2010-2014, Michael Bostock
  - D3 v3.5.6 (http://d3js.org/) - Copyright (c) 2010-2015, Michael Bostock
+ - jpmml-model(https://github.com/jpmml/jpmml-model) - Copyright (c) 2009, University of Tartu
 
 All rights reserved.
 

--- a/flink-staging/flink-ml/pom.xml
+++ b/flink-staging/flink-ml/pom.xml
@@ -47,6 +47,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.jpmml</groupId>
+			<artifactId>pmml-model</artifactId>
+			<version>1.2.6</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients</artifactId>
 			<version>${project.version}</version>

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/MLUtils.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/MLUtils.scala
@@ -24,6 +24,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.ml.common.LabeledVector
 import org.apache.flink.ml.math.SparseVector
+import org.dmg.pmml.Application
 
 /** Convenience functions for machine learning tasks
   *
@@ -38,6 +39,10 @@ import org.apache.flink.ml.math.SparseVector
   *   is specified [http://svmlight.joachims.org/ here].
   */
 object MLUtils {
+
+  val pmmlApp = new Application()
+    .setName("Flink ML")
+    .setVersion(getClass.getPackage.getImplementationVersion)
 
   val DIMENSION = "dimension"
 

--- a/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/PMMLExportable.scala
+++ b/flink-staging/flink-ml/src/main/scala/org/apache/flink/ml/common/PMMLExportable.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common
+
+import java.io._
+import javax.xml.transform.stream.StreamResult
+
+import org.apache.flink.ml.MLUtils
+import org.dmg.pmml.{Header, PMML}
+import org.jpmml.model.JAXBUtil
+
+/**
+ * Allows a trained model to be exported in PMML format
+ *
+ * Predictive Model Markup Language is an XML based file format developed by the Data Mining
+ * Group [[http://www.dmg.org]] to provide a way for applications to describe and exchange models
+ * produced by Machine learning and data mining algorithms.
+ */
+trait PMMLExportable {
+
+  /**
+   * Export the model to a file
+   *
+   * @param path Path to the file
+   */
+  final def exportToPMML(path: String): Unit = {
+    val pmml = toPMML()
+    if (pmml.getHeader == null) pmml.setHeader(new Header())
+    pmml.getHeader.setApplication(MLUtils.pmmlApp)
+    if (pmml.getHeader.getDescription == null) pmml.getHeader.setDescription(getClass.getName)
+    JAXBUtil.marshalPMML(pmml, new StreamResult(new File(path)))
+  }
+
+  /**
+   * Exports the trained model to PMML format.
+   *
+   * @return Model in PMML format
+   */
+  private[ml] def toPMML(): PMML
+}

--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
@@ -18,11 +18,17 @@
 
 package org.apache.flink.ml.classification
 
-import org.scalatest.{FlatSpec, Matchers}
-import org.apache.flink.ml.math.DenseVector
+import java.io.File
+import javax.xml.transform.stream.StreamSource
 
 import org.apache.flink.api.scala._
+import org.apache.flink.ml.math.DenseVector
 import org.apache.flink.test.util.FlinkTestBase
+import org.dmg.pmml._
+import org.jpmml.model.JAXBUtil
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
 
 class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
 
@@ -101,4 +107,72 @@ class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
 
 
   }
+
+  it should "export a valid PMML object" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val svm = SVM().setThreshold(0.5)
+    svm.weightsOption = Some(env.fromElements(DenseVector(scala.Array(1.0, 2.0))))
+
+    val tempFile = File.createTempFile("svm-export-test", null)
+    svm.exportToPMML(tempFile.toString)
+
+    // ------------ VERIFY THE EXPORT ---------------------------
+    val pmml = JAXBUtil.unmarshalPMML(new StreamSource(tempFile))
+
+    // header verification
+    pmml.getHeader.getApplication.getName should equal("Flink ML")
+    pmml.getHeader.getDescription should equal("Support Vector Machine")
+
+    // dictionary verification
+    val dataFields = pmml.getDataDictionary.getDataFields.asScala
+    dataFields.size should equal(3)
+    val field1 = dataFields.find(_.getName.getValue == "field_0")
+    val field2 = dataFields.find(_.getName.getValue == "field_1")
+    val field3 = dataFields.find(_.getName.getValue == "prediction")
+    field1 should not be None
+    field2 should not be None
+    field3 should not be None
+    field1.get.getDataType should equal(DataType.DOUBLE)
+    field2.get.getDataType should equal(DataType.DOUBLE)
+    field3.get.getDataType should equal(DataType.STRING)
+    field1.get.getOpType should equal(OpType.CONTINUOUS)
+    field2.get.getOpType should equal(OpType.CONTINUOUS)
+    field3.get.getOpType should equal(OpType.CATEGORICAL)
+    val values = field3.get.getValues.asScala.map(_.getValue)
+    values.size should equal(2)
+    values should contain("NO")
+    values should contain("YES")
+
+    // get the model
+    pmml.getModels.size() should equal(1)
+    val model = pmml.getModels.get(0) match {
+      case m: SupportVectorMachineModel => m
+      case default => throw new Exception("Invalid model type")
+    }
+
+    // verify the model
+    model.getFunctionName should equal(MiningFunctionType.CLASSIFICATION)
+    model.getSvmRepresentation should equal(SvmRepresentationType.COEFFICIENTS)
+    model.getThreshold.toDouble should equal(0.5)
+    model.getKernel match {
+      case _: LinearKernel =>
+      case default => throw new Exception("Invalid kernel type")
+    }
+    val schema = model.getMiningSchema.getMiningFields.asScala
+    schema.size should equal(3)
+    val schema1 = schema.find(_.getName.getValue == "field_0")
+    val schema2 = schema.find(_.getName.getValue == "field_1")
+    val schema3 = schema.find(_.getName.getValue == "prediction")
+    schema1 should not be None
+    schema2 should not be None
+    schema3 should not be None
+    schema1.get.getUsageType should equal(FieldUsageType.ACTIVE)
+    schema2.get.getUsageType should equal(FieldUsageType.ACTIVE)
+    schema3.get.getUsageType should equal(FieldUsageType.PREDICTED)
+    val ws = model.getSupportVectorMachines.get(0).getCoefficients.getCoefficients.asScala
+    ws.head.getValue.toDouble should equal(1.0)
+    ws.last.getValue.toDouble should equal(2.0)
+  }
+
 }


### PR DESCRIPTION
1. Adds an interface to allow exporting of models to PMML format.
2. Implements export methods for the existing SVM and Regression algorithms.
