### PR TITLE
[Flink-2768][Documentation] Fix wrong java version requirement in quickstart

### DIFF
--- a/docs/quickstart/java_api_quickstart.md
+++ b/docs/quickstart/java_api_quickstart.md
@@ -28,7 +28,7 @@ Start working on your Flink Java program in a few simple steps.
 
 ## Requirements
 
-The only requirements are working __Maven 3.0.4__ (or higher) and __Java 6.x__ (or higher) installations.
+The only requirements are working __Maven 3.0.4__ (or higher) and __Java 7.x__ (or higher) installations.
 
 ## Create Project
 

--- a/docs/quickstart/scala_api_quickstart.md
+++ b/docs/quickstart/scala_api_quickstart.md
@@ -28,7 +28,7 @@ Start working on your Flink Scala program in a few simple steps.
 
 ## Requirements
 
-The only requirements are working __Maven 3.0.4__ (or higher) and __Java 6.x__ (or higher) installations.
+The only requirements are working __Maven 3.0.4__ (or higher) and __Java 7.x__ (or higher) installations.
 
 
 ## Create Project

--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -28,7 +28,7 @@ Get Flink up and running in a few simple steps.
 ## Requirements
 
 Flink runs on __Linux, Mac OS X, and Windows__. To be able to run Flink, the
-only requirement is to have a working __Java 6.x__ (or higher)
+only requirement is to have a working __Java 7.x__ (or higher)
 installation. Windows users, please take a look at the
 [Flink on Windows]({{ site.baseurl }}/setup/local_setup.html#flink-on-windows) guide which describes
 how to run Flink on Windows for local setups.

--- a/docs/setup/local_setup.md
+++ b/docs/setup/local_setup.md
@@ -31,7 +31,7 @@ Go to the [downloads page]({{ site.download_url}}) and get the ready to run pack
 
 ## Requirements
 
-Flink runs on **Linux**, **Mac OS X** and **Windows**. The only requirement for a local setup is **Java 1.6.x** or higher. The following manual assumes a *UNIX-like environment*, for Windows see [Flink on Windows](#flink-on-windows).
+Flink runs on **Linux**, **Mac OS X** and **Windows**. The only requirement for a local setup is **Java 1.7.x** or higher. The following manual assumes a *UNIX-like environment*, for Windows see [Flink on Windows](#flink-on-windows).
 
 You can check the correct installation of Java by issuing the following command:
 


### PR DESCRIPTION
Fix wrong java version requirement in quickstart (1.6 -> 1.7)