### PR TITLE
[FLINK-2703] Prepare Flink for using it with Logback.

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -334,6 +334,8 @@ under the License.
 									<exclude>org.apache.flink:flink-scala-examples</exclude>
 									<exclude>org.apache.flink:flink-streaming-examples</exclude>
 									<exclude>org.apache.flink:flink-python</exclude>
+									<exclude>org.slf4j:slf4j-log4j12</exclude>
+									<exclude>log4j:log4j</exclude>
 								</excludes>
 							</artifactSet>
 							<transformers>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -40,6 +40,9 @@ under the License.
 
 			<includes>
 				<include>org.apache.flink:flink-python</include>
+				<include>org.apache.flink:flink-python</include>
+				<include>org.slf4j:slf4j-log4j12</include>
+				<include>log4j:log4j</include>
 			</includes>
 		</dependencySet>
 	</dependencySets>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -40,7 +40,6 @@ under the License.
 
 			<includes>
 				<include>org.apache.flink:flink-python</include>
-				<include>org.apache.flink:flink-python</include>
 				<include>org.slf4j:slf4j-log4j12</include>
 				<include>log4j:log4j</include>
 			</includes>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -85,7 +85,14 @@ under the License.
 								<filter>
 									<artifact>org.slf4j:*</artifact>
 									<excludes>
-										<exclude>org/slf4j/impl/StaticLoggerBinder*</exclude>
+										<exclude>org/slf4j/impl/**</exclude>
+									</excludes>
+								</filter>
+								<!-- Exclude Hadoop's log4j. Hadoop can use Flink's log4j dependency -->
+								<filter>
+									<artifact>log4j:*</artifact>
+									<excludes>
+										<exclude>org/apache/log4j/**</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -54,7 +54,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	@Test
 	public void testClientStartup() {
 		LOG.info("Starting testClientStartup()");
-		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 						"-n", "1",
 						"-jm", "768",
 						"-tm", "1024", "-qu", "qa-team"},
@@ -72,6 +72,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		LOG.info("Starting testNonexistingQueue()");
 		addTestAppender(FlinkYarnClient.class, Level.WARN);
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+				"-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "1",
 				"-jm", "768",
 				"-tm", "1024",

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -101,7 +101,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	@Test
 	public void testClientStartup() {
 		LOG.info("Starting testClientStartup()");
-		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), /* "-t", flinkLibFolder.getAbsolutePath(), */
+		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 						"-n", "1",
 						"-jm", "768",
 						"-tm", "1024",
@@ -119,6 +119,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		LOG.info("Starting testDetachedMode()");
 		addTestAppender(FlinkYarnSessionCli.class, Level.INFO);
 		Runner runner = startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+						"-t", flinkLibFolder.getAbsolutePath(),
 						"-n", "1",
 						"-jm", "768",
 						"-tm", "1024",
@@ -166,7 +167,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	@Test(timeout=100000) // timeout after 100 seconds
 	public void testTaskManagerFailure() {
 		LOG.info("Starting testTaskManagerFailure()");
-		Runner runner = startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+		Runner runner = startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "1",
 				"-jm", "768",
 				"-tm", "1024",
@@ -338,6 +339,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	public void testNonexistingQueue() {
 		LOG.info("Starting testNonexistingQueue()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+				"-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "1",
 				"-jm", "768",
 				"-tm", "1024",
@@ -362,7 +364,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	public void testResourceComputation() {
 		addTestAppender(FlinkYarnClient.class, Level.WARN);
 		LOG.info("Starting testResourceComputation()");
-		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "5",
 				"-jm", "256",
 				"-tm", "1585"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
@@ -390,7 +392,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	public void testfullAlloc() {
 		addTestAppender(FlinkYarnClient.class, Level.WARN);
 		LOG.info("Starting testfullAlloc()");
-		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "2",
 				"-jm", "256",
 				"-tm", "3840"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
@@ -413,7 +415,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		File exampleJarLocation = YarnTestBase.findFile("..", new ContainsName(new String[] {"-WordCount.jar"} , "streaming")); // exclude streaming wordcount here.
 		Assert.assertNotNull("Could not find wordcount jar", exampleJarLocation);
 		runWithArgs(new String[]{"run", "-m", "yarn-cluster",
-						"-yj", flinkUberjar.getAbsolutePath(),
+						"-yj", flinkUberjar.getAbsolutePath(), "-yt", flinkLibFolder.getAbsolutePath(),
 						"-yn", "1",
 						"-ys", "2", //test that the job is executed with a DOP of 2
 						"-yjm", "768",
@@ -441,6 +443,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 						"-p", "2", //test that the job is executed with a DOP of 2
 						"-m", "yarn-cluster",
 						"-yj", flinkUberjar.getAbsolutePath(),
+						"-yt", flinkLibFolder.getAbsolutePath(),
 						"-yn", "1",
 						"-yjm", "768",
 						"-ytm", "1024", exampleJarLocation.getAbsolutePath()},
@@ -477,6 +480,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		}
 
 		Runner runner = startWithArgs(new String[]{"run", "-m", "yarn-cluster", "-yj", flinkUberjar.getAbsolutePath(),
+						"-yt", flinkLibFolder.getAbsolutePath(),
 						"-yn", "1",
 						"-yjm", "768",
 						"-yD", "yarn.heap-cutoff-ratio=0.5", // test if the cutoff is passed correctly
@@ -621,6 +625,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		flinkYarnClient.setJobManagerMemory(768);
 		flinkYarnClient.setTaskManagerMemory(1024);
 		flinkYarnClient.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
+		flinkYarnClient.setShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
 		String confDirPath = System.getenv("FLINK_CONF_DIR");
 		flinkYarnClient.setConfigurationDirectory(confDirPath);
 		flinkYarnClient.setFlinkConfigurationObject(GlobalConfiguration.getConfiguration());
@@ -632,9 +637,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			yarnCluster = flinkYarnClient.deploy();
 			yarnCluster.connectToCluster();
 		} catch (Exception e) {
-			System.err.println("Error while deploying YARN cluster: "+e.getMessage());
 			LOG.warn("Failing test", e);
-			Assert.fail();
+			Assert.fail("Error while deploying YARN cluster: "+e.getMessage());
 		}
 		FlinkYarnClusterStatus expectedStatus = new FlinkYarnClusterStatus(1, 1);
 		for(int second = 0; second < WAIT_TIME * 2; second++) { // run "forever"

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -101,7 +101,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	@Test
 	public void testClientStartup() {
 		LOG.info("Starting testClientStartup()");
-		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), /* "-t", flinkLibFolder.getAbsolutePath(), */
 						"-n", "1",
 						"-jm", "768",
 						"-tm", "1024",

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
@@ -98,9 +98,17 @@ public abstract class YarnTestBase extends TestLogger {
 
 	protected static MiniYARNCluster yarnCluster = null;
 
+	/**
+	 * Uberjar (fat jar) file of Flink
+	 */
 	protected static File flinkUberjar;
 
 	protected static final Configuration yarnConfiguration;
+
+	/**
+	 * lib/ folder of the flink distribution.
+	 */
+	protected static File flinkLibFolder;
 
 	static {
 		yarnConfiguration = new YarnConfiguration();
@@ -329,6 +337,10 @@ public abstract class YarnTestBase extends TestLogger {
 		flinkUberjar = findFile(uberjarStartLoc, new RootDirFilenameFilter());
 		Assert.assertNotNull("Flink uberjar not found", flinkUberjar);
 		String flinkDistRootDir = flinkUberjar.getParentFile().getParent();
+		flinkLibFolder = flinkUberjar.getParentFile(); // the uberjar is located in lib/
+		Assert.assertNotNull("Flink flinkLibFolder not found", flinkLibFolder);
+		Assert.assertTrue("lib folder not found", flinkLibFolder.exists());
+		Assert.assertTrue("lib folder not found", flinkLibFolder.isDirectory());
 
 		if (!flinkUberjar.exists()) {
 			Assert.fail("Unable to locate yarn-uberjar.jar");

--- a/flink-yarn-tests/src/main/resources/log4j-test.properties
+++ b/flink-yarn-tests/src/main/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=FATAL, console
+log4j.rootLogger=INFO, console
 
 # Log all infos in the given file
 log4j.appender.console=org.apache.log4j.ConsoleAppender

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnClient.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -248,15 +247,14 @@ public class FlinkYarnClient extends AbstractFlinkYarnClient {
 	@Override
 	public void setShipFiles(List<File> shipFiles) {
 		File shipFile;
-		for(Iterator<File> it = shipFiles.iterator(); it.hasNext(); ) {
-			shipFile = it.next();
+		for (File shipFile1 : shipFiles) {
+			shipFile = shipFile1;
 			// remove uberjar from ship list (by default everything in the lib/ folder is added to
 			// the list of files to ship, but we handle the uberjar separately.
-			if(shipFile.getName().startsWith("flink-dist-") && shipFile.getName().endsWith("jar")) {
-				it.remove();
+			if (!(shipFile.getName().startsWith("flink-dist-") && shipFile.getName().endsWith("jar"))) {
+				this.shipFiles.add(shipFile);
 			}
 		}
-		this.shipFiles.addAll(shipFiles);
 	}
 
 	public void setDynamicPropertiesEncoded(String dynamicPropertiesEncoded) {


### PR DESCRIPTION
i was talking to a user recently who asked for using Logback instead of Log4j.

This pull request is adding a section in the "Best practices" page which describes how to use Logback for running Flink locally from the IDE and on a cluster.
I also needed to change the pom's of `flink-dist`: They are now placing log4j and slf4j-log4j as separate jars into the lib/ folder (instead of packing them into the fat jar).