### PR TITLE
[FLINK-2666] Add timestamp extraction operator

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -47,6 +47,7 @@ import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.datastream.temporal.StreamCrossOperator;
 import org.apache.flink.streaming.api.datastream.temporal.StreamJoinOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.TimestampExtractor;
 import org.apache.flink.streaming.api.functions.sink.FileSinkFunctionByMillis;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
@@ -76,6 +77,7 @@ import org.apache.flink.streaming.api.windowing.time.AbstractTime;
 import org.apache.flink.streaming.api.windowing.time.EventTime;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.ExtractTimestampsOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.CustomPartitionerWrapper;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
@@ -879,6 +881,30 @@ public class DataStream<T> {
 	 */
 	public <W extends Window> NonParallelWindowDataStream<T, W> windowAll(WindowAssigner<? super T, W> assigner) {
 		return new NonParallelWindowDataStream<>(this, assigner);
+	}
+
+	/**
+	 * Extracts a timestamp from an element and assigns it as the internal timestamp of that element.
+	 * The internal timestamps are, for example, used to to event-time window operations.
+	 *
+	 * <p>
+	 * If you know that the timestamps are strictly increasing you can use an
+	 * {@link org.apache.flink.streaming.api.functions.AscendingTimestampExtractor}. Otherwise,
+	 * you should provide a {@link TimestampExtractor} that also implements
+	 * {@link TimestampExtractor#getCurrentWatermark()} to keep track of watermarks.
+	 *
+	 * @see org.apache.flink.streaming.api.watermark.Watermark
+	 *
+	 * @param extractor The TimestampExtractor that is called for each element of the DataStream.
+	 */
+	public SingleOutputStreamOperator<T, ?> extractTimestamp(TimestampExtractor<T> extractor) {
+		// match parallelism to input, otherwise dop=1 sources could lead to some strange
+		// behaviour: the watermark will creep along very slowly because the elements
+		// from the source go to each extraction operator round robin.
+		int inputParallelism = getTransformation().getParallelism();
+		ExtractTimestampsOperator<T> operator = new ExtractTimestampsOperator<>(clean(extractor));
+		return transform("ExtractTimestamps", getTransformation().getOutputType(), operator)
+				.setParallelism(inputParallelism);
 	}
 
 	/**

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.functions;
+
+/**
+ * Interface for user functions that extract timestamps from elements. The extracting timestamps
+ * must be monotonically increasing.
+ *
+ * @param <T> The type of the elements that this function can extract timestamps from
+ */
+public abstract class AscendingTimestampExtractor<T> implements TimestampExtractor<T> {
+
+	long currentTimestamp = 0;
+
+	/**
+	 * Extracts a timestamp from an element. The timestamp must be monotonically increasing.
+	 *
+	 * @param element The element that the timestamp is extracted from.
+	 * @param currentTimestamp The current internal timestamp of the element.
+	 * @return The new timestamp.
+	 */
+	public abstract long extractAscendingTimestamp(T element, long currentTimestamp);
+
+	@Override
+	public final long extractTimestamp(T element, long currentTimestamp) {
+		long newTimestamp = extractAscendingTimestamp(element, currentTimestamp);
+		if (newTimestamp < this.currentTimestamp) {
+			throw new RuntimeException("Timestamp is lower than previously extracted timestamp. " +
+					"You should implement a custom TimestampExtractor.");
+		}
+		this.currentTimestamp = newTimestamp;
+		return this.currentTimestamp;
+	}
+
+	@Override
+	public final long emitWatermark(T element, long currentTimestamp) {
+		return Long.MIN_VALUE;
+	}
+
+	@Override
+	public final long getCurrentWatermark() {
+		return currentTimestamp - 1;
+	}
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/TimestampExtractor.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/api/functions/TimestampExtractor.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.functions;
+
+import org.apache.flink.api.common.functions.Function;
+
+/**
+ * Interface for user functions that extract timestamps from elements.
+ *
+ * <p>
+ * The extractor must also keep track of the current watermark. The system will periodically
+ * retrieve this watermark using {@link #getCurrentWatermark()} and submit it throughout the topology.
+ *
+ * <p>
+ * Note: If you know that timestamps are monotonically increasing you can use
+ * {@link org.apache.flink.streaming.api.functions.AscendingTimestampExtractor}. This will
+ * keep track of watermarks.
+ *
+ * @see org.apache.flink.streaming.api.watermark.Watermark
+ *
+ * @param <T> The type of the elements that this function can extract timestamps from
+ */
+public interface TimestampExtractor<T> extends Function {
+
+	/**
+	 * Extracts a timestamp from an element.
+	 *
+	 * @param element The element that the timestamp is extracted from.
+	 * @param currentTimestamp The current internal timestamp of the element.
+	 * @return The new timestamp.
+	 */
+	long extractTimestamp(T element, long currentTimestamp);
+
+	/**
+	 * Asks the extractor if it wants to emit a watermark now that it has seen the given element.
+	 * This is called right after {@link #extractTimestamp}. With the same element. The method
+	 * can return {@code Long.MIN_VALUE} to indicate that no watermark should be emitted, a value of 0 or
+	 * greater will be emitted as a watermark if it is higher than the last-emitted watermark.
+	 *
+	 * @param element The element that we last saw.
+	 * @param currentTimestamp The current timestamp of the element that we last saw.
+	 * @return {@code Long.MIN_VALUE} if no watermark should be emitted, positive value for
+	 *          emitting this value as a watermark.
+	 */
+	long emitWatermark(T element, long currentTimestamp);
+
+	/**
+	 * Returns the current watermark. This is periodically called by the system to determine
+	 * the current watermark and forward it.
+	 *
+	 * @see org.apache.flink.streaming.api.watermark.Watermark
+	 */
+	long getCurrentWatermark();
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/operators/ExtractTimestampsOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/operators/ExtractTimestampsOperator.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A {@link org.apache.flink.streaming.api.operators.StreamOperator} for extracting timestamps
+ * from user elements and assigning them as the internal timestamp of the {@link StreamRecord}.
+ *
+ * @param <T> The type of the input elements
+ */
+public class ExtractTimestampsOperator<T>
+		extends AbstractUdfStreamOperator<T, TimestampExtractor<T>>
+		implements OneInputStreamOperator<T, T>, Triggerable {
+
+	private static final long serialVersionUID = 1L;
+
+	transient long watermarkInterval;
+
+	transient long currentWatermark;
+
+	public ExtractTimestampsOperator(TimestampExtractor<T> extractor) {
+		super(extractor);
+		chainingStrategy = ChainingStrategy.ALWAYS;
+
+		// we don't give the element to any user code, so input copy is not necessary
+		disableInputCopy();
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		watermarkInterval = getRuntimeContext().getExecutionConfig().getAutoWatermarkInterval();
+		if (watermarkInterval > 0) {
+			getRuntimeContext().registerTimer(System.currentTimeMillis() + watermarkInterval, this);
+		}
+
+		currentWatermark = Long.MIN_VALUE;
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+
+		// emit a final +Inf watermark, just like the sources
+		output.emitWatermark(new Watermark(Long.MAX_VALUE));
+	}
+
+	@Override
+	public void processElement(StreamRecord<T> element) throws Exception {
+		long newTimestamp = userFunction.extractTimestamp(element.getValue(), element.getTimestamp());
+		output.collect(element.replace(element.getValue(), newTimestamp));
+		long watermark = userFunction.emitWatermark(element.getValue(), newTimestamp);
+		if (watermark > currentWatermark) {
+			currentWatermark = watermark;
+			output.emitWatermark(new Watermark(currentWatermark));
+		}
+	}
+
+	@Override
+	public void trigger(long timestamp) throws Exception {
+		// register next timer
+		getRuntimeContext().registerTimer(System.currentTimeMillis() + watermarkInterval, this);
+		long lastWatermark = currentWatermark;
+		currentWatermark = userFunction.getCurrentWatermark();
+
+		if (currentWatermark > lastWatermark) {
+			// emit watermark
+			output.emitWatermark(new Watermark(currentWatermark));
+		}
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		// ingore them, since we are basically a watermark source
+	}
+}


### PR DESCRIPTION
This adds a user function TimestampExtractor and an operator
ExtractTimestampsOperator that can be used to extract timestamps and
attach them to elements to do event-time windowing.

Users can either use an AscendingTimestampExtractor that assumes that
timestamps are monotonically increasing. (This allows it to derive the
watermark very easily.) Or they use a TimestampExtractor, where they
also have to provide the watermark.

The ExtractTimestampOperator periodically (on the auto watermark
interval) calls the extractor to get the current watermark and forwards
it.

This also adds an ITCase for this behaviour.

(Ignore the other two commits, I'm just basing my work on top of these)