### PR TITLE
[FLINK-2773] remove strict upper direct memory limit

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -91,11 +91,6 @@ KEY_JOBM_MEM_SIZE="jobmanager.heap.mb"
 KEY_TASKM_MEM_SIZE="taskmanager.heap.mb"
 KEY_TASKM_MEM_MANAGED_SIZE="taskmanager.memory.size"
 KEY_TASKM_MEM_MANAGED_FRACTION="taskmanager.memory.fraction"
-KEY_TASKM_MEM_NETWORK_BUFFERS="taskmanager.network.numberOfBuffers"
-# BEGIN:deprecated
-KEY_TASKM_MEM_NETWORK_BUFFER_SIZE="taskmanager.network.bufferSizeInBytes"
-# END:deprecated
-KEY_TASKM_MEM_SEGMENT_SIZE="taskmanager.memory.segment-size"
 KEY_TASKM_OFFHEAP="taskmanager.memory.off-heap"
 
 KEY_ENV_PID_DIR="env.pid.dir"
@@ -199,16 +194,6 @@ fi
 # Define FLINK_TM_MEM_MANAGED_FRACTION if it is not already set
 if [ -z "${FLINK_TM_MEM_MANAGED_FRACTION}" ]; then
     FLINK_TM_MEM_MANAGED_FRACTION=$(readFromConfig ${KEY_TASKM_MEM_MANAGED_FRACTION} 0 "${YAML_CONF}")
-fi
-
-# Define FLINK_TM_MEM_NETWORK_SIZE if it is not already set
-if [ -z "${FLINK_TM_MEM_NETWORK_SIZE}" ]; then
-    BUFFER_SIZE=$(readFromConfig ${KEY_TASKM_MEM_SEGMENT_SIZE} "0" "${YAML_CONF}")
-    if [ "${BUFFER_SIZE}" -eq "0" ]; then
-        BUFFER_SIZE=$(readFromConfig ${KEY_TASKM_MEM_NETWORK_BUFFER_SIZE} "$((32 * 1024))" "${YAML_CONF}")
-    fi
-    NUM_BUFFERS=$(readFromConfig ${KEY_TASKM_MEM_NETWORK_BUFFERS} "2048" "${YAML_CONF}")
-    FLINK_TM_MEM_NETWORK_SIZE=$((((NUM_BUFFERS * BUFFER_SIZE) >> 20) + 1))
 fi
 
 # Define FLINK_TM_OFFHEAP if it is not already set

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1596,30 +1596,8 @@ object TaskManager {
       }
       else if (memType == MemoryType.OFF_HEAP) {
 
-        val networkBufferSizeNew = configuration.getLong(
-          ConfigConstants.TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY,
-          ConfigConstants.DEFAULT_TASK_MANAGER_MEMORY_SEGMENT_SIZE)
-
-        val networkBufferSizeOld = configuration.getLong(
-          ConfigConstants.TASK_MANAGER_NETWORK_BUFFER_SIZE_KEY, -1)
-        val networkBufferSize =
-          if (networkBufferSizeNew != -1) {
-            networkBufferSizeNew
-          } else if (networkBufferSizeOld == -1) {
-            ConfigConstants.DEFAULT_TASK_MANAGER_MEMORY_SEGMENT_SIZE
-          } else {
-            networkBufferSizeOld
-          }
-
-        val numNetworkBuffers = configuration.getLong(
-          ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY,
-          ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_NUM_BUFFERS)
-
-        // direct memory for Netty's off-heap buffers
-        val networkMemory = (numNetworkBuffers * networkBufferSize) + (1 << 20)
-
         // The maximum heap memory has been adjusted according to the fraction
-        val maxMemory = EnvironmentInformation.getMaxJvmHeapMemory() + networkMemory
+        val maxMemory = EnvironmentInformation.getMaxJvmHeapMemory()
         val directMemorySize = (maxMemory / (1.0 - fraction) * fraction).toLong
 
         LOG.info(s"Using $fraction of the maximum memory size for " +

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -551,9 +551,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			});
 			Assert.assertNotNull("Unable to locate JobManager log", jobmanagerLog);
 			content = FileUtils.readFileToString(jobmanagerLog);
-			// TM was started with 1024 but we cut off 50% (NOT THE DEFAULT VALUE) and then divide
-			// between heap and off-heap memory (see {@link ApplicationMasterActor}).
-			String expected = "Starting TM with command=$JAVA_HOME/bin/java -Xms359m -Xmx359m -XX:MaxDirectMemorySize=65m";
+			// TM was started with 1024 but we cut off 50% (NOT THE DEFAULT VALUE)
+			String expected = "Starting TM with command=$JAVA_HOME/bin/java -Xms424m -Xmx424m";
 			Assert.assertTrue("Expected string '" + expected + "' not found in JobManager log: '"+jobmanagerLog+"'",
 					content.contains(expected));
 			expected = " (2/2) (attempt #0) to ";

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterActor.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterActor.scala
@@ -562,11 +562,11 @@ trait ApplicationMasterActor extends FlinkActor {
     log.info("Create container launch context.")
     val ctx = Records.newRecord(classOf[ContainerLaunchContext])
 
-    val (heapLimit, offHeapLimit) = calculateMemoryLimits(memoryLimit, streamingMode)
+    val heapLimit = calculateMemoryLimits(memoryLimit, streamingMode)
 
     val javaOpts = flinkConfiguration.getString(ConfigConstants.FLINK_JVM_OPTIONS, "")
     val tmCommand = new StringBuilder(s"$$JAVA_HOME/bin/java -Xms${heapLimit}m " +
-      s"-Xmx${heapLimit}m -XX:MaxDirectMemorySize=${offHeapLimit}m $javaOpts")
+      s"-Xmx${heapLimit}m -XX:MaxDirectMemorySize=${memoryLimit}m $javaOpts")
 
     if (hasLogback || hasLog4j) {
       tmCommand ++=
@@ -621,28 +621,12 @@ trait ApplicationMasterActor extends FlinkActor {
   }
 
   /**
-   * Calculate the correct JVM heap and off-heap memory limits.
+   * Calculate the correct JVM heap memory limit.
    * @param memoryLimit The maximum memory in megabytes.
    * @param streamingMode True if this is a streaming cluster.
    * @return A Tuple2 containing the heap and the offHeap limit in megabytes.
    */
-  private def calculateMemoryLimits(memoryLimit: Long, streamingMode: Boolean): (Long, Long) = {
-
-    // The new config entry overrides the old one
-    val networkBufferSizeOld = flinkConfiguration.getLong(
-      ConfigConstants.TASK_MANAGER_NETWORK_BUFFER_SIZE_KEY,
-      ConfigConstants.DEFAULT_TASK_MANAGER_MEMORY_SEGMENT_SIZE)
-
-    val networkBufferSize = flinkConfiguration.getLong(
-      ConfigConstants.TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY,
-      networkBufferSizeOld)
-
-    val numNetworkBuffers = flinkConfiguration.getLong(
-      ConfigConstants.TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY,
-      ConfigConstants.DEFAULT_TASK_MANAGER_NETWORK_NUM_BUFFERS)
-
-    // direct memory for Netty's off-heap buffers
-    val networkMemory = ((numNetworkBuffers * networkBufferSize) >> 20) + 1
+  private def calculateMemoryLimits(memoryLimit: Long, streamingMode: Boolean): Long = {
 
     val useOffHeap = flinkConfiguration.getBoolean(
       ConfigConstants.TASK_MANAGER_MEMORY_OFF_HEAP_KEY, false)
@@ -650,17 +634,19 @@ trait ApplicationMasterActor extends FlinkActor {
     if (useOffHeap && !streamingMode){
       val fixedOffHeapSize = flinkConfiguration.getLong(
         ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, -1L)
+
       if (fixedOffHeapSize > 0) {
-        (memoryLimit - fixedOffHeapSize - networkMemory, fixedOffHeapSize + networkMemory)
+        memoryLimit - fixedOffHeapSize
       } else {
         val fraction = flinkConfiguration.getFloat(
           ConfigConstants.TASK_MANAGER_MEMORY_FRACTION_KEY,
           ConfigConstants.DEFAULT_MEMORY_MANAGER_MEMORY_FRACTION)
         val offHeapSize = (fraction * memoryLimit).toLong
-        (memoryLimit - offHeapSize - networkMemory, offHeapSize + networkMemory)
+        memoryLimit - offHeapSize
       }
+
     } else {
-      (memoryLimit - networkMemory, networkMemory)
+      memoryLimit
     }
   }
 }


### PR DESCRIPTION
Setting a strict upper limit for the direct memory size can cause
problems with the direct memory allocation of the Netty network stack
leading to OutOfMemoryExceptions.