### PR TITLE
[FLINK-2785] [gelly] implements fromCsvReader for gelly-scala

### DIFF
--- a/docs/libs/gelly_guide.md
+++ b/docs/libs/gelly_guide.md
@@ -178,7 +178,7 @@ Graph<String, Long, Double> graph = Graph.fromCsvReader("path/to/vertex/input", 
 					.types(String.class, Long.class, Double.class);
 
 
-// create a Graph with no Vertex or Edge values
+// create a Graph with neither Vertex nor Edge values
 Graph<Long, NullValue, NullValue> simpleGraph = Graph.fromCsvReader("path/to/edge/input", env).keyType(Long.class);
 {% endhighlight %}
 </div>
@@ -192,6 +192,28 @@ val vertexTuples = env.readCsvFile[String, Long]("path/to/vertex/input")
 val edgeTuples = env.readCsvFile[String, String, Double]("path/to/edge/input")
 
 val graph = Graph.fromTupleDataSet(vertexTuples, edgeTuples, env)
+{% endhighlight %}
+
+* from a CSV file of Edge data and an optional CSV file of Vertex data.
+In this case, Gelly will convert each row from the Edge CSV file to an `Edge`, where the first field will be the source ID, the second field will be the target ID and the third field (if present) will be the edge value. If the edges have no associated value, set the `hasEdgeValues` parameter to `false`. The parameter `readVertices` defines whether vertex data are provided. If `readVertices` is set to `true`, then `pathVertices` must be specified. In this case, each row from the Vertex CSV file will be converted to a `Vertex`, where the first field will be the vertex ID and the second field will be the vertex value. If `readVertices` is set to false, then Vertex data will be ignored and vertices will be automatically created from the edges input.
+
+{% highlight scala %}
+val env = ExecutionEnvironment.getExecutionEnvironment
+
+// create a Graph with String Vertex IDs, Long Vertex values and Double Edge values
+val graph = Graph.fromCsvReader[String, Long, Double](
+		readVertices = true,
+		pathVertices = "path/to/vertex/input",
+		pathEdges = "path/to/edge/input",
+		env = env)
+
+
+// create a Graph with neither Vertex nor Edge values
+val simpleGraph = Graph.fromCsvReader[Long, NullValue, NullVale](
+		readVertices = false,
+		pathEdges = "path/to/edge/input",
+		hasEdgeValues = false,
+		env = env)
 {% endhighlight %}
 </div>
 </div>

--- a/flink-staging/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/GellyScalaAPICompletenessTest.scala
+++ b/flink-staging/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/GellyScalaAPICompletenessTest.scala
@@ -32,9 +32,7 @@ class GellyScalaAPICompletenessTest extends ScalaAPICompletenessTestBase {
 
   override def isExcludedByName(method: Method): Boolean = {
     val name = method.getDeclaringClass.getName + "." + method.getName
-    val excludedNames = Seq("org.apache.flink.graph.Graph.getContext",
-        // NOTE: until fromCsvReader() is added to to the Scala API Graph
-        "org.apache.flink.graph.Graph.fromCsvReader")
+    val excludedNames = Seq("org.apache.flink.graph.Graph.getContext")
     excludedNames.contains(name)
   }
 

--- a/flink-staging/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphCreationWithCsvITCase.scala
+++ b/flink-staging/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphCreationWithCsvITCase.scala
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.scala.test.operations
+
+import org.apache.flink.api.scala._
+import org.apache.flink.graph.scala._
+import org.apache.flink.graph.scala.test.TestGraphUtils
+import org.apache.flink.test.util.{MultipleProgramsTestBase, TestBaseUtils}
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.{After, Before, Rule, Test}
+import _root_.scala.collection.JavaConverters._
+import java.io.IOException
+import org.apache.flink.core.fs.FileInputSplit
+import java.io.File
+import java.io.OutputStreamWriter
+import java.io.FileOutputStream
+import java.io.FileOutputStream
+import com.google.common.base.Charsets
+import org.apache.flink.core.fs.Path
+import org.apache.flink.types.NullValue
+import org.apache.flink.api.common.functions.MapFunction
+
+@RunWith(classOf[Parameterized])
+class GraphCreationWithCsvITCase(mode: MultipleProgramsTestBase.TestExecutionMode) extends
+MultipleProgramsTestBase(mode) {
+
+  private var expectedResult: String = null
+
+  @Test
+  @throws(classOf[Exception])
+  def testCsvWithValues {
+    /*
+     * Test with two Csv files, both vertices and edges have values
+     */
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val verticesContent =  "1,1\n2,2\n3,3\n"
+    val verticesSplit = createTempFile(verticesContent)
+    val edgesContent =  "1,2,ot\n3,2,tt\n3,1,to\n"
+    val edgesSplit = createTempFile(edgesContent)
+    val graph = Graph.fromCsvReader[Long, Long, String](
+        readVertices = true,
+        pathVertices = verticesSplit.getPath.toString,
+        pathEdges = edgesSplit.getPath.toString,
+        env = env)
+    
+    val result = graph.getTriplets.collect()
+    expectedResult = "1,2,1,2,ot\n3,2,3,2,tt\n3,1,3,1,to\n"
+    TestBaseUtils.compareResultAsTuples(result.asJava, expectedResult);
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testCsvNoEdgeValues {
+    /*
+     * Test with two Csv files; edges have no values
+     */
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val verticesContent =  "1,one\n2,two\n3,three\n"
+    val verticesSplit = createTempFile(verticesContent)
+    val edgesContent =  "1,2\n3,2\n3,1\n"
+    val edgesSplit = createTempFile(edgesContent)
+    val graph = Graph.fromCsvReader[Long, String, NullValue](
+        readVertices = true,
+        pathVertices = verticesSplit.getPath.toString,
+        pathEdges = edgesSplit.getPath.toString,
+        hasEdgeValues = false,
+        env = env)
+    
+    val result = graph.getTriplets.collect()
+    expectedResult = "1,2,one,two,(null)\n3,2,three,two,(null)\n3,1,three,one,(null)\n"
+    TestBaseUtils.compareResultAsTuples(result.asJava, expectedResult);
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testCsvWithMapperValues {
+    /*
+     * Test with edges Csv file and vertex mapper initializer
+     */
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val edgesContent =  "1,2,12\n3,2,32\n3,1,31\n"
+    val edgesSplit = createTempFile(edgesContent)
+    val graph = Graph.fromCsvReader[Long, Double, Long](
+        readVertices = false,
+        pathEdges = edgesSplit.getPath.toString,
+        mapper = new VertexDoubleIdAssigner(),
+        env = env)
+    
+    val result = graph.getTriplets.collect()
+    expectedResult = "1,2,1.0,2.0,12\n3,2,3.0,2.0,32\n3,1,3.0,1.0,31\n"
+    TestBaseUtils.compareResultAsTuples(result.asJava, expectedResult);
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testCsvNoVertexValues {
+    /*
+     * Test with edges Csv file: no vertex values
+     */
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val edgesContent =  "1,2,12\n3,2,32\n3,1,31\n"
+    val edgesSplit = createTempFile(edgesContent)
+    val graph = Graph.fromCsvReader[Long, NullValue, Long](
+        readVertices = false,
+        pathEdges = edgesSplit.getPath.toString,
+        env = env)
+    
+    val result = graph.getTriplets.collect()
+    expectedResult = "1,2,(null),(null),12\n3,2,(null),(null),32\n" +
+      "3,1,(null),(null),31\n"
+    TestBaseUtils.compareResultAsTuples(result.asJava, expectedResult);
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testCsvNoValues {
+    /*
+     * Test with edges Csv file: neither vertex nor edge values
+     */
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val edgesContent =  "1,2\n3,2\n3,1\n"
+    val edgesSplit = createTempFile(edgesContent)
+    val graph = Graph.fromCsvReader[Long, NullValue, NullValue](
+        readVertices = false,
+        pathEdges = edgesSplit.getPath.toString,
+        hasEdgeValues = false,
+        env = env)
+    
+    val result = graph.getTriplets.collect()
+    expectedResult = "1,2,(null),(null),(null)\n" +
+      "3,2,(null),(null),(null)\n3,1,(null),(null),(null)\n"
+    TestBaseUtils.compareResultAsTuples(result.asJava, expectedResult);
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testCsvOptionsVertices {
+    /*
+     * Test the options for vertices: delimiters, comments, ignore first line.
+     */
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val verticesContent =  "42#42\t" + "%this-is-a-comment\t" +
+      "1#1\t" + "2#2\t" + "3#3\t"
+    val verticesSplit = createTempFile(verticesContent)
+    val edgesContent =  "1,2,ot\n3,2,tt\n3,1,to\n"
+    val edgesSplit = createTempFile(edgesContent)
+    val graph = Graph.fromCsvReader[Long, Long, String](
+        readVertices = true,
+        pathVertices = verticesSplit.getPath.toString,
+        lineDelimiterVertices = "\t",
+        fieldDelimiterVertices = "#",
+        ignoreFirstLineVertices = true,
+        ignoreCommentsVertices = "%",
+        pathEdges = edgesSplit.getPath.toString,
+        env = env)
+    
+    val result = graph.getTriplets.collect()
+    expectedResult = "1,2,1,2,ot\n3,2,3,2,tt\n3,1,3,1,to\n"
+    TestBaseUtils.compareResultAsTuples(result.asJava, expectedResult);
+  }
+
+  @Test
+  @throws(classOf[Exception])
+  def testCsvOptionsEdges {
+    /*
+     * Test the options for edges: delimiters, comments, ignore first line.
+     */
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val verticesContent =  "1,1\n2,2\n3,3\n"
+    val verticesSplit = createTempFile(verticesContent)
+    val edgesContent =  "42#42#ignore&" + "1#2#ot&" + "3#2#tt&" + "3#1#to&" +
+      "//this-is-a-comment"
+    val edgesSplit = createTempFile(edgesContent)
+    val graph = Graph.fromCsvReader[Long, Long, String](
+        pathVertices = verticesSplit.getPath.toString,
+        readVertices = true,
+        lineDelimiterEdges = "&",
+        fieldDelimiterEdges = "#",
+        ignoreFirstLineEdges = true,
+        ignoreCommentsEdges = "//",
+        pathEdges = edgesSplit.getPath.toString,
+        env = env)
+    
+    val result = graph.getTriplets.collect()
+    expectedResult = "1,2,1,2,ot\n3,2,3,2,tt\n3,1,3,1,to\n"
+    TestBaseUtils.compareResultAsTuples(result.asJava, expectedResult);
+  }
+
+  @throws(classOf[IOException])
+  def createTempFile(content: String): FileInputSplit = {
+    val tempFile = File.createTempFile("test_contents", "tmp")
+    tempFile.deleteOnExit()
+
+    val wrt = new OutputStreamWriter(new FileOutputStream(tempFile), Charsets.UTF_8)
+    wrt.write(content)
+    wrt.close()
+
+    new FileInputSplit(0, new Path(tempFile.toURI.toString), 0, tempFile.length,
+        Array("localhost"));
+    }
+
+    final class VertexDoubleIdAssigner extends MapFunction[Long, Double] {
+      @throws(classOf[Exception])
+      def map(id: Long): Double = {id.toDouble}
+    }
+
+}


### PR DESCRIPTION
This is the last method missing from the Scala Graph implementation.
In order to be as close as possible to the Java implementation, I implemented one method where different options are given with optional parameters. This resulted into the method exceeding the allowed max number of parameters, as defined in the scala checkstyle. I decided to disable the checkstyle for this particular method, because most of the parameters are optional and are there mainly for completeness. In the common case, a user would only give the path and delimiters. If you think there's a better way to do this without having to disable the checkstyle, let me know!