### PR TITLE
[hotfix] Execute YARN integration tests only upon request 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ matrix:
     - jdk: "openjdk7" # this uploads the Hadoop 1 build to Maven and S3
       env: PROFILE="-Dhadoop.profile=1"
     - jdk: "oraclejdk7" # this uploads the Hadoop 2 build to Maven and S3
-      env: PROFILE="-Dhadoop.version=2.3.0 -P!include-yarn-tests"
+      env: PROFILE="-Dhadoop.version=2.3.0"
     - jdk: "openjdk7"
-      env: PROFILE="-Dhadoop.version=2.4.0 -Dscala-2.11"
+      env: PROFILE="-Dhadoop.version=2.4.0 -Dscala-2.11 -Pinclude-yarn-tests"
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.5.0 -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.5.0 -Dmaven.javadoc.skip=true -Pinclude-yarn-tests"
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.6.0 -Dscala-2.11 -Pinclude-tez -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.6.0 -Dscala-2.11 -Pinclude-tez -Pinclude-yarn-tests -Dmaven.javadoc.skip=true"
 
 
 git:

--- a/pom.xml
+++ b/pom.xml
@@ -413,12 +413,6 @@ under the License.
 		<!-- Profile to deactivate the YARN tests -->
 		<profile>
 			<id>include-yarn-tests</id>
-			<activation>
-				<property>
-					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
-					<!--hadoop2--><name>!hadoop.profile</name>
-				</property>
-			</activation>
 			<modules>
 				<module>flink-yarn-tests</module>
 			</modules>


### PR DESCRIPTION
...by activating the 'include-yarn-tests' profile

The default Hadoop version set in Flink (2.3.0) is causing the MiniYarnCluster to fail on some machines with some ip/hostname resolution issues.

The YARN tests are all executed in travis profiles with Hadoop versions above 2.3.0

**I'm opening this quickly as a PR to see if somebody disagrees or has valid concerns. I'm probably going to merge it in the next 8 hours**.