### PR TITLE
[FLINK-2802] [streaming] Remove cyclic watermark dependencies for iterations

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -79,7 +79,7 @@ public class StreamInputProcessor<IN> {
 
 	private final DeserializationDelegate<StreamElement> deserializationDelegate;
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings("unchecked")
 	public StreamInputProcessor(InputGate[] inputGates, TypeSerializer<IN> inputSerializer,
 								EventListener<CheckpointBarrier> checkpointListener,
 								CheckpointingMode checkpointMode,
@@ -125,7 +125,6 @@ public class StreamInputProcessor<IN> {
 		lastEmittedWatermark = Long.MIN_VALUE;
 	}
 
-	@SuppressWarnings("unchecked")
 	public boolean processInput(OneInputStreamOperator<IN, ?> streamOperator, Object lock) throws Exception {
 		if (isFinished) {
 			return false;

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamtask/StreamIterationHeadTest.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/api/streamtask/StreamIterationHeadTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.streamtask;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.tasks.StreamIterationHead;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskTestHarness;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ResultPartitionWriter.class })
+public class StreamIterationHeadTest {
+
+	@Test
+	public void testIterationHeadWatermarkEmission() throws Exception {
+		StreamIterationHead<Integer> head = new StreamIterationHead<>();
+		StreamTaskTestHarness<Integer> harness = new StreamTaskTestHarness<>(head,
+				BasicTypeInfo.INT_TYPE_INFO);
+		harness.getStreamConfig().setIterationId("1");
+		harness.getStreamConfig().setIterationWaitTime(1);
+
+		harness.invoke();
+		harness.waitForTaskCompletion();
+
+		assertEquals(1, harness.getOutput().size());
+		assertEquals(new Watermark(Long.MAX_VALUE), harness.getOutput().peek());
+	}
+
+}

--- a/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -228,12 +228,12 @@ public class StreamMockEnvironment implements Environment {
 
 	@Override
 	public String getTaskName() {
-		return null;
+		return "";
 	}
 
 	@Override
 	public String getTaskNameWithSubtasks() {
-		return null;
+		return "";
 	}
 
 	@Override


### PR DESCRIPTION
This PR contains a simple change so that if timestamps are enabled, iteration sources automatically emit a `Long.MAX_VALUE` watermark.

While this will not help making event/processing time windows consistent across cycles (which is inherently problematic due to the cyclic time dependency), at least these programs will not deadlock.
