### PR TITLE
[FLINK-2809] [scala-api] Added UnitTypeInfo and UnitSerializer.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CollectionInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CollectionInputFormat.java
@@ -130,8 +130,15 @@ public class CollectionInputFormat<T> extends GenericInputFormat<T> implements N
 			if (elem == null) {
 				throw new IllegalArgumentException("The collection must not contain null elements.");
 			}
-			
-			if (!viewedAs.isAssignableFrom(elem.getClass())) {
+
+			// The second part of the condition is a workaround for the situation that can arise from eg.
+			// "env.fromElements((),(),())"
+			// In this situation, UnitTypeInfo.getTypeClass returns void.class (when we are in the Java world), but
+			// the actual objects that we will be working with, will be BoxedUnits.
+			// Note: TypeInformationGenTest.testUnit tests this condition.
+			if (!viewedAs.isAssignableFrom(elem.getClass()) &&
+					!(elem.getClass().toString().equals("class scala.runtime.BoxedUnit") && viewedAs.equals(void.class))) {
+
 				throw new IllegalArgumentException("The elements in the collection are not all subclasses of " + 
 							viewedAs.getCanonicalName());
 			}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
@@ -56,7 +56,9 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
 
           case ArrayType(elemTpe) => analyzeArray(id, tpe, elemTpe)
 
-          case NothingType() => NothingDesciptor(id, tpe)
+          case NothingType() => NothingDescriptor(id, tpe)
+
+          case UnitType() => UnitDescriptor(id, tpe)
 
           case EitherType(leftTpe, rightTpe) => analyzeEither(id, tpe, leftTpe, rightTpe)
 
@@ -337,6 +339,10 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
 
     private object NothingType {
       def unapply(tpe: Type): Boolean = tpe =:= typeOf[Nothing]
+    }
+
+    private object UnitType {
+      def unapply(tpe: Type): Boolean = tpe =:= typeOf[Unit]
     }
 
     private object EitherType {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeDescriptors.scala
@@ -39,7 +39,9 @@ private[flink] trait TypeDescriptors[C <: Context] { this: MacroContextHolder[C]
   case class PrimitiveDescriptor(id: Int, tpe: Type, default: Literal, wrapper: Type)
     extends UDTDescriptor
 
-  case class NothingDesciptor(id: Int, tpe: Type) extends UDTDescriptor
+  case class NothingDescriptor(id: Int, tpe: Type) extends UDTDescriptor
+
+  case class UnitDescriptor(id: Int, tpe: Type) extends UDTDescriptor
 
   case class EitherDescriptor(id: Int, tpe: Type, left: UDTDescriptor, right: UDTDescriptor)
     extends UDTDescriptor

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo._
 import org.apache.flink.api.common.typeutils._
 import org.apache.flink.api.java.typeutils._
-import org.apache.flink.api.scala.typeutils.{CaseClassSerializer, CaseClassTypeInfo, ScalaNothingTypeInfo}
+import org.apache.flink.api.scala.typeutils._
 import org.apache.flink.types.Value
 import org.apache.hadoop.io.Writable
 
@@ -59,8 +59,10 @@ private[flink] trait TypeInformationGen[C <: Context] {
     case p : PrimitiveDescriptor => mkPrimitiveTypeInfo(p.tpe)
     case p : BoxedPrimitiveDescriptor => mkPrimitiveTypeInfo(p.tpe)
 
-    case n: NothingDesciptor =>
+    case n: NothingDescriptor =>
       reify { new ScalaNothingTypeInfo().asInstanceOf[TypeInformation[T]] }
+
+    case u: UnitDescriptor => reify { new UnitTypeInfo().asInstanceOf[TypeInformation[T]] }
 
     case e: EitherDescriptor => mkEitherTypeInfo(e)
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitSerializer.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+
+class UnitSerializer extends TypeSerializerSingleton[Unit] {
+
+  def isImmutableType(): Boolean = true
+
+  def createInstance(): Unit = ()
+
+  def copy(from: Unit): Unit = ()
+
+  def copy(from: Unit, reuse: Unit): Unit = ()
+
+  def getLength(): Int = 1
+
+  def serialize(record: Unit, target: DataOutputView) {
+    target.write(0)
+  }
+
+  def deserialize(source: DataInputView): Unit = {
+    source.readByte()
+    ()
+  }
+
+  def deserialize(reuse: Unit, source: DataInputView): Unit = {
+    source.readByte()
+    ()
+  }
+
+  def copy(source: DataInputView, target: DataOutputView) {
+    target.write(source.readByte)
+  }
+
+  override def hashCode(): Int = classOf[UnitSerializer].hashCode
+
+  override def canEqual(obj: scala.Any): Boolean = {
+    obj.isInstanceOf[UnitSerializer]
+  }
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.TypeSerializer
+
+class UnitTypeInfo extends TypeInformation[Unit] {
+  override def isBasicType(): Boolean = false
+  override def isTupleType(): Boolean = false
+  override def getArity(): Int = 0
+  override def getTotalFields(): Int = 0
+  override def getTypeClass(): Class[Unit] = classOf[Unit]
+  override def isKeyType(): Boolean = false
+
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[Unit] =
+    (new UnitSerializer).asInstanceOf[TypeSerializer[Unit]]
+
+  override def canEqual(obj: scala.Any): Boolean = {
+    obj.isInstanceOf[UnitTypeInfo]
+  }
+
+  override def toString() = "UnitTypeInfo"
+
+  override def equals(obj: scala.Any) = {
+    obj.isInstanceOf[UnitTypeInfo]
+  }
+
+  override def hashCode() = classOf[UnitTypeInfo].hashCode
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
@@ -20,13 +20,14 @@ package org.apache.flink.api.scala.types
 import java.io.{DataInput, DataOutput}
 
 import org.apache.flink.api.java.`type`.extractor.TypeExtractorTest.CustomTuple
+import org.apache.flink.api.java.io.CollectionInputFormat
 import org.apache.hadoop.io.Writable
 import org.junit.{Assert, Test}
 
 import org.apache.flink.api.common.typeinfo._
 import org.apache.flink.api.java.typeutils._
 import org.apache.flink.api.scala._
-import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
+import org.apache.flink.api.scala.typeutils.{UnitTypeInfo, CaseClassTypeInfo}
 import org.apache.flink.types.{IntValue, StringValue}
 
 class MyWritable extends Writable {
@@ -591,6 +592,17 @@ class TypeInformationGenTest {
       f(???) // O will be Nothing
     }
     // (Do not call g, because it throws NotImplementedError. This is a compile time test.)
+  }
+
+  @Test
+  def testUnit(): Unit = {
+    val ti = createTypeInformation[Unit]
+    Assert.assertTrue(ti.isInstanceOf[UnitTypeInfo])
+
+    // This checks the condition in checkCollection. If this fails with IllegalArgumentException,
+    // then things like "env.fromElements((),(),())" won't work.
+    import scala.collection.JavaConversions._
+    CollectionInputFormat.checkCollection(Seq((),(),()), (new UnitTypeInfo).getTypeClass)
   }
 }
 


### PR DESCRIPTION
Created UnitTypeInfo and UnitSerializer, which will be created for a DataSet[Unit].
Also added a test.

There is a funny situation in CollectionInputFormat.checkCollection: when ExecutionEnvironment.fromCollection calls it, the call to type.getTypeClass() returns void.class, even though it should be classOf[Unit]. This is probably some automatic conversion that happens when classOf[Unit] passes from the Scala world to the Java world. I worked around this by adding a check for this specific case.