### PR TITLE
[FLINK-2818] [runtime] Corrected javadocs of *ReduceDriver classes

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/base/GroupCombineOperatorBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/base/GroupCombineOperatorBase.java
@@ -43,7 +43,7 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * Base operator for the combineGroup transformation. It receives the UDF GroupCombineOperator as an input.
+ * Base operator for the combineGroup transformation. It receives the UDF GroupCombineFunction as an input.
  * This class is later processed by the compiler to generate the plan.
  * @see org.apache.flink.api.common.functions.CombineFunction
  */

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -465,7 +465,7 @@ public abstract class DataSet<T> {
 	}
 
 	/**
-	 * Applies a CombineFunction on a non-grouped {@link DataSet}.
+	 * Applies a GroupCombineFunction on a non-grouped {@link DataSet}.
 	 * A CombineFunction is similar to a GroupReduceFunction but does not perform a full data exchange. Instead, the
 	 * CombineFunction calls the combine method once per partition for combining a group of results. This
 	 * operator is suitable for combining values into an intermediate format before doing a proper groupReduce where
@@ -473,12 +473,12 @@ public abstract class DataSet<T> {
 	 * a combiner by implementing the RichGroupReduce function. The combine method of the RichGroupReduce function
 	 * demands input and output type to be the same. The CombineFunction, on the other side, can have an arbitrary
 	 * output type.
-	 * @param combiner The CombineFunction that is applied on the DataSet.
-	 * @return A GroupCombineOperator which represents the combined DataSet.
+	 * @param combiner The GroupCombineFunction that is applied on the DataSet.
+	 * @return A {@link GroupCombineOperator} which represents the combined DataSet.
 	 */
 	public <R> GroupCombineOperator<T, R> combineGroup(GroupCombineFunction<T, R> combiner) {
 		if (combiner == null) {
-			throw new NullPointerException("GroupReduce function must not be null.");
+			throw new NullPointerException("GroupCombine function must not be null.");
 		}
 
 		String callLocation = Utils.getCallLocationName();

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SortedGrouping.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SortedGrouping.java
@@ -167,7 +167,7 @@ public class SortedGrouping<T> extends Grouping<T> {
 	}
 
 	/**
-	 * Applies a CombineFunction on a grouped {@link DataSet}.
+	 * Applies a GroupCombineFunction on a grouped {@link DataSet}.
 	 * A CombineFunction is similar to a GroupReduceFunction but does not perform a full data exchange. Instead, the
 	 * CombineFunction calls the combine method once per partition for combining a group of results. This
 	 * operator is suitable for combining values into an intermediate format before doing a proper groupReduce where
@@ -175,12 +175,12 @@ public class SortedGrouping<T> extends Grouping<T> {
 	 * a combiner by implementing the RichGroupReduce function. The combine method of the RichGroupReduce function
 	 * demands input and output type to be the same. The CombineFunction, on the other side, can have an arbitrary
 	 * output type.
-	 * @param combiner The CombineFunction that is applied on the DataSet.
-	 * @return A GroupCombineOperator which represents the combined DataSet.
+	 * @param combiner The GroupCombineFunction that is applied on the DataSet.
+	 * @return A {@link GroupCombineOperator} which represents the combined DataSet.
 	 */
 	public <R> GroupCombineOperator<T, R> combineGroup(GroupCombineFunction<T, R> combiner) {
 		if (combiner == null) {
-			throw new NullPointerException("GroupReduce function must not be null.");
+			throw new NullPointerException("GroupCombine function must not be null.");
 		}
 		TypeInformation<R> resultType = TypeExtractor.getGroupCombineReturnTypes(combiner, this.getDataSet().getType());
 
@@ -191,7 +191,7 @@ public class SortedGrouping<T> extends Grouping<T> {
 	/**
 	 * Returns a new set containing the first n elements in this grouped and sorted {@link DataSet}.<br/>
 	 * @param n The desired number of elements for each group.
-	 * @return A ReduceGroupOperator that represents the DataSet containing the elements.
+	 * @return A GroupReduceOperator that represents the DataSet containing the elements.
 	*/
 	public GroupReduceOperator<T, T> first(int n) {
 		if(n < 1) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/UnsortedGrouping.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/UnsortedGrouping.java
@@ -162,20 +162,20 @@ public class UnsortedGrouping<T> extends Grouping<T> {
 	}
 
 	/**
-	 * Applies a CombineFunction on a grouped {@link DataSet}.
-	 * A CombineFunction is similar to a GroupReduceFunction but does not perform a full data exchange. Instead, the
+	 * Applies a GroupCombineFunction on a grouped {@link DataSet}.
+	 * A GroupCombineFunction is similar to a GroupReduceFunction but does not perform a full data exchange. Instead, the
 	 * CombineFunction calls the combine method once per partition for combining a group of results. This
 	 * operator is suitable for combining values into an intermediate format before doing a proper groupReduce where
 	 * the data is shuffled across the node for further reduction. The GroupReduce operator can also be supplied with
 	 * a combiner by implementing the RichGroupReduce function. The combine method of the RichGroupReduce function
 	 * demands input and output type to be the same. The CombineFunction, on the other side, can have an arbitrary
 	 * output type.
-	 * @param combiner The CombineFunction that is applied on the DataSet.
-	 * @return A GroupCombineOperator which represents the combined DataSet.
+	 * @param combiner The GroupCombineFunction that is applied on the DataSet.
+	 * @return A {@link GroupCombineOperator} which represents the combined DataSet.
 	 */
 	public <R> GroupCombineOperator<T, R> combineGroup(GroupCombineFunction<T, R> combiner) {
 		if (combiner == null) {
-			throw new NullPointerException("GroupReduce function must not be null.");
+			throw new NullPointerException("GroupCombine function must not be null.");
 		}
 		TypeInformation<R> resultType = TypeExtractor.getGroupCombineReturnTypes(combiner, this.getDataSet().getType());
 
@@ -185,7 +185,7 @@ public class UnsortedGrouping<T> extends Grouping<T> {
 	/**
 	 * Returns a new set containing the first n elements in this grouped {@link DataSet}.<br/>
 	 * @param n The desired number of elements for each group.
-	 * @return A ReduceGroupOperator that represents the DataSet containing the elements.
+	 * @return A GroupReduceOperator that represents the DataSet containing the elements.
 	*/
 	public GroupReduceOperator<T, T> first(int n) {
 		if(n < 1) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllGroupReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllGroupReduceDriver.java
@@ -34,14 +34,14 @@ import org.apache.flink.util.MutableObjectIterator;
 /**
  * GroupReduceDriver task which is executed by a Task Manager. The task has a
  * single input and one or multiple outputs. It is provided with a GroupReduceFunction
- * implementation or a RichGroupFunction. This Driver performs
+ * implementation or a RichGroupReduceFunction. This Driver performs
  * multiple tasks depending on the DriverStrategy. In case of a ALL_GROUP_REDUCE_COMBINE
  * it uses the combine function of the supplied user function. In case
  * of the ALL_GROUP_REDUCE, it uses the reduce function of the supplied user function to
  * process all elements. In either case, the function is executed on all elements.
  * <p>
- * The GroupReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
- * key. The iterator is handed to the <code>reduce()</code> method of the GroupReduceFunction.
+ * The AllGroupReduceDriver creates an iterator over all records from its input.
+ * The iterator is handed to the <code>reduce()</code> method of the GroupReduceFunction.
  * 
  * @see org.apache.flink.api.common.functions.GroupReduceFunction
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllReduceDriver.java
@@ -33,8 +33,8 @@ import org.apache.flink.util.MutableObjectIterator;
  * single input and one or multiple outputs. It is provided with a ReduceFunction
  * implementation.
  * <p>
- * The ReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
- * key. The iterator is handed to the <code>reduce()</code> method of the ReduceFunction.
+ * The AllReduceDriver creates an iterator over all records from its input.
+ * The elements are handed pairwise to the <code>reduce()</code> method of the ReduceFunction.
  * 
  * @see org.apache.flink.api.common.functions.ReduceFunction
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceCombineDriver.java
@@ -50,7 +50,7 @@ import java.util.List;
  * to have the same input and output type to be able to reduce the elements after the combine from 
  * {@code IN} to {@code OUT}.
  *
- * <p>The CombineTask uses a combining iterator over its input. The output of the iterator is emitted.</p>
+ * <p>The GroupReduceCombineDriver uses a combining iterator over its input. The output of the iterator is emitted.</p>
  * 
  * @param <IN> The data type consumed by the combiner.
  * @param <OUT> The data type produced by the combiner.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceDriver.java
@@ -35,7 +35,7 @@ import org.apache.flink.util.MutableObjectIterator;
  * single input and one or multiple outputs. It is provided with a GroupReduceFunction
  * implementation.
  * <p>
- * The GroupReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
+ * The GroupReduceDriver creates a iterator over all records from its input. The iterator returns all records grouped by their
  * key. The iterator is handed to the <code>reduce()</code> method of the GroupReduceFunction.
  * 
  * @see org.apache.flink.api.common.functions.GroupReduceFunction

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
@@ -30,12 +30,12 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 
 /**
- * Reduce task which is executed by a Task Manager. The task has a
+ * Reduce driver which is executed by a Task Manager. The task has a
  * single input and one or multiple outputs. It is provided with a ReduceFunction
  * implementation.
  * <p>
- * The ReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
- * key. The iterator is handed to the <code>reduce()</code> method of the ReduceFunction.
+ * The ReduceDriver creates an iterator over all records from its input. The iterator returns all records grouped by their
+ * key. The elements are handed pairwise to the <code>reduce()</code> method of the ReduceFunction.
  * 
  * @see org.apache.flink.api.common.functions.ReduceFunction
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/GroupCombineChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/GroupCombineChainedDriver.java
@@ -44,7 +44,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Chained variant of the GroupCombineDriver
+ * Chained variant of the GroupReduceCombineDriver
  * 
  * Acts like a combiner with a custom output type OUT.
  *

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -641,9 +641,9 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   }
 
   /**
-   *  Applies a CombineFunction on a grouped [[DataSet]].  A
-   *  CombineFunction is similar to a GroupReduceFunction but does not
-   *  perform a full data exchange. Instead, the CombineFunction calls
+   *  Applies a GroupCombineFunction on a grouped [[DataSet]].  A
+   *  GroupCombineFunction is similar to a GroupReduceFunction but does not
+   *  perform a full data exchange. Instead, the GroupCombineFunction calls
    *  the combine method once per partition for combining a group of
    *  results. This operator is suitable for combining values into an
    *  intermediate format before doing a proper groupReduce where the
@@ -651,7 +651,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    *  GroupReduce operator can also be supplied with a combiner by
    *  implementing the RichGroupReduce function. The combine method of
    *  the RichGroupReduce function demands input and output type to be
-   *  the same. The CombineFunction, on the other side, can have an
+   *  the same. The GroupCombineFunction, on the other side, can have an
    *  arbitrary output type.
    */
   def combineGroup[R: TypeInformation: ClassTag](
@@ -666,9 +666,9 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   }
 
   /**
-   *  Applies a CombineFunction on a grouped [[DataSet]].  A
-   *  CombineFunction is similar to a GroupReduceFunction but does not
-   *  perform a full data exchange. Instead, the CombineFunction calls
+   *  Applies a GroupCombineFunction on a grouped [[DataSet]].  A
+   *  GroupCombineFunction is similar to a GroupReduceFunction but does not
+   *  perform a full data exchange. Instead, the GroupCombineFunction calls
    *  the combine method once per partition for combining a group of
    *  results. This operator is suitable for combining values into an
    *  intermediate format before doing a proper groupReduce where the
@@ -676,7 +676,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    *  GroupReduce operator can also be supplied with a combiner by
    *  implementing the RichGroupReduce function. The combine method of
    *  the RichGroupReduce function demands input and output type to be
-   *  the same. The CombineFunction, on the other side, can have an
+   *  the same. The GroupCombineFunction, on the other side, can have an
    *  arbitrary output type.
    */
   def combineGroup[R: TypeInformation: ClassTag](


### PR DESCRIPTION
- "The iterator is handed to the <code>reduce()</code> method of the ReduceFunction."
	In the cases of ReduceDriver and AllReduceDriver, it is not the iterator which is handed to reduce(), but the elements pairwise
- "The iterator returns all records grouped by their key"
	I guess this is not the case with AllReduceDriver and AllGroupReduceDriver. But someone who knows the code please confirm this!
- AllGroupReduceDriver refers to "RichGroupFunction"
	There is no such thing. I guess this should be RichGroupReduceFunction.
- GroupCombineChainedDriver refers to "GroupCombineDriver"
	There is no such thing. I guess this should be GroupReduceCombineDriver? (please confirm)
- *Driver instead of *Task

- In the combineGroup methods in DataSet, SortedGrouping, and UnsortedGrouping, the text of the NullPointerException is wrong.
- The @return annotation of the first() method refers to "ReduceGroupOperator" instead of "GroupReduceOperator".
- The javadoc of combineGroup() refers to CombineFunction instead of GroupCombineFunction

- minor typos

- CombineFunction is not used anywhere (except in comments), but I didn't do anything about this, because I'm not sure whether it should be removed, or perhaps there are plans for using it in the future.