### PR TITLE
[FLINK-2805] [blobmanager] Write JARs to file state backend for recovery

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -442,6 +442,12 @@ public final class ConfigConstants {
 	 * Directory for saving streaming checkpoints
 	 */
 	public static final String STATE_BACKEND_FS_DIR = "state.backend.fs.checkpointdir";
+
+	/**
+	 * File system state backend base path for recoverable state handles. Recovery state is written
+	 * to this path and the file state handles are persisted for recovery.
+	 */
+	public static final String STATE_BACKEND_FS_RECOVERY_PATH = "state.backend.fs.dir.recovery";
 	
 	// ----------------------------- Miscellaneous ----------------------------
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -93,11 +93,20 @@ public class BlobServer extends Thread implements BlobService {
 		this.storageDir = BlobUtils.initStorageDirectory(storageDirectory);
 		LOG.info("Created BLOB server storage directory {}", storageDir);
 
+		// No recovery.
 		if (recoveryMode == RecoveryMode.STANDALONE) {
 			this.blobStore = new VoidBlobStore();
 		}
+		// Recovery. Check that everything has been setup correctly. This is not clean, but it's
+		// better to resolve this with some upcoming changes to the state backend setup.
+		else if (config.containsKey(ConfigConstants.STATE_BACKEND) &&
+				config.containsKey(ConfigConstants.STATE_BACKEND_FS_RECOVERY_PATH)) {
+
+			this.blobStore = new FileSystemBlobStore(config);
+		}
+		// Fallback.
 		else {
-			this.blobStore =new FileSystemBlobStore(config);
+			this.blobStore = new VoidBlobStore();
 		}
 
 		// configure the maximum number of concurrent connections

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -83,7 +83,7 @@ public class BlobServer extends Thread implements BlobService {
 
 	/**
 	 * Shutdown hook thread to ensure deletion of the storage directory (or <code>null</code> if
-	 * {@link RecoveryMode#STANDALONE})
+	 * the configured recovery mode does not equal{@link RecoveryMode#STANDALONE})
 	 */
 	private final Thread shutdownHook;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+
+import java.io.File;
+
+/**
+ * A blob store.
+ */
+interface BlobStore {
+
+	/**
+	 * Copies the local file to the blob store.
+	 *
+	 * @param localFile The file to copy
+	 * @param blobKey   The ID for the file in the blob store
+	 * @throws Exception If the copy fails
+	 */
+	void put(File localFile, BlobKey blobKey) throws Exception;
+
+	/**
+	 * Copies a local file to the blob store.
+	 *
+	 * <p>The job ID and key make up a composite key for the file.
+	 *
+	 * @param localFile The file to copy
+	 * @param jobId     The JobID part of ID for the file in the blob store
+	 * @param key       The String part of ID for the file in the blob store
+	 * @throws Exception If the copy fails
+	 */
+	void put(File localFile, JobID jobId, String key) throws Exception;
+
+	/**
+	 * Copies a blob to a local file.
+	 *
+	 * @param blobKey   The blob ID
+	 * @param localFile The local file to copy to
+	 * @throws Exception If the copy fails
+	 */
+	void get(BlobKey blobKey, File localFile) throws Exception;
+
+	/**
+	 * Copies a blob to a local file.
+	 *
+	 * @param jobId     The JobID part of ID for the blob
+	 * @param key       The String part of ID for the blob
+	 * @param localFile The local file to copy to
+	 * @throws Exception If the copy fails
+	 */
+	void get(JobID jobId, String key, File localFile) throws Exception;
+
+	/**
+	 * Deletes a blob.
+	 *
+	 * @param blobKey The blob ID
+	 */
+	void delete(BlobKey blobKey);
+
+	/**
+	 * Deletes a blob.
+	 *
+	 * @param jobId The JobID part of ID for the blob
+	 * @param key   The String part of ID for the blob
+	 */
+	void delete(JobID jobId, String key);
+
+	/**
+	 * Deletes blobs.
+	 *
+	 * @param jobId The JobID part of all blobs to delete
+	 */
+	void deleteAll(JobID jobId);
+
+	/**
+	 * Cleans up the store and deletes all blobs.
+	 */
+	void cleanUp();
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -54,12 +54,12 @@ public class BlobUtils {
 	/**
 	 * The prefix of all BLOB files stored by the BLOB server.
 	 */
-	private static final String BLOB_FILE_PREFIX = "blob_";
+	static final String BLOB_FILE_PREFIX = "blob_";
 
 	/**
 	 * The prefix of all job-specific directories created by the BLOB server.
 	 */
-	private static final String JOB_DIR_PREFIX = "job_";
+	static final String JOB_DIR_PREFIX = "job_";
 
 	/**
 	 * The default character set to translate between characters and bytes.
@@ -179,7 +179,7 @@ public class BlobUtils {
 	 *        the user's key for a BLOB
 	 * @return the internal name for the BLOB as used by the BLOB server
 	 */
-	private static String encodeKey(String key) {
+	static String encodeKey(String key) {
 		return BaseEncoding.base64().encode(key.getBytes(DEFAULT_CHARSET));
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -21,14 +21,19 @@ package org.apache.flink.runtime.blob;
 import com.google.common.io.BaseEncoding;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.util.IOUtils;
 import org.slf4j.Logger;
 
 import java.io.EOFException;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -103,7 +108,7 @@ public class BlobUtils {
 	static File getIncomingDirectory(File storageDir) {
 		final File incomingDir = new File(storageDir, "incoming");
 
-		if (!incomingDir.exists() && !incomingDir.mkdir()) {
+		if (!incomingDir.exists() && !incomingDir.mkdirs()) {
 			throw new RuntimeException("Cannot create directory for incoming files " + incomingDir.getAbsolutePath());
 		}
 
@@ -119,7 +124,7 @@ public class BlobUtils {
 	private static File getCacheDirectory(File storageDir) {
 		final File cacheDirectory = new File(storageDir, "cache");
 
-		if (!cacheDirectory.exists() && !cacheDirectory.mkdir()) {
+		if (!cacheDirectory.exists() && !cacheDirectory.mkdirs()) {
 			throw new RuntimeException("Could not create cache directory '" + cacheDirectory.getAbsolutePath() + "'.");
 		}
 
@@ -323,6 +328,66 @@ public class BlobUtils {
 					LOG.debug("Error while closing resource after BLOB transfer.", t);
 				}
 			}
+		}
+	}
+
+	/**
+	 * Returns the path for the given blob key.
+	 *
+	 * <p>The returned path can be used with the state backend for recovery purposes.
+	 *
+	 * <p>This follows the same scheme as {@link #getStorageLocation(File, BlobKey)}.
+	 */
+	static String getRecoveryPath(String basePath, BlobKey blobKey) {
+		// format: $base/cache/blob_$key
+		return String.format("%s/cache/%s", basePath, BLOB_FILE_PREFIX + blobKey.toString());
+	}
+
+	/**
+	 * Returns the path for the given job ID and key.
+	 *
+	 * <p>The returned path can be used with the state backend for recovery purposes.
+	 *
+	 * <p>This follows the same scheme as {@link #getStorageLocation(File, JobID, String)}.
+	 */
+	static String getRecoveryPath(String basePath, JobID jobId, String key) {
+		// format: $base/job_$id/blob_$key
+		return String.format("%s/%s/%s", basePath, JOB_DIR_PREFIX + jobId.toString(),
+				BLOB_FILE_PREFIX + encodeKey(key));
+	}
+
+	/**
+	 * Returns the path for the given job ID.
+	 *
+	 * <p>The returned path can be used with the state backend for recovery purposes.
+	 */
+	static String getRecoveryPath(String basePath, JobID jobId) {
+		return String.format("%s/%s", basePath, JOB_DIR_PREFIX + jobId.toString());
+	}
+
+	/**
+	 * Copies the file from the recovery path to the local file.
+	 */
+	static void copyFromRecoveryPath(String recoveryPath, File localBlobFile) throws Exception {
+		if (recoveryPath == null) {
+			throw new IllegalStateException("Failed to determine recovery path.");
+		}
+
+		if (!localBlobFile.createNewFile()) {
+			throw new IllegalStateException("Failed to create new local file to copy to");
+		}
+
+		URI uri = new URI(recoveryPath);
+		Path path = new Path(recoveryPath);
+
+		if (FileSystem.get(uri).exists(path)) {
+			try (InputStream is = FileSystem.get(uri).open(path)) {
+				FileOutputStream fos = new FileOutputStream(localBlobFile);
+				IOUtils.copyBytes(is, fos); // closes the streams
+			}
+		}
+		else {
+			throw new IOException("Cannot find required BLOB at '" + recoveryPath + "' for recovery.");
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import com.google.common.io.Files;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Blob store backed by {@link FileSystem}.
+ */
+class FileSystemBlobStore implements BlobStore {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FileSystemBlobStore.class);
+
+	/** The base path of the blob store */
+	private final String basePath;
+
+	FileSystemBlobStore(Configuration config) throws IOException {
+		StateBackend stateBackend = StateBackend.fromConfig(config);
+
+		if (stateBackend == StateBackend.FILESYSTEM) {
+			String stateBackendBasePath = config.getString(
+					ConfigConstants.STATE_BACKEND_FS_RECOVERY_PATH, "");
+
+			if (stateBackendBasePath.equals("")) {
+				throw new IllegalConfigurationException(String.format("Missing configuration for " +
+						"file system state backend recovery path. Please specify via " +
+						"'%s' key.", ConfigConstants.STATE_BACKEND_FS_RECOVERY_PATH));
+			}
+
+			stateBackendBasePath += "/blob";
+
+			this.basePath = stateBackendBasePath;
+
+			try {
+				FileSystem.get(new URI(basePath)).mkdirs(new Path(basePath));
+			}
+			catch (URISyntaxException e) {
+				throw new IOException(e);
+			}
+
+			LOG.info("Created blob directory {}.", basePath);
+		}
+		else {
+			// Nothing else support at the moment
+			throw new IllegalConfigurationException(
+					String.format("Illegal state backend " +
+									"configuration '%s'. Please configure '%s' as state " +
+									"backend and specify the recovery path via '%s' key.",
+							stateBackend, StateBackend.FILESYSTEM,
+							ConfigConstants.STATE_BACKEND_FS_RECOVERY_PATH));
+		}
+	}
+
+	// - Put ------------------------------------------------------------------
+
+	@Override
+	public void put(File localFile, BlobKey blobKey) throws Exception {
+		put(localFile, getRecoveryPath(blobKey));
+	}
+
+	@Override
+	public void put(File localFile, JobID jobId, String key) throws Exception {
+		put(localFile, getRecoveryPath(jobId, key));
+	}
+
+	private void put(File fromFile, String toBlobPath) throws Exception {
+		try (OutputStream os = FileSystem.get(new URI(toBlobPath))
+				.create(new Path(toBlobPath), true)) {
+
+			LOG.debug("Copying from {} to {}.", fromFile, toBlobPath);
+			Files.copy(fromFile, os);
+		}
+	}
+
+	// - Get ------------------------------------------------------------------
+
+	@Override
+	public void get(BlobKey blobKey, File localFile) throws Exception {
+		get(getRecoveryPath(blobKey), localFile);
+	}
+
+	@Override
+	public void get(JobID jobId, String key, File localFile) throws Exception {
+		get(getRecoveryPath(jobId, key), localFile);
+	}
+
+	private void get(String fromBlobPath, File toFile) throws Exception {
+		checkNotNull(fromBlobPath, "Blob path");
+		checkNotNull(toFile, "File");
+
+		if (!toFile.exists() && !toFile.createNewFile()) {
+			throw new IllegalStateException("Failed to create target file to copy to");
+		}
+
+		final URI fromUri = new URI(fromBlobPath);
+		final Path fromPath = new Path(fromBlobPath);
+
+		if (FileSystem.get(fromUri).exists(fromPath)) {
+			try (InputStream is = FileSystem.get(fromUri).open(fromPath)) {
+				FileOutputStream fos = new FileOutputStream(toFile);
+
+				LOG.debug("Copying from {} to {}.", fromBlobPath, toFile);
+				IOUtils.copyBytes(is, fos); // closes the streams
+			}
+		}
+		else {
+			throw new IOException(fromBlobPath + " does not exist.");
+		}
+	}
+
+	// - Delete ---------------------------------------------------------------
+
+	@Override
+	public void delete(BlobKey blobKey) {
+		delete(getRecoveryPath(blobKey));
+	}
+
+	@Override
+	public void delete(JobID jobId, String key) {
+		delete(getRecoveryPath(jobId, key));
+	}
+
+	@Override
+	public void deleteAll(JobID jobId) {
+		delete(getRecoveryPath(jobId));
+	}
+
+	private void delete(String blobPath) {
+		try {
+			LOG.debug("Deleting {}.", blobPath);
+
+			FileSystem.get(new URI(blobPath)).delete(new Path(blobPath), true);
+		}
+		catch (Exception e) {
+			LOG.warn("Failed to delete blob at " + blobPath);
+		}
+	}
+
+	@Override
+	public void cleanUp() {
+		try {
+			LOG.debug("Cleaning up {}.", basePath);
+
+			FileSystem.get(new URI(basePath)).delete(new Path(basePath), true);
+		}
+		catch (Exception e) {
+			LOG.error("Failed to clean up recovery directory.");
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns the path for the given blob key.
+	 */
+	private String getRecoveryPath(BlobKey blobKey) {
+		// format: $base/cache/blob_$key
+		return String.format("%s/cache/%s", basePath, BlobUtils.BLOB_FILE_PREFIX + blobKey.toString());
+	}
+
+	/**
+	 * Returns the path for the given job ID and key.
+	 */
+	private String getRecoveryPath(JobID jobId, String key) {
+		// format: $base/job_$id/blob_$key
+		return String.format("%s/%s/%s", basePath, BlobUtils.JOB_DIR_PREFIX + jobId.toString(),
+				BlobUtils.BLOB_FILE_PREFIX + BlobUtils.encodeKey(key));
+	}
+
+	/**
+	 * Returns the path for the given job ID.
+	 */
+	private String getRecoveryPath(JobID jobId) {
+		return String.format("%s/%s", basePath, BlobUtils.JOB_DIR_PREFIX + jobId.toString());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+
+import java.io.File;
+
+/**
+ * A blob store doing nothing.
+ */
+class VoidBlobStore implements BlobStore {
+
+	@Override
+	public void put(File localFile, BlobKey blobKey) throws Exception {
+	}
+
+	@Override
+	public void put(File localFile, JobID jobId, String key) throws Exception {
+	}
+
+	@Override
+	public void get(BlobKey blobKey, File localFile) throws Exception {
+	}
+
+	@Override
+	public void get(JobID jobId, String key, File localFile) throws Exception {
+	}
+
+	@Override
+	public void delete(BlobKey blobKey) {
+	}
+
+	@Override
+	public void delete(JobID jobId, String key) {
+	}
+
+	@Override
+	public void deleteAll(JobID jobId) {
+	}
+
+	@Override
+	public void cleanUp() {
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/RecoveryMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/RecoveryMode.java
@@ -18,16 +18,32 @@
 
 package org.apache.flink.runtime.jobmanager;
 
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+
 /**
  * Recovery mode for Flink's cluster execution. Currently supported modes are:
  *
- *   - Standalone: No recovery from JobManager failures
- *   - ZooKeeper: JobManager high availability via ZooKeeper
- *     ZooKeeper is used to select a leader among a group of JobManager. This JobManager
- *     is responsible for the job execution. Upon failure of the leader a new leader is elected
- *     which will take over the responsibilities of the old leader
+ * - Standalone: No recovery from JobManager failures
+ * - ZooKeeper: JobManager high availability via ZooKeeper
+ * ZooKeeper is used to select a leader among a group of JobManager. This JobManager
+ * is responsible for the job execution. Upon failure of the leader a new leader is elected
+ * which will take over the responsibilities of the old leader
  */
 public enum RecoveryMode {
 	STANDALONE,
-	ZOOKEEPER
+	ZOOKEEPER;
+
+	/**
+	 * Return the configured {@link RecoveryMode}.
+	 *
+	 * @param config The config to parse
+	 * @return Configured recovery mode or {@link ConfigConstants#DEFAULT_RECOVERY_MODE} if not
+	 * configured.
+	 */
+	public static RecoveryMode fromConfig(Configuration config) {
+		return RecoveryMode.valueOf(config.getString(
+				ConfigConstants.RECOVERY_MODE,
+				ConfigConstants.DEFAULT_RECOVERY_MODE).toUpperCase());
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+
+public enum StateBackend {
+	JOBMANAGER, FILESYSTEM;
+
+	/**
+	 * Returns the configured {@link StateBackend}.
+	 *
+	 * @param config The config to parse
+	 * @return Configured state backend or {@link ConfigConstants#DEFAULT_RECOVERY_MODE} if not
+	 * configured.
+	 */
+	public static StateBackend fromConfig(Configuration config) {
+		return StateBackend.valueOf(config.getString(
+				ConfigConstants.STATE_BACKEND,
+				ConfigConstants.DEFAULT_STATE_BACKEND).toUpperCase());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -80,20 +80,20 @@ public class BlobRecoveryITCase {
 			client = new BlobClient(serverAddress[0]);
 
 			// Random data
-			byte[] actual = new byte[1024];
-			rand.nextBytes(actual);
+			byte[] expected = new byte[1024];
+			rand.nextBytes(expected);
 
 			BlobKey[] keys = new BlobKey[2];
 
 			// Put data
-			keys[0] = client.put(actual); // Request 1
-			keys[1] = client.put(actual, 32, 256); // Request 2
+			keys[0] = client.put(expected); // Request 1
+			keys[1] = client.put(expected, 32, 256); // Request 2
 
 			JobID[] jobId = new JobID[] { new JobID(), new JobID() };
 			String[] testKey = new String[] { "test-key-1", "test-key-2" };
 
-			client.put(jobId[0], testKey[0], actual); // Request 3
-			client.put(jobId[1], testKey[1], actual, 32, 256); // Request 4
+			client.put(jobId[0], testKey[0], expected); // Request 3
+			client.put(jobId[1], testKey[1], expected, 32, 256); // Request 4
 
 			// Close the client and connect to the other server
 			client.close();
@@ -101,42 +101,42 @@ public class BlobRecoveryITCase {
 
 			// Verify request 1
 			try (InputStream is = client.get(keys[0])) {
-				byte[] expected = new byte[actual.length];
+				byte[] actual = new byte[expected.length];
 
-				BlobUtils.readFully(is, expected, 0, actual.length, null);
+				BlobUtils.readFully(is, actual, 0, expected.length, null);
 
-				for (int i = 0; i < actual.length; i++) {
-					assertEquals(actual[i], expected[i]);
+				for (int i = 0; i < expected.length; i++) {
+					assertEquals(expected[i], actual[i]);
 				}
 			}
 
 			// Verify request 2
 			try (InputStream is = client.get(keys[1])) {
-				byte[] expected = new byte[256];
-				BlobUtils.readFully(is, expected, 0, 256, null);
+				byte[] actual = new byte[256];
+				BlobUtils.readFully(is, actual, 0, 256, null);
 
 				for (int i = 32, j = 0; i < 256; i++, j++) {
-					assertEquals(actual[i], expected[j]);
+					assertEquals(expected[i], actual[j]);
 				}
 			}
 
 			// Verify request 3
 			try (InputStream is = client.get(jobId[0], testKey[0])) {
-				byte[] expected = new byte[actual.length];
-				BlobUtils.readFully(is, expected, 0, actual.length, null);
+				byte[] actual = new byte[expected.length];
+				BlobUtils.readFully(is, actual, 0, expected.length, null);
 
-				for (int i = 0; i < actual.length; i++) {
-					assertEquals(actual[i], expected[i]);
+				for (int i = 0; i < expected.length; i++) {
+					assertEquals(expected[i], actual[i]);
 				}
 			}
 
 			// Verify request 4
 			try (InputStream is = client.get(jobId[1], testKey[1])) {
-				byte[] expected = new byte[256];
-				BlobUtils.readFully(is, expected, 0, 256, null);
+				byte[] actual = new byte[256];
+				BlobUtils.readFully(is, actual, 0, 256, null);
 
 				for (int i = 32, j = 0; i < 256; i++, j++) {
-					assertEquals(actual[i], expected[j]);
+					assertEquals(expected[i], actual[j]);
 				}
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobmanager.RecoveryMode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlobRecoveryITCase {
+
+	private File recoveryDir;
+
+	@Before
+	public void setUp() throws Exception {
+		recoveryDir = new File(FileUtils.getTempDirectory(), "BlobRecoveryITCaseDir");
+		if (!recoveryDir.exists() && !recoveryDir.mkdirs()) {
+			throw new IllegalStateException("Failed to create temp directory for test");
+		}
+	}
+
+	@After
+	public void cleanUp() throws Exception {
+		if (recoveryDir != null) {
+			FileUtils.deleteDirectory(recoveryDir);
+		}
+	}
+
+	/**
+	 * Tests that with {@link RecoveryMode#ZOOKEEPER} distributed JARs are recoverable from any
+	 * participating BlobServer.
+	 */
+	@Test
+	public void testBlobServerRecovery() throws Exception {
+		Random rand = new Random();
+
+		BlobServer[] server = new BlobServer[2];
+		InetSocketAddress[] serverAddress = new InetSocketAddress[2];
+		BlobClient client = null;
+
+		try {
+			Configuration config = new Configuration();
+			config.setString(ConfigConstants.RECOVERY_MODE, "ZOOKEEPER");
+			config.setString(ConfigConstants.STATE_BACKEND, "FILESYSTEM");
+			config.setString(ConfigConstants.STATE_BACKEND_FS_RECOVERY_PATH, recoveryDir.getPath());
+
+			for (int i = 0; i < server.length; i++) {
+				server[i] = new BlobServer(config);
+				serverAddress[i] = new InetSocketAddress("localhost", server[i].getPort());
+			}
+
+			client = new BlobClient(serverAddress[0]);
+
+			// Random data
+			byte[] actual = new byte[1024];
+			rand.nextBytes(actual);
+
+			BlobKey[] keys = new BlobKey[2];
+
+			// Put data
+			keys[0] = client.put(actual); // Request 1
+			keys[1] = client.put(actual, 32, 256); // Request 2
+
+			JobID[] jobId = new JobID[] { new JobID(), new JobID() };
+			String[] testKey = new String[] { "test-key-1", "test-key-2" };
+
+			client.put(jobId[0], testKey[0], actual); // Request 3
+			client.put(jobId[1], testKey[1], actual, 32, 256); // Request 4
+
+			// Close the client and connect to the other server
+			client.close();
+			client = new BlobClient(serverAddress[1]);
+
+			// Verify request 1
+			try (InputStream is = client.get(keys[0])) {
+				byte[] expected = new byte[actual.length];
+
+				BlobUtils.readFully(is, expected, 0, actual.length, null);
+
+				for (int i = 0; i < actual.length; i++) {
+					assertEquals(actual[i], expected[i]);
+				}
+			}
+
+			// Verify request 2
+			try (InputStream is = client.get(keys[1])) {
+				byte[] expected = new byte[256];
+				BlobUtils.readFully(is, expected, 0, 256, null);
+
+				for (int i = 32, j = 0; i < 256; i++, j++) {
+					assertEquals(actual[i], expected[j]);
+				}
+			}
+
+			// Verify request 3
+			try (InputStream is = client.get(jobId[0], testKey[0])) {
+				byte[] expected = new byte[actual.length];
+				BlobUtils.readFully(is, expected, 0, actual.length, null);
+
+				for (int i = 0; i < actual.length; i++) {
+					assertEquals(actual[i], expected[i]);
+				}
+			}
+
+			// Verify request 4
+			try (InputStream is = client.get(jobId[1], testKey[1])) {
+				byte[] expected = new byte[256];
+				BlobUtils.readFully(is, expected, 0, 256, null);
+
+				for (int i = 32, j = 0; i < 256; i++, j++) {
+					assertEquals(actual[i], expected[j]);
+				}
+			}
+		}
+		finally {
+			for (BlobServer s : server) {
+				if (s != null) {
+					s.shutdown();
+				}
+			}
+
+			if (client != null) {
+				client.close();
+			}
+		}
+
+		// Verify everything is clean
+		File[] recoveryFiles = recoveryDir.listFiles();
+		assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles), 0, recoveryFiles.length);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.execution.librarycache;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobClient;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobmanager.RecoveryMode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlobLibraryCacheRecoveryITCase {
+
+	private File recoveryDir;
+
+	@Before
+	public void setUp() throws Exception {
+		recoveryDir = new File(FileUtils.getTempDirectory(), "BlobRecoveryITCaseDir");
+		if (!recoveryDir.exists() && !recoveryDir.mkdirs()) {
+			throw new IllegalStateException("Failed to create temp directory for test");
+		}
+	}
+
+	@After
+	public void cleanUp() throws Exception {
+		if (recoveryDir != null) {
+			FileUtils.deleteDirectory(recoveryDir);
+		}
+	}
+
+	/**
+	 * Tests that with {@link RecoveryMode#ZOOKEEPER} distributed JARs are recoverable from any
+	 * participating BlobLibraryCacheManager.
+	 */
+	@Test
+	public void testRecoveryRegisterAndDownload() throws Exception {
+		Random rand = new Random();
+
+		BlobServer[] server = new BlobServer[2];
+		InetSocketAddress[] serverAddress = new InetSocketAddress[2];
+		BlobLibraryCacheManager[] libServer = new BlobLibraryCacheManager[2];
+		BlobCache cache = null;
+		BlobLibraryCacheManager libCache = null;
+
+		try {
+			Configuration config = new Configuration();
+			config.setString(ConfigConstants.RECOVERY_MODE, "ZOOKEEPER");
+			config.setString(ConfigConstants.STATE_BACKEND, "FILESYSTEM");
+			config.setString(ConfigConstants.STATE_BACKEND_FS_RECOVERY_PATH, recoveryDir.getPath());
+
+			for (int i = 0; i < server.length; i++) {
+				server[i] = new BlobServer(config);
+				serverAddress[i] = new InetSocketAddress("localhost", server[i].getPort());
+				libServer[i] = new BlobLibraryCacheManager(server[i], 3600 * 1000);
+			}
+
+			// Random data
+			byte[] actual = new byte[1024];
+			rand.nextBytes(actual);
+
+			List<BlobKey> keys = new ArrayList<>(2);
+
+			// Upload some data (libraries)
+			try (BlobClient client = new BlobClient(serverAddress[0])) {
+				keys.add(client.put(actual)); // Request 1
+				keys.add(client.put(actual, 32, 256)); // Request 2
+			}
+
+			// The cache
+			cache = new BlobCache(serverAddress[0], config);
+			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
+
+			// Register uploaded libraries
+			JobID jobId = new JobID();
+			ExecutionAttemptID executionId = new ExecutionAttemptID();
+			libServer[0].registerTask(jobId, executionId, keys);
+
+			// Verify key 1
+			File f = libCache.getFile(keys.get(0));
+			assertEquals(actual.length, f.length());
+
+			try (FileInputStream fis = new FileInputStream(f)) {
+				for (int i = 0; i < actual.length && fis.available() > 0; i++) {
+					assertEquals(actual[i], (byte) fis.read());
+				}
+
+				assertEquals(0, fis.available());
+			}
+
+			// Shutdown cache and start with other server
+			cache.shutdown();
+			libCache.shutdown();
+
+			cache = new BlobCache(serverAddress[1], config);
+			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
+
+			// Verify key 1
+			f = libCache.getFile(keys.get(0));
+			assertEquals(actual.length, f.length());
+
+			try (FileInputStream fis = new FileInputStream(f)) {
+				for (int i = 0; i < actual.length && fis.available() > 0; i++) {
+					assertEquals(actual[i], (byte) fis.read());
+				}
+
+				assertEquals(0, fis.available());
+			}
+
+			// Verify key 2
+			f = libCache.getFile(keys.get(1));
+			assertEquals(256, f.length());
+
+			try (FileInputStream fis = new FileInputStream(f)) {
+				for (int i = 0; i < 256 && fis.available() > 0; i++) {
+					assertEquals(actual[32 + i], (byte) fis.read());
+				}
+
+				assertEquals(0, fis.available());
+			}
+		}
+		finally {
+			for (BlobServer s : server) {
+				if (s != null) {
+					s.shutdown();
+				}
+			}
+
+			if (cache != null) {
+				cache.shutdown();
+			}
+
+			if (libCache != null) {
+				libCache.shutdown();
+			}
+		}
+
+		// Verify everything is clean
+		File[] recoveryFiles = recoveryDir.listFiles();
+		assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles), 0, recoveryFiles.length);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -88,15 +88,15 @@ public class BlobLibraryCacheRecoveryITCase {
 			}
 
 			// Random data
-			byte[] actual = new byte[1024];
-			rand.nextBytes(actual);
+			byte[] expected = new byte[1024];
+			rand.nextBytes(expected);
 
 			List<BlobKey> keys = new ArrayList<>(2);
 
 			// Upload some data (libraries)
 			try (BlobClient client = new BlobClient(serverAddress[0])) {
-				keys.add(client.put(actual)); // Request 1
-				keys.add(client.put(actual, 32, 256)); // Request 2
+				keys.add(client.put(expected)); // Request 1
+				keys.add(client.put(expected, 32, 256)); // Request 2
 			}
 
 			// The cache
@@ -110,11 +110,11 @@ public class BlobLibraryCacheRecoveryITCase {
 
 			// Verify key 1
 			File f = libCache.getFile(keys.get(0));
-			assertEquals(actual.length, f.length());
+			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
-				for (int i = 0; i < actual.length && fis.available() > 0; i++) {
-					assertEquals(actual[i], (byte) fis.read());
+				for (int i = 0; i < expected.length && fis.available() > 0; i++) {
+					assertEquals(expected[i], (byte) fis.read());
 				}
 
 				assertEquals(0, fis.available());
@@ -129,11 +129,11 @@ public class BlobLibraryCacheRecoveryITCase {
 
 			// Verify key 1
 			f = libCache.getFile(keys.get(0));
-			assertEquals(actual.length, f.length());
+			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
-				for (int i = 0; i < actual.length && fis.available() > 0; i++) {
-					assertEquals(actual[i], (byte) fis.read());
+				for (int i = 0; i < expected.length && fis.available() > 0; i++) {
+					assertEquals(expected[i], (byte) fis.read());
 				}
 
 				assertEquals(0, fis.available());
@@ -145,7 +145,7 @@ public class BlobLibraryCacheRecoveryITCase {
 
 			try (FileInputStream fis = new FileInputStream(f)) {
 				for (int i = 0; i < 256 && fis.available() > 0; i++) {
-					assertEquals(actual[32 + i], (byte) fis.read());
+					assertEquals(expected[32 + i], (byte) fis.read());
 				}
 
 				assertEquals(0, fis.available());

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.state.FileStateHandle;
 import org.apache.flink.runtime.state.LocalStateHandle;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StateHandleProvider;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
@@ -456,10 +457,6 @@ public abstract class StreamTask<OUT, O extends StreamOperator<OUT>> extends Abs
 			LOG.info("Using user defined state backend for streaming checkpoitns.");
 			return provider;
 		}
-	}
-
-	private enum StateBackend {
-		JOBMANAGER, FILESYSTEM
 	}
 
 	/**


### PR DESCRIPTION
This is a follow up to #1153. I've taken two changes from #1153 for convenience. Other than that, this is independent.

When running the `BlobServer` in `RecoveryMode#ZOOKEEPER`, this will upload the JARs to the configured file system backend (e.g. HDFS). **Important**: it introduces a hard dependency to have a configured file state backend when running the blob server with recovery. This is in line with #1153.

This JAR copying only happens on the server side, e.g. the client uploads to the server and the server uploads it to the state backend. Same when requesting a locally non-existing blob: the client requests from the server and the server downloads if not available and then answers the client.

There are other ways to implement this, but this one was minimally invasive and fully circumvents any Akka actor threads for downloading/uploading. A more invasive change could allow to directly interact with the state backend on the client side [task manager] as well. This would spread the load better across the cluster in case of a DFS and save unnecessary network transfers.