### PR TITLE
Create a deep-copy of the record when changing timestamps.

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/operators/ExtractTimestampsOperator.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/operators/ExtractTimestampsOperator.java
@@ -43,9 +43,6 @@ public class ExtractTimestampsOperator<T>
 	public ExtractTimestampsOperator(TimestampExtractor<T> extractor) {
 		super(extractor);
 		chainingStrategy = ChainingStrategy.ALWAYS;
-
-		// we don't give the element to any user code, so input copy is not necessary
-		disableInputCopy();
 	}
 
 	@Override


### PR DESCRIPTION
This is too fix the problem of changing the timestamps in-place, versus creating a deep-copy and changing the timestamp in the new copy of each record in the stream.