### PR TITLE
[FLINK-2828] [table] Add interfaces for Table API input formats

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/AbstractExecutionEnvironment.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/AbstractExecutionEnvironment.java
@@ -15,22 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.expressions.analysis
 
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.plan.PlanNode
-import org.apache.flink.api.table.trees.Analyzer
+package org.apache.flink.api.common;
 
 /**
- * Analyzer for predicates, i.e. filter operations and where clauses of joins.
+ * The AbstractExecutionEnvironment is the context in which a program is executed. The context can be a
+ * ExecutionEnvironment for working with DataSets or a StreamExecutionEnvironment for working
+ * with DataStreams.
  */
-class PredicateAnalyzer(inputOperation: PlanNode)
-  extends Analyzer[Expression] {
-  def rules = Seq(
-    new ResolveFieldReferences(inputOperation, true),
-    new InsertAutoCasts,
-    new TypeCheck,
-    new VerifyNoAggregates,
-    new VerifyBoolean,
-    new PredicatePushdown(inputOperation))
+public interface AbstractExecutionEnvironment {
+
+	/**
+	 * Gets the config object.
+	 */
+	public ExecutionConfig getConfig();
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.flink.api.common.AbstractExecutionEnvironment;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -92,7 +93,7 @@ import com.google.common.base.Preconditions;
  * @see LocalEnvironment
  * @see RemoteEnvironment
  */
-public abstract class ExecutionEnvironment {
+public abstract class ExecutionEnvironment implements AbstractExecutionEnvironment {
 
 	/** The logger used by the environment and its subclasses */
 	protected static final Logger LOG = LoggerFactory.getLogger(ExecutionEnvironment.class);
@@ -141,6 +142,7 @@ public abstract class ExecutionEnvironment {
 	 *
 	 * @return The environment's execution configuration.
 	 */
+	@Override
 	public ExecutionConfig getConfig() {
 		return config;
 	}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -22,7 +22,7 @@ import com.google.common.base.Preconditions
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult, JobID}
+import org.apache.flink.api.common.{AbstractExecutionEnvironment, ExecutionConfig, JobExecutionResult, JobID}
 import org.apache.flink.api.java.io._
 import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -73,10 +73,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) extends AbstractExecutionEnvironmen
   /**
    * Gets the config object.
    */
-  @Override
-  def getConfig: ExecutionConfig = {
-    javaEnv.getConfig
-  }
+  override def getConfig: ExecutionConfig = javaEnv.getConfig
 
   /**
    * Sets the parallelism (parallelism) for operations executed through this environment.

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -43,7 +43,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 /**
- * The ExecutionEnviroment is the context in which a program is executed. A local environment will
+ * The ExecutionEnvironment is the context in which a program is executed. A local environment will
  * cause execution in the current JVM, a remote environment will cause execution on a remote
  * cluster installation.
  *
@@ -61,15 +61,19 @@ import scala.reflect.ClassTag
  *  created. If the program is submitted to a cluster a remote execution environment will
  *  be created.
  */
-class ExecutionEnvironment(javaEnv: JavaEnv) {
+class ExecutionEnvironment(javaEnv: JavaEnv) extends AbstractExecutionEnvironment {
 
   /**
-   * @return the Java Execution environment.
+   * Returns the enclosed Java ExecutionEnvironment for special use cases.
+   *
+   * @return reference to the ExecutionEnvironment of the Java API
    */
   def getJavaEnv: JavaEnv = javaEnv
+
   /**
    * Gets the config object.
    */
+  @Override
   def getConfig: ExecutionConfig = {
     javaEnv.getConfig
   }

--- a/flink-staging/flink-table/src/main/java/org/apache/flink/examples/java/JavaTableExample.java
+++ b/flink-staging/flink-table/src/main/java/org/apache/flink/examples/java/JavaTableExample.java
@@ -50,7 +50,7 @@ public class JavaTableExample {
 
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<WC> input = env.fromElements(
 				new WC("Hello", 1),

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
@@ -27,8 +27,9 @@ import org.apache.flink.api.java.aggregation.AggregationFunction
 import org.apache.flink.api.java.operators.JoinOperator.EquiJoin
 import org.apache.flink.api.java.operators.Keys.ExpressionKeys
 import org.apache.flink.api.java.operators.{GroupReduceOperator, Keys, MapOperator, UnsortedGrouping}
-import org.apache.flink.api.java.{DataSet => JavaDataSet}
+import org.apache.flink.api.java.{DataSet => JavaDataSet, ExecutionEnvironment}
 import org.apache.flink.api.table.expressions.analysis.ExtractEquiJoinFields
+import org.apache.flink.api.table.input.{StaticTableSource, AdaptiveTableSource, TableSource}
 import org.apache.flink.api.table.plan._
 import org.apache.flink.api.table.runtime.{ExpressionAggregateFunction, ExpressionFilterFunction, ExpressionJoinFunction, ExpressionSelectFunction}
 import org.apache.flink.api.table.expressions._
@@ -39,7 +40,7 @@ import org.apache.flink.api.table.{ExpressionException, Row, Table}
  * [[PlanTranslator]] for creating [[Table]]s from Java [[org.apache.flink.api.java.DataSet]]s and
  * translating them back to Java [[org.apache.flink.api.java.DataSet]]s.
  */
-class JavaBatchTranslator extends PlanTranslator {
+class JavaBatchTranslator(env: ExecutionEnvironment = null) extends PlanTranslator {
 
   type Representation[A] = JavaDataSet[A]
 
@@ -52,6 +53,21 @@ class JavaBatchTranslator extends PlanTranslator {
     val rowDataSet = createSelect(expressions, repr, inputType)
 
     Table(Root(rowDataSet, resultFields))
+  }
+
+  override def createTable(tableSource: TableSource): Table = {
+    // a TableSource requires an ExecutionEnvironment
+    if (env == null) {
+      throw new ExpressionException("This operation requires an ExecutionEnvironment.")
+    }
+    tableSource match {
+      case adaptive: AdaptiveTableSource => Table(Root(adaptive, adaptive.getOutputFields()))
+
+      case static: StaticTableSource =>
+        createTable(static.createStaticDataSet(env), static.getOutputFieldNames().mkString(","))
+
+      case _ => throw new ExpressionException("Unknown TableSource type.")
+    }
   }
 
   override def translate[A](op: PlanNode)(implicit tpe: TypeInformation[A]): JavaDataSet[A] = {
@@ -117,6 +133,12 @@ class JavaBatchTranslator extends PlanTranslator {
     op match {
       case Root(dataSet: JavaDataSet[Row], resultFields) =>
         dataSet
+
+      case Root(tableSource: AdaptiveTableSource, resultFields) =>
+        if (env == null) {
+          throw new ExpressionException("This operation requires a TableEnvironment.")
+        }
+        tableSource.createAdaptiveDataSet(env)
 
       case Root(_, _) =>
         throw new ExpressionException("Invalid Root for JavaBatchTranslator: " + op + ". " +

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
@@ -64,7 +64,8 @@ class JavaBatchTranslator(env: Option[ExecutionEnvironment]) extends PlanTransla
       case adaptive: AdaptiveTableSource => Table(Root(adaptive, adaptive.getOutputFields()))
 
       case static: StaticTableSource =>
-        createTable(static.createStaticDataSet(env.get), static.getOutputFieldNames().mkString(","))
+        createTable(static.createStaticDataSet(env.get),
+          static.getOutputFieldNames().mkString(","))
 
       case _ => throw new ExpressionException("Unknown TableSource type.")
     }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaStreamingTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaStreamingTranslator.scala
@@ -64,7 +64,8 @@ class JavaStreamingTranslator(env: Option[StreamExecutionEnvironment]) extends P
       case adaptive: AdaptiveTableSource => Table(Root(adaptive, adaptive.getOutputFields()))
 
       case static: StaticTableSource =>
-        createTable(static.createStaticDataStream(env.get), static.getOutputFieldNames().mkString(","))
+        createTable(static.createStaticDataStream(env.get),
+          static.getOutputFieldNames().mkString(","))
 
       case _ => throw new ExpressionException("Unknown TableSource type.")
     }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
@@ -37,9 +37,9 @@ class TableEnvironment(environment: AbstractExecutionEnvironment) {
   private def translatorFromEnv = {
     environment match {
       case batchEnv: ExecutionEnvironment =>
-        new JavaBatchTranslator(batchEnv)
+        new JavaBatchTranslator(Some(batchEnv))
       case streamEnv: StreamExecutionEnvironment =>
-        new JavaStreamingTranslator(streamEnv)
+        new JavaStreamingTranslator(Some(streamEnv))
       case _ =>
         throw new IllegalArgumentException("ExecutionEnvironment is invalid for the " +
           "Java TableEnvironment.")

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataSetConversions.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataSetConversions.scala
@@ -41,7 +41,7 @@ class DataSetConversions[T](set: DataSet[T], inputType: CompositeType[T]) {
    * of type `Int`.
    */
   def as(fields: Expression*): Table = {
-     new ScalaBatchTranslator(set.getExecutionEnvironment.getJavaEnv)
+     new ScalaBatchTranslator(Some(set.getExecutionEnvironment.getJavaEnv))
        .createTable(set, fields.toArray)
   }
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataSetConversions.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataSetConversions.scala
@@ -41,7 +41,8 @@ class DataSetConversions[T](set: DataSet[T], inputType: CompositeType[T]) {
    * of type `Int`.
    */
   def as(fields: Expression*): Table = {
-     new ScalaBatchTranslator().createTable(set, fields.toArray)
+     new ScalaBatchTranslator(set.getExecutionEnvironment.getJavaEnv)
+       .createTable(set, fields.toArray)
   }
 
   /**

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataStreamConversions.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataStreamConversions.scala
@@ -38,7 +38,7 @@ class DataStreamConversions[T](stream: DataStream[T], inputType: CompositeType[T
    */
 
   def as(fields: Expression*): Table = {
-     new ScalaStreamingTranslator().createTable(
+     new ScalaStreamingTranslator(stream.getExecutionEnvironment.getJavaEnv).createTable(
        stream,
        fields.toArray,
        checkDeterministicFields = true)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataStreamConversions.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/DataStreamConversions.scala
@@ -38,7 +38,7 @@ class DataStreamConversions[T](stream: DataStream[T], inputType: CompositeType[T
    */
 
   def as(fields: Expression*): Table = {
-     new ScalaStreamingTranslator(stream.getExecutionEnvironment.getJavaEnv).createTable(
+     new ScalaStreamingTranslator(Some(stream.getExecutionEnvironment.getJavaEnv)).createTable(
        stream,
        fields.toArray,
        checkDeterministicFields = true)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
@@ -36,7 +36,7 @@ import scala.reflect.ClassTag
  * [[PlanTranslator]] for creating [[Table]]s from Scala [[DataSet]]s and
  * translating them back to Scala [[DataSet]]s.
  */
-class ScalaBatchTranslator(javaEnv: ExecutionEnvironment = null) extends PlanTranslator {
+class ScalaBatchTranslator(javaEnv: Option[ExecutionEnvironment]) extends PlanTranslator {
 
   private val javaTranslator = new JavaBatchTranslator(javaEnv)
 
@@ -69,7 +69,7 @@ class ScalaBatchTranslator(javaEnv: ExecutionEnvironment = null) extends PlanTra
 
   override def createTable(tableSource: TableSource): Table = {
     // a TableSource requires an ExecutionEnvironment
-    if (javaEnv == null) {
+    if (javaEnv.isEmpty) {
       throw new ExpressionException("This operation requires an ExecutionEnvironment." +
         "Scala implicit conversions can not be used in this case. Use a TableEnvironment instead.")
     }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
@@ -19,14 +19,15 @@
 package org.apache.flink.api.scala.table
 
 
-import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.api.java.table.JavaBatchTranslator
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.scala.wrap
-import org.apache.flink.api.table.plan._
-import org.apache.flink.api.table.Table
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.scala.DataSet
+import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.java.ExecutionEnvironment
+import org.apache.flink.api.java.table.JavaBatchTranslator
+import org.apache.flink.api.scala.{DataSet, wrap}
+import org.apache.flink.api.table.{ExpressionException, Table}
+import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.input.TableSource
+import org.apache.flink.api.table.plan._
 
 import scala.reflect.ClassTag
 
@@ -35,9 +36,9 @@ import scala.reflect.ClassTag
  * [[PlanTranslator]] for creating [[Table]]s from Scala [[DataSet]]s and
  * translating them back to Scala [[DataSet]]s.
  */
-class ScalaBatchTranslator extends PlanTranslator {
+class ScalaBatchTranslator(javaEnv: ExecutionEnvironment = null) extends PlanTranslator {
 
-  private val javaTranslator = new JavaBatchTranslator
+  private val javaTranslator = new JavaBatchTranslator(javaEnv)
 
   type Representation[A] = DataSet[A]
 
@@ -64,5 +65,16 @@ class ScalaBatchTranslator extends PlanTranslator {
     val result = javaTranslator.createTable(repr.javaSet, inputType, expressions, resultFields)
 
     Table(result.operation)
+  }
+
+  override def createTable(tableSource: TableSource): Table = {
+    // a TableSource requires an ExecutionEnvironment
+    if (javaEnv == null) {
+      throw new ExpressionException("This operation requires an ExecutionEnvironment." +
+        "Scala implicit conversions can not be used in this case. Use a TableEnvironment instead.")
+    }
+    val result = javaTranslator.createTable(tableSource)
+
+    new Table(result.operation)
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
@@ -35,7 +35,7 @@ import org.apache.flink.streaming.api.scala.{DataStream, javaToScalaStream}
  * This is very limited right now. Only select and filter are implemented. Also, the expression
  * operations must be extended to allow windowing operations.
  */
-class ScalaStreamingTranslator(javaEnv: StreamExecutionEnvironment = null)
+class ScalaStreamingTranslator(javaEnv: Option[StreamExecutionEnvironment])
   extends PlanTranslator {
 
   private val javaTranslator = new JavaStreamingTranslator(javaEnv)
@@ -61,7 +61,7 @@ class ScalaStreamingTranslator(javaEnv: StreamExecutionEnvironment = null)
 
   override def createTable(tableSource: TableSource): Table = {
     // a TableSource requires an StreamExecutionEnvironment
-    if (javaEnv == null) {
+    if (javaEnv.isEmpty) {
       throw new ExpressionException("This operation requires a StreamExecutionEnvironment." +
         "Scala implicit conversions can not be used in this case. Use a TableEnvironment instead.")
     }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
@@ -21,9 +21,11 @@ package org.apache.flink.api.scala.table
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.java.table.JavaStreamingTranslator
-import org.apache.flink.api.table.Table
-import org.apache.flink.api.table.plan._
+import org.apache.flink.api.table.{ExpressionException, Table}
 import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.input.TableSource
+import org.apache.flink.api.table.plan._
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.scala.{DataStream, javaToScalaStream}
 
 /**
@@ -33,9 +35,10 @@ import org.apache.flink.streaming.api.scala.{DataStream, javaToScalaStream}
  * This is very limited right now. Only select and filter are implemented. Also, the expression
  * operations must be extended to allow windowing operations.
  */
-class ScalaStreamingTranslator extends PlanTranslator {
+class ScalaStreamingTranslator(javaEnv: StreamExecutionEnvironment = null)
+  extends PlanTranslator {
 
-  private val javaTranslator = new JavaStreamingTranslator
+  private val javaTranslator = new JavaStreamingTranslator(javaEnv)
 
   override type Representation[A] = DataStream[A]
 
@@ -52,6 +55,17 @@ class ScalaStreamingTranslator extends PlanTranslator {
 
     val result =
       javaTranslator.createTable(repr.getJavaStream, inputType, expressions, resultFields)
+
+    new Table(result.operation)
+  }
+
+  override def createTable(tableSource: TableSource): Table = {
+    // a TableSource requires an StreamExecutionEnvironment
+    if (javaEnv == null) {
+      throw new ExpressionException("This operation requires a StreamExecutionEnvironment." +
+        "Scala implicit conversions can not be used in this case. Use a TableEnvironment instead.")
+    }
+    val result = javaTranslator.createTable(tableSource)
 
     new Table(result.operation)
   }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableConversions.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableConversions.scala
@@ -34,14 +34,14 @@ class TableConversions(table: Table) {
    * Converts the [[Table]] to a [[DataSet]].
    */
   def toDataSet[T: TypeInformation]: DataSet[T] = {
-     new ScalaBatchTranslator().translate[T](table.operation)
+     new ScalaBatchTranslator(None).translate[T](table.operation)
   }
 
   /**
    * Converts the [[Table]] to a [[DataStream]].
    */
   def toDataStream[T: TypeInformation]: DataStream[T] = {
-    new ScalaStreamingTranslator().translate[T](table.operation)
+    new ScalaStreamingTranslator(None).translate[T](table.operation)
   }
 }
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
@@ -34,9 +34,9 @@ class TableEnvironment(environment: AbstractExecutionEnvironment) {
   private def translatorFromEnv = {
     environment match {
       case batchEnv: ExecutionEnvironment =>
-        new ScalaBatchTranslator(batchEnv.getJavaEnv)
+        new ScalaBatchTranslator(Some(batchEnv.getJavaEnv))
       case streamEnv: StreamExecutionEnvironment =>
-        new ScalaStreamingTranslator(streamEnv.getJavaEnv)
+        new ScalaStreamingTranslator(Some(streamEnv.getJavaEnv))
       case _ =>
         throw new IllegalArgumentException("ExecutionEnvironment is invalid for the " +
           "Scala TableEnvironment.")

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.table
+
+import org.apache.flink.api.common.AbstractExecutionEnvironment
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.table.Table
+import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+
+/**
+ * Environment for working with the Table API.
+ *
+ * Conversion from [[DataSet]] or [[DataStream]] to a [[Table]] happen implicitly in Scala.
+ */
+class TableEnvironment(environment: AbstractExecutionEnvironment) {
+  require(environment != null, "The environment must not be null.")
+
+  private def translatorFromEnv = {
+    environment match {
+      case batchEnv: ExecutionEnvironment =>
+        new ScalaBatchTranslator(batchEnv.getJavaEnv)
+      case streamEnv: StreamExecutionEnvironment =>
+        new ScalaStreamingTranslator(streamEnv.getJavaEnv)
+      case _ =>
+        throw new IllegalArgumentException("ExecutionEnvironment is invalid for the " +
+          "Scala TableEnvironment.")
+    }
+  }
+
+  /**
+   * Converts the [[Table]] to a [[DataSet]].
+   */
+  def toDataSet[T: TypeInformation](table: Table): DataSet[T] = {
+    translatorFromEnv match {
+      case batchTranslator: ScalaBatchTranslator =>
+        batchTranslator.translate[T](table.operation)
+      case _ =>
+        throw new IllegalArgumentException("ExecutionEnvironment does not support Scala DataSets.")
+    }
+  }
+
+  /**
+   * Converts the [[Table]] to a [[DataStream]].
+   */
+  def toDataStream[T: TypeInformation](table: Table): DataStream[T] = {
+    translatorFromEnv match {
+      case streamTranslator: ScalaStreamingTranslator =>
+        streamTranslator.translate[T](table.operation)
+      case _ =>
+        throw new IllegalArgumentException("ExecutionEnvironment does not support Scala " +
+          "DataStreams.")
+    }
+  }
+}
+

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/package.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/package.scala
@@ -78,7 +78,7 @@ package object table extends ImplicitExpressionConversions {
 
   implicit def table2RowDataSet(
       table: Table): DataSet[Row] = {
-    new ScalaBatchTranslator().translate[Row](table.operation)
+    new ScalaBatchTranslator(None).translate[Row](table.operation)
   }
 
   implicit def rowDataSet2Table(
@@ -95,7 +95,7 @@ package object table extends ImplicitExpressionConversions {
 
   implicit def table2RowDataStream(
       table: Table): DataStream[Row] = {
-    new ScalaStreamingTranslator().translate[Row](table.operation)
+    new ScalaStreamingTranslator(None).translate[Row](table.operation)
   }
 
   implicit def rowDataStream2Table(

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
@@ -59,7 +59,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def select(fields: Expression*): Table = {
-    val analyzer = new SelectionAnalyzer(operation.outputFields)
+    val analyzer = new SelectionAnalyzer(operation)
     val analyzedFields = fields.map(analyzer.analyze)
     val fieldNames = analyzedFields map(_.name)
     if (fieldNames.toSet.size != fieldNames.size) {
@@ -130,7 +130,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def filter(predicate: Expression): Table = {
-    val analyzer = new PredicateAnalyzer(operation.outputFields)
+    val analyzer = new PredicateAnalyzer(operation)
     val analyzedPredicate = analyzer.analyze(predicate)
     this.copy(operation = Filter(operation, analyzedPredicate))
   }
@@ -189,7 +189,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def groupBy(fields: Expression*): Table = {
-    val analyzer = new GroupByAnalyzer(operation.outputFields)
+    val analyzer = new GroupByAnalyzer(operation)
     val analyzedFields = fields.map(analyzer.analyze)
 
     val illegalKeys = analyzedFields filter {

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions.analysis
+
+import org.apache.flink.api.table.expressions.{Naming, ResolvedFieldReference}
+import org.apache.flink.api.table.input.{AdaptiveTableSource, TableSource}
+import org.apache.flink.api.table.plan._
+
+object FieldBacktracker {
+
+  /**
+   * Tracks a field back to its Root and returns its original name and AdaptiveTableSource
+   * if possible.
+   * This only happens if the field is forwarded unmodified. Renaming operations are reverted.
+   *
+   * @param op start operator
+   * @param fieldName field name at start operator
+   * @return original field name with corresponding AdaptiveTableSource or null
+   */
+  def resolveFieldNameAndTableSource(op: PlanNode, fieldName: String):
+      (AdaptiveTableSource, String) = {
+    op match {
+      case s@Select(input, selection) =>
+        var resolvedField: (AdaptiveTableSource, String) = null
+        // only follow unmodified fields
+        selection.foreach {
+          case ResolvedFieldReference(name, _) if name == fieldName =>
+            resolvedField = resolveFieldNameAndTableSource(input, fieldName)
+          case n@Naming(ResolvedFieldReference(oldName,_), newName) if newName == fieldName =>
+            resolvedField = resolveFieldNameAndTableSource(input, oldName)
+          case _ => // do nothing
+        }
+        resolvedField
+      case Filter(input, _) =>
+        resolveFieldNameAndTableSource(input, fieldName)
+      case Join(leftPlanNode, rightPlanNode) =>
+        if (leftPlanNode.outputFields.map(_._1).contains(fieldName)) {
+          resolveFieldNameAndTableSource(leftPlanNode, fieldName)
+        }
+        else if (rightPlanNode.outputFields.map(_._1).contains(fieldName)) {
+          resolveFieldNameAndTableSource(rightPlanNode, fieldName)
+        }
+        else {
+          null
+        }
+      case As(input, newFieldNames) =>
+        val oldName = input.outputFields(newFieldNames.indexOf(fieldName))._1
+        resolveFieldNameAndTableSource(input, oldName)
+      case GroupBy(input, fields) if fields.filter(_.isInstanceOf[ResolvedFieldReference])
+          .map(_.name).contains(fieldName) =>
+        resolveFieldNameAndTableSource(input, fieldName)
+      // original AdaptiveTableSource name can be resolved
+      case r@Root(tableSource: AdaptiveTableSource, outputFields) if outputFields.map(_._1)
+          .contains(fieldName) =>
+        (tableSource, fieldName)
+      case _ => null
+    }
+  }
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
@@ -31,13 +31,13 @@ object FieldBacktracker {
    *
    * @param op start operator
    * @param fieldName field name at start operator
-   * @return original field name with corresponding AdaptiveTableSource or null
+   * @return original field name with corresponding AdaptiveTableSource
    */
   def resolveFieldNameAndTableSource(op: PlanNode, fieldName: String):
-      (AdaptiveTableSource, String) = {
+      Option[(AdaptiveTableSource, String)] = {
     op match {
       case s@Select(input, selection) =>
-        var resolvedField: (AdaptiveTableSource, String) = null
+        var resolvedField: Option[(AdaptiveTableSource, String)] = None
         // only follow unmodified fields
         selection.foreach {
           case ResolvedFieldReference(name, _) if name == fieldName =>
@@ -57,7 +57,7 @@ object FieldBacktracker {
           resolveFieldNameAndTableSource(rightPlanNode, fieldName)
         }
         else {
-          null
+          None
         }
       case As(input, newFieldNames) =>
         val oldName = input.outputFields(newFieldNames.indexOf(fieldName))._1
@@ -68,8 +68,8 @@ object FieldBacktracker {
       // original AdaptiveTableSource name can be resolved
       case r@Root(tableSource: AdaptiveTableSource, outputFields) if outputFields.map(_._1)
           .contains(fieldName) =>
-        (tableSource, fieldName)
-      case _ => null
+        Some((tableSource, fieldName))
+      case _ => None
     }
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/FieldBacktracker.scala
@@ -39,13 +39,17 @@ object FieldBacktracker {
       case s@Select(input, selection) =>
         var resolvedField: Option[(AdaptiveTableSource, String)] = None
         // only follow unmodified fields
-        selection.foreach {
-          case ResolvedFieldReference(name, _) if name == fieldName =>
-            resolvedField = resolveFieldNameAndTableSource(input, fieldName)
-          case n@Naming(ResolvedFieldReference(oldName,_), newName) if newName == fieldName =>
-            resolvedField = resolveFieldNameAndTableSource(input, oldName)
-          case _ => // do nothing
-        }
+        selection.foreach(expr => {
+          if (resolvedField.isEmpty) {
+            expr match {
+              case ResolvedFieldReference(name, _) if name == fieldName =>
+                resolvedField = resolveFieldNameAndTableSource(input, fieldName)
+              case n@Naming(ResolvedFieldReference(oldName, _), newName) if newName == fieldName =>
+                resolvedField = resolveFieldNameAndTableSource(input, oldName)
+              case _ => // do nothing
+            }
+          }
+        })
         resolvedField
       case Filter(input, _) =>
         resolveFieldNameAndTableSource(input, fieldName)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/GroupByAnalyzer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/GroupByAnalyzer.scala
@@ -19,7 +19,7 @@ package org.apache.flink.api.table.expressions.analysis
 
 import org.apache.flink.api.table._
 import org.apache.flink.api.table.expressions.{ResolvedFieldReference, Expression}
-import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.table.plan.PlanNode
 
 import scala.collection.mutable
 
@@ -29,10 +29,10 @@ import org.apache.flink.api.table.trees.{Rule, Analyzer}
 /**
  * Analyzer for grouping expressions. Only field expressions are allowed as grouping expressions.
  */
-class GroupByAnalyzer(inputFields: Seq[(String, TypeInformation[_])])
+class GroupByAnalyzer(inputOperation: PlanNode)
   extends Analyzer[Expression] {
 
-  def rules = Seq(new ResolveFieldReferences(inputFields), CheckGroupExpression)
+  def rules = Seq(new ResolveFieldReferences(inputOperation, false), CheckGroupExpression)
 
   object CheckGroupExpression extends Rule[Expression] {
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePruner.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePruner.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions.analysis
+
+import org.apache.flink.api.table.expressions._
+
+object PredicatePruner {
+
+  /**
+   * Prunes an expression according to the given filter.
+   * One part of a conjunction remains if the other part is filtered out.
+   * A disjunction is removed if one part is filtered out.
+   *
+   * @param filter filter function
+   * @param expr expression to be copied and pruned
+   * @return new pruned expression
+   */
+  def pruneExpr(filter: (Expression) => Boolean, expr: Expression): Expression = {
+    expr match {
+      case And(left, right) =>
+        val prunedLeft = pruneExpr(filter, left)
+        val prunedRight = pruneExpr(filter, right)
+
+        if (prunedLeft.isInstanceOf[NopExpression]) {
+          prunedRight
+        }
+        else if (prunedRight.isInstanceOf[NopExpression]) {
+          prunedLeft
+        }
+        else {
+          And(prunedLeft, prunedRight)
+        }
+      case Or(left, right) =>
+        if (filter(left) && filter(right)) {
+          val prunedLeft = pruneExpr(filter, left)
+          val prunedRight = pruneExpr(filter, right)
+
+          if (prunedLeft.isInstanceOf[NopExpression] || prunedRight.isInstanceOf[NopExpression]) {
+            NopExpression()
+          }
+          else {
+            Or(prunedLeft, prunedRight)
+          }
+        }
+        else {
+          NopExpression()
+        }
+      case Not(e) =>
+        if (filter(e)) {
+          val prunedE = pruneExpr(filter, e)
+          if (prunedE.isInstanceOf[NopExpression]){
+            NopExpression()
+          }
+          else {
+            Not(e)
+          }
+        }
+        else {
+          NopExpression()
+        }
+      case e: Expression =>
+        if (filter(e)) {
+          e
+        }
+        else {
+          NopExpression()
+        }
+      case _ => NopExpression()
+    }
+  }
+
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePruner.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePruner.scala
@@ -43,6 +43,10 @@ object PredicatePruner {
         else if (prunedRight.isInstanceOf[NopExpression]) {
           prunedLeft
         }
+        else if (prunedLeft.isInstanceOf[NopExpression]
+            && prunedRight.isInstanceOf[NopExpression]) {
+          NopExpression()
+        }
         else {
           And(prunedLeft, prunedRight)
         }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePruner.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePruner.scala
@@ -31,7 +31,7 @@ object PredicatePruner {
    * @param expr expression to be copied and pruned
    * @return new pruned expression
    */
-  def pruneExpr(filter: (Expression) => Boolean, expr: Expression): Expression = {
+  def pruneExpr(filter: Expression => Boolean, expr: Expression): Expression = {
     expr match {
       case And(left, right) =>
         val prunedLeft = pruneExpr(filter, left)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePushdown.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePushdown.scala
@@ -49,7 +49,7 @@ class PredicatePushdown(val inputOperation: PlanNode) extends Rule[Expression] {
       val result = tsExpr.transformPost {
         case rfr@ResolvedFieldReference(fieldName, typeInfo) =>
           ResolvedFieldReference(
-            resolveFieldNameAndTableSource(inputOperation, fieldName)._2,
+            resolveFieldNameAndTableSource(inputOperation, fieldName).get._2,
             typeInfo
           )
       }
@@ -105,15 +105,15 @@ class PredicatePushdown(val inputOperation: PlanNode) extends Rule[Expression] {
       case bc: BinaryComparison if bc.right.isInstanceOf[ResolvedFieldReference] =>
         val fieldRef = bc.right.asInstanceOf[ResolvedFieldReference]
         val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
-        resolvedField != null && resolvedField._1 == ts
+        resolvedField.isDefined && resolvedField.get._1 == ts
       case bc: BinaryComparison if bc.left.isInstanceOf[ResolvedFieldReference] =>
         val fieldRef = bc.left.asInstanceOf[ResolvedFieldReference]
         val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
-        resolvedField != null && resolvedField._1 == ts
+        resolvedField.isDefined && resolvedField.get._1 == ts
       case ue@(IsNotNull(_) | IsNull(_)) =>
         val fieldRef = ue.asInstanceOf[UnaryExpression].child.asInstanceOf[ResolvedFieldReference]
         val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
-        resolvedField != null && resolvedField._1 == ts
+        resolvedField.isDefined && resolvedField.get._1 == ts
       case _ => false
     }
   }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePushdown.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/PredicatePushdown.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions.analysis
+
+import org.apache.flink.api.table.expressions._
+import org.apache.flink.api.table.expressions.analysis.FieldBacktracker
+  .resolveFieldNameAndTableSource
+import org.apache.flink.api.table.expressions.analysis.PredicatePruner.pruneExpr
+import org.apache.flink.api.table.input.AdaptiveTableSource
+import org.apache.flink.api.table.plan._
+import org.apache.flink.api.table.trees.Rule
+
+/**
+ * Pushes constant predicates (e.g. a===12 && b.isNotNull) to each corresponding
+ * AdaptiveTableSource that support predicates.
+ */
+class PredicatePushdown(val inputOperation: PlanNode) extends Rule[Expression] {
+
+  def apply(expr: Expression) = {
+    // get all table sources where predicates can be push into
+    val tableSources = getPushableTableSources(inputOperation)
+
+    // prune expression tree such that it only contains constant predicates
+    // such as a=1,a="Hello World", isNull(a) but not a=b
+    val constantExpr = pruneExpr(isResolvedAndConstant, expr)
+
+    // push predicates to each table source respectively
+    for (ts <- tableSources) {
+      // prune expression tree such that it only contains field references of ts
+      val tsExpr = pruneExpr((e) => isSameTableSource(e, ts), constantExpr)
+
+      // resolve field names to field names of the table source
+      val result = tsExpr.transformPost {
+        case rfr@ResolvedFieldReference(fieldName, typeInfo) =>
+          ResolvedFieldReference(
+            resolveFieldNameAndTableSource(inputOperation, fieldName)._2,
+            typeInfo
+          )
+      }
+      // push down predicates
+      if (result != NopExpression()) {
+        ts.notifyPredicates(result)
+      }
+    }
+    expr
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+   * @return all AdaptiveTableSources the given PlanNode contains
+   */
+  def getPushableTableSources(tree: PlanNode): Seq[AdaptiveTableSource] = tree match {
+    case Root(ts: AdaptiveTableSource, _) => Seq(ts)
+    case pn: PlanNode =>
+      pn.children flatMap { child => getPushableTableSources(child ) }
+    case _ => Seq() // add nothing
+  }
+
+  /**
+   * 
+   * @return true if the given expression is a predicate that consists of a
+   *         ResolvedFieldReference and a constant/literal
+   *         e.g. a=1, 2<c
+   */
+  def isResolvedAndConstant(expr: Expression) : Boolean = {
+    expr match {
+      case bc: BinaryComparison if bc.left.isInstanceOf[Literal]
+          && bc.right.isInstanceOf[ResolvedFieldReference] =>
+        true
+      case bc: BinaryComparison if bc.right.isInstanceOf[Literal]
+          && bc.left.isInstanceOf[ResolvedFieldReference] =>
+        true
+      case ue@(IsNotNull(_) | IsNull(_)) =>
+        val child = ue.asInstanceOf[UnaryExpression].child
+        child.isInstanceOf[ResolvedFieldReference]
+      case And(_,_) | Or(_,_) | Not(_) =>
+        true
+      case _ => false
+    }
+  }
+
+  /**
+   * @return true if the given expression only consists of ResolvedFieldReference of
+   *         the same given AdaptiveTableSource
+   */
+  def isSameTableSource(expr: Expression, ts: AdaptiveTableSource) : Boolean = {
+    expr match {
+      case bc: BinaryComparison if bc.right.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.right.asInstanceOf[ResolvedFieldReference]
+        val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
+        resolvedField != null && resolvedField._1 == ts
+      case bc: BinaryComparison if bc.left.isInstanceOf[ResolvedFieldReference] =>
+        val fieldRef = bc.left.asInstanceOf[ResolvedFieldReference]
+        val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
+        resolvedField != null && resolvedField._1 == ts
+      case ue@(IsNotNull(_) | IsNull(_)) =>
+        val fieldRef = ue.asInstanceOf[UnaryExpression].child.asInstanceOf[ResolvedFieldReference]
+        val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldRef.name)
+        resolvedField != null && resolvedField._1 == ts
+      case _ => false
+    }
+  }
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/ResolveFieldReferences.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/ResolveFieldReferences.scala
@@ -56,10 +56,11 @@ class ResolveFieldReferences(inputFields: Seq[(String, TypeInformation[_])],
         inputOperation.outputFields.find { _._1 == fieldName } match {
           case Some((_, tpe)) =>
 
-            val resolvedField = resolveFieldNameAndTableSource(inputOperation, fieldName)
+            val resolvedFieldOption = resolveFieldNameAndTableSource(inputOperation, fieldName)
 
             // notify AdaptiveTableSource about field access
-            if (resolvedField != null) {
+            if (resolvedFieldOption.isDefined) {
+              val resolvedField = resolvedFieldOption.get
               resolvedField._1.notifyResolvedField(resolvedField._2, filtering)
             }
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/SelectionAnalyzer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/SelectionAnalyzer.scala
@@ -19,16 +19,21 @@ package org.apache.flink.api.table.expressions.analysis
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.plan.PlanNode
 import org.apache.flink.api.table.trees.Analyzer
 
 /**
  * This analyzes selection expressions.
  */
-class SelectionAnalyzer(inputFields: Seq[(String, TypeInformation[_])])
-  extends Analyzer[Expression] {
+class SelectionAnalyzer(inputFields: Seq[(String, TypeInformation[_])], inputOperation: PlanNode)
+    extends Analyzer[Expression] {
+
+  def this(inputOperation: PlanNode) = this(inputOperation.outputFields, inputOperation)
+
+  def this(inputFields: Seq[(String, TypeInformation[_])]) = this(inputFields, null)
 
   def rules = Seq(
-    new ResolveFieldReferences(inputFields),
+    new ResolveFieldReferences(inputFields, inputOperation, false),
     new VerifyNoNestedAggregates,
     new InsertAutoCasts,
     new TypeCheck)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/AdaptiveTableSource.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/AdaptiveTableSource.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.table.Row
+import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+/**
+ * AdaptiveTableSources can adapt their output to the requirements of the plan.
+ * Although the output schema stays the same, the TableSource can react on
+ * field resolution and/or predicates internally and can return adapted DataSet/DataStream
+ * versions in the "translate" step.
+ */
+trait AdaptiveTableSource extends TableSource {
+
+  /**
+   * Returns the schema of the resulting rows. The schema remains constant even if the
+   * TableSource adapts to information passed in notify-methods.
+   *
+   * @return schema of the result rows
+   */
+  def getOutputFields(): Seq[(String, TypeInformation[_])]
+
+  /**
+   * Notifies the TableSource about a resolved field.
+   *
+   * @param field resolved field name
+   * @param filtering `true` if field has been resolved as part of a filter
+   *                  operation. At least one `false` indicates that a wildcard
+   *                  selection does not take place.
+   */
+  def notifyResolvedField(field: String, filtering: Boolean)
+
+  /**
+   * Notifies the TableSource about predicates that apply to its fields. The
+   * predicates are already cleaned such that they only contain comparisons
+   * with literals `a===5 or b==='10'` or `a.notNull and c.isNull`.
+   *
+   * @param expression expression tree only consisting of predicates relevant for this
+   *                   TableSource with literal comparisons
+   */
+  def notifyPredicates(expression: Expression)
+
+  /**
+   * Returns the [[DataSet]] of [[Row]]s that sticks to the schema defined in `getOutputFields()`.
+   * The TableSource may has modified unresolved fields (e.g. has fields set to `null`) and
+   * added pre-filters.
+   *
+   * @param env execution environment
+   * @return adapted data set
+   */
+  def createAdaptiveDataSet(env: ExecutionEnvironment) : DataSet[Row]
+
+  /**
+   * Returns the [[DataStream]] of [[Row]]s that sticks to schema defined in `getOutputFields()`.
+   * The TableSource may has modified unresolved fields (e.g. has fields set to `null`) and
+   * added pre-filters.
+   *
+   * @param env stream execution environment
+   * @return adapted data stream
+   */
+  def createAdaptiveDataStream(env: StreamExecutionEnvironment) : DataStream[Row]
+
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/StaticTableSource.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/StaticTableSource.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+/**
+ * StaticTableSources are an easy way to provide the Table API with additional input formats.
+ * For more advanced TableSources that also adapt to field accesses and
+ * predicates see [[AdaptiveTableSource]].
+ */
+trait StaticTableSource extends TableSource {
+
+  /**
+   * Define name and order of output fields.
+   *
+   * @return output field names
+   */
+  def getOutputFieldNames(): Seq[String]
+
+  /**
+   * Returns a [[DataSet]] of a [[org.apache.flink.api.common.typeutils.CompositeType]].
+   *
+   * @param env execution environment
+   * @return data set
+   */
+  def createStaticDataSet(env: ExecutionEnvironment) : DataSet[_]
+
+  /**
+   * Returns a [[DataStream]] of a [[org.apache.flink.api.common.typeutils.CompositeType]].
+   *
+   * @param env execution environment
+   * @return data stream
+   */
+  def createStaticDataStream(env: StreamExecutionEnvironment) : DataStream[_]
+
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/TableSource.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/input/TableSource.scala
@@ -15,22 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.expressions.analysis
 
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.plan.PlanNode
-import org.apache.flink.api.table.trees.Analyzer
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.table.Table
 
 /**
- * Analyzer for predicates, i.e. filter operations and where clauses of joins.
+ * Base class for input formats of [[Table]]s.
+ *
+ * See also [[AdaptiveTableSource]] and [[StaticTableSource]].
  */
-class PredicateAnalyzer(inputOperation: PlanNode)
-  extends Analyzer[Expression] {
-  def rules = Seq(
-    new ResolveFieldReferences(inputOperation, true),
-    new InsertAutoCasts,
-    new TypeCheck,
-    new VerifyNoAggregates,
-    new VerifyBoolean,
-    new PredicatePushdown(inputOperation))
+trait TableSource {
+
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/ExpandAggregations.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/ExpandAggregations.scala
@@ -111,7 +111,7 @@ object ExpandAggregations {
         }
       }
 
-      val intermediateAnalyzer = new SelectionAnalyzer(input.outputFields)
+      val intermediateAnalyzer = new SelectionAnalyzer(input)
       val analyzedIntermediates = intermediateFields.toSeq.map(intermediateAnalyzer.analyze)
 
       val finalAnalyzer =

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/PlanTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/PlanTranslator.scala
@@ -21,6 +21,7 @@ import java.lang.reflect.Modifier
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.table.input.TableSource
 import org.apache.flink.api.table.parser.ExpressionParser
 import org.apache.flink.api.table.expressions.{Expression, Naming, ResolvedFieldReference, UnresolvedFieldReference}
 import org.apache.flink.api.table.typeinfo.RowTypeInfo
@@ -50,6 +51,11 @@ abstract class PlanTranslator {
       inputType: CompositeType[A],
       expressions: Array[Expression],
       resultFields: Seq[(String, TypeInformation[_])]): Table
+
+  /**
+   * Creates a [[Table]] from a given table source.
+   */
+  def createTable(tableSource: TableSource): Table
 
   /**
    * Creates a [[Table]] from the given DataSet or DataStream.
@@ -101,7 +107,7 @@ abstract class PlanTranslator {
         new Table(
           Root(repr, expressions))
 
-      case c: CompositeType[A] => // us ok
+      case c: CompositeType[A] => // is ok
 
       case tpe => throw new ExpressionException("Only DataSets or DataStreams of composite type" +
         "can be transformed to a Table. These would be tuples, case classes and " +

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
@@ -20,6 +20,7 @@ package org.apache.flink.api.table.plan
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.aggregation.Aggregations
 import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.input.TableSource
 import org.apache.flink.api.table.trees.TreeNode
 
 /**
@@ -32,6 +33,8 @@ sealed abstract class PlanNode extends TreeNode[PlanNode] { self: Product =>
 /**
  * Operation that transforms a [[org.apache.flink.api.scala.DataSet]] or
  * [[org.apache.flink.streaming.api.scala.DataStream]] into a [[org.apache.flink.api.table.Table]].
+ * The input can also be a [[org.apache.flink.api.table.input.AdaptiveTableSource]] that provides
+ * both a DataSet or a DataStream.
  */
 case class Root[T](input: T, outputFields: Seq[(String, TypeInformation[_])]) extends PlanNode {
   val children = Nil
@@ -92,7 +95,7 @@ case class As(input: PlanNode, names: Seq[String]) extends PlanNode {
 }
 
 /**
- * Grouping operation. Keys are specified using field references. A group by operation os only
+ * Grouping operation. Keys are specified using field references. A group by operation is only
  * useful when performing a select with aggregates afterwards.
  * @param input
  * @param fields

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
@@ -82,7 +82,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAggregationTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table = tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env));
 
@@ -99,7 +99,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAggregationOnNonExistingField() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env));
@@ -118,7 +118,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testWorkingAggregationDataTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(
@@ -142,7 +142,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAggregationWithArithmetic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, String>> input =
 				env.fromElements(
@@ -167,7 +167,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNonWorkingDataTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, String>> input = env.fromElements(new Tuple2<Float, String>(1f,
 				"Hello"));
@@ -190,7 +190,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNoNestedAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, String>> input = env.fromElements(new Tuple2<Float, String>(1f, "Hello"));
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AsITCase.java
@@ -62,7 +62,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAs() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c");
@@ -83,7 +83,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToFewFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b");
@@ -99,7 +99,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToManyFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c, d");
@@ -115,7 +115,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithAmbiguousFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, b");
@@ -131,7 +131,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithNonFieldReference1() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a + 1, b, c");
@@ -147,7 +147,7 @@ public class AsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithNonFieldReference2() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table =
 				tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a as foo, b," +

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
@@ -63,7 +63,7 @@ public class CastingITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAutoCastToString() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(new Tuple7<Byte, Short, Integer, Long, Float, Double, String>(
@@ -86,7 +86,7 @@ public class CastingITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testNumericAutocastInArithmetic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(new Tuple7<Byte, Short, Integer, Long, Float, Double, String>(
@@ -109,7 +109,7 @@ public class CastingITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testNumericAutocastInComparison() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple7<Byte, Short, Integer, Long, Float, Double, String>> input =
 				env.fromElements(
@@ -133,7 +133,7 @@ public class CastingITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testCastFromString() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple3<String, String, String>> input =
 				env.fromElements(new Tuple3<String, String, String>("1", "true", "2.0"));

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
@@ -64,7 +64,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testArithmetic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Integer, Integer>> input =
 				env.fromElements(new Tuple2<Integer, Integer>(5, 10));
@@ -86,7 +86,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testLogic() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Integer, Boolean>> input =
 				env.fromElements(new Tuple2<Integer, Boolean>(5, true));
@@ -108,7 +108,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testComparisons() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple3<Integer, Integer, Integer>> input =
 				env.fromElements(new Tuple3<Integer, Integer, Integer>(5, 5, 4));
@@ -130,7 +130,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testBitwiseOperation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Byte, Byte>> input =
 				env.fromElements(new Tuple2<Byte, Byte>((byte) 3, (byte) 5));
@@ -152,7 +152,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testBitwiseWithAutocast() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Integer, Byte>> input =
 				env.fromElements(new Tuple2<Integer, Byte>(3, (byte) 5));
@@ -174,7 +174,7 @@ public class ExpressionsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testBitwiseWithNonWorkingAutocast() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSource<Tuple2<Float, Byte>> input =
 				env.fromElements(new Tuple2<Float, Byte>(3.0f, (byte) 5));

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FilterITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FilterITCase.java
@@ -62,7 +62,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAllRejectingFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -83,7 +83,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testAllPassingFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -109,7 +109,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testFilterOnIntegerTupleField() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -132,7 +132,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testNotEquals() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -155,7 +155,7 @@ public class FilterITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testIntegerBiggerThan128() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = env.fromElements(new Tuple3<Integer, Long, String>(300, 1L, "Hello"));
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
@@ -63,7 +63,7 @@ public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testGroupingOnNonExistentField() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -84,7 +84,7 @@ public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testGroupedAggregate() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 
@@ -109,7 +109,7 @@ public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 		// if we don't want the key in the output
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/JoinITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/JoinITCase.java
@@ -64,7 +64,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoin() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -85,7 +85,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoinWithFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -106,7 +106,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoinWithMultipleKeys() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.get3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -128,7 +128,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testJoinNonExistingKey() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -149,7 +149,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testJoinWithNonMatchingKeyTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -171,7 +171,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testJoinWithAmbiguousFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -193,7 +193,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testJoinWithAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/PojoGroupingITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/PojoGroupingITCase.java
@@ -47,7 +47,7 @@ public class PojoGroupingITCase extends MultipleProgramsTestBase {
 			new Tuple3<String, Double, String>("A", 24.0, "Y"),
 			new Tuple3<String, Double, String>("B", 1.0, "Z"));
 
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		Table table = tableEnv
 			.fromDataSet(data, "groupMe, value, name")

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/SelectITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/SelectITCase.java
@@ -63,7 +63,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSimpleSelectAllWithAs() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -89,7 +89,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSimpleSelectWithNaming() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -112,7 +112,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToFewFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -129,7 +129,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithToManyFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -146,7 +146,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testAsWithAmbiguousFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 
@@ -163,7 +163,7 @@ public class SelectITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testOnlyFieldRefInAs() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/StringExpressionsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/StringExpressionsITCase.java
@@ -62,7 +62,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSubstring() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, Integer>> ds = env.fromElements(
 				new Tuple2<String, Integer>("AAAA", 2),
@@ -84,7 +84,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testSubstringWithMaxEnd() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, Integer>> ds = env.fromElements(
 				new Tuple2<String, Integer>("ABCD", 2),
@@ -106,7 +106,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNonWorkingSubstring1() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, Float>> ds = env.fromElements(
 				new Tuple2<String, Float>("ABCD", 2.0f),
@@ -128,7 +128,7 @@ public class StringExpressionsITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testNonWorkingSubstring2() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple2<String, String>> ds = env.fromElements(
 				new Tuple2<String, String>("ABCD", "a"),

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
@@ -45,7 +45,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testUnion() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
@@ -64,7 +64,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testUnionWithFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -83,7 +83,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testUnionFieldsNameNotOverlap1() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -102,7 +102,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	@Test(expected = ExpressionException.class)
 	public void testUnionFieldsNameNotOverlap2() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -121,7 +121,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testUnionWithAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = new TableEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment(env);
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithPushdown.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithPushdown.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.api.table.Row
+import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.Set
+
+class DummyTableSourceWithPushdown extends AdaptiveTableSource {
+
+  val resolvedFields = Set[(String, Boolean)]()
+  val predicates = ListBuffer[Expression]()
+
+  override def getOutputFields(): Seq[(String, TypeInformation[_])] = {
+    List(("a", BasicTypeInfo.INT_TYPE_INFO),
+      ("b", BasicTypeInfo.INT_TYPE_INFO),
+      ("c", BasicTypeInfo.STRING_TYPE_INFO))
+  }
+
+  override def notifyResolvedField(field: String, filtering: Boolean): Unit = {
+    resolvedFields += ((field, filtering))
+  }
+
+  override def notifyPredicates(expression: Expression): Unit = {
+    predicates += expression
+  }
+
+  override def createAdaptiveDataStream(env: StreamExecutionEnvironment): DataStream[Row] = null
+
+  override def createAdaptiveDataSet(env: ExecutionEnvironment): DataSet[Row] = null
+
+}

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithoutPushdown.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/DummyTableSourceWithoutPushdown.scala
@@ -15,22 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.expressions.analysis
 
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.plan.PlanNode
-import org.apache.flink.api.table.trees.Analyzer
+package org.apache.flink.api.table.input
 
-/**
- * Analyzer for predicates, i.e. filter operations and where clauses of joins.
- */
-class PredicateAnalyzer(inputOperation: PlanNode)
-  extends Analyzer[Expression] {
-  def rules = Seq(
-    new ResolveFieldReferences(inputOperation, true),
-    new InsertAutoCasts,
-    new TypeCheck,
-    new VerifyNoAggregates,
-    new VerifyBoolean,
-    new PredicatePushdown(inputOperation))
+import org.apache.flink.api.java.tuple.Tuple1
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+class DummyTableSourceWithoutPushdown extends StaticTableSource {
+
+  override def getOutputFieldNames(): Seq[String] = Seq("field")
+
+  override def createStaticDataStream(env: StreamExecutionEnvironment): DataStream[_] = null
+
+  override def createStaticDataSet(env: ExecutionEnvironment): DataSet[_] = {
+    env.fromElements(
+      new Tuple1[String]("A"),
+      new Tuple1[String]("B"),
+      new Tuple1[String]("C"),
+      new Tuple1[String]("D"))
+  }
+
 }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
@@ -164,19 +164,19 @@ class TableSourceTest {
 
   @Test(expected = classOf[ExpressionException])
   def testScalaImplicitConversions(): Unit = {
-    getTableJava(new DummyTableSourceWithPushdown())
+    getTableScala(new DummyTableSourceWithPushdown())
         .toDataSet[MyResult]
   }
 
   // ----------------------------------------------------------------------------------------------
 
   def getTableJava(tableSource: TableSource): Table = {
-    val translator = new JavaBatchTranslator(JavaEnv.getExecutionEnvironment)
+    val translator = new JavaBatchTranslator(Some(JavaEnv.getExecutionEnvironment))
     translator.createTable(tableSource)
   }
 
   def getTableScala(tableSource: TableSource): Table = {
-    val translator = new JavaBatchTranslator(JavaEnv.getExecutionEnvironment)
+    val translator = new ScalaBatchTranslator(Some(JavaEnv.getExecutionEnvironment))
     translator.createTable(tableSource)
   }
 

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.input
+
+import org.apache.flink.api.java.{ExecutionEnvironment => JavaEnv}
+import org.apache.flink.api.java.table.JavaBatchTranslator
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.table._
+import org.apache.flink.api.table.{ExpressionException, Table}
+import org.apache.flink.api.table.expressions._
+import org.apache.flink.api.table.input.TableSourceTest.MyResult
+import org.apache.flink.api.table.parser.ExpressionParser
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TableSourceTest {
+
+  @Test
+  def testResolvedFieldPushDown() = {
+    val tableSource1 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource1)
+      .filter("a===10")
+    assertEquals(Set(("a", true)), tableSource1.resolvedFields)
+
+    val tableSource2 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource2)
+      .filter("a===b")
+    assertEquals(Set(("a", true), ("b", true)), tableSource2.resolvedFields)
+
+    val tableSource3 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource3)
+      .select("a, b")
+    assertEquals(Set(("a", false), ("b", false)), tableSource3.resolvedFields)
+
+    val tableSource4 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource4)
+      .filter("a===b")
+      .select("a")
+    assertEquals(Set(("a", true), ("b", true), ("a", false)), tableSource4.resolvedFields)
+
+    val tableSource5 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource5)
+      .filter("a===b")
+      .select("b")
+    assertEquals(Set(("a", true), ("b", true), ("b", false)), tableSource5.resolvedFields)
+
+    val tableSource6 = new DummyTableSourceWithPushdown
+    val tableSource7 = new DummyTableSourceWithPushdown
+    val t6 = getTableJava(tableSource6)
+      .filter("a===b")
+      .select("a as a6")
+    val t7 = getTableJava(tableSource7)
+      .filter("a===b")
+      .select("a as a7")
+    t6.join(t7).where("a6===a7");
+    assertEquals(Set(("a", true), ("b", true), ("a", false)), tableSource6.resolvedFields)
+    assertEquals(Set(("a", true), ("b", true), ("a", false)), tableSource7.resolvedFields)
+
+    val tableSource8 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource8)
+      .select("c.substring(0,2) as X")
+    assertEquals(Set(("c", false)), tableSource8.resolvedFields)
+
+    val tableSource9 = new DummyTableSourceWithPushdown
+    val tableSource10 = new DummyTableSourceWithPushdown
+    val t9 = getTableJava(tableSource9)
+      .select("a as a9, b as b9, c as c9");
+    getTableJava(tableSource10)
+      .join(t9)
+      .where("a9===a")
+      .groupBy("b")
+    assertEquals(Set(("a", true), ("a", false), ("b", false), ("c", false)),
+      tableSource9.resolvedFields)
+    assertEquals(Set(("a", true), ("b", false)), tableSource10.resolvedFields)
+
+    val tableSource11 = new DummyTableSourceWithPushdown
+    val tableSource12 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource11)
+      .filter("a===5 || a===6")
+      .select("a as a4, b as b4, c as c4")
+      .filter("b4===7")
+      .join(getTableJava(tableSource12))
+      .where("a===a4 && c==='Test' && c4==='Test2'")
+    assertEquals(Set(("a", true), ("a", false), ("b", true), ("b", false), ("c", false),
+      ("c", true)), tableSource11.resolvedFields)
+    assertEquals(Set(("a", true), ("c", true)), tableSource12.resolvedFields)
+  }
+
+  @Test
+  def testPredicatePushDown() = {
+    val tableSource1 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource1)
+      .filter("a===10")
+    comparePredicateList(List("a===10"), tableSource1)
+
+    val tableSource2 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource2)
+      .filter("a===10 && b===a")
+    comparePredicateList(List("a===10"), tableSource2)
+
+    val tableSource3 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource3)
+      .filter("(a===10 || b===a) && b===15")
+    comparePredicateList(List("b===15"), tableSource3)
+
+    val tableSource4 = new DummyTableSourceWithPushdown
+    val tableSource5 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource4)
+      .filter("a===5 || a===6")
+      .select("a as a4, b as b4, c as c4")
+      .filter("b4===7")
+      .join(getTableJava(tableSource5))
+      .where("a===a4 && c==='Test' && c4==='Test2'")
+    comparePredicateList(List("a===5 || a===6", "b===7", "c==='Test2'"), tableSource4)
+    comparePredicateList(List("c==='Test'"), tableSource5)
+
+    val tableSource6 = new DummyTableSourceWithPushdown
+    val tableSource7 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource6)
+      .filter("a===5 || a===6")
+      .select("b, c")
+      .as("X, Y")
+      .filter("X===34")
+      .join(getTableJava(tableSource7))
+      .where("X===b && Y==='Test2' && c==='Test'")
+    comparePredicateList(List("a===5 || a===6", "b===34", "c==='Test2'"), tableSource6)
+    comparePredicateList(List("c==='Test'"), tableSource7)
+
+    val tableSource8 = new DummyTableSourceWithPushdown
+    getTableJava(tableSource8)
+      .select("a, b")
+      .groupBy("a")
+      .select("a, b.avg as b")
+      .filter("a===5 && b>6")
+      .select("b, a.max as c")
+      .filter("c<4")
+    comparePredicateList(List("a===5"), tableSource8)
+  }
+
+  @Test
+  def testStaticTableSource() = {
+    val ds = getTableJava(new DummyTableSourceWithoutPushdown)
+      .filter("field!=='D'")
+      .toDataSet[MyResult]
+      .collect()
+    assertEquals(Seq(MyResult("A"), MyResult("B"), MyResult("C")), ds)
+  }
+
+  @Test(expected = classOf[ExpressionException])
+  def testScalaImplicitConversions(): Unit = {
+    getTableJava(new DummyTableSourceWithPushdown())
+        .toDataSet[MyResult]
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  def getTableJava(tableSource: TableSource): Table = {
+    val translator = new JavaBatchTranslator(JavaEnv.getExecutionEnvironment)
+    translator.createTable(tableSource)
+  }
+
+  def getTableScala(tableSource: TableSource): Table = {
+    val translator = new JavaBatchTranslator(JavaEnv.getExecutionEnvironment)
+    translator.createTable(tableSource)
+  }
+
+  def comparePredicateList(expected: List[String], ts: DummyTableSourceWithPushdown) = {
+    val expectedExpr: List[Expression] = expected.map(ExpressionParser.parseExpression(_))
+    val actual = ts.predicates.map( _.transformPost {
+      case rfr@ResolvedFieldReference(fieldName, typeInfo) =>
+        UnresolvedFieldReference(fieldName)
+    })
+    assertEquals(expectedExpr, actual)
+  }
+}
+
+object TableSourceTest {
+  case class MyResult(field: String)
+}

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/table/input/TableSourceTest.scala
@@ -45,7 +45,7 @@ class TableSourceTest {
 
     val tableSource3 = new DummyTableSourceWithPushdown
     getTableJava(tableSource3)
-      .select("a, b")
+      .select("1, a, b")
     assertEquals(Set(("a", false), ("b", false)), tableSource3.resolvedFields)
 
     val tableSource4 = new DummyTableSourceWithPushdown

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -19,7 +19,7 @@ package org.apache.flink.streaming.api.environment;
 
 import com.esotericsoftware.kryo.Serializer;
 import com.google.common.base.Preconditions;
-
+import org.apache.flink.api.common.AbstractExecutionEnvironment;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -92,7 +92,7 @@ import static java.util.Objects.requireNonNull;
  * @see org.apache.flink.streaming.api.environment.LocalStreamEnvironment
  * @see org.apache.flink.streaming.api.environment.RemoteStreamEnvironment
  */
-public abstract class StreamExecutionEnvironment {
+public abstract class StreamExecutionEnvironment implements AbstractExecutionEnvironment {
 
 	/** The default name to use for a streaming job if no other name has been specified */
 	public static final String DEFAULT_JOB_NAME = "Flink Streaming Job";
@@ -140,6 +140,7 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * Gets the config object.
 	 */
+	@Override
 	public ExecutionConfig getConfig() {
 		return config;
 	}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -60,6 +60,14 @@ class DataStream[T](javaStream: JavaStream[T]) {
   def getType(): TypeInformation[T] = javaStream.getType()
 
   /**
+   * Returns the execution environment associated with the current DataStream.
+   *
+   * @return associated execution environment
+   */
+  def getExecutionEnvironment: StreamExecutionEnvironment =
+    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment)
+
+  /**
    * Sets the parallelism of this operation. This must be at least 1.
    */
   def setParallelism(parallelism: Int): DataStream[T] = {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -48,13 +48,12 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) extends AbstractExecutionEnvi
    *
    * @return reference to the StreamExecutionEnvironment of the Java API
    */
-  @Override
   def getJavaEnv: JavaEnv = javaEnv
 
   /**
    * Gets the config object.
    */
-  def getConfig = javaEnv.getConfig
+  override def getConfig = javaEnv.getConfig
 
   /**
    * Sets the parallelism for operations executed through this environment.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -22,6 +22,7 @@ import java.util.Objects
 import java.util.Objects._
 
 import com.esotericsoftware.kryo.Serializer
+import org.apache.flink.api.common.AbstractExecutionEnvironment
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -40,7 +41,15 @@ import scala.reflect.ClassTag
 
 import _root_.scala.language.implicitConversions
 
-class StreamExecutionEnvironment(javaEnv: JavaEnv) {
+class StreamExecutionEnvironment(javaEnv: JavaEnv) extends AbstractExecutionEnvironment {
+
+  /**
+   * Returns the enclosed Java StreamExecutionEnvironment for special use cases.
+   *
+   * @return reference to the StreamExecutionEnvironment of the Java API
+   */
+  @Override
+  def getJavaEnv: JavaEnv = javaEnv
 
   /**
    * Gets the config object.


### PR DESCRIPTION
This PR implements TableSources as described in FLINK-2828. It is an uncoupling of #1127 for FLINK-2167. All feedback I got from @aljoscha is implemented.