### PR TITLE
[FLINK-2853] [tests] Apply JMH on MutableHashTablePerformanceBenchmark…

### DIFF
--- a/flink-benchmark/pom.xml
+++ b/flink-benchmark/pom.xml
@@ -57,6 +57,13 @@ under the License.
       <version>${jmh.version}</version>
       <scope>provided</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.flink</groupId>
+          <artifactId>flink-runtime</artifactId>
+          <version>0.10-SNAPSHOT</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/flink-benchmark/src/test/java/org/apache/flink/runtime/operators/hash/MutableHashTablePerformanceBenchmark.java
+++ b/flink-benchmark/src/test/java/org/apache/flink/runtime/operators/hash/MutableHashTablePerformanceBenchmark.java
@@ -18,10 +18,6 @@
 
 package org.apache.flink.runtime.operators.hash;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -37,16 +33,19 @@ import org.apache.flink.runtime.operators.testutils.types.StringPairComparator;
 import org.apache.flink.runtime.operators.testutils.types.StringPairPairComparator;
 import org.apache.flink.runtime.operators.testutils.types.StringPairSerializer;
 import org.apache.flink.util.MutableObjectIterator;
-
 import org.junit.Assert;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.fail;
 
-@State(Scope.Thread)
+@State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class MutableHashTablePerformanceBenchmark {

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -210,7 +210,12 @@ under the License.
 			<version>${curator.version}</version>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <version>0.10-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/MutableHashTablePerformanceBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/MutableHashTablePerformanceBenchmark.java
@@ -90,7 +90,7 @@ public class MutableHashTablePerformanceBenchmark {
 	}
 	
 	@Benchmark
-	public void compareMutableHashTablePerformance1() throws IOException {
+	public void compareMutableHashTableWithBloomFilter1() throws IOException {
 		// ----------------------------------------------90% filtered during probe spill phase-----------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 10000000] with step of 10 for nearby records.
 		int buildSize = 1000000;
@@ -103,19 +103,40 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = 500000;
 		
-		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
-		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
 		
 		System.out.println("HybridHashJoin2:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
 	}
 	
 	@Benchmark
-	public void compareMutableHashTablePerformance2() throws IOException {
+	public void compareMutableHashTableWithoutBloomFilter1() throws IOException {
+		// ----------------------------------------------90% filtered during probe spill phase-----------------------------------------
+		// create a build input with 1000000 records with key spread between [0 -- 10000000] with step of 10 for nearby records.
+		int buildSize = 1000000;
+		int buildStep = 10;
+		int buildScope = buildStep * buildSize;
+		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
+		int probeSize = 5000000;
+		int probeStep = 1;
+		int probeScope = buildSize;
+
+		int expectedResult = 500000;
+		
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+
+		System.out.println("HybridHashJoin2:");
+		System.out.println("Build input size: " + 100 * buildSize);
+		System.out.println("Probe input size: " + 100 * probeSize);
+		System.out.println("Available memory: " + this.memManager.getMemorySize());
+		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
+	}
+	
+	@Benchmark
+	public void compareMutableHashTableWithBloomFilter2() throws IOException {
 		// ----------------------------------------------80% filtered during probe spill phase-----------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 5000000] with step of 5 for nearby records.
 		int buildSize = 1000000;
@@ -128,19 +149,40 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = 1000000;
 		
-		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
-		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
 		
 		System.out.println("HybridHashJoin3:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
 	}
 	
 	@Benchmark
-	public void compareMutableHashTablePerformance3() throws IOException {
+	public void compareMutableHashTableWithoutBloomFilter2() throws IOException {
+		// ----------------------------------------------80% filtered during probe spill phase-----------------------------------------
+		// create a build input with 1000000 records with key spread between [0 -- 5000000] with step of 5 for nearby records.
+		int buildSize = 1000000;
+		int buildStep = 5;
+		int buildScope = buildStep * buildSize;
+		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
+		int probeSize = 5000000;
+		int probeStep = 1;
+		int probeScope = buildSize;
+
+		int expectedResult = 1000000;
+		
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+
+		System.out.println("HybridHashJoin3:");
+		System.out.println("Build input size: " + 100 * buildSize);
+		System.out.println("Probe input size: " + 100 * probeSize);
+		System.out.println("Available memory: " + this.memManager.getMemorySize());
+		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
+	}
+	
+	@Benchmark
+	public void compareMutableHashTableWithBloomFilter3() throws IOException {
 		// ----------------------------------------------50% filtered during probe spill phase-------------------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 2000000] with step of 2 for nearby records.
 		int buildSize = 1000000;
@@ -153,19 +195,40 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = 2500000;
 		
-		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
-		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
 		
 		System.out.println("HybridHashJoin4:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
 	}
 	
 	@Benchmark
-	public void compareMutableHashTablePerformance4() throws IOException {
+	public void compareMutableHashTableWithoutBloomFilter3() throws IOException {
+		// ----------------------------------------------50% filtered during probe spill phase-------------------------------------------------
+		// create a build input with 1000000 records with key spread between [0 -- 2000000] with step of 2 for nearby records.
+		int buildSize = 1000000;
+		int buildStep = 2;
+		int buildScope = buildStep * buildSize;
+		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
+		int probeSize = 5000000;
+		int probeStep = 1;
+		int probeScope = buildSize;
+
+		int expectedResult = 2500000;
+
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+
+		System.out.println("HybridHashJoin4:");
+		System.out.println("Build input size: " + 100 * buildSize);
+		System.out.println("Probe input size: " + 100 * probeSize);
+		System.out.println("Available memory: " + this.memManager.getMemorySize());
+		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
+	}
+	
+	@Benchmark
+	public void compareMutableHashTableWithBloomFilter4() throws IOException {
 		// ----------------------------------------------0% filtered during probe spill phase-----------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 1000000] with step of 1 for nearby records.
 		int buildSize = 1000000;
@@ -178,15 +241,36 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = probeSize / buildStep;
 		
-		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
-		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
 		
 		System.out.println("HybridHashJoin5:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
+	}
+	
+	@Benchmark
+	public void compareMutableHashTableWithoutBloomFilter4() throws IOException {
+		// ----------------------------------------------0% filtered during probe spill phase-----------------------------------------
+		// create a build input with 1000000 records with key spread between [0 -- 1000000] with step of 1 for nearby records.
+		int buildSize = 1000000;
+		int buildStep = 1;
+		int buildScope = buildStep * buildSize;
+		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
+		int probeSize = 5000000;
+		int probeStep = 1;
+		int probeScope = buildSize;
+
+		int expectedResult = probeSize / buildStep;
+		
+		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+
+		System.out.println("HybridHashJoin5:");
+		System.out.println("Build input size: " + 100 * buildSize);
+		System.out.println("Probe input size: " + 100 * probeSize);
+		System.out.println("Available memory: " + this.memManager.getMemorySize());
+		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
 	}
 	
 	private long hybridHashJoin(int buildSize, int buildStep, int buildScope, int probeSize,
@@ -207,7 +291,6 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		// ----------------------------------------------------------------------------------------
 		
-		long start = System.currentTimeMillis();
 		final MutableHashTable<StringPair, StringPair> join = new MutableHashTable<StringPair, StringPair>(
 			this.pairBuildSideAccesssor, this.pairProbeSideAccesssor,
 			this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
@@ -226,11 +309,11 @@ public class MutableHashTablePerformanceBenchmark {
 		Assert.assertEquals("Wrong number of records in join result.", expectedResultSize, numRecordsInJoinResult);
 		
 		join.close();
-		long cost = System.currentTimeMillis() - start;
 		// ----------------------------------------------------------------------------------------
 		
 		this.memManager.release(join.getFreedMemory());
-		return cost;
+		//return cost;
+		return 1;
 	}
 	
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/MutableHashTablePerformanceBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/MutableHashTablePerformanceBenchmark.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.operators.hash;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
@@ -38,17 +37,13 @@ import org.apache.flink.runtime.operators.testutils.types.StringPairPairComparat
 import org.apache.flink.runtime.operators.testutils.types.StringPairSerializer;
 import org.apache.flink.util.MutableObjectIterator;
 
+import org.junit.After;
 import org.junit.Assert;
-import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.fail;
 
-@State(Scope.Thread)
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class MutableHashTablePerformanceBenchmark {
 	
 	private static final AbstractInvokable MEM_OWNER = new DummyInvokable();
@@ -65,7 +60,7 @@ public class MutableHashTablePerformanceBenchmark {
 	private static final String COMMENT = "this comments should contains a 96 byte data, 100 plus another integer value and seperator char.";
 	
 	
-	@Setup
+	@Before
 	public void setup() {
 		this.pairBuildSideAccesssor = new StringPairSerializer();
 		this.pairProbeSideAccesssor = new StringPairSerializer();
@@ -77,7 +72,7 @@ public class MutableHashTablePerformanceBenchmark {
 		this.ioManager = new IOManagerAsync();
 	}
 	
-	@TearDown
+	@After
 	public void tearDown() {
 		// shut down I/O manager and Memory Manager and verify the correct shutdown
 		this.ioManager.shutdown();
@@ -89,8 +84,8 @@ public class MutableHashTablePerformanceBenchmark {
 		}
 	}
 	
-	@Benchmark
-	public void compareMutableHashTableWithBloomFilter1() throws IOException {
+	@Test
+	public void compareMutableHashTablePerformance1() throws IOException {
 		// ----------------------------------------------90% filtered during probe spill phase-----------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 10000000] with step of 10 for nearby records.
 		int buildSize = 1000000;
@@ -103,40 +98,19 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = 500000;
 		
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
 		
 		System.out.println("HybridHashJoin2:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
+		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
 	}
 	
-	@Benchmark
-	public void compareMutableHashTableWithoutBloomFilter1() throws IOException {
-		// ----------------------------------------------90% filtered during probe spill phase-----------------------------------------
-		// create a build input with 1000000 records with key spread between [0 -- 10000000] with step of 10 for nearby records.
-		int buildSize = 1000000;
-		int buildStep = 10;
-		int buildScope = buildStep * buildSize;
-		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
-		int probeSize = 5000000;
-		int probeStep = 1;
-		int probeScope = buildSize;
-
-		int expectedResult = 500000;
-		
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
-
-		System.out.println("HybridHashJoin2:");
-		System.out.println("Build input size: " + 100 * buildSize);
-		System.out.println("Probe input size: " + 100 * probeSize);
-		System.out.println("Available memory: " + this.memManager.getMemorySize());
-		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-	}
-	
-	@Benchmark
-	public void compareMutableHashTableWithBloomFilter2() throws IOException {
+	@Test
+	public void compareMutableHashTablePerformance2() throws IOException {
 		// ----------------------------------------------80% filtered during probe spill phase-----------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 5000000] with step of 5 for nearby records.
 		int buildSize = 1000000;
@@ -149,40 +123,19 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = 1000000;
 		
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
 		
 		System.out.println("HybridHashJoin3:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
+		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
 	}
 	
-	@Benchmark
-	public void compareMutableHashTableWithoutBloomFilter2() throws IOException {
-		// ----------------------------------------------80% filtered during probe spill phase-----------------------------------------
-		// create a build input with 1000000 records with key spread between [0 -- 5000000] with step of 5 for nearby records.
-		int buildSize = 1000000;
-		int buildStep = 5;
-		int buildScope = buildStep * buildSize;
-		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
-		int probeSize = 5000000;
-		int probeStep = 1;
-		int probeScope = buildSize;
-
-		int expectedResult = 1000000;
-		
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
-
-		System.out.println("HybridHashJoin3:");
-		System.out.println("Build input size: " + 100 * buildSize);
-		System.out.println("Probe input size: " + 100 * probeSize);
-		System.out.println("Available memory: " + this.memManager.getMemorySize());
-		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-	}
-	
-	@Benchmark
-	public void compareMutableHashTableWithBloomFilter3() throws IOException {
+	@Test
+	public void compareMutableHashTablePerformance3() throws IOException {
 		// ----------------------------------------------50% filtered during probe spill phase-------------------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 2000000] with step of 2 for nearby records.
 		int buildSize = 1000000;
@@ -195,40 +148,19 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = 2500000;
 		
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
+		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
 		
 		System.out.println("HybridHashJoin4:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
+		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
 	}
 	
-	@Benchmark
-	public void compareMutableHashTableWithoutBloomFilter3() throws IOException {
-		// ----------------------------------------------50% filtered during probe spill phase-------------------------------------------------
-		// create a build input with 1000000 records with key spread between [0 -- 2000000] with step of 2 for nearby records.
-		int buildSize = 1000000;
-		int buildStep = 2;
-		int buildScope = buildStep * buildSize;
-		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
-		int probeSize = 5000000;
-		int probeStep = 1;
-		int probeScope = buildSize;
-
-		int expectedResult = 2500000;
-
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
-
-		System.out.println("HybridHashJoin4:");
-		System.out.println("Build input size: " + 100 * buildSize);
-		System.out.println("Probe input size: " + 100 * probeSize);
-		System.out.println("Available memory: " + this.memManager.getMemorySize());
-		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-	}
-	
-	@Benchmark
-	public void compareMutableHashTableWithBloomFilter4() throws IOException {
+	@Test
+	public void compareMutableHashTablePerformance4() throws IOException {
 		// ----------------------------------------------0% filtered during probe spill phase-----------------------------------------
 		// create a build input with 1000000 records with key spread between [0 -- 1000000] with step of 1 for nearby records.
 		int buildSize = 1000000;
@@ -241,36 +173,15 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		int expectedResult = probeSize / buildStep;
 		
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		long withBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, true);
+		long withoutBloomFilterCost = hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
 		
 		System.out.println("HybridHashJoin5:");
 		System.out.println("Build input size: " + 100 * buildSize);
 		System.out.println("Probe input size: " + 100 * probeSize);
 		System.out.println("Available memory: " + this.memManager.getMemorySize());
 		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
-	}
-	
-	@Benchmark
-	public void compareMutableHashTableWithoutBloomFilter4() throws IOException {
-		// ----------------------------------------------0% filtered during probe spill phase-----------------------------------------
-		// create a build input with 1000000 records with key spread between [0 -- 1000000] with step of 1 for nearby records.
-		int buildSize = 1000000;
-		int buildStep = 1;
-		int buildScope = buildStep * buildSize;
-		// create a probe input with 5000000 records with key spread between [0 -- 1000000] with distance of 1 for nearby records.
-		int probeSize = 5000000;
-		int probeStep = 1;
-		int probeScope = buildSize;
-
-		int expectedResult = probeSize / buildStep;
-		
-		this.hybridHashJoin(buildSize, buildStep, buildScope, probeSize, probeStep, probeScope, expectedResult, false);
-
-		System.out.println("HybridHashJoin5:");
-		System.out.println("Build input size: " + 100 * buildSize);
-		System.out.println("Probe input size: " + 100 * probeSize);
-		System.out.println("Available memory: " + this.memManager.getMemorySize());
-		System.out.println("Probe record be filtered before spill: " + (1 - (double)probeScope / buildScope) * 100 + "% percent.");
+		System.out.println(String.format("Cost: without bloom filter(%d), with bloom filter(%d)", withoutBloomFilterCost, withBloomFilterCost));
 	}
 	
 	private long hybridHashJoin(int buildSize, int buildStep, int buildScope, int probeSize,
@@ -291,6 +202,7 @@ public class MutableHashTablePerformanceBenchmark {
 		
 		// ----------------------------------------------------------------------------------------
 		
+		long start = System.currentTimeMillis();
 		final MutableHashTable<StringPair, StringPair> join = new MutableHashTable<StringPair, StringPair>(
 			this.pairBuildSideAccesssor, this.pairProbeSideAccesssor,
 			this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
@@ -309,11 +221,11 @@ public class MutableHashTablePerformanceBenchmark {
 		Assert.assertEquals("Wrong number of records in join result.", expectedResultSize, numRecordsInJoinResult);
 		
 		join.close();
+		long cost = System.currentTimeMillis() - start;
 		// ----------------------------------------------------------------------------------------
 		
 		this.memManager.release(join.getFreedMemory());
-		//return cost;
-		return 1;
+		return cost;
 	}
 	
 	
@@ -346,15 +258,5 @@ public class MutableHashTablePerformanceBenchmark {
 		public StringPair next() throws IOException {
 			return next(new StringPair());
 		}
-	}
-	
-	public static void main(String[] args) throws Exception {
-		Options opt = new OptionsBuilder()
-				.include(MutableHashTablePerformanceBenchmark.class.getSimpleName())
-				.warmupIterations(2)
-				.measurementIterations(2)
-				.forks(1)
-				.build();
-		new Runner(opt).run();
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,17 @@ under the License.
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.11</version>
+            <scope>provided</scope>
+        </dependency>
 	</dependencies>
 
 	<!-- this section defines the module versions that are used if nothing else is specified. -->


### PR DESCRIPTION
JMH is a Java harness for building, running, and analysing nano/micro/milli/macro benchmarks.Use JMH to replace the old micro benchmarks method in order to get much more accurate results.Modify the `MutableHashTablePerformanceBenchmark` class and move it to `flink-benchmark` module.