### PR TITLE
[FLINK-2107] Add hash-based strategies for left and right outer joins.

### DIFF
--- a/docs/apis/dataset_transformations.md
+++ b/docs/apis/dataset_transformations.md
@@ -1408,25 +1408,25 @@ Not supported.
 
 The following hints are available:
 
-* OPTIMIZER_CHOOSES: Equivalent to not giving a hint at all, leaves the choice to the system.
+* `OPTIMIZER_CHOOSES`: Equivalent to not giving a hint at all, leaves the choice to the system.
 
-* BROADCAST_HASH_FIRST: Broadcasts the first input and builds a hash table from it, which is
+* `BROADCAST_HASH_FIRST`: Broadcasts the first input and builds a hash table from it, which is
   probed by the second input. A good strategy if the first input is very small.
 
-* BROADCAST_HASH_SECOND: Broadcasts the second input and builds a hash table from it, which is
+* `BROADCAST_HASH_SECOND`: Broadcasts the second input and builds a hash table from it, which is
   probed by the first input. A good strategy if the second input is very small.
 
-* REPARTITION_HASH_FIRST: The system partitions (shuffles) each input (unless the input is already
+* `REPARTITION_HASH_FIRST`: The system partitions (shuffles) each input (unless the input is already
   partitioned) and builds a hash table from the first input. This strategy is good if the first
   input is smaller than the second, but both inputs are still large.
   *Note:* This is the default fallback strategy that the system uses if no size estimates can be made
   and no pre-existing partitiongs and sort-orders can be re-used.
 
-* REPARTITION_HASH_SECOND: The system partitions (shuffles) each input (unless the input is already
+* `REPARTITION_HASH_SECOND`: The system partitions (shuffles) each input (unless the input is already
   partitioned) and builds a hash table from the second input. This strategy is good if the second
   input is smaller than the first, but both inputs are still large.
 
-* REPARTITION_SORT_MERGE: The system partitions (shuffles) each input (unless the input is already
+* `REPARTITION_SORT_MERGE`: The system partitions (shuffles) each input (unless the input is already
   partitioned) and sorts each input (unless it is already sorted). The inputs are joined by
   a streamed merge of the sorted inputs. This strategy is good if one or both of the inputs are
   already sorted.
@@ -1558,8 +1558,12 @@ to manually pick a strategy, in case you want to enforce a specific way of execu
 DataSet<SomeType> input1 = // [...]
 DataSet<AnotherType> input2 = // [...]
 
-DataSet<Tuple2<SomeType, AnotherType> result =
+DataSet<Tuple2<SomeType, AnotherType> result1 =
       input1.leftOuterJoin(input2, JoinHint.REPARTITION_SORT_MERGE)
+            .where("id").equalTo("key");
+
+DataSet<Tuple2<SomeType, AnotherType> result2 =
+      input1.rightOuterJoin(input2, JoinHint.BROADCAST_HASH_FIRST)
             .where("id").equalTo("key");
 ~~~
 
@@ -1573,6 +1577,8 @@ val input2: DataSet[AnotherType] = // [...]
 // hint that the second DataSet is very small
 val result1 = input1.leftOuterJoin(input2, JoinHint.REPARTITION_SORT_MERGE).where("id").equalTo("key")
 
+val result2 = input1.rightOuterJoin(input2, JoinHint.BROADCAST_HASH_FIRST).where("id").equalTo("key")
+
 ~~~
 
 </div>
@@ -1585,14 +1591,46 @@ Not supported.
 </div>
 </div>
 
-**NOTE:** Right now, outer joins can only be executed using the `REPARTITION_SORT_MERGE` strategy. Further execution strategies will be added in the future.
+The following hints are available.
 
-* OPTIMIZER_CHOOSES: Equivalent to not giving a hint at all, leaves the choice to the system.
+* `OPTIMIZER_CHOOSES`: Equivalent to not giving a hint at all, leaves the choice to the system.
 
-* REPARTITION_SORT_MERGE: The system partitions (shuffles) each input (unless the input is already
+* `BROADCAST_HASH_FIRST`: Broadcasts the first input and builds a hash table from it, which is
+  probed by the second input. A good strategy if the first input is very small.
+
+* `BROADCAST_HASH_SECOND`: Broadcasts the second input and builds a hash table from it, which is
+  probed by the first input. A good strategy if the second input is very small.
+
+* `REPARTITION_HASH_FIRST`: The system partitions (shuffles) each input (unless the input is already
+  partitioned) and builds a hash table from the first input. This strategy is good if the first
+  input is smaller than the second, but both inputs are still large.
+  
+* `REPARTITION_HASH_SECOND`: The system partitions (shuffles) each input (unless the input is already
+  partitioned) and builds a hash table from the second input. This strategy is good if the second
+  input is smaller than the first, but both inputs are still large.
+
+* `REPARTITION_SORT_MERGE`: The system partitions (shuffles) each input (unless the input is already
   partitioned) and sorts each input (unless it is already sorted). The inputs are joined by
   a streamed merge of the sorted inputs. This strategy is good if one or both of the inputs are
   already sorted.
+
+**NOTE:** Not all execution strategies are supported by every outer join type, yet.
+
+* `LeftOuterJoin` supports:
+  * `OPTIMIZER_CHOOSES`
+  * `BROADCAST_HASH_SECOND`
+  * `REPARTITION_HASH_SECOND`
+  * `REPARTITION_SORT_MERGE`
+
+* `RightOuterJoin` supports:
+  * `OPTIMIZER_CHOOSES`
+  * `BROADCAST_HASH_FIRST`
+  * `REPARTITION_HASH_FIRST`
+  * `REPARTITION_SORT_MERGE`
+
+* `FullOuterJoin` supports:
+  * `OPTIMIZER_CHOOSES`
+  * `REPARTITION_SORT_MERGE`
 
 
 ### Cross

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -841,7 +841,16 @@ public abstract class DataSet<T> {
 	 * @see DataSet
 	 */
 	public <R> JoinOperatorSetsBase<T, R> leftOuterJoin(DataSet<R> other, JoinHint strategy) {
-		return new JoinOperatorSetsBase<>(this, other, strategy, JoinType.LEFT_OUTER);
+		switch(strategy) {
+			case OPTIMIZER_CHOOSES:
+			case REPARTITION_SORT_MERGE:
+			case REPARTITION_HASH_SECOND:
+			case BROADCAST_HASH_SECOND:
+				return new JoinOperatorSetsBase<>(this, other, strategy, JoinType.LEFT_OUTER);
+			default:
+				throw new InvalidProgramException("Invalid JoinHint for LeftOuterJoin: "+strategy);
+		}
+
 	}
 
 	/**
@@ -881,7 +890,15 @@ public abstract class DataSet<T> {
 	 * @see DataSet
 	 */
 	public <R> JoinOperatorSetsBase<T, R> rightOuterJoin(DataSet<R> other, JoinHint strategy) {
-		return new JoinOperatorSetsBase<>(this, other, strategy, JoinType.RIGHT_OUTER);
+		switch(strategy) {
+			case OPTIMIZER_CHOOSES:
+			case REPARTITION_SORT_MERGE:
+			case REPARTITION_HASH_FIRST:
+			case BROADCAST_HASH_FIRST:
+				return new JoinOperatorSetsBase<>(this, other, strategy, JoinType.RIGHT_OUTER);
+			default:
+			throw new InvalidProgramException("Invalid JoinHint for RightOuterJoin: "+strategy);
+		}
 	}
 
 	/**
@@ -921,7 +938,13 @@ public abstract class DataSet<T> {
 	 * @see DataSet
 	 */
 	public <R> JoinOperatorSetsBase<T, R> fullOuterJoin(DataSet<R> other, JoinHint strategy) {
-		return new JoinOperatorSetsBase<>(this, other, strategy, JoinType.FULL_OUTER);
+		switch(strategy) {
+			case OPTIMIZER_CHOOSES:
+			case REPARTITION_SORT_MERGE:
+				return new JoinOperatorSetsBase<>(this, other, strategy, JoinType.FULL_OUTER);
+			default:
+			throw new InvalidProgramException("Invalid JoinHint for FullOuterJoin: "+strategy);
+		}
 	}
 
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/FullOuterJoinOperatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/FullOuterJoinOperatorTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.operator;
+
+import org.apache.flink.api.common.InvalidProgramException;
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FullOuterJoinOperatorTest {
+
+	// TUPLE DATA
+	private static final List<Tuple5<Integer, Long, String, Long, Integer>> emptyTupleData =
+		new ArrayList<>();
+
+	private final TupleTypeInfo<Tuple5<Integer, Long, String, Long, Integer>> tupleTypeInfo = new
+		TupleTypeInfo<>(
+		BasicTypeInfo.INT_TYPE_INFO,
+		BasicTypeInfo.LONG_TYPE_INFO,
+		BasicTypeInfo.STRING_TYPE_INFO,
+		BasicTypeInfo.LONG_TYPE_INFO,
+		BasicTypeInfo.INT_TYPE_INFO
+	);
+
+	@Test
+	public void testFullOuter1() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.fullOuterJoin(ds2)
+			.where(0).equalTo(4)
+			.with(new DummyJoin());
+	}
+
+	@Test
+	public void testFullOuter2() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.fullOuterJoin(ds2)
+				.where("f1").equalTo("f3")
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testFullOuter3() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.fullOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo(new IntKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testFullOuter4() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.fullOuterJoin(ds2)
+				.where(0).equalTo(new IntKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testFullOuter5() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.fullOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo("f4")
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testFullOuter6() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.fullOuterJoin(ds2)
+				.where("f0").equalTo(4)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFullOuter7() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// invalid key position
+		ds1.fullOuterJoin(ds2)
+				.where(5).equalTo(0)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = CompositeType.InvalidFieldReferenceException.class)
+	public void testFullOuter8() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// invalid key reference
+		ds1.fullOuterJoin(ds2)
+				.where(1).equalTo("f5")
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testFullOuter9() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// key types do not match
+		ds1.fullOuterJoin(ds2)
+				.where(0).equalTo(1)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testFullOuter10() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// key types do not match
+		ds1.fullOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo(new LongKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testFullOuterStrategy1() {
+		this.testFullOuterStrategies(JoinHint.OPTIMIZER_CHOOSES);
+	}
+
+	@Test
+	public void testFullOuterStrategy2() {
+		this.testFullOuterStrategies(JoinHint.REPARTITION_SORT_MERGE);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testFullOuterStrategy3() {
+		this.testFullOuterStrategies(JoinHint.REPARTITION_HASH_SECOND);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testFullOuterStrategy4() {
+		this.testFullOuterStrategies(JoinHint.BROADCAST_HASH_SECOND);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testFullOuterStrategy5() {
+		this.testFullOuterStrategies(JoinHint.REPARTITION_HASH_FIRST);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testFullOuterStrategy6() {
+		this.testFullOuterStrategies(JoinHint.BROADCAST_HASH_FIRST);
+	}
+
+
+	private void testFullOuterStrategies(JoinHint hint) {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.fullOuterJoin(ds2, hint)
+				.where(0).equalTo(4)
+				.with(new DummyJoin());
+	}
+
+	
+	/*
+	 * ####################################################################
+	 */
+
+	@SuppressWarnings("serial")
+	public static class DummyJoin implements
+			JoinFunction<Tuple5<Integer, Long, String, Long, Integer>, Tuple5<Integer, Long, String, Long, Integer>, Long> {
+
+		@Override
+		public Long join(Tuple5<Integer, Long, String, Long, Integer> v1, Tuple5<Integer, Long, String, Long, Integer> v2) throws Exception {
+			return 1L;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class IntKeySelector implements KeySelector<Tuple5<Integer, Long, String, Long, Integer>, Integer> {
+
+		@Override
+		public Integer getKey(Tuple5<Integer, Long, String, Long, Integer> v) throws Exception {
+			return v.f0;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class LongKeySelector implements KeySelector<Tuple5<Integer, Long, String, Long, Integer>, Long> {
+
+		@Override
+		public Long getKey(Tuple5<Integer, Long, String, Long, Integer> v) throws Exception {
+			return v.f1;
+		}
+	}
+
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/LeftOuterJoinOperatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/LeftOuterJoinOperatorTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.operator;
+
+import org.apache.flink.api.common.InvalidProgramException;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+
+import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LeftOuterJoinOperatorTest {
+
+	// TUPLE DATA
+	private static final List<Tuple5<Integer, Long, String, Long, Integer>> emptyTupleData =
+		new ArrayList<>();
+
+	private final TupleTypeInfo<Tuple5<Integer, Long, String, Long, Integer>> tupleTypeInfo = new
+		TupleTypeInfo<>(
+		BasicTypeInfo.INT_TYPE_INFO,
+		BasicTypeInfo.LONG_TYPE_INFO,
+		BasicTypeInfo.STRING_TYPE_INFO,
+		BasicTypeInfo.LONG_TYPE_INFO,
+		BasicTypeInfo.INT_TYPE_INFO
+	);
+
+	@Test
+	public void testLeftOuter1() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.leftOuterJoin(ds2)
+			.where(0).equalTo(4)
+			.with(new DummyJoin());
+	}
+
+	@Test
+	public void testLeftOuter2() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.leftOuterJoin(ds2)
+				.where("f1").equalTo("f3")
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testLeftOuter3() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.leftOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo(new IntKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testLeftOuter4() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.leftOuterJoin(ds2)
+				.where(0).equalTo(new IntKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testLeftOuter5() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.leftOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo("f4")
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testLeftOuter6() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.leftOuterJoin(ds2)
+				.where("f0").equalTo(4)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLeftOuter7() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// invalid key position
+		ds1.leftOuterJoin(ds2)
+				.where(5).equalTo(0)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = CompositeType.InvalidFieldReferenceException.class)
+	public void testLeftOuter8() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// invalid key reference
+		ds1.leftOuterJoin(ds2)
+				.where(1).equalTo("f5")
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testLeftOuter9() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// key types do not match
+		ds1.leftOuterJoin(ds2)
+				.where(0).equalTo(1)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testLeftOuter10() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// key types do not match
+		ds1.leftOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo(new LongKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testLeftOuterStrategy1() {
+		this.testLeftOuterStrategies(JoinHint.OPTIMIZER_CHOOSES);
+	}
+
+	@Test
+	public void testLeftOuterStrategy2() {
+		this.testLeftOuterStrategies(JoinHint.REPARTITION_SORT_MERGE);
+	}
+
+	@Test
+	public void testLeftOuterStrategy3() {
+		this.testLeftOuterStrategies(JoinHint.REPARTITION_HASH_SECOND);
+	}
+
+	@Test
+	public void testLeftOuterStrategy4() {
+		this.testLeftOuterStrategies(JoinHint.BROADCAST_HASH_SECOND);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testLeftOuterStrategy5() {
+		this.testLeftOuterStrategies(JoinHint.REPARTITION_HASH_FIRST);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testLeftOuterStrategy6() {
+		this.testLeftOuterStrategies(JoinHint.BROADCAST_HASH_FIRST);
+	}
+
+
+	private void testLeftOuterStrategies(JoinHint hint) {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.leftOuterJoin(ds2, hint)
+				.where(0).equalTo(4)
+				.with(new DummyJoin());
+	}
+
+	
+	/*
+	 * ####################################################################
+	 */
+
+	@SuppressWarnings("serial")
+	public static class DummyJoin implements
+			JoinFunction<Tuple5<Integer, Long, String, Long, Integer>, Tuple5<Integer, Long, String, Long, Integer>, Long> {
+
+		@Override
+		public Long join(Tuple5<Integer, Long, String, Long, Integer> v1, Tuple5<Integer, Long, String, Long, Integer> v2) throws Exception {
+			return 1L;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class IntKeySelector implements KeySelector<Tuple5<Integer, Long, String, Long, Integer>, Integer> {
+
+		@Override
+		public Integer getKey(Tuple5<Integer, Long, String, Long, Integer> v) throws Exception {
+			return v.f0;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class LongKeySelector implements KeySelector<Tuple5<Integer, Long, String, Long, Integer>, Long> {
+
+		@Override
+		public Long getKey(Tuple5<Integer, Long, String, Long, Integer> v) throws Exception {
+			return v.f1;
+		}
+	}
+
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/RightOuterJoinOperatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/RightOuterJoinOperatorTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.operator;
+
+import org.apache.flink.api.common.InvalidProgramException;
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RightOuterJoinOperatorTest {
+
+	// TUPLE DATA
+	private static final List<Tuple5<Integer, Long, String, Long, Integer>> emptyTupleData =
+		new ArrayList<>();
+
+	private final TupleTypeInfo<Tuple5<Integer, Long, String, Long, Integer>> tupleTypeInfo = new
+		TupleTypeInfo<>(
+		BasicTypeInfo.INT_TYPE_INFO,
+		BasicTypeInfo.LONG_TYPE_INFO,
+		BasicTypeInfo.STRING_TYPE_INFO,
+		BasicTypeInfo.LONG_TYPE_INFO,
+		BasicTypeInfo.INT_TYPE_INFO
+	);
+
+	@Test
+	public void testRightOuter1() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.rightOuterJoin(ds2)
+			.where(0).equalTo(4)
+			.with(new DummyJoin());
+	}
+
+	@Test
+	public void testRightOuter2() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.rightOuterJoin(ds2)
+				.where("f1").equalTo("f3")
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testRightOuter3() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.rightOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo(new IntKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testRightOuter4() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.rightOuterJoin(ds2)
+				.where(0).equalTo(new IntKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testRightOuter5() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.rightOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo("f4")
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testRightOuter6() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.rightOuterJoin(ds2)
+				.where("f0").equalTo(4)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testRightOuter7() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// invalid key position
+		ds1.rightOuterJoin(ds2)
+				.where(5).equalTo(0)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = CompositeType.InvalidFieldReferenceException.class)
+	public void testRightOuter8() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// invalid key reference
+		ds1.rightOuterJoin(ds2)
+				.where(1).equalTo("f5")
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testRightOuter9() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// key types do not match
+		ds1.rightOuterJoin(ds2)
+				.where(0).equalTo(1)
+				.with(new DummyJoin());
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testRightOuter10() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// key types do not match
+		ds1.rightOuterJoin(ds2)
+				.where(new IntKeySelector()).equalTo(new LongKeySelector())
+				.with(new DummyJoin());
+	}
+
+	@Test
+	public void testRightOuterStrategy1() {
+		this.testRightOuterStrategies(JoinHint.OPTIMIZER_CHOOSES);
+	}
+
+	@Test
+	public void testRightOuterStrategy2() {
+		this.testRightOuterStrategies(JoinHint.REPARTITION_SORT_MERGE);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testRightOuterStrategy3() {
+		this.testRightOuterStrategies(JoinHint.REPARTITION_HASH_SECOND);
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testRightOuterStrategy4() {
+		this.testRightOuterStrategies(JoinHint.BROADCAST_HASH_SECOND);
+	}
+
+	@Test
+	public void testRightOuterStrategy5() {
+		this.testRightOuterStrategies(JoinHint.REPARTITION_HASH_FIRST);
+	}
+
+	@Test
+	public void testRightOuterStrategy6() {
+		this.testRightOuterStrategies(JoinHint.BROADCAST_HASH_FIRST);
+	}
+
+
+	private void testRightOuterStrategies(JoinHint hint) {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		ds1.rightOuterJoin(ds2, hint)
+				.where(0).equalTo(4)
+				.with(new DummyJoin());
+	}
+
+	
+	/*
+	 * ####################################################################
+	 */
+
+	@SuppressWarnings("serial")
+	public static class DummyJoin implements
+			JoinFunction<Tuple5<Integer, Long, String, Long, Integer>, Tuple5<Integer, Long, String, Long, Integer>, Long> {
+
+		@Override
+		public Long join(Tuple5<Integer, Long, String, Long, Integer> v1, Tuple5<Integer, Long, String, Long, Integer> v2) throws Exception {
+			return 1L;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class IntKeySelector implements KeySelector<Tuple5<Integer, Long, String, Long, Integer>, Integer> {
+
+		@Override
+		public Integer getKey(Tuple5<Integer, Long, String, Long, Integer> v) throws Exception {
+			return v.f0;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class LongKeySelector implements KeySelector<Tuple5<Integer, Long, String, Long, Integer>, Long> {
+
+		@Override
+		public Long getKey(Tuple5<Integer, Long, String, Long, Integer> v) throws Exception {
+			return v.f1;
+		}
+	}
+
+}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/costs/CostEstimator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/costs/CostEstimator.java
@@ -202,9 +202,11 @@ public abstract class CostEstimator {
 			addLocalMergeCost(firstInput, secondInput, driverCosts, costWeight);
 			break;
 		case HYBRIDHASH_BUILD_FIRST:
+		case RIGHT_HYBRIDHASH_BUILD_FIRST:
 			addHybridHashCosts(firstInput, secondInput, driverCosts, costWeight);
 			break;
 		case HYBRIDHASH_BUILD_SECOND:
+		case LEFT_HYBRIDHASH_BUILD_SECOND:
 			addHybridHashCosts(secondInput, firstInput, driverCosts, costWeight);
 			break;
 		case HYBRIDHASH_BUILD_FIRST_CACHED:

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/HashLeftOuterJoinBuildSecondDescriptor.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/HashLeftOuterJoinBuildSecondDescriptor.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.optimizer.operators;
+
+import org.apache.flink.api.common.operators.util.FieldList;
+import org.apache.flink.optimizer.dag.TwoInputNode;
+import org.apache.flink.optimizer.dataproperties.LocalProperties;
+import org.apache.flink.optimizer.dataproperties.RequestedLocalProperties;
+import org.apache.flink.optimizer.plan.Channel;
+import org.apache.flink.optimizer.plan.DualInputPlanNode;
+import org.apache.flink.runtime.operators.DriverStrategy;
+
+import java.util.Collections;
+import java.util.List;
+
+public class HashLeftOuterJoinBuildSecondDescriptor extends AbstractJoinDescriptor {
+
+	public HashLeftOuterJoinBuildSecondDescriptor(FieldList keys1, FieldList keys2,
+													boolean broadcastSecondAllowed, boolean repartitionAllowed) {
+		super(keys1, keys2, false, broadcastSecondAllowed, repartitionAllowed);
+	}
+
+	@Override
+	public DriverStrategy getStrategy() {
+		return DriverStrategy.LEFT_HYBRIDHASH_BUILD_SECOND;
+	}
+
+	@Override
+	protected List<LocalPropertiesPair> createPossibleLocalProperties() {
+		// all properties are possible
+		return Collections.singletonList(new LocalPropertiesPair(new RequestedLocalProperties(), new RequestedLocalProperties()));
+	}
+	
+	@Override
+	public boolean areCoFulfilled(RequestedLocalProperties requested1, RequestedLocalProperties requested2,
+			LocalProperties produced1, LocalProperties produced2) {
+		return true;
+	}
+
+	@Override
+	public DualInputPlanNode instantiate(Channel in1, Channel in2, TwoInputNode node) {
+
+		String nodeName = "LeftOuterJoin("+node.getOperator().getName()+")";
+		return new DualInputPlanNode(node, nodeName, in1, in2, getStrategy(), this.keys1, this.keys2);
+	}
+	
+	@Override
+	public LocalProperties computeLocalProperties(LocalProperties in1, LocalProperties in2) {
+		return new LocalProperties();
+	}
+}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/HashRightOuterJoinBuildFirstDescriptor.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/HashRightOuterJoinBuildFirstDescriptor.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.optimizer.operators;
+
+import org.apache.flink.api.common.operators.util.FieldList;
+import org.apache.flink.optimizer.dag.TwoInputNode;
+import org.apache.flink.optimizer.dataproperties.LocalProperties;
+import org.apache.flink.optimizer.dataproperties.RequestedLocalProperties;
+import org.apache.flink.optimizer.plan.Channel;
+import org.apache.flink.optimizer.plan.DualInputPlanNode;
+import org.apache.flink.runtime.operators.DriverStrategy;
+
+import java.util.Collections;
+import java.util.List;
+
+public class HashRightOuterJoinBuildFirstDescriptor extends AbstractJoinDescriptor {
+
+	public HashRightOuterJoinBuildFirstDescriptor(FieldList keys1, FieldList keys2,
+													boolean broadcastFirstAllowed, boolean repartitionAllowed) {
+		super(keys1, keys2, broadcastFirstAllowed, false, repartitionAllowed);
+	}
+
+	@Override
+	public DriverStrategy getStrategy() {
+		return DriverStrategy.RIGHT_HYBRIDHASH_BUILD_FIRST;
+	}
+
+	@Override
+	protected List<LocalPropertiesPair> createPossibleLocalProperties() {
+		// all properties are possible
+		return Collections.singletonList(new LocalPropertiesPair(new RequestedLocalProperties(), new RequestedLocalProperties()));
+	}
+	
+	@Override
+	public boolean areCoFulfilled(RequestedLocalProperties requested1, RequestedLocalProperties requested2,
+			LocalProperties produced1, LocalProperties produced2) {
+		return true;
+	}
+
+	@Override
+	public DualInputPlanNode instantiate(Channel in1, Channel in2, TwoInputNode node) {
+
+		String nodeName = "RightOuterJoin("+node.getOperator().getName()+")";
+		return new DualInputPlanNode(node, nodeName, in1, in2, getStrategy(), this.keys1, this.keys2);
+	}
+	
+	@Override
+	public LocalProperties computeLocalProperties(LocalProperties in1, LocalProperties in2) {
+		return new LocalProperties();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractCachedBuildSideJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractCachedBuildSideJoinDriver.java
@@ -25,10 +25,10 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.runtime.operators.hash.NonReusingBuildFirstReOpenableHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.NonReusingBuildSecondReOpenableHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.ReusingBuildFirstReOpenableHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.ReusingBuildSecondReOpenableHashMatchIterator;
+import org.apache.flink.runtime.operators.hash.NonReusingBuildFirstReOpenableHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.NonReusingBuildSecondReOpenableHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildFirstReOpenableHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildSecondReOpenableHashJoinIterator;
 import org.apache.flink.runtime.operators.util.JoinTaskIterator;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.util.Collector;
@@ -85,7 +85,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 		if (objectReuseEnabled) {
 			if (buildSideIndex == 0 && probeSideIndex == 1) {
 
-				matchIterator = new ReusingBuildFirstReOpenableHashMatchIterator<IT1, IT2, OT>(
+				matchIterator = new ReusingBuildFirstReOpenableHashJoinIterator<IT1, IT2, OT>(
 						input1, input2,
 						serializer1, comparator1,
 						serializer2, comparator2,
@@ -94,12 +94,13 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 						this.taskContext.getIOManager(),
 						this.taskContext.getOwningNepheleTask(),
 						availableMemory,
+						false,
 						hashJoinUseBitMaps);
 
 
 			} else if (buildSideIndex == 1 && probeSideIndex == 0) {
 
-				matchIterator = new ReusingBuildSecondReOpenableHashMatchIterator<IT1, IT2, OT>(
+				matchIterator = new ReusingBuildSecondReOpenableHashJoinIterator<IT1, IT2, OT>(
 						input1, input2,
 						serializer1, comparator1,
 						serializer2, comparator2,
@@ -108,6 +109,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 						this.taskContext.getIOManager(),
 						this.taskContext.getOwningNepheleTask(),
 						availableMemory,
+						false,
 						hashJoinUseBitMaps);
 
 			} else {
@@ -116,7 +118,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 		} else {
 			if (buildSideIndex == 0 && probeSideIndex == 1) {
 
-				matchIterator = new NonReusingBuildFirstReOpenableHashMatchIterator<IT1, IT2, OT>(
+				matchIterator = new NonReusingBuildFirstReOpenableHashJoinIterator<IT1, IT2, OT>(
 						input1, input2,
 						serializer1, comparator1,
 						serializer2, comparator2,
@@ -125,12 +127,13 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 						this.taskContext.getIOManager(),
 						this.taskContext.getOwningNepheleTask(),
 						availableMemory,
+						false,
 						hashJoinUseBitMaps);
 
 
 			} else if (buildSideIndex == 1 && probeSideIndex == 0) {
 
-				matchIterator = new NonReusingBuildSecondReOpenableHashMatchIterator<IT1, IT2, OT>(
+				matchIterator = new NonReusingBuildSecondReOpenableHashJoinIterator<IT1, IT2, OT>(
 						input1, input2,
 						serializer1, comparator1,
 						serializer2, comparator2,
@@ -139,6 +142,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 						this.taskContext.getIOManager(),
 						this.taskContext.getOwningNepheleTask(),
 						availableMemory,
+						false,
 						hashJoinUseBitMaps);
 
 			} else {
@@ -173,20 +177,20 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 
 		if (objectReuseEnabled) {
 			if (buildSideIndex == 0 && probeSideIndex == 1) {
-				final ReusingBuildFirstReOpenableHashMatchIterator<IT1, IT2, OT> matchIterator = (ReusingBuildFirstReOpenableHashMatchIterator<IT1, IT2, OT>) this.matchIterator;
+				final ReusingBuildFirstReOpenableHashJoinIterator<IT1, IT2, OT> matchIterator = (ReusingBuildFirstReOpenableHashJoinIterator<IT1, IT2, OT>) this.matchIterator;
 
 				matchIterator.reopenProbe(input2);
 			} else {
-				final ReusingBuildSecondReOpenableHashMatchIterator<IT1, IT2, OT> matchIterator = (ReusingBuildSecondReOpenableHashMatchIterator<IT1, IT2, OT>) this.matchIterator;
+				final ReusingBuildSecondReOpenableHashJoinIterator<IT1, IT2, OT> matchIterator = (ReusingBuildSecondReOpenableHashJoinIterator<IT1, IT2, OT>) this.matchIterator;
 				matchIterator.reopenProbe(input1);
 			}
 		} else {
 			if (buildSideIndex == 0 && probeSideIndex == 1) {
-				final NonReusingBuildFirstReOpenableHashMatchIterator<IT1, IT2, OT> matchIterator = (NonReusingBuildFirstReOpenableHashMatchIterator<IT1, IT2, OT>) this.matchIterator;
+				final NonReusingBuildFirstReOpenableHashJoinIterator<IT1, IT2, OT> matchIterator = (NonReusingBuildFirstReOpenableHashJoinIterator<IT1, IT2, OT>) this.matchIterator;
 
 				matchIterator.reopenProbe(input2);
 			} else {
-				final NonReusingBuildSecondReOpenableHashMatchIterator<IT1, IT2, OT> matchIterator = (NonReusingBuildSecondReOpenableHashMatchIterator<IT1, IT2, OT>) this.matchIterator;
+				final NonReusingBuildSecondReOpenableHashJoinIterator<IT1, IT2, OT> matchIterator = (NonReusingBuildSecondReOpenableHashJoinIterator<IT1, IT2, OT>) this.matchIterator;
 				matchIterator.reopenProbe(input1);
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
@@ -81,8 +81,7 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 		final IOManager ioManager = this.taskContext.getIOManager();
 		
 		// set up memory and I/O parameters
-		final double fractionAvailableMemory = config.getRelativeMemoryDriver();
-		final int numPages = memoryManager.computeNumberOfPages(fractionAvailableMemory);
+		final double driverMemFraction = config.getRelativeMemoryDriver();
 		
 		final DriverStrategy ls = config.getDriverStrategy();
 		
@@ -121,7 +120,7 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 					pairComparatorFactory,
 					memoryManager,
 					ioManager,
-					numPages
+					driverMemFraction
 			);
 		} else {
 			this.outerJoinIterator = getNonReusingOuterJoinIterator(
@@ -135,7 +134,7 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 					pairComparatorFactory,
 					memoryManager,
 					ioManager,
-					numPages
+					driverMemFraction
 			);
 		}
 		
@@ -183,7 +182,7 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception;
 	
 	protected abstract JoinTaskIterator<IT1, IT2, OT> getNonReusingOuterJoinIterator(
@@ -197,6 +196,6 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DriverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DriverStrategy.java
@@ -73,11 +73,8 @@ public enum DriverStrategy {
 
 	// both inputs are merged, but materialized to the side for block-nested-loop-join among values with equal key
 	INNER_MERGE(JoinDriver.class, null, MATERIALIZING, MATERIALIZING, 2),
-
 	LEFT_OUTER_MERGE(LeftOuterJoinDriver.class, null, MATERIALIZING, MATERIALIZING, 2),
-
 	RIGHT_OUTER_MERGE(RightOuterJoinDriver.class, null, MATERIALIZING, MATERIALIZING, 2),
-
 	FULL_OUTER_MERGE(FullOuterJoinDriver.class, null, MATERIALIZING, MATERIALIZING, 2),
 
 	// co-grouping inputs
@@ -94,6 +91,11 @@ public enum DriverStrategy {
 	HYBRIDHASH_BUILD_FIRST_CACHED(BuildFirstCachedJoinDriver.class, null, FULL_DAM, MATERIALIZING, 2),
 	//  cached variant of HYBRIDHASH_BUILD_SECOND, that can only be used inside of iterations
 	HYBRIDHASH_BUILD_SECOND_CACHED(BuildSecondCachedJoinDriver.class, null, MATERIALIZING, FULL_DAM, 2),
+
+	// right outer join, the first input is build side, the second side is probe side of a hybrid hash table
+	RIGHT_HYBRIDHASH_BUILD_FIRST(RightOuterJoinDriver.class, null, FULL_DAM, MATERIALIZING, 2),
+	// left outer join, the second input is build side, the first side is probe side of a hybrid hash table
+	LEFT_HYBRIDHASH_BUILD_SECOND(LeftOuterJoinDriver.class, null, MATERIALIZING, FULL_DAM, 2),
 	
 	// the second input is inner loop, the first input is outer loop and block-wise processed
 	NESTEDLOOP_BLOCKED_OUTER_FIRST(CrossDriver.class, null, MATERIALIZING, FULL_DAM, 0),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/FullOuterJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/FullOuterJoinDriver.java
@@ -47,10 +47,11 @@ public class FullOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<I
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception {
 		switch (driverStrategy) {
 			case FULL_OUTER_MERGE:
+				int numPages = memoryManager.computeNumberOfPages(driverMemFraction);
 				return new ReusingMergeOuterJoinIterator<>(
 						OuterJoinType.FULL,
 						in1,
@@ -82,10 +83,11 @@ public class FullOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<I
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception {
 		switch (driverStrategy) {
 			case FULL_OUTER_MERGE:
+				int numPages = memoryManager.computeNumberOfPages(driverMemFraction);
 				return new NonReusingMergeOuterJoinIterator<>(
 						OuterJoinType.FULL,
 						in1,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinDriver.java
@@ -26,10 +26,10 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.operators.hash.NonReusingBuildFirstHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.NonReusingBuildSecondHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashMatchIterator;
+import org.apache.flink.runtime.operators.hash.NonReusingBuildFirstHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.NonReusingBuildSecondHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashJoinIterator;
 import org.apache.flink.runtime.operators.sort.NonReusingMergeInnerJoinIterator;
 import org.apache.flink.runtime.operators.sort.ReusingMergeInnerJoinIterator;
 import org.apache.flink.runtime.operators.util.JoinTaskIterator;
@@ -133,23 +133,25 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 							memoryManager, ioManager, numPages, this.taskContext.getOwningNepheleTask());
 					break;
 				case HYBRIDHASH_BUILD_FIRST:
-					this.joinIterator = new ReusingBuildFirstHashMatchIterator<>(in1, in2,
+					this.joinIterator = new ReusingBuildFirstHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator21(comparator1, comparator2),
 							memoryManager, ioManager,
 							this.taskContext.getOwningNepheleTask(),
 							fractionAvailableMemory,
+							false,
 							hashJoinUseBitMaps);
 					break;
 				case HYBRIDHASH_BUILD_SECOND:
-					this.joinIterator = new ReusingBuildSecondHashMatchIterator<>(in1, in2,
+					this.joinIterator = new ReusingBuildSecondHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator12(comparator1, comparator2),
 							memoryManager, ioManager,
 							this.taskContext.getOwningNepheleTask(),
 							fractionAvailableMemory,
+							false,
 							hashJoinUseBitMaps);
 					break;
 				default:
@@ -166,23 +168,25 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 
 					break;
 				case HYBRIDHASH_BUILD_FIRST:
-					this.joinIterator = new NonReusingBuildFirstHashMatchIterator<>(in1, in2,
+					this.joinIterator = new NonReusingBuildFirstHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator21(comparator1, comparator2),
 							memoryManager, ioManager,
 							this.taskContext.getOwningNepheleTask(),
 							fractionAvailableMemory,
+							false,
 							hashJoinUseBitMaps);
 					break;
 				case HYBRIDHASH_BUILD_SECOND:
-					this.joinIterator = new NonReusingBuildSecondHashMatchIterator<>(in1, in2,
+					this.joinIterator = new NonReusingBuildSecondHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator12(comparator1, comparator2),
 							memoryManager, ioManager,
 							this.taskContext.getOwningNepheleTask(),
 							fractionAvailableMemory,
+							false,
 							hashJoinUseBitMaps);
 					break;
 				default:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/LeftOuterJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/LeftOuterJoinDriver.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.hash.NonReusingBuildSecondHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashJoinIterator;
 import org.apache.flink.runtime.operators.sort.NonReusingMergeOuterJoinIterator;
 import org.apache.flink.runtime.operators.sort.ReusingMergeOuterJoinIterator;
 import org.apache.flink.runtime.operators.util.JoinTaskIterator;
@@ -47,10 +49,11 @@ public class LeftOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<I
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception {
 		switch (driverStrategy) {
 			case LEFT_OUTER_MERGE:
+				int numPages = memoryManager.computeNumberOfPages(driverMemFraction);
 				return new ReusingMergeOuterJoinIterator<>(
 						OuterJoinType.LEFT,
 						in1,
@@ -65,6 +68,16 @@ public class LeftOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<I
 						numPages,
 						super.taskContext.getOwningNepheleTask()
 				);
+			case LEFT_HYBRIDHASH_BUILD_SECOND:
+				return new ReusingBuildSecondHashJoinIterator<>(in1, in2,
+						serializer1, comparator1,
+						serializer2, comparator2,
+						pairComparatorFactory.createComparator12(comparator1, comparator2),
+						memoryManager, ioManager,
+						this.taskContext.getOwningNepheleTask(),
+						driverMemFraction,
+						true,
+						false);
 			default:
 				throw new Exception("Unsupported driver strategy for left outer join driver: " + driverStrategy.name());
 		}
@@ -82,10 +95,11 @@ public class LeftOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<I
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception {
 		switch (driverStrategy) {
 			case LEFT_OUTER_MERGE:
+				int numPages = memoryManager.computeNumberOfPages(driverMemFraction);
 				return new NonReusingMergeOuterJoinIterator<>(
 						OuterJoinType.LEFT,
 						in1,
@@ -100,6 +114,16 @@ public class LeftOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<I
 						numPages,
 						super.taskContext.getOwningNepheleTask()
 				);
+			case LEFT_HYBRIDHASH_BUILD_SECOND:
+				return new NonReusingBuildSecondHashJoinIterator<>(in1, in2,
+						serializer1, comparator1,
+						serializer2, comparator2,
+						pairComparatorFactory.createComparator12(comparator1, comparator2),
+						memoryManager, ioManager,
+						this.taskContext.getOwningNepheleTask(),
+						driverMemFraction,
+						true,
+						false);
 			default:
 				throw new Exception("Unsupported driver strategy for left outer join driver: " + driverStrategy.name());
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/RightOuterJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/RightOuterJoinDriver.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.hash.NonReusingBuildFirstHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashJoinIterator;
 import org.apache.flink.runtime.operators.sort.NonReusingMergeOuterJoinIterator;
 import org.apache.flink.runtime.operators.sort.ReusingMergeOuterJoinIterator;
 import org.apache.flink.runtime.operators.util.JoinTaskIterator;
@@ -47,10 +49,11 @@ public class RightOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception {
 		switch (driverStrategy) {
 			case RIGHT_OUTER_MERGE:
+				int numPages = memoryManager.computeNumberOfPages(driverMemFraction);
 				return new ReusingMergeOuterJoinIterator<>(
 						OuterJoinType.RIGHT,
 						in1,
@@ -65,6 +68,16 @@ public class RightOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<
 						numPages,
 						super.taskContext.getOwningNepheleTask()
 				);
+			case RIGHT_HYBRIDHASH_BUILD_FIRST:
+				return new ReusingBuildFirstHashJoinIterator<>(in1, in2,
+						serializer1, comparator1,
+						serializer2, comparator2,
+						pairComparatorFactory.createComparator21(comparator1, comparator2),
+						memoryManager, ioManager,
+						this.taskContext.getOwningNepheleTask(),
+						driverMemFraction,
+						true,
+						false);
 			default:
 				throw new Exception("Unsupported driver strategy for right outer join driver: " + driverStrategy.name());
 		}
@@ -82,10 +95,11 @@ public class RightOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<
 			TypePairComparatorFactory<IT1, IT2> pairComparatorFactory,
 			MemoryManager memoryManager,
 			IOManager ioManager,
-			int numPages
+			double driverMemFraction
 	) throws Exception {
 		switch (driverStrategy) {
 			case RIGHT_OUTER_MERGE:
+				int numPages = memoryManager.computeNumberOfPages(driverMemFraction);
 				return new NonReusingMergeOuterJoinIterator<>(
 						OuterJoinType.RIGHT,
 						in1,
@@ -100,6 +114,16 @@ public class RightOuterJoinDriver<IT1, IT2, OT> extends AbstractOuterJoinDriver<
 						numPages,
 						super.taskContext.getOwningNepheleTask()
 				);
+			case RIGHT_HYBRIDHASH_BUILD_FIRST:
+				return new NonReusingBuildFirstHashJoinIterator<>(in1, in2,
+						serializer1, comparator1,
+						serializer2, comparator2,
+						pairComparatorFactory.createComparator21(comparator1, comparator2),
+						memoryManager, ioManager,
+						this.taskContext.getOwningNepheleTask(),
+						driverMemFraction,
+						true,
+						false);
 			default:
 				throw new Exception("Unsupported driver strategy for right outer join driver: " + driverStrategy.name());
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashJoinIteratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashJoinIteratorBase.java
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  * Common methods for all Hash Join Iterators.
  */
-public class HashMatchIteratorBase {
+public class HashJoinIteratorBase {
 	
 	public <BT, PT> MutableHashTable<BT, PT> getHashJoin(
 			TypeSerializer<BT> buildSideSerializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,9 +18,6 @@
 
 
 package org.apache.flink.runtime.operators.hash;
-
-import java.io.IOException;
-import java.util.List;
 
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
@@ -35,63 +32,68 @@ import org.apache.flink.runtime.operators.util.JoinTaskIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 
+import java.io.IOException;
+import java.util.List;
+
 
 /**
  * An implementation of the {@link org.apache.flink.runtime.operators.util.JoinTaskIterator} that uses a hybrid-hash-join
- * internally to match the records with equal key. The build side of the hash is the second input of the match.  
+ * internally to match the records with equal key. The build side of the hash is the first input of the match.
+ * This implementation DOES NOT reuse objects.
  */
-public class ReusingBuildSecondHashMatchIterator<V1, V2, O> extends HashMatchIteratorBase implements JoinTaskIterator<V1, V2, O> {
-	
-	protected final MutableHashTable<V2, V1> hashJoin;
-	
-	private final V2 nextBuildSideObject;
-	
-	private final V2 tempBuildSideRecord;
-	
-	protected final TypeSerializer<V1> probeSideSerializer;
-	
+public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIteratorBase implements JoinTaskIterator<V1, V2, O> {
+
+	protected final MutableHashTable<V1, V2> hashJoin;
+
+	protected final TypeSerializer<V2> probeSideSerializer;
+
 	private final MemoryManager memManager;
-	
+
 	private final MutableObjectIterator<V1> firstInput;
-	
+
 	private final MutableObjectIterator<V2> secondInput;
-	
+
+	private final boolean joinWithEmptyBuildSide;
+
 	private volatile boolean running = true;
-	
+
 	// --------------------------------------------------------------------------------------------
-	
-	public ReusingBuildSecondHashMatchIterator(
+
+	public NonReusingBuildFirstHashJoinIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
 			TypeSerializer<V1> serializer1,
 			TypeComparator<V1> comparator1,
 			TypeSerializer<V2> serializer2,
 			TypeComparator<V2> comparator2,
-			TypePairComparator<V1, V2> pairComparator,
-			MemoryManager memManager,
-			IOManager ioManager,
+			TypePairComparator<V2, V1> pairComparator,
+			MemoryManager memManager, IOManager ioManager,
 			AbstractInvokable ownerTask,
 			double memoryFraction,
+			boolean joinWithEmptyBuildSide,
 			boolean useBitmapFilters) throws MemoryAllocationException {
 		
 		this.memManager = memManager;
 		this.firstInput = firstInput;
 		this.secondInput = secondInput;
-		this.probeSideSerializer = serializer1;
-		
-		this.nextBuildSideObject = serializer2.createInstance();
-		this.tempBuildSideRecord = serializer2.createInstance();
+		this.probeSideSerializer = serializer2;
 
-		this.hashJoin = getHashJoin(serializer2, comparator2, serializer1, comparator1, pairComparator,
-			memManager, ioManager, ownerTask, memoryFraction, useBitmapFilters);
+		if(useBitmapFilters && joinWithEmptyBuildSide) {
+			throw new IllegalArgumentException("Bitmap filter may not be activated for joining with empty build side");
+		}
+		this.joinWithEmptyBuildSide = joinWithEmptyBuildSide;
+
+		this.hashJoin = getHashJoin(serializer1, comparator1, serializer2, comparator2,
+				pairComparator, memManager, ioManager, ownerTask, memoryFraction, useBitmapFilters);
 	}
 	
 	// --------------------------------------------------------------------------------------------
 	
 	@Override
 	public void open() throws IOException, MemoryAllocationException, InterruptedException {
-		this.hashJoin.open(this.secondInput, this.firstInput);
+		this.hashJoin.open(this.firstInput, this.secondInput);
 	}
+	
 
 	@Override
 	public void close() {
@@ -104,38 +106,50 @@ public class ReusingBuildSecondHashMatchIterator<V1, V2, O> extends HashMatchIte
 	}
 
 	@Override
-	public boolean callWithNextKey(FlatJoinFunction<V1, V2, O> matchFunction, Collector<O> collector)
+	public final boolean callWithNextKey(FlatJoinFunction<V1, V2, O> matchFunction, Collector<O> collector)
 	throws Exception
 	{
 		if (this.hashJoin.nextRecord())
 		{
 			// we have a next record, get the iterators to the probe and build side values
-			final MutableHashTable.HashBucketIterator<V2, V1> buildSideIterator = this.hashJoin.getBuildSideIterator();
-			V2 nextBuildSideRecord = this.nextBuildSideObject;
+			final MutableHashTable.HashBucketIterator<V1, V2> buildSideIterator = this.hashJoin.getBuildSideIterator();
+			V1 nextBuildSideRecord;
 			
 			// get the first build side value
-			if ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null) {
-				V2 tmpRec = this.tempBuildSideRecord;
-				final V1 probeRecord = this.hashJoin.getCurrentProbeRecord();
+			if ((nextBuildSideRecord = buildSideIterator.next()) != null) {
+				V1 tmpRec;
+				final V2 probeRecord = this.hashJoin.getCurrentProbeRecord();
 				
 				// check if there is another build-side value
-				if ((tmpRec = buildSideIterator.next(tmpRec)) != null) {
+				if ((tmpRec = buildSideIterator.next()) != null) {
+					// more than one build-side value --> copy the probe side
+					V2 probeCopy;
+					probeCopy = this.probeSideSerializer.copy(probeRecord);
+					
 					// call match on the first pair
-					matchFunction.join(probeRecord, nextBuildSideRecord, collector);
+					matchFunction.join(nextBuildSideRecord, probeCopy, collector);
 					
 					// call match on the second pair
-					matchFunction.join(probeRecord, tmpRec, collector);
+					probeCopy = this.probeSideSerializer.copy(probeRecord);
+					matchFunction.join(tmpRec, probeCopy, collector);
 					
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
+					while (this.running && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
 						// call match on the next pair
 						// make sure we restore the value of the probe side record
-						matchFunction.join(probeRecord, nextBuildSideRecord, collector);
+						probeCopy = this.probeSideSerializer.copy(probeRecord);
+						matchFunction.join(nextBuildSideRecord, probeCopy, collector);
 					}
 				}
 				else {
 					// only single pair matches
-					matchFunction.join(probeRecord, nextBuildSideRecord, collector);
+					matchFunction.join(nextBuildSideRecord, probeRecord, collector);
 				}
+			}
+			else if(joinWithEmptyBuildSide) {
+				// build side is empty, join with null
+				final V2 probeRecord = this.hashJoin.getCurrentProbeRecord();
+
+				matchFunction.join(null, probeRecord, collector);
 			}
 			return true;
 		}
@@ -143,7 +157,7 @@ public class ReusingBuildSecondHashMatchIterator<V1, V2, O> extends HashMatchIte
 			return false;
 		}
 	}
-	
+
 	@Override
 	public void abort() {
 		this.running = false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstReOpenableHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstReOpenableHashJoinIterator.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,9 +19,6 @@
 
 package org.apache.flink.runtime.operators.hash;
 
-import java.io.IOException;
-import java.util.List;
-
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -32,29 +29,34 @@ import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.MutableObjectIterator;
 
-public class ReusingBuildSecondReOpenableHashMatchIterator<V1, V2, O> extends ReusingBuildSecondHashMatchIterator<V1, V2, O> {
+import java.io.IOException;
+import java.util.List;
 
-	
-	private final ReOpenableMutableHashTable<V2, V1> reopenHashTable;
-	
-	public ReusingBuildSecondReOpenableHashMatchIterator(
+public class NonReusingBuildFirstReOpenableHashJoinIterator<V1, V2, O> extends NonReusingBuildFirstHashJoinIterator<V1, V2, O> {
+
+
+	private final ReOpenableMutableHashTable<V1, V2> reopenHashTable;
+
+	public NonReusingBuildFirstReOpenableHashJoinIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
 			TypeSerializer<V1> serializer1,
 			TypeComparator<V1> comparator1,
 			TypeSerializer<V2> serializer2,
 			TypeComparator<V2> comparator2,
-			TypePairComparator<V1, V2> pairComparator,
+			TypePairComparator<V2, V1> pairComparator,
 			MemoryManager memManager,
 			IOManager ioManager,
 			AbstractInvokable ownerTask,
 			double memoryFraction,
+			boolean joinWithEmptyBuildSide,
 			boolean useBitmapFilters) throws MemoryAllocationException {
 		
 		super(firstInput, secondInput, serializer1, comparator1, serializer2,
-				comparator2, pairComparator, memManager, ioManager, ownerTask, memoryFraction, useBitmapFilters);
+				comparator2, pairComparator, memManager, ioManager, ownerTask,
+				memoryFraction, joinWithEmptyBuildSide, useBitmapFilters);
 		
-		reopenHashTable = (ReOpenableMutableHashTable<V2, V1>) hashJoin;
+		reopenHashTable = (ReOpenableMutableHashTable<V1, V2>) hashJoin;
 	}
 
 	@Override
@@ -74,12 +76,12 @@ public class ReusingBuildSecondReOpenableHashMatchIterator<V1, V2, O> extends Re
 				buildSideComparator, probeSideComparator, pairComparator,
 				memorySegments, ioManager, useBitmapFilters);
 	}
-	
+
 	/**
 	 * Set new input for probe side
-	 * @throws IOException 
+	 * @throws java.io.IOException
 	 */
-	public void reopenProbe(MutableObjectIterator<V1> probeInput) throws IOException {
+	public void reopenProbe(MutableObjectIterator<V2> probeInput) throws IOException {
 		reopenHashTable.reopenProbe(probeInput);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,9 +18,6 @@
 
 
 package org.apache.flink.runtime.operators.hash;
-
-import java.io.IOException;
-import java.util.List;
 
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
@@ -35,64 +32,66 @@ import org.apache.flink.runtime.operators.util.JoinTaskIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
 
+import java.io.IOException;
+import java.util.List;
+
 
 /**
  * An implementation of the {@link org.apache.flink.runtime.operators.util.JoinTaskIterator} that uses a hybrid-hash-join
- * internally to match the records with equal key. The build side of the hash is the first input of the match.
+ * internally to match the records with equal key. The build side of the hash is the second input of the match.  
  */
-public class ReusingBuildFirstHashMatchIterator<V1, V2, O> extends HashMatchIteratorBase implements JoinTaskIterator<V1, V2, O> {
-	
-	protected final MutableHashTable<V1, V2> hashJoin;
-	
-	private final V1 nextBuildSideObject;
+public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIteratorBase implements JoinTaskIterator<V1, V2, O> {
 
-	private final V1 tempBuildSideRecord;
+	protected final MutableHashTable<V2, V1> hashJoin;
 
-	protected final TypeSerializer<V2> probeSideSerializer;
-	
+	protected final TypeSerializer<V1> probeSideSerializer;
+
 	private final MemoryManager memManager;
-	
+
 	private final MutableObjectIterator<V1> firstInput;
-	
+
 	private final MutableObjectIterator<V2> secondInput;
-	
+
+	private final boolean joinWithEmptyBuildSide;
+
 	private volatile boolean running = true;
-	
+
 	// --------------------------------------------------------------------------------------------
-	
-	public ReusingBuildFirstHashMatchIterator(
+
+	public NonReusingBuildSecondHashJoinIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
 			TypeSerializer<V1> serializer1,
 			TypeComparator<V1> comparator1,
 			TypeSerializer<V2> serializer2,
 			TypeComparator<V2> comparator2,
-			TypePairComparator<V2, V1> pairComparator,
-			MemoryManager memManager,
-			IOManager ioManager,
+			TypePairComparator<V1, V2> pairComparator,
+			MemoryManager memManager, IOManager ioManager,
 			AbstractInvokable ownerTask,
 			double memoryFraction,
+			boolean joinWithEmptyBuildSide,
 			boolean useBitmapFilters) throws MemoryAllocationException {
 		
 		this.memManager = memManager;
 		this.firstInput = firstInput;
 		this.secondInput = secondInput;
-		this.probeSideSerializer = serializer2;
-		
-		this.nextBuildSideObject = serializer1.createInstance();
-		this.tempBuildSideRecord = serializer1.createInstance();
+		this.probeSideSerializer = serializer1;
 
-		this.hashJoin = getHashJoin(serializer1, comparator1, serializer2,
-				comparator2, pairComparator, memManager, ioManager, ownerTask, memoryFraction, useBitmapFilters);
+		if(useBitmapFilters && joinWithEmptyBuildSide) {
+			throw new IllegalArgumentException("Bitmap filter may not be activated for joining with empty build side");
+		}
+		this.joinWithEmptyBuildSide = joinWithEmptyBuildSide;
+		
+		this.hashJoin = getHashJoin(serializer2, comparator2, serializer1,
+				comparator1, pairComparator, memManager, ioManager, ownerTask, memoryFraction, useBitmapFilters);
 	}
 	
 	// --------------------------------------------------------------------------------------------
 	
 	@Override
 	public void open() throws IOException, MemoryAllocationException, InterruptedException {
-		this.hashJoin.open(this.firstInput, this.secondInput);
+		this.hashJoin.open(this.secondInput, this.firstInput);
 	}
-	
 
 	@Override
 	public void close() {
@@ -105,39 +104,50 @@ public class ReusingBuildFirstHashMatchIterator<V1, V2, O> extends HashMatchIter
 	}
 
 	@Override
-	public final boolean callWithNextKey(FlatJoinFunction<V1, V2, O> matchFunction, Collector<O> collector)
+	public boolean callWithNextKey(FlatJoinFunction<V1, V2, O> matchFunction, Collector<O> collector)
 	throws Exception
 	{
 		if (this.hashJoin.nextRecord())
 		{
 			// we have a next record, get the iterators to the probe and build side values
-			final MutableHashTable.HashBucketIterator<V1, V2> buildSideIterator = this.hashJoin.getBuildSideIterator();
-			V1 nextBuildSideRecord = this.nextBuildSideObject;
+			final MutableHashTable.HashBucketIterator<V2, V1> buildSideIterator = this.hashJoin.getBuildSideIterator();
+			V2 nextBuildSideRecord;
 			
 			// get the first build side value
-			if ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null) {
-				V1 tmpRec = this.tempBuildSideRecord;
-				final V2 probeRecord = this.hashJoin.getCurrentProbeRecord();
+			if ((nextBuildSideRecord = buildSideIterator.next()) != null) {
+				V2 tmpRec;
+				final V1 probeRecord = this.hashJoin.getCurrentProbeRecord();
 				
 				// check if there is another build-side value
-				if ((tmpRec = buildSideIterator.next(tmpRec)) != null) {
+				if ((tmpRec = buildSideIterator.next()) != null) {
+					// more than one build-side value --> copy the probe side
+					V1 probeCopy;
+					probeCopy = this.probeSideSerializer.copy(probeRecord);
 
 					// call match on the first pair
-					matchFunction.join(nextBuildSideRecord, probeRecord, collector);
+					matchFunction.join(probeCopy, nextBuildSideRecord, collector);
 					
 					// call match on the second pair
-					matchFunction.join(tmpRec, probeRecord, collector);
+					probeCopy = this.probeSideSerializer.copy(probeRecord);
+					matchFunction.join(probeCopy, tmpRec, collector);
 					
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
+					while (this.running && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
 						// call match on the next pair
 						// make sure we restore the value of the probe side record
-						matchFunction.join(nextBuildSideRecord, probeRecord, collector);
+						probeCopy = this.probeSideSerializer.copy(probeRecord);
+						matchFunction.join(probeCopy, nextBuildSideRecord, collector);
 					}
 				}
 				else {
 					// only single pair matches
-					matchFunction.join(nextBuildSideRecord, probeRecord, collector);
+					matchFunction.join(probeRecord, nextBuildSideRecord, collector);
 				}
+			}
+			else if(joinWithEmptyBuildSide) {
+				// build side is empty, join with null
+				final V1 probeRecord = this.hashJoin.getCurrentProbeRecord();
+
+				matchFunction.join(probeRecord, null, collector);
 			}
 			return true;
 		}
@@ -145,7 +155,7 @@ public class ReusingBuildFirstHashMatchIterator<V1, V2, O> extends HashMatchIter
 			return false;
 		}
 	}
-
+	
 	@Override
 	public void abort() {
 		this.running = false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondReOpenableHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondReOpenableHashJoinIterator.java
@@ -32,35 +32,37 @@ import org.apache.flink.util.MutableObjectIterator;
 import java.io.IOException;
 import java.util.List;
 
-public class NonReusingBuildFirstReOpenableHashMatchIterator<V1, V2, O> extends NonReusingBuildFirstHashMatchIterator<V1, V2, O> {
+public class NonReusingBuildSecondReOpenableHashJoinIterator<V1, V2, O> extends NonReusingBuildSecondHashJoinIterator<V1, V2, O> {
 
 
-	private final ReOpenableMutableHashTable<V1, V2> reopenHashTable;
+	private final ReOpenableMutableHashTable<V2, V1> reopenHashTable;
 
-	public NonReusingBuildFirstReOpenableHashMatchIterator(
+	public NonReusingBuildSecondReOpenableHashJoinIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
 			TypeSerializer<V1> serializer1,
 			TypeComparator<V1> comparator1,
 			TypeSerializer<V2> serializer2,
 			TypeComparator<V2> comparator2,
-			TypePairComparator<V2, V1> pairComparator,
+			TypePairComparator<V1, V2> pairComparator,
 			MemoryManager memManager,
 			IOManager ioManager,
 			AbstractInvokable ownerTask,
 			double memoryFraction,
+			boolean joinWithEmptyBuildSide,
 			boolean useBitmapFilters) throws MemoryAllocationException {
 		
 		super(firstInput, secondInput, serializer1, comparator1, serializer2,
 				comparator2, pairComparator, memManager, ioManager, ownerTask,
-				memoryFraction, useBitmapFilters);
+				memoryFraction, joinWithEmptyBuildSide, useBitmapFilters);
 		
-		reopenHashTable = (ReOpenableMutableHashTable<V1, V2>) hashJoin;
+		reopenHashTable = (ReOpenableMutableHashTable<V2, V1>) hashJoin;
 	}
 
 	@Override
 	public <BT, PT> MutableHashTable<BT, PT> getHashJoin(
-			TypeSerializer<BT> buildSideSerializer, TypeComparator<BT> buildSideComparator,
+			TypeSerializer<BT> buildSideSerializer,
+			TypeComparator<BT> buildSideComparator,
 			TypeSerializer<PT> probeSideSerializer, TypeComparator<PT> probeSideComparator,
 			TypePairComparator<PT, BT> pairComparator,
 			MemoryManager memManager, IOManager ioManager,
@@ -80,7 +82,7 @@ public class NonReusingBuildFirstReOpenableHashMatchIterator<V1, V2, O> extends 
 	 * Set new input for probe side
 	 * @throws java.io.IOException
 	 */
-	public void reopenProbe(MutableObjectIterator<V2> probeInput) throws IOException {
+	public void reopenProbe(MutableObjectIterator<V1> probeInput) throws IOException {
 		reopenHashTable.reopenProbe(probeInput);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstReOpenableHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstReOpenableHashJoinIterator.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,9 @@
 
 package org.apache.flink.runtime.operators.hash;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -29,38 +32,36 @@ import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.MutableObjectIterator;
 
-import java.io.IOException;
-import java.util.List;
+public class ReusingBuildFirstReOpenableHashJoinIterator<V1, V2, O> extends ReusingBuildFirstHashJoinIterator<V1, V2, O> {
 
-public class NonReusingBuildSecondReOpenableHashMatchIterator<V1, V2, O> extends NonReusingBuildSecondHashMatchIterator<V1, V2, O> {
-
-
-	private final ReOpenableMutableHashTable<V2, V1> reopenHashTable;
-
-	public NonReusingBuildSecondReOpenableHashMatchIterator(
+	
+	private final ReOpenableMutableHashTable<V1, V2> reopenHashTable;
+	
+	public ReusingBuildFirstReOpenableHashJoinIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
 			TypeSerializer<V1> serializer1,
 			TypeComparator<V1> comparator1,
 			TypeSerializer<V2> serializer2,
 			TypeComparator<V2> comparator2,
-			TypePairComparator<V1, V2> pairComparator,
+			TypePairComparator<V2, V1> pairComparator,
 			MemoryManager memManager,
 			IOManager ioManager,
 			AbstractInvokable ownerTask,
 			double memoryFraction,
-			boolean useBitmapFilters) throws MemoryAllocationException {
-		
+			boolean joinWithEmptyBuildSide,
+			boolean useBitmapFilters)
+		throws MemoryAllocationException
+	{
 		super(firstInput, secondInput, serializer1, comparator1, serializer2,
-				comparator2, pairComparator, memManager, ioManager, ownerTask, memoryFraction, useBitmapFilters);
-		
-		reopenHashTable = (ReOpenableMutableHashTable<V2, V1>) hashJoin;
+				comparator2, pairComparator, memManager, ioManager, ownerTask,
+				memoryFraction, joinWithEmptyBuildSide, useBitmapFilters);
+		reopenHashTable = (ReOpenableMutableHashTable<V1, V2>) hashJoin;
 	}
 
 	@Override
 	public <BT, PT> MutableHashTable<BT, PT> getHashJoin(
-			TypeSerializer<BT> buildSideSerializer,
-			TypeComparator<BT> buildSideComparator,
+			TypeSerializer<BT> buildSideSerializer, TypeComparator<BT> buildSideComparator,
 			TypeSerializer<PT> probeSideSerializer, TypeComparator<PT> probeSideComparator,
 			TypePairComparator<PT, BT> pairComparator,
 			MemoryManager memManager, IOManager ioManager,
@@ -75,12 +76,12 @@ public class NonReusingBuildSecondReOpenableHashMatchIterator<V1, V2, O> extends
 				buildSideComparator, probeSideComparator, pairComparator,
 				memorySegments, ioManager, useBitmapFilters);
 	}
-
+	
 	/**
 	 * Set new input for probe side
-	 * @throws java.io.IOException
+	 * @throws IOException 
 	 */
-	public void reopenProbe(MutableObjectIterator<V1> probeInput) throws IOException {
+	public void reopenProbe(MutableObjectIterator<V2> probeInput) throws IOException {
 		reopenHashTable.reopenProbe(probeInput);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondReOpenableHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondReOpenableHashJoinIterator.java
@@ -32,30 +32,31 @@ import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.MutableObjectIterator;
 
-public class ReusingBuildFirstReOpenableHashMatchIterator<V1, V2, O> extends ReusingBuildFirstHashMatchIterator<V1, V2, O> {
+public class ReusingBuildSecondReOpenableHashJoinIterator<V1, V2, O> extends ReusingBuildSecondHashJoinIterator<V1, V2, O> {
 
 	
-	private final ReOpenableMutableHashTable<V1, V2> reopenHashTable;
+	private final ReOpenableMutableHashTable<V2, V1> reopenHashTable;
 	
-	public ReusingBuildFirstReOpenableHashMatchIterator(
+	public ReusingBuildSecondReOpenableHashJoinIterator(
 			MutableObjectIterator<V1> firstInput,
 			MutableObjectIterator<V2> secondInput,
 			TypeSerializer<V1> serializer1,
 			TypeComparator<V1> comparator1,
 			TypeSerializer<V2> serializer2,
 			TypeComparator<V2> comparator2,
-			TypePairComparator<V2, V1> pairComparator,
+			TypePairComparator<V1, V2> pairComparator,
 			MemoryManager memManager,
 			IOManager ioManager,
 			AbstractInvokable ownerTask,
 			double memoryFraction,
-			boolean useBitmapFilters)
-		throws MemoryAllocationException
-	{
+			boolean joinWithEmptyBuildSide,
+			boolean useBitmapFilters) throws MemoryAllocationException {
+		
 		super(firstInput, secondInput, serializer1, comparator1, serializer2,
 				comparator2, pairComparator, memManager, ioManager, ownerTask,
-				memoryFraction, useBitmapFilters);
-		reopenHashTable = (ReOpenableMutableHashTable<V1, V2>) hashJoin;
+				memoryFraction, joinWithEmptyBuildSide, useBitmapFilters);
+		
+		reopenHashTable = (ReOpenableMutableHashTable<V2, V1>) hashJoin;
 	}
 
 	@Override
@@ -80,7 +81,7 @@ public class ReusingBuildFirstReOpenableHashMatchIterator<V1, V2, O> extends Reu
 	 * Set new input for probe side
 	 * @throws IOException 
 	 */
-	public void reopenProbe(MutableObjectIterator<V2> probeInput) throws IOException {
+	public void reopenProbe(MutableObjectIterator<V1> probeInput) throws IOException {
 		reopenHashTable.reopenProbe(probeInput);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskExternalITCase.java
@@ -37,9 +37,9 @@ import org.junit.Test;
 
 public abstract class AbstractOuterJoinTaskExternalITCase extends BinaryOperatorTestBase<FlatJoinFunction<Tuple2<Integer, Integer>,
 		Tuple2<Integer, Integer>, Tuple2<Integer, Integer>>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> {
-	
-	private static final long HASH_MEM = 4 * 1024 * 1024;
-	
+
+	protected static final long HASH_MEM = 4 * 1024 * 1024;
+
 	private static final long SORT_MEM = 3 * 1024 * 1024;
 	
 	private static final long BNLJN_MEM = 10 * PAGE_SIZE;
@@ -47,33 +47,30 @@ public abstract class AbstractOuterJoinTaskExternalITCase extends BinaryOperator
 	private final double bnljn_frac;
 	
 	@SuppressWarnings("unchecked")
-	private final TypeComparator<Tuple2<Integer, Integer>> comparator1 = new TupleComparator<>(
+	protected final TypeComparator<Tuple2<Integer, Integer>> comparator1 = new TupleComparator<>(
 			new int[]{0},
 			new TypeComparator<?>[]{new IntComparator(true)},
 			new TypeSerializer<?>[]{IntSerializer.INSTANCE}
 	);
 	
 	@SuppressWarnings("unchecked")
-	private final TypeComparator<Tuple2<Integer, Integer>> comparator2 = new TupleComparator<>(
+	protected final TypeComparator<Tuple2<Integer, Integer>> comparator2 = new TupleComparator<>(
 			new int[]{0},
 			new TypeComparator<?>[]{new IntComparator(true)},
 			new TypeSerializer<?>[]{IntSerializer.INSTANCE}
 	);
 	
 	@SuppressWarnings("unchecked")
-	private final TypeSerializer<Tuple2<Integer, Integer>> serializer = new TupleSerializer<>(
+	protected final TypeSerializer<Tuple2<Integer, Integer>> serializer = new TupleSerializer<>(
 			(Class<Tuple2<Integer, Integer>>) (Class<?>) Tuple2.class,
 			new TypeSerializer<?>[]{IntSerializer.INSTANCE, IntSerializer.INSTANCE}
 	);
 	
-	private final CountingOutputCollector<Tuple2<Integer, Integer>> output = new CountingOutputCollector<>();
+	protected final CountingOutputCollector<Tuple2<Integer, Integer>> output = new CountingOutputCollector<>();
 	
-	private final DriverStrategy driverStrategy;
-	
-	public AbstractOuterJoinTaskExternalITCase(ExecutionConfig config, DriverStrategy driverStrategy) {
+	public AbstractOuterJoinTaskExternalITCase(ExecutionConfig config) {
 		super(config, HASH_MEM, 2, SORT_MEM);
 		bnljn_frac = (double) BNLJN_MEM / this.getMemoryManager().getMemorySize();
-		this.driverStrategy = driverStrategy;
 	}
 	
 	@Test
@@ -90,7 +87,7 @@ public abstract class AbstractOuterJoinTaskExternalITCase extends BinaryOperator
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortStrategy());
 		getTaskConfig().setRelativeMemoryDriver(bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -106,6 +103,8 @@ public abstract class AbstractOuterJoinTaskExternalITCase extends BinaryOperator
 	protected abstract int calculateExpectedCount(int keyCnt1, int valCnt1, int keyCnt2, int valCnt2);
 	
 	protected abstract AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> getOuterJoinDriver();
+
+	protected abstract DriverStrategy getSortStrategy();
 	
 	// =================================================================================================
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskTest.java
@@ -60,35 +60,32 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 	
 	private final double bnljn_frac;
 	
-	private final DriverStrategy driverStrategy;
-	
 	@SuppressWarnings("unchecked")
-	private final TypeComparator<Tuple2<Integer, Integer>> comparator1 = new TupleComparator<>(
+	protected final TypeComparator<Tuple2<Integer, Integer>> comparator1 = new TupleComparator<>(
 			new int[]{0},
 			new TypeComparator<?>[]{new IntComparator(true)},
 			new TypeSerializer<?>[]{IntSerializer.INSTANCE}
 	);
 	
 	@SuppressWarnings("unchecked")
-	private final TypeComparator<Tuple2<Integer, Integer>> comparator2 = new TupleComparator<>(
+	protected final TypeComparator<Tuple2<Integer, Integer>> comparator2 = new TupleComparator<>(
 			new int[]{0},
 			new TypeComparator<?>[]{new IntComparator(true)},
 			new TypeSerializer<?>[]{IntSerializer.INSTANCE}
 	);
 	
-	private final List<Tuple2<Integer, Integer>> outList = new ArrayList<>();
+	protected final List<Tuple2<Integer, Integer>> outList = new ArrayList<>();
 	
 	@SuppressWarnings("unchecked")
-	private final TypeSerializer<Tuple2<Integer, Integer>> serializer = new TupleSerializer<>(
+	protected final TypeSerializer<Tuple2<Integer, Integer>> serializer = new TupleSerializer<>(
 			(Class<Tuple2<Integer, Integer>>) (Class<?>) Tuple2.class,
 			new TypeSerializer<?>[]{IntSerializer.INSTANCE, IntSerializer.INSTANCE}
 	);
 	
 	
-	public AbstractOuterJoinTaskTest(ExecutionConfig config, DriverStrategy driverStrategy) {
+	public AbstractOuterJoinTaskTest(ExecutionConfig config) {
 		super(config, HASH_MEM, NUM_SORTER, SORT_MEM);
 		bnljn_frac = (double) BNLJN_MEM / this.getMemoryManager().getMemorySize();
-		this.driverStrategy = driverStrategy;
 	}
 	
 	@Test
@@ -162,7 +159,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(this.driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(this.bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -191,7 +188,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(this.driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(this.bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -220,7 +217,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(this.driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(this.bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -249,7 +246,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(this.driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(this.bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -266,7 +263,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		
 		this.outList.clear();
 	}
-	
+
 	@Test(expected = ExpectedTestException.class)
 	public void testFailingOuterJoinTask() throws Exception {
 		int keyCnt1 = 20;
@@ -279,7 +276,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(this.driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(this.bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -297,7 +294,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(this.driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(this.bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -324,7 +321,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		
 		cancel();
 		taskRunner.interrupt();
-		
+
 		taskRunner.join(60000);
 		
 		assertFalse("Task thread did not finish within 60 seconds", taskRunner.isAlive());
@@ -341,7 +338,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(this.driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(this.bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -385,7 +382,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		addDriverComparator(this.comparator1);
 		addDriverComparator(this.comparator2);
 		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
-		getTaskConfig().setDriverStrategy(driverStrategy);
+		getTaskConfig().setDriverStrategy(this.getSortDriverStrategy());
 		getTaskConfig().setRelativeMemoryDriver(bnljn_frac);
 		setNumFileHandlesForSort(4);
 		
@@ -426,6 +423,8 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 	protected abstract AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> getOuterJoinDriver();
 	
 	protected abstract int calculateExpectedCount(int keyCnt1, int valCnt1, int keyCnt2, int valCnt2);
+
+	protected abstract DriverStrategy getSortDriverStrategy();
 	
 	// =================================================================================================
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/FullOuterJoinTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/FullOuterJoinTaskExternalITCase.java
@@ -26,7 +26,7 @@ public class FullOuterJoinTaskExternalITCase extends AbstractOuterJoinTaskExtern
 	
 	
 	public FullOuterJoinTaskExternalITCase(ExecutionConfig config) {
-		super(config, DriverStrategy.FULL_OUTER_MERGE);
+		super(config);
 	}
 	
 	@Override
@@ -37,5 +37,10 @@ public class FullOuterJoinTaskExternalITCase extends AbstractOuterJoinTaskExtern
 	@Override
 	protected AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> getOuterJoinDriver() {
 		return new FullOuterJoinDriver<>();
+	}
+
+	@Override
+	protected DriverStrategy getSortStrategy() {
+		return DriverStrategy.FULL_OUTER_MERGE;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/FullOuterJoinTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/FullOuterJoinTaskTest.java
@@ -26,7 +26,12 @@ public class FullOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 	
 	
 	public FullOuterJoinTaskTest(ExecutionConfig config) {
-		super(config, DriverStrategy.FULL_OUTER_MERGE);
+		super(config);
+	}
+
+	@Override
+	protected DriverStrategy getSortDriverStrategy() {
+		return DriverStrategy.FULL_OUTER_MERGE;
 	}
 	
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskExternalITCase.java
@@ -21,12 +21,18 @@ package org.apache.flink.runtime.operators;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.RuntimePairComparatorFactory;
+import org.apache.flink.runtime.operators.testutils.UniformIntTupleGenerator;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class LeftOuterJoinTaskExternalITCase extends AbstractOuterJoinTaskExternalITCase {
-	
+
+	private final double hash_frac;
 	
 	public LeftOuterJoinTaskExternalITCase(ExecutionConfig config) {
-		super(config, DriverStrategy.LEFT_OUTER_MERGE);
+		super(config);
+		hash_frac = (double)HASH_MEM/this.getMemoryManager().getMemorySize();
 	}
 	
 	@Override
@@ -37,5 +43,37 @@ public class LeftOuterJoinTaskExternalITCase extends AbstractOuterJoinTaskExtern
 	@Override
 	protected AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> getOuterJoinDriver() {
 		return new LeftOuterJoinDriver<>();
+	}
+
+	@Override
+	protected DriverStrategy getSortStrategy() {
+		return DriverStrategy.LEFT_OUTER_MERGE;
+	}
+
+	@Test
+	public void testExternalHashLeftOuterJoinTask() throws Exception {
+
+		final int keyCnt1 = 65536;
+		final int valCnt1 = 8;
+
+		final int keyCnt2 = 32768;
+		final int valCnt2 = 8;
+
+		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
+
+		setOutput(this.output);
+		addDriverComparator(this.comparator1);
+		addDriverComparator(this.comparator2);
+		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
+		getTaskConfig().setDriverStrategy(DriverStrategy.LEFT_HYBRIDHASH_BUILD_SECOND);
+		getTaskConfig().setRelativeMemoryDriver(hash_frac);
+
+		final AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> testTask = getOuterJoinDriver();
+
+		addInputSorted(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), serializer, this.comparator1.duplicate());
+		addInputSorted(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), serializer, this.comparator2.duplicate());
+		testDriver(testTask, MockJoinStub.class);
+
+		Assert.assertEquals("Wrong result set size.", expCnt, this.output.getNumberOfRecords());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskTest.java
@@ -19,23 +19,245 @@
 
 package org.apache.flink.runtime.operators;
 
+import com.google.common.base.Throwables;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.record.RecordPairComparatorFactory;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.RuntimePairComparatorFactory;
+import org.apache.flink.runtime.operators.testutils.DelayingInfinitiveInputIterator;
+import org.apache.flink.runtime.operators.testutils.DelayingIterator;
+import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.runtime.operators.testutils.InfiniteIntTupleIterator;
+import org.apache.flink.runtime.operators.testutils.NirvanaOutputList;
+import org.apache.flink.runtime.operators.testutils.UniformIntTupleGenerator;
+import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
+import org.apache.flink.types.Record;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 public class LeftOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
-	
-	
+
+	private static final long HASH_MEM = 6*1024*1024;
+
+	private final double hash_frac;
+
 	public LeftOuterJoinTaskTest(ExecutionConfig config) {
-		super(config, DriverStrategy.LEFT_OUTER_MERGE);
+		super(config);
+		hash_frac = (double)HASH_MEM/this.getMemoryManager().getMemorySize();
 	}
 	
 	@Override
 	protected int calculateExpectedCount(int keyCnt1, int valCnt1, int keyCnt2, int valCnt2) {
 		return valCnt1 * valCnt2 * Math.min(keyCnt1, keyCnt2) + (keyCnt1 > keyCnt2 ? (keyCnt1 - keyCnt2) * valCnt1 : 0);
 	}
-	
+
+	@Override
+	protected DriverStrategy getSortDriverStrategy() {
+		return DriverStrategy.LEFT_OUTER_MERGE;
+	}
+
 	@Override
 	protected AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> getOuterJoinDriver() {
 		return new LeftOuterJoinDriver<>();
+	}
+
+	@Test
+	public void testHash1LeftOuterJoinTask() throws Exception {
+		final int keyCnt1 = 20;
+		final int valCnt1 = 1;
+
+		final int keyCnt2 = 10;
+		final int valCnt2 = 2;
+
+		testHashLeftOuterJoinTask(keyCnt1, valCnt1, keyCnt2, valCnt2);
+	}
+
+	@Test
+	public void testHash2LeftOuterJoinTask() throws Exception {
+		final int keyCnt1 = 20;
+		final int valCnt1 = 1;
+
+		final int keyCnt2 = 20;
+		final int valCnt2 = 1;
+
+		testHashLeftOuterJoinTask(keyCnt1, valCnt1, keyCnt2, valCnt2);
+	}
+
+	@Test
+	public void testHash3LeftOuterJoinTask() throws Exception {
+		int keyCnt1 = 20;
+		int valCnt1 = 1;
+
+		int keyCnt2 = 20;
+		int valCnt2 = 20;
+
+		testHashLeftOuterJoinTask(keyCnt1, valCnt1, keyCnt2, valCnt2);
+	}
+
+	@Test
+	public void testHash4LeftOuterJoinTask() throws Exception {
+		int keyCnt1 = 20;
+		int valCnt1 = 20;
+
+		int keyCnt2 = 20;
+		int valCnt2 = 1;
+
+		testHashLeftOuterJoinTask(keyCnt1, valCnt1, keyCnt2, valCnt2);
+	}
+
+	@Test
+	public void testHash5LeftOuterJoinTask() throws Exception {
+		int keyCnt1 = 20;
+		int valCnt1 = 20;
+
+		int keyCnt2 = 20;
+		int valCnt2 = 20;
+
+		testHashLeftOuterJoinTask(keyCnt1, valCnt1, keyCnt2, valCnt2);
+	}
+
+	@Test
+	public void testHash6LeftOuterJoinTask() throws Exception {
+		int keyCnt1 = 10;
+		int valCnt1 = 1;
+
+		int keyCnt2 = 20;
+		int valCnt2 = 2;
+
+		testHashLeftOuterJoinTask(keyCnt1, valCnt1, keyCnt2, valCnt2);
+	}
+
+	private void testHashLeftOuterJoinTask(int keyCnt1, int valCnt1, int keyCnt2, int valCnt2) throws Exception {
+
+		setOutput(this.outList, this.serializer);
+		addDriverComparator(this.comparator1);
+		addDriverComparator(this.comparator2);
+		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
+		getTaskConfig().setDriverStrategy(DriverStrategy.LEFT_HYBRIDHASH_BUILD_SECOND);
+		getTaskConfig().setRelativeMemoryDriver(hash_frac);
+
+		final AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> testTask = getOuterJoinDriver();
+
+		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), this.serializer);
+		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), this.serializer);
+		testDriver(testTask, MockJoinStub.class);
+
+		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
+
+		Assert.assertTrue("Result set size was " + this.outList.size() + ". Expected was " + expCnt, this.outList.size() == expCnt);
+
+		this.outList.clear();
+	}
+
+	@Test(expected = ExpectedTestException.class)
+	public void testFailingHashLeftOuterJoinTask() throws Exception {
+		int keyCnt1 = 20;
+		int valCnt1 = 20;
+
+		int keyCnt2 = 20;
+		int valCnt2 = 20;
+
+		setOutput(new DiscardingOutputCollector<Tuple2<Integer, Integer>>());
+		addDriverComparator(this.comparator1);
+		addDriverComparator(this.comparator2);
+		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
+		getTaskConfig().setDriverStrategy(DriverStrategy.LEFT_HYBRIDHASH_BUILD_SECOND);
+		getTaskConfig().setRelativeMemoryDriver(this.hash_frac);
+
+		final AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> testTask = getOuterJoinDriver();
+
+		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, true), this.serializer);
+		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, true), this.serializer);
+
+		testDriver(testTask, MockFailingJoinStub.class);
+	}
+
+	@Test
+	public void testCancelLeftOuterJoinTaskWhileBuilding() throws Exception {
+		setOutput(new DiscardingOutputCollector<Tuple2<Integer, Integer>>());
+		addDriverComparator(this.comparator1);
+		addDriverComparator(this.comparator2);
+		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
+		getTaskConfig().setDriverStrategy(DriverStrategy.LEFT_HYBRIDHASH_BUILD_SECOND);
+		getTaskConfig().setRelativeMemoryDriver(this.hash_frac);
+
+		final AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> testTask = getOuterJoinDriver();
+
+		addInput(new UniformIntTupleGenerator(100, 100, true), this.serializer);
+		addInput(new DelayingIterator<>(new InfiniteIntTupleIterator(), 100), this.serializer);
+
+		final AtomicReference<Throwable> error = new AtomicReference<>();
+
+		final Thread taskRunner = new Thread("Task runner for testCancelOuterJoinTaskWhileSort1()") {
+			@Override
+			public void run() {
+				try {
+					testDriver(testTask, MockJoinStub.class);
+				} catch (Throwable t) {
+					error.set(t);
+				}
+			}
+		};
+		taskRunner.start();
+
+		Thread.sleep(1000);
+
+		cancel();
+		taskRunner.join(60000);
+
+		assertFalse("Task thread did not finish within 60 seconds", taskRunner.isAlive());
+
+		final Throwable taskError = error.get();
+		if (taskError != null) {
+			fail("Error in task while canceling:\n" + Throwables.getStackTraceAsString(taskError));
+		}
+	}
+
+	@Test
+	public void testCancelLeftOuterJoinTaskWhileProbing() throws Exception {
+		setOutput(new DiscardingOutputCollector<Tuple2<Integer, Integer>>());
+		addDriverComparator(this.comparator1);
+		addDriverComparator(this.comparator2);
+		getTaskConfig().setDriverPairComparator(new RuntimePairComparatorFactory());
+		getTaskConfig().setDriverStrategy(DriverStrategy.LEFT_HYBRIDHASH_BUILD_SECOND);
+		getTaskConfig().setRelativeMemoryDriver(this.hash_frac);
+
+		final AbstractOuterJoinDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> testTask = getOuterJoinDriver();
+
+		addInput(new DelayingIterator<>(new InfiniteIntTupleIterator(), 100), this.serializer);
+		addInput(new UniformIntTupleGenerator(1, 1, true), this.serializer);
+
+		final AtomicReference<Throwable> error = new AtomicReference<>();
+
+		final Thread taskRunner = new Thread("Task runner for testCancelOuterJoinTaskWhileSort1()") {
+			@Override
+			public void run() {
+				try {
+					testDriver(testTask, MockJoinStub.class);
+				} catch (Throwable t) {
+					error.set(t);
+				}
+			}
+		};
+		taskRunner.start();
+
+		Thread.sleep(1000);
+
+		cancel();
+		taskRunner.join(60000);
+
+		assertFalse("Task thread did not finish within 60 seconds", taskRunner.isAlive());
+
+		final Throwable taskError = error.get();
+		if (taskError != null) {
+			fail("Error in task while canceling:\n" + Throwables.getStackTraceAsString(taskError));
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingHashJoinIteratorITCase.java
@@ -55,7 +55,7 @@ import org.apache.flink.api.common.typeutils.GenericPairComparator;
 import org.apache.flink.api.java.tuple.Tuple2;
 
 @SuppressWarnings({"serial", "deprecation"})
-public class NonReusingHashMatchIteratorITCase {
+public class NonReusingHashJoinIteratorITCase {
 	
 	private static final int MEMORY_SIZE = 16000000;		// total memory
 
@@ -129,9 +129,9 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<Tuple2<Integer, String>>();
@@ -143,11 +143,11 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			NonReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new NonReusingBuildFirstHashMatchIterator<>(
+			NonReusingBuildFirstHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildFirstHashJoinIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-						this.memoryManager, ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -202,9 +202,9 @@ public class NonReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -230,11 +230,11 @@ public class NonReusingHashMatchIteratorITCase {
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
-			NonReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new NonReusingBuildFirstHashMatchIterator<>(
+			NonReusingBuildFirstHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildFirstHashJoinIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-						this.memoryManager, ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 
 			iterator.open();
 			
@@ -265,9 +265,9 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
@@ -279,11 +279,11 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values			
-			NonReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-				new NonReusingBuildSecondHashMatchIterator<>(
+			NonReusingBuildSecondHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new NonReusingBuildSecondHashJoinIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-					this.memoryManager, ioManager, this.parentTask, 1.0, true);
+					this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 
 			iterator.open();
 			
@@ -338,9 +338,9 @@ public class NonReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -366,11 +366,11 @@ public class NonReusingHashMatchIteratorITCase {
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 
-			NonReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-				new NonReusingBuildSecondHashMatchIterator<>(
+			NonReusingBuildSecondHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new NonReusingBuildSecondHashJoinIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-					this.memoryManager, ioManager, this.parentTask, 1.0, true);
+					this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -400,12 +400,12 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
-				collectIntPairData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = joinIntPairs(
+					collectIntPairData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
-			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<Tuple2<Integer, String>>();
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
 			// reset the generators
 			input1 = new UniformIntPairGenerator(500, 40, false);
@@ -413,11 +413,11 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			NonReusingBuildSecondHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new NonReusingBuildSecondHashMatchIterator<>(
+			NonReusingBuildSecondHashJoinIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildSecondHashJoinIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator,
 						this.recordSerializer, this.record2Comparator, this.pairRecordPairComparator,
-						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, this.ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -447,9 +447,9 @@ public class NonReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
-				collectIntPairData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = joinIntPairs(
+					collectIntPairData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
@@ -460,11 +460,11 @@ public class NonReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			NonReusingBuildFirstHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new NonReusingBuildFirstHashMatchIterator<>(
+			NonReusingBuildFirstHashJoinIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildFirstHashJoinIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairPairComparator,
-						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, this.ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -484,6 +484,104 @@ public class NonReusingHashMatchIteratorITCase {
 			Assert.fail("An exception occurred during the test: " + e.getMessage());
 		}
 	}
+
+	@Test
+	public void testBuildFirstJoinWithEmptyBuild() {
+		try {
+			TupleGenerator generator1 = new TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator2 = new TupleGenerator(SEED2, 1000, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
+
+			// collect expected data
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = rightOuterJoinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
+
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
+
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+			input1.reset();
+			input2.reset();
+
+			// compare with iterator values
+			NonReusingBuildFirstHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildFirstHashJoinIterator<>(
+							input1, input2, this.recordSerializer, this.record1Comparator,
+							this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+							this.memoryManager, ioManager, this.parentTask, 1.0, true, false);
+
+			iterator.open();
+
+			while (iterator.callWithNextKey(matcher, collector));
+
+			iterator.close();
+
+			// assert that each expected match was seen
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testBuildSecondJoinWithEmptyBuild() {
+		try {
+			TupleGenerator generator1 = new TupleGenerator(SEED1, 1000, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TupleGenerator generator2 = new TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
+
+			// collect expected data
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = leftOuterJoinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
+
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
+
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+			input1.reset();
+			input2.reset();
+
+			// compare with iterator values
+			NonReusingBuildSecondHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new NonReusingBuildSecondHashJoinIterator<>(
+							input1, input2, this.recordSerializer, this.record1Comparator,
+							this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+							this.memoryManager, ioManager, this.parentTask, 1.0, true, false);
+
+			iterator.open();
+
+			while (iterator.callWithNextKey(matcher, collector));
+
+			iterator.close();
+
+			// assert that each expected match was seen
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
 	
 	// --------------------------------------------------------------------------------------------
 	//                                    Utilities
@@ -491,7 +589,7 @@ public class NonReusingHashMatchIteratorITCase {
 
 	
 	
-	static Map<Integer, Collection<TupleMatch>> matchSecondTupleFields(
+	public static Map<Integer, Collection<TupleMatch>> joinTuples(
 			Map<Integer, Collection<String>> leftMap,
 			Map<Integer, Collection<String>> rightMap)
 	{
@@ -520,10 +618,72 @@ public class NonReusingHashMatchIteratorITCase {
 
 		return map;
 	}
+
+	public static Map<Integer, Collection<TupleMatch>> leftOuterJoinTuples(
+			Map<Integer, Collection<String>> leftMap,
+			Map<Integer, Collection<String>> rightMap)
+	{
+		Map<Integer, Collection<TupleMatch>> map = new HashMap<>();
+
+		for (Integer key : leftMap.keySet()) {
+			Collection<String> leftValues = leftMap.get(key);
+			Collection<String> rightValues = rightMap.get(key);
+
+			if (!map.containsKey(key)) {
+				map.put(key, new ArrayList<TupleMatch>());
+			}
+
+			Collection<TupleMatch> matchedValues = map.get(key);
+
+			for (String leftValue : leftValues) {
+				if(rightValues != null) {
+					for (String rightValue : rightValues) {
+						matchedValues.add(new TupleMatch(leftValue, rightValue));
+					}
+				}
+				else {
+					matchedValues.add(new TupleMatch(leftValue, null));
+				}
+			}
+		}
+
+		return map;
+	}
+
+	public static Map<Integer, Collection<TupleMatch>> rightOuterJoinTuples(
+			Map<Integer, Collection<String>> leftMap,
+			Map<Integer, Collection<String>> rightMap)
+	{
+		Map<Integer, Collection<TupleMatch>> map = new HashMap<>();
+
+		for (Integer key : rightMap.keySet()) {
+			Collection<String> leftValues = leftMap.get(key);
+			Collection<String> rightValues = rightMap.get(key);
+
+			if (!map.containsKey(key)) {
+				map.put(key, new ArrayList<TupleMatch>());
+			}
+
+			Collection<TupleMatch> matchedValues = map.get(key);
+
+			for (String rightValue : rightValues) {
+				if(leftValues != null) {
+					for (String leftValue : leftValues) {
+						matchedValues.add(new TupleMatch(leftValue, rightValue));
+					}
+				}
+				else {
+					matchedValues.add(new TupleMatch(null, rightValue));
+				}
+			}
+		}
+
+		return map;
+	}
 	
-	static Map<Integer, Collection<TupleIntPairMatch>> matchTupleIntPairValues(
-		Map<Integer, Collection<Integer>> leftMap,
-		Map<Integer, Collection<String>> rightMap)
+	public static Map<Integer, Collection<TupleIntPairMatch>> joinIntPairs(
+			Map<Integer, Collection<Integer>> leftMap,
+			Map<Integer, Collection<String>> rightMap)
 	{
 		final Map<Integer, Collection<TupleIntPairMatch>> map = new HashMap<>();
 	
@@ -553,7 +713,7 @@ public class NonReusingHashMatchIteratorITCase {
 	}
 
 	
-	static Map<Integer, Collection<String>> collectTupleData(MutableObjectIterator<Tuple2<Integer, String>> iter)
+	public static Map<Integer, Collection<String>> collectTupleData(MutableObjectIterator<Tuple2<Integer, String>> iter)
 	throws Exception
 	{
 		Map<Integer, Collection<String>> map = new HashMap<>();
@@ -573,10 +733,10 @@ public class NonReusingHashMatchIteratorITCase {
 		return map;
 	}
 	
-	static Map<Integer, Collection<Integer>> collectIntPairData(MutableObjectIterator<IntPair> iter)
+	public static Map<Integer, Collection<Integer>> collectIntPairData(MutableObjectIterator<IntPair> iter)
 	throws Exception
 	{
-		Map<Integer, Collection<Integer>> map = new HashMap<Integer, Collection<Integer>>();
+		Map<Integer, Collection<Integer>> map = new HashMap<>();
 		IntPair pair = new IntPair();
 		
 		while ((pair = iter.next(pair)) != null) {
@@ -595,9 +755,9 @@ public class NonReusingHashMatchIteratorITCase {
 	}
 
 	/**
-	 * Private class used for storage of the expected matches in a hash-map.
+	 * Class used for storage of the expected matches in a hash-map.
 	 */
-	static class TupleMatch {
+	public static class TupleMatch {
 		
 		private final String left;
 		private final String right;
@@ -610,24 +770,43 @@ public class NonReusingHashMatchIteratorITCase {
 		@Override
 		public boolean equals(Object obj) {
 			TupleMatch o = (TupleMatch) obj;
-			return this.left.equals(o.left) && this.right.equals(o.right);
+
+			if(left != null && o.left != null && right != null && o.right != null) {
+				return this.left.equals(o.left) && this.right.equals(o.right);
+			}
+			else if(left == null && o.left == null) {
+				return this.right.equals(o.right);
+			}
+			else if(right == null && o.right == null) {
+				return this.left.equals(o.left);
+			}
+			else if(left == null && o.left == null && right == null && o.right == null) {
+				return true;
+			}
+			else {
+				return false;
+			}
 		}
 		
 		@Override
 		public int hashCode() {
-			return this.left.hashCode() ^ this.right.hashCode();
+			int hc = this.left != null ? this.left.hashCode() : 23;
+			hc = hc ^ (this.right != null ? this.right.hashCode() : 41);
+			return hc;
 		}
 
 		@Override
 		public String toString() {
-			return left + ", " + right;
+			String s = left == null ? "<null>" : left;
+			s += ", " + right == null ? "<null>" : right;
+			return s;
 		}
 	}
 	
 	/**
 	 * Private class used for storage of the expected matches in a hash-map.
 	 */
-	static class TupleIntPairMatch
+	public static class TupleIntPairMatch
 	{
 		private final int left;
 		private final String right;
@@ -665,9 +844,11 @@ public class NonReusingHashMatchIteratorITCase {
 		@Override
 		public void join(Tuple2<Integer, String> rec1, Tuple2<Integer, String> rec2, Collector<Tuple2<Integer, String>> out) throws Exception
 		{
-			int key = rec1.f0;
-			String value1 = rec1.f1;
-			String value2 = rec2.f1;
+
+			int key = rec1 != null ? rec1.f0 : rec2.f0;
+			String value1 = rec1 != null ? rec1.f1 : null;
+			String value2 = rec2 != null ? rec2.f1 : null;
+
 			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.f0);
 			Collection<TupleMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/NonReusingReOpenableHashTableITCase.java
@@ -30,8 +30,8 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.hash.MutableHashTable.HashBucketIterator;
-import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase.TupleMatch;
-import org.apache.flink.runtime.operators.hash.NonReusingHashMatchIteratorITCase.TupleMatchRemovingJoin;
+import org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.TupleMatch;
+import org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.TupleMatchRemovingJoin;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -204,7 +204,7 @@ public class NonReusingReOpenableHashTableITCase {
 
 	private void doTest(TestData.TupleGeneratorIterator buildInput, TestData.TupleGeneratorIterator probeInput, TupleGenerator bgen, TupleGenerator pgen) throws Exception {
 		// collect expected data
-		final Map<Integer, Collection<TupleMatch>> expectedFirstMatchesMap = NonReusingHashMatchIteratorITCase.matchSecondTupleFields(NonReusingHashMatchIteratorITCase.collectTupleData(buildInput), NonReusingHashMatchIteratorITCase.collectTupleData(probeInput));
+		final Map<Integer, Collection<TupleMatch>> expectedFirstMatchesMap = NonReusingHashJoinIteratorITCase.joinTuples(NonReusingHashJoinIteratorITCase.collectTupleData(buildInput), NonReusingHashJoinIteratorITCase.collectTupleData(probeInput));
 
 		final List<Map<Integer, Collection<TupleMatch>>> expectedNMatchesMapList = new ArrayList<>(NUM_PROBES);
 		final FlatJoinFunction[] nMatcher = new TupleMatchRemovingJoin[NUM_PROBES];
@@ -225,11 +225,11 @@ public class NonReusingReOpenableHashTableITCase {
 		probeInput.reset();
 
 		// compare with iterator values
-		NonReusingBuildFirstReOpenableHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-				new NonReusingBuildFirstReOpenableHashMatchIterator<>(
+		NonReusingBuildFirstReOpenableHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new NonReusingBuildFirstReOpenableHashJoinIterator<>(
 						buildInput, probeInput, this.recordSerializer, this.record1Comparator,
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-					this.memoryManager, ioManager, this.parentTask, 1.0, true);
+					this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 
 		iterator.open();
 		// do first join with both inputs

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/ReusingHashJoinIteratorITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.operators.hash;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -37,6 +36,8 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.TupleMatch;
+import org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.TupleIntPairMatch;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.TestData;
@@ -54,8 +55,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.joinTuples;
+import static org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.leftOuterJoinTuples;
+import static org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.rightOuterJoinTuples;
+import static org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.joinIntPairs;
+import static org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.collectTupleData;
+import static org.apache.flink.runtime.operators.hash.NonReusingHashJoinIteratorITCase.collectIntPairData;
+
 @SuppressWarnings({"serial", "deprecation"})
-public class ReusingHashMatchIteratorITCase {
+public class ReusingHashJoinIteratorITCase {
 	
 	private static final int MEMORY_SIZE = 16000000;		// total memory
 
@@ -129,9 +137,9 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
@@ -143,11 +151,11 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			ReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new ReusingBuildFirstHashMatchIterator<>(
+			ReusingBuildFirstHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashJoinIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-						this.memoryManager, ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -202,9 +210,9 @@ public class ReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -224,17 +232,17 @@ public class ReusingHashMatchIteratorITCase {
 			inList2.add(gen2Iter);
 			inList2.add(const2Iter);
 	
-			input1 = new UnionIterator<Tuple2<Integer, String>>(inList1);
-			input2 = new UnionIterator<Tuple2<Integer, String>>(inList2);
+			input1 = new UnionIterator<>(inList1);
+			input2 = new UnionIterator<>(inList2);
 			
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
-			ReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new ReusingBuildFirstHashMatchIterator<>(
+			ReusingBuildFirstHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashJoinIterator<>(
 						input1, input2, this.recordSerializer, this.record1Comparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-						this.memoryManager, ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 
 			iterator.open();
 			
@@ -265,9 +273,9 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
@@ -279,11 +287,11 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values			
-			ReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>,Tuple2<Integer, String> ,Tuple2<Integer, String> > iterator =
-				new ReusingBuildSecondHashMatchIterator<>(
+			ReusingBuildSecondHashJoinIterator<Tuple2<Integer, String>,Tuple2<Integer, String> ,Tuple2<Integer, String> > iterator =
+				new ReusingBuildSecondHashJoinIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-					this.memoryManager, ioManager, this.parentTask, 1.0, true);
+					this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 
 			iterator.open();
 			
@@ -338,9 +346,9 @@ public class ReusingHashMatchIteratorITCase {
 			
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = matchSecondTupleFields(
-				collectTupleData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = joinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
 			
 			// re-create the whole thing for actual processing
 			
@@ -366,11 +374,11 @@ public class ReusingHashMatchIteratorITCase {
 			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
 	
-			ReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-				new ReusingBuildSecondHashMatchIterator<>(
+			ReusingBuildSecondHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+				new ReusingBuildSecondHashJoinIterator<>(
 					input1, input2, this.recordSerializer, this.record1Comparator, 
 					this.recordSerializer, this.record2Comparator, this.recordPairComparator,
-					this.memoryManager, ioManager, this.parentTask, 1.0, true);
+					this.memoryManager, ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -400,9 +408,9 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
-				collectIntPairData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = joinIntPairs(
+					collectIntPairData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
@@ -413,11 +421,11 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			ReusingBuildSecondHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new ReusingBuildSecondHashMatchIterator<>(
+			ReusingBuildSecondHashJoinIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildSecondHashJoinIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator,
 						this.recordSerializer, this.record2Comparator, this.pairRecordPairComparator,
-						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, this.ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -447,9 +455,9 @@ public class ReusingHashMatchIteratorITCase {
 			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
 			
 			// collect expected data
-			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = matchTupleIntPairValues(
-				collectIntPairData(input1),
-				collectTupleData(input2));
+			final Map<Integer, Collection<TupleIntPairMatch>> expectedMatchesMap = joinIntPairs(
+					collectIntPairData(input1),
+					collectTupleData(input2));
 			
 			final FlatJoinFunction<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> matcher = new TupleIntPairMatchRemovingMatcher(expectedMatchesMap);
 			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
@@ -460,11 +468,11 @@ public class ReusingHashMatchIteratorITCase {
 			input2.reset();
 	
 			// compare with iterator values
-			ReusingBuildFirstHashMatchIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new ReusingBuildFirstHashMatchIterator<>(
+			ReusingBuildFirstHashJoinIterator<IntPair, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashJoinIterator<>(
 						input1, input2, this.pairSerializer, this.pairComparator, 
 						this.recordSerializer, this.record2Comparator, this.recordPairPairComparator,
-						this.memoryManager, this.ioManager, this.parentTask, 1.0, true);
+						this.memoryManager, this.ioManager, this.parentTask, 1.0, false, true);
 			
 			iterator.open();
 			
@@ -484,178 +492,111 @@ public class ReusingHashMatchIteratorITCase {
 			Assert.fail("An exception occurred during the test: " + e.getMessage());
 		}
 	}
+
+	@Test
+	public void testBuildFirstJoinWithEmptyBuild() {
+		try {
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, 500, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 1000, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
+
+			// collect expected data
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = rightOuterJoinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
+
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
+
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+			input1.reset();
+			input2.reset();
+
+			// compare with iterator values
+			ReusingBuildFirstHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashJoinIterator<>(
+							input1, input2, this.recordSerializer, this.record1Comparator,
+							this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+							this.memoryManager, ioManager, this.parentTask, 1.0, true, false);
+
+			iterator.open();
+
+			while (iterator.callWithNextKey(matcher, collector));
+
+			iterator.close();
+
+			// assert that each expected match was seen
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testBuildSecondJoinWithEmptyBuild() {
+		try {
+			TestData.TupleGenerator generator1 = new TestData.TupleGenerator(SEED1, 1000, 4096, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+			TestData.TupleGenerator generator2 = new TestData.TupleGenerator(SEED2, 500, 2048, KeyMode.RANDOM, ValueMode.RANDOM_LENGTH);
+
+			final TestData.TupleGeneratorIterator input1 = new TestData.TupleGeneratorIterator(generator1, INPUT_1_SIZE);
+			final TestData.TupleGeneratorIterator input2 = new TestData.TupleGeneratorIterator(generator2, INPUT_2_SIZE);
+
+			// collect expected data
+			final Map<Integer, Collection<TupleMatch>> expectedMatchesMap = leftOuterJoinTuples(
+					collectTupleData(input1),
+					collectTupleData(input2));
+
+			final FlatJoinFunction matcher = new TupleMatchRemovingJoin(expectedMatchesMap);
+			final Collector<Tuple2<Integer, String>> collector = new DiscardingOutputCollector<>();
+
+			// reset the generators
+			generator1.reset();
+			generator2.reset();
+			input1.reset();
+			input2.reset();
+
+			// compare with iterator values
+			ReusingBuildSecondHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildSecondHashJoinIterator<>(
+							input1, input2, this.recordSerializer, this.record1Comparator,
+							this.recordSerializer, this.record2Comparator, this.recordPairComparator,
+							this.memoryManager, ioManager, this.parentTask, 1.0, true, false);
+
+			iterator.open();
+
+			while (iterator.callWithNextKey(matcher, collector));
+
+			iterator.close();
+
+			// assert that each expected match was seen
+			for (Entry<Integer, Collection<TupleMatch>> entry : expectedMatchesMap.entrySet()) {
+				if (!entry.getValue().isEmpty()) {
+					Assert.fail("Collection for key " + entry.getKey() + " is not empty");
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("An exception occurred during the test: " + e.getMessage());
+		}
+	}
+
 	
 	// --------------------------------------------------------------------------------------------
 	//                                    Utilities
 	// --------------------------------------------------------------------------------------------
 
-	
-	
-	static Map<Integer, Collection<TupleMatch>> matchSecondTupleFields(
-			Map<Integer, Collection<String>> leftMap,
-			Map<Integer, Collection<String>> rightMap)
-	{
-		Map<Integer, Collection<TupleMatch>> map = new HashMap<>();
 
-		for (Integer key : leftMap.keySet()) {
-			Collection<String> leftValues = leftMap.get(key);
-			Collection<String> rightValues = rightMap.get(key);
-
-			if (rightValues == null) {
-				continue;
-			}
-
-			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<TupleMatch>());
-			}
-
-			Collection<TupleMatch> matchedValues = map.get(key);
-
-			for (String leftValue : leftValues) {
-				for (String rightValue : rightValues) {
-					matchedValues.add(new TupleMatch(leftValue, rightValue));
-				}
-			}
-		}
-
-		return map;
-	}
-	
-	static Map<Integer, Collection<TupleIntPairMatch>> matchTupleIntPairValues(
-		Map<Integer, Collection<Integer>> leftMap,
-		Map<Integer, Collection<String>> rightMap)
-	{
-		final Map<Integer, Collection<TupleIntPairMatch>> map = new HashMap<>();
-	
-		for (Integer i : leftMap.keySet()) {
-			
-			final Integer key = new Integer(i.intValue());
-			
-			final Collection<Integer> leftValues = leftMap.get(i);
-			final Collection<String> rightValues = rightMap.get(key);
-	
-			if (rightValues == null) {
-				continue;
-			}
-	
-			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<TupleIntPairMatch>());
-			}
-	
-			final Collection<TupleIntPairMatch> matchedValues = map.get(key);
-	
-			for (Integer v : leftValues) {
-				for (String val : rightValues) {
-					matchedValues.add(new TupleIntPairMatch(v, val));
-				}
-			}
-		}
-	
-		return map;
-	}
-
-	
-	static Map<Integer, Collection<String>> collectTupleData(MutableObjectIterator<Tuple2<Integer, String>> iter)
-	throws Exception
-	{
-		Map<Integer, Collection<String>> map = new HashMap<>();
-		Tuple2<Integer, String> pair = new Tuple2<>();
-		
-		while ((pair = iter.next(pair)) != null) {
-
-			Integer key = pair.f0;
-			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<String>());
-			}
-
-			Collection<String> values = map.get(key);
-			values.add(pair.f1);
-		}
-
-		return map;
-	}
-	
-	static Map<Integer, Collection<Integer>> collectIntPairData(MutableObjectIterator<IntPair> iter)
-	throws Exception
-	{
-		Map<Integer, Collection<Integer>> map = new HashMap<>();
-		IntPair pair = new IntPair();
-		
-		while ((pair = iter.next(pair)) != null) {
-
-			final int key = pair.getKey();
-			final int value = pair.getValue();
-			if (!map.containsKey(key)) {
-				map.put(key, new ArrayList<Integer>());
-			}
-
-			Collection<Integer> values = map.get(key);
-			values.add(value);
-		}
-
-		return map;
-	}
-
-	/**
-	 * Private class used for storage of the expected matches in a hash-map.
-	 */
-	static class TupleMatch {
-		
-		private final String left;
-		private final String right;
-
-		public TupleMatch(String left, String right) {
-			this.left = left;
-			this.right = right;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			TupleMatch o = (TupleMatch) obj;
-			return this.left.equals(o.left) && this.right.equals(o.right);
-		}
-		
-		@Override
-		public int hashCode() {
-			return this.left.hashCode() ^ this.right.hashCode();
-		}
-
-		@Override
-		public String toString() {
-			return left + ", " + right;
-		}
-	}
-	
-	/**
-	 * Private class used for storage of the expected matches in a hash-map.
-	 */
-	static class TupleIntPairMatch
-	{
-		private final int left;
-		private final String right;
-
-		public TupleIntPairMatch(int left, String right) {
-			this.left = left;
-			this.right = right;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			TupleIntPairMatch o = (TupleIntPairMatch) obj;
-			return this.left == o.left && this.right.equals(o.right);
-		}
-		
-		@Override
-		public int hashCode() {
-			return this.left ^ this.right.hashCode();
-		}
-
-		@Override
-		public String toString() {
-			return left + ", " + right;
-		}
-	}
-	
 	static final class TupleMatchRemovingJoin implements FlatJoinFunction<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>>
 	{
 		private final Map<Integer, Collection<TupleMatch>> toRemoveFrom;
@@ -667,9 +608,9 @@ public class ReusingHashMatchIteratorITCase {
 		@Override
 		public void join(Tuple2<Integer, String> rec1, Tuple2<Integer, String> rec2, Collector<Tuple2<Integer, String>> out) throws Exception
 		{
-			Integer key = rec1.f0;
-			String value1 = rec1.f1;
-			String value2 = rec2.f1;
+			Integer key = rec1 != null ? rec1.f0 : rec2.f0;
+			String value1 = rec1 != null ? rec1.f1 : null;
+			String value2 = rec2 != null ? rec2.f1 : null;
 			//System.err.println("rec1 key = "+key+"  rec2 key= "+rec2.getField(0, TestData.Key.class));
 			Collection<TupleMatch> matches = this.toRemoveFrom.get(key);
 			if (matches == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/util/HashVsSortMiniBenchmark.java
@@ -29,8 +29,8 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashMatchIterator;
-import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashMatchIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildFirstHashJoinIterator;
+import org.apache.flink.runtime.operators.hash.ReusingBuildSecondHashJoinIterator;
 import org.apache.flink.runtime.operators.sort.ReusingMergeInnerJoinIterator;
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
 import org.apache.flink.runtime.operators.testutils.DiscardingOutputCollector;
@@ -180,11 +180,11 @@ public class HashVsSortMiniBenchmark {
 			long start = System.nanoTime();
 			
 			// compare with iterator values
-			final ReusingBuildFirstHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new ReusingBuildFirstHashMatchIterator<>(
+			final ReusingBuildFirstHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildFirstHashJoinIterator<>(
 						input1, input2, this.serializer1.getSerializer(), this.comparator1, 
 							this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
-							this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE, true);
+							this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE, false, true);
 			
 			iterator.open();
 			
@@ -219,11 +219,11 @@ public class HashVsSortMiniBenchmark {
 			long start = System.nanoTime();
 			
 			// compare with iterator values
-			ReusingBuildSecondHashMatchIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
-					new ReusingBuildSecondHashMatchIterator<>(
+			ReusingBuildSecondHashJoinIterator<Tuple2<Integer, String>, Tuple2<Integer, String>, Tuple2<Integer, String>> iterator =
+					new ReusingBuildSecondHashJoinIterator<>(
 						input1, input2, this.serializer1.getSerializer(), this.comparator1, 
 						this.serializer2.getSerializer(), this.comparator2, this.pairComparator11,
-						this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE, true);
+						this.memoryManager, this.ioManager, this.parentTask, MEMORY_SIZE, false, true);
 			
 			iterator.open();
 			

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -932,7 +932,13 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    * use. If null is given as the join strategy, then the optimizer will pick the strategy.
    */
   def fullOuterJoin[O](other: DataSet[O], strategy: JoinHint): UnfinishedOuterJoinOperation[T, O] =
-    new UnfinishedOuterJoinOperation(this, other, strategy, JoinType.FULL_OUTER)
+    strategy match {
+      case JoinHint.OPTIMIZER_CHOOSES |
+           JoinHint.REPARTITION_SORT_MERGE =>
+        new UnfinishedOuterJoinOperation(this, other, strategy, JoinType.FULL_OUTER)
+      case _ =>
+        throw new InvalidProgramException("Invalid JoinHint for FullOuterJoin: " + strategy)
+    }
 
   /**
    * An outer join on the left side.
@@ -960,7 +966,15 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    * @see #fullOuterJoin
    */
   def leftOuterJoin[O](other: DataSet[O], strategy: JoinHint): UnfinishedOuterJoinOperation[T, O] =
-    new UnfinishedOuterJoinOperation(this, other, strategy, JoinType.LEFT_OUTER)
+    strategy match {
+      case JoinHint.OPTIMIZER_CHOOSES |
+           JoinHint.REPARTITION_SORT_MERGE |
+           JoinHint.REPARTITION_HASH_SECOND |
+      JoinHint.BROADCAST_HASH_SECOND =>
+        new UnfinishedOuterJoinOperation(this, other, strategy, JoinType.LEFT_OUTER)
+      case _ =>
+        throw new InvalidProgramException("Invalid JoinHint for LeftOuterJoin: " + strategy)
+    }
 
   /**
    * An outer join on the right side.
@@ -988,7 +1002,15 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    * @see #fullOuterJoin
    */
   def rightOuterJoin[O](other: DataSet[O], strategy: JoinHint): UnfinishedOuterJoinOperation[T, O] =
-    new UnfinishedOuterJoinOperation(this, other, strategy, JoinType.RIGHT_OUTER)
+    strategy match {
+      case JoinHint.OPTIMIZER_CHOOSES |
+           JoinHint.REPARTITION_SORT_MERGE |
+           JoinHint.REPARTITION_HASH_FIRST |
+      JoinHint.BROADCAST_HASH_FIRST =>
+        new UnfinishedOuterJoinOperation(this, other, strategy, JoinType.RIGHT_OUTER)
+      case _ =>
+        throw new InvalidProgramException("Invalid JoinHint for RightOuterJoin: " + strategy)
+    }
 
   // --------------------------------------------------------------------------------------------
   //  Co-Group

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/OuterJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/OuterJoinITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.javaApiOperators;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.functions.RichFlatJoinFunction;
+import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -50,7 +51,21 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testUDFLeftOuterJoinOnTuplesWithKeyFieldPositions() throws Exception {
+	public void testLeftOuterJoin1() throws Exception {
+		testLeftOuterJoinOnTuplesWithKeyPositions(JoinHint.REPARTITION_SORT_MERGE);
+	}
+
+	@Test
+	public void testLeftOuterJoin2() throws Exception {
+		testLeftOuterJoinOnTuplesWithKeyPositions(JoinHint.REPARTITION_HASH_SECOND);
+	}
+
+	@Test
+	public void testLeftOuterJoin3() throws Exception {
+		testLeftOuterJoinOnTuplesWithKeyPositions(JoinHint.BROADCAST_HASH_SECOND);
+	}
+
+	private void testLeftOuterJoinOnTuplesWithKeyPositions(JoinHint hint) throws Exception {
 		/*
 		 * UDF Join on tuples with key field positions
 		 */
@@ -60,7 +75,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.getSmall5TupleDataSet(env);
 		DataSet<Tuple2<String, String>> joinDs =
-				ds1.leftOuterJoin(ds2)
+				ds1.leftOuterJoin(ds2, hint)
 						.where(0)
 						.equalTo(0)
 						.with(new T3T5FlatJoin());
@@ -76,7 +91,21 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testUDFRightOuterJoinOnTuplesWithKeyFieldPositions() throws Exception {
+	public void testRightOuterJoin1() throws Exception {
+		testRightOuterJoinOnTuplesWithKeyPositions(JoinHint.REPARTITION_SORT_MERGE);
+	}
+
+	@Test
+	public void testRightOuterJoin2() throws Exception {
+		testRightOuterJoinOnTuplesWithKeyPositions(JoinHint.REPARTITION_HASH_FIRST);
+	}
+
+	@Test
+	public void testRightOuterJoin3() throws Exception {
+		testRightOuterJoinOnTuplesWithKeyPositions(JoinHint.BROADCAST_HASH_FIRST);
+	}
+
+	private void testRightOuterJoinOnTuplesWithKeyPositions(JoinHint hint) throws Exception {
 		/*
 		 * UDF Join on tuples with key field positions
 		 */
@@ -86,7 +115,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.getSmall5TupleDataSet(env);
 		DataSet<Tuple2<String, String>> joinDs =
-				ds1.rightOuterJoin(ds2)
+				ds1.rightOuterJoin(ds2, hint)
 						.where(1)
 						.equalTo(1)
 						.with(new T3T5FlatJoin());
@@ -102,7 +131,11 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testUDFFullOuterJoinOnTuplesWithKeyFieldPositions() throws Exception {
+	public void testFullOuterJoin1() throws Exception {
+		testFullOuterJoinOnTuplesWithKeyPositions(JoinHint.REPARTITION_SORT_MERGE);
+	}
+
+	private void testFullOuterJoinOnTuplesWithKeyPositions(JoinHint hint) throws Exception {
 		/*
 		 * UDF Join on tuples with key field positions
 		 */
@@ -112,7 +145,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.getSmall5TupleDataSet(env);
 		DataSet<Tuple2<String, String>> joinDs =
-				ds1.fullOuterJoin(ds2)
+				ds1.fullOuterJoin(ds2, hint)
 						.where(0)
 						.equalTo(2)
 						.with(new T3T5FlatJoin());
@@ -128,7 +161,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testUDFJoinOnTuplesWithMultipleKeyFieldPositions() throws Exception {
+	public void testJoinOnTuplesWithCompositeKeyPositions() throws Exception {
 		/*
 		 * UDF Join on tuples with multiple key field positions
 		 */
@@ -183,7 +216,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testJoinOnACustomTypeInputWithKeyExtractorAndATupleInputWithKeyFieldSelector() throws Exception {
+	public void testJoinWithMixedKeyTypes1() throws Exception {
 		/*
 		 * Join on a tuple input with key field selector and a custom type input with key extractor
 		 */
@@ -218,7 +251,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 
 
 	@Test
-	public void testJoinOnATupleInputWithKeyFieldSelectorAndACustomTypeInputWithKeyExtractor()
+	public void testJoinWithMixedKeyTypes2()
 			throws Exception {
 		/*
 		 * Join on a tuple input with key field selector and a custom type input with key extractor
@@ -252,7 +285,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testUDFJoinOnTuplesWithTupleReturningKeySelectors() throws Exception {
+	public void testJoinWithTupleReturningKeySelectors() throws Exception {
 		/*
 		 * UDF Join on tuples with tuple-returning key selectors
 		 */
@@ -296,7 +329,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testJoinNestedPojoAgainstTupleSelectedUsingString() throws Exception {
+	public void testJoinWithNestedKeyExpression1() throws Exception {
 		/*
 		 * Join nested pojo against tuple (selected using a string)
 		 */
@@ -308,7 +341,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 				ds1.fullOuterJoin(ds2)
 						.where("nestedPojo.longNumber")
 						.equalTo("f6")
-						.with(new ProjectBothFunction());
+						.with(new ProjectBothFunction<POJO, Tuple7<Integer, String, Integer, Integer, Long, String, Long>>());
 
 		List<Tuple2<POJO, Tuple7<Integer, String, Integer, Integer, Long, String, Long>>> result = joinDs.collect();
 
@@ -320,7 +353,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testJoinNestedPojoAgainstTupleSelectedUsingInteger() throws Exception {
+	public void testJoinWithNestedKeyExpression2() throws Exception {
 		/*
 		 * Join nested pojo against tuple (selected as an integer)
 		 */
@@ -344,7 +377,7 @@ public class OuterJoinITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testSelectingMultipleFieldsUsingExpressionLanguage() throws Exception {
+	public void testJoinWithCompositeKeyExpressions() throws Exception {
 		/*
 		 * selecting multiple fields using expression language
 		 */


### PR DESCRIPTION
This PR adds hash-based execution strategies for left and right outer joins, that have the outer side as the probe side of a hash table.