### PR TITLE
[FLINK-2857] [gelly] API improvements

### DIFF
--- a/docs/libs/gelly_guide.md
+++ b/docs/libs/gelly_guide.md
@@ -149,6 +149,30 @@ val graph = Graph.fromDataSet(vertices, edges, env)
 </div>
 </div>
 
+* from a `DataSet` of `Tuple2` representing the edges. Gelly will convert each `Tuple2` to an `Edge`, where the first field will be the source ID and the second field will be the target ID. Both vertex and edge values will be set to `NullValue`.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+DataSet<Tuple2<String, String>> edges = ...
+
+Graph<String, NullValue, NullValue> graph = Graph.fromTuple2DataSet(edges, env);
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val env = ExecutionEnvironment.getExecutionEnvironment
+
+val edges: DataSet[(String, String)] = ...
+
+val graph = Graph.fromTuple2DataSet(edges, env)
+{% endhighlight %}
+</div>
+</div>
+
 * from a `DataSet` of `Tuple3` and an optional `DataSet` of `Tuple2`. In this case, Gelly will convert each `Tuple3` to an `Edge`, where the first field will be the source ID, the second field will be the target ID and the third field will be the edge value. Equivalently, each `Tuple2` will be converted to a `Vertex`, where the first field will be the vertex ID and the second field will be the vertex value:
 
 <div class="codetabs" markdown="1">
@@ -424,8 +448,8 @@ graph.subgraph((vertex => vertex.getValue > 0), (edge => edge.getValue < 0))
     <img alt="Filter Transformations" width="80%" src="fig/gelly-filter.png"/>
 </p>
 
-* <strong>Join</strong>: Gelly provides specialized methods for joining the vertex and edge datasets with other input datasets. `joinWithVertices` joins the vertices with a `Tuple2` input data set. The join is performed using the vertex ID and the first field of the `Tuple2` input as the join keys. The method returns a new `Graph` where the vertex values have been updated according to a provided user-defined map function.
-Similarly, an input dataset can be joined with the edges, using one of three methods. `joinWithEdges` expects an input `DataSet` of `Tuple3` and joins on the composite key of both source and target vertex IDs. `joinWithEdgesOnSource` expects a `DataSet` of `Tuple2` and joins on the source key of the edges and the first attribute of the input dataset and `joinWithEdgesOnTarget` expects a `DataSet` of `Tuple2` and joins on the target key of the edges and the first attribute of the input dataset. All three methods apply a map function on the edge and the input data set values.
+* <strong>Join</strong>: Gelly provides specialized methods for joining the vertex and edge datasets with other input datasets. `joinWithVertices` joins the vertices with a `Tuple2` input data set. The join is performed using the vertex ID and the first field of the `Tuple2` input as the join keys. The method returns a new `Graph` where the vertex values have been updated according to a provided user-defined tranformation function.
+Similarly, an input dataset can be joined with the edges, using one of three methods. `joinWithEdges` expects an input `DataSet` of `Tuple3` and joins on the composite key of both source and target vertex IDs. `joinWithEdgesOnSource` expects a `DataSet` of `Tuple2` and joins on the source key of the edges and the first attribute of the input dataset and `joinWithEdgesOnTarget` expects a `DataSet` of `Tuple2` and joins on the target key of the edges and the first attribute of the input dataset. All three methods apply a transformation function on the edge and the input data set values.
 Note that if the input dataset contains a key multiple times, all Gelly join methods will only consider the first value encountered.
 
 <div class="codetabs" markdown="1">
@@ -437,9 +461,9 @@ DataSet<Tuple2<Long, Long>> vertexOutDegrees = network.outDegrees();
 
 // assign the transition probabilities as the edge weights
 Graph<Long, Double, Double> networkWithWeights = network.joinWithEdgesOnSource(vertexOutDegrees,
-				new MapFunction<Tuple2<Double, Long>, Double>() {
-					public Double map(Tuple2<Double, Long> value) {
-						return value.f0 / value.f1;
+				new VertexJoinFunction<Double, Long>() {
+					public Double vertexJoin(Double vertexValue, Long inputValue) {
+						return vertexValue / inputValue;
 					}
 				});
 {% endhighlight %}

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -54,12 +54,13 @@ object Graph {
   /**
   * Creates a graph from a DataSet of edges.
   * Vertices are created automatically and their values are set by applying the provided
-  * map function to the vertex ids.
+  * vertexValueInitializer map function to the vertex ids.
   */
   def fromDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
-  TypeInformation : ClassTag](edges: DataSet[Edge[K, EV]], mapper: MapFunction[K, VV],
-      env: ExecutionEnvironment): Graph[K, VV, EV] = {
-    wrapGraph(jg.Graph.fromDataSet[K, VV, EV](edges.javaSet, mapper, env.getJavaEnv))
+  TypeInformation : ClassTag](edges: DataSet[Edge[K, EV]],
+  vertexValueInitializer: MapFunction[K, VV], env: ExecutionEnvironment): Graph[K, VV, EV] = {
+    wrapGraph(jg.Graph.fromDataSet[K, VV, EV](edges.javaSet, vertexValueInitializer,
+      env.getJavaEnv))
   }
 
   /**
@@ -84,16 +85,22 @@ object Graph {
   /**
   * Creates a graph from a Seq of edges.
   * Vertices are created automatically and their values are set by applying the provided
-  * map function to the vertex ids.
+  * vertexValueInitializer map function to the vertex ids.
   */
   def fromCollection[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
-  TypeInformation : ClassTag](edges: Seq[Edge[K, EV]], mapper: MapFunction[K, VV],
-      env: ExecutionEnvironment): Graph[K, VV, EV] = {
-    wrapGraph(jg.Graph.fromCollection[K, VV, EV](edges.asJavaCollection, mapper, env.getJavaEnv))
+  TypeInformation : ClassTag](edges: Seq[Edge[K, EV]], vertexValueInitializer: MapFunction[K, VV],
+  env: ExecutionEnvironment): Graph[K, VV, EV] = {
+    wrapGraph(jg.Graph.fromCollection[K, VV, EV](edges.asJavaCollection, vertexValueInitializer,
+      env.getJavaEnv))
   }
 
   /**
-  * Creates a Graph from a DataSets of Tuples.
+   * Creates a graph from DataSets of tuples for vertices and for edges.
+   * The first field of the Tuple2 vertex object will become the vertex ID
+   * and the second field will become the vertex value.
+   * The first field of the Tuple3 object for edges will become the source ID,
+   * the second field will become the target ID, and the third field will become
+   * the edge value. 
   */
   def fromTupleDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](vertices: DataSet[(K, VV)], edges: DataSet[(K, K, EV)],
@@ -101,11 +108,14 @@ object Graph {
     val javaTupleVertices = vertices.map(v => new jtuple.Tuple2(v._1, v._2)).javaSet
     val javaTupleEdges = edges.map(v => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
     wrapGraph(jg.Graph.fromTupleDataSet[K, VV, EV](javaTupleVertices, javaTupleEdges,
-        env.getJavaEnv))
+      env.getJavaEnv))
   }
 
   /**
   * Creates a Graph from a DataSet of Tuples representing the edges.
+  * The first field of the Tuple3 object for edges will become the source ID,
+  * the second field will become the target ID, and the third field will become
+  * the edge value. 
   * Vertices are created automatically and their values are set to NullValue.
   */
   def fromTupleDataSet[K: TypeInformation : ClassTag, EV: TypeInformation : ClassTag]
@@ -116,14 +126,45 @@ object Graph {
 
   /**
   * Creates a Graph from a DataSet of Tuples representing the edges.
+  * The first field of the Tuple3 object for edges will become the source ID,
+  * the second field will become the target ID, and the third field will become
+  * the edge value. 
   * Vertices are created automatically and their values are set by applying the provided
-  * map function to the vertex ids.
+  * vertexValueInitializer map function to the vertex ids.
   */
   def fromTupleDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
-  TypeInformation : ClassTag](edges: DataSet[(K, K, EV)], mapper: MapFunction[K, VV],
-      env: ExecutionEnvironment): Graph[K, VV, EV] = {
+  TypeInformation : ClassTag](edges: DataSet[(K, K, EV)],
+  vertexValueInitializer: MapFunction[K, VV], env: ExecutionEnvironment): Graph[K, VV, EV] = {
     val javaTupleEdges = edges.map(v => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
-    wrapGraph(jg.Graph.fromTupleDataSet[K, VV, EV](javaTupleEdges, mapper, env.getJavaEnv))
+    wrapGraph(jg.Graph.fromTupleDataSet[K, VV, EV](javaTupleEdges, vertexValueInitializer,
+      env.getJavaEnv))
+  }
+
+    /**
+  * Creates a Graph from a DataSet of Tuple2's representing the edges.
+  * The first field of the Tuple2 object for edges will become the source ID,
+  * the second field will become the target ID. The edge value will be set to NullValue.
+  * Vertices are created automatically and their values are set to NullValue.
+  */
+  def fromTuple2DataSet[K: TypeInformation : ClassTag](edges: DataSet[(K, K)],
+  env: ExecutionEnvironment): Graph[K, NullValue, NullValue] = {
+    val javaTupleEdges = edges.map(v => new jtuple.Tuple2(v._1, v._2)).javaSet
+    wrapGraph(jg.Graph.fromTuple2DataSet[K](javaTupleEdges, env.getJavaEnv))
+  }
+
+  /**
+  * Creates a Graph from a DataSet of Tuple2's representing the edges.
+  * The first field of the Tuple2 object for edges will become the source ID,
+  * the second field will become the target ID. The edge value will be set to NullValue.
+  * Vertices are created automatically and their values are set by applying the provided
+  * vertexValueInitializer map function to the vertex IDs.
+  */
+  def fromTuple2DataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag]
+  (edges: DataSet[(K, K)], vertexValueInitializer: MapFunction[K, VV],
+  env: ExecutionEnvironment): Graph[K, VV, NullValue] = {
+    val javaTupleEdges = edges.map(v => new jtuple.Tuple2(v._1, v._2)).javaSet
+    wrapGraph(jg.Graph.fromTuple2DataSet[K, VV](javaTupleEdges, vertexValueInitializer,
+      env.getJavaEnv))
   }
 
   /**
@@ -160,7 +201,8 @@ object Graph {
   * edges file.
   * @param includedFieldsEdges The fields in the edges file that should be read.
   * By default all fields are read.
-  * @param mapper If no vertex values are provided, this mapper can be used to initialize them.
+  * @param vertexValueInitializer If no vertex values are provided,
+  * this mapper can be used to initialize them, by applying a map transformation on the vertex IDs.
   * 
   */
   // scalastyle:off
@@ -186,7 +228,7 @@ object Graph {
       ignoreCommentsEdges: String = null,
       lenientEdges: Boolean = false,
       includedFieldsEdges: Array[Int] = null,
-      mapper: MapFunction[K, VV] = null) = {
+      vertexValueInitializer: MapFunction[K, VV] = null) = {
 
     // with vertex and edge values
     if (readVertices && hasEdgeValues) {
@@ -229,8 +271,8 @@ object Graph {
         includedFieldsEdges)
 
       // initializer provided
-      if (mapper != null) {
-        fromTupleDataSet[K, VV, EV](edges, mapper, env)
+      if (vertexValueInitializer != null) {
+        fromTupleDataSet[K, VV, EV](edges, vertexValueInitializer, env)
       }
       else {
         fromTupleDataSet[K, EV](edges, env) 
@@ -243,8 +285,8 @@ object Graph {
       lenientEdges, includedFieldsEdges).map(edge => (edge._1, edge._2, NullValue.getInstance))
 
       // no initializer provided
-      if (mapper != null) {
-        fromTupleDataSet[K, VV, NullValue](edges, mapper, env)
+      if (vertexValueInitializer != null) {
+        fromTupleDataSet[K, VV, NullValue](edges, vertexValueInitializer, env)
       }
       else {
         fromTupleDataSet[K, NullValue](edges, env) 

--- a/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphCreationWithCsvITCase.scala
+++ b/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphCreationWithCsvITCase.scala
@@ -101,7 +101,7 @@ MultipleProgramsTestBase(mode) {
     val graph = Graph.fromCsvReader[Long, Double, Long](
         readVertices = false,
         pathEdges = edgesSplit.getPath.toString,
-        mapper = new VertexDoubleIdAssigner(),
+        vertexValueInitializer = new VertexDoubleIdAssigner(),
         env = env)
     
     val result = graph.getTriplets.collect()

--- a/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/JoinWithEdgesITCase.scala
+++ b/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/JoinWithEdgesITCase.scala
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{After, Before, Rule, Test}
 import _root_.scala.collection.JavaConverters._
+import org.apache.flink.graph.EdgeJoinFunction
 
 @RunWith(classOf[Parameterized])
 class JoinWithEdgesITCase(mode: MultipleProgramsTestBase.TestExecutionMode) extends
@@ -127,10 +128,10 @@ MultipleProgramsTestBase(mode) {
   }
 
 
-  final class AddValuesMapper extends MapFunction[(Long, Long), Long] {
+  final class AddValuesMapper extends EdgeJoinFunction[Long, Long] {
     @throws(classOf[Exception])
-    def map(tuple: (Long, Long)): Long = {
-      tuple._1 + tuple._2
+    def edgeJoin(edgeValue: Long, inputValue: Long): Long = {
+      edgeValue + inputValue
     }
   }
 

--- a/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/JoinWithVerticesITCase.scala
+++ b/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/JoinWithVerticesITCase.scala
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{After, Before, Rule, Test}
 import _root_.scala.collection.JavaConverters._
+import org.apache.flink.graph.VertexJoinFunction
 
 @RunWith(classOf[Parameterized])
 class JoinWithVerticesITCase(mode: MultipleProgramsTestBase.TestExecutionMode) extends
@@ -63,11 +64,10 @@ MultipleProgramsTestBase(mode) {
     TestBaseUtils.compareResultAsTuples(res.asJava, expectedResult)
   }
 
-
-  final class AddValuesMapper extends MapFunction[(Long, Long), Long] {
+  final class AddValuesMapper extends VertexJoinFunction[Long, Long] {
     @throws(classOf[Exception])
-    def map(tuple: (Long, Long)): Long = {
-      tuple._1 + tuple._2
+    def vertexJoin(vertexValue: Long, inputValue: Long): Long = {
+      vertexValue + inputValue
     }
   }
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/EdgeJoinFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/EdgeJoinFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph;
+
+import java.io.Serializable;
+
+import org.apache.flink.api.common.functions.Function;
+
+/**
+ * Interface to be implemented by the transformation function
+ * applied in {@link Graph#joinWithEdges(DataSet, EdgeJoinFunction)},
+ * {@link Graph#joinWithEdgesOnSource(DataSet, EdgeJoinFunction)}, and
+ * {@link Graph#joinWithEdgesOnTarget(DataSet, EdgeJoinFunction)} methods.
+ *
+ * @param <EV> the edge value type
+ * @param <T> the input value type
+ */
+public interface EdgeJoinFunction<EV, T> extends Function, Serializable {
+
+	/**
+	 * Applies a transformation on the current edge value
+	 * and the value of the matched tuple of the input DataSet.
+	 * 
+	 * @param edgeValue the current edge value
+	 * @param inputValue the value of the matched Tuple2 input
+	 * @return the new edge value
+	 */
+	EV edgeJoin(EV edgeValue, T inputValue) throws Exception;
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/EdgesFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/EdgesFunction.java
@@ -34,5 +34,24 @@ import org.apache.flink.util.Collector;
  */
 public interface EdgesFunction<K, EV, O> extends Function, Serializable {
 
+	/**
+	 * This method is called per vertex and can iterate over all of its neighboring edges
+	 * with the specified direction.
+	 * <p>
+	 * If called with {@link EdgeDirection#OUT} the group will contain
+	 * the out-edges of the grouping vertex.
+	 * If called with {@link EdgeDirection#IN} the group will contain
+	 * the in-edges of the grouping vertex.
+	 * If called with {@link EdgeDirection#ALL} the group will contain
+	 * all edges of the grouping vertex.
+	 * <p>
+	 * The method can emit any number of output elements, including none.
+	 * 
+	 * @param edges the neighboring edges of the grouping vertex.
+	 * The first filed of each Tuple2 is the ID of the grouping vertex.
+	 * The second field is the neighboring edge.
+	 * @param out the collector to emit results to
+	 * @throws Exception
+	*/
 	void iterateEdges(Iterable<Tuple2<K, Edge<K, EV>>> edges, Collector<O> out) throws Exception;
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/EdgesFunctionWithVertexValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/EdgesFunctionWithVertexValue.java
@@ -35,5 +35,23 @@ import org.apache.flink.util.Collector;
  */
 public interface EdgesFunctionWithVertexValue<K, VV, EV, O> extends Function, Serializable {
 
-	void iterateEdges(Vertex<K, VV> v, Iterable<Edge<K, EV>> edges, Collector<O> out) throws Exception;
+	/**
+	 * This method is called per vertex and can iterate over all of its neighboring edges
+	 * with the specified direction.
+	 * <p>
+	 * If called with {@link EdgeDirection#OUT} the group will contain
+	 * the out-edges of the grouping vertex.
+	 * If called with {@link EdgeDirection#IN} the group will contain
+	 * the in-edges of the grouping vertex.
+	 * If called with {@link EdgeDirection#ALL} the group will contain
+	 * all edges of the grouping vertex.
+	 * <p>
+	 * The method can emit any number of output elements, including none.
+	 * 
+	 * @param vertex the grouping vertex
+	 * @param edges the neighboring edges of the grouping vertex.
+	 * @param out the collector to emit results to
+	 * @throws Exception
+	*/
+	void iterateEdges(Vertex<K, VV> vertex, Iterable<Edge<K, EV>> edges, Collector<O> out) throws Exception;
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -879,20 +879,21 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Compute an aggregate over the edges of each vertex. The function applied
-	 * on the edges has access to the vertex value.
+	 * Groups by vertex and computes a GroupReduce transformation over the edge values of each vertex.
+	 * The edgesFunction applied on the edges has access to both the id and the value
+	 * of the grouping vertex.
 	 * 
-	 * @param edgesFunction
-	 *            the function to apply to the neighborhood
-	 * @param direction
-	 *            the edge direction (in-, out-, all-)
-	 * @param <T>
-	 *            the output type
-	 * @return a dataset of a T
+	 * For each vertex, the edgesFunction can iterate over all edges of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param edgesFunction the group reduce function to apply to the neighboring edges of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
+	 * @param <T> the output type
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnEdges(EdgesFunctionWithVertexValue<K, VV, EV, T> edgesFunction,
-											EdgeDirection direction) throws IllegalArgumentException {
+			EdgeDirection direction) throws IllegalArgumentException {
 
 		switch (direction) {
 		case IN:
@@ -910,21 +911,22 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Compute an aggregate over the edges of each vertex. The function applied
-	 * on the edges has access to the vertex value.
-	 *
-	 * @param edgesFunction
-	 *            the function to apply to the neighborhood
-	 * @param direction
-	 *            the edge direction (in-, out-, all-)
-	 * @param <T>
-	 *            the output type
+	 * Groups by vertex and computes a GroupReduce transformation over the edge values of each vertex.
+	 * The edgesFunction applied on the edges has access to both the id and the value
+	 * of the grouping vertex.
+	 * 
+	 * For each vertex, the edgesFunction can iterate over all edges of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param edgesFunction the group reduce function to apply to the neighboring edges of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
+	 * @param <T> the output type
 	 * @param typeInfo the explicit return type.
-	 * @return a dataset of a T
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnEdges(EdgesFunctionWithVertexValue<K, VV, EV, T> edgesFunction,
-											EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
+			EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
 
 		switch (direction) {
 			case IN:
@@ -942,18 +944,19 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Compute an aggregate over the edges of each vertex. The function applied
-	 * on the edges only has access to the vertex id (not the vertex value).
+	 * Groups by vertex and computes a GroupReduce transformation over the edge values of each vertex.
+	 * The edgesFunction applied on the edges only has access to the vertex id (not the vertex value)
+	 * of the grouping vertex.
 	 * 
-	 * @param edgesFunction
-	 *            the function to apply to the neighborhood
-	 * @param direction
-	 *            the edge direction (in-, out-, all-)
-	 * @param <T>
-	 *            the output type
-	 * @return a dataset of T
+	 * For each vertex, the edgesFunction can iterate over all edges of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param edgesFunction the group reduce function to apply to the neighboring edges of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
+	 * @param <T> the output type
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnEdges(EdgesFunction<K, EV, T> edgesFunction,
 			EdgeDirection direction) throws IllegalArgumentException {
 
@@ -975,21 +978,22 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Compute an aggregate over the edges of each vertex. The function applied
-	 * on the edges only has access to the vertex id (not the vertex value).
-	 *
-	 * @param edgesFunction
-	 *            the function to apply to the neighborhood
-	 * @param direction
-	 *            the edge direction (in-, out-, all-)
-	 * @param <T>
-	 *            the output type
+	 * Groups by vertex and computes a GroupReduce transformation over the edge values of each vertex.
+	 * The edgesFunction applied on the edges only has access to the vertex id (not the vertex value)
+	 * of the grouping vertex.
+	 * 
+	 * For each vertex, the edgesFunction can iterate over all edges of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param edgesFunction the group reduce function to apply to the neighboring edges of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
+	 * @param <T> the output type
 	 * @param typeInfo the explicit return type.
-	 * @return a dataset of T
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnEdges(EdgesFunction<K, EV, T> edgesFunction,
-											EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
+			EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
 
 		switch (direction) {
 			case IN:
@@ -1596,18 +1600,22 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Compute an aggregate over the neighbors (edges and vertices) of each
-	 * vertex. The function applied on the neighbors has access to the vertex
-	 * value.
+	 * Groups by vertex and computes a GroupReduce transformation over the neighbors (both edges and vertices)
+	 * of each vertex. The neighborsFunction applied on the neighbors only has access to both the vertex id
+	 * and the vertex value of the grouping vertex.
 	 * 
-	 * @param neighborsFunction the function to apply to the neighborhood
-	 * @param direction the edge direction (in-, out-, all-)
+	 * For each vertex, the neighborsFunction can iterate over all neighbors of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param neighborsFunction the group reduce function to apply to the neighboring edges and vertices
+	 * of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
 	 * @param <T> the output type
-	 * @return a dataset of a T
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnNeighbors(NeighborsFunctionWithVertexValue<K, VV, EV, T> neighborsFunction,
-												EdgeDirection direction) throws IllegalArgumentException {
+			EdgeDirection direction) throws IllegalArgumentException {
 		switch (direction) {
 		case IN:
 			// create <edge-sourceVertex> pairs
@@ -1639,19 +1647,23 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Compute an aggregate over the neighbors (edges and vertices) of each
-	 * vertex. The function applied on the neighbors has access to the vertex
-	 * value.
-	 *
-	 * @param neighborsFunction the function to apply to the neighborhood
-	 * @param direction the edge direction (in-, out-, all-)
+	 * Groups by vertex and computes a GroupReduce transformation over the neighbors (both edges and vertices)
+	 * of each vertex. The neighborsFunction applied on the neighbors only has access to both the vertex id
+	 * and the vertex value of the grouping vertex.
+	 * 
+	 * For each vertex, the neighborsFunction can iterate over all neighbors of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param neighborsFunction the group reduce function to apply to the neighboring edges and vertices
+	 * of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
 	 * @param <T> the output type
-	 * @param typeInfo the explicit return type.
-	 * @return a dataset of a T
+	 * @param typeInfo the explicit return type
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnNeighbors(NeighborsFunctionWithVertexValue<K, VV, EV, T> neighborsFunction,
-												EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
+			EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
 		switch (direction) {
 			case IN:
 				// create <edge-sourceVertex> pairs
@@ -1682,20 +1694,23 @@ public class Graph<K, VV, EV> {
 		}
 	}
 
-
 	/**
-	 * Compute an aggregate over the neighbors (edges and vertices) of each
-	 * vertex. The function applied on the neighbors only has access to the
-	 * vertex id (not the vertex value).
+	 * Groups by vertex and computes a GroupReduce transformation over the neighbors (both edges and vertices)
+	 * of each vertex. The neighborsFunction applied on the neighbors only has access to the vertex id
+	 * (not the vertex value) of the grouping vertex.
 	 * 
-	 * @param neighborsFunction the function to apply to the neighborhood
-	 * @param direction the edge direction (in-, out-, all-)
+	 * For each vertex, the neighborsFunction can iterate over all neighbors of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param neighborsFunction the group reduce function to apply to the neighboring edges and vertices
+	 * of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
 	 * @param <T> the output type
-	 * @return a dataset of a T
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnNeighbors(NeighborsFunction<K, VV, EV, T> neighborsFunction,
-												EdgeDirection direction) throws IllegalArgumentException {
+			EdgeDirection direction) throws IllegalArgumentException {
 		switch (direction) {
 		case IN:
 			// create <edge-sourceVertex> pairs
@@ -1728,19 +1743,23 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Compute an aggregate over the neighbors (edges and vertices) of each
-	 * vertex. The function applied on the neighbors only has access to the
-	 * vertex id (not the vertex value).
-	 *
-	 * @param neighborsFunction the function to apply to the neighborhood
-	 * @param direction the edge direction (in-, out-, all-)
+	 * Groups by vertex and computes a GroupReduce transformation over the neighbors (both edges and vertices)
+	 * of each vertex. The neighborsFunction applied on the neighbors only has access to the vertex id
+	 * (not the vertex value) of the grouping vertex.
+	 * 
+	 * For each vertex, the neighborsFunction can iterate over all neighbors of this vertex
+	 * with the specified direction, and emit any number of output elements, including none.
+	 * 
+	 * @param neighborsFunction the group reduce function to apply to the neighboring edges and vertices
+	 * of each vertex.
+	 * @param direction the edge direction (in-, out-, all-).
 	 * @param <T> the output type
-	 * @param typeInfo the explicit return type.
-	 * @return a dataset of a T
+	 * @param typeInfo the explicit return type
+	 * @return a DataSet containing elements of type T
 	 * @throws IllegalArgumentException
-	 */
+	*/
 	public <T> DataSet<T> groupReduceOnNeighbors(NeighborsFunction<K, VV, EV, T> neighborsFunction,
-												EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
+			EdgeDirection direction, TypeInformation<T> typeInfo) throws IllegalArgumentException {
 		switch (direction) {
 			case IN:
 				// create <edge-sourceVertex> pairs
@@ -1988,7 +2007,7 @@ public class Graph<K, VV, EV> {
 	/**
 	 * Compute a reduce transformation over the edge values of each vertex.
 	 * For each vertex, the transformation consecutively calls a
-	 * {@link ReduceEdgesFunction} until only a single value for each vertex remains.
+	 * {@link ReduceEdgesFunction} until only a single value for each edge remains.
 	 * The {@link ReduceEdgesFunction} combines two edge values into one new value of the same type.
 	 *
 	 * @param reduceEdgesFunction the reduce function to apply to the neighbors of each vertex.
@@ -1999,7 +2018,7 @@ public class Graph<K, VV, EV> {
 	 * @throws IllegalArgumentException
 	*/
 	public DataSet<Tuple2<K, EV>> reduceOnEdges(ReduceEdgesFunction<EV> reduceEdgesFunction,
-								EdgeDirection direction) throws IllegalArgumentException {
+			EdgeDirection direction) throws IllegalArgumentException {
 
 		switch (direction) {
 			case IN:

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/NeighborsFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/NeighborsFunction.java
@@ -36,5 +36,24 @@ import org.apache.flink.util.Collector;
  */
 public interface NeighborsFunction<K, VV, EV, O> extends Function, Serializable {
 
+	/**
+	 * This method is called per vertex and can iterate over all of its neighbors
+	 * with the specified direction.
+	 * <p>
+	 * If called with {@link EdgeDirection#OUT} the group will contain
+	 * the out-edges and neighboring vertices of the grouping vertex.
+	 * If called with {@link EdgeDirection#IN} the group will contain
+	 * the in-edges and neighboring vertices of the grouping vertex.
+	 * If called with {@link EdgeDirection#ALL} the group will contain
+	 * all edges and neighboring vertices of the grouping vertex.
+	 * <p>
+	 * The method can emit any number of output elements, including none.
+	 * 
+	 * @param neighbors the neighbors of the grouping vertex.
+	 * The first filed of each Tuple3 is the ID of the grouping vertex.
+	 * The second field is the neighboring edge, and the third field is the neighboring vertex.
+	 * @param out the collector to emit results to
+	 * @throws Exception
+	*/
 	void iterateNeighbors(Iterable<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> neighbors, Collector<O> out) throws Exception;
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/NeighborsFunctionWithVertexValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/NeighborsFunctionWithVertexValue.java
@@ -36,5 +36,25 @@ import org.apache.flink.util.Collector;
  */
 public interface NeighborsFunctionWithVertexValue<K, VV, EV, O> extends Function, Serializable {
 
+	/**
+	 * This method is called per vertex and can iterate over all of its neighbors
+	 * with the specified direction.
+	 * <p>
+	 * If called with {@link EdgeDirection#OUT} the group will contain
+	 * the out-edges and neighboring vertices of the grouping vertex.
+	 * If called with {@link EdgeDirection#IN} the group will contain
+	 * the in-edges and neighboring vertices of the grouping vertex.
+	 * If called with {@link EdgeDirection#ALL} the group will contain
+	 * all edges and neighboring vertices of the grouping vertex.
+	 * <p>
+	 * The method can emit any number of output elements, including none.
+	 * 
+	 * @param vertex the grouping Vertex
+	 * @param neighbors the neighbors of the grouping vertex.
+	 * The first filed of each Tuple3 is the ID of the grouping vertex.
+	 * The second field is the neighboring edge, and the third field is the neighboring vertex.
+	 * @param out the collector to emit results to
+	 * @throws Exception
+	 */
 	void iterateNeighbors(Vertex<K, VV> vertex, Iterable<Tuple2<Edge<K, EV>, Vertex<K, VV>>> neighbors, Collector<O> out) throws Exception;
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/ReduceEdgesFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/ReduceEdgesFunction.java
@@ -30,5 +30,14 @@ import java.io.Serializable;
  */
 public interface ReduceEdgesFunction<EV> extends Function, Serializable {
 
+	/**
+	 * It combines two neighboring edge values into one new value of the same type.
+	 * For each vertex, this function is consecutively called,
+	 * until only a single value for each edge remains.
+	 * 
+	 * @param firstEdgeValue the first neighboring edge value to combine
+	 * @param secondEdgeValue the second neighboring edge value to combine
+	 * @return the combined value of both input values
+	 */
 	EV reduceEdges(EV firstEdgeValue, EV secondEdgeValue);
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/ReduceNeighborsFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/ReduceNeighborsFunction.java
@@ -31,5 +31,14 @@ import java.io.Serializable;
  */
 public interface ReduceNeighborsFunction <VV> extends Function, Serializable {
 
+	/**
+	 * It combines two neighboring vertex values into one new value of the same type.
+	 * For each vertex, this function is consecutively called,
+	 * until only a single value for each vertex remains.
+	 * 
+	 * @param firstNeighborValue the first neighboring vertex value to combine
+	 * @param secondNeighborValue the second neighboring vertex value to combine
+	 * @return the combined value of both input values
+	 */
 	VV reduceNeighbors(VV firstNeighborValue, VV secondNeighborValue);
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/VertexJoinFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/VertexJoinFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph;
+
+import java.io.Serializable;
+
+import org.apache.flink.api.common.functions.Function;
+
+/**
+ * Interface to be implemented by the transformation function
+ * applied in {@link Graph#joinWithVertices(DataSet, VertexJoinFunction)} method.
+ *
+ * @param <VV> the vertex value type
+ * @param <T> the input value type
+ */
+public interface VertexJoinFunction<VV, T> extends Function, Serializable {
+
+	/**
+	 * Applies a transformation on the current vertex value
+	 * and the value of the matched tuple of the input DataSet.
+	 * 
+	 * @param vertexValue the current vertex value
+	 * @param inputValue the value of the matched Tuple2 input
+	 * @return the new vertex value
+	 */
+	VV vertexJoin(VV vertexValue, T inputValue) throws Exception;
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/EuclideanGraphWeighing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/EuclideanGraphWeighing.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.EdgeJoinFunction;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Triplet;
 import org.apache.flink.graph.Vertex;
@@ -90,11 +91,10 @@ public class EuclideanGraphWeighing implements ProgramDescription {
 				});
 
 		Graph<Long, Point, Double> resultedGraph = graph.joinWithEdges(edgesWithEuclideanWeight,
-				new MapFunction<Tuple2<Double, Double>, Double>() {
+				new EdgeJoinFunction<Double, Double>() {
 
-					@Override
-					public Double map(Tuple2<Double, Double> distance) throws Exception {
-						return distance.f1;
+					public Double edgeJoin(Double edgeValue, Double inputValue) {
+						return inputValue;
 					}
 				});
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/JaccardSimilarityMeasure.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/JaccardSimilarityMeasure.java
@@ -29,6 +29,7 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.ReduceNeighborsFunction;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.Triplet;
+import org.apache.flink.graph.VertexJoinFunction;
 import org.apache.flink.graph.example.utils.JaccardSimilarityMeasureData;
 
 import java.util.HashSet;
@@ -88,12 +89,11 @@ public class JaccardSimilarityMeasure implements ProgramDescription {
 
 		// join with the vertices to update the node values
 		Graph<Long, HashSet<Long>, Double> graphWithVertexValues =
-				graph.joinWithVertices(computedNeighbors, new MapFunction<Tuple2<HashSet<Long>, HashSet<Long>>,
+				graph.joinWithVertices(computedNeighbors, new VertexJoinFunction<HashSet<Long>,
 						HashSet<Long>>() {
 
-					@Override
-					public HashSet<Long> map(Tuple2<HashSet<Long>, HashSet<Long>> tuple2) throws Exception {
-						return tuple2.f1;
+					public HashSet<Long> vertexJoin(HashSet<Long> vertexValue, HashSet<Long> inputValue) {
+						return inputValue;
 					}
 				});
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/MusicProfiles.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/MusicProfiles.java
@@ -37,6 +37,7 @@ import org.apache.flink.graph.EdgeDirection;
 import org.apache.flink.graph.EdgesFunctionWithVertexValue;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.VertexJoinFunction;
 import org.apache.flink.graph.example.utils.MusicProfilesData;
 import org.apache.flink.graph.library.LabelPropagation;
 import org.apache.flink.types.NullValue;
@@ -149,9 +150,9 @@ public class MusicProfiles implements ProgramDescription {
 
 		DataSet<Vertex<String, Long>> verticesWithCommunity = similarUsersGraph
 				.joinWithVertices(idsWithInitialLabels,
-						new MapFunction<Tuple2<Long, Long>, Long>() {
-							public Long map(Tuple2<Long, Long> value) {
-								return value.f1;
+						new VertexJoinFunction<Long, Long>() {
+							public Long vertexJoin(Long vertexValue, Long inputValue) {
+								return inputValue;
 							}
 						}).run(new LabelPropagation<String, NullValue>(maxIterations));
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAPageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAPageRank.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.graph.library;
 
-import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.EdgeJoinFunction;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
@@ -68,7 +68,7 @@ public class GSAPageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet
 		DataSet<Tuple2<K, Long>> vertexOutDegrees = network.outDegrees();
 
 		Graph<K, Double, Double> networkWithWeights = network
-				.joinWithEdgesOnSource(vertexOutDegrees, new InitWeightsMapper());
+				.joinWithEdgesOnSource(vertexOutDegrees, new InitWeights());
 
 		return networkWithWeights.runGatherSumApplyIteration(new GatherRanks(numberOfVertices), new SumRanks(),
 				new UpdateRanks<K>(beta, numberOfVertices), maxIterations)
@@ -127,9 +127,10 @@ public class GSAPageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet
 	}
 
 	@SuppressWarnings("serial")
-	private static final class InitWeightsMapper implements MapFunction<Tuple2<Double, Long>, Double> {
-		public Double map(Tuple2<Double, Long> value) {
-			return value.f0 / value.f1;
+	private static final class InitWeights implements EdgeJoinFunction<Double, Long> {
+
+		public Double edgeJoin(Double edgeValue, Long inputValue) {
+			return edgeValue / (double) inputValue;
 		}
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSATriangleCount.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSATriangleCount.java
@@ -31,6 +31,7 @@ import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Triplet;
 import org.apache.flink.graph.EdgeDirection;
 import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.VertexJoinFunction;
 import org.apache.flink.types.NullValue;
 
 import java.util.TreeMap;
@@ -143,12 +144,13 @@ public class GSATriangleCount<K extends Comparable<K>, VV, EV> implements
 	}
 
 	@SuppressWarnings("serial")
-	private static final class AttachValues<K> implements MapFunction<Tuple2<TreeMap<K, Integer>,
-			TreeMap<K, Integer>>, TreeMap<K, Integer>> {
+	private static final class AttachValues<K> implements VertexJoinFunction<TreeMap<K, Integer>,
+			TreeMap<K, Integer>> {
 
 		@Override
-		public TreeMap<K, Integer> map(Tuple2<TreeMap<K, Integer>, TreeMap<K, Integer>> tuple2) throws Exception {
-			return tuple2.f1;
+		public TreeMap<K, Integer> vertexJoin(TreeMap<K, Integer> vertexValue,
+				TreeMap<K, Integer> inputValue) {
+			return inputValue;
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/PageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/PageRank.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.graph.library;
 
-import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.EdgeJoinFunction;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
@@ -74,7 +74,7 @@ public class PageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet<Ve
 		DataSet<Tuple2<K, Long>> vertexOutDegrees = network.outDegrees();
 
 		Graph<K, Double, Double> networkWithWeights = network
-				.joinWithEdgesOnSource(vertexOutDegrees, new InitWeightsMapper());
+				.joinWithEdgesOnSource(vertexOutDegrees, new InitWeights());
 
 		return networkWithWeights.runVertexCentricIteration(new VertexRankUpdater<K>(beta, numberOfVertices),
 				new RankMessenger<K>(numberOfVertices), maxIterations)
@@ -137,9 +137,10 @@ public class PageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet<Ve
 	}
 
 	@SuppressWarnings("serial")
-	private static final class InitWeightsMapper implements MapFunction<Tuple2<Double, Long>, Double> {
-		public Double map(Tuple2<Double, Long> value) {
-			return value.f0 / value.f1;
+	private static final class InitWeights implements EdgeJoinFunction<Double, Long> {
+
+		public Double edgeJoin(Double edgeValue, Long inputValue) {
+			return edgeValue / (double) inputValue;
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationITCase.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
@@ -151,6 +152,59 @@ public class GraphCreationITCase extends MultipleProgramsTestBase {
 		compareResultAsText(result, expectedResult);
 	}
 
+	@Test
+	public void testFromTuple2() throws Exception {
+		/*
+		 * Test graph creation with fromTuple2DataSet
+		 */
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<Long, Long>> edges = TestGraphUtils.getLongLongTuple2Data(env);
+
+		Graph<Long, NullValue, NullValue> graph = Graph.fromTuple2DataSet(edges, env);
+
+        List<Vertex<Long, NullValue>> result = graph.getVertices().collect();
+        
+		expectedResult = "1,(null)\n" +
+					"2,(null)\n" +
+					"3,(null)\n" +
+					"4,(null)\n" +
+					"6,(null)\n" +
+					"10,(null)\n" +
+					"20,(null)\n" +
+					"30,(null)\n" +
+					"40,(null)\n" +
+					"60,(null)\n";
+
+		compareResultAsTuples(result, expectedResult);
+	}
+
+	@Test
+	public void testFromTuple2WithMapper() throws Exception {
+		/*
+		 * Test graph creation with fromTuple2DataSet with vertex initializer
+		 */
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple2<Long, Long>> edges = TestGraphUtils.getLongLongTuple2Data(env);
+
+		Graph<Long, String, NullValue> graph = Graph.fromTuple2DataSet(edges,
+				new BooMapper(), env);
+
+        List<Vertex<Long, String>> result = graph.getVertices().collect();
+        
+		expectedResult = "1,boo\n" +
+					"2,boo\n" +
+					"3,boo\n" +
+					"4,boo\n" +
+					"6,boo\n" +
+					"10,boo\n" +
+					"20,boo\n" +
+					"30,boo\n" +
+					"40,boo\n" +
+					"60,boo\n";
+
+		compareResultAsTuples(result, expectedResult);
+	}
+
 	@SuppressWarnings("serial")
 	private static final class AssignIdAsValueMapper implements MapFunction<Long, Long> {
 		public Long map(Long vertexId) {
@@ -170,5 +224,10 @@ public class GraphCreationITCase extends MultipleProgramsTestBase {
 			dummyValue.setTField(vertexId*2.0);
 			return dummyValue;
 		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class BooMapper implements MapFunction<Long, String> {
+		public String map(Long value) {	return "boo"; }
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithEdgesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithEdgesITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.EdgeJoinFunction;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.test.TestGraphUtils;
 import org.apache.flink.graph.test.TestGraphUtils.DummyCustomParameterizedType;
@@ -462,9 +463,10 @@ public class JoinWithEdgesITCase extends MultipleProgramsTestBase {
     }
 
 	@SuppressWarnings("serial")
-	private static final class AddValuesMapper implements MapFunction<Tuple2<Long, Long>, Long> {
-		public Long map(Tuple2<Long, Long> tuple) throws Exception {
-			return tuple.f0 + tuple.f1;
+	private static final class AddValuesMapper implements EdgeJoinFunction<Long, Long> {
+
+		public Long edgeJoin(Long edgeValue, Long inputValue) throws Exception {
+			return edgeValue + inputValue;
 		}
 	}
 
@@ -477,29 +479,34 @@ public class JoinWithEdgesITCase extends MultipleProgramsTestBase {
     }
 
 	@SuppressWarnings("serial")
-	private static final class DoubleIfTrueMapper implements MapFunction<Tuple2<Long, Boolean>, Long> {
-        public Long map(Tuple2<Long, Boolean> tuple) throws Exception {
-            if(tuple.f1) {
-                return tuple.f0 * 2;
+	private static final class DoubleIfTrueMapper implements EdgeJoinFunction<Long, Boolean> {
+
+		public Long edgeJoin(Long edgeValue, Boolean inputValue) {
+            if(inputValue) {
+                return edgeValue * 2;
             }
             else {
-                return tuple.f0;
+                return edgeValue;
             }
-        }
+		}
     }
 
 	@SuppressWarnings("serial")
-	private static final class DoubleValueMapper implements MapFunction<Tuple2<Long, Long>, Long> {
-        public Long map(Tuple2<Long, Long> tuple) throws Exception {
-            return tuple.f1 * 2;
-        }
+	private static final class DoubleValueMapper implements EdgeJoinFunction<Long, Long> {
+ 
+		public Long edgeJoin(Long edgeValue, Long inputValue) {
+			return inputValue*2;
+		}
     }
 
 	@SuppressWarnings("serial")
-	private static final class CustomValueMapper implements MapFunction<Tuple2<Long, DummyCustomParameterizedType<Float>>, Long> {
-        public Long map(Tuple2<Long, DummyCustomParameterizedType<Float>> tuple) throws Exception {
-            return (long) tuple.f1.getIntField();
-        }
+	private static final class CustomValueMapper implements EdgeJoinFunction<
+	Long, DummyCustomParameterizedType<Float>> {
+
+		public Long edgeJoin(Long edgeValue,
+				DummyCustomParameterizedType<Float> inputValue) {
+			return (long) inputValue.getIntField();
+		}
     }
 
 	@SuppressWarnings("serial")

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithVerticesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithVerticesITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.VertexJoinFunction;
 import org.apache.flink.graph.test.TestGraphUtils;
 import org.apache.flink.graph.test.TestGraphUtils.DummyCustomParameterizedType;
 import org.apache.flink.graph.utils.VertexToTuple2Map;
@@ -173,9 +174,10 @@ public class JoinWithVerticesITCase extends MultipleProgramsTestBase {
     }
 
 	@SuppressWarnings("serial")
-	private static final class AddValuesMapper implements MapFunction<Tuple2<Long, Long>, Long> {
-		public Long map(Tuple2<Long, Long> tuple) throws Exception {
-			return tuple.f0 + tuple.f1;
+	private static final class AddValuesMapper implements VertexJoinFunction<Long, Long> {
+
+		public Long vertexJoin(Long vertexValue, Long inputValue) {
+			return vertexValue + inputValue;
 		}
 	}
 
@@ -187,28 +189,32 @@ public class JoinWithVerticesITCase extends MultipleProgramsTestBase {
     }
 
 	@SuppressWarnings("serial")
-	private static final class DoubleIfTrueMapper implements MapFunction<Tuple2<Long, Boolean>, Long> {
-        public Long map(Tuple2<Long, Boolean> tuple) throws Exception {
-            if(tuple.f1) {
-                return tuple.f0 * 2;
+	private static final class DoubleIfTrueMapper implements VertexJoinFunction<Long, Boolean> {
+
+		public Long vertexJoin(Long vertexValue, Boolean inputValue) {
+            if(inputValue) {
+                return vertexValue * 2;
             }
             else {
-                return tuple.f0;
+                return vertexValue;
             }
-        }
+		}
     }
 
 	@SuppressWarnings("serial")
-	private static final class ProjectSecondMapper implements MapFunction<Tuple2<Long, Long>, Long> {
-        public Long map(Tuple2<Long, Long> tuple) throws Exception {
-            return tuple.f1;
-        }
+	private static final class ProjectSecondMapper implements VertexJoinFunction<Long, Long> {
+
+		public Long vertexJoin(Long vertexValue, Long inputValue) {
+			return inputValue;
+		}
     }
 
 	@SuppressWarnings("serial")
-	private static final class CustomValueMapper implements MapFunction<Tuple2<Long, DummyCustomParameterizedType<Float>>, Long> {
-        public Long map(Tuple2<Long, DummyCustomParameterizedType<Float>> tuple) throws Exception {
-            return (long) tuple.f1.getIntField();
-        }
+	private static final class CustomValueMapper implements VertexJoinFunction<Long,
+		DummyCustomParameterizedType<Float>> {
+
+		public Long vertexJoin(Long vertexValue, DummyCustomParameterizedType<Float> inputValue) {
+			return (long) inputValue.getIntField();
+		}
     }
 }


### PR DESCRIPTION
This PR:
- renames the mapper parameter in creation methods to `vertexInitializer`, so that its purpose is easier to understand.
- add `fromTuple2DataSet` methods to easily create graphs from `Tuple2` datasets, i.e. edges with no values.
- replaces the mapper UDFs in the `joinWith*` with `VertexJoinFunction` and `EdgeJoinFunction`. These have flattened parameters and their purpose is more intuitive.
- improves the java/scala docs of several methods.
- updates docs accordingly.