### PR TITLE
[FLINK-2872] [Documentation] Update the documentation for Scala part to add ExecutionEnvironment.readFileOfPrimitives.

### DIFF
--- a/docs/apis/programming_guide.md
+++ b/docs/apis/programming_guide.md
@@ -1721,7 +1721,8 @@ File-based:
   Returns a DataSet of tuples or POJOs. Supports the basic java types and their Value counterparts as field
   types.
 
-- `readFileOfPrimitives(path, Class)` / `PrimitiveInputFormat` - Parses files of new-line (or another char sequence) delimited primitive data types such as `String` or `Integer`. 
+- `readFileOfPrimitives(path, Class)` / `PrimitiveInputFormat` - Parses files of new-line (or another char sequence)
+  delimited primitive data types such as `String` or `Integer`. 
 
 Collection-based:
 
@@ -1855,6 +1856,9 @@ File-based:
 - `readCsvFile(path)` / `CsvInputFormat` - Parses files of comma (or another char) delimited fields.
   Returns a DataSet of tuples, case class objects, or POJOs. Supports the basic java types and their Value counterparts as field
   types.
+
+- `readFileOfPrimitives(path, delimiter)` / `PrimitiveInputFormat` - Parses files of new-line (or another char sequence)
+  delimited primitive data types such as `String` or `Integer`.
 
 Collection-based:
 

--- a/docs/apis/programming_guide.md
+++ b/docs/apis/programming_guide.md
@@ -1722,7 +1722,10 @@ File-based:
   types.
 
 - `readFileOfPrimitives(path, Class)` / `PrimitiveInputFormat` - Parses files of new-line (or another char sequence)
-  delimited primitive data types such as `String` or `Integer`. 
+  delimited primitive data types such as `String` or `Integer`.
+   
+- `readFileOfPrimitives(path, delimiter, Class)` / `PrimitiveInputFormat` - Parses files of new-line (or another char sequence)
+   delimited primitive data types such as `String` or `Integer` using the given delimiter.
 
 Collection-based:
 
@@ -1858,7 +1861,7 @@ File-based:
   types.
 
 - `readFileOfPrimitives(path, delimiter)` / `PrimitiveInputFormat` - Parses files of new-line (or another char sequence)
-  delimited primitive data types such as `String` or `Integer`.
+  delimited primitive data types such as `String` or `Integer` using the given delimiter.
 
 Collection-based:
 


### PR DESCRIPTION
Add the missing Scala part for ExecutionEnvironment.readFileOfPrimitives API doc in the
programming guide.