### PR TITLE
[FLINK-2880] [streaming] [API-Breaking] Allow DeserializationSchema to forward exceptions

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-staging/flink-streaming/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -76,6 +76,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import scala.collection.Seq;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1012,7 +1013,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 	private static void printTopic(String topicName, ConsumerConfig config,
 								DeserializationSchema<?> deserializationSchema,
-								int stopAfter) {
+								int stopAfter) throws IOException {
 
 		List<MessageAndMetadata<byte[], byte[]>> contents = readTopicToList(topicName, config, stopAfter);
 		LOG.info("Printing contents of topic {} in consumer grouo {}", topicName, config.groupId());
@@ -1023,7 +1024,9 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		}
 	}
 
-	private static void printTopic(String topicName, int elements,DeserializationSchema<?> deserializer) {
+	private static void printTopic(String topicName, int elements,DeserializationSchema<?> deserializer) 
+			throws IOException
+	{
 		// write the sequence to log for debugging purposes
 		Properties stdProps = standardCC.props().props();
 		Properties newProps = new Properties(stdProps);

--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/util/serialization/DeserializationSchema.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/util/serialization/DeserializationSchema.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.util.serialization;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -36,7 +37,7 @@ public interface DeserializationSchema<T> extends Serializable, ResultTypeQuerya
 	 * @param message The message, as a byte array.
 	 * @return The deserialized message as an object.
 	 */
-	T deserialize(byte[] message);
+	T deserialize(byte[] message) throws IOException;
 
 	/**
 	 * Method to decide whether the element signals the end of the stream. If


### PR DESCRIPTION
The DeserializationSchema is now allowed to forward exceptions on deserialization.
This is useful because many non-trivial decoders (Flink's TypeSerializers, Avro, etc) may throw exceptions. Otherwise, this leads to clumly catching and nesting of exceptions.
