### PR TITLE
[FLINK-2878] [webmonitor] Fix unexpected leader address pattern

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/HandlerRedirectUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/HandlerRedirectUtils.java
@@ -25,9 +25,11 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.webmonitor.files.MimeTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Option;
 import scala.Tuple2;
 
 import java.io.UnsupportedEncodingException;
@@ -58,7 +60,10 @@ public class HandlerRedirectUtils {
 		final String leaderAddress = leader._1().path();
 		final int webMonitorPort = leader._2();
 
-		if (!localJobManagerAddress.equals(leaderAddress)) {
+		final String jobManagerName = localJobManagerAddress.substring(localJobManagerAddress.lastIndexOf("/") + 1);
+
+		if (!localJobManagerAddress.equals(leaderAddress) &&
+			!leaderAddress.equals(JobManager.getLocalJobManagerAkkaURL(Option.apply(jobManagerName)))) {
 			// We are not the leader and need to redirect
 			Matcher matcher = LeaderAddressHostPattern.matcher(leaderAddress);
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/HandlerRedirectUtilsTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/HandlerRedirectUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
+import org.junit.Test;
+import org.junit.Assert;
+import scala.Tuple2;
+
+public class HandlerRedirectUtilsTest {
+
+	static final String localJobManagerAddress = "akka.tcp://flink@127.0.0.1:1234/user/foobar";
+	static final String remoteURL = "127.0.0.2:1235";
+	static final String remotePath = "akka.tcp://flink@" + remoteURL + "/user/jobmanager";
+
+	@Test
+	public void testGetRedirectAddressWithLocalAkkaPath() throws Exception {
+		ActorGateway leaderGateway = new DummyActorGateway("akka://flink/user/foobar");
+
+		Tuple2<ActorGateway, Integer> leader = new Tuple2<>(leaderGateway, 1235);
+
+		String redirectingAddress =HandlerRedirectUtils.getRedirectAddress(localJobManagerAddress, leader);
+
+		Assert.assertNull(redirectingAddress);
+	}
+
+	@Test
+	public void testGetRedirectAddressWithRemoteAkkaPath() throws Exception {
+		ActorGateway leaderGateway = new DummyActorGateway(remotePath);
+
+		Tuple2<ActorGateway, Integer> leader = new Tuple2<>(leaderGateway, 1235);
+
+		String redirectingAddress =HandlerRedirectUtils.getRedirectAddress(localJobManagerAddress, leader);
+
+		Assert.assertEquals(remoteURL, redirectingAddress);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyActorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/DummyActorGateway.java
@@ -30,6 +30,17 @@ import java.util.UUID;
  */
 public class DummyActorGateway implements ActorGateway {
 	public static final DummyActorGateway INSTANCE = new DummyActorGateway();
+	private static final long serialVersionUID = -833861606769367952L;
+
+	private final String path;
+
+	public DummyActorGateway() {
+		this("DummyActorGateway");
+	}
+
+	public DummyActorGateway(String path) {
+		this.path = path;
+	}
 
 	@Override
 	public Future<Object> ask(Object message, FiniteDuration timeout) {
@@ -52,7 +63,7 @@ public class DummyActorGateway implements ActorGateway {
 
 	@Override
 	public String path() {
-		return "DummyInstanceGateway";
+		return path;
 	}
 
 	@Override


### PR DESCRIPTION
The HandlerRedirectUtils.getRedirectAddress decides whether the retrieved leader address is equal to the local job manager address. The local job manager address is, however, in the form akka.tcp://flink@url/user/jobmanager whereas the leader address can be akka://flink/user/jobmanager if the local job manager is the current leader. Such a case produced a warning which is not correct. This PR checks for the local job manager address and signals that no redirection has to be done if it receives akka://flink/user/jobmanager.