### PR TITLE
FLINK-2866 Potential resource leak due to unclosed ObjectInputStream in FileSerializableStateHandle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileSerializableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileSerializableStateHandle.java
@@ -46,8 +46,9 @@ public class FileSerializableStateHandle<T> extends AbstractFileState implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public T getState(ClassLoader classLoader) throws Exception {
-		FSDataInputStream inStream = getFileSystem().open(getFilePath());
-		ObjectInputStream ois = new InstantiationUtil.ClassLoaderObjectInputStream(inStream, classLoader);
-		return (T) ois.readObject();
+		try (FSDataInputStream inStream = getFileSystem().open(getFilePath())) {
+			ObjectInputStream ois = new InstantiationUtil.ClassLoaderObjectInputStream(inStream, classLoader);
+			return (T) ois.readObject();
+		}
 	}
 }


### PR DESCRIPTION
Use try-with-resources to close FSDataInputStream