### PR TITLE
[FLINK-2891] Set KV-State key upon Window Evaluation in General Windows

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/NonKeyedWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/NonKeyedWindowOperator.java
@@ -241,10 +241,12 @@ public class NonKeyedWindowOperator<IN, OUT, W extends Window>
 	protected void emitWindow(Context context) throws Exception {
 		timestampedCollector.setTimestamp(context.window.maxTimestamp());
 
-		userFunction.apply(
-				context.window,
-				context.windowBuffer.getUnpackedElements(),
-				timestampedCollector);
+		if (context.windowBuffer.size() > 0) {
+			userFunction.apply(
+					context.window,
+					context.windowBuffer.getUnpackedElements(),
+					timestampedCollector);
+		}
 	}
 
 	private void processTriggerResult(Trigger.TriggerResult triggerResult, W window) throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -286,10 +286,15 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 	protected void emitWindow(Context context) throws Exception {
 		timestampedCollector.setTimestamp(context.window.maxTimestamp());
 
-		userFunction.apply(context.key,
-				context.window,
-				context.windowBuffer.getUnpackedElements(),
-				timestampedCollector);
+
+		if (context.windowBuffer.size() > 0) {
+			setKeyContextElement(context.windowBuffer.getElements().iterator().next());
+
+			userFunction.apply(context.key,
+					context.window,
+					context.windowBuffer.getUnpackedElements(),
+					timestampedCollector);
+		}
 	}
 
 	private void processTriggerResult(Trigger.TriggerResult triggerResult, K key, W window) throws Exception {


### PR DESCRIPTION
Before, this was not set, leading to incorrect results if KV-State was
used in the WindowFunction.

This also adds a test.