### PR TITLE
[FLINK-2866] [FLINK-2888] [FLINK-2891] Fixes for various release blocking issues

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapKvState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapKvState.java
@@ -88,7 +88,8 @@ public abstract class AbstractHeapKvState<K, V, Backend extends StateBackend<Bac
 	@Override
 	public V value() {
 		V value = state.get(currentKey);
-		return value != null ? value : defaultValue;
+		return value != null ? value : 
+				(defaultValue == null ? null : valueSerializer.copy(defaultValue));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileSerializableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileSerializableStateHandle.java
@@ -46,8 +46,9 @@ public class FileSerializableStateHandle<T> extends AbstractFileState implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public T getState(ClassLoader classLoader) throws Exception {
-		FSDataInputStream inStream = getFileSystem().open(getFilePath());
-		ObjectInputStream ois = new InstantiationUtil.ClassLoaderObjectInputStream(inStream, classLoader);
-		return (T) ois.readObject();
+		try (FSDataInputStream inStream = getFileSystem().open(getFilePath())) {
+			ObjectInputStream ois = new InstantiationUtil.ClassLoaderObjectInputStream(inStream, classLoader);
+			return (T) ois.readObject();
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
@@ -21,14 +21,11 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.FloatSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.IntValueSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.typeutils.runtime.ValueSerializer;
-import org.apache.flink.runtime.state.KvState;
-import org.apache.flink.runtime.state.KvStateSnapshot;
-import org.apache.flink.runtime.state.StateBackend;
-import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.types.IntValue;
 import org.apache.flink.types.StringValue;
 import org.junit.Test;
 
@@ -273,6 +270,30 @@ public class MemoryStateBackendTest {
 			} catch (Exception e) {
 				fail("wrong exception");
 			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testCopyDefaultValue() {
+		try {
+			MemoryStateBackend backend = new MemoryStateBackend();
+			KvState<Integer, IntValue, MemoryStateBackend> kv =
+					backend.createKvState(IntSerializer.INSTANCE, IntValueSerializer.INSTANCE, new IntValue(-1));
+
+			kv.setCurrentKey(1);
+			IntValue default1 = kv.value();
+
+			kv.setCurrentKey(2);
+			IntValue default2 = kv.value();
+			
+			assertNotNull(default1);
+			assertNotNull(default2);
+			assertEquals(default1, default2);
+			assertFalse(default1 == default2);
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -343,6 +343,15 @@ public abstract class AbstractStreamOperator<OUT>
 			}
 		}
 	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public void setKeyContext(Object key) {
+		if (keyValueStates != null) {
+			for (KvState kv : keyValueStates) {
+				kv.setCurrentKey(key);
+			}
+		}
+	}
 	
 	// ------------------------------------------------------------------------
 	//  Context and chaining properties

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
@@ -239,7 +239,7 @@ public abstract class AbstractAlignedProcessingTimeWindowOperator<KEY, IN, OUT, 
 	private void computeWindow(long timestamp) throws Exception {
 		out.setTimestamp(timestamp);
 		panes.truncatePanes(numPanesPerWindow);
-		panes.evaluateWindow(out, new TimeWindow(timestamp, timestamp + windowSize));
+		panes.evaluateWindow(out, new TimeWindow(timestamp, timestamp + windowSize), this);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractKeyedTimePanes.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractKeyedTimePanes.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
 
@@ -47,7 +48,7 @@ public abstract class AbstractKeyedTimePanes<Type, Key, Aggregate, Result> {
 
 	public abstract void addElementToLatestPane(Type element) throws Exception;
 
-	public abstract void evaluateWindow(Collector<Result> out, TimeWindow window) throws Exception;
+	public abstract void evaluateWindow(Collector<Result> out, TimeWindow window, AbstractStreamOperator<Result> operator) throws Exception;
 	
 	
 	public void dispose() {


### PR DESCRIPTION
Default state value is returned as copies in key value state. To circumvent this (if ever becomes a performance issue), one can use null as the default state and manually check/initialize to an immutable default value.

Window user functions have access to key/value state even window is evaluated (part 2 - pert 1 was committed by Aljoscha earlier). The main part here is a rework of the PreAggregatingWindow tests to make them more meaningful.

This also includes #1282 