### PR TITLE
[hotfix] Fix Mutable Object window aggregator/Disable Object Copy

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
@@ -81,7 +81,13 @@ public abstract class Tuple implements java.io.Serializable {
 	 * @return The number of fields in the tuple.
 	 */
 	public abstract int getArity();
-	
+
+	/**
+	 * Shallow tuple copy.
+	 * @return A new Tuple with the same fields as this.
+	 */
+	public abstract <T extends Tuple> T copy();
+
 	// --------------------------------------------------------------------------------------------
 	
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple0.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple0.java
@@ -50,6 +50,16 @@ public class Tuple0 extends Tuple {
 		throw new IndexOutOfBoundsException(String.valueOf(pos));
 	}
 
+	/**
+	 * Shallow tuple copy.
+	 * @return A new Tuple with the same fields as this.
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public Tuple0 copy(){
+		return new Tuple0();
+	}
+
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
 	// -------------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
@@ -134,6 +134,8 @@ public class Tuple1<T0> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple1<T0> copy(){ 
 		return new Tuple1<T0>(this.f0);
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
@@ -260,6 +260,8 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple10<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9> copy(){ 
 		return new Tuple10<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
@@ -274,6 +274,8 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple11<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10> copy(){ 
 		return new Tuple11<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
@@ -288,6 +288,8 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple12<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11> copy(){ 
 		return new Tuple12<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
@@ -302,6 +302,8 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple13<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12> copy(){ 
 		return new Tuple13<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
@@ -316,6 +316,8 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple14<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13> copy(){ 
 		return new Tuple14<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
@@ -330,6 +330,8 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple15<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14> copy(){ 
 		return new Tuple15<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
@@ -344,6 +344,8 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple16<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15> copy(){ 
 		return new Tuple16<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
@@ -358,6 +358,8 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple17<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16> copy(){ 
 		return new Tuple17<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
@@ -372,6 +372,8 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple18<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17> copy(){ 
 		return new Tuple18<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
@@ -386,6 +386,8 @@ public class Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple19<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18> copy(){ 
 		return new Tuple19<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
@@ -156,6 +156,8 @@ public class Tuple2<T0, T1> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple2<T0,T1> copy(){ 
 		return new Tuple2<T0,T1>(this.f0,
 			this.f1);

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
@@ -400,6 +400,8 @@ public class Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple20<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19> copy(){ 
 		return new Tuple20<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
@@ -414,6 +414,8 @@ public class Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple21<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20> copy(){ 
 		return new Tuple21<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
@@ -428,6 +428,8 @@ public class Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple22<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21> copy(){ 
 		return new Tuple22<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
@@ -442,6 +442,8 @@ public class Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple23<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22> copy(){ 
 		return new Tuple23<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
@@ -456,6 +456,8 @@ public class Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple24<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23> copy(){ 
 		return new Tuple24<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
@@ -470,6 +470,8 @@ public class Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple25<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24> copy(){ 
 		return new Tuple25<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
@@ -162,6 +162,8 @@ public class Tuple3<T0, T1, T2> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple3<T0,T1,T2> copy(){ 
 		return new Tuple3<T0,T1,T2>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
@@ -176,6 +176,8 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple4<T0,T1,T2,T3> copy(){ 
 		return new Tuple4<T0,T1,T2,T3>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
@@ -190,6 +190,8 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple5<T0,T1,T2,T3,T4> copy(){ 
 		return new Tuple5<T0,T1,T2,T3,T4>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
@@ -204,6 +204,8 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple6<T0,T1,T2,T3,T4,T5> copy(){ 
 		return new Tuple6<T0,T1,T2,T3,T4,T5>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
@@ -218,6 +218,8 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple7<T0,T1,T2,T3,T4,T5,T6> copy(){ 
 		return new Tuple7<T0,T1,T2,T3,T4,T5,T6>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
@@ -232,6 +232,8 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple8<T0,T1,T2,T3,T4,T5,T6,T7> copy(){ 
 		return new Tuple8<T0,T1,T2,T3,T4,T5,T6,T7>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
@@ -246,6 +246,8 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 	* Shallow tuple copy.
 	* @return A new Tuple with the same fields as this.
 	*/
+	@Override
+	@SuppressWarnings("unchecked")
 	public Tuple9<T0,T1,T2,T3,T4,T5,T6,T7,T8> copy(){ 
 		return new Tuple9<T0,T1,T2,T3,T4,T5,T6,T7,T8>(this.f0,
 			this.f1,

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -727,6 +727,8 @@ class TupleGenerator {
 		w.println("\t* Shallow tuple copy.");
 		w.println("\t* @return A new Tuple with the same fields as this.");
 		w.println("\t*/");
+		w.println("\t@Override");
+		w.println("\t@SuppressWarnings(\"unchecked\")");
 		w.println("\tpublic " + className + tupleTypes + " copy(){ ");
 
 		w.print("\t\treturn new " + className + tupleTypes + "(this.f0");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/aggregation/AggregationFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/aggregation/AggregationFunction.java
@@ -22,13 +22,7 @@ import org.apache.flink.api.common.functions.RichReduceFunction;
 public abstract class AggregationFunction<T> extends RichReduceFunction<T> {
 	private static final long serialVersionUID = 1L;
 
-	public int position;
-
-	public AggregationFunction(int pos) {
-		this.position = pos;
-	}
-
-	public static enum AggregationType {
+	public enum AggregationType {
 		SUM, MIN, MAX, MINBY, MAXBY,
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/NonKeyedWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/NonKeyedWindowOperator.java
@@ -231,9 +231,8 @@ public class NonKeyedWindowOperator<IN, OUT, W extends Window>
 				context = new Context(window, windowBuffer);
 				windows.put(window, context);
 			}
-			StreamRecord<IN> elementCopy = new StreamRecord<>(inputSerializer.copy(element.getValue()), element.getTimestamp());
-			context.windowBuffer.storeElement(elementCopy);
-			Trigger.TriggerResult triggerResult = trigger.onElement(elementCopy.getValue(), elementCopy.getTimestamp(), window, context);
+			context.windowBuffer.storeElement(element);
+			Trigger.TriggerResult triggerResult = trigger.onElement(element.getValue(), element.getTimestamp(), window, context);
 			processTriggerResult(triggerResult, window);
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -276,9 +276,8 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 				context = new Context(key, window, windowBuffer);
 				keyWindows.put(window, context);
 			}
-			StreamRecord<IN> elementCopy = new StreamRecord<>(inputSerializer.copy(element.getValue()), element.getTimestamp());
-			context.windowBuffer.storeElement(elementCopy);
-			Trigger.TriggerResult triggerResult = trigger.onElement(elementCopy.getValue(), elementCopy.getTimestamp(), window, context);
+			context.windowBuffer.storeElement(element);
+			Trigger.TriggerResult triggerResult = trigger.onElement(element.getValue(), element.getTimestamp(), window, context);
 			processTriggerResult(triggerResult, key, window);
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -301,22 +301,19 @@ public class OperatorChain<OUT> {
 		
 		private final TypeSerializer<T> serializer;
 		
-		private final StreamRecord<T> copyRecord;
-
 		public CopyingChainingOutput(OneInputStreamOperator<T, ?> operator, TypeSerializer<T> serializer) {
 			super(operator);
 			this.serializer = serializer;
-			this.copyRecord = new StreamRecord<T>(null, 0L);
 		}
 
 		@Override
 		public void collect(StreamRecord<T> record) {
 			try {
-				T copy = serializer.copy(record.getValue());
-				copyRecord.replace(copy, record.getTimestamp());
-				
-				operator.setKeyContextElement(copyRecord);
-				operator.processElement(copyRecord);
+
+				StreamRecord<T> copy = new StreamRecord<>(serializer.copy(record.getValue()), record.getTimestamp());
+
+				operator.setKeyContextElement(copy);
+				operator.processElement(copy);
 			}
 			catch (Exception e) {
 				throw new RuntimeException("Could not forward element to next operator", e);


### PR DESCRIPTION
This fixes the aggregators to make copies of the objects so that it
works with window operators that are not mutable-object safe.

This also disables object copy in WindowOperator and
NonKeyedWindowOperator.