### PR TITLE
[FLINK-2919] [tests] Apply JMH on FieldAccessMinibenchmark class.

### DIFF
--- a/flink-benchmark/pom.xml
+++ b/flink-benchmark/pom.xml
@@ -36,7 +36,7 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jmh.version>1.4.1</jmh.version>
+    <jmh.version>1.11</jmh.version>
     <uberjar.name>benchmarks</uberjar.name>
   </properties>
 


### PR DESCRIPTION
JMH is a Java harness for building, running, and analysing nano/micro/milli/macro benchmarks.Use JMH to replace the old micro benchmarks method in order to get much more accurate results.Modify the `FieldAccessMinibenchmark` class and move it to `flink-benchmark` module.