### PR TITLE
Add org.apache.httpcomponents:(httpcore, httpclient) to dependency management

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -78,7 +78,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.2</version>
+			<!-- Version is set in root POM -->
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,18 @@ under the License.
 				<artifactId>netty-all</artifactId>
 				<version>4.0.31.Final</version>
 			</dependency>
+
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>4.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.2</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
Hadoop 2.4.0 has `httpcomponents` dependencies, which breaks Flink on Amazon EMR AMI 3.9, because 4.1.2 is missing a method, on which `EmrFileSystem` relies.
```bash
[INFO] org.apache.flink:flink-shaded-hadoop2:jar:1.0-SNAPSHOT
...
[INFO] |  +- net.java.dev.jets3t:jets3t:jar:0.9.0:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.1.2:compile
[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.1.2:compile
[INFO] |  |  \- com.jamesmurty.utils:java-xmlbuilder:jar:0.4:compile
```

This change moves both `httpclient` and `httpcore` to our root pom dependency management section, which makes `net.java.dev.jets3t:jets3t:jar` pull in the 4.2 version. This has been tested on the named EMR version.

If there is a new RC, we should merge this. I don't think that we have to cancel an ongoing RC. We can add it to 0.10.1.

Thanks for @tillrohrmann for spotting a crucial client vs. core typo, which was driving me nuts while testing the change.