### PR TITLE
[FLINK-2920] [tests] Apply JMH on KryoVersusAvroMinibenchmark class.

### DIFF
--- a/flink-benchmark/pom.xml
+++ b/flink-benchmark/pom.xml
@@ -60,7 +60,7 @@ under the License.
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-runtime</artifactId>
-      <version>0.10-SNAPSHOT</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
JMH is a Java harness for building, running, and analysing nano/micro/milli/macro benchmarks.Use JMH to replace the old micro benchmarks method in order to get much more accurate results.Modify the `KryoVersusAvroMinibenchmark` class and move it to `flink-benchmark` module.