### PR TITLE
[FLINK-2930] Respect ExecutionConfig execution retry delay

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -248,7 +248,7 @@ public class ExecutionConfig implements Serializable {
 	}
 	
 	/**
-	 * @return The delay between retires.
+	 * Returns the delay between execution retries.
 	 */
 	public long getExecutionRetryDelay() {
 		return executionRetryDelay;

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -246,7 +246,7 @@ public class ExecutionConfig implements Serializable {
 	public int getNumberOfExecutionRetries() {
 		return numberOfExecutionRetries;
 	}
-	
+
 	/**
 	 * Returns the delay between execution retries.
 	 */
@@ -269,9 +269,9 @@ public class ExecutionConfig implements Serializable {
 		this.numberOfExecutionRetries = numberOfExecutionRetries;
 		return this;
 	}
-	
+
 	/**
-	 * Sets the delay between executions. A value of {@code -1} indicates that the default value 
+	 * Sets the delay between executions. A value of {@code -1} indicates that the default value
 	 * should be used.
 	 * @param executionRetryDelay The number of milliseconds the system will wait to retry.
 	 */

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -199,31 +199,6 @@ public abstract class ExecutionEnvironment {
 	}
 	
 	/**
-	 * Sets the delay that failed tasks are re-executed in milliseconds. A value of
-	 * zero effectively disables fault tolerance. A value of {@code -1}
-	 * indicates that the system default value (as defined in the configuration)
-	 * should be used.
-	 *
-	 * @param executionRetryDelay
-	 * 		The delay of time the system will wait to re-execute failed
-	 * 		tasks.
-	 */
-	public void setExecutionRetryDelay(long executionRetryDelay) {
-		config.setExecutionRetryDelay(executionRetryDelay);
-	}
-	
-	/**
-	 * Gets the delay time in milliseconds the system will wait to re-execute failed tasks.
-	 * A value of {@code -1} indicates that the system default value (as defined
-	 * in the configuration) should be used.
-	 *
-	 * @return The delay time the system will wait to re-execute failed tasks.
-	 */
-	public long getExecutionRetryDelay() {
-		return config.getExecutionRetryDelay();
-	}
-	
-	/**
 	 * Returns the {@link org.apache.flink.api.common.JobExecutionResult} of the last executed job.
 	 * 
 	 * @return The execution result from the latest job execution.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -818,8 +818,16 @@ class JobManager(
         } else {
           defaultExecutionRetries
         }
+
+        val executionRetryDelay = if (jobGraph.getExecutionRetryDelay() >= 0) {
+          jobGraph.getExecutionRetryDelay()
+        }
+        else {
+          delayBetweenRetries
+        }
+
         executionGraph.setNumberOfRetriesLeft(jobNumberRetries)
-        executionGraph.setDelayBeforeRetrying(delayBetweenRetries)
+        executionGraph.setDelayBeforeRetrying(executionRetryDelay)
         executionGraph.setScheduleMode(jobGraph.getScheduleMode())
         executionGraph.setQueuedSchedulingAllowed(jobGraph.getAllowQueuedScheduling())
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -110,22 +110,6 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
 
   /**
-   * Sets the delay that failed tasks are re-executed. A value of
-   * zero effectively disables fault tolerance. A value of "-1"
-   * indicates that the system default value (as defined in the configuration)
-   * should be used.
-   */
-  def setExecutionRetryDelay(executionRetryDelay: Long): Unit = {
-    javaEnv.setExecutionRetryDelay(executionRetryDelay)
-  }
-
-  /**
-   * Gets the delay time in milliseconds the system will wait to re-execute failed tasks.
-   * A value of "-1" indicates that the system default value (as defined
-   * in the configuration) should be used.
-   */
-  def getExecutionRetryDelay = javaEnv.getExecutionRetryDelay
-  /**
    * Gets the UUID by which this environment is identified. The UUID sets the execution context
    * in the cluster or local environment.
    */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -426,30 +426,6 @@ public abstract class StreamExecutionEnvironment {
 	}
 
 	/**
-	 * Sets the delay that failed tasks are re-executed. A value of
-	 * zero effectively disables fault tolerance. A value of {@code -1}
-	 * indicates that the system default value (as defined in the configuration)
-	 * should be used.
-	 *
-	 * @param executionRetryDelay
-	 * 		The delay of time the system will wait to re-execute failed
-	 * 		tasks.
-	 */
-	public void setExecutionRetryDelay(long executionRetryDelay) {
-		config.setExecutionRetryDelay(executionRetryDelay);
-	}
-	
-	/**
-	 * Gets the delay time in milliseconds the system will wait to re-execute failed tasks.
-	 * A value of {@code -1} indicates that the system default value (as defined
-	 * in the configuration) should be used.
-	 *
-	 * @return The delay time the system will wait to re-execute failed tasks.
-	 */
-	public long getExecutionRetryDelay() {
-		return config.getExecutionRetryDelay();
-	}
-	/**
 	 * Sets the default parallelism that will be used for the local execution
 	 * environment created by {@link #createLocalEnvironment()}.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -99,7 +99,7 @@ public class StreamingJobGraphGenerator {
 		configureCheckpointing();
 
 		configureExecutionRetries();
-		
+
 		configureExecutionRetryDelay();
 
 		try {
@@ -416,10 +416,6 @@ public class StreamingJobGraphGenerator {
 			if(executionRetries == -1) {
 				streamGraph.getExecutionConfig().setNumberOfExecutionRetries(Integer.MAX_VALUE);
 			}
-			long executionRetryDelay = streamGraph.getExecutionConfig().getExecutionRetryDelay();
-			if(executionRetryDelay == -1) {
-				streamGraph.getExecutionConfig().setExecutionRetryDelay(100 * 1000);
-			}
 		}
 	}
 
@@ -432,13 +428,9 @@ public class StreamingJobGraphGenerator {
 			jobGraph.setNumberOfExecutionRetries(0);
 		}
 	}
-	
+
 	private void configureExecutionRetryDelay() {
 		long executionRetryDelay = streamGraph.getExecutionConfig().getExecutionRetryDelay();
-		if (executionRetryDelay != -1) {
-			jobGraph.setExecutionRetryDelay(executionRetryDelay);
-		} else {
-			jobGraph.setExecutionRetryDelay(100 * 1000);
-		}
+		jobGraph.setExecutionRetryDelay(executionRetryDelay);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -421,12 +421,7 @@ public class StreamingJobGraphGenerator {
 
 	private void configureExecutionRetries() {
 		int executionRetries = streamGraph.getExecutionConfig().getNumberOfExecutionRetries();
-		if (executionRetries != -1) {
-			jobGraph.setNumberOfExecutionRetries(executionRetries);
-		} else {
-			// if the user didn't configure anything, the number of retries is 0.
-			jobGraph.setNumberOfExecutionRetries(0);
-		}
+		jobGraph.setNumberOfExecutionRetries(executionRetries);
 	}
 
 	private void configureExecutionRetryDelay() {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -233,23 +233,6 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
 
-  /**
-   * Sets the delay that failed tasks are re-executed. A value of
-   * zero effectively disables fault tolerance. A value of "-1"
-   * indicates that the system default value (as defined in the configuration)
-   * should be used.
-   */
-  def setExecutionRetryDelay(executionRetryDelay: Long): Unit = {
-    javaEnv.setExecutionRetryDelay(executionRetryDelay)
-  }
-
-  /**
-   * Gets the delay time in milliseconds the system will wait to re-execute failed tasks.
-   * A value of "-1" indicates that the system default value (as defined
-   * in the configuration) should be used.
-   */
-  def getExecutionRetryDelay = javaEnv.getExecutionRetryDelay
-
   // --------------------------------------------------------------------------------------------
   // Registry for types and serializers
   // --------------------------------------------------------------------------------------------

--- a/flink-tests/src/test/resources/log4j-test.properties
+++ b/flink-tests/src/test/resources/log4j-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
This only affects job recovery on non-master failures.