### PR TITLE
[FLINK-2951] [Table API] add union operator to Table API.

### DIFF
--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
@@ -252,6 +252,11 @@ class JavaBatchTranslator extends PlanTranslator {
         val inType = translatedInput.getType.asInstanceOf[CompositeType[Row]]
         val filter = new ExpressionFilterFunction[Row](predicate, inType)
         translatedInput.filter(filter).name(predicate.toString)
+
+      case uni@UnionAll(left, right) =>
+        val translatedLeft = translateInternal(left)
+        val translatedRight = translateInternal(right)
+        translatedLeft.union(translatedRight).name("Union: " + uni)
     }
   }
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaStreamingTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaStreamingTranslator.scala
@@ -197,6 +197,11 @@ class JavaStreamingTranslator extends PlanTranslator {
         val inType = translatedInput.getType.asInstanceOf[CompositeType[Row]]
         val filter = new ExpressionFilterFunction[Row](predicate, inType)
         translatedInput.filter(filter)
+
+      case UnionAll(left, right) =>
+        val translatedLeft = translateInternal(left)
+        val translatedRight = translateInternal(right)
+        translatedLeft.union(translatedRight)
     }
   }
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
@@ -243,5 +243,29 @@ case class Table(private[flink] val operation: PlanNode) {
     this.copy(operation = Join(operation, right.operation))
   }
 
+  /**
+   * Union two[[Table]]s. Similar to an SQL UNION ALL. The fields of the two union operations
+   * must fully overlap.
+   *
+   * Example:
+   *
+   * {{{
+   *   left.unionAll(right)
+   * }}}
+   */
+  def unionAll(right: Table): Table = {
+    val leftInputNames = operation.outputFields.map(_._1).toSet
+    val rightInputNames = right.operation.outputFields.map(_._1).toSet
+    if (!leftInputNames.equals(rightInputNames)) {
+      throw new ExpressionException(
+        "The fields names of join inputs should be fully overlapped, current inputs fields name:" +
+          operation.outputFields.mkString(", ") +
+          " and " +
+          right.operation.outputFields.mkString(", ")
+      )
+    }
+    this.copy(operation = UnionAll(operation, right.operation))
+  }
+
   override def toString: String = s"Expression($operation)"
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
@@ -254,8 +254,8 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def unionAll(right: Table): Table = {
-    val leftInputFields = operation.outputFields.toSet
-    val rightInputFields = right.operation.outputFields.toSet
+    val leftInputFields = operation.outputFields
+    val rightInputFields = right.operation.outputFields
     if (!leftInputFields.equals(rightInputFields)) {
       throw new ExpressionException(
         "The fields names of join inputs should be fully overlapped, left inputs fields:" +

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
@@ -254,13 +254,13 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def unionAll(right: Table): Table = {
-    val leftInputNames = operation.outputFields.map(_._1).toSet
-    val rightInputNames = right.operation.outputFields.map(_._1).toSet
-    if (!leftInputNames.equals(rightInputNames)) {
+    val leftInputFields = operation.outputFields.toSet
+    val rightInputFields = right.operation.outputFields.toSet
+    if (!leftInputFields.equals(rightInputFields)) {
       throw new ExpressionException(
-        "The fields names of join inputs should be fully overlapped, current inputs fields name:" +
+        "The fields names of join inputs should be fully overlapped, left inputs fields:" +
           operation.outputFields.mkString(", ") +
-          " and " +
+          " and right inputs fields" +
           right.operation.outputFields.mkString(", ")
       )
     }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
@@ -121,6 +121,9 @@ case class Aggregate(
   override def toString = s"Aggregate($input, ${aggregations.mkString(",")})"
 }
 
+/**
+ * UnionAll operation, union all elements from left and right.
+ */
 case class UnionAll(left: PlanNode, right: PlanNode) extends PlanNode{
   val children = Seq(left, right)
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/operations.scala
@@ -120,3 +120,11 @@ case class Aggregate(
 
   override def toString = s"Aggregate($input, ${aggregations.mkString(",")})"
 }
+
+case class UnionAll(left: PlanNode, right: PlanNode) extends PlanNode{
+  val children = Seq(left, right)
+
+  def outputFields = left.outputFields
+
+  override def toString = s"Union($left, $right)"
+}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.table.test;
+
+import org.apache.flink.api.common.InvalidProgramException;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.table.TableEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.table.ExpressionException;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.Table;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.test.javaApiOperators.util.CollectionDataSets;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class UnionITCase extends MultipleProgramsTestBase {
+
+
+	public UnionITCase(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	private String resultPath;
+	private String expected = "";
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Before
+	public void before() throws Exception {
+		resultPath = tempFolder.newFile().toURI().toString();
+	}
+
+	@After
+	public void after() throws Exception {
+		compareResultsByLinesInMemory(expected, resultPath);
+	}
+
+	@Test
+	public void testJoin() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
+
+		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
+		Table in2 = tableEnv.fromDataSet(ds2, "a, b, c");
+
+		Table result = in1.unionAll(in2).select("c");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+		env.execute();
+
+		expected = "Hi\n" + "Hello\n" + "Hello world\n" + "Hi\n" + "Hello\n" + "Hello world\n";
+	}
+
+	@Test
+	public void testJoinWithFilter() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
+
+		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
+		Table in2 = tableEnv.fromDataSet(ds2, "a, b, d, c, e").select("a, b, c");
+
+		Table result = in1.unionAll(in2).where("b < 2").select("c");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+		env.execute();
+
+		expected = "Hi\n" + "Hallo\n";
+	}
+
+	@Test(expected = ExpressionException.class)
+	public void testUnionFieldsNameNotOverlap1() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
+
+		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
+		Table in2 = tableEnv.fromDataSet(ds2, "d, e, f, g, h");
+
+		Table result = in1.unionAll(in2);
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+		env.execute();
+
+		expected = "";
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testUnionFieldsNameNotOverlap2() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
+
+		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
+		Table in2 = tableEnv.fromDataSet(ds2, "a, b, c, d, e").select("a, b, c");
+
+		Table result = in1.unionAll(in2);
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+		env.execute();
+
+		expected = "";
+	}
+
+	@Test
+	public void testJoinWithAggregation() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
+
+		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
+		Table in2 = tableEnv.fromDataSet(ds2, "a, b, d, c, e").select("a, b, c");
+
+		Table result = in1.unionAll(in2).select("c.count");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+		env.execute();
+
+		expected = "18";
+	}
+
+}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
@@ -27,16 +27,13 @@ import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.api.table.ExpressionException;
 import org.apache.flink.api.table.Row;
 import org.apache.flink.api.table.Table;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.test.javaApiOperators.util.CollectionDataSets;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.List;
 
 @RunWith(Parameterized.class)
 public class UnionITCase extends MultipleProgramsTestBase {
@@ -44,22 +41,6 @@ public class UnionITCase extends MultipleProgramsTestBase {
 
 	public UnionITCase(TestExecutionMode mode) {
 		super(mode);
-	}
-
-	private String resultPath;
-	private String expected = "";
-
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
-
-	@Before
-	public void before() throws Exception {
-		resultPath = tempFolder.newFile().toURI().toString();
-	}
-
-	@After
-	public void after() throws Exception {
-		compareResultsByLinesInMemory(expected, resultPath);
 	}
 
 	@Test
@@ -73,14 +54,12 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
 		Table in2 = tableEnv.fromDataSet(ds2, "a, b, c");
 
-		Table result = in1.unionAll(in2).select("c");
+		Table selected = in1.unionAll(in2).select("c");
+		DataSet<Row> ds = tableEnv.toDataSet(selected, Row.class);
+		List<Row> results = ds.collect();
 
-		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
-		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
-
-		env.execute();
-
-		expected = "Hi\n" + "Hello\n" + "Hello world\n" + "Hi\n" + "Hello\n" + "Hello world\n";
+		String expected = "Hi\n" + "Hello\n" + "Hello world\n" + "Hi\n" + "Hello\n" + "Hello world\n";
+		compareResults(results, expected);
 	}
 
 	@Test
@@ -94,14 +73,12 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
 		Table in2 = tableEnv.fromDataSet(ds2, "a, b, d, c, e").select("a, b, c");
 
-		Table result = in1.unionAll(in2).where("b < 2").select("c");
+		Table selected = in1.unionAll(in2).where("b < 2").select("c");
+		DataSet<Row> ds = tableEnv.toDataSet(selected, Row.class);
+		List<Row> results = ds.collect();
 
-		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
-		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
-
-		env.execute();
-
-		expected = "Hi\n" + "Hallo\n";
+		String expected = "Hi\n" + "Hallo\n";
+		compareResults(results, expected);
 	}
 
 	@Test(expected = ExpressionException.class)
@@ -115,14 +92,12 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
 		Table in2 = tableEnv.fromDataSet(ds2, "d, e, f, g, h");
 
-		Table result = in1.unionAll(in2);
+		Table selected = in1.unionAll(in2);
+		DataSet<Row> ds = tableEnv.toDataSet(selected, Row.class);
+		List<Row> results = ds.collect();
 
-		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
-		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
-
-		env.execute();
-
-		expected = "";
+		String expected = "";
+		compareResults(results, expected);
 	}
 
 	@Test(expected = InvalidProgramException.class)
@@ -136,14 +111,12 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
 		Table in2 = tableEnv.fromDataSet(ds2, "a, b, c, d, e").select("a, b, c");
 
-		Table result = in1.unionAll(in2);
+		Table selected = in1.unionAll(in2);
+		DataSet<Row> ds = tableEnv.toDataSet(selected, Row.class);
+		List<Row> results = ds.collect();
 
-		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
-		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
-
-		env.execute();
-
-		expected = "";
+		String expected = "";
+		compareResults(results, expected);
 	}
 
 	@Test
@@ -157,14 +130,12 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		Table in1 = tableEnv.fromDataSet(ds1, "a, b, c");
 		Table in2 = tableEnv.fromDataSet(ds2, "a, b, d, c, e").select("a, b, c");
 
-		Table result = in1.unionAll(in2).select("c.count");
+		Table selected = in1.unionAll(in2).select("c.count");
+		DataSet<Row> ds = tableEnv.toDataSet(selected, Row.class);
+		List<Row> results = ds.collect();
 
-		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
-		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
-
-		env.execute();
-
-		expected = "18";
+		String expected = "18";
+		compareResults(results, expected);
 	}
 
 }

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
@@ -63,7 +63,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testJoin() throws Exception {
+	public void testUnion() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		TableEnvironment tableEnv = new TableEnvironment();
 
@@ -84,7 +84,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testJoinWithFilter() throws Exception {
+	public void testUnionWithFilter() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		TableEnvironment tableEnv = new TableEnvironment();
 
@@ -147,7 +147,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
-	public void testJoinWithAggregation() throws Exception {
+	public void testUnionWithAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		TableEnvironment tableEnv = new TableEnvironment();
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.table.test;
 
-import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.table.TableEnvironment;
@@ -59,7 +58,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		List<Row> results = ds.collect();
 
 		String expected = "Hi\n" + "Hello\n" + "Hello world\n" + "Hi\n" + "Hello\n" + "Hello world\n";
-		compareResults(results, expected);
+		compareResultAsText(results, expected);
 	}
 
 	@Test
@@ -78,7 +77,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		List<Row> results = ds.collect();
 
 		String expected = "Hi\n" + "Hallo\n";
-		compareResults(results, expected);
+		compareResultAsText(results, expected);
 	}
 
 	@Test(expected = ExpressionException.class)
@@ -97,10 +96,10 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		List<Row> results = ds.collect();
 
 		String expected = "";
-		compareResults(results, expected);
+		compareResultAsText(results, expected);
 	}
 
-	@Test(expected = InvalidProgramException.class)
+	@Test(expected = ExpressionException.class)
 	public void testUnionFieldsNameNotOverlap2() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		TableEnvironment tableEnv = new TableEnvironment();
@@ -116,7 +115,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		List<Row> results = ds.collect();
 
 		String expected = "";
-		compareResults(results, expected);
+		compareResultAsText(results, expected);
 	}
 
 	@Test
@@ -135,7 +134,7 @@ public class UnionITCase extends MultipleProgramsTestBase {
 		List<Row> results = ds.collect();
 
 		String expected = "18";
-		compareResults(results, expected);
+		compareResultAsText(results, expected);
 	}
 
 }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/UnionITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/UnionITCase.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.table.test
+
+import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.table._
+import org.apache.flink.api.scala.util.CollectionDataSets
+import org.apache.flink.api.table.{ExpressionException, Row}
+import org.apache.flink.core.fs.FileSystem.WriteMode
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
+import org.apache.flink.test.util.{MultipleProgramsTestBase, TestBaseUtils}
+import org.junit._
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(classOf[Parameterized])
+class UnionITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode) {
+  private var resultPath: String = null
+  private var expected: String = ""
+  private val _tempFolder = new TemporaryFolder()
+
+  @Rule
+  def tempFolder = _tempFolder
+
+  @Before
+  def before(): Unit = {
+    resultPath = tempFolder.newFile().toURI.toString
+  }
+
+  @After
+  def after(): Unit = {
+    TestBaseUtils.compareResultsByLinesInMemory(expected, resultPath)
+  }
+
+  @Test
+  def testUnion(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).as('a, 'b, 'c)
+
+    val unionDs = ds1.unionAll(ds2).select('c)
+
+    unionDs.toDataSet[Row].writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
+    env.execute()
+    expected = "Hi\n" + "Hello\n" + "Hello world\n" + "Hi\n" + "Hello\n" + "Hello world\n"
+  }
+
+  @Test
+  def testUnionWithFilter(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).as('a, 'b, 'd, 'c, 'e)
+
+    val joinDs = ds1.unionAll(ds2.select('a, 'b, 'c)).filter('b < 2).select('c)
+
+    joinDs.toDataSet[Row].writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
+    env.execute()
+    expected = "Hi\n" + "Hallo\n"
+  }
+
+  @Test(expected = classOf[ExpressionException])
+  def testUnionFieldsNameNotOverlap1(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).as('a, 'b, 'd, 'c, 'e)
+
+    val unionDs = ds1.unionAll(ds2)
+
+    unionDs.toDataSet[Row].writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
+    env.execute()
+    expected = ""
+  }
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testUnionFieldsNameNotOverlap2(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).as('a, 'b, 'c, 'd, 'e).select('a, 'b, 'c)
+
+    val unionDs = ds1.unionAll(ds2)
+
+    unionDs.toDataSet[Row].writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
+    env.execute()
+    expected = ""
+  }
+
+  @Test
+  def testUnionWithAggregation(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).as('a, 'b, 'd, 'c, 'e)
+
+    val unionDs = ds1.unionAll(ds2.select('a, 'b, 'c)).select('c.count)
+
+    unionDs.toDataSet[Row].writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
+    env.execute()
+    expected = "18"
+  }
+}

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/UnionITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/UnionITCase.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.scala.table.test
 
-import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.table._
 import org.apache.flink.api.scala.util.CollectionDataSets
@@ -44,7 +43,7 @@ class UnionITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode
 
     val results = unionDs.toDataSet[Row].collect()
     val expected = "Hi\n" + "Hello\n" + "Hello world\n" + "Hi\n" + "Hello\n" + "Hello world\n"
-    TestBaseUtils.compareResults(JavaConversions.seqAsJavaList(results), expected)
+    TestBaseUtils.compareResultAsText(JavaConversions.seqAsJavaList(results), expected)
   }
 
   @Test
@@ -57,7 +56,7 @@ class UnionITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode
 
     val results = joinDs.toDataSet[Row].collect()
     val expected = "Hi\n" + "Hallo\n"
-    TestBaseUtils.compareResults(JavaConversions.seqAsJavaList(results), expected)
+    TestBaseUtils.compareResultAsText(JavaConversions.seqAsJavaList(results), expected)
   }
 
   @Test(expected = classOf[ExpressionException])
@@ -70,10 +69,10 @@ class UnionITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode
 
     val results = unionDs.toDataSet[Row].collect()
     val expected = ""
-    TestBaseUtils.compareResults(JavaConversions.seqAsJavaList(results), expected)
+    TestBaseUtils.compareResultAsText(JavaConversions.seqAsJavaList(results), expected)
   }
 
-  @Test(expected = classOf[InvalidProgramException])
+  @Test(expected = classOf[ExpressionException])
   def testUnionFieldsNameNotOverlap2(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).as('a, 'b, 'c)
@@ -83,7 +82,7 @@ class UnionITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode
 
     val results = unionDs.toDataSet[Row].collect()
     val expected = ""
-    TestBaseUtils.compareResults(JavaConversions.seqAsJavaList(results), expected)
+    TestBaseUtils.compareResultAsText(JavaConversions.seqAsJavaList(results), expected)
   }
 
   @Test
@@ -96,6 +95,6 @@ class UnionITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode
 
     val results = unionDs.toDataSet[Row].collect()
     val expected = "18"
-    TestBaseUtils.compareResults(JavaConversions.seqAsJavaList(results), expected)
+    TestBaseUtils.compareResultAsText(JavaConversions.seqAsJavaList(results), expected)
   }
 }

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -310,20 +310,6 @@ public class TestBaseUtils extends TestLogger {
 		Assert.assertArrayEquals(expected, result);
 	}
 
-	public static void compareResults(List<?> results, String expectedResults) {
-		String[] collected = new String[results.size()];
-		for (int i=0; i<results.size(); i++) {
-			collected[i] = results.get(i).toString();
-		}
-
-		String[] expected = expectedResults.split("\n");
-
-		Arrays.sort(collected);
-		Arrays.sort(expected);
-		Assert.assertEquals("Different number of lines in expected and obtained result.", expected.length, collected.length);
-		Assert.assertArrayEquals(expected, collected);
-	}
-
 	public static void compareResultsByLinesInMemoryWithStrictOrder(String expectedResultStr,
 																	String resultPath) throws Exception {
 		compareResultsByLinesInMemoryWithStrictOrder(expectedResultStr, resultPath, new String[]{});

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -310,6 +310,20 @@ public class TestBaseUtils extends TestLogger {
 		Assert.assertArrayEquals(expected, result);
 	}
 
+	public static void compareResults(List<?> results, String expectedResults) {
+		String[] collected = new String[results.size()];
+		for (int i=0; i<results.size(); i++) {
+			collected[i] = results.get(i).toString();
+		}
+
+		String[] expected = expectedResults.split("\n");
+
+		Arrays.sort(collected);
+		Arrays.sort(expected);
+		Assert.assertEquals("Different number of lines in expected and obtained result.", expected.length, collected.length);
+		Assert.assertArrayEquals(expected, collected);
+	}
+
 	public static void compareResultsByLinesInMemoryWithStrictOrder(String expectedResultStr,
 																	String resultPath) throws Exception {
 		compareResultsByLinesInMemoryWithStrictOrder(expectedResultStr, resultPath, new String[]{});


### PR DESCRIPTION
Currently, union operation is supported by DataSet/DataStream API, not available in Table API. To union two tables, user has to transform the parameter input to DataSet/DataStream, for example:
`val unionDs = left.union(right.toDataSet[Row])`
It should be more API friendly to user if add union operation to Table API, like:
`val unionDs = left.union(right)`