### PR TITLE
[FLINK-2961] [table] Add support for basic type Date in Table API

### DIFF
--- a/docs/libs/table.md
+++ b/docs/libs/table.md
@@ -355,7 +355,7 @@ aggregation = atom , [ ".sum" | ".min" | ".max" | ".count" | "avg" ] ;
 
 cast = atom , ".cast(" , data type , ")" ;
 
-data type = "BYTE" | "SHORT" | "INT" | "LONG" | "FLOAT" | "DOUBLE" | "BOOL" | "BOOLEAN" | "STRING" ;
+data type = "BYTE" | "SHORT" | "INT" | "LONG" | "FLOAT" | "DOUBLE" | "BOOL" | "BOOLEAN" | "STRING" | "DATE" ;
 
 as = atom , ".as(" , field reference , ")" ;
 
@@ -371,4 +371,6 @@ atom = ( "(" , single expression , ")" ) | literal | field reference ;
 
 Here, `literal` is a valid Java literal and `field reference` specifies a column in the data. The
 column names follow Java identifier syntax.
+
+Only the types `LONG` and `STRING` can be casted to `DATE` and vice versa. A `LONG` casted to `DATE` must be a milliseconds timestamp. A `STRING` casted to `DATE` must have the format "`yyyy-MM-dd HH:mm:ss.SSS`", "`yyyy-MM-dd`", "`HH:mm:ss`", or a milliseconds timestamp. All timestamps refer to the UTC timezone beginning from January 1, 1970, 00:00:00 in milliseconds.
 

--- a/docs/libs/table.md
+++ b/docs/libs/table.md
@@ -351,7 +351,7 @@ unary = [ "!" | "-" | "~" ] , suffix ;
 
 suffix = atom | aggregation | cast | as | substring ;
 
-aggregation = atom , [ ".sum" | ".min" | ".max" | ".count" | "avg" ] ;
+aggregation = atom , [ ".sum" | ".min" | ".max" | ".count" | ".avg" ] ;
 
 cast = atom , ".cast(" , data type , ")" ;
 
@@ -372,5 +372,5 @@ atom = ( "(" , single expression , ")" ) | literal | field reference ;
 Here, `literal` is a valid Java literal and `field reference` specifies a column in the data. The
 column names follow Java identifier syntax.
 
-Only the types `LONG` and `STRING` can be casted to `DATE` and vice versa. A `LONG` casted to `DATE` must be a milliseconds timestamp. A `STRING` casted to `DATE` must have the format "`yyyy-MM-dd HH:mm:ss.SSS`", "`yyyy-MM-dd`", "`HH:mm:ss`", or a milliseconds timestamp. All timestamps refer to the UTC timezone beginning from January 1, 1970, 00:00:00 in milliseconds.
+Only the types `LONG` and `STRING` can be casted to `DATE` and vice versa. A `LONG` casted to `DATE` must be a milliseconds timestamp. A `STRING` casted to `DATE` must have the format "`yyyy-MM-dd HH:mm:ss.SSS`", "`yyyy-MM-dd`", "`HH:mm:ss`", or a milliseconds timestamp. By default, all timestamps refer to the UTC timezone beginning from January 1, 1970, 00:00:00 in milliseconds.
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/TableConfig.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/TableConfig.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table
+
+import java.util.TimeZone
+
+/**
+ * A config to define the runtime behavior of the Table API.
+ */
+class TableConfig extends Serializable {
+
+  /**
+   * Defines the timezone for date/time/timestamp conversions.
+   */
+  private var timeZone: TimeZone = TimeZone.getTimeZone("UTC")
+
+  /**
+   * Defines if all fields need to be checked for NULL first.
+   */
+  private var nullCheck: Boolean = false
+
+  /**
+   * Sets the timezone for date/time/timestamp conversions.
+   */
+  def setTimeZone(timeZone: TimeZone) = {
+    require(timeZone != null, "timeZone must not be null.")
+    this.timeZone = timeZone
+  }
+
+  /**
+   * Returns the timezone for date/time/timestamp conversions.
+   */
+  def getTimeZone = timeZone
+
+  /**
+   * Returns the NULL check. If enabled, all fields need to be checked for NULL first.
+   */
+  def getNullCheck = nullCheck
+
+  /**
+   * Sets the NULL check. If enabled, all fields need to be checked for NULL first.
+   */
+  def setNullCheck(nullCheck: Boolean) = {
+    this.nullCheck = nullCheck
+  }
+
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/TableConfig.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/TableConfig.scala
@@ -60,3 +60,7 @@ class TableConfig extends Serializable {
   }
 
 }
+
+object TableConfig {
+  val DEFAULT = new TableConfig()
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionCodeGenerator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionCodeGenerator.scala
@@ -102,9 +102,9 @@ abstract class ExpressionCodeGenerator[R](
             |boolean $nullTerm = ${leftCode.nullTerm} || ${rightCode.nullTerm};
             |$resultTpe $resultTerm;
             |if ($nullTerm) {
-            |  $resultTerm = ${defaultPrimitive(resultType)}
+            |  $resultTerm = ${defaultPrimitive(resultType)};
             |} else {
-            |  $resultTerm = ${expr(leftCode.resultTerm, rightCode.resultTerm)}
+            |  $resultTerm = ${expr(leftCode.resultTerm, rightCode.resultTerm)};
             |}
           """.stripMargin
       } else {
@@ -165,7 +165,7 @@ abstract class ExpressionCodeGenerator[R](
       case expressions.Literal(doubleValue: Double, DOUBLE_TYPE_INFO) =>
         if (nullCheck) {
           s"""
-            |val $nullTerm = false
+            |boolean $nullTerm = false;
             |$resultTpe $resultTerm = $doubleValue;
           """.stripMargin
         } else {
@@ -177,7 +177,7 @@ abstract class ExpressionCodeGenerator[R](
       case expressions.Literal(floatValue: Float, FLOAT_TYPE_INFO) =>
         if (nullCheck) {
           s"""
-            |val $nullTerm = false
+            |boolean $nullTerm = false;
             |$resultTpe $resultTerm = ${floatValue}f;
           """.stripMargin
         } else {
@@ -189,7 +189,7 @@ abstract class ExpressionCodeGenerator[R](
       case expressions.Literal(strValue: String, STRING_TYPE_INFO) =>
         if (nullCheck) {
           s"""
-            |val $nullTerm = false
+            |boolean $nullTerm = false;
             |$resultTpe $resultTerm = "$strValue";
           """.stripMargin
         } else {
@@ -201,7 +201,7 @@ abstract class ExpressionCodeGenerator[R](
       case expressions.Literal(boolValue: Boolean, BOOLEAN_TYPE_INFO) =>
         if (nullCheck) {
           s"""
-            |val $nullTerm = false
+            |boolean $nullTerm = false;
             |$resultTpe $resultTerm = $boolValue;
           """.stripMargin
         } else {
@@ -218,7 +218,7 @@ abstract class ExpressionCodeGenerator[R](
 
         if (nullCheck) {
           s"""
-            |val $nullTerm = false
+            |boolean $nullTerm = false;
             |$resultTpe $resultTerm = $dateName;
           """.stripMargin
         } else {
@@ -537,10 +537,11 @@ abstract class ExpressionCodeGenerator[R](
           childCode.code +
             s"""
               |boolean $nullTerm = ${childCode.nullTerm};
+              |$resultTpe $resultTerm;
               |if ($nullTerm) {
-              |  ${defaultPrimitive(child.typeInfo)};
+              |  $resultTerm = ${defaultPrimitive(child.typeInfo)};
               |} else {
-              |  $resultTpe $resultTerm = -(${childCode.resultTerm});
+              |  $resultTerm = -(${childCode.resultTerm});
               |}
             """.stripMargin
         } else {
@@ -571,10 +572,11 @@ abstract class ExpressionCodeGenerator[R](
           childCode.code +
             s"""
               |boolean $nullTerm = ${childCode.nullTerm};
+              |$resultTpe $resultTerm;
               |if ($nullTerm) {
-              |  ${defaultPrimitive(child.typeInfo)};
+              |  $resultTerm = ${defaultPrimitive(child.typeInfo)};
               |} else {
-              |  $resultTpe $resultTerm = ~((int) ${childCode.resultTerm});
+              |  $resultTerm = ~((int) ${childCode.resultTerm});
               |}
             """.stripMargin
         } else {
@@ -590,10 +592,11 @@ abstract class ExpressionCodeGenerator[R](
           childCode.code +
             s"""
               |boolean $nullTerm = ${childCode.nullTerm};
+              |$resultTpe $resultTerm;
               |if ($nullTerm) {
-              |  ${defaultPrimitive(child.typeInfo)};
+              |  $resultTerm = ${defaultPrimitive(child.typeInfo)};
               |} else {
-              |  $resultTpe $resultTerm = !(${childCode.resultTerm});
+              |  $resultTerm = !(${childCode.resultTerm});
               |}
             """.stripMargin
         } else {
@@ -608,12 +611,7 @@ abstract class ExpressionCodeGenerator[R](
         if (nullCheck) {
           childCode.code +
             s"""
-              |boolean $nullTerm = ${childCode.nullTerm};
-              |if ($nullTerm) {
-              |  ${defaultPrimitive(child.typeInfo)};
-              |} else {
-              |  $resultTpe $resultTerm = (${childCode.resultTerm}) == null;
-              |}
+              |$resultTpe $resultTerm = ${childCode.nullTerm};
             """.stripMargin
         } else {
           childCode.code +
@@ -627,12 +625,7 @@ abstract class ExpressionCodeGenerator[R](
         if (nullCheck) {
           childCode.code +
             s"""
-              |boolean $nullTerm = ${childCode.nullTerm};
-              |if ($nullTerm) {
-              |  ${defaultPrimitive(child.typeInfo)};
-              |} else {
-              |  $resultTpe $resultTerm = (${childCode.resultTerm}) != null;
-              |}
+              |$resultTpe $resultTerm = !${childCode.nullTerm};
             """.stripMargin
         } else {
           childCode.code +
@@ -647,10 +640,11 @@ abstract class ExpressionCodeGenerator[R](
           childCode.code +
             s"""
               |boolean $nullTerm = ${childCode.nullTerm};
+              |$resultTpe $resultTerm;
               |if ($nullTerm) {
-              |  ${defaultPrimitive(child.typeInfo)};
+              |  $resultTerm = ${defaultPrimitive(child.typeInfo)};
               |} else {
-              |  $resultTpe $resultTerm = Math.abs(${childCode.resultTerm});
+              |  $resultTerm = Math.abs(${childCode.resultTerm});
               |}
             """.stripMargin
         } else {

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateFilter.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateFilter.scala
@@ -19,12 +19,12 @@ package org.apache.flink.api.table.codegen
 
 import java.io.StringReader
 
-import org.slf4j.LoggerFactory
-
 import org.apache.flink.api.common.functions.FilterFunction
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.codegen.Indenter._
 import org.apache.flink.api.table.expressions.Expression
+import org.slf4j.LoggerFactory
 
 /**
  * Code generator for a unary predicate, i.e. a Filter.
@@ -32,9 +32,11 @@ import org.apache.flink.api.table.expressions.Expression
 class GenerateFilter[T](
     inputType: CompositeType[T],
     predicate: Expression,
-    cl: ClassLoader) extends ExpressionCodeGenerator[FilterFunction[T]](
+    cl: ClassLoader,
+    config: TableConfig) extends ExpressionCodeGenerator[FilterFunction[T]](
       Seq(("in0", inputType)),
-      cl = cl) {
+      cl = cl,
+      config) {
 
   val LOG = LoggerFactory.getLogger(this.getClass)
 
@@ -50,6 +52,12 @@ class GenerateFilter[T](
       j"""
         public class $generatedName
             implements org.apache.flink.api.common.functions.FilterFunction<$tpe> {
+
+          public org.apache.flink.api.table.TableConfig config = null;
+          public $generatedName(org.apache.flink.api.table.TableConfig config) {
+            this.config = config;
+          }
+
           public boolean filter(Object _in0) {
             $tpe in0 = ($tpe) _in0;
             ${pred.code}
@@ -65,6 +73,12 @@ class GenerateFilter[T](
       j"""
         public class $generatedName
             implements org.apache.flink.api.common.functions.FilterFunction<$tpe> {
+
+          public org.apache.flink.api.table.TableConfig config = null;
+          public $generatedName(org.apache.flink.api.table.TableConfig config) {
+            this.config = config;
+          }
+
           public boolean filter(Object _in0) {
             $tpe in0 = ($tpe) _in0;
             ${pred.code}
@@ -77,6 +91,7 @@ class GenerateFilter[T](
     LOG.debug(s"""Generated unary predicate "$predicate":\n$code""")
     compiler.cook(new StringReader(code))
     val clazz = compiler.getClassLoader().loadClass(generatedName)
-    clazz.newInstance().asInstanceOf[FilterFunction[T]]
+    val constructor = clazz.getConstructor(classOf[TableConfig])
+    constructor.newInstance(config).asInstanceOf[FilterFunction[T]]
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateFilter.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateFilter.scala
@@ -53,7 +53,8 @@ class GenerateFilter[T](
         public class $generatedName
             implements org.apache.flink.api.common.functions.FilterFunction<$tpe> {
 
-          public org.apache.flink.api.table.TableConfig config = null;
+          org.apache.flink.api.table.TableConfig config = null;
+
           public $generatedName(org.apache.flink.api.table.TableConfig config) {
             this.config = config;
           }
@@ -74,7 +75,8 @@ class GenerateFilter[T](
         public class $generatedName
             implements org.apache.flink.api.common.functions.FilterFunction<$tpe> {
 
-          public org.apache.flink.api.table.TableConfig config = null;
+          org.apache.flink.api.table.TableConfig config = null;
+
           public $generatedName(org.apache.flink.api.table.TableConfig config) {
             this.config = config;
           }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateJoin.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateJoin.scala
@@ -114,9 +114,11 @@ class GenerateJoin[L, R, O](
 
           ${reuseCode(resultTypeInfo)}
 
-          public org.apache.flink.api.table.TableConfig config = null;
+          org.apache.flink.api.table.TableConfig config = null;
+
           public $generatedName(org.apache.flink.api.table.TableConfig config) {
             this.config = config;
+            ${reuseInitCode()}
           }
 
           public void join(Object _in0, Object _in1, org.apache.flink.util.Collector coll) {
@@ -138,9 +140,11 @@ class GenerateJoin[L, R, O](
 
           ${reuseCode(resultTypeInfo)}
 
-          public org.apache.flink.api.table.TableConfig config = null;
+          org.apache.flink.api.table.TableConfig config = null;
+
           public $generatedName(org.apache.flink.api.table.TableConfig config) {
             this.config = config;
+            ${reuseInitCode()}
           }
 
           public void join(Object _in0, Object _in1, org.apache.flink.util.Collector coll) {

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateJoin.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateJoin.scala
@@ -19,12 +19,12 @@ package org.apache.flink.api.table.codegen
 
 import java.io.StringReader
 
-import org.slf4j.LoggerFactory
-
 import org.apache.flink.api.common.functions.FlatJoinFunction
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.codegen.Indenter._
 import org.apache.flink.api.table.expressions.{Expression, NopExpression}
+import org.slf4j.LoggerFactory
 
 /**
  * Code generator for assembling the result of a binary operation.
@@ -35,10 +35,12 @@ class GenerateJoin[L, R, O](
     resultTypeInfo: CompositeType[O],
     predicate: Expression,
     outputFields: Seq[Expression],
-    cl: ClassLoader)
+    cl: ClassLoader,
+    config: TableConfig)
   extends GenerateResultAssembler[FlatJoinFunction[L, R, O]](
     Seq(("in0", leftTypeInfo), ("in1", rightTypeInfo)),
-    cl = cl) {
+    cl = cl,
+    config) {
 
   val LOG = LoggerFactory.getLogger(this.getClass)
 
@@ -66,6 +68,11 @@ class GenerateJoin[L, R, O](
 
           ${reuseCode(resultTypeInfo)}
 
+          public org.apache.flink.api.table.TableConfig config = null;
+          public $generatedName(org.apache.flink.api.table.TableConfig config) {
+            this.config = config;
+          }
+
           public void join(Object _in0, Object _in1, org.apache.flink.util.Collector coll) {
             $leftTpe in0 = ($leftTpe) _in0;
             $rightTpe in1 = ($rightTpe) _in1;
@@ -80,6 +87,11 @@ class GenerateJoin[L, R, O](
             implements org.apache.flink.api.common.functions.FlatJoinFunction {
 
           ${reuseCode(resultTypeInfo)}
+
+          public org.apache.flink.api.table.TableConfig config = null;
+          public $generatedName(org.apache.flink.api.table.TableConfig config) {
+            this.config = config;
+          }
 
           public void join(Object _in0, Object _in1, org.apache.flink.util.Collector coll) {
             $leftTpe in0 = ($leftTpe) _in0;
@@ -102,6 +114,11 @@ class GenerateJoin[L, R, O](
 
           ${reuseCode(resultTypeInfo)}
 
+          public org.apache.flink.api.table.TableConfig config = null;
+          public $generatedName(org.apache.flink.api.table.TableConfig config) {
+            this.config = config;
+          }
+
           public void join(Object _in0, Object _in1, org.apache.flink.util.Collector coll) {
             $leftTpe in0 = ($leftTpe) _in0;
             $rightTpe in1 = ($rightTpe) _in1;
@@ -121,6 +138,11 @@ class GenerateJoin[L, R, O](
 
           ${reuseCode(resultTypeInfo)}
 
+          public org.apache.flink.api.table.TableConfig config = null;
+          public $generatedName(org.apache.flink.api.table.TableConfig config) {
+            this.config = config;
+          }
+
           public void join(Object _in0, Object _in1, org.apache.flink.util.Collector coll) {
             $leftTpe in0 = ($leftTpe) _in0;
             $rightTpe in1 = ($rightTpe) _in1;
@@ -139,6 +161,7 @@ class GenerateJoin[L, R, O](
     LOG.debug(s"""Generated join:\n$code""")
     compiler.cook(new StringReader(code))
     val clazz = compiler.getClassLoader().loadClass(generatedName)
-    clazz.newInstance().asInstanceOf[FlatJoinFunction[L, R, O]]
+    val constructor = clazz.getConstructor(classOf[TableConfig])
+    constructor.newInstance(config).asInstanceOf[FlatJoinFunction[L, R, O]]
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateResultAssembler.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateResultAssembler.scala
@@ -20,6 +20,7 @@ package org.apache.flink.api.table.codegen
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.api.table.typeinfo.RowTypeInfo
 
@@ -28,8 +29,9 @@ import org.apache.flink.api.table.typeinfo.RowTypeInfo
  */
 abstract class GenerateResultAssembler[R](
     inputs: Seq[(String, CompositeType[_])],
-    cl: ClassLoader)
-  extends ExpressionCodeGenerator[R](inputs, cl = cl) {
+    cl: ClassLoader,
+    config: TableConfig)
+  extends ExpressionCodeGenerator[R](inputs, cl = cl, config) {
 
   def reuseCode[A](resultTypeInfo: CompositeType[A]) = {
       val resultTpe = typeTermForTypeInfo(resultTypeInfo)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateResultAssembler.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateResultAssembler.scala
@@ -37,11 +37,11 @@ abstract class GenerateResultAssembler[R](
       val resultTpe = typeTermForTypeInfo(resultTypeInfo)
       resultTypeInfo match {
         case pj: PojoTypeInfo[_] =>
-          super.reuseCode() +
+          super.reuseMemberCode() +
             s"$resultTpe out = new ${pj.getTypeClass.getCanonicalName}();"
 
         case row: RowTypeInfo =>
-          super.reuseCode() +
+          super.reuseMemberCode() +
             s"org.apache.flink.api.table.Row out =" +
             s" new org.apache.flink.api.table.Row(${row.getArity});"
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateResultAssembler.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateResultAssembler.scala
@@ -34,10 +34,13 @@ abstract class GenerateResultAssembler[R](
   def reuseCode[A](resultTypeInfo: CompositeType[A]) = {
       val resultTpe = typeTermForTypeInfo(resultTypeInfo)
       resultTypeInfo match {
-        case pj: PojoTypeInfo[_] => s"$resultTpe out = new ${pj.getTypeClass.getCanonicalName}();"
+        case pj: PojoTypeInfo[_] =>
+          super.reuseCode() +
+            s"$resultTpe out = new ${pj.getTypeClass.getCanonicalName}();"
 
         case row: RowTypeInfo =>
-          s"org.apache.flink.api.table.Row out =" +
+          super.reuseCode() +
+            s"org.apache.flink.api.table.Row out =" +
             s" new org.apache.flink.api.table.Row(${row.getArity});"
 
         case _ => ""

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateSelect.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateSelect.scala
@@ -19,12 +19,12 @@ package org.apache.flink.api.table.codegen
 
 import java.io.StringReader
 
-import org.slf4j.LoggerFactory
-
 import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.codegen.Indenter._
 import org.apache.flink.api.table.expressions.Expression
+import org.slf4j.LoggerFactory
 
 /**
  * Code generator for assembling the result of a select operation.
@@ -33,10 +33,12 @@ class GenerateSelect[I, O](
     inputTypeInfo: CompositeType[I],
     resultTypeInfo: CompositeType[O],
     outputFields: Seq[Expression],
-    cl: ClassLoader)
+    cl: ClassLoader,
+    config: TableConfig)
   extends GenerateResultAssembler[MapFunction[I, O]](
     Seq(("in0", inputTypeInfo)),
-    cl = cl) {
+    cl = cl,
+    config) {
 
   val LOG = LoggerFactory.getLogger(this.getClass)
 
@@ -58,6 +60,11 @@ class GenerateSelect[I, O](
 
           ${reuseCode(resultTypeInfo)}
 
+          public org.apache.flink.api.table.TableConfig config = null;
+          public $generatedName(org.apache.flink.api.table.TableConfig config) {
+            this.config = config;
+          }
+
           @Override
           public Object map(Object _in0) {
             $inputTpe in0 = ($inputTpe) _in0;
@@ -69,6 +76,7 @@ class GenerateSelect[I, O](
     LOG.debug(s"""Generated select:\n$code""")
     compiler.cook(new StringReader(code))
     val clazz = compiler.getClassLoader().loadClass(generatedName)
-    clazz.newInstance().asInstanceOf[MapFunction[I, O]]
+    val constructor = clazz.getConstructor(classOf[TableConfig])
+    constructor.newInstance(config).asInstanceOf[MapFunction[I, O]]
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateSelect.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/GenerateSelect.scala
@@ -60,9 +60,11 @@ class GenerateSelect[I, O](
 
           ${reuseCode(resultTypeInfo)}
 
-          public org.apache.flink.api.table.TableConfig config = null;
+          org.apache.flink.api.table.TableConfig config = null;
+
           public $generatedName(org.apache.flink.api.table.TableConfig config) {
             this.config = config;
+            ${reuseInitCode()}
           }
 
           @Override

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/literals.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/literals.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.table.expressions
 
+import java.util.Date
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.scala.table.ImplicitExpressionOperations
 
@@ -28,6 +29,7 @@ object Literal {
     case f: Float => Literal(f, BasicTypeInfo.FLOAT_TYPE_INFO)
     case str: String => Literal(str, BasicTypeInfo.STRING_TYPE_INFO)
     case bool: Boolean => Literal(bool, BasicTypeInfo.BOOLEAN_TYPE_INFO)
+    case date: Date => Literal(date, BasicTypeInfo.DATE_TYPE_INFO)
   }
 }
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/parser/ExpressionParser.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/parser/ExpressionParser.scala
@@ -117,7 +117,8 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
     atom <~ ".cast(DOUBLE)" ^^ { e => Cast(e, BasicTypeInfo.DOUBLE_TYPE_INFO) } |
     atom <~ ".cast(BOOL)" ^^ { e => Cast(e, BasicTypeInfo.BOOLEAN_TYPE_INFO) } |
     atom <~ ".cast(BOOLEAN)" ^^ { e => Cast(e, BasicTypeInfo.BOOLEAN_TYPE_INFO) } |
-    atom <~ ".cast(STRING)" ^^ { e => Cast(e, BasicTypeInfo.STRING_TYPE_INFO) }
+    atom <~ ".cast(STRING)" ^^ { e => Cast(e, BasicTypeInfo.STRING_TYPE_INFO) } |
+    atom <~ ".cast(DATE)" ^^ { e => Cast(e, BasicTypeInfo.DATE_TYPE_INFO) }
 
   lazy val as: PackratParser[Expression] = atom ~ ".as(" ~ fieldReference ~ ")" ^^ {
     case e ~ _ ~ as ~ _ => Naming(e, as.name)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionFilterFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionFilterFunction.scala
@@ -19,6 +19,7 @@ package org.apache.flink.api.table.runtime
 
 import org.apache.flink.api.common.functions.{FilterFunction, RichFilterFunction}
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.codegen.GenerateFilter
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.configuration.Configuration
@@ -29,16 +30,18 @@ import org.apache.flink.configuration.Configuration
  */
 class ExpressionFilterFunction[T](
     predicate: Expression,
-    inputType: CompositeType[T]) extends RichFilterFunction[T] {
+    inputType: CompositeType[T],
+    config: TableConfig = new TableConfig()) extends RichFilterFunction[T] {
 
   var compiledFilter: FilterFunction[T] = null
 
-  override def open(config: Configuration): Unit = {
+  override def open(c: Configuration): Unit = {
     if (compiledFilter == null) {
       val codegen = new GenerateFilter[T](
         inputType,
         predicate,
-        getRuntimeContext.getUserCodeClassLoader)
+        getRuntimeContext.getUserCodeClassLoader,
+        config)
       compiledFilter = codegen.generate()
     }
   }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionFilterFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionFilterFunction.scala
@@ -31,7 +31,7 @@ import org.apache.flink.configuration.Configuration
 class ExpressionFilterFunction[T](
     predicate: Expression,
     inputType: CompositeType[T],
-    config: TableConfig = new TableConfig()) extends RichFilterFunction[T] {
+    config: TableConfig = TableConfig.DEFAULT) extends RichFilterFunction[T] {
 
   var compiledFilter: FilterFunction[T] = null
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionJoinFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionJoinFunction.scala
@@ -35,7 +35,7 @@ class ExpressionJoinFunction[L, R, O](
     rightType: CompositeType[R],
     resultType: CompositeType[O],
     outputFields: Seq[Expression],
-    config: TableConfig = new TableConfig()) extends RichFlatJoinFunction[L, R, O] {
+    config: TableConfig = TableConfig.DEFAULT) extends RichFlatJoinFunction[L, R, O] {
 
   var compiledJoin: FlatJoinFunction[L, R, O] = null
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionJoinFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionJoinFunction.scala
@@ -19,6 +19,7 @@ package org.apache.flink.api.table.runtime
 
 import org.apache.flink.api.common.functions.{FlatJoinFunction, RichFlatJoinFunction}
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.codegen.GenerateJoin
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.configuration.Configuration
@@ -33,18 +34,20 @@ class ExpressionJoinFunction[L, R, O](
     leftType: CompositeType[L],
     rightType: CompositeType[R],
     resultType: CompositeType[O],
-    outputFields: Seq[Expression]) extends RichFlatJoinFunction[L, R, O] {
+    outputFields: Seq[Expression],
+    config: TableConfig = new TableConfig()) extends RichFlatJoinFunction[L, R, O] {
 
   var compiledJoin: FlatJoinFunction[L, R, O] = null
 
-  override def open(config: Configuration): Unit = {
+  override def open(c: Configuration): Unit = {
     val codegen = new GenerateJoin[L, R, O](
       leftType,
       rightType,
       resultType,
       predicate,
       outputFields,
-      getRuntimeContext.getUserCodeClassLoader)
+      getRuntimeContext.getUserCodeClassLoader,
+      config)
     compiledJoin = codegen.generate()
   }
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionSelectFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionSelectFunction.scala
@@ -32,7 +32,7 @@ class ExpressionSelectFunction[I, O](
      inputType: CompositeType[I],
      resultType: CompositeType[O],
      outputFields: Seq[Expression],
-     config: TableConfig = new TableConfig()) extends RichMapFunction[I, O] {
+     config: TableConfig = TableConfig.DEFAULT) extends RichMapFunction[I, O] {
 
   var compiledSelect: MapFunction[I, O] = null
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionSelectFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionSelectFunction.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.table.runtime
 
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.api.common.functions.{MapFunction, RichMapFunction}
 import org.apache.flink.api.common.typeutils.CompositeType
@@ -30,18 +31,20 @@ import org.apache.flink.configuration.Configuration
 class ExpressionSelectFunction[I, O](
      inputType: CompositeType[I],
      resultType: CompositeType[O],
-     outputFields: Seq[Expression]) extends RichMapFunction[I, O] {
+     outputFields: Seq[Expression],
+     config: TableConfig = new TableConfig()) extends RichMapFunction[I, O] {
 
   var compiledSelect: MapFunction[I, O] = null
 
-  override def open(config: Configuration): Unit = {
+  override def open(c: Configuration): Unit = {
 
     if (compiledSelect == null) {
       val resultCodegen = new GenerateSelect[I, O](
         inputType,
         resultType,
         outputFields,
-        getRuntimeContext.getUserCodeClassLoader)
+        getRuntimeContext.getUserCodeClassLoader,
+        config)
 
       compiledSelect = resultCodegen.generate()
     }

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.table.test;
 
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.api.table.Table;
 import org.apache.flink.api.table.Row;
 import org.apache.flink.api.java.DataSet;
@@ -120,6 +121,28 @@ public class CastingITCase extends MultipleProgramsTestBase {
 		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
 		List<Row> results = ds.collect();
 		String expected = "1,1,1,1,2.0,2.0,true\n";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testCastDateFromString() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSource<Tuple4<String, String, String, String>> input =
+				env.fromElements(new Tuple4<>("2011-05-03", "15:51:36", "2011-05-03 15:51:36.000", "1446473775"));
+
+		Table table =
+				tableEnv.fromDataSet(input);
+
+		Table result = table
+				.select("f0.cast(DATE) AS f0, f1.cast(DATE) AS f1, f2.cast(DATE) AS f2, f3.cast(DATE) AS f3")
+				.select("f0.cast(STRING), f1.cast(STRING), f2.cast(STRING), f3.cast(STRING)");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "2011-05-03 00:00:00.000,1970-01-01 15:51:36.000,2011-05-03 15:51:36.000," +
+				"1970-01-17 17:47:53.775\n";
 		compareResultAsText(results, expected);
 	}
 }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/CastingITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/CastingITCase.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.scala.table.test
 
+import java.util.Date
+
 import org.junit._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -38,10 +40,10 @@ class CastingITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
   def testAutoCastToString(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val ds = env.fromElements((1: Byte, 1: Short, 1, 1L, 1.0f, 1.0d)).toTable
-      .select('_1 + "b", '_2 + "s", '_3 + "i", '_4 + "L", '_5 + "f", '_6 + "d")
+    val ds = env.fromElements((1: Byte, 1: Short, 1, 1L, 1.0f, 1.0d, new Date(0))).toTable
+      .select('_1 + "b", '_2 + "s", '_3 + "i", '_4 + "L", '_5 + "f", '_6 + "d", '_7 + "Date")
       .toDataSet[Row]
-    val expected = "1b,1s,1i,1L,1.0f,1.0d"
+    val expected = "1b,1s,1i,1L,1.0f,1.0d,1970-01-01 00:00:00.0Date"
     val results = ds.collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
@@ -80,7 +82,9 @@ class CastingITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
   def testCastFromString: Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val ds = env.fromElements(("1", "true", "2.0")).toTable
+    val ds = env.fromElements(("1", "true", "2.0",
+        "2011-05-03", "15:51:36", "2011-05-03 15:51:36.000", "1446473775"))
+      .toTable
       .select(
         '_1.cast(BasicTypeInfo.BYTE_TYPE_INFO),
         '_1.cast(BasicTypeInfo.SHORT_TYPE_INFO),
@@ -88,9 +92,15 @@ class CastingITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
         '_1.cast(BasicTypeInfo.LONG_TYPE_INFO),
         '_3.cast(BasicTypeInfo.DOUBLE_TYPE_INFO),
         '_3.cast(BasicTypeInfo.FLOAT_TYPE_INFO),
-        '_2.cast(BasicTypeInfo.BOOLEAN_TYPE_INFO))
+        '_2.cast(BasicTypeInfo.BOOLEAN_TYPE_INFO),
+        '_4.cast(BasicTypeInfo.DATE_TYPE_INFO).cast(BasicTypeInfo.STRING_TYPE_INFO),
+        '_5.cast(BasicTypeInfo.DATE_TYPE_INFO).cast(BasicTypeInfo.STRING_TYPE_INFO),
+        '_6.cast(BasicTypeInfo.DATE_TYPE_INFO).cast(BasicTypeInfo.STRING_TYPE_INFO),
+        '_7.cast(BasicTypeInfo.DATE_TYPE_INFO).cast(BasicTypeInfo.STRING_TYPE_INFO))
     .toDataSet[Row]
-    val expected = "1,1,1,1,2.0,2.0,true\n"
+    val expected = "1,1,1,1,2.0,2.0,true," +
+      "2011-05-03 00:00:00.000,1970-01-01 15:51:36.000,2011-05-03 15:51:36.000," +
+      "1970-01-17 17:47:53.775\n"
     val results = ds.collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/CastingITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/CastingITCase.scala
@@ -43,7 +43,7 @@ class CastingITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds = env.fromElements((1: Byte, 1: Short, 1, 1L, 1.0f, 1.0d, new Date(0))).toTable
       .select('_1 + "b", '_2 + "s", '_3 + "i", '_4 + "L", '_5 + "f", '_6 + "d", '_7 + "Date")
       .toDataSet[Row]
-    val expected = "1b,1s,1i,1L,1.0f,1.0d,1970-01-01 00:00:00.0Date"
+    val expected = "1b,1s,1i,1L,1.0f,1.0d,1970-01-01 00:00:00.000Date"
     val results = ds.collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
@@ -18,6 +18,10 @@
 
 package org.apache.flink.api.scala.table.test
 
+import java.util.Date
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.table.expressions.Literal
 import org.apache.flink.api.table.{Row, ExpressionException}
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.table._
@@ -111,6 +115,21 @@ class ExpressionsITCase(mode: TestExecutionMode) extends MultipleProgramsTestBas
     val expected = "3,1"
     val results = ds.collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testDateLiteral(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val ds = env.fromElements((0L, "test")).as('a, 'b)
+      .select('a,
+        Literal(new Date(0)).cast(BasicTypeInfo.STRING_TYPE_INFO),
+        'a.cast(BasicTypeInfo.DATE_TYPE_INFO).cast(BasicTypeInfo.STRING_TYPE_INFO))
+      .toDataSet[Row]
+
+    ds.writeAsText(resultPath, WriteMode.OVERWRITE)
+    env.execute()
+    expected = "0,1970-01-01 00:00:00.000,1970-01-01 00:00:00.000"
   }
 
 }

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
@@ -126,10 +126,9 @@ class ExpressionsITCase(mode: TestExecutionMode) extends MultipleProgramsTestBas
         Literal(new Date(0)).cast(BasicTypeInfo.STRING_TYPE_INFO),
         'a.cast(BasicTypeInfo.DATE_TYPE_INFO).cast(BasicTypeInfo.STRING_TYPE_INFO))
       .toDataSet[Row]
-
-    ds.writeAsText(resultPath, WriteMode.OVERWRITE)
-    env.execute()
-    expected = "0,1970-01-01 00:00:00.000,1970-01-01 00:00:00.000"
+    val expected = "0,1970-01-01 00:00:00.000,1970-01-01 00:00:00.000"
+    val results = ds.collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
 }


### PR DESCRIPTION
Currently, the basic type Date is not implemented in the Table API. In order to have a mapping of the most important ANSI SQL types for FLINK-2099. It makes sense to add support for Date to represent date, time and timestamps of milliseconds precision. This PR implements FLINK-2961.