### PR TITLE
[FLINK-2972] [JavaAPI] Remove Chill dependency from flink-java.

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -74,6 +74,19 @@ under the License.
 			<version>${guava.version}</version>
 		</dependency>
 
+		<!--
+		Chill is added to flink-clients because the KryoSerializer dynamically loads a Kryo instance
+		via Chill if Chill is in the classpath. Since Chill is (transitively through flink-scala)
+		in the classpath of a running JM and TM, we add Chill to flink-clients to ensure that Kyro
+		serialization happens on both ends with Chill's Kryo instance when sending data to a cluster
+		instance.
+		-->
+		<dependency>
+			<groupId>com.twitter</groupId>
+			<artifactId>chill_${scala.binary.version}</artifactId>
+			<version>${chill.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -53,12 +53,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.twitter</groupId>
-			<artifactId>chill_${scala.binary.version}</artifactId>
-			<version>${chill.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -65,13 +65,7 @@ under the License.
 
 		<dependency>
 			<groupId>com.twitter</groupId>
-			<artifactId>chill_${scala.binary.version}</artifactId>
-			<version>${chill.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.twitter</groupId>
-			<artifactId>chill-avro_${scala.binary.version}</artifactId>
+			<artifactId>chill-java</artifactId>
 			<version>${chill.version}</version>
 		</dependency>
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -69,13 +69,19 @@ under the License.
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
-            <version>${asm.version}</version>
+			<version>${asm.version}</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.twitter</groupId>
+			<artifactId>chill_${scala.binary.version}</artifactId>
+			<version>${chill.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
This PR replaces `flink-java`'s `chill` dependency by `chill-java` to decouple `flink-java` from Scala.
Chill is used within the `KryoSerializer` to obtain a "Scala-preconfigured" Kryo instance. Hence, Chill is still required for Scala DataSet or DataStream programs. Separate KryoSerializers for Scala and Java are hard to provide, because `GenericTypeInformation` can be generated through the `TypeExtractor`, `TypeParser`, and the Scala compiler marko. 

In this PR, the `KryoSerializer` tries to dynamically load Chill's `ScalaKryoInstantiator` and generate a Kryo instance through reflection to circumvent the Chill dependency. As a fallback, a regular Kryo instance is created. Consequently, Chill's Kryo instance is used whenever Chill is present in the classpath. To ensure that client, JM, and TM have Chill in their classpath, we add Chill as a dependency to `flink-client`.

**Note**: Before merging, we need to check if this works for Java and Scala programs which are submitted to a cluster (including some collection data sources which are serialized at the client).