### PR TITLE
[FLINK-2972] [JavaAPI] Remove Chill dependency from flink-java.

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -53,12 +53,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.twitter</groupId>
-			<artifactId>chill_${scala.binary.version}</artifactId>
-			<version>${chill.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -65,13 +65,7 @@ under the License.
 
 		<dependency>
 			<groupId>com.twitter</groupId>
-			<artifactId>chill_${scala.binary.version}</artifactId>
-			<version>${chill.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.twitter</groupId>
-			<artifactId>chill-avro_${scala.binary.version}</artifactId>
+			<artifactId>chill-java</artifactId>
 			<version>${chill.version}</version>
 		</dependency>
 
@@ -110,6 +104,15 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.twitter</groupId>
+			<artifactId>chill_${scala.binary.version}</artifactId>
+			<version>${chill.version}</version>
+			<!-- For execution, Chill is added to the classpath through flink-runtime. -->
+			<scope>test</scope>
+		</dependency>
+		
 	</dependencies>
 
 	<!-- Because flink-scala and flink-avro uses it in tests -->

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -180,6 +180,18 @@ under the License.
 			<artifactId>zookeeper</artifactId>
 		</dependency>
 
+		<!--
+		The KryoSerializer dynamically loads Kryo instances via Chill and requires that Chill
+		is in the classpath. Because we do not want to have transitive Scala dependencies
+		in Flink's API modules (such as flink-java) due to Chill, Chill is added to flink-runtime
+		to ensure that Chill is always present in the classpath.
+		-->
+		<dependency>
+			<groupId>com.twitter</groupId>
+			<artifactId>chill_${scala.binary.version}</artifactId>
+			<version>${chill.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-curator-recipes</artifactId>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -69,7 +69,7 @@ under the License.
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
-            <version>${asm.version}</version>
+			<version>${asm.version}</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
This PR replaces `flink-java`'s `chill` dependency by `chill-java` to decouple `flink-java` from Scala.
Chill is used within the `KryoSerializer` to obtain a "Scala-preconfigured" Kryo instance. Hence, Chill is still required for Scala DataSet or DataStream programs. Separate KryoSerializers for Scala and Java are hard to provide, because `GenericTypeInformation` can be generated through the `TypeExtractor`, `TypeParser`, and the Scala compiler marko. 

In this PR, the `KryoSerializer` tries to dynamically load Chill's `ScalaKryoInstantiator` and generate a Kryo instance through reflection to circumvent the Chill dependency. As a fallback, a regular Kryo instance is created. Consequently, Chill's Kryo instance is used whenever Chill is present in the classpath. To ensure that client, JM, and TM have Chill in their classpath, we add Chill as a dependency to `flink-client`.

**Note**: Before merging, we need to check if this works for Java and Scala programs which are submitted to a cluster (including some collection data sources which are serialized at the client).