### PR TITLE
[FLINK-2947] [scala shell] Add color support to Scala Shell

### DIFF
--- a/flink-staging/flink-scala-shell/src/main/scala-2.10/org/apache/flink/api/scala/ILoopCompat.scala
+++ b/flink-staging/flink-scala-shell/src/main/scala-2.10/org/apache/flink/api/scala/ILoopCompat.scala
@@ -26,4 +26,6 @@ class ILoopCompat(
     in0: Option[BufferedReader],
     out0: JPrintWriter)
     extends ILoop(in0, out0) {
+
+  override def prompt = "Scala-Flink> "
 }

--- a/flink-staging/flink-scala-shell/src/main/scala-2.11/org/apache/flink/api/scala/ILoopCompat.scala
+++ b/flink-staging/flink-scala-shell/src/main/scala-2.11/org/apache/flink/api/scala/ILoopCompat.scala
@@ -21,11 +21,17 @@ package org.apache.flink.api.scala
 import java.io.BufferedReader
 
 import _root_.scala.tools.nsc.interpreter._
+import _root_.scala.io.AnsiColor.{MAGENTA, RESET}
 
 class ILoopCompat(
     in0: Option[BufferedReader],
     out0: JPrintWriter)
     extends ILoop(in0, out0) {
+
+  override def prompt = {
+    val promptStr = "Scala-Flink> "
+    s"$MAGENTA$promptStr$RESET"
+  }
 
   protected def addThunk(f: => Unit): Unit = f
 }

--- a/flink-staging/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
+++ b/flink-staging/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
@@ -175,11 +175,6 @@ class FlinkILoop(
   }
 
   /**
-   * CUSTOM START METHODS OVERRIDE:
-   */
-  override def prompt = "Scala-Flink> "
-
-  /**
    * custom welcome message
    */
   override def printWelcome() {

--- a/flink-staging/flink-scala-shell/start-script/start-scala-shell.sh
+++ b/flink-staging/flink-scala-shell/start-script/start-scala-shell.sh
@@ -77,9 +77,9 @@ done
 
 if ${EXTERNAL_LIB_FOUND}
 then
-    java -cp "$FLINK_CLASSPATH" org.apache.flink.api.scala.FlinkShell $@ --addclasspath "$EXT_CLASSPATH" 
+    java -Dscala.color -cp "$FLINK_CLASSPATH" org.apache.flink.api.scala.FlinkShell $@ --addclasspath "$EXT_CLASSPATH"
 else
-    java -cp "$FLINK_CLASSPATH" org.apache.flink.api.scala.FlinkShell $@
+    java -Dscala.color -cp "$FLINK_CLASSPATH" org.apache.flink.api.scala.FlinkShell $@
 fi
 
 #restore echo


### PR DESCRIPTION
This PR adds color support to Scala Shell with Scala 2.11. Color scheme is inherited from Scala 2.11 default color scheme.

<img width="682" alt="screen shot 2015-11-07 at 4 05 27 pm" src="https://cloud.githubusercontent.com/assets/1941681/11014109/00543688-856c-11e5-82fa-597778a6e317.png">
