### PR TITLE
[FLINK-2987] Remove jersey-core and jersey-client dependency exclusions

### DIFF
--- a/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
@@ -90,10 +90,6 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
 					<artifactId>jersey-json</artifactId>
 				</exclusion>
 				<exclusion>
@@ -127,10 +123,6 @@ under the License.
 				<exclusion>
 					<groupId>javax.servlet</groupId>
 					<artifactId>javax.servlet-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-client</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
@@ -222,10 +214,6 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
 					<artifactId>jersey-json</artifactId>
 				</exclusion>
 				<exclusion>
@@ -259,10 +247,6 @@ under the License.
 				<exclusion>
 					<groupId>javax.servlet</groupId>
 					<artifactId>javax.servlet-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-client</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
@@ -366,10 +350,6 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
 					<artifactId>jersey-json</artifactId>
 				</exclusion>
 				<exclusion>
@@ -403,10 +383,6 @@ under the License.
 				<exclusion>
 					<groupId>javax.servlet</groupId>
 					<artifactId>javax.servlet-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-client</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
@@ -510,10 +486,6 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
 					<artifactId>jersey-json</artifactId>
 				</exclusion>
 				<exclusion>
@@ -547,10 +519,6 @@ under the License.
 				<exclusion>
 					<groupId>javax.servlet</groupId>
 					<artifactId>javax.servlet-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-client</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
@@ -654,10 +622,6 @@ under the License.
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
 					<artifactId>jersey-json</artifactId>
 				</exclusion>
 				<exclusion>
@@ -691,10 +655,6 @@ under the License.
 				<exclusion>
 					<groupId>javax.servlet</groupId>
 					<artifactId>javax.servlet-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-client</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
… to make Flink on Hadoop 2.6.0+ work again.

This PR is for the 0.10 release branch.
Please review this quickly. I'd like to get it into the next RC.