### PR TITLE
[refactor] Rename OperatorState to ValueState, add ListState

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -29,7 +29,9 @@ import org.apache.flink.api.common.accumulators.Histogram;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.common.cache.DistributedCache;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateIdentifier;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 /**
@@ -164,8 +166,58 @@ public interface RuntimeContext {
 	// --------------------------------------------------------------------------------------------
 
 	/**
+	 * Gets the partitioned state, which is only accessible if the function is executed on
+	 * a KeyedStream. When interacting with the state only the instance bound to the key of the
+	 * element currently processed by the function is changed.
+	 * Each operator may maintain multiple partitioned states, addressed with different names.
+	 *
+	 * <p>Because the scope of each value is the key of the currently processed element,
+	 * and the elements are distributed by the Flink runtime, the system can transparently
+	 * scale out and redistribute the state and KeyedStream.
+	 *
+	 * <p>The following code example shows how to implement a continuous counter that counts
+	 * how many times elements of a certain key occur, and emits an updated count for that
+	 * element on each occurrence.
+	 *
+	 * <pre>{@code
+	 * DataStream<MyType> stream = ...;
+	 * KeyedStream<MyType> keyedStream = stream.keyBy("id");
+	 *
+	 * keyedStream.map(new RichMapFunction<MyType, Tuple2<MyType, Long>>() {
+	 *
+	 *     private ValueStateIdentifier<Long> countIdentifier =
+	 *         new ValueStateIdentifier<>("count", 0L, LongSerializer.INSTANCE);
+	 *
+	 *     private ValueState<Long> count;
+	 *
+	 *     public void open(Configuration cfg) {
+	 *         state = getRuntimeContext().getPartitionedState(countIdentifier);
+	 *     }
+	 *
+	 *     public Tuple2<MyType, Long> map(MyType value) {
+	 *         long count = state.value();
+	 *         state.update(value + 1);
+	 *         return new Tuple2<>(value, count);
+	 *     }
+	 * });
+	 *
+	 * }</pre>
+	 *
+	 * @param stateIdentifier The StateIdentifier that contains the name and type of the
+	 *                        state that is being accessed.
+	 *
+	 * @param <S> The type of the state.
+	 *
+	 * @return The partitioned state object.
+	 *
+	 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+	 *                                       function (function is not part os a KeyedStream).
+	 */
+	<S extends State> S getPartitionedState(StateIdentifier<S> stateIdentifier);
+
+	/**
 	 * Gets the key/value state, which is only accessible if the function is executed on
-	 * a KeyedStream. Upon calling {@link OperatorState#value()}, the key/value state will
+	 * a KeyedStream. Upon calling {@link ValueState#value()}, the key/value state will
 	 * return the value bound to the key of the element currently processed by the function.
 	 * Each operator may maintain multiple key/value states, addressed with different names.
 	 *
@@ -215,11 +267,12 @@ public interface RuntimeContext {
 	 * @throws UnsupportedOperationException Thrown, if no key/value state is available for the
 	 *                                       function (function is not part os a KeyedStream).
 	 */
-	<S> OperatorState<S> getKeyValueState(String name, Class<S> stateType, S defaultState);
+	@Deprecated
+	<S> ValueState<S> getKeyValueState(String name, Class<S> stateType, S defaultState);
 
 	/**
 	 * Gets the key/value state, which is only accessible if the function is executed on
-	 * a KeyedStream. Upon calling {@link OperatorState#value()}, the key/value state will
+	 * a KeyedStream. Upon calling {@link ValueState#value()}, the key/value state will
 	 * return the value bound to the key of the element currently processed by the function.
 	 * Each operator may maintain multiple key/value states, addressed with different names.
 	 * 
@@ -264,5 +317,6 @@ public interface RuntimeContext {
 	 * @throws UnsupportedOperationException Thrown, if no key/value state is available for the
 	 *                                       function (function is not part os a KeyedStream).
 	 */
-	<S> OperatorState<S> getKeyValueState(String name, TypeInformation<S> stateType, S defaultState);
+	@Deprecated
+	<S> ValueState<S> getKeyValueState(String name, TypeInformation<S> stateType, S defaultState);
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -33,7 +33,9 @@ import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateIdentifier;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.core.fs.Path;
 
@@ -165,13 +167,22 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 	}
 
 	@Override
-	public <S> OperatorState<S> getKeyValueState(String name, Class<S> stateType, S defaultState) {
+	public <S extends State> S getPartitionedState(StateIdentifier<S> stateIdentifier) {
+		throw new UnsupportedOperationException(
+				"This state is only accessible by functions executed on a KeyedStream");
+
+	}
+
+	@Override
+	@Deprecated
+	public <S> ValueState<S> getKeyValueState(String name, Class<S> stateType, S defaultState) {
 		throw new UnsupportedOperationException(
 				"This state is only accessible by functions executed on a KeyedStream");
 	}
 
 	@Override
-	public <S> OperatorState<S> getKeyValueState(String name, TypeInformation<S> stateType, S defaultState) {
+	@Deprecated
+	public <S> ValueState<S> getKeyValueState(String name, TypeInformation<S> stateType, S defaultState) {
 		throw new UnsupportedOperationException(
 				"This state is only accessible by functions executed on a KeyedStream");
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
@@ -16,34 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.common.typeutils.base;
+package org.apache.flink.api.common.state;
 
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-
-public abstract class TypeSerializerSingleton<T> extends TypeSerializer<T>{
-
-	private static final long serialVersionUID = 8766687317209282373L;
-
-	// --------------------------------------------------------------------------------------------
-
-	@Override
-	public TypeSerializerSingleton<T> duplicate() {
-		return this;
-	}
-
-	@Override
-	public int hashCode() {
-		return this.getClass().hashCode();
-	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		if (obj instanceof TypeSerializerSingleton) {
-			TypeSerializerSingleton<?> other = (TypeSerializerSingleton<?>) obj;
-
-			return other.canEqual(this);
-		} else {
-			return false;
-		}
-	}
-}
+/**
+ * This state interface abstracts persistent partitioned list state in streaming programs.
+ * The state is accessed and modified by user functions, and checkpointed consistently
+ * by the system as part of the distributed snapshots.
+ * 
+ * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * automatically supplied by the system, so the function always sees the value mapped to the
+ * key of the current element. That way, the system can handle stream and state partitioning
+ * consistently together.
+ * 
+ * @param <T> Type of the value in the operator state
+ */
+public interface ListState<T> extends MergingState<T, Iterable<T>> {}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateIdentifier.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateIdentifier.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link StateIdentifier} for {@link ListState}. This can be used to create partitioned
+ * value state using
+ * {@link org.apache.flink.api.common.functions.RuntimeContext#getPartitionedState(StateIdentifier)}.
+ *
+ * @param <T> The type of the values that can be added to the list state.
+ */
+public class ListStateIdentifier<T> extends StateIdentifier<ListState<T>> {
+	private static final long serialVersionUID = 1L;
+
+	private final TypeSerializer<T> serializer;
+
+	/**
+	 * Creates a new {@code ListStateIdentifier} with the given name.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param serializer {@link TypeSerializer} for the state values.
+	 */
+	public ListStateIdentifier(String name, TypeSerializer<T> serializer) {
+		super(requireNonNull(name));
+		this.serializer = requireNonNull(serializer);
+	}
+
+	@Override
+	public ListState<T> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createListState(this);
+	}
+
+	/**
+	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
+	 */
+	public TypeSerializer<T> getSerializer() {
+		return serializer;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ListStateIdentifier<?> that = (ListStateIdentifier<?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/MergingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/MergingState.java
@@ -44,9 +44,19 @@ public interface MergingState<IN, OUT> extends State {
 	 * 
 	 * @return The operator state value corresponding to the current input.
 	 * 
-	 * @throws Exception Thrown if the system cannot access the state.
+	 * @throws IOException Thrown if the system cannot access the state.
 	 */
-	OUT get() throws Exception ;
+	OUT get() throws IOException ;
+
+	/**
+	 * Returns the values for all keys of the partitioned state that are stored in the local
+	 * operator instance.
+	 *
+	 * @return The operator state of all keys that this instance is responsible for.
+	 *
+	 * @throws IOException Thrown if the system cannot access the state.
+	 */
+	Iterable<OUT> getAll() throws IOException;
 
 	/**
 	 * Updates the operator state accessible by {@link #get()} by adding the given value
@@ -58,6 +68,6 @@ public interface MergingState<IN, OUT> extends State {
 	 *            
 	 * @throws IOException Thrown if the system cannot access the state.
 	 */
-	void add(IN value) throws Exception;
+	void add(IN value) throws IOException;
 	
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/MergingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/MergingState.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import java.io.IOException;
+
+/**
+ * This state interface abstracts persistent partitioned list state in streaming programs.
+ * The state is accessed and modified by user functions, and checkpointed consistently
+ * by the system as part of the distributed snapshots.
+ * 
+ * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * automatically supplied by the system, so the function always sees the value mapped to the
+ * key of the current element. That way, the system can handle stream and state partitioning
+ * consistently together.
+ * 
+ * @param <IN> Type of the value that can be added to the state.
+ * @param <OUT> Type of the value that can be retrieved from the state.
+ */
+public interface MergingState<IN, OUT> extends State {
+
+	/**
+	 * Returns the current value for the state. When the state is not
+	 * partitioned the returned value is the same for all inputs in a given
+	 * operator instance. If state partitioning is applied, the value returned
+	 * depends on the current operator input, as the operator maintains an
+	 * independent state for each partition.
+	 * 
+	 * @return The operator state value corresponding to the current input.
+	 * 
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	OUT get() throws Exception ;
+
+	/**
+	 * Updates the operator state accessible by {@link #get()} by adding the given value
+	 * to the list of values. The next time {@link #get()} is called (for the same state
+	 * partition) the returned state will represent the updated list.
+	 * 
+	 * @param value
+	 *            The new value for the state.
+	 *            
+	 * @throws IOException Thrown if the system cannot access the state.
+	 */
+	void add(IN value) throws Exception;
+	
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingState.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.api.common.state;
 
-import java.io.IOException;
-
 /**
- * This state interface abstracts persistent key/value state in streaming programs.
+ * This state interface abstracts persistent partitioned list state in streaming programs.
  * The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  * 
@@ -32,33 +30,4 @@ import java.io.IOException;
  * 
  * @param <T> Type of the value in the operator state
  */
-public interface OperatorState<T> {
-
-	/**
-	 * Returns the current value for the state. When the state is not
-	 * partitioned the returned value is the same for all inputs in a given
-	 * operator instance. If state partitioning is applied, the value returned
-	 * depends on the current operator input, as the operator maintains an
-	 * independent state for each partition.
-	 * 
-	 * @return The operator state value corresponding to the current input.
-	 * 
-	 * @throws IOException Thrown if the system cannot access the state.
-	 */
-	T value() throws IOException;
-
-	/**
-	 * Updates the operator state accessible by {@link #value()} to the given
-	 * value. The next time {@link #value()} is called (for the same state
-	 * partition) the returned state will represent the updated value. When a
-	 * partitioned state is updated with null, the state for the current key 
-	 * will be removed and the default value is returned on the next access.
-	 * 
-	 * @param value
-	 *            The new value for the state.
-	 *            
-	 * @throws IOException Thrown if the system cannot access the state.
-	 */
-	void update(T value) throws IOException;
-	
-}
+public interface ReducingState<T> extends MergingState<T, T> {}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingStateIdentifier.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingStateIdentifier.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link StateIdentifier} for {@link ReducingState}. This can be used to create partitioned
+ * value state using
+ * {@link org.apache.flink.api.common.functions.RuntimeContext#getPartitionedState(StateIdentifier)}.
+ *
+ * @param <T> The type of the values that can be added to the list state.
+ */
+public class ReducingStateIdentifier<T> extends StateIdentifier<ReducingState<T>> {
+	private static final long serialVersionUID = 1L;
+
+	private final TypeSerializer<T> serializer;
+
+	private final ReduceFunction<T> reduceFunction;
+
+	/**
+	 * Creates a new {@code ReducingStateIdentifier} with the given name and reduce function.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param serializer {@link TypeSerializer} for the state values.
+	 */
+	public ReducingStateIdentifier(String name,
+			ReduceFunction<T> reduceFunction,
+			TypeSerializer<T> serializer) {
+		super(requireNonNull(name));
+		this.serializer = requireNonNull(serializer);
+		this.reduceFunction = reduceFunction;
+	}
+
+	@Override
+	public ReducingState<T> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createReducingState(this);
+	}
+
+	/**
+	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
+	 */
+	public TypeSerializer<T> getSerializer() {
+		return serializer;
+	}
+
+	/**
+	 * Returns the reduce function to be used for the reducing state.
+	 */
+	public ReduceFunction<T> getReduceFunction() {
+		return reduceFunction;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ReducingStateIdentifier<?> that = (ReducingStateIdentifier<?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.state;
+
+/**
+ * Interface that different types of partitioned state must implement.
+ *
+ * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * automatically supplied by the system, so the function always sees the value mapped to the
+ * key of the current element. That way, the system can handle stream and state partitioning
+ * consistently together.
+ */
+public interface State {
+	void clear();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateBackend.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateBackend.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.state;
+
+/**
+ * The {@code StateBackend} is used by {@link StateIdentifier} instances to create actual state
+ * representations.
+ */
+public interface StateBackend {
+
+	/**
+	 * Creates and returns a new {@link ValueState}.
+	 * @param stateIdentifier The {@code StateIdentifier} that contains the name of the state.
+	 *
+	 * @param <T> The type of the value that the {@code ValueState} can store.
+	 */
+	<T> ValueState<T> createValueState(ValueStateIdentifier<T> stateIdentifier) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link ListState}.
+	 * @param stateIdentifier The {@code StateIdentifier} that contains the name of the state.
+	 *
+	 * @param <T> The type of the values that the {@code ListState} can store.
+	 */
+	<T> ListState<T> createListState(ListStateIdentifier<T> stateIdentifier) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link ReducingState}.
+	 * @param stateIdentifier The {@code StateIdentifier} that contains the name of the state.
+	 *
+	 * @param <T> The type of the values that the {@code ListState} can store.
+	 */
+	<T> ReducingState<T> createReducingState(ReducingStateIdentifier<T> stateIdentifier) throws Exception;
+
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateIdentifier.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateIdentifier.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.state;
+
+import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class for state identifiers. A {@code StateIdentifier} is used as a tag for partitioned
+ * state in stateful operations. This contains the name and can create an actual state object
+ * given a {@link StateBackend} using {@link #bind(StateBackend)}.
+ *
+ * <p>Subclasses must correctly implement {@link #equals(Object)} and {@link #hashCode()}.
+ *
+ * @param <S> The type of the State objects created from this {@code StateIdentifier}.
+ */
+public abstract class StateIdentifier<S extends State> implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	/** Name that uniquely identifies state created from this StateIdentifier. */
+	protected final String name;
+
+	/**
+	 * Create a new {@code StateIdentifier} with the given name.
+	 * @param name The name of the {@code StateIdentifier}.
+	 */
+	public StateIdentifier(String name) {
+		this.name = requireNonNull(name);;
+	}
+
+	/**
+	 * Returns the name of this {@code StateIdentifier}.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Creates a new {@link State} on the given {@link StateBackend}.
+	 *
+	 * @param stateBackend The {@code StateBackend} on which to create the {@link State}.
+	 */
+	public abstract S bind(StateBackend stateBackend) throws Exception ;
+
+	// Force subclasses to implement
+	public abstract boolean equals(Object o);
+
+	// Force subclasses to implement
+	public abstract int hashCode();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
@@ -48,6 +48,16 @@ public interface ValueState<T> extends State {
 	T value() throws IOException;
 
 	/**
+	 * Returns the values for all keys of the partitioned state that are stored in the local
+	 * operator instance.
+	 *
+	 * @return The operator state of all keys that this instance is responsible for.
+	 *
+	 * @throws IOException Thrown if the system cannot access the state.
+	 */
+	Iterable<T> getAll() throws IOException;
+
+	/**
 	 * Updates the operator state accessible by {@link #value()} to the given
 	 * value. The next time {@link #value()} is called (for the same state
 	 * partition) the returned state will represent the updated value. When a

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import java.io.IOException;
+
+/**
+ * This state interface abstracts persistent key/value state in streaming programs.
+ * The state is accessed and modified by user functions, and checkpointed consistently
+ * by the system as part of the distributed snapshots.
+ * 
+ * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * automatically supplied by the system, so the function always sees the value mapped to the
+ * key of the current element. That way, the system can handle stream and state partitioning
+ * consistently together.
+ * 
+ * @param <T> Type of the value in the state.
+ */
+public interface ValueState<T> extends State {
+
+	/**
+	 * Returns the current value for the state. When the state is not
+	 * partitioned the returned value is the same for all inputs in a given
+	 * operator instance. If state partitioning is applied, the value returned
+	 * depends on the current operator input, as the operator maintains an
+	 * independent state for each partition.
+	 * 
+	 * @return The operator state value corresponding to the current input.
+	 * 
+	 * @throws IOException Thrown if the system cannot access the state.
+	 */
+	T value() throws IOException;
+
+	/**
+	 * Updates the operator state accessible by {@link #value()} to the given
+	 * value. The next time {@link #value()} is called (for the same state
+	 * partition) the returned state will represent the updated value. When a
+	 * partitioned state is updated with null, the state for the current key 
+	 * will be removed and the default value is returned on the next access.
+	 * 
+	 * @param value
+	 *            The new value for the state.
+	 *            
+	 * @throws IOException Thrown if the system cannot access the state.
+	 */
+	void update(T value) throws IOException;
+	
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateIdentifier.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateIdentifier.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.InputViewDataInputStreamWrapper;
+import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link StateIdentifier} for {@link ValueState}. This can be used to create partitioned
+ * value state using
+ * {@link org.apache.flink.api.common.functions.RuntimeContext#getPartitionedState(StateIdentifier)}.
+ *
+ * @param <T> The type of the values that the value state can hold.
+ */
+public class ValueStateIdentifier<T> extends StateIdentifier<ValueState<T>> {
+	private static final long serialVersionUID = 1L;
+
+	private transient T defaultValue;
+
+	private final TypeSerializer<T> serializer;
+
+	/**
+	 * Creates a new {@code ValueStateIdentifier} with the given name and default value.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 * @param serializer {@link TypeSerializer} for the state values.
+	 */
+	public ValueStateIdentifier(String name, T defaultValue, TypeSerializer<T> serializer) {
+		super(requireNonNull(name));
+		this.defaultValue = defaultValue;
+		this.serializer = requireNonNull(serializer);
+	}
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		out.defaultWriteObject();
+
+		if (defaultValue == null) {
+			// we don't have a default value
+			out.writeBoolean(false);
+		} else {
+			out.writeBoolean(true);
+
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			OutputViewDataOutputStreamWrapper outView =
+					new OutputViewDataOutputStreamWrapper(new DataOutputStream(baos));
+
+			try {
+				serializer.serialize(defaultValue, outView);
+			} catch (IOException ioe) {
+				throw new RuntimeException("Unable to serialize default value of type " +
+						defaultValue.getClass().getSimpleName() + ".", ioe);
+			}
+
+			outView.close();
+
+			out.writeInt(baos.size());
+			out.write(baos.toByteArray());
+		}
+
+	}
+
+	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+
+		boolean hasDefaultValue = in.readBoolean();
+
+		if (hasDefaultValue) {
+			int size = in.readInt();
+			byte[] buffer = new byte[size];
+			int bytesRead = in.read(buffer);
+
+			if (bytesRead != size) {
+				throw new RuntimeException("Read size does not match expected size.");
+			}
+
+			ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+			InputViewDataInputStreamWrapper inView =
+					new InputViewDataInputStreamWrapper(new DataInputStream(bais));
+			defaultValue = serializer.deserialize(inView);
+		} else {
+			defaultValue = null;
+		}
+	}
+
+	@Override
+	public ValueState<T> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createValueState(this);
+	}
+
+	/**
+	 * Returns the default value.
+	 */
+	public T getDefaultValue() {
+		if (defaultValue != null) {
+			return serializer.copy(defaultValue);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
+	 */
+	public TypeSerializer<T> getSerializer() {
+		return serializer;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ValueStateIdentifier<?> that = (ValueStateIdentifier<?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "ValueStateIdentifier{" +
+				"name=" + name +
+				", defaultValue=" + defaultValue +
+				", serializer=" + serializer +
+				'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapListState.java
@@ -101,6 +101,12 @@ public abstract class AbstractHeapListState<K, V, Backend extends AbstractStateB
 	}
 
 	@Override
+	@SuppressWarnings("unchecked,rawtypes")
+	public Iterable<Iterable<V>> getAll() {
+		return (Iterable) state.values();
+	}
+
+	@Override
 	public void add(V value) {
 		List<V> list = state.get(currentKey);
 		if (list == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapListState.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class for partitioned {@link ListState} implementations that are backed by a regular
+ * heap hash map. The concrete implementations define how the state is checkpointed.
+ * 
+ * @param <K> The type of the key.
+ * @param <V> The type of the values in the list state.
+ * @param <Backend> The type of the backend that snapshots this key/value state.
+ */
+public abstract class AbstractHeapListState<K, V, Backend extends AbstractStateBackend>
+		implements KvState<K, ListState<V>, ListStateIdentifier<V>, Backend>, ListState<V> {
+
+	/** Map containing the actual key/value pairs */
+	private final HashMap<K, List<V>> state;
+
+	/** The serializer for the keys */
+	private final TypeSerializer<K> keySerializer;
+
+	/** This holds the name of the state and can create an initial default value for the state. */
+	protected final ListStateIdentifier<V> stateIdentifier;
+
+	/** The current key, which the next value methods will refer to */
+	private K currentKey;
+
+	private final Backend backend;
+
+	/**
+	 * Creates a new empty key/value state.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 *                           and can create a default state value.
+	 */
+	protected AbstractHeapListState(Backend backend,
+			TypeSerializer<K> keySerializer,
+			ListStateIdentifier<V> stateIdentifier) {
+		this(backend, keySerializer, stateIdentifier, new HashMap<K, List<V>>());
+	}
+
+	/**
+	 * Creates a new key/value state for the given hash map of key/value pairs.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 *                           and can create a default state value.
+	 * @param state The state map to use in this kev/value state. May contain initial state.
+	 */
+	protected AbstractHeapListState(Backend backend,
+			TypeSerializer<K> keySerializer,
+			ListStateIdentifier<V> stateIdentifier,
+			HashMap<K, List<V>> state) {
+		this.state = requireNonNull(state);
+		this.keySerializer = requireNonNull(keySerializer);
+		this.stateIdentifier = stateIdentifier;
+		this.backend = backend;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public Iterable<V> get() {
+		List<V> result = state.get(currentKey);
+		if (result == null) {
+			return Collections.emptyList();
+		} else {
+			return result;
+		}
+	}
+
+	@Override
+	public void add(V value) {
+		List<V> list = state.get(currentKey);
+		if (list == null) {
+			list = new ArrayList<>();
+			state.put(currentKey, list);
+		}
+		list.add(value);
+	}
+
+	@Override
+	public void clear() {
+		state.remove(currentKey);
+		if (state.size() == 0) {
+			backend.clear(stateIdentifier);
+		}
+	}
+
+	@Override
+	public void setCurrentKey(K currentKey) {
+		this.currentKey = currentKey;
+	}
+
+	@Override
+	public int size() {
+		return state.size();
+	}
+
+	@Override
+	public void dispose() {
+		state.clear();
+	}
+
+	/**
+	 * Gets the serializer for the keys.
+	 * @return The serializer for the keys.
+	 */
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializer;
+	}
+
+	// ------------------------------------------------------------------------
+	//  checkpointing utilities
+	// ------------------------------------------------------------------------
+	
+	protected void writeStateToOutputView(final DataOutputView out) throws IOException {
+		TypeSerializer<V> valueSerializer = stateIdentifier.getSerializer();
+		for (Map.Entry<K, List<V>> entry : state.entrySet()) {
+			keySerializer.serialize(entry.getKey(), out);
+			List<V> list = entry.getValue();
+			out.writeInt(list.size());
+			for (V value: list) {
+				valueSerializer.serialize(value, out);
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapReducingState.java
@@ -97,12 +97,21 @@ public abstract class AbstractHeapReducingState<K, V, Backend extends AbstractSt
 	}
 
 	@Override
-	public void add(V value) throws Exception {
+	public Iterable<V> getAll() {
+		return state.values();
+	}
+
+	@Override
+	public void add(V value) throws IOException {
 		V currentValue = state.get(currentKey);
 		if (currentValue == null) {
 			state.put(currentKey, value);
 		} else {
-			state.put(currentKey, reduceFunction.reduce(currentValue, value));
+			try {
+				state.put(currentKey, reduceFunction.reduce(currentValue, value));
+			} catch (Exception e) {
+				throw new RuntimeException("Could not add value to reducing state.", e);
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapReducingState.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class for partitioned {@link ReducingState} implementations that are backed by a regular
+ * heap hash map. The concrete implementations define how the state is checkpointed.
+ * 
+ * @param <K> The type of the key.
+ * @param <V> The type of the values in the list state.
+ * @param <Backend> The type of the backend that snapshots this key/value state.
+ */
+public abstract class AbstractHeapReducingState<K, V, Backend extends AbstractStateBackend>
+		implements KvState<K, ReducingState<V>, ReducingStateIdentifier<V>, Backend>, ReducingState<V> {
+
+	/** Map containing the actual key/value pairs */
+	private final HashMap<K, V> state;
+
+	/** The serializer for the keys */
+	private final TypeSerializer<K> keySerializer;
+
+	/** This holds the name of the state and can create an initial default value for the state. */
+	protected final ReducingStateIdentifier<V> stateIdentifier;
+
+	/** The current key, which the next value methods will refer to */
+	private K currentKey;
+
+	private final ReduceFunction<V> reduceFunction;
+
+	private final Backend backend;
+
+	/**
+	 * Creates a new empty key/value state.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 *                           and can create a default state value.
+	 */
+	protected AbstractHeapReducingState(Backend backend,
+			TypeSerializer<K> keySerializer,
+			ReducingStateIdentifier<V> stateIdentifier) {
+		this(backend, keySerializer, stateIdentifier, new HashMap<K, V>());
+	}
+
+	/**
+	 * Creates a new key/value state for the given hash map of key/value pairs.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 *                           and can create a default state value.
+	 * @param state The state map to use in this kev/value state. May contain initial state.
+	 */
+	protected AbstractHeapReducingState(Backend backend,
+			TypeSerializer<K> keySerializer,
+			ReducingStateIdentifier<V> stateIdentifier,
+			HashMap<K, V> state) {
+		this.state = requireNonNull(state);
+		this.keySerializer = requireNonNull(keySerializer);
+		this.stateIdentifier = stateIdentifier;
+		this.backend = backend;
+		this.reduceFunction = stateIdentifier.getReduceFunction();
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public V get() {
+		return state.get(currentKey);
+	}
+
+	@Override
+	public void add(V value) throws Exception {
+		V currentValue = state.get(currentKey);
+		if (currentValue == null) {
+			state.put(currentKey, value);
+		} else {
+			state.put(currentKey, reduceFunction.reduce(currentValue, value));
+		}
+	}
+
+	@Override
+	public void clear() {
+		state.remove(currentKey);
+		if (state.size() == 0) {
+			backend.clear(stateIdentifier);
+		}
+	}
+
+	@Override
+	public void setCurrentKey(K currentKey) {
+		this.currentKey = currentKey;
+	}
+
+	@Override
+	public int size() {
+		return state.size();
+	}
+
+	@Override
+	public void dispose() {
+		state.clear();
+	}
+
+	/**
+	 * Gets the serializer for the keys.
+	 * @return The serializer for the keys.
+	 */
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializer;
+	}
+
+	// ------------------------------------------------------------------------
+	//  checkpointing utilities
+	// ------------------------------------------------------------------------
+	
+	protected void writeStateToOutputView(final DataOutputView out) throws IOException {
+		TypeSerializer<V> valueSerializer = stateIdentifier.getSerializer();
+		for (Map.Entry<K, V> entry : state.entrySet()) {
+			keySerializer.serialize(entry.getKey(), out);
+			valueSerializer.serialize(entry.getValue(), out);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractHeapValueState.java
@@ -94,6 +94,11 @@ public abstract class AbstractHeapValueState<K, V, Backend extends AbstractState
 	}
 
 	@Override
+	public Iterable<V> getAll() {
+		return state.values();
+	}
+
+	@Override
 	public void update(V value) {
 		if (value != null) {
 			state.put(currentKey, value);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvState.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateIdentifier;
 
 /**
  * Key/Value state implementation for user-defined state. The state is backed by a state
@@ -29,9 +30,8 @@ import org.apache.flink.api.common.state.OperatorState;
  * metadata of what is considered part of the checkpoint.
  * 
  * @param <K> The type of the key.
- * @param <V> The type of the value.
  */
-public interface KvState<K, V, Backend extends StateBackend<Backend>> extends OperatorState<V> {
+public interface KvState<K, S extends State, SI extends StateIdentifier<S>, Backend extends AbstractStateBackend> {
 
 	/**
 	 * Sets the current key, which will be used to retrieve values for the next calls to
@@ -51,7 +51,7 @@ public interface KvState<K, V, Backend extends StateBackend<Backend>> extends Op
 	 * @throws Exception Exceptions during snapshotting the state should be forwarded, so the system
 	 *                   can react to failed snapshots.
 	 */
-	KvStateSnapshot<K, V, Backend> snapshot(long checkpointId, long timestamp) throws Exception;
+	KvStateSnapshot<K, S, SI, Backend> snapshot(long checkpointId, long timestamp) throws Exception;
 
 	/**
 	 * Gets the number of key/value pairs currently stored in the state. Note that is a key

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvStateSnapshot.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateIdentifier;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 /**
@@ -32,10 +34,9 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * a file and this snapshot object contains a pointer to that file.
  *
  * @param <K> The type of the key
- * @param <V> The type of the value
  * @param <Backend> The type of the backend that can restore the state from this snapshot.
  */
-public interface KvStateSnapshot<K, V, Backend extends StateBackend<Backend>> extends java.io.Serializable {
+public interface KvStateSnapshot<K, S extends State, SI extends StateIdentifier<S>, Backend extends AbstractStateBackend> extends java.io.Serializable {
 
 	/**
 	 * Loads the key/value state back from this snapshot.
@@ -44,19 +45,18 @@ public interface KvStateSnapshot<K, V, Backend extends StateBackend<Backend>> ex
 	 * @param stateBackend The state backend that created this snapshot and can restore the key/value state
 	 *                     from this snapshot.
 	 * @param keySerializer The serializer for the keys.
-	 * @param valueSerializer The serializer for the values.
-	 * @param defaultValue The value that is returned when no other value has been associated with a key, yet.   
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 *                           and can create a default state value.
 	 * @param classLoader The class loader for user-defined types.
 	 * 
 	 * @return An instance of the key/value state loaded from this snapshot.
 	 * 
 	 * @throws Exception Exceptions can occur during the state loading and are forwarded. 
 	 */
-	KvState<K, V, Backend> restoreState(
+	KvState<K, S, SI, Backend> restoreState(
 			Backend stateBackend,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<V> valueSerializer,
-			V defaultValue,
+			SI stateIdentifier,
 			ClassLoader classLoader) throws Exception;
 
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.Configuration;
  * 
  * @param <T> The type of the state backend created.
  */
-public interface StateBackendFactory<T extends StateBackend<T>> {
+public interface StateBackendFactory<T extends AbstractStateBackend> {
 
 	/**
 	 * Creates the state backend, optionally using the given configuration.
@@ -36,5 +36,5 @@ public interface StateBackendFactory<T extends StateBackend<T>> {
 	 * 
 	 * @throws Exception Exceptions during instantiation can be forwarded.
 	 */
-	StateBackend<T> createFromConfig(Configuration config) throws Exception;
+	AbstractStateBackend createFromConfig(Configuration config) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapReducingState.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.state.ReducingStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
+import org.apache.flink.runtime.state.AbstractHeapReducingState;
+
+import java.io.DataOutputStream;
+import java.util.HashMap;
+
+/**
+ * Heap-backed partitioned {@link org.apache.flink.api.common.state.ListState} that is snapshotted
+ * into files.
+ * 
+ * @param <K> The type of the key.
+ * @param <V> The type of the value.
+ */
+public class FsHeapReducingState<K, V> extends AbstractHeapReducingState<K, V, FsStateBackend> {
+
+	/** The file system state backend backing snapshots of this state */
+	private final FsStateBackend backend;
+
+	/**
+	 * Creates a new and empty partitioned state.
+	 *
+	 * @param keySerializer The serializer for the key.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 * and can create a default state value.
+	 * @param backend The file system state backend backing snapshots of this state
+	 */
+	public FsHeapReducingState(TypeSerializer<K> keySerializer, ReducingStateIdentifier<V> stateIdentifier, FsStateBackend backend) {
+		super(backend, keySerializer, stateIdentifier);
+		this.backend = backend;
+	}
+
+	/**
+	 * Creates a new key/value state with the given state contents.
+	 * This method is used to re-create key/value state with existing data, for example from
+	 * a snapshot.
+	 *
+	 * @param keySerializer The serializer for the key.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 *                           and can create a default state value.
+	 * @param state The map of key/value pairs to initialize the state with.
+	 * @param backend The file system state backend backing snapshots of this state
+	 */
+	public FsHeapReducingState(TypeSerializer<K> keySerializer, ReducingStateIdentifier<V> stateIdentifier, HashMap<K, V> state, FsStateBackend backend) {
+		super(backend, keySerializer, stateIdentifier, state);
+		this.backend = backend;
+	}
+
+
+
+	@Override
+	public FsHeapReducingStateSnapshot<K, V> snapshot(long checkpointId, long timestamp) throws Exception {
+		// first, create an output stream to write to
+		try (FsStateBackend.FsCheckpointStateOutputStream out = 
+					backend.createCheckpointStateOutputStream(checkpointId, timestamp)) {
+
+			// serialize the state to the output stream
+			OutputViewDataOutputStreamWrapper outView = 
+					new OutputViewDataOutputStreamWrapper(new DataOutputStream(out));
+			outView.writeInt(size());
+			writeStateToOutputView(outView);
+			outView.flush();
+			
+			// create a handle to the state
+			return new FsHeapReducingStateSnapshot<K, V>(getKeySerializer(), stateIdentifier, out.closeAndGetPath());
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapReducingStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapReducingStateSnapshot.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.InputViewDataInputStreamWrapper;
+import org.apache.flink.runtime.state.KvStateSnapshot;
+
+import java.io.DataInputStream;
+import java.util.HashMap;
+
+/**
+ * A snapshot of a heap partitioned {@link ListState} stored in a
+ * file.
+ *
+ * @param <K> The type of the key in the snapshot state.
+ * @param <V> The type of the values.
+ */
+public class FsHeapReducingStateSnapshot<K, V> extends AbstractFileState implements KvStateSnapshot<K, ReducingState<V>, ReducingStateIdentifier<V>, FsStateBackend> {
+
+	private static final long serialVersionUID = 1L;
+
+	/** Name of the key serializer class */
+	private final String keySerializerClassName;
+
+	/** Hash of the StateIdentifier, for sanity checks */
+	int stateIdentifierHash;
+
+	/**
+	 * Creates a new state snapshot with data in the file system.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param filePath The path where the snapshot data is stored.
+	 */
+	public FsHeapReducingStateSnapshot(TypeSerializer<K> keySerializer, ReducingStateIdentifier<V> stateIdentifiers, Path filePath) {
+		super(filePath);
+		this.keySerializerClassName = keySerializer.getClass().getName();
+		this.stateIdentifierHash = stateIdentifiers.hashCode();
+	}
+
+	@Override
+	public FsHeapReducingState<K, V> restoreState(
+			FsStateBackend stateBackend,
+			final TypeSerializer<K> keySerializer,
+			ReducingStateIdentifier<V> stateIdentifier,
+			ClassLoader classLoader) throws Exception {
+
+		// validity checks
+		if (!keySerializer.getClass().getName().equals(keySerializerClassName)
+				|| stateIdentifierHash != stateIdentifier.hashCode()) {
+			throw new IllegalArgumentException(
+					"Cannot restore the state from the snapshot with the given serializers. " +
+							"State (K/V) was serialized with " +
+							"(" + keySerializerClassName + "/" + stateIdentifierHash + ") " +
+							"now is (" + keySerializer.getClass().getName() + "/" + stateIdentifier.hashCode() + ")");
+		}
+
+		// state restore
+		try (FSDataInputStream inStream = stateBackend.getFileSystem().open(getFilePath())) {
+			InputViewDataInputStreamWrapper inView = new InputViewDataInputStreamWrapper(new DataInputStream(inStream));
+
+			final int numEntries = inView.readInt();
+			HashMap<K, V> stateMap = new HashMap<>(numEntries);
+
+			TypeSerializer<V> valueSerializer = stateIdentifier.getSerializer();
+			for (int i = 0; i < numEntries; i++) {
+				K key = keySerializer.deserialize(inView);
+				V value = valueSerializer.deserialize(inView);
+				stateMap.put(key, value);
+			}
+
+			return new FsHeapReducingState<>(keySerializer, stateIdentifier, stateMap, stateBackend);
+		}
+		catch (Exception e) {
+			throw new Exception("Failed to restore state from file system", e);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapValueState.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.state.ValueStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
+import org.apache.flink.runtime.state.AbstractHeapValueState;
+
+import java.io.DataOutputStream;
+import java.util.HashMap;
+
+/**
+ * Heap-backed partitioned {@link org.apache.flink.api.common.state.ValueState} that is snapshotted
+ * into files.
+ * 
+ * @param <K> The type of the key.
+ * @param <V> The type of the value.
+ */
+public class FsHeapValueState<K, V> extends AbstractHeapValueState<K, V, FsStateBackend> {
+	
+	/**
+	 * Creates a new and empty key/value state.
+	 * 
+	 * @param keySerializer The serializer for the key.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 * and can create a default state value.
+	 * @param backend The file system state backend backing snapshots of this state
+	 */
+	public FsHeapValueState(TypeSerializer<K> keySerializer, ValueStateIdentifier<V> stateIdentifier, FsStateBackend backend) {
+		super(backend, keySerializer, stateIdentifier);
+	}
+
+	/**
+	 * Creates a new key/value state with the given state contents.
+	 * This method is used to re-create key/value state with existing data, for example from
+	 * a snapshot.
+	 * 
+	 * @param keySerializer The serializer for the key.
+	 * @param stateIdentifier The state identifier for the state. This contains name
+	 *                           and can create a default state value.
+	 * @param state The map of key/value pairs to initialize the state with.
+	 * @param backend The file system state backend backing snapshots of this state
+	 */
+	public FsHeapValueState(TypeSerializer<K> keySerializer, ValueStateIdentifier<V> stateIdentifier, HashMap<K, V> state, FsStateBackend backend) {
+		super(backend, keySerializer, stateIdentifier, state);
+	}
+
+
+
+	@Override
+	public FsHeapValueStateSnapshot<K, V> snapshot(long checkpointId, long timestamp) throws Exception {
+		// first, create an output stream to write to
+		try (FsStateBackend.FsCheckpointStateOutputStream out = 
+					backend.createCheckpointStateOutputStream(checkpointId, timestamp)) {
+
+			// serialize the state to the output stream
+			OutputViewDataOutputStreamWrapper outView = 
+					new OutputViewDataOutputStreamWrapper(new DataOutputStream(out));
+			outView.writeInt(size());
+			writeStateToOutputView(outView);
+			outView.flush();
+			
+			// create a handle to the state
+			return new FsHeapValueStateSnapshot<K, V>(getKeySerializer(), stateIdentifier, out.closeAndGetPath());
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapValueStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsHeapValueStateSnapshot.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.InputViewDataInputStreamWrapper;
+import org.apache.flink.runtime.state.KvStateSnapshot;
+
+import java.io.DataInputStream;
+import java.util.HashMap;
+
+/**
+ * A snapshot of a heap key/value state stored in a file.
+ * 
+ * @param <K> The type of the key in the snapshot state.
+ * @param <V> The type of the value.
+ */
+public class FsHeapValueStateSnapshot<K, V> extends AbstractFileState implements KvStateSnapshot<K, ValueState<V>, ValueStateIdentifier<V>, FsStateBackend> {
+	
+	private static final long serialVersionUID = 1L;
+
+	/** Name of the key serializer class */
+	private final String keySerializerClassName;
+
+	/** Hash of the StateIdentifier, for sanity checks */
+	int stateIdentifierHash;
+
+	/**
+	 * Creates a new state snapshot with data in the file system.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param filePath The path where the snapshot data is stored.
+	 */
+	public FsHeapValueStateSnapshot(TypeSerializer<K> keySerializer, ValueStateIdentifier<V> stateIdentifiers, Path filePath) {
+		super(filePath);
+		this.stateIdentifierHash = stateIdentifiers.hashCode();
+		this.keySerializerClassName = keySerializer.getClass().getName();
+	}
+
+	@Override
+	public FsHeapValueState<K, V> restoreState(
+			FsStateBackend stateBackend,
+			final TypeSerializer<K> keySerializer,
+			ValueStateIdentifier<V> stateIdentifier,
+			ClassLoader classLoader) throws Exception {
+
+		// validity checks
+		if (!keySerializer.getClass().getName().equals(keySerializerClassName)
+				|| stateIdentifierHash != stateIdentifier.hashCode()) {
+			throw new IllegalArgumentException(
+					"Cannot restore the state from the snapshot with the given serializers. " +
+							"State (K/V) was serialized with " +
+							"(" + keySerializerClassName + "/" + stateIdentifierHash + ") " +
+							"now is (" + keySerializer.getClass().getName() + "/" + stateIdentifier.hashCode() + ")");
+		}
+
+		// state restore
+		try (FSDataInputStream inStream = stateBackend.getFileSystem().open(getFilePath())) {
+			InputViewDataInputStreamWrapper inView = new InputViewDataInputStreamWrapper(new DataInputStream(inStream));
+
+			final int numEntries = inView.readInt();
+			HashMap<K, V> stateMap = new HashMap<>(numEntries);
+
+			TypeSerializer<V> valueSerializer = stateIdentifier.getSerializer();
+			for (int i = 0; i < numEntries; i++) {
+				K key = keySerializer.deserialize(inView);
+				V initialState = valueSerializer.deserialize(inView);
+				stateMap.put(key, initialState);
+			}
+
+			return new FsHeapValueState<>(keySerializer, stateIdentifier, stateMap, stateBackend);
+		}
+		catch (Exception e) {
+			throw new Exception("Failed to restore state from file system", e);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -19,12 +19,18 @@
 package org.apache.flink.runtime.state.filesystem;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateIdentifier;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateIdentifier;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +51,7 @@ import java.util.UUID;
  * 
  * {@code hdfs://namenode:port/flink-checkpoints/<job-id>/chk-17/6ba7b810-9dad-11d1-80b4-00c04fd430c8 }
  */
-public class FsStateBackend extends StateBackend<FsStateBackend> {
+public class FsStateBackend extends AbstractStateBackend {
 
 	private static final long serialVersionUID = -8191916350224044011L;
 	
@@ -203,13 +209,15 @@ public class FsStateBackend extends StateBackend<FsStateBackend> {
 	// ------------------------------------------------------------------------
 	//  initialization and cleanup
 	// ------------------------------------------------------------------------
-	
+
 	@Override
-	public void initializeForJob(JobID jobId) throws Exception {
+	public void initializeForJob(JobID jobId, TypeSerializer<?> keySerializer, ClassLoader userCodeClassLoader) throws Exception {
+		super.initializeForJob(jobId, keySerializer, userCodeClassLoader);
+
 		Path dir = new Path(basePath, jobId.toString());
-		
+
 		LOG.info("Initializing file state backend to URI " + dir);
-		
+
 		filesystem = basePath.getFileSystem();
 		filesystem.mkdirs(dir);
 
@@ -237,12 +245,22 @@ public class FsStateBackend extends StateBackend<FsStateBackend> {
 	// ------------------------------------------------------------------------
 	//  state backend operations
 	// ------------------------------------------------------------------------
-	
+
 	@Override
-	public <K, V> FsHeapKvState<K, V> createKvState(
-			TypeSerializer<K> keySerializer, TypeSerializer<V> valueSerializer, V defaultValue) throws Exception {
-		return new FsHeapKvState<K, V>(keySerializer, valueSerializer, defaultValue, this);
+	public <V> ValueState<V> createValueState(ValueStateIdentifier<V> stateIdentifier) throws Exception {
+		return new FsHeapValueState<>(keySerializer, stateIdentifier, this);
 	}
+
+	@Override
+	public <T> ListState<T> createListState(ListStateIdentifier<T> stateIdentifier) throws Exception {
+		return new FsHeapListState<>(keySerializer, stateIdentifier, this);
+	}
+
+	@Override
+	public <T> ReducingState<T> createReducingState(ReducingStateIdentifier<T> stateIdentifier) throws Exception {
+		return new FsHeapReducingState<>(keySerializer, stateIdentifier, this);
+	}
+
 
 	@Override
 	public <S extends Serializable> StateHandle<S> checkpointStateSerializable(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemHeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemHeapReducingState.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.memory;
+
+import org.apache.flink.api.common.state.ReducingStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.AbstractHeapReducingState;
+import org.apache.flink.runtime.util.DataOutputSerializer;
+
+import java.util.HashMap;
+
+/**
+ * Heap-backed partitioned {@link org.apache.flink.api.common.state.ReducingState} that is
+ * snapshotted into a serialized memory copy.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the values in the list state.
+ */
+public class MemHeapReducingState<K, V> extends AbstractHeapReducingState<K, V, MemoryStateBackend> {
+
+	public MemHeapReducingState(MemoryStateBackend backend, TypeSerializer<K> keySerializer, ReducingStateIdentifier<V> stateIdentifier) {
+		super(backend, keySerializer, stateIdentifier);
+	}
+
+	public MemHeapReducingState(MemoryStateBackend backend, TypeSerializer<K> keySerializer, ReducingStateIdentifier<V> stateIdentifier, HashMap<K, V> state) {
+		super(backend, keySerializer, stateIdentifier, state);
+	}
+
+	@Override
+	public MemoryHeapReducingStateSnapshot<K, V> snapshot(long checkpointId, long timestamp) throws Exception {
+		DataOutputSerializer ser = new DataOutputSerializer(Math.max(size() * 16, 16));
+		writeStateToOutputView(ser);
+		byte[] bytes = ser.getCopyOfBuffer();
+
+		return new MemoryHeapReducingStateSnapshot<>(getKeySerializer(), stateIdentifier, bytes, size());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemHeapValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemHeapValueState.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.memory;
+
+import org.apache.flink.api.common.state.ValueStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.util.DataOutputSerializer;
+import org.apache.flink.runtime.state.AbstractHeapValueState;
+
+import java.util.HashMap;
+
+/**
+ * Heap-backed key/value state that is snapshotted into a serialized memory copy.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the value.
+ */
+public class MemHeapValueState<K, V> extends AbstractHeapValueState<K, V, MemoryStateBackend> {
+	
+	public MemHeapValueState(MemoryStateBackend backend, TypeSerializer<K> keySerializer, ValueStateIdentifier<V> stateIdentifier) {
+		super(backend, keySerializer, stateIdentifier);
+	}
+
+	public MemHeapValueState(MemoryStateBackend backend, TypeSerializer<K> keySerializer, ValueStateIdentifier<V> stateIdentifier, HashMap<K, V> state) {
+		super(backend, keySerializer, stateIdentifier, state);
+	}
+	
+	@Override
+	public MemoryHeapValueStateSnapshot<K, V> snapshot(long checkpointId, long timestamp) throws Exception {
+		DataOutputSerializer ser = new DataOutputSerializer(Math.max(size() * 16, 16));
+		writeStateToOutputView(ser);
+		byte[] bytes = ser.getCopyOfBuffer();
+		
+		return new MemoryHeapValueStateSnapshot<>(getKeySerializer(), stateIdentifier, bytes, size());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryHeapListStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryHeapListStateSnapshot.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.memory;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.KvStateSnapshot;
+import org.apache.flink.runtime.util.DataInputDeserializer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * A snapshot of a {@link MemHeapListState} for a checkpoint. The data is stored in a heap byte
+ * array, in serialized form.
+ * 
+ * @param <K> The type of the key in the snapshot state.
+ * @param <V> The type of the values in the snapshot state.
+ */
+public class MemoryHeapListStateSnapshot<K, V> implements KvStateSnapshot<K, ListState<V>, ListStateIdentifier<V>,  MemoryStateBackend> {
+
+	private static final long serialVersionUID = 1L;
+
+	/** Name of the key serializer class */
+	private final String keySerializerClassName;
+
+	/** Hash of the StateIdentifier, for sanity checks */
+	int stateIdentifierHash;
+
+	/** The serialized data of the state key/value pairs */
+	private final byte[] data;
+
+	/** The number of key/value pairs */
+	private final int numEntries;
+
+	/**
+	 * Creates a new heap memory state snapshot.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param data The serialized data of the state key/value pairs
+	 * @param numEntries The number of key/value pairs
+	 */
+	public MemoryHeapListStateSnapshot(TypeSerializer<K> keySerializer, ListStateIdentifier<V> stateIdentifiers, byte[] data, int numEntries) {
+		this.keySerializerClassName = keySerializer.getClass().getName();
+		this.stateIdentifierHash = stateIdentifiers.hashCode();
+		this.data = data;
+		this.numEntries = numEntries;
+	}
+
+
+
+	@Override
+	public MemHeapListState<K, V> restoreState(
+			MemoryStateBackend stateBackend,
+			final TypeSerializer<K> keySerializer,
+			ListStateIdentifier<V> stateIdentifier,
+			ClassLoader classLoader) throws Exception {
+
+		// validity checks
+		if (!keySerializer.getClass().getName().equals(keySerializerClassName)
+				|| stateIdentifierHash != stateIdentifier.hashCode()) {
+			throw new IllegalArgumentException(
+					"Cannot restore the state from the snapshot with the given serializers. " +
+							"State (K/V) was serialized with " +
+							"(" + keySerializerClassName + "/" + stateIdentifierHash + ") " +
+							"now is (" + keySerializer.getClass().getName() + "/" + stateIdentifier.hashCode() + ")");
+		}
+		
+		// restore state
+		HashMap<K, List<V>> stateMap = new HashMap<>(numEntries);
+		DataInputDeserializer in = new DataInputDeserializer(data, 0, data.length);
+
+		TypeSerializer<V> valueSerializer = stateIdentifier.getSerializer();
+		for (int i = 0; i < numEntries; i++) {
+			K key = keySerializer.deserialize(in);
+			int listSize = in.readInt();
+			List<V> list = new ArrayList<>(listSize);
+			for (int j = 0; j < listSize; j++) {
+				V value = valueSerializer.deserialize(in);
+				list.add(value);
+			}
+			stateMap.put(key, list);
+		}
+		
+		return new MemHeapListState<>(stateBackend, keySerializer, stateIdentifier, stateMap);
+	}
+
+	/**
+	 * Discarding the heap state is a no-op.
+	 */
+	@Override
+	public void discardState() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryHeapReducingStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryHeapReducingStateSnapshot.java
@@ -18,32 +18,34 @@
 
 package org.apache.flink.runtime.state.memory;
 
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateIdentifier;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.util.DataInputDeserializer;
 import org.apache.flink.runtime.state.KvStateSnapshot;
+import org.apache.flink.runtime.util.DataInputDeserializer;
 
 import java.util.HashMap;
 
 /**
- * A snapshot of a {@link MemHeapKvState} for a checkpoint. The data is stored in a heap byte
+ * A snapshot of a {@link MemHeapListState} for a checkpoint. The data is stored in a heap byte
  * array, in serialized form.
  * 
  * @param <K> The type of the key in the snapshot state.
- * @param <V> The type of the value in the snapshot state.
+ * @param <V> The type of the values in the snapshot state.
  */
-public class MemoryHeapKvStateSnapshot<K, V> implements KvStateSnapshot<K, V, MemoryStateBackend> {
-	
+public class MemoryHeapReducingStateSnapshot<K, V> implements KvStateSnapshot<K, ReducingState<V>, ReducingStateIdentifier<V>,  MemoryStateBackend> {
+
 	private static final long serialVersionUID = 1L;
-	
+
 	/** Name of the key serializer class */
 	private final String keySerializerClassName;
 
-	/** Name of the value serializer class */
-	private final String valueSerializerClassName;
-	
+	/** Hash of the StateIdentifier, for sanity checks */
+	int stateIdentifierHash;
+
 	/** The serialized data of the state key/value pairs */
 	private final byte[] data;
-	
+
 	/** The number of key/value pairs */
 	private final int numEntries;
 
@@ -51,47 +53,47 @@ public class MemoryHeapKvStateSnapshot<K, V> implements KvStateSnapshot<K, V, Me
 	 * Creates a new heap memory state snapshot.
 	 *
 	 * @param keySerializer The serializer for the keys.
-	 * @param valueSerializer The serializer for the values.
 	 * @param data The serialized data of the state key/value pairs
 	 * @param numEntries The number of key/value pairs
 	 */
-	public MemoryHeapKvStateSnapshot(TypeSerializer<K> keySerializer,
-						TypeSerializer<V> valueSerializer, byte[] data, int numEntries) {
+	public MemoryHeapReducingStateSnapshot(TypeSerializer<K> keySerializer, ReducingStateIdentifier<V> stateIdentifiers, byte[] data, int numEntries) {
 		this.keySerializerClassName = keySerializer.getClass().getName();
-		this.valueSerializerClassName = valueSerializer.getClass().getName();
+		this.stateIdentifierHash = stateIdentifiers.hashCode();
 		this.data = data;
 		this.numEntries = numEntries;
 	}
 
 
+
 	@Override
-	public MemHeapKvState<K, V> restoreState(
+	public MemHeapReducingState<K, V> restoreState(
 			MemoryStateBackend stateBackend,
 			final TypeSerializer<K> keySerializer,
-			final TypeSerializer<V> valueSerializer,
-			V defaultValue,
+			ReducingStateIdentifier<V> stateIdentifier,
 			ClassLoader classLoader) throws Exception {
 
 		// validity checks
-		if (!keySerializer.getClass().getName().equals(keySerializerClassName) ||
-			!valueSerializer.getClass().getName().equals(valueSerializerClassName)) {
-				throw new IllegalArgumentException(
-						"Cannot restore the state from the snapshot with the given serializers. " +
-						"State (K/V) was serialized with (" + valueSerializerClassName + 
-						"/" + keySerializerClassName + ")");
+		if (!keySerializer.getClass().getName().equals(keySerializerClassName)
+				|| stateIdentifierHash != stateIdentifier.hashCode()) {
+			throw new IllegalArgumentException(
+					"Cannot restore the state from the snapshot with the given serializers. " +
+							"State (K/V) was serialized with " +
+							"(" + keySerializerClassName + "/" + stateIdentifierHash + ") " +
+							"now is (" + keySerializer.getClass().getName() + "/" + stateIdentifier.hashCode() + ")");
 		}
 		
 		// restore state
 		HashMap<K, V> stateMap = new HashMap<>(numEntries);
 		DataInputDeserializer in = new DataInputDeserializer(data, 0, data.length);
-		
+
+		TypeSerializer<V> valueSerializer = stateIdentifier.getSerializer();
 		for (int i = 0; i < numEntries; i++) {
 			K key = keySerializer.deserialize(in);
 			V value = valueSerializer.deserialize(in);
 			stateMap.put(key, value);
 		}
 		
-		return new MemHeapKvState<K, V>(keySerializer, valueSerializer, defaultValue, stateMap);
+		return new MemHeapReducingState<>(stateBackend, keySerializer, stateIdentifier, stateMap);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryHeapValueStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryHeapValueStateSnapshot.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.memory;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.util.DataInputDeserializer;
+import org.apache.flink.runtime.state.KvStateSnapshot;
+
+import java.util.HashMap;
+
+/**
+ * A snapshot of a {@link MemHeapValueState} for a checkpoint. The data is stored in a heap byte
+ * array, in serialized form.
+ * 
+ * @param <K> The type of the key in the snapshot state.
+ * @param <V> The type of the value in the snapshot state.
+ */
+public class MemoryHeapValueStateSnapshot<K, V> implements KvStateSnapshot<K, ValueState<V>, ValueStateIdentifier<V>,  MemoryStateBackend> {
+	
+	private static final long serialVersionUID = 1L;
+	
+	/** Name of the key serializer class */
+	private final String keySerializerClassName;
+
+	/** Hash of the StateIdentifier, for sanity checks */
+	int stateIdentifierHash;
+
+	private final ValueStateIdentifier<V> oldStateIdentifier;
+
+	/** The serialized data of the state key/value pairs */
+	private final byte[] data;
+	
+	/** The number of key/value pairs */
+	private final int numEntries;
+
+	/**
+	 * Creates a new heap memory state snapshot.
+	 *
+	 * @param keySerializer The serializer for the keys.
+	 * @param data The serialized data of the state key/value pairs
+	 * @param numEntries The number of key/value pairs
+	 */
+	public MemoryHeapValueStateSnapshot(TypeSerializer<K> keySerializer, ValueStateIdentifier<V> stateIdentifiers, byte[] data, int numEntries) {
+		this.keySerializerClassName = keySerializer.getClass().getName();
+		this.stateIdentifierHash = stateIdentifiers.hashCode();
+		this.oldStateIdentifier = stateIdentifiers;
+		this.data = data;
+		this.numEntries = numEntries;
+	}
+
+
+
+	@Override
+	public MemHeapValueState<K, V> restoreState(
+			MemoryStateBackend stateBackend,
+			final TypeSerializer<K> keySerializer,
+			ValueStateIdentifier<V> stateIdentifier,
+			ClassLoader classLoader) throws Exception {
+
+		// validity checks
+		if (!keySerializer.getClass().getName().equals(keySerializerClassName)
+				|| stateIdentifierHash != stateIdentifier.hashCode()) {
+				throw new IllegalArgumentException(
+						"Cannot restore the state from the snapshot with the given serializers. " +
+						"State (K/V) was serialized with " +
+						"(" + keySerializerClassName + "/" + stateIdentifierHash + ") " +
+						"now is (" + keySerializer.getClass().getName() + "/" + stateIdentifier.hashCode() + ")");
+		}
+		
+		// restore state
+		HashMap<K, V> stateMap = new HashMap<>(numEntries);
+		DataInputDeserializer in = new DataInputDeserializer(data, 0, data.length);
+
+		TypeSerializer<V> valueSerializer = stateIdentifier.getSerializer();
+		for (int i = 0; i < numEntries; i++) {
+			K key = keySerializer.deserialize(in);
+			V value = valueSerializer.deserialize(in);
+			stateMap.put(key, value);
+		}
+		
+		return new MemHeapValueState<>(stateBackend, keySerializer, stateIdentifier, stateMap);
+	}
+
+	/**
+	 * Discarding the heap state is a no-op.
+	 */
+	@Override
+	public void discardState() {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
@@ -18,21 +18,24 @@
 
 package org.apache.flink.runtime.state;
 
+import com.google.common.base.Joiner;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateIdentifier;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.FloatSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.IntValueSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.api.java.typeutils.runtime.ValueSerializer;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.state.filesystem.FileStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.StringValue;
 
 import org.junit.Test;
 
@@ -46,24 +49,24 @@ import java.util.UUID;
 import static org.junit.Assert.*;
 
 public class FileStateBackendTest {
-	
+
 	@Test
 	public void testSetupAndSerialization() {
 		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
 		try {
 			final String backendDir = localFileUri(tempDir);
 			FsStateBackend originalBackend = new FsStateBackend(backendDir);
-			
+
 			assertFalse(originalBackend.isInitialized());
 			assertEquals(new URI(backendDir), originalBackend.getBasePath().toUri());
 			assertNull(originalBackend.getCheckpointDirectory());
-			
+
 			// serialize / copy the backend
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(originalBackend);
 			assertFalse(backend.isInitialized());
 			assertEquals(new URI(backendDir), backend.getBasePath().toUri());
 			assertNull(backend.getCheckpointDirectory());
-			
+
 			// no file operations should be possible right now
 			try {
 				backend.checkpointStateSerializable("exception train rolling in", 2L, System.currentTimeMillis());
@@ -71,17 +74,17 @@ public class FileStateBackendTest {
 			} catch (IllegalStateException e) {
 				// supreme!
 			}
-			
-			backend.initializeForJob(new JobID());
+
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 			assertNotNull(backend.getCheckpointDirectory());
-			
+
 			File checkpointDir = new File(backend.getCheckpointDirectory().toUri().getPath());
 			assertTrue(checkpointDir.exists());
 			assertTrue(isDirectoryEmpty(checkpointDir));
-			
+
 			backend.disposeAllStateForCurrentJob();
 			assertNull(backend.getCheckpointDirectory());
-			
+
 			assertTrue(isDirectoryEmpty(tempDir));
 		}
 		catch (Exception e) {
@@ -92,20 +95,20 @@ public class FileStateBackendTest {
 			deleteDirectorySilently(tempDir);
 		}
 	}
-	
+
 	@Test
 	public void testSerializableState() {
 		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
 		try {
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(localFileUri(tempDir)));
-			backend.initializeForJob(new JobID());
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 
 			File checkpointDir = new File(backend.getCheckpointDirectory().toUri().getPath());
 
 			String state1 = "dummy state";
 			String state2 = "row row row your boat";
 			Integer state3 = 42;
-			
+
 			StateHandle<String> handle1 = backend.checkpointStateSerializable(state1, 439568923746L, System.currentTimeMillis());
 			StateHandle<String> handle2 = backend.checkpointStateSerializable(state2, 439568923746L, System.currentTimeMillis());
 			StateHandle<Integer> handle3 = backend.checkpointStateSerializable(state3, 439568923746L, System.currentTimeMillis());
@@ -113,15 +116,15 @@ public class FileStateBackendTest {
 			assertFalse(isDirectoryEmpty(checkpointDir));
 			assertEquals(state1, handle1.getState(getClass().getClassLoader()));
 			handle1.discardState();
-			
+
 			assertFalse(isDirectoryEmpty(checkpointDir));
 			assertEquals(state2, handle2.getState(getClass().getClassLoader()));
 			handle2.discardState();
-			
+
 			assertFalse(isDirectoryEmpty(checkpointDir));
 			assertEquals(state3, handle3.getState(getClass().getClassLoader()));
 			handle3.discardState();
-			
+
 			assertTrue(isDirectoryEmpty(checkpointDir));
 		}
 		catch (Exception e) {
@@ -138,7 +141,7 @@ public class FileStateBackendTest {
 		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
 		try {
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(localFileUri(tempDir)));
-			backend.initializeForJob(new JobID());
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 
 			File checkpointDir = new File(backend.getCheckpointDirectory().toUri().getPath());
 
@@ -146,7 +149,7 @@ public class FileStateBackendTest {
 			byte[] state2 = new byte[1];
 			byte[] state3 = new byte[0];
 			byte[] state4 = new byte[177];
-			
+
 			Random rnd = new Random();
 			rnd.nextBytes(state1);
 			rnd.nextBytes(state2);
@@ -155,31 +158,31 @@ public class FileStateBackendTest {
 
 			long checkpointId = 97231523452L;
 
-			FsStateBackend.FsCheckpointStateOutputStream stream1 = 
+			FsStateBackend.FsCheckpointStateOutputStream stream1 =
 					backend.createCheckpointStateOutputStream(checkpointId, System.currentTimeMillis());
 			FsStateBackend.FsCheckpointStateOutputStream stream2 =
 					backend.createCheckpointStateOutputStream(checkpointId, System.currentTimeMillis());
 			FsStateBackend.FsCheckpointStateOutputStream stream3 =
 					backend.createCheckpointStateOutputStream(checkpointId, System.currentTimeMillis());
-			
+
 			stream1.write(state1);
 			stream2.write(state2);
 			stream3.write(state3);
-			
+
 			FileStreamStateHandle handle1 = stream1.closeAndGetHandle();
 			FileStreamStateHandle handle2 = stream2.closeAndGetHandle();
 			FileStreamStateHandle handle3 = stream3.closeAndGetHandle();
-			
+
 			// use with try-with-resources
 			StreamStateHandle handle4;
-			try (StateBackend.CheckpointStateOutputStream stream4 =
+			try (AbstractStateBackend.CheckpointStateOutputStream stream4 =
 					backend.createCheckpointStateOutputStream(checkpointId, System.currentTimeMillis())) {
 				stream4.write(state4);
 				handle4 = stream4.closeAndGetHandle();
 			}
-			
+
 			// close before accessing handle
-			StateBackend.CheckpointStateOutputStream stream5 =
+			AbstractStateBackend.CheckpointStateOutputStream stream5 =
 					backend.createCheckpointStateOutputStream(checkpointId, System.currentTimeMillis());
 			stream5.write(state4);
 			stream5.close();
@@ -189,22 +192,22 @@ public class FileStateBackendTest {
 			} catch (IOException e) {
 				// uh-huh
 			}
-			
+
 			validateBytesInStream(handle1.getState(getClass().getClassLoader()), state1);
 			handle1.discardState();
 			assertFalse(isDirectoryEmpty(checkpointDir));
 			ensureLocalFileDeleted(handle1.getFilePath());
-			
+
 			validateBytesInStream(handle2.getState(getClass().getClassLoader()), state2);
 			handle2.discardState();
 			assertFalse(isDirectoryEmpty(checkpointDir));
 			ensureLocalFileDeleted(handle2.getFilePath());
-			
+
 			validateBytesInStream(handle3.getState(getClass().getClassLoader()), state3);
 			handle3.discardState();
 			assertFalse(isDirectoryEmpty(checkpointDir));
 			ensureLocalFileDeleted(handle3.getFilePath());
-			
+
 			validateBytesInStream(handle4.getState(getClass().getClassLoader()), state4);
 			handle4.discardState();
 			assertTrue(isDirectoryEmpty(checkpointDir));
@@ -219,78 +222,93 @@ public class FileStateBackendTest {
 	}
 
 	@Test
-	public void testKeyValueState() {
+	public void testValueState() {
 		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
 		try {
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(localFileUri(tempDir)));
-			backend.initializeForJob(new JobID());
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 
 			File checkpointDir = new File(backend.getCheckpointDirectory().toUri().getPath());
 
-			KvState<Integer, String, FsStateBackend> kv =
-					backend.createKvState(IntSerializer.INSTANCE, StringSerializer.INSTANCE, null);
+			ValueStateIdentifier<String> kvId = new ValueStateIdentifier<>("id", null, StringSerializer.INSTANCE);
+			ValueState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend> kv =
+					(KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend>) state;
 
 			assertEquals(0, kv.size());
 
 			// some modifications to the state
 			kv.setCurrentKey(1);
-			assertNull(kv.value());
-			kv.update("1");
+			assertNull(state.value());
+			state.update("1");
 			assertEquals(1, kv.size());
 			kv.setCurrentKey(2);
-			assertNull(kv.value());
-			kv.update("2");
+			assertNull(state.value());
+			state.update("2");
 			assertEquals(2, kv.size());
 			kv.setCurrentKey(1);
-			assertEquals("1", kv.value());
+			assertEquals("1", state.value());
 			assertEquals(2, kv.size());
 
 			// draw a snapshot
-			KvStateSnapshot<Integer, String, FsStateBackend> snapshot1 =
+			KvStateSnapshot<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend> snapshot1 =
 					kv.snapshot(682375462378L, System.currentTimeMillis());
 
 			// make some more modifications
 			kv.setCurrentKey(1);
-			kv.update("u1");
+			state.update("u1");
 			kv.setCurrentKey(2);
-			kv.update("u2");
+			state.update("u2");
 			kv.setCurrentKey(3);
-			kv.update("u3");
+			state.update("u3");
 
 			// draw another snapshot
-			KvStateSnapshot<Integer, String, FsStateBackend> snapshot2 =
+			KvStateSnapshot<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend> snapshot2 =
 					kv.snapshot(682375462379L, System.currentTimeMillis());
 
 			// validate the original state
 			assertEquals(3, kv.size());
 			kv.setCurrentKey(1);
-			assertEquals("u1", kv.value());
+			assertEquals("u1", state.value());
 			kv.setCurrentKey(2);
-			assertEquals("u2", kv.value());
+			assertEquals("u2", state.value());
 			kv.setCurrentKey(3);
-			assertEquals("u3", kv.value());
+			assertEquals("u3", state.value());
 
-			// restore the first snapshot and validate it
-			KvState<Integer, String, FsStateBackend> restored1 = snapshot1.restoreState(backend,
-					IntSerializer.INSTANCE, StringSerializer.INSTANCE, null, getClass().getClassLoader());
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend> restored1 = snapshot1.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ValueState<String> restored1State = (ValueState<String>) restored1;
 
 			assertEquals(2, restored1.size());
 			restored1.setCurrentKey(1);
-			assertEquals("1", restored1.value());
+			assertEquals("1", restored1State.value());
 			restored1.setCurrentKey(2);
-			assertEquals("2", restored1.value());
+			assertEquals("2", restored1State.value());
 
 			// restore the first snapshot and validate it
-			KvState<Integer, String, FsStateBackend> restored2 = snapshot2.restoreState(backend,
-					IntSerializer.INSTANCE, StringSerializer.INSTANCE, null, getClass().getClassLoader());
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend> restored2 = snapshot2.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ValueState<String> restored2State = (ValueState<String>) restored2;
 
 			assertEquals(3, restored2.size());
 			restored2.setCurrentKey(1);
-			assertEquals("u1", restored2.value());
+			assertEquals("u1", restored2State.value());
 			restored2.setCurrentKey(2);
-			assertEquals("u2", restored2.value());
+			assertEquals("u2", restored2State.value());
 			restored2.setCurrentKey(3);
-			assertEquals("u3", restored2.value());
+			assertEquals("u3", restored2State.value());
 
 			snapshot1.discardState();
 			assertFalse(isDirectoryEmpty(checkpointDir));
@@ -308,47 +326,168 @@ public class FileStateBackendTest {
 	}
 
 	@Test
-	public void testRestoreWithWrongSerializers() {
+	public void testListState() {
 		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
 		try {
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(localFileUri(tempDir)));
-			backend.initializeForJob(new JobID());
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 
 			File checkpointDir = new File(backend.getCheckpointDirectory().toUri().getPath());
-			
-			KvState<Integer, String, FsStateBackend> kv =
-					backend.createKvState(IntSerializer.INSTANCE, StringSerializer.INSTANCE, null);
+
+			ListStateIdentifier<String> kvId = new ListStateIdentifier<>("id", StringSerializer.INSTANCE);
+			ListState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend> kv =
+					(KvState<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend>) state;
+
+			assertEquals(0, kv.size());
+
+			Joiner joiner = Joiner.on(",");
+			// some modifications to the state
+			kv.setCurrentKey(1);
+			assertEquals("", joiner.join(state.get()));
+			state.add("1");
+			assertEquals(1, kv.size());
+			kv.setCurrentKey(2);
+			assertEquals("", joiner.join(state.get()));
+			state.add("2");
+			assertEquals(2, kv.size());
+			kv.setCurrentKey(1);
+			assertEquals("1", joiner.join(state.get()));
+			assertEquals(2, kv.size());
+
+			// draw a snapshot
+			KvStateSnapshot<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend> snapshot1 =
+					kv.snapshot(682375462378L, System.currentTimeMillis());
+
+			// make some more modifications
+			kv.setCurrentKey(1);
+			state.add("u1");
+			kv.setCurrentKey(2);
+			state.add("u2");
+			kv.setCurrentKey(3);
+			state.add("u3");
+
+			// draw another snapshot
+			KvStateSnapshot<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend> snapshot2 =
+					kv.snapshot(682375462379L, System.currentTimeMillis());
+
+			// validate the original state
+			assertEquals(3, kv.size());
+			kv.setCurrentKey(1);
+			assertEquals("1,u1", joiner.join(state.get()));
+			kv.setCurrentKey(2);
+			assertEquals("2,u2", joiner.join(state.get()));
+			kv.setCurrentKey(3);
+			assertEquals("u3", joiner.join(state.get()));
+
+			// restore the first snapshot and validate it
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend> restored1 = snapshot1.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ListState<String> restored1State = (ListState<String>) restored1;
+
+			assertEquals(2, restored1.size());
+			restored1.setCurrentKey(1);
+			assertEquals("1", joiner.join(restored1State.get()));
+			restored1.setCurrentKey(2);
+			assertEquals("2", joiner.join(restored1State.get()));
+
+			// restore the second snapshot and validate it
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend> restored2 = snapshot2.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ListState<String> restored2State = (ListState<String>) restored2;
+
+			assertEquals(3, restored2.size());
+			restored2.setCurrentKey(1);
+			assertEquals("1,u1", joiner.join(restored2State.get()));
+			restored2.setCurrentKey(2);
+			assertEquals("2,u2", joiner.join(restored2State.get()));
+			restored2.setCurrentKey(3);
+			assertEquals("u3", joiner.join(restored2State.get()));
+
+			snapshot1.discardState();
+			assertFalse(isDirectoryEmpty(checkpointDir));
+
+			snapshot2.discardState();
+			assertTrue(isDirectoryEmpty(checkpointDir));
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+		finally {
+			deleteDirectorySilently(tempDir);
+		}
+	}
+
+	@Test
+	public void testValueStateRestoreWithWrongSerializers() {
+		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
+		try {
+			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(localFileUri(tempDir)));
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			File checkpointDir = new File(backend.getCheckpointDirectory().toUri().getPath());
+
+			ValueStateIdentifier<String> kvId = new ValueStateIdentifier<>("id", null, StringSerializer.INSTANCE);
+			ValueState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend> kv =
+					(KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend>) state;
 
 			kv.setCurrentKey(1);
-			kv.update("1");
+			state.update("1");
 			kv.setCurrentKey(2);
-			kv.update("2");
+			state.update("2");
 
-			KvStateSnapshot<Integer, String, FsStateBackend> snapshot =
+			KvStateSnapshot<Integer, ValueState<String>, ValueStateIdentifier<String>, FsStateBackend> snapshot =
 					kv.snapshot(682375462378L, System.currentTimeMillis());
+
 
 
 			@SuppressWarnings("unchecked")
 			TypeSerializer<Integer> fakeIntSerializer =
 					(TypeSerializer<Integer>) (TypeSerializer<?>) FloatSerializer.INSTANCE;
 
-			@SuppressWarnings("unchecked")
-			TypeSerializer<String> fakeStringSerializer =
-					(TypeSerializer<String>) (TypeSerializer<?>) new ValueSerializer<StringValue>(StringValue.class);
-
 			try {
 				snapshot.restoreState(backend, fakeIntSerializer,
-						StringSerializer.INSTANCE, null, getClass().getClassLoader());
+						kvId, getClass().getClassLoader());
 				fail("should recognize wrong serializers");
 			} catch (IllegalArgumentException e) {
 				// expected
 			} catch (Exception e) {
 				fail("wrong exception");
 			}
+
+			@SuppressWarnings("unchecked")
+			ValueStateIdentifier<String> fakeKvId =
+					(ValueStateIdentifier<String>)(ValueStateIdentifier<?>) new ValueStateIdentifier<>("id", null, FloatSerializer.INSTANCE);
 
 			try {
 				snapshot.restoreState(backend, IntSerializer.INSTANCE,
-						fakeStringSerializer, null, getClass().getClassLoader());
+						fakeKvId, getClass().getClassLoader());
+				fail("should recognize wrong serializers");
+			} catch (IllegalArgumentException e) {
+				// expected
+			} catch (Exception e) {
+				fail("wrong exception " + e);
+			}
+
+			try {
+				snapshot.restoreState(backend, fakeIntSerializer,
+						fakeKvId, getClass().getClassLoader());
 				fail("should recognize wrong serializers");
 			} catch (IllegalArgumentException e) {
 				// expected
@@ -356,16 +495,83 @@ public class FileStateBackendTest {
 				fail("wrong exception");
 			}
 
+			snapshot.discardState();
+
+			assertTrue(isDirectoryEmpty(checkpointDir));
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+		finally {
+			deleteDirectorySilently(tempDir);
+		}
+	}
+
+	@Test
+	public void testListStateRestoreWithWrongSerializers() {
+		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
+		try {
+			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(localFileUri(tempDir)));
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			File checkpointDir = new File(backend.getCheckpointDirectory().toUri().getPath());
+
+			ListStateIdentifier<String> kvId = new ListStateIdentifier<>("id", StringSerializer.INSTANCE);
+			ListState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend> kv =
+					(KvState<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend>) state;
+
+			kv.setCurrentKey(1);
+			state.add("1");
+			kv.setCurrentKey(2);
+			state.add("2");
+
+			KvStateSnapshot<Integer, ListState<String>, ListStateIdentifier<String>, FsStateBackend> snapshot =
+					kv.snapshot(682375462378L, System.currentTimeMillis());
+
+
+
+			@SuppressWarnings("unchecked")
+			TypeSerializer<Integer> fakeIntSerializer =
+					(TypeSerializer<Integer>) (TypeSerializer<?>) FloatSerializer.INSTANCE;
+
 			try {
 				snapshot.restoreState(backend, fakeIntSerializer,
-						fakeStringSerializer, null, getClass().getClassLoader());
+						kvId, getClass().getClassLoader());
 				fail("should recognize wrong serializers");
 			} catch (IllegalArgumentException e) {
 				// expected
 			} catch (Exception e) {
 				fail("wrong exception");
 			}
-			
+
+			@SuppressWarnings("unchecked")
+			ListStateIdentifier<String> fakeKvId =
+					(ListStateIdentifier<String>)(ListStateIdentifier<?>) new ListStateIdentifier<>("id", FloatSerializer.INSTANCE);
+
+			try {
+				snapshot.restoreState(backend, IntSerializer.INSTANCE,
+						fakeKvId, getClass().getClassLoader());
+				fail("should recognize wrong serializers");
+			} catch (IllegalArgumentException e) {
+				// expected
+			} catch (Exception e) {
+				fail("wrong exception " + e);
+			}
+
+			try {
+				snapshot.restoreState(backend, fakeIntSerializer,
+						fakeKvId, getClass().getClassLoader());
+				fail("should recognize wrong serializers");
+			} catch (IllegalArgumentException e) {
+				// expected
+			} catch (Exception e) {
+				fail("wrong exception");
+			}
+
 			snapshot.discardState();
 
 			assertTrue(isDirectoryEmpty(checkpointDir));
@@ -384,16 +590,20 @@ public class FileStateBackendTest {
 		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
 		try {
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(localFileUri(tempDir)));
-			backend.initializeForJob(new JobID());
-			
-			KvState<Integer, IntValue, FsStateBackend> kv =
-					backend.createKvState(IntSerializer.INSTANCE, IntValueSerializer.INSTANCE, new IntValue(-1));
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			ValueStateIdentifier<IntValue> kvId = new ValueStateIdentifier<>("id", new IntValue(-1), IntValueSerializer.INSTANCE);
+			ValueState<IntValue> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ValueState<IntValue>, ValueStateIdentifier<IntValue>, FsStateBackend> kv =
+					(KvState<Integer, ValueState<IntValue>, ValueStateIdentifier<IntValue>, FsStateBackend>) state;
 
 			kv.setCurrentKey(1);
-			IntValue default1 = kv.value();
+			IntValue default1 = state.value();
 
 			kv.setCurrentKey(2);
-			IntValue default2 = kv.value();
+			IntValue default2 = state.value();
 
 			assertNotNull(default1);
 			assertNotNull(default2);
@@ -408,11 +618,11 @@ public class FileStateBackendTest {
 			deleteDirectorySilently(tempDir);
 		}
 	}
-	
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
-	
+
 	private static void ensureLocalFileDeleted(Path path) {
 		URI uri = path.toUri();
 		if ("file".equals(uri.getScheme())) {
@@ -423,23 +633,23 @@ public class FileStateBackendTest {
 			throw new IllegalArgumentException("not a local path");
 		}
 	}
-	
+
 	private static void deleteDirectorySilently(File dir) {
 		try {
 			FileUtils.deleteDirectory(dir);
 		}
 		catch (IOException ignored) {}
 	}
-	
+
 	private static boolean isDirectoryEmpty(File directory) {
 		String[] nested = directory.list();
 		return  nested == null || nested.length == 0;
 	}
-	
+
 	private static String localFileUri(File path) {
 		return path.toURI().toString();
 	}
-	
+
 	private static void validateBytesInStream(InputStream is, byte[] data) throws IOException {
 		byte[] holder = new byte[data.length];
 		assertEquals("not enough data", holder.length, is.read(holder));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
@@ -18,15 +18,19 @@
 
 package org.apache.flink.runtime.state;
 
+import com.google.common.base.Joiner;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateIdentifier;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.FloatSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.IntValueSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.api.java.typeutils.runtime.ValueSerializer;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.StringValue;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -40,7 +44,7 @@ import static org.junit.Assert.*;
  * Tests for the {@link org.apache.flink.runtime.state.memory.MemoryStateBackend}.
  */
 public class MemoryStateBackendTest {
-	
+
 	@Test
 	public void testSerializableState() {
 		try {
@@ -49,10 +53,10 @@ public class MemoryStateBackendTest {
 			HashMap<String, Integer> state = new HashMap<>();
 			state.put("hey there", 2);
 			state.put("the crazy brown fox stumbles over a sentence that does not contain every letter", 77);
-			
+
 			StateHandle<HashMap<String, Integer>> handle = backend.checkpointStateSerializable(state, 12, 459);
 			assertNotNull(handle);
-			
+
 			HashMap<String, Integer> restored = handle.getState(getClass().getClassLoader());
 			assertEquals(state, restored);
 		}
@@ -94,12 +98,12 @@ public class MemoryStateBackendTest {
 			state.put("hey there", 2);
 			state.put("the crazy brown fox stumbles over a sentence that does not contain every letter", 77);
 
-			StateBackend.CheckpointStateOutputStream os = backend.createCheckpointStateOutputStream(1, 2);
+			AbstractStateBackend.CheckpointStateOutputStream os = backend.createCheckpointStateOutputStream(1, 2);
 			ObjectOutputStream oos = new ObjectOutputStream(os);
 			oos.writeObject(state);
 			oos.flush();
 			StreamStateHandle handle = os.closeAndGetHandle();
-			
+
 			assertNotNull(handle);
 
 			ObjectInputStream ois = new ObjectInputStream(handle.getState(getClass().getClassLoader()));
@@ -122,9 +126,9 @@ public class MemoryStateBackendTest {
 			state.put("hey there", 2);
 			state.put("the crazy brown fox stumbles over a sentence that does not contain every letter", 77);
 
-			StateBackend.CheckpointStateOutputStream os = backend.createCheckpointStateOutputStream(1, 2);
+			AbstractStateBackend.CheckpointStateOutputStream os = backend.createCheckpointStateOutputStream(1, 2);
 			ObjectOutputStream oos = new ObjectOutputStream(os);
-			
+
 			try {
 				oos.writeObject(state);
 				oos.flush();
@@ -140,130 +144,250 @@ public class MemoryStateBackendTest {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
-	public void testKeyValueState() {
+	public void testValueState() {
 		try {
 			MemoryStateBackend backend = new MemoryStateBackend();
-			
-			KvState<Integer, String, MemoryStateBackend> kv = 
-					backend.createKvState(IntSerializer.INSTANCE, StringSerializer.INSTANCE, null);
-			
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			ValueStateIdentifier<String> kvId = new ValueStateIdentifier<>("id", null, StringSerializer.INSTANCE);
+			ValueState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend> kv =
+					(KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend>) state;
+
 			assertEquals(0, kv.size());
-			
+
 			// some modifications to the state
 			kv.setCurrentKey(1);
-			assertNull(kv.value());
-			kv.update("1");
+			assertNull(state.value());
+			state.update("1");
 			assertEquals(1, kv.size());
 			kv.setCurrentKey(2);
-			assertNull(kv.value());
-			kv.update("2");
+			assertNull(state.value());
+			state.update("2");
 			assertEquals(2, kv.size());
 			kv.setCurrentKey(1);
-			assertEquals("1", kv.value());
+			assertEquals("1", state.value());
 			assertEquals(2, kv.size());
-			
+
 			// draw a snapshot
-			KvStateSnapshot<Integer, String, MemoryStateBackend> snapshot1 = 
+			KvStateSnapshot<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend> snapshot1 =
 					kv.snapshot(682375462378L, System.currentTimeMillis());
-			
+
 			// make some more modifications
 			kv.setCurrentKey(1);
-			kv.update("u1");
+			state.update("u1");
 			kv.setCurrentKey(2);
-			kv.update("u2");
+			state.update("u2");
 			kv.setCurrentKey(3);
-			kv.update("u3");
+			state.update("u3");
 
 			// draw another snapshot
-			KvStateSnapshot<Integer, String, MemoryStateBackend> snapshot2 =
+			KvStateSnapshot<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend> snapshot2 =
 					kv.snapshot(682375462379L, System.currentTimeMillis());
-			
+
 			// validate the original state
 			assertEquals(3, kv.size());
 			kv.setCurrentKey(1);
-			assertEquals("u1", kv.value());
+			assertEquals("u1", state.value());
 			kv.setCurrentKey(2);
-			assertEquals("u2", kv.value());
+			assertEquals("u2", state.value());
 			kv.setCurrentKey(3);
-			assertEquals("u3", kv.value());
-			
+			assertEquals("u3", state.value());
+
 			// restore the first snapshot and validate it
-			KvState<Integer, String, MemoryStateBackend> restored1 = snapshot1.restoreState(backend, 
-							IntSerializer.INSTANCE, StringSerializer.INSTANCE, null, getClass().getClassLoader());
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend> restored1 = snapshot1.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ValueState<String> restored1State = (ValueState<String>) restored1;
 
 			assertEquals(2, restored1.size());
 			restored1.setCurrentKey(1);
-			assertEquals("1", restored1.value());
+			assertEquals("1", restored1State.value());
 			restored1.setCurrentKey(2);
-			assertEquals("2", restored1.value());
+			assertEquals("2", restored1State.value());
 
-			// restore the first snapshot and validate it
-			KvState<Integer, String, MemoryStateBackend> restored2 = snapshot2.restoreState(backend,
-					IntSerializer.INSTANCE, StringSerializer.INSTANCE, null, getClass().getClassLoader());
+			// restore the second snapshot and validate it
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend> restored2 = snapshot2.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ValueState<String> restored2State = (ValueState<String>) restored2;
 
 			assertEquals(3, restored2.size());
 			restored2.setCurrentKey(1);
-			assertEquals("u1", restored2.value());
+			assertEquals("u1", restored2State.value());
 			restored2.setCurrentKey(2);
-			assertEquals("u2", restored2.value());
+			assertEquals("u2", restored2State.value());
 			restored2.setCurrentKey(3);
-			assertEquals("u3", restored2.value());
+			assertEquals("u3", restored2State.value());
 		}
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
-	public void testRestoreWithWrongSerializers() {
+	public void testListState() {
 		try {
 			MemoryStateBackend backend = new MemoryStateBackend();
-			KvState<Integer, String, MemoryStateBackend> kv =
-					backend.createKvState(IntSerializer.INSTANCE, StringSerializer.INSTANCE, null);
-			
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			ListStateIdentifier<String> kvId = new ListStateIdentifier<>("id", StringSerializer.INSTANCE);
+			ListState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend> kv =
+					(KvState<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend>) state;
+
+			assertEquals(0, kv.size());
+
+			Joiner joiner = Joiner.on(",");
+			// some modifications to the state
 			kv.setCurrentKey(1);
-			kv.update("1");
+			assertEquals("", joiner.join(state.get()));
+			state.add("1");
+			assertEquals(1, kv.size());
 			kv.setCurrentKey(2);
-			kv.update("2");
-			
-			KvStateSnapshot<Integer, String, MemoryStateBackend> snapshot =
+			assertEquals("", joiner.join(state.get()));
+			state.add("2");
+			assertEquals(2, kv.size());
+			kv.setCurrentKey(1);
+			assertEquals("1", joiner.join(state.get()));
+			assertEquals(2, kv.size());
+
+			// draw a snapshot
+			KvStateSnapshot<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend> snapshot1 =
+					kv.snapshot(682375462378L, System.currentTimeMillis());
+
+			// make some more modifications
+			kv.setCurrentKey(1);
+			state.add("u1");
+			kv.setCurrentKey(2);
+			state.add("u2");
+			kv.setCurrentKey(3);
+			state.add("u3");
+
+			// draw another snapshot
+			KvStateSnapshot<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend> snapshot2 =
+					kv.snapshot(682375462379L, System.currentTimeMillis());
+
+			// validate the original state
+			assertEquals(3, kv.size());
+			kv.setCurrentKey(1);
+			assertEquals("1,u1", joiner.join(state.get()));
+			kv.setCurrentKey(2);
+			assertEquals("2,u2", joiner.join(state.get()));
+			kv.setCurrentKey(3);
+			assertEquals("u3", joiner.join(state.get()));
+
+			// restore the first snapshot and validate it
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend> restored1 = snapshot1.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ListState<String> restored1State = (ListState<String>) restored1;
+
+			assertEquals(2, restored1.size());
+			restored1.setCurrentKey(1);
+			assertEquals("1", joiner.join(restored1State.get()));
+			restored1.setCurrentKey(2);
+			assertEquals("2", joiner.join(restored1State.get()));
+
+			// restore the second snapshot and validate it
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend> restored2 = snapshot2.restoreState(
+					backend,
+					IntSerializer.INSTANCE,
+					kvId,
+					this.getClass().getClassLoader());
+
+			@SuppressWarnings("unchecked")
+			ListState<String> restored2State = (ListState<String>) restored2;
+
+			assertEquals(3, restored2.size());
+			restored2.setCurrentKey(1);
+			assertEquals("1,u1", joiner.join(restored2State.get()));
+			restored2.setCurrentKey(2);
+			assertEquals("2,u2", joiner.join(restored2State.get()));
+			restored2.setCurrentKey(3);
+			assertEquals("u3", joiner.join(restored2State.get()));
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+
+	@Test
+	public void testValueStateRestoreWithWrongSerializers() {
+		try {
+			MemoryStateBackend backend = new MemoryStateBackend();
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			ValueStateIdentifier<String> kvId = new ValueStateIdentifier<>("id", null, StringSerializer.INSTANCE);
+			ValueState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend> kv =
+					(KvState<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend>) state;
+
+			kv.setCurrentKey(1);
+			state.update("1");
+			kv.setCurrentKey(2);
+			state.update("2");
+
+			KvStateSnapshot<Integer, ValueState<String>, ValueStateIdentifier<String>, MemoryStateBackend> snapshot =
 					kv.snapshot(682375462378L, System.currentTimeMillis());
 
 
-			@SuppressWarnings("unchecked")
-			TypeSerializer<Integer> fakeIntSerializer = 
-					(TypeSerializer<Integer>) (TypeSerializer<?>) FloatSerializer.INSTANCE;
 
 			@SuppressWarnings("unchecked")
-			TypeSerializer<String> fakeStringSerializer = 
-					(TypeSerializer<String>) (TypeSerializer<?>) new ValueSerializer<StringValue>(StringValue.class);
+			TypeSerializer<Integer> fakeIntSerializer =
+					(TypeSerializer<Integer>) (TypeSerializer<?>) FloatSerializer.INSTANCE;
 
 			try {
 				snapshot.restoreState(backend, fakeIntSerializer,
-						StringSerializer.INSTANCE, null, getClass().getClassLoader());
+						kvId, getClass().getClassLoader());
 				fail("should recognize wrong serializers");
 			} catch (IllegalArgumentException e) {
 				// expected
 			} catch (Exception e) {
 				fail("wrong exception");
 			}
+
+
+			@SuppressWarnings("unchecked")
+			ValueStateIdentifier<String> fakeKvId =
+					(ValueStateIdentifier<String>)(ValueStateIdentifier<?>) new ValueStateIdentifier<>("id", null, FloatSerializer.INSTANCE);
 
 			try {
 				snapshot.restoreState(backend, IntSerializer.INSTANCE,
-						fakeStringSerializer, null, getClass().getClassLoader());
+						fakeKvId, getClass().getClassLoader());
 				fail("should recognize wrong serializers");
 			} catch (IllegalArgumentException e) {
 				// expected
 			} catch (Exception e) {
-				fail("wrong exception");
+				fail("wrong exception " + e);
 			}
 
 			try {
 				snapshot.restoreState(backend, fakeIntSerializer,
-						fakeStringSerializer, null, getClass().getClassLoader());
+						fakeKvId, getClass().getClassLoader());
 				fail("should recognize wrong serializers");
 			} catch (IllegalArgumentException e) {
 				// expected
@@ -276,20 +400,95 @@ public class MemoryStateBackendTest {
 			fail(e.getMessage());
 		}
 	}
-	
+
+	@Test
+	public void testListStateRestoreWithWrongSerializers() {
+		try {
+			MemoryStateBackend backend = new MemoryStateBackend();
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			ListStateIdentifier<String> kvId = new ListStateIdentifier<>("id", StringSerializer.INSTANCE);
+			ListState<String> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend> kv =
+					(KvState<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend>) state;
+
+			kv.setCurrentKey(1);
+			state.add("1");
+			kv.setCurrentKey(2);
+			state.add("2");
+
+			KvStateSnapshot<Integer, ListState<String>, ListStateIdentifier<String>, MemoryStateBackend> snapshot =
+					kv.snapshot(682375462378L, System.currentTimeMillis());
+
+
+
+			@SuppressWarnings("unchecked")
+			TypeSerializer<Integer> fakeIntSerializer =
+					(TypeSerializer<Integer>) (TypeSerializer<?>) FloatSerializer.INSTANCE;
+
+			try {
+				snapshot.restoreState(backend, fakeIntSerializer,
+						kvId, getClass().getClassLoader());
+				fail("should recognize wrong serializers");
+			} catch (IllegalArgumentException e) {
+				// expected
+			} catch (Exception e) {
+				fail("wrong exception");
+			}
+
+
+			@SuppressWarnings("unchecked")
+			ListStateIdentifier<String> fakeKvId =
+					(ListStateIdentifier<String>)(ListStateIdentifier<?>) new ListStateIdentifier<>("id", FloatSerializer.INSTANCE);
+
+			try {
+				snapshot.restoreState(backend, IntSerializer.INSTANCE,
+						fakeKvId, getClass().getClassLoader());
+				fail("should recognize wrong serializers");
+			} catch (IllegalArgumentException e) {
+				// expected
+			} catch (Exception e) {
+				fail("wrong exception " + e);
+			}
+
+			try {
+				snapshot.restoreState(backend, fakeIntSerializer,
+						fakeKvId, getClass().getClassLoader());
+				fail("should recognize wrong serializers");
+			} catch (IllegalArgumentException e) {
+				// expected
+			} catch (Exception e) {
+				fail("wrong exception");
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+
 	@Test
 	public void testCopyDefaultValue() {
 		try {
 			MemoryStateBackend backend = new MemoryStateBackend();
-			KvState<Integer, IntValue, MemoryStateBackend> kv =
-					backend.createKvState(IntSerializer.INSTANCE, IntValueSerializer.INSTANCE, new IntValue(-1));
+			backend.initializeForJob(new JobID(0L, 0L), IntSerializer.INSTANCE, this.getClass().getClassLoader());
+
+			ValueStateIdentifier<IntValue> kvId = new ValueStateIdentifier<>("id", new IntValue(-1), IntValueSerializer.INSTANCE);
+			ValueState<IntValue> state = kvId.bind(backend);
+
+			@SuppressWarnings("unchecked")
+			KvState<Integer, ValueState<IntValue>, ValueStateIdentifier<IntValue>, MemoryStateBackend> kv =
+					(KvState<Integer, ValueState<IntValue>, ValueStateIdentifier<IntValue>, MemoryStateBackend>) state;
 
 			kv.setCurrentKey(1);
-			IntValue default1 = kv.value();
+			IntValue default1 = state.value();
 
 			kv.setCurrentKey(2);
-			IntValue default2 = kv.value();
-			
+			IntValue default2 = state.value();
+
 			assertNotNull(default1);
 			assertNotNull(default2);
 			assertEquals(default1, default2);

--- a/flink-staging/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/FileStateBackendTest.java
+++ b/flink-staging/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/FileStateBackendTest.java
@@ -29,8 +29,9 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -127,7 +128,7 @@ public class FileStateBackendTest {
 				// supreme!
 			}
 
-			backend.initializeForJob(new JobID());
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 			assertNotNull(backend.getCheckpointDirectory());
 
 			Path checkpointDir = backend.getCheckpointDirectory();
@@ -150,7 +151,7 @@ public class FileStateBackendTest {
 		
 		try {
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(randomHdfsFileUri()));
-			backend.initializeForJob(new JobID());
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 
 			Path checkpointDir = backend.getCheckpointDirectory();
 
@@ -186,7 +187,7 @@ public class FileStateBackendTest {
 	public void testStateOutputStream() {
 		try {
 			FsStateBackend backend = CommonTestUtils.createCopySerializable(new FsStateBackend(randomHdfsFileUri()));
-			backend.initializeForJob(new JobID());
+			backend.initializeForJob(new JobID(), IntSerializer.INSTANCE, this.getClass().getClassLoader());
 
 			Path checkpointDir = backend.getCheckpointDirectory();
 
@@ -220,14 +221,14 @@ public class FileStateBackendTest {
 
 			// use with try-with-resources
 			StreamStateHandle handle4;
-			try (StateBackend.CheckpointStateOutputStream stream4 =
+			try (AbstractStateBackend.CheckpointStateOutputStream stream4 =
 						 backend.createCheckpointStateOutputStream(checkpointId, System.currentTimeMillis())) {
 				stream4.write(state4);
 				handle4 = stream4.closeAndGetHandle();
 			}
 
 			// close before accessing handle
-			StateBackend.CheckpointStateOutputStream stream5 =
+			AbstractStateBackend.CheckpointStateOutputStream stream5 =
 					backend.createCheckpointStateOutputStream(checkpointId, System.currentTimeMillis());
 			stream5.write(state4);
 			stream5.close();

--- a/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockRuntimeContext.java
+++ b/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockRuntimeContext.java
@@ -27,7 +27,9 @@ import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
 import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateIdentifier;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import java.io.Serializable;
@@ -121,12 +123,17 @@ public class MockRuntimeContext implements RuntimeContext {
 	}
 
 	@Override
-	public <S> OperatorState<S> getKeyValueState(String name, Class<S> stateType, S defaultState) {
+	public <S> ValueState<S> getKeyValueState(String name, Class<S> stateType, S defaultState) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public <S> OperatorState<S> getKeyValueState(String name, TypeInformation<S> stateType, S defaultState) {
+	public <S> ValueState<S> getKeyValueState(String name, TypeInformation<S> stateType, S defaultState) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <S extends State> S getPartitionedState(StateIdentifier<S> stateIdentifier) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
+++ b/flink-streaming-examples/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.examples.windowing;
 
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -108,7 +108,7 @@ public class SessionWindowing {
 		@Override
 		public TriggerResult onElement(Tuple3<String, Long, Integer> element, long timestamp, GlobalWindow window, TriggerContext ctx) throws Exception {
 
-			OperatorState<Long> lastSeenState = ctx.getKeyValueState("last-seen", 1L);
+			ValueState<Long> lastSeenState = ctx.getKeyValueState("last-seen", 1L);
 			Long lastSeen = lastSeenState.value();
 
 			Long timeSinceLastEvent = timestamp - lastSeen;
@@ -127,7 +127,7 @@ public class SessionWindowing {
 
 		@Override
 		public TriggerResult onEventTime(long time, GlobalWindow window, TriggerContext ctx) throws Exception {
-			OperatorState<Long> lastSeenState = ctx.getKeyValueState("last-seen", 1L);
+			ValueState<Long> lastSeenState = ctx.getKeyValueState("last-seen", 1L);
 			Long lastSeen = lastSeenState.value();
 
 			if (time - lastSeen >= sessionTimeout) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
@@ -321,6 +321,21 @@ public class ConnectedStreams<IN1, IN2> {
 				outTypeInfo,
 				environment.getParallelism());
 
+		if (inputStream1 instanceof KeyedStream && inputStream2 instanceof KeyedStream) {
+			KeyedStream<IN1, ?> keyedInput1 = (KeyedStream<IN1, ?>) inputStream1;
+			KeyedStream<IN2, ?> keyedInput2 = (KeyedStream<IN2, ?>) inputStream2;
+
+			TypeInformation<?> keyType1 = keyedInput1.getKeyType();
+			TypeInformation<?> keyType2 = keyedInput2.getKeyType();
+			if (!(keyType1.canEqual(keyType2) && keyType1.equals(keyType2))) {
+				throw new UnsupportedOperationException("Key types if input KeyedStreams " +
+						"don't match: " + keyType1 + " and " + keyType2 + ".");
+			}
+
+			transform.setStateKeySelectors(keyedInput1.getKeySelector(), keyedInput2.getKeySelector());
+			transform.setStateKeyType(keyType1);
+		}
+
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		SingleOutputStreamOperator<OUT, ?> returnStream = new SingleOutputStreamOperator(environment, transform);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ClosureCleaner;
@@ -63,7 +64,7 @@ import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.operators.StreamSource;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.streaming.api.transformations.StreamTransformation;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.util.SplittableIterator;
@@ -129,7 +130,7 @@ public abstract class StreamExecutionEnvironment {
 	protected boolean forceCheckpointing = false;
 	
 	/** The state backend used for storing k/v state and state snapshots */
-	private StateBackend<?> defaultStateBackend;
+	private AbstractStateBackend defaultStateBackend;
 	
 	/** The time characteristic used by the data streams */
 	private TimeCharacteristic timeCharacteristic = DEFAULT_TIME_CHARACTERISTIC;
@@ -366,7 +367,7 @@ public abstract class StreamExecutionEnvironment {
 
 	/**
 	 * Sets the state backend that describes how to store and checkpoint operator state. It defines in
-	 * what form the key/value state ({@link org.apache.flink.api.common.state.OperatorState}, accessible
+	 * what form the key/value state ({@link ValueState}, accessible
 	 * from operations on {@link org.apache.flink.streaming.api.datastream.KeyedStream}) is maintained
 	 * (heap, managed memory, externally), and where state snapshots/checkpoints are stored, both for
 	 * the key/value state, and for checkpointed functions (implementing the interface
@@ -386,7 +387,7 @@ public abstract class StreamExecutionEnvironment {
 	 * 
 	 * @see #getStateBackend()
 	 */
-	public StreamExecutionEnvironment setStateBackend(StateBackend<?> backend) {
+	public StreamExecutionEnvironment setStateBackend(AbstractStateBackend backend) {
 		this.defaultStateBackend = requireNonNull(backend);
 		return this;
 	}
@@ -395,9 +396,9 @@ public abstract class StreamExecutionEnvironment {
 	 * Returns the state backend that defines how to store and checkpoint state.
 	 * @return The state backend that defines how to store and checkpoint state.
 	 * 
-	 * @see #setStateBackend(StateBackend)
+	 * @see #setStateBackend(AbstractStateBackend)
 	 */
-	public StateBackend<?> getStateBackend() {
+	public AbstractStateBackend getStateBackend() {
 		return defaultStateBackend;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.util.ClassLoaderUtil;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.collector.selector.OutputSelectorWrapper;
 import org.apache.flink.streaming.api.operators.StreamOperator;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskException;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -370,7 +370,7 @@ public class StreamConfig implements Serializable {
 	//  State backend
 	// ------------------------------------------------------------------------
 	
-	public void setStateBackend(StateBackend<?> backend) {
+	public void setStateBackend(AbstractStateBackend backend) {
 		try {
 			InstantiationUtil.writeObjectToConfig(backend, this.config, STATE_BACKEND);
 		} catch (Exception e) {
@@ -378,7 +378,7 @@ public class StreamConfig implements Serializable {
 		}
 	}
 	
-	public StateBackend<?> getStateBackend(ClassLoader cl) {
+	public AbstractStateBackend getStateBackend(ClassLoader cl) {
 		try {
 			return InstantiationUtil.readObjectFromConfig(this.config, STATE_BACKEND, cl);
 		} catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -386,17 +386,17 @@ public class StreamConfig implements Serializable {
 		}
 	}
 	
-	public void setStatePartitioner(KeySelector<?, ?> partitioner) {
+	public void setStatePartitioner(int input, KeySelector<?, ?> partitioner) {
 		try {
-			InstantiationUtil.writeObjectToConfig(partitioner, this.config, STATE_PARTITIONER);
+			InstantiationUtil.writeObjectToConfig(partitioner, this.config, STATE_PARTITIONER + input);
 		} catch (IOException e) {
 			throw new StreamTaskException("Could not serialize state partitioner.", e);
 		}
 	}
 	
-	public KeySelector<?, Serializable> getStatePartitioner(ClassLoader cl) {
+	public KeySelector<?, Serializable> getStatePartitioner(int input, ClassLoader cl) {
 		try {
-			return InstantiationUtil.readObjectFromConfig(this.config, STATE_PARTITIONER, cl);
+			return InstantiationUtil.readObjectFromConfig(this.config, STATE_PARTITIONER + input, cl);
 		} catch (Exception e) {
 			throw new StreamTaskException("Could not instantiate state partitioner.", e);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -50,7 +50,7 @@ import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
@@ -94,7 +94,7 @@ public class StreamGraph extends StreamingPlan {
 
 	protected Map<Integer, String> vertexIDtoBrokerID;
 	protected Map<Integer, Long> vertexIDtoLoopTimeout;
-	private StateBackend<?> stateBackend;
+	private AbstractStateBackend stateBackend;
 	private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
 
 	private boolean forceCheckpoint = false;
@@ -150,11 +150,11 @@ public class StreamGraph extends StreamingPlan {
 		this.forceCheckpoint = true;
 	}
 
-	public void setStateBackend(StateBackend<?> backend) {
+	public void setStateBackend(AbstractStateBackend backend) {
 		this.stateBackend = backend;
 	}
 
-	public StateBackend<?> getStateBackend() {
+	public AbstractStateBackend getStateBackend() {
 		return this.stateBackend;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -397,9 +397,16 @@ public class StreamGraph extends StreamingPlan {
 		}
 	}
 
-	public void setKey(Integer vertexID, KeySelector<?, ?> keySelector, TypeSerializer<?> keySerializer) {
+	public void setOneInputStateKey(Integer vertexID, KeySelector<?, ?> keySelector, TypeSerializer<?> keySerializer) {
 		StreamNode node = getStreamNode(vertexID);
-		node.setStatePartitioner(keySelector);
+		node.setStatePartitioner1(keySelector);
+		node.setStateKeySerializer(keySerializer);
+	}
+
+	public void setTwoInputStateKey(Integer vertexID, KeySelector<?, ?> keySelector1, KeySelector<?, ?> keySelector2, TypeSerializer<?> keySerializer) {
+		StreamNode node = getStreamNode(vertexID);
+		node.setStatePartitioner1(keySelector1);
+		node.setStatePartitioner2(keySelector2);
 		node.setStateKeySerializer(keySerializer);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -446,7 +446,7 @@ public class StreamGraphGenerator {
 
 		if (sink.getStateKeySelector() != null) {
 			TypeSerializer<?> keySerializer = sink.getStateKeyType().createSerializer(env.getConfig());
-			streamGraph.setKey(sink.getId(), sink.getStateKeySelector(), keySerializer);
+			streamGraph.setOneInputStateKey(sink.getId(), sink.getStateKeySelector(), keySerializer);
 		}
 
 		return Collections.emptyList();
@@ -476,10 +476,7 @@ public class StreamGraphGenerator {
 
 		if (transform.getStateKeySelector() != null) {
 			TypeSerializer<?> keySerializer = transform.getStateKeyType().createSerializer(env.getConfig());
-			streamGraph.setKey(transform.getId(), transform.getStateKeySelector(), keySerializer);
-		}
-		if (transform.getStateKeyType() != null) {
-			
+			streamGraph.setOneInputStateKey(transform.getId(), transform.getStateKeySelector(), keySerializer);
 		}
 
 		streamGraph.setParallelism(transform.getId(), transform.getParallelism());
@@ -515,6 +512,12 @@ public class StreamGraphGenerator {
 				transform.getInputType2(),
 				transform.getOutputType(),
 				transform.getName());
+
+		if (transform.getStateKeySelector1() != null) {
+			TypeSerializer<?> keySerializer = transform.getStateKeyType().createSerializer(env.getConfig());
+			streamGraph.setTwoInputStateKey(transform.getId(), transform.getStateKeySelector1(), transform.getStateKeySelector2(), keySerializer);
+		}
+
 
 		streamGraph.setParallelism(transform.getId(), transform.getParallelism());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -49,7 +49,8 @@ public class StreamNode implements Serializable {
 	private String operatorName;
 	private Integer slotSharingID;
 	private boolean isolatedSlot = false;
-	private KeySelector<?,?> statePartitioner;
+	private KeySelector<?,?> statePartitioner1;
+	private KeySelector<?,?> statePartitioner2;
 	private TypeSerializer<?> stateKeySerializer;
 
 	private transient StreamOperator<?> operator;
@@ -226,12 +227,20 @@ public class StreamNode implements Serializable {
 		return operatorName + "-" + id;
 	}
 
-	public KeySelector<?, ?> getStatePartitioner() {
-		return statePartitioner;
+	public KeySelector<?, ?> getStatePartitioner1() {
+		return statePartitioner1;
 	}
 
-	public void setStatePartitioner(KeySelector<?, ?> statePartitioner) {
-		this.statePartitioner = statePartitioner;
+	public KeySelector<?, ?> getStatePartitioner2() {
+		return statePartitioner2;
+	}
+
+	public void setStatePartitioner1(KeySelector<?, ?> statePartitioner) {
+		this.statePartitioner1 = statePartitioner;
+	}
+
+	public void setStatePartitioner2(KeySelector<?, ?> statePartitioner) {
+		this.statePartitioner2 = statePartitioner;
 	}
 
 	public TypeSerializer<?> getStateKeySerializer() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.api.graph;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,7 +28,6 @@ import java.util.Map.Entry;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -277,7 +275,8 @@ public class StreamingJobGraphGenerator {
 			// so we use that one if checkpointing is not enabled
 			config.setCheckpointMode(CheckpointingMode.AT_LEAST_ONCE);
 		}
-		config.setStatePartitioner((KeySelector<?, Serializable>) vertex.getStatePartitioner());
+		config.setStatePartitioner(0, vertex.getStatePartitioner1());
+		config.setStatePartitioner(1, vertex.getStatePartitioner2());
 		config.setStateKeySerializer(vertex.getStateKeySerializer());
 
 		

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.streaming.api.checkpoint.CheckpointNotifier;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskState;
@@ -131,7 +131,7 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function> extends
 			
 			if (udfState != null) {
 				try {
-					StateBackend<?> stateBackend = getStateBackend();
+					AbstractStateBackend stateBackend = getStateBackend();
 					StateHandle<Serializable> handle = 
 							stateBackend.checkpointStateSerializable(udfState, checkpointId, timestamp);
 					state.setFunctionState(handle);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedFold.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedFold.java
@@ -25,7 +25,8 @@ import java.io.IOException;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.FoldFunction;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.InputViewDataInputStreamWrapper;
@@ -42,7 +43,7 @@ public class StreamGroupedFold<IN, OUT, KEY>
 	private static final String STATE_NAME = "_op_state";
 
 	// Grouped values
-	private transient OperatorState<OUT> values;
+	private transient ValueState<OUT> values;
 	
 	private transient OUT initialValue;
 	
@@ -70,7 +71,8 @@ public class StreamGroupedFold<IN, OUT, KEY>
 				new DataInputStream(bais)
 		);
 		initialValue = outTypeSerializer.deserialize(in);
-		values = createKeyValueState(STATE_NAME, outTypeSerializer, null);
+		ValueStateIdentifier<OUT> stateId = new ValueStateIdentifier<>(STATE_NAME, null, outTypeSerializer);
+		values = getPartitionedState(stateId);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduce.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduce.java
@@ -18,7 +18,8 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -30,7 +31,7 @@ public class StreamGroupedReduce<IN> extends AbstractUdfStreamOperator<IN, Reduc
 
 	private static final String STATE_NAME = "_op_state";
 	
-	private transient OperatorState<IN> values;
+	private transient ValueState<IN> values;
 	
 	private TypeSerializer<IN> serializer;
 
@@ -43,7 +44,8 @@ public class StreamGroupedReduce<IN> extends AbstractUdfStreamOperator<IN, Reduc
 	@Override
 	public void open() throws Exception {
 		super.open();
-		values = createKeyValueState(STATE_NAME, serializer, null);
+		ValueStateIdentifier<IN> stateId = new ValueStateIdentifier<>(STATE_NAME, null, serializer);
+		values = getPartitionedState(stateId);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -132,8 +132,10 @@ public interface StreamOperator<OUT> extends Serializable {
 	//  miscellaneous
 	// ------------------------------------------------------------------------
 	
-	void setKeyContextElement(StreamRecord<?> record) throws Exception;
-	
+	void setKeyContextElement1(StreamRecord<?> record) throws Exception;
+
+	void setKeyContextElement2(StreamRecord<?> record) throws Exception;
+
 	/**
 	 * An operator can return true here to disable copying of its input elements. This overrides
 	 * the object-reuse setting on the {@link org.apache.flink.api.common.ExecutionConfig}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.api.transformations;
 
 import com.google.common.collect.Lists;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 
@@ -40,6 +41,12 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends StreamTransformation<
 	private final StreamTransformation<IN2> input2;
 
 	private final TwoInputStreamOperator<IN1, IN2, OUT> operator;
+
+	private KeySelector<IN1, ?> stateKeySelector1;
+
+	private KeySelector<IN2, ?> stateKeySelector2;
+
+	private TypeInformation<?> stateKeyType;
 
 	/**
 	 * Creates a new {@code TwoInputTransformation} from the given inputs and operator.
@@ -97,6 +104,46 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends StreamTransformation<
 	 */
 	public TwoInputStreamOperator<IN1, IN2, OUT> getOperator() {
 		return operator;
+	}
+
+	/**
+	 * Sets the {@link KeySelector KeySelectors} that must be used for partitioning keyed state of
+	 * this transformation.
+	 *
+	 * @param stateKeySelector1 The {@code KeySelector} to set for the first input
+	 * @param stateKeySelector2 The {@code KeySelector} to set for the first input
+	 */
+	public void setStateKeySelectors(KeySelector<IN1, ?> stateKeySelector1, KeySelector<IN2, ?> stateKeySelector2) {
+		this.stateKeySelector1 = stateKeySelector1;
+		this.stateKeySelector2 = stateKeySelector2;
+	}
+
+	/**
+	 * Returns the {@code KeySelector} that must be used for partitioning keyed state in this
+	 * Operation for the first input.
+	 *
+	 * @see #setStateKeySelectors
+	 */
+	public KeySelector<IN1, ?> getStateKeySelector1() {
+		return stateKeySelector1;
+	}
+
+	/**
+	 * Returns the {@code KeySelector} that must be used for partitioning keyed state in this
+	 * Operation for the second input.
+	 *
+	 * @see #setStateKeySelectors
+	 */
+	public KeySelector<IN2, ?> getStateKeySelector2() {
+		return stateKeySelector2;
+	}
+
+	public void setStateKeyType(TypeInformation<?> stateKeyType) {
+		this.stateKeyType = stateKeyType;
+	}
+
+	public TypeInformation<?> getStateKeyType() {
+		return stateKeyType;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.api.windowing.triggers;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.streaming.api.windowing.time.AbstractTime;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
@@ -42,7 +42,7 @@ public class ContinuousEventTimeTrigger<W extends Window> implements Trigger<Obj
 	@Override
 	public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws Exception {
 
-		OperatorState<Boolean> first = ctx.getKeyValueState("first", true);
+		ValueState<Boolean> first = ctx.getKeyValueState("first", true);
 
 		if (first.value()) {
 			long start = timestamp - (timestamp % interval);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.api.windowing.triggers;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.streaming.api.windowing.time.AbstractTime;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
@@ -41,7 +41,7 @@ public class ContinuousProcessingTimeTrigger<W extends Window> implements Trigge
 	public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws Exception {
 		long currentTime = System.currentTimeMillis();
 
-		OperatorState<Long> fireState = ctx.getKeyValueState("fire-timestamp", 0L);
+		ValueState<Long> fireState = ctx.getKeyValueState("fire-timestamp", 0L);
 		long nextFireTimestamp = fireState.value();
 
 		if (nextFireTimestamp == 0) {
@@ -70,7 +70,7 @@ public class ContinuousProcessingTimeTrigger<W extends Window> implements Trigge
 	@Override
 	public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) throws Exception {
 
-		OperatorState<Long> fireState = ctx.getKeyValueState("fire-timestamp", 0L);
+		ValueState<Long> fireState = ctx.getKeyValueState("fire-timestamp", 0L);
 		long nextFireTimestamp = fireState.value();
 
 		// only fire if an element didn't already fire

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.streaming.api.windowing.triggers;
 
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
 import java.io.IOException;
@@ -38,7 +38,7 @@ public class CountTrigger<W extends Window> implements Trigger<Object, W> {
 
 	@Override
 	public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws IOException {
-		OperatorState<Long> count = ctx.getKeyValueState("count", 0L);
+		ValueState<Long> count = ctx.getKeyValueState("count", 0L);
 		long currentCount = count.value() + 1;
 		count.update(currentCount);
 		if (currentCount >= maxCount) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.streaming.api.windowing.triggers;
 
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.streaming.api.functions.windowing.delta.DeltaFunction;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
@@ -46,7 +46,7 @@ public class DeltaTrigger<T extends Serializable, W extends Window> implements T
 
 	@Override
 	public TriggerResult onElement(T element, long timestamp, W window, TriggerContext ctx) throws Exception {
-		OperatorState<T> lastElementState = ctx.getKeyValueState("last-element", null);
+		ValueState<T> lastElementState = ctx.getKeyValueState("last-element", null);
 		if (lastElementState.value() == null) {
 			lastElementState.update(element);
 			return TriggerResult.CONTINUE;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.streaming.api.windowing.triggers;
 
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
 import java.io.Serializable;
@@ -149,13 +149,13 @@ public interface Trigger<T, W extends Window> extends Serializable {
 		void registerEventTimeTimer(long time);
 
 		/**
-		 * Retrieves an {@link OperatorState} object that can be used to interact with
+		 * Retrieves an {@link ValueState} object that can be used to interact with
 		 * fault-tolerant state that is scoped to the window and key of the current
 		 * trigger invocation.
 		 *
 		 * @param name A unique key for the state.
 		 * @param defaultState The default value of the state.
 		 */
-		<S extends Serializable> OperatorState<S> getKeyValueState(final String name, final S defaultState);
+		<S extends Serializable> ValueState<S> getKeyValueState(final String name, final S defaultState);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -162,7 +162,7 @@ public class StreamInputProcessor<IN> {
 						// now we can do the actual processing
 						StreamRecord<IN> record = recordOrWatermark.asRecord();
 						synchronized (lock) {
-							streamOperator.setKeyContextElement(record);
+							streamOperator.setKeyContextElement1(record);
 							streamOperator.processElement(record);
 						}
 						return true;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -186,6 +186,7 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 						}
 						else {
 							synchronized (lock) {
+								streamOperator.setKeyContextElement1(recordOrWatermark.<IN1>asRecord());
 								streamOperator.processElement1(recordOrWatermark.<IN1>asRecord());
 							}
 							return true;
@@ -200,6 +201,7 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 						}
 						else {
 							synchronized (lock) {
+								streamOperator.setKeyContextElement2(recordOrWatermark.<IN2>asRecord());
 								streamOperator.processElement2(recordOrWatermark.<IN2>asRecord());
 							}
 							return true;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.util.MathUtils;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.runtime.operators.Triggerable;
@@ -252,7 +252,7 @@ public abstract class AbstractAlignedProcessingTimeWindowOperator<KEY, IN, OUT, 
 		
 		// we write the panes with the key/value maps into the stream, as well as when this state
 		// should have triggered and slided
-		StateBackend.CheckpointStateOutputView out = 
+		AbstractStateBackend.CheckpointStateOutputView out =
 				getStateBackend().createCheckpointStateOutputView(checkpointId, timestamp);
 
 		out.writeLong(nextEvaluationTime);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/NonKeyedWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/NonKeyedWindowOperator.java
@@ -20,12 +20,12 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
@@ -391,7 +391,7 @@ public class NonKeyedWindowOperator<IN, OUT, W extends Window>
 			}
 		}
 
-		protected void writeToState(StateBackend.CheckpointStateOutputView out) throws IOException {
+		protected void writeToState(AbstractStateBackend.CheckpointStateOutputView out) throws IOException {
 			windowSerializer.serialize(window, out);
 			out.writeLong(watermarkTimer);
 			out.writeLong(processingTimeTimer);
@@ -409,8 +409,8 @@ public class NonKeyedWindowOperator<IN, OUT, W extends Window>
 		}
 
 		@SuppressWarnings("unchecked")
-		public <S extends Serializable> OperatorState<S> getKeyValueState(final String name, final S defaultState) {
-			return new OperatorState<S>() {
+		public <S extends Serializable> ValueState<S> getKeyValueState(final String name, final S defaultState) {
+			return new ValueState<S>() {
 				@Override
 				public S value() throws IOException {
 					Serializable value = state.get(name);
@@ -424,6 +424,11 @@ public class NonKeyedWindowOperator<IN, OUT, W extends Window>
 				@Override
 				public void update(S value) throws IOException {
 					state.put(name, value);
+				}
+
+				@Override
+				public void clear() {
+					state.remove(name);
 				}
 			};
 		}
@@ -518,7 +523,7 @@ public class NonKeyedWindowOperator<IN, OUT, W extends Window>
 		StreamTaskState taskState = super.snapshotOperatorState(checkpointId, timestamp);
 
 		// we write the panes with the key/value maps into the stream
-		StateBackend.CheckpointStateOutputView out = getStateBackend().createCheckpointStateOutputView(checkpointId, timestamp);
+		AbstractStateBackend.CheckpointStateOutputView out = getStateBackend().createCheckpointStateOutputView(checkpointId, timestamp);
 
 		int numWindows = windows.size();
 		out.writeInt(numWindows);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -20,13 +20,13 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
@@ -433,7 +433,7 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 		/**
 		 * Constructs a new {@code Context} by reading from a {@link DataInputView} that
 		 * contains a serialized context that we wrote in
-		 * {@link #writeToState(StateBackend.CheckpointStateOutputView)}
+		 * {@link #writeToState(AbstractStateBackend.CheckpointStateOutputView)}
 		 */
 		@SuppressWarnings("unchecked")
 		protected Context(DataInputView in) throws Exception {
@@ -459,7 +459,7 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 		/**
 		 * Writes the {@code Context} to the given state checkpoint output.
 		 */
-		protected void writeToState(StateBackend.CheckpointStateOutputView out) throws IOException {
+		protected void writeToState(AbstractStateBackend.CheckpointStateOutputView out) throws IOException {
 			keySerializer.serialize(key, out);
 			windowSerializer.serialize(window, out);
 			out.writeLong(watermarkTimer);
@@ -478,8 +478,8 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 		}
 
 		@SuppressWarnings("unchecked")
-		public <S extends Serializable> OperatorState<S> getKeyValueState(final String name, final S defaultState) {
-			return new OperatorState<S>() {
+		public <S extends Serializable> ValueState<S> getKeyValueState(final String name, final S defaultState) {
+			return new ValueState<S>() {
 				@Override
 				public S value() throws IOException {
 					Serializable value = state.get(name);
@@ -493,6 +493,11 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 				@Override
 				public void update(S value) throws IOException {
 					state.put(name, value);
+				}
+
+				@Override
+				public void clear() {
+					state.remove(name);
 				}
 			};
 		}
@@ -587,7 +592,7 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 		StreamTaskState taskState = super.snapshotOperatorState(checkpointId, timestamp);
 
 		// we write the panes with the key/value maps into the stream
-		StateBackend.CheckpointStateOutputView out = getStateBackend().createCheckpointStateOutputView(checkpointId, timestamp);
+		AbstractStateBackend.CheckpointStateOutputView out = getStateBackend().createCheckpointStateOutputView(checkpointId, timestamp);
 
 		int numKeys = windows.size();
 		out.writeInt(numKeys);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -299,7 +299,7 @@ public class WindowOperator<K, IN, OUT, W extends Window>
 
 
 		if (context.windowBuffer.size() > 0) {
-			setKeyContextElement(context.windowBuffer.getElements().iterator().next());
+			setKeyContextElement1(context.windowBuffer.getElements().iterator().next());
 
 			userFunction.apply(context.key,
 					context.window,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -268,7 +268,7 @@ public class OperatorChain<OUT> {
 		@Override
 		public void collect(StreamRecord<T> record) {
 			try {
-				operator.setKeyContextElement(record);
+				operator.setKeyContextElement1(record);
 				operator.processElement(record);
 			}
 			catch (Exception e) {
@@ -312,7 +312,7 @@ public class OperatorChain<OUT> {
 
 				StreamRecord<T> copy = new StreamRecord<>(serializer.copy(record.getValue()), record.getTimestamp());
 
-				operator.setKeyContextElement(copy);
+				operator.setKeyContextElement1(copy);
 				operator.processElement(copy);
 			}
 			catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -35,7 +36,7 @@ import org.apache.flink.runtime.util.event.EventListener;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateBackendFactory;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
@@ -119,9 +120,6 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 	/** The class loader used to load dynamic classes of a job */
 	private ClassLoader userClassLoader;
 	
-	/** The state backend that stores the state and checkpoints for this task */
-	private StateBackend<?> stateBackend;
-	
 	/** The executor service that schedules and calls the triggers of this task*/
 	private ScheduledExecutorService timerService;
 	
@@ -167,9 +165,6 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 			userClassLoader = getUserCodeClassLoader();
 			configuration = new StreamConfig(getTaskConfiguration());
 			accumulatorMap = accumulatorRegistry.getUserMap();
-
-			stateBackend = createStateBackend();
-			stateBackend.initializeForJob(getEnvironment().getJobID());
 
 			headOperator = configuration.getStreamOperator(userClassLoader);
 			operatorChain = new OperatorChain<>(this, headOperator, accumulatorRegistry.getReadWriteReporter());
@@ -262,14 +257,6 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 			// if the operators were not disposed before, do a hard dispose
 			if (!disposed) {
 				disposeAllOperators();
-			}
-
-			try {
-				if (stateBackend != null) {
-					stateBackend.close();
-				}
-			} catch (Throwable t) {
-				LOG.error("Error while closing the state backend", t);
 			}
 		}
 	}
@@ -480,23 +467,12 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 	//  State backend
 	// ------------------------------------------------------------------------
 
-	/**
-	 * Gets the state backend used by this task. The state backend defines how to maintain the
-	 * key/value state and how and where to store state snapshots.
-	 * 
-	 * @return The state backend used by this task.
-	 */
-	public StateBackend<?> getStateBackend() {
-		return stateBackend;
-	}
-	
-	private StateBackend<?> createStateBackend() throws Exception {
-		StateBackend<?> configuredBackend = configuration.getStateBackend(userClassLoader);
+	public AbstractStateBackend createStateBackend(TypeSerializer<?> keySerializer) throws Exception {
+		AbstractStateBackend stateBackend = configuration.getStateBackend(userClassLoader);
 
-		if (configuredBackend != null) {
+		if (stateBackend != null) {
 			// backend has been configured on the environment
-			LOG.info("Using user-defined state backend: " + configuredBackend);
-			return configuredBackend;
+			LOG.info("Using user-defined state backend: " + stateBackend);
 		} else {
 			// see if we have a backend specified in the configuration
 			Configuration flinkConfig = getEnvironment().getTaskManagerInfo().getConfiguration();
@@ -511,13 +487,15 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 			switch (backendName) {
 				case "jobmanager":
 					LOG.info("State backend is set to heap memory (checkpoint to jobmanager)");
-					return MemoryStateBackend.defaultInstance();
+					stateBackend = MemoryStateBackend.create();
+					break;
 
 				case "filesystem":
 					FsStateBackend backend = new FsStateBackendFactory().createFromConfig(flinkConfig);
 					LOG.info("State backend is set to heap memory (checkpoints to filesystem \""
 						+ backend.getBasePath() + "\")");
-					return backend;
+					stateBackend = backend;
+					break;
 
 				default:
 					try {
@@ -525,7 +503,7 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 						Class<? extends StateBackendFactory> clazz =
 							Class.forName(backendName, false, userClassLoader).asSubclass(StateBackendFactory.class);
 
-						return (StateBackend<?>) clazz.newInstance();
+						stateBackend = ((StateBackendFactory<?>) clazz.newInstance()).createFromConfig(configuration.getConfiguration());
 					} catch (ClassNotFoundException e) {
 						throw new IllegalConfigurationException("Cannot find configured state backend: " + backendName);
 					} catch (ClassCastException e) {
@@ -537,6 +515,11 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 					}
 			}
 		}
+		stateBackend.initializeForJob(getEnvironment().getJobID(),
+				keySerializer,
+				getUserCodeClassLoader());
+		return stateBackend;
+
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskState.java
@@ -43,7 +43,7 @@ public class StreamTaskState implements Serializable {
 
 	private StateHandle<Serializable> functionState;
 
-	private HashMap<String, KvStateSnapshot<?, ?, ?>> kvStates;
+	private HashMap<String, KvStateSnapshot<?, ?, ?, ?>> kvStates;
 
 	// ------------------------------------------------------------------------
 
@@ -63,11 +63,11 @@ public class StreamTaskState implements Serializable {
 		this.functionState = functionState;
 	}
 
-	public HashMap<String, KvStateSnapshot<?, ?, ?>> getKvStates() {
+	public HashMap<String, KvStateSnapshot<?, ?, ?, ?>> getKvStates() {
 		return kvStates;
 	}
 
-	public void setKvStates(HashMap<String, KvStateSnapshot<?, ?, ?>> kvStates) {
+	public void setKvStates(HashMap<String, KvStateSnapshot<?, ?, ?, ?>> kvStates) {
 		this.kvStates = kvStates;
 	}
 
@@ -92,7 +92,7 @@ public class StreamTaskState implements Serializable {
 	public void discardState() throws Exception {
 		StateHandle<?> operatorState = this.operatorState;
 		StateHandle<?> functionState = this.functionState;
-		HashMap<String, KvStateSnapshot<?, ?, ?>> kvStates = this.kvStates;
+		HashMap<String, KvStateSnapshot<?, ?, ?, ?>> kvStates = this.kvStates;
 		
 		if (operatorState != null) {
 			operatorState.discardState();
@@ -103,9 +103,9 @@ public class StreamTaskState implements Serializable {
 		if (kvStates != null) {
 			while (kvStates.size() > 0) {
 				try {
-					Iterator<KvStateSnapshot<?, ?, ?>> values = kvStates.values().iterator();
+					Iterator<KvStateSnapshot<?, ?, ?, ?>> values = kvStates.values().iterator();
 					while (values.hasNext()) {
-						KvStateSnapshot<?, ?, ?> s = values.next();
+						KvStateSnapshot<?, ?, ?, ?> s = values.next();
 						s.discardState();
 						values.remove();
 					}
@@ -121,4 +121,3 @@ public class StreamTaskState implements Serializable {
 		this.kvStates = null;
 	}
 }
- 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -524,7 +524,7 @@ public class DataStreamTest extends StreamingMultipleProgramsTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		DataStreamSink<Long> sink = env.generateSequence(1, 100).print();
-		assertTrue(env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getStatePartitioner() == null);
+		assertTrue(env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getStatePartitioner1() == null);
 		assertTrue(env.getStreamGraph().getStreamNode(sink.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof ForwardPartitioner);
 
 		KeySelector<Long, Long> key1 = new KeySelector<Long, Long>() {
@@ -539,10 +539,10 @@ public class DataStreamTest extends StreamingMultipleProgramsTestBase {
 
 		DataStreamSink<Long> sink2 = env.generateSequence(1, 100).keyBy(key1).print();
 
-		assertNotNull(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStatePartitioner());
+		assertNotNull(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
 		assertNotNull(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
 		assertNotNull(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
-		assertEquals(key1, env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStatePartitioner());
+		assertEquals(key1, env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
 		assertTrue(env.getStreamGraph().getStreamNode(sink2.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof HashPartitioner);
 
 		KeySelector<Long, Long> key2 = new KeySelector<Long, Long>() {
@@ -557,8 +557,8 @@ public class DataStreamTest extends StreamingMultipleProgramsTestBase {
 
 		DataStreamSink<Long> sink3 = env.generateSequence(1, 100).keyBy(key2).print();
 
-		assertTrue(env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getStatePartitioner() != null);
-		assertEquals(key2, env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getStatePartitioner());
+		assertTrue(env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1() != null);
+		assertEquals(key2, env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1());
 		assertTrue(env.getStreamGraph().getStreamNode(sink3.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof HashPartitioner);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingAlignedProcessingTimeWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingAlignedProcessingTimeWindowOperatorTest.java
@@ -940,7 +940,7 @@ public class AccumulatingAlignedProcessingTimeWindowOperatorTest {
 	
 	private static StreamConfig createTaskConfig(KeySelector<?, ?> partitioner, TypeSerializer<?> keySerializer) {
 		StreamConfig cfg = new StreamConfig(new Configuration());
-		cfg.setStatePartitioner(partitioner);
+		cfg.setStatePartitioner(0, partitioner);
 		cfg.setStateKeySerializer(keySerializer);
 		return cfg;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AggregatingAlignedProcessingTimeWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AggregatingAlignedProcessingTimeWindowOperatorTest.java
@@ -263,7 +263,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = 0; i < numElements; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -324,7 +324,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 					int val = ((int) nextTime) ^ ((int) (nextTime >>> 32));
 
 					StreamRecord<Tuple2<Integer, Integer>> next =  new StreamRecord<>(new Tuple2<>(val, val));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 
 					if (nextTime != previousNextTime) {
@@ -383,7 +383,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = 0; i < numElements; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -449,11 +449,11 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 
 			synchronized (lock) {
 				StreamRecord<Tuple2<Integer, Integer>> next1 = new StreamRecord<>(new Tuple2<>(1, 1));
-				op.setKeyContextElement(next1);
+				op.setKeyContextElement1(next1);
 				op.processElement(next1);
 				
 				StreamRecord<Tuple2<Integer, Integer>> next2 = new StreamRecord<>(new Tuple2<>(2, 2));
-				op.setKeyContextElement(next2);
+				op.setKeyContextElement1(next2);
 				op.processElement(next2);
 			}
 
@@ -510,7 +510,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (Integer i : data) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 			}
@@ -563,14 +563,14 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = 0; i < 100; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(1, 1)); 
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 			}
 			
 			try {
 				StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(1, 1));
-				op.setKeyContextElement(next);
+				op.setKeyContextElement1(next);
 				op.processElement(next);
 				fail("This fail with an exception");
 			}
@@ -615,7 +615,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = 0; i < numElementsFirst; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -638,7 +638,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = numElementsFirst; i < numElements; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -661,7 +661,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = numElementsFirst; i < numElements; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -721,7 +721,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = 0; i < numElementsFirst; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -744,7 +744,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = numElementsFirst; i < numElements; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -768,7 +768,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			for (int i = numElementsFirst; i < numElements; i++) {
 				synchronized (lock) {
 					StreamRecord<Tuple2<Integer, Integer>> next = new StreamRecord<>(new Tuple2<>(i, i));
-					op.setKeyContextElement(next);
+					op.setKeyContextElement1(next);
 					op.processElement(next);
 				}
 				Thread.sleep(1);
@@ -834,11 +834,11 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 			synchronized (lock) {
 				for (int i = 0; i < 10; i++) {
 					StreamRecord<Tuple2<Integer, Integer>> next1 = new StreamRecord<>(new Tuple2<>(1, i));
-					op.setKeyContextElement(next1);
+					op.setKeyContextElement1(next1);
 					op.processElement(next1);
 	
 					StreamRecord<Tuple2<Integer, Integer>> next2 = new StreamRecord<>(new Tuple2<>(2, i));
-					op.setKeyContextElement(next2);
+					op.setKeyContextElement1(next2);
 					op.processElement(next2);
 				}
 
@@ -902,13 +902,13 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 
 				// because we do not release the lock between elements, they end up in the same windows
 				synchronized (lock) {
-					op.setKeyContextElement(next1);
+					op.setKeyContextElement1(next1);
 					op.processElement(next1);
-					op.setKeyContextElement(next2);
+					op.setKeyContextElement1(next2);
 					op.processElement(next2);
-					op.setKeyContextElement(next3);
+					op.setKeyContextElement1(next3);
 					op.processElement(next3);
-					op.setKeyContextElement(next4);
+					op.setKeyContextElement1(next4);
 					op.processElement(next4);
 				}
 
@@ -1067,7 +1067,7 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 
 	private static StreamConfig createTaskConfig(KeySelector<?, ?> partitioner, TypeSerializer<?> keySerializer) {
 		StreamConfig cfg = new StreamConfig(new Configuration());
-		cfg.setStatePartitioner(partitioner);
+		cfg.setStatePartitioner(0, partitioner);
 		cfg.setStateKeySerializer(keySerializer);
 		return cfg;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockContext.java
@@ -89,7 +89,7 @@ public class MockContext<IN, OUT> {
 		StreamConfig config = new StreamConfig(new Configuration());
 		if (keySelector != null && keyType != null) {
 			config.setStateKeySerializer(keyType.createSerializer(new ExecutionConfig()));
-			config.setStatePartitioner(keySelector);
+			config.setStatePartitioner(0, keySelector);
 		}
 		
 		final ScheduledExecutorService timerService = Executors.newSingleThreadScheduledExecutor();
@@ -104,7 +104,7 @@ public class MockContext<IN, OUT> {
 			for (IN in: inputs) {
 				record = record.replace(in);
 				synchronized (lock) {
-					operator.setKeyContextElement(record);
+					operator.setKeyContextElement1(record);
 					operator.processElement(record);
 				}
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -105,7 +105,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT> {
 
 	public <K> void configureForKeyedStream(KeySelector<IN, K> keySelector, TypeInformation<K> keyType) {
 		ClosureCleaner.clean(keySelector, false);
-		config.setStatePartitioner(keySelector);
+		config.setStatePartitioner(0, keySelector);
 		config.setStateKeySerializer(keyType.createSerializer(executionConfig));
 	}
 	
@@ -135,13 +135,13 @@ public class OneInputStreamOperatorTestHarness<IN, OUT> {
 	}
 
 	public void processElement(StreamRecord<IN> element) throws Exception {
-		operator.setKeyContextElement(element);
+		operator.setKeyContextElement1(element);
 		operator.processElement(element);
 	}
 
 	public void processElements(Collection<StreamRecord<IN>> elements) throws Exception {
 		for (StreamRecord<IN> element: elements) {
-			operator.setKeyContextElement(element);
+			operator.setKeyContextElement1(element);
 			operator.processElement(element);
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -75,12 +75,6 @@ public class TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> {
 		when(mockTask.getConfiguration()).thenReturn(config);
 		when(mockTask.getEnvironment()).thenReturn(env);
 		when(mockTask.getExecutionConfig()).thenReturn(executionConfig);
-
-		// ugly Java generic hacks
-		@SuppressWarnings("unchecked")
-		OngoingStubbing<StateBackend<?>> stubbing =
-				(OngoingStubbing<StateBackend<?>>) (OngoingStubbing<?>) when(mockTask.getStateBackend());
-		stubbing.thenReturn(MemoryStateBackend.defaultInstance());
 
 		operator.setup(mockTask, new StreamConfig(new Configuration()), new MockOutput());
 	}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
-import org.apache.flink.runtime.state.StateBackend
+import org.apache.flink.runtime.state.AbstractStateBackend
 import org.apache.flink.streaming.api.{TimeCharacteristic, CheckpointingMode}
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
 import org.apache.flink.streaming.api.functions.source.FileMonitoringFunction.WatchType
@@ -207,7 +207,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * program can be executed highly available and strongly consistent (assuming that Flink
    * is run in high-availability mode).
    */
-  def setStateBackend(backend: StateBackend[_]): StreamExecutionEnvironment = {
+  def setStateBackend(backend: AbstractStateBackend): StreamExecutionEnvironment = {
     javaEnv.setStateBackend(backend)
     this
   }
@@ -215,7 +215,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   /**
    * Returns the state backend that defines how to store and checkpoint state.
    */
-  def getStateBackend: StateBackend[_] = javaEnv.getStateBackend()
+  def getStateBackend: AbstractStateBackend = javaEnv.getStateBackend()
   
   /**
    * Sets the number of times that failed tasks are re-executed. A value of zero

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
@@ -19,9 +19,9 @@
 package org.apache.flink.streaming.api.scala.function
 
 import org.apache.flink.api.common.functions.RichFunction
+import org.apache.flink.api.common.state.ValueState
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.api.common.state.OperatorState
 
 /**
  * Trait implementing the functionality necessary to apply stateful functions in 
@@ -30,7 +30,7 @@ import org.apache.flink.api.common.state.OperatorState
  */
 trait StatefulFunction[I, O, S] extends RichFunction {
   
-  var state: OperatorState[S] = _
+  var state: ValueState[S] = _
   val stateType: TypeInformation[S]
 
   def applyWithState(in: I, fun: (I, Option[S]) => (O, Option[S])): O = {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -19,7 +19,7 @@
 package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.functions.RichReduceFunction;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
@@ -173,7 +173,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
 						private boolean open = false;
 
-						private OperatorState<Integer> count;
+						private ValueState<Integer> count;
 
 						@Override
 						public void open(Configuration parameters) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/PartitionedStateCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/PartitionedStateCheckpointingITCase.java
@@ -28,7 +28,9 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateIdentifier;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -152,7 +154,7 @@ public class PartitionedStateCheckpointingITCase extends StreamFaultToleranceTes
 		private long failurePos;
 		private long count;
 
-		private OperatorState<Long> sum;
+		private ValueState<Long> sum;
 
 		OnceFailingPartitionedSum(long numElements) {
 			this.numElements = numElements;
@@ -189,14 +191,17 @@ public class PartitionedStateCheckpointingITCase extends StreamFaultToleranceTes
 
 		private static Map<Integer, Long> allCounts = new ConcurrentHashMap<Integer, Long>();
 
-		private OperatorState<NonSerializableLong> aCounts;
-		private OperatorState<Long> bCounts;
+		private ValueStateIdentifier<Long> bCountsId = new ValueStateIdentifier<>("b", 0L,
+				LongSerializer.INSTANCE);
+
+		private ValueState<NonSerializableLong> aCounts;
+		private ValueState<Long> bCounts;
 
 		@Override
 		public void open(Configuration parameters) throws IOException {
 			aCounts = getRuntimeContext().getKeyValueState(
 					"a", NonSerializableLong.class, NonSerializableLong.of(0L));
-			bCounts = getRuntimeContext().getKeyValueState("b", Long.class, 0L);
+			bCounts = getRuntimeContext().getPartitionedState(bCountsId);
 		}
 
 		@Override
@@ -222,6 +227,22 @@ public class PartitionedStateCheckpointingITCase extends StreamFaultToleranceTes
 
 		public static NonSerializableLong of(long value) {
 			return new NonSerializableLong(value);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+
+			NonSerializableLong that = (NonSerializableLong) o;
+
+			return value.equals(that.value);
+
+		}
+
+		@Override
+		public int hashCode() {
+			return value.hashCode();
 		}
 	}
 	

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateCheckpointedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateCheckpointedITCase.java
@@ -21,7 +21,7 @@ package org.apache.flink.test.checkpointing;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.checkpoint.CheckpointNotifier;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
  * A simple test that runs a streaming topology with checkpointing enabled.
  *
  * The test triggers a failure after a while and verifies that, after completion, the
- * state defined with either the {@link OperatorState} or the {@link Checkpointed}
+ * state defined with either the {@link ValueState} or the {@link Checkpointed}
  * interface reflects the "exactly once" semantics.
  * 
  * The test throttles the input until at least two checkpoints are completed, to make sure that

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
@@ -20,7 +20,7 @@ package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -238,7 +238,7 @@ public class StreamCheckpointingITCase extends StreamFaultToleranceTestBase {
 		private long failurePos;
 		private long count;
 		
-		private OperatorState<Long> pCount;
+		private ValueState<Long> pCount;
 		private long inputCount;
 
 		OnceFailingPrefixCounter(long numElements) {


### PR DESCRIPTION
ValueState behaves exactly the same as OperatorState. ListState is a
stateful list to which elements can be added and for which the elements
that it contains can be obtained. To create a ValueState the user
passes a ValueStateIdentifier to
StreamingRuntimeContext.getPartitionedState() while they would pass a
ListStateIdentifier to the same function to retrieve a ListState.

This change is necessary to give the system more information about the
nature of the operator state. We want this to be able to do incremental
snapshots. This would not be possible, for example, if the user had a
List as a state. Inside OperatorState this list would be opaque and
Flink could not create good incremental snapshots.

This also refactors the StateBackend. Before, the logic for partitioned
state was spread out over StreamingRuntimeContext,
AbstractStreamOperator and StateBackend. Now it is consolidated in
StateBackend.