### PR TITLE
[FLINK-2879] [docs] Fixed broken links on the architecture page

### DIFF
--- a/docs/internals/general_arch.md
+++ b/docs/internals/general_arch.md
@@ -61,23 +61,23 @@ You can click on the components in the figure to learn more.
 <img src="../fig/overview-stack-0.9.png" width="893" height="450" alt="Stack" usemap="#overview-stack">
 
 <map name="overview-stack">
-  <area shape="rect" coords="188,0,263,200" alt="Graph API: Gelly" href="libs/gelly_guide.html">
-  <area shape="rect" coords="268,0,343,200" alt="Flink ML" href="libs/ml/">
-  <area shape="rect" coords="348,0,423,200" alt="Table" href="libs/table.html">
+  <area shape="rect" coords="188,0,263,200" alt="Graph API: Gelly" href="../libs/gelly_guide.html">
+  <area shape="rect" coords="268,0,343,200" alt="Flink ML" href="../libs/ml/">
+  <area shape="rect" coords="348,0,423,200" alt="Table" href="../libs/table.html">
 
-  <area shape="rect" coords="188,205,538,260" alt="DataSet API (Java/Scala)" href="apis/programming_guide.html">
-  <area shape="rect" coords="543,205,893,260" alt="DataStream API (Java/Scala)" href="apis/streaming_guide.html">
+  <area shape="rect" coords="188,205,538,260" alt="DataSet API (Java/Scala)" href="../apis/programming_guide.html">
+  <area shape="rect" coords="543,205,893,260" alt="DataStream API (Java/Scala)" href="../apis/streaming_guide.html">
 
   <!-- <area shape="rect" coords="188,275,538,330" alt="Optimizer" href="optimizer.html"> -->
   <!-- <area shape="rect" coords="543,275,893,330" alt="Stream Builder" href="streambuilder.html"> -->
 
-  <area shape="rect" coords="188,335,893,385" alt="Flink Runtime" href="internals/general_arch.html">
+  <area shape="rect" coords="188,335,893,385" alt="Flink Runtime" href="general_arch.html">
 
-  <area shape="rect" coords="188,405,328,455" alt="Local" href="apis/local_execution.html">
-  <area shape="rect" coords="333,405,473,455" alt="Remote" href="apis/cluster_execution.html">
-  <area shape="rect" coords="478,405,638,455" alt="Embedded" href="apis/local_execution.html">
-  <area shape="rect" coords="643,405,765,455" alt="YARN" href="setup/yarn_setup.html">
-  <area shape="rect" coords="770,405,893,455" alt="Tez" href="setup/flink_on_tez.html">
+  <area shape="rect" coords="188,405,328,455" alt="Local" href="../apis/local_execution.html">
+  <area shape="rect" coords="333,405,473,455" alt="Remote" href="../apis/cluster_execution.html">
+  <area shape="rect" coords="478,405,638,455" alt="Embedded" href="../apis/local_execution.html">
+  <area shape="rect" coords="643,405,765,455" alt="YARN" href="../setup/yarn_setup.html">
+  <area shape="rect" coords="770,405,893,455" alt="Tez" href="../setup/flink_on_tez.html">
 </map>
 
 ## Projects and Dependencies


### PR DESCRIPTION
Fixed the links on the general architecture page. They were pointing to non-existing htmls.  