### PR TITLE
[FLINK-2913] Close of ObjectOutputStream should be enclosed in finall…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -269,8 +269,11 @@ public class FsStateBackend extends StateBackend<FsStateBackend> {
 			}
 
 			ObjectOutputStream os = new ObjectOutputStream(outStream);
-			os.writeObject(state);
-			os.close();
+			try {
+				os.writeObject(state);
+			} finally {
+				os.close();
+			}
 			return new FileSerializableStateHandle<S>(targetPath);
 		}
 		

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@ under the License.
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
…y block in FsStateBackend