### PR TITLE
minor javadoc fix in JobManager

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -80,7 +80,7 @@ import scala.language.postfixOps
  *
  *  - [[SubmitJob]] is sent by a client which wants to submit a job to the system. The submit
  *  message contains the job description in the form of the JobGraph. The JobGraph is appended to
- *  the ExecutionGraph and the corresponding JobExecutionVertices are scheduled for execution on
+ *  the ExecutionGraph and the corresponding ExecutionJobVertices are scheduled for execution on
  *  the TaskManagers.
  *
  *  - [[CancelJob]] requests to cancel the job with the specified jobID. A successful cancellation


### PR DESCRIPTION
JobExecutionVertices should be ExecutionJobVertices?
I found it while I have been drawing a Flink local execution diagram.
It is still a half way but let me know if you have any feedback.
https://docs.google.com/drawings/d/1lZg8LkhAlI5lMc2EGCPlYArBmv7cCj-By-phuG6rGE8/edit