### PR TITLE
[FLINK-2967] Enhance TaskManager network detection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -25,7 +25,6 @@ import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/FLINK-2967
- Increase timeout for `LOCAL_HOST` address detection strategy
- give the local host address a higher priority
