### PR TITLE
[FLINK-3009] Add dockerized jekyll environment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,20 @@ install all needed software via the following commands:
 Note that in Ubuntu based systems, it may be necessary to install the `ruby-dev` and 
 `python-setuptools` packages via apt.
 
+# Using Dockerized Jekyll
+
+We dockerized the jekyll environment above. If you have [docker](https://docs.docker.com/), 
+you can run following command to start the container.
+
+```
+cd flink/docs/docker
+./run.sh
+```
+
+It takes a few moment to build the image for the first time, but will be a second from the second time.
+The run.sh command brings you in a bash session where you can run following doc commands.
+
+
 # Build
 
 The `docs/build_docs.sh` script calls Jekyll and generates the documentation in `docs/target`. You

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -63,7 +63,7 @@ highlighter: pygments
 kramdown:
     toc_levels: 1..3
 
-host: localhost
+host: 0.0.0.0
 
 # please use a protocol relative URL here
 baseurl: //ci.apache.org/projects/flink/flink-docs-master

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:centos7
+
+RUN yum install -y vim gem ruby-devel make gcc gcc-c++ python-setuptools && \
+	gem install jekyll -v 2.5.3 && \
+	gem install kramdown -v 1.9.0 && \
+	gem install pygments.rb -v 0.6.3 && \
+	gem install therubyracer -v 0.12.2 && \
+	easy_install Pygments
+

--- a/docs/docker/run.sh
+++ b/docs/docker/run.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -x -u
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+export IMAGE_NAME="flink/docs"
+
+pushd ${SCRIPT_DIR}
+
+docker build --rm=true -t ${IMAGE_NAME} .
+
+popd
+
+if [ "$(uname -s)" == "Linux" ]; then
+  USER_NAME=${SUDO_USER:=$USER}
+  USER_ID=$(id -u "${USER_NAME}")
+  GROUP_ID=$(id -g "${USER_NAME}")
+else # boot2docker uid and gid
+  USER_NAME=$USER
+  USER_ID=1000
+  GROUP_ID=50
+fi
+
+docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
+FROM ${IMAGE_NAME}
+RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
+  useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
+ENV  HOME /home/${USER_NAME}
+UserSpecificDocker
+
+FLINK_DOC_ROOT=${SCRIPT_DIR}/..
+
+CMD="
+echo
+echo 'Welcome to Flink docs'
+echo 'To build, execute'
+echo '  ./build_docs.sh'
+echo 'To watch and regenerate automatically'
+echo '  ./build_docs.sh -p'
+echo 'and access http://localhost:4000'
+echo
+bash
+"
+
+pushd ${FLINK_DOC_ROOT}
+
+docker run -i -t \
+  --rm=true \
+  -w ${FLINK_DOC_ROOT} \
+  -u "${USER}" \
+  -v "${FLINK_DOC_ROOT}:${FLINK_DOC_ROOT}" \
+  -v "/home/${USER_NAME}:/home/${USER_NAME}" \
+  -p 4000:4000 \
+  ${IMAGE_NAME}-${USER_NAME} \
+  bash -c "${CMD}"
+
+popd
+

--- a/docs/docker/run.sh
+++ b/docs/docker/run.sh
@@ -48,7 +48,7 @@ FLINK_DOC_ROOT=${SCRIPT_DIR}/..
 
 CMD="
 echo
-echo 'Welcome to Flink docs'
+echo 'Welcome to Apache Flink docs'
 echo 'To build, execute'
 echo '  ./build_docs.sh'
 echo 'To watch and regenerate automatically'


### PR DESCRIPTION
This is not to fulfill what FLINK-3009 is originally asking,
but I'm piggybacking to contribute a docker environment with jekyll
so that users won't have to deal with environment versions.