### PR TITLE
[FLINK-3025] [kafka consumer] Bump transitive ZkClient dependency to 0.7 for bugfixes

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka/pom.xml
@@ -113,6 +113,16 @@ under the License.
 		</dependency>
 
 	</dependencies>
+	
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.101tec</groupId>
+				<artifactId>zkclient</artifactId>
+				<version>0.7</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
Gives us a fix against deadlocks in the ZkClient which have caused the Kafka Consumer to freeze.