### PR TITLE
[FLINK-3021] Fix class loading issue for streaming sources

### DIFF
--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -392,6 +392,25 @@ under the License.
 						</configuration>
 					</execution>
 					<execution>
+						<id>create-streaming-custominputsplit-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.test.classloading.jar.StreamingCustomInputSplitProgram</mainClass>
+								</manifest>
+							</archive>
+							<finalName>streaming-customsplit</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-streaming-custominput-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+					<execution>
 						<id>create-streamingclassloader-jar</id>
 						<phase>process-test-classes</phase>
 						<goals>

--- a/flink-tests/src/test/assembly/test-streaming-custominput-assembly.xml
+++ b/flink-tests/src/test/assembly/test-streaming-custominput-assembly.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!--modify/add include to match your package(s) -->
+			<includes>
+				<include>org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.class</include>
+				<include>org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram$*.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -37,6 +37,8 @@ public class ClassLoaderITCase {
 
 	private static final String INPUT_SPLITS_PROG_JAR_FILE = "target/customsplit-test-jar.jar";
 
+	private static final String STREAMING_INPUT_SPLITS_PROG_JAR_FILE = "target/streaming-customsplit-test-jar.jar";
+
 	private static final String STREAMING_PROG_JAR_FILE = "target/streamingclassloader-test-jar.jar";
 
 	private static final String STREAMING_CHECKPOINTED_PROG_JAR_FILE = "target/streaming-checkpointed-classloader-test-jar.jar";
@@ -76,6 +78,15 @@ public class ClassLoaderITCase {
 									});
 				inputSplitTestProg.invokeInteractiveModeForExecution();
 
+				PackagedProgram streamingInputSplitTestProg = new PackagedProgram(
+						new File(STREAMING_INPUT_SPLITS_PROG_JAR_FILE),
+						new String[] { STREAMING_INPUT_SPLITS_PROG_JAR_FILE,
+								"localhost",
+								String.valueOf(port),
+								"4" // parallelism
+						});
+				streamingInputSplitTestProg.invokeInteractiveModeForExecution();
+
 				String classpath = new File(INPUT_SPLITS_PROG_JAR_FILE).toURI().toURL().toString();
 				PackagedProgram inputSplitTestProg2 = new PackagedProgram(new File(INPUT_SPLITS_PROG_JAR_FILE),
 						new String[] { "",
@@ -89,7 +100,7 @@ public class ClassLoaderITCase {
 				// regular streaming job
 				PackagedProgram streamingProg = new PackagedProgram(
 						new File(STREAMING_PROG_JAR_FILE),
-						new String[] { 
+						new String[] {
 								STREAMING_PROG_JAR_FILE,
 								"localhost",
 								String.valueOf(port)
@@ -102,7 +113,7 @@ public class ClassLoaderITCase {
 					PackagedProgram streamingCheckpointedProg = new PackagedProgram(
 							new File(STREAMING_CHECKPOINTED_PROG_JAR_FILE),
 							new String[] {
-									STREAMING_CHECKPOINTED_PROG_JAR_FILE, 
+									STREAMING_CHECKPOINTED_PROG_JAR_FILE,
 									"localhost",
 									String.valueOf(port)});
 					streamingCheckpointedProg.invokeInteractiveModeForExecution();

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.classloading.jar;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.core.io.InputSplitAssigner;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@SuppressWarnings("serial")
+public class StreamingCustomInputSplitProgram {
+	
+	public static void main(String[] args) throws Exception {
+		final String jarFile = args[0];
+		final String host = args[1];
+		final int port = Integer.parseInt(args[2]);
+		final int parallelism = Integer.parseInt(args[3]);
+
+		Configuration config = new Configuration();
+
+		config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, "5 s");
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment(host, port, config, jarFile);
+		env.getConfig().disableSysoutLogging();
+		env.setParallelism(parallelism);
+
+		DataStream<Integer> data = env.createInput(new CustomInputFormat());
+
+		data.map(new MapFunction<Integer, Tuple2<Integer, Double>>() {
+			@Override
+			public Tuple2<Integer, Double> map(Integer value) throws Exception {
+				return new Tuple2<Integer, Double>(value, value * 0.5);
+			}
+		}).addSink(new NoOpSink());
+
+		env.execute();
+	}
+	// --------------------------------------------------------------------------------------------
+	
+	public static final class CustomInputFormat implements InputFormat<Integer, CustomInputSplit>, ResultTypeQueryable<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		private Integer value;
+
+		CustomInputSplit split = new CustomInputSplit(0);
+
+		@Override
+		public void configure(Configuration parameters) {}
+
+		@Override
+		public BaseStatistics getStatistics(BaseStatistics cachedStatistics) {
+			return null;
+		}
+
+		@Override
+		public CustomInputSplit[] createInputSplits(int minNumSplits) {
+			CustomInputSplit[] splits = new CustomInputSplit[minNumSplits];
+			for (int i = 0; i < minNumSplits; i++) {
+				splits[i] = new CustomInputSplit(i);
+			}
+			return splits;
+		}
+
+		@Override
+		public InputSplitAssigner getInputSplitAssigner(CustomInputSplit[] inputSplits) {
+			return new CustomSplitAssigner(inputSplits);
+		}
+
+		@Override
+		public void open(CustomInputSplit split) {
+			this.value = split.getSplitNumber();
+		}
+
+		@Override
+		public boolean reachedEnd() {
+			return this.value == null;
+		}
+
+		@Override
+		public Integer nextRecord(Integer reuse) {
+			Integer val = this.value;
+			this.value = null;
+			return val;
+		}
+
+		@Override
+		public void close() {}
+
+		@Override
+		public TypeInformation<Integer> getProducedType() {
+			return BasicTypeInfo.INT_TYPE_INFO;
+		}
+	}
+
+	public static final class CustomInputSplit implements InputSplit {
+
+		private static final long serialVersionUID = 1L;
+
+		private final int splitNumber;
+
+		public CustomInputSplit(int splitNumber) {
+			this.splitNumber = splitNumber;
+		}
+
+		@Override
+		public int getSplitNumber() {
+			return this.splitNumber;
+		}
+	}
+
+	public static final class CustomSplitAssigner implements InputSplitAssigner, Serializable {
+
+		private final List<CustomInputSplit> remainingSplits;
+
+		public CustomSplitAssigner(CustomInputSplit[] splits) {
+			this.remainingSplits = new ArrayList<CustomInputSplit>(Arrays.asList(splits));
+		}
+
+		@Override
+		public InputSplit getNextInputSplit(String host, int taskId) {
+			synchronized (this) {
+				int size = remainingSplits.size();
+				if (size > 0) {
+					return remainingSplits.remove(size - 1);
+				} else {
+					return null;
+				}
+			}
+		}
+	}
+
+	public static class NoOpSink implements SinkFunction<Tuple2<Integer, Double>> {
+		@Override
+		public void invoke(Tuple2<Integer, Double> value) throws Exception {
+		}
+	}
+}


### PR DESCRIPTION
Streaming sources were directly assigned their InputFormat in the StreamingJobGraphGenerator. As a consequence, the input formats were directly serialized/deserialized by Akka when the JobGraph was sent to the JobManager. In cases where the user provided a custom input format or an input format with custom types, this could lead to a ClassDefNotFoundException, because the system class loader instead of the user code class loader is used by Akka for the deserialization.

The problem was fixed by wrapping the InputFormat into a UserCodeObjectWrapper which is shipped ot the JobManager via the JobVertex's configuration. By instantiating stream sources as InputFormatVertices, the corresponding InputFormat is retrieved from the Configuration in the initializeOnMaster method call.