### PR TITLE
[FLINK-3032] Fix jackson-core dependency conflict with Hadoop 2.7.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ language: java
 matrix:
   include:
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.0 -Dscala-2.11 -Pinclude-tez -Pinclude-yarn-tests"
+      env: PROFILE="-Dhadoop.version=2.7.1 -Dscala-2.11 -Pinclude-tez -Pinclude-yarn-tests"
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.5.0 -Pinclude-yarn-tests"
     - jdk: "openjdk7"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
@@ -320,6 +320,8 @@ public class EnvironmentInformation {
 				}
 			}
 
+			log.info(" Classpath: " + System.getProperty("java.class.path"));
+
 			log.info("--------------------------------------------------------------------------------");
 		}
 	}

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -72,6 +72,7 @@ under the License.
 							<shadedArtifactAttached>false</shadedArtifactAttached>
 							<createDependencyReducedPom>true</createDependencyReducedPom>
 							<dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
 							<filters>
 								<!-- Exclude signatures -->
 								<filter>
@@ -101,6 +102,17 @@ under the License.
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
 							</transformers>
+							<artifactSet>
+								<includes>
+									<include>com.google.guava:*</include>
+									<include>com.google.protobuf:*</include>
+									<include>com.google.code.findbugs:*</include>
+									<include>asm:asm</include>
+									<include>io.netty:netty:*</include>
+									<include>org.apache.curator:*</include>
+									<include>org.apache.hadoop:*</include>
+								</includes>
+							</artifactSet>
 							<relocations>
 								<relocation>
 									<pattern>com.google</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@ under the License.
 		<tez.version>0.6.1</tez.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<curator.version>2.8.0</curator.version>
+		<jackson.version>2.4.2</jackson.version>
 	</properties>
 
 	<dependencies>
@@ -349,6 +350,24 @@ under the License.
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
 				<version>4.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>${jackson.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
This commit is changing how we build the "flink-shaded-hadoop" artifact.
In the past, we were including all Hadoop dependencies into a fat jar, without relocating all of them.
Maven was not able to see Hadoop's dependencies and classes ended up in the classpath multiple times.
This has also lead to classes overwriting each other in the final fat jar. Even worse, this overwriting might not happen consistently across different build systems (jvm version, maven version)

With this change, only shaded Hadoop dependencies are included into the jar. The shade plugin will also remove only the shaded dependencies from the pom file.

This change is also fixing the issue with the `flink-neo4j` connector discussed on the mailing list.
Another user had a dependency conflict with Hadoop's httpcomponents library. This change has been tested by the user and its resolving the issue.