### PR TITLE
[FLINK-2249] Ignore calls to execute without sinks

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -18,14 +18,24 @@
 
 package org.apache.flink.api.java;
 
+import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.operators.CollectionExecutor;
+import static org.apache.flink.api.java.ExecutionEnvironment.LOG;
 
 public class CollectionEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
+		if (sinks.isEmpty()) {
+			if (this.lastJobExecutionResult == null) {
+				throw new InvalidProgramException("No sinks have been defined.");
+			}
+			LOG.warn("Detected call to execute without any data sinks. Not executing.");
+			return this.lastJobExecutionResult;
+		}
+
 		Plan p = createProgramPlan(jobName);
 
 		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -105,7 +105,7 @@ public abstract class ExecutionEnvironment {
 
 	// --------------------------------------------------------------------------------------------
 
-	private final List<DataSink<?>> sinks = new ArrayList<>();
+	protected final List<DataSink<?>> sinks = new ArrayList<>();
 
 	private final List<Tuple2<String, DistributedCacheEntry>> cacheFile = new ArrayList<>();
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -74,6 +74,14 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
+		if (sinks.isEmpty()) {
+			if (this.lastJobExecutionResult == null) {
+				throw new InvalidProgramException("No sinks have been defined.");
+			}
+			LOG.warn("Detected call to execute without any new data sinks. Not executing.");
+			return this.lastJobExecutionResult;
+		}
+
 		if (executor == null) {
 			startNewSession();
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -149,6 +149,14 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
+		if (sinks.isEmpty()) {
+			if (this.lastJobExecutionResult == null) {
+				throw new InvalidProgramException("No sinks have been defined.");
+			}
+			LOG.warn("Detected call to execute without any data sinks. Not executing.");
+			return this.lastJobExecutionResult;
+		}
+
 		ensureExecutorCreated();
 
 		Plan p = createProgramPlan(jobName);


### PR DESCRIPTION
This PR makes the following changes:
* DataSet actions store the last jobExecutionResult in the environment
* Environment.execute() ...
 * fails, if no sinks is defined with an InvalidProgramException,
 * returns the last result and prints a warning, if no sink was defined since the last execution,
 * executes as usual if a sink was defined since the last execution.