### PR TITLE
[FLINK-2115] [Table API] support no aggregation after groupBy.

### DIFF
--- a/docs/libs/table.md
+++ b/docs/libs/table.md
@@ -188,11 +188,18 @@ Table result = in.where("b = 'red'");
     <tr>
       <td><strong>GroupBy</strong></td>
       <td>
-        <p>Similar to a SQL GROUPBY clause. Group the elements on the grouping keys, with a following aggregation</p>
-        <p>operator to aggregate on per-group basis.</p>
+        <p>Similar to a SQL GROUPBY clause. Group the elements on the grouping keys, with a following aggregation
+        operator to aggregate on per-group basis.</p>
 {% highlight java %}
 Table in = tableEnv.fromDataSet(ds, "a, b, c");
 Table result = in.groupBy("a").select("a, b.sum as d");
+{% endhighlight %}
+        <p><i>Note:</i> Flink can refer to nonaggregated columns in the select list that are not named in
+        the groupBy clause, it could be used to get better performance by avoiding unnecessary column sorting and
+        grouping while nonaggregated column is cogrouped with columns in groupBy clause. For example:</p>
+{% highlight java %}
+Table in = tableEnv.fromDataSet(ds, "a, b, c");
+Table result = in.groupBy("a").select("a, b, c.sum as d");
 {% endhighlight %}
       </td>
     </tr>
@@ -200,8 +207,8 @@ Table result = in.groupBy("a").select("a, b.sum as d");
     <tr>
       <td><strong>Join</strong></td>
       <td>
-        <p>Similar to a SQL JOIN clause. Join two tables, both tables must have distinct field name, and the where</p>
-        <p>clause is mandatory for join condition.</p>
+        <p>Similar to a SQL JOIN clause. Join two tables, both tables must have distinct field name, and the where
+        clause is mandatory for join condition.</p>
 {% highlight java %}
 Table left = tableEnv.fromDataSet(ds1, "a, b, c");
 Table right = tableEnv.fromDataSet(ds2, "d, e, f");
@@ -284,11 +291,18 @@ val result = in.where('b === "red");
     <tr>
       <td><strong>GroupBy</strong></td>
       <td>
-        <p>Similar to a SQL GROUPBY clause. Group the elements on the grouping keys, with a following aggregation</p>
-        <p>operator to aggregate on per-group basis.</p>
+        <p>Similar to a SQL GROUPBY clause. Group the elements on the grouping keys, with a following aggregation
+        operator to aggregate on per-group basis.</p>
 {% highlight scala %}
 val in = ds.as('a, 'b, 'c);
 val result = in.groupBy('a).select('a, 'b.sum as 'd);
+{% endhighlight %}
+        <p><i>Note:</i> Flink can refer to nonaggregated columns in the select list that are not named in
+        the groupBy clause, it could be used to get better performance by avoiding unnecessary column sorting and
+        grouping while nonaggregated column is cogrouped with columns in groupBy clause. For example:</p>
+{% highlight scala %}
+val in = ds.as('a, 'b, 'c);
+val result = in.groupBy('a).select('a, 'b, 'c.sum as 'd);
 {% endhighlight %}
       </td>
     </tr>
@@ -296,8 +310,8 @@ val result = in.groupBy('a).select('a, 'b.sum as 'd);
     <tr>
       <td><strong>Join</strong></td>
       <td>
-        <p>Similar to a SQL JOIN clause. Join two tables, both tables must have distinct field name, and the where</p>
-        <p>clause is mandatory for join condition.</p>
+        <p>Similar to a SQL JOIN clause. Join two tables, both tables must have distinct field name, and the where
+        clause is mandatory for join condition.</p>
 {% highlight scala %}
 val left = ds1.as('a, 'b, 'c);
 val right = ds2.as('d, 'e, 'f);

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionAggregateFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionAggregateFunction.scala
@@ -70,3 +70,20 @@ class ExpressionAggregateFunction(
   }
 
 }
+
+@Combinable
+class NoExpressionAggregateFunction() extends RichGroupReduceFunction[Row, Row] {
+
+  override def reduce(in: java.lang.Iterable[Row], out: Collector[Row]): Unit = {
+
+    var first: Row = null
+
+    val values = in.iterator()
+    if (values.hasNext) {
+      first = values.next()
+    }
+
+    out.collect(first)
+  }
+
+}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
@@ -126,5 +126,27 @@ public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 
 		expected = "1\n" + "5\n" + "15\n" + "34\n" + "65\n" + "111\n";
 	}
+
+	@Test
+	public void testGroupNoAggregation() throws Exception {
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSet<Tuple3<Integer, Long, String>> input = CollectionDataSets.get3TupleDataSet(env);
+
+		Table table =
+			tableEnv.fromDataSet(input, "a, b, c");
+
+		Table result = table
+			.groupBy("b").select("a.sum as d, b").groupBy("b, d").select("b");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		ds.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+		env.execute();
+
+		expected = "1\n" + "2\n" + "3\n" + "4\n" + "5\n" + "6\n";
+	}
 }
 

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/GroupedAggreagationsITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/GroupedAggreagationsITCase.scala
@@ -114,4 +114,21 @@ class GroupedAggreagationsITCase(mode: TestExecutionMode) extends MultipleProgra
     env.execute()
     expected = "231,231,1,1,21,21,11,11,21,21"
   }
+
+  @Test
+  def testGroupNoAggregation(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val ds = CollectionDataSets.get3TupleDataSet(env)
+      .as('a, 'b, 'c)
+      .groupBy('b)
+      .select('a.sum as 'd, 'b)
+      .groupBy('b, 'd)
+      .select('b)
+      .toDataSet[Row]
+
+    ds.writeAsText(resultPath, WriteMode.OVERWRITE)
+    env.execute()
+    expected = "1\n" + "2\n" + "3\n" + "4\n" + "5\n" + "6\n"
+  }
 }


### PR DESCRIPTION
`JavaBatchTranslator` does not support no aggregation `select` after `groupBy` previously, add the logic in this PR.