### PR TITLE
[FLINK-2686] Show exchange mode in JSON plan

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/PlanJSONDumpGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/PlanJSONDumpGenerator.java
@@ -382,6 +382,11 @@ public class PlanJSONDumpGenerator {
 						String tempMode = channel.getTempMode().toString();
 						writer.print(", \"temp_mode\": \"" + tempMode + "\"");
 					}
+
+					if (channel != null) {
+						String exchangeMode = channel.getDataExchangeMode().toString();
+						writer.print(", \"exchange_mode\": \"" + exchangeMode + "\"");
+					}
 				}
 				
 				writer.print('}');


### PR DESCRIPTION
Extends the PlanJSONDumpGenerator to also include the Data Exchange mode. It will be shown like this:

```
...
"parallelism": "2",
"predecessors": [
	{"id": 5, "ship_strategy": "Forward", "exchange_mode": "PIPELINED"}
],
"driver_strategy": "Map",
...
```