### PR TITLE
[FLINK-2429] [streaming] Deprecate the "enableCheckpointing()" method with no interval argument.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -332,7 +332,10 @@ public abstract class StreamExecutionEnvironment {
 	 * the moment. For that reason, iterative jobs will not be started if used
 	 * with enabled checkpointing. To override this mechanism, use the 
 	 * {@link #enableCheckpointing(long, CheckpointingMode, boolean)} method.</p>
+	 * 
+	 * @deprecated Use {@link #enableCheckpointing(long)} instead.
 	 */
+	@Deprecated
 	public StreamExecutionEnvironment enableCheckpointing() {
 		enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
 		return this;


### PR DESCRIPTION
The default checkpoint interval is a bit intransparent. Dropping that method makes the user think about what interval they want to chose.

We could (and should) later add a way that auto-tunes the checkpoint interval, based on the time checkpoints take to complete.