### PR TITLE
[FLINK-3052] [optimizer] Fix instantiation of bulk iteration candidates

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/UnaryOperatorNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/UnaryOperatorNode.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.optimizer.dag;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.apache.flink.api.common.operators.SemanticProperties;
+import org.apache.flink.api.common.operators.SingleInputOperator;
 import org.apache.flink.api.common.operators.SingleInputSemanticProperties;
 import org.apache.flink.api.common.operators.util.FieldSet;
 import org.apache.flink.optimizer.DataStatistics;
@@ -30,11 +32,17 @@ import org.apache.flink.optimizer.operators.OperatorDescriptorSingle;
 
 public class UnaryOperatorNode extends SingleInputNode {
 	
-	private final List<OperatorDescriptorSingle> operator;
+	private final List<OperatorDescriptorSingle> operators;
 	
 	private final String name;
 
+	public UnaryOperatorNode(String name, SingleInputOperator<?, ?, ?> operator, boolean onDynamicPath) {
+		super(operator);
 
+		this.name = name;
+		this.operators = new ArrayList<>();
+		this.onDynamicPath = onDynamicPath;
+	}
 	
 	public UnaryOperatorNode(String name, FieldSet keys, OperatorDescriptorSingle ... operators) {
 		this(name, keys, Arrays.asList(operators));
@@ -43,13 +51,13 @@ public class UnaryOperatorNode extends SingleInputNode {
 	public UnaryOperatorNode(String name, FieldSet keys, List<OperatorDescriptorSingle> operators) {
 		super(keys);
 		
-		this.operator = operators;
+		this.operators = operators;
 		this.name = name;
 	}
 
 	@Override
 	protected List<OperatorDescriptorSingle> getPossibleProperties() {
-		return this.operator;
+		return this.operators;
 	}
 
 	@Override

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/WorksetIterationNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/WorksetIterationNode.java
@@ -52,6 +52,7 @@ import org.apache.flink.optimizer.plan.WorksetIterationPlanNode;
 import org.apache.flink.optimizer.plan.WorksetPlanNode;
 import org.apache.flink.optimizer.plan.PlanNode.FeedbackPropertiesMeetRequirementsReport;
 import org.apache.flink.optimizer.util.NoOpBinaryUdfOp;
+import org.apache.flink.optimizer.util.NoOpUnaryUdfOp;
 import org.apache.flink.runtime.operators.DriverStrategy;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.apache.flink.runtime.operators.util.LocalStrategy;
@@ -307,7 +308,8 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 		this.nextWorkset.accept(InterestingPropertiesClearer.INSTANCE);
 		this.solutionSetDelta.accept(InterestingPropertiesClearer.INSTANCE);
 	}
-	
+
+	@SuppressWarnings("unchecked")
 	@Override
 	protected void instantiate(OperatorDescriptorDual operator, Channel solutionSetIn, Channel worksetIn,
 			List<Set<? extends NamedChannel>> broadcastPlanChannels, List<PlanNode> target, CostEstimator estimator,
@@ -367,9 +369,14 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 					globPropsReqWorkset.parameterizeChannel(toNoOp, false,
 															nextWorksetRootConnection.getDataExchangeMode(), false);
 					locPropsReqWorkset.parameterizeChannel(toNoOp);
-					
-					UnaryOperatorNode rebuildWorksetPropertiesNode = new UnaryOperatorNode("Rebuild Workset Properties",
-																							FieldList.EMPTY_LIST);
+
+					NoOpUnaryUdfOp noOpUnaryUdfOp = new NoOpUnaryUdfOp<>();
+					noOpUnaryUdfOp.setInput(candidate.getProgramOperator());
+
+					UnaryOperatorNode rebuildWorksetPropertiesNode = new UnaryOperatorNode(
+						"Rebuild Workset Properties",
+						noOpUnaryUdfOp,
+						true);
 					
 					rebuildWorksetPropertiesNode.setParallelism(candidate.getParallelism());
 					

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/util/NoOpUnaryUdfOp.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/util/NoOpUnaryUdfOp.java
@@ -36,7 +36,7 @@ public class NoOpUnaryUdfOp<OUT> extends SingleInputOperator<OUT, OUT, NoOpFunct
 	@SuppressWarnings("rawtypes")
 	public static final NoOpUnaryUdfOp INSTANCE = new NoOpUnaryUdfOp();
 	
-	private NoOpUnaryUdfOp() {
+	public NoOpUnaryUdfOp() {
 		// pass null here because we override getOutputType to return type
 		// of input operator
 		super(new UserCodeClassWrapper<NoOpFunction>(NoOpFunction.class), null, "");


### PR DESCRIPTION
When a candidate for a bulk iteration is instantiated, then the optimizer creates candidates
for the step function. It is then checked that there exists a candidate solution for the step
function whose properties met the properties of the input to the bulk iteration. Sometimes
it is necessary to add a no-op plan node to the end of the step function to generate the
correct properties. These new candidates have to be added to the final set of the accepted
candidates.

This commit adds that these new candidates are properly added to the set of accepted candidates.

Fix test and add new iteration tests

Add predecessor operator and dynamic path information to no op operator in bulk iterations