### PR TITLE
[hotfix] Register signal handler for JobManager and TaskManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -203,6 +203,8 @@ public final class BlobCache implements BlobService {
 	@Override
 	public void shutdown() {
 		if (shutdownRequested.compareAndSet(false, true)) {
+			LOG.info("Shutting down BlobCache");
+
 			// Clean up the storage directory
 			try {
 				FileUtils.deleteDirectory(storageDir);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1382,6 +1382,8 @@ object JobManager {
     // startup checks and logging
     EnvironmentInformation.logEnvironmentInfo(LOG.logger, "JobManager", args)
     EnvironmentInformation.checkJavaVersion()
+    // register signal handler
+    SignalHandler.register(LOG.logger)
 
     // parsing the command line arguments
     val (configuration: Configuration,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -64,7 +64,7 @@ import org.apache.flink.util.NetUtils
 import org.apache.flink.runtime.process.ProcessReaper
 import org.apache.flink.runtime.security.SecurityUtils
 import org.apache.flink.runtime.security.SecurityUtils.FlinkSecuredRunner
-import org.apache.flink.runtime.util.{LeaderRetrievalUtils, MathUtils, EnvironmentInformation}
+import org.apache.flink.runtime.util.{SignalHandler, LeaderRetrievalUtils, MathUtils, EnvironmentInformation}
 
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -1204,6 +1204,8 @@ object TaskManager {
     // startup checks and logging
     EnvironmentInformation.logEnvironmentInfo(LOG.logger, "TaskManager", args)
     EnvironmentInformation.checkJavaVersion()
+    // register signal logger
+    SignalHandler.register(LOG.logger)
 
     val maxOpenFileHandles = EnvironmentInformation.getOpenFileHandlesLimit()
     if (maxOpenFileHandles != -1) {


### PR DESCRIPTION
I've spend some time today helping a user to debug an issue with a TaskManager which was stopping for no apparent reason.
The following changes in the code will make it easier in the future to resolve similar issues.

The BlobCache (running on the TM) will log that its shutting down.
Also, the JM and TM will log when they get killed by an external system.

I didn't push this hotfix immediately because I might have overseen an entry point into the JM / TM.