### PR TITLE
[github] change tab size to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
The default tab size on GitHub is 8 spaces. This change decreases the
tab size to 4. I think this will make reviewing of code on GitHub easier.

Left: tab size 4
Right: tab size 8 (status quo)
<img width="1437" alt="tabsize" src="https://cloud.githubusercontent.com/assets/837221/11393917/c4d651d6-9362-11e5-8ab6-c31cc47c927d.png">
