### PR TITLE
typo in DelimitedInputFormat

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -78,9 +78,9 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 	 */
 	private static int MAX_SAMPLE_LEN;
 	
-	static { loadGloablConfigParams(); }
+	static { loadGlobalConfigParams(); }
 	
-	protected static void loadGloablConfigParams() {
+	protected static void loadGlobalConfigParams() {
 		int maxSamples = GlobalConfiguration.getInteger(ConfigConstants.DELIMITED_FORMAT_MAX_LINE_SAMPLES_KEY,
 				ConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_LINE_SAMPLES);
 		int minSamples = GlobalConfiguration.getInteger(ConfigConstants.DELIMITED_FORMAT_MIN_LINE_SAMPLES_KEY,

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
@@ -288,7 +288,7 @@ public class DelimitedInputFormatSamplingTest {
 		}
 		
 		public static void prepare() {
-			DelimitedInputFormat.loadGloablConfigParams();
+			DelimitedInputFormat.loadGlobalConfigParams();
 		}
 	}
 }


### PR DESCRIPTION
in both DelimitedInputFormat.java and DelimitedInputFormatSamplingTest.java it's written loadGloablConfigParams insted of loadGlobalConfigParams, is it safe to correct it?