### PR TITLE
[FLINK-3051] Control the maximum number of concurrent checkpoints

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -88,7 +88,7 @@ public class ExecutionConfig implements Serializable {
 	/** If set to true, progress updates are printed to System.out during execution */
 	private boolean printProgressDuringExecution = true;
 
-	private GlobalJobParameters globalJobParameters = null;
+	private GlobalJobParameters globalJobParameters;
 
 	private long autoWatermarkInterval = 0;
 
@@ -99,17 +99,17 @@ public class ExecutionConfig implements Serializable {
 	// Serializers and types registered with Kryo and the PojoSerializer
 	// we store them in linked maps/sets to ensure they are registered in order in all kryo instances.
 
-	private final LinkedHashMap<Class<?>, SerializableSerializer<?>> registeredTypesWithKryoSerializers = new LinkedHashMap<Class<?>, SerializableSerializer<?>>();
+	private final LinkedHashMap<Class<?>, SerializableSerializer<?>> registeredTypesWithKryoSerializers = new LinkedHashMap<>();
 
-	private final LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> registeredTypesWithKryoSerializerClasses = new LinkedHashMap<Class<?>, Class<? extends Serializer<?>>>();
+	private final LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> registeredTypesWithKryoSerializerClasses = new LinkedHashMap<>();
 
-	private final LinkedHashMap<Class<?>, SerializableSerializer<?>> defaultKryoSerializers = new LinkedHashMap<Class<?>, SerializableSerializer<?>>();
+	private final LinkedHashMap<Class<?>, SerializableSerializer<?>> defaultKryoSerializers = new LinkedHashMap<>();
 
-	private final LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> defaultKryoSerializerClasses = new LinkedHashMap<Class<?>, Class<? extends Serializer<?>>>();
+	private final LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> defaultKryoSerializerClasses = new LinkedHashMap<>();
 
-	private final LinkedHashSet<Class<?>> registeredKryoTypes = new LinkedHashSet<Class<?>>();
+	private final LinkedHashSet<Class<?>> registeredKryoTypes = new LinkedHashSet<>();
 
-	private final LinkedHashSet<Class<?>> registeredPojoTypes = new LinkedHashSet<Class<?>>();
+	private final LinkedHashSet<Class<?>> registeredPojoTypes = new LinkedHashSet<>();
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
@@ -32,19 +32,15 @@ import java.util.UUID;
 public class CheckpointCoordinatorDeActivator extends FlinkUntypedActor {
 
 	private final CheckpointCoordinator coordinator;
-	private final long interval;
 	private final UUID leaderSessionID;
 	
 	public CheckpointCoordinatorDeActivator(
 			CheckpointCoordinator coordinator,
-			long interval,
 			UUID leaderSessionID) {
 
 		LOG.info("Create CheckpointCoordinatorDeActivator");
 
 		this.coordinator = Preconditions.checkNotNull(coordinator, "The checkpointCoordinator must not be null.");
-
-		this.interval = interval;
 		this.leaderSessionID = leaderSessionID;
 	}
 
@@ -55,11 +51,10 @@ public class CheckpointCoordinatorDeActivator extends FlinkUntypedActor {
 			
 			if (status == JobStatus.RUNNING) {
 				// start the checkpoint scheduler
-				coordinator.startPeriodicCheckpointScheduler(interval);
-			}
-			else {
+				coordinator.startCheckpointScheduler();
+			} else {
 				// anything else should stop the trigger for now
-				coordinator.stopPeriodicCheckpointScheduler();
+				coordinator.stopCheckpointScheduler();
 			}
 		}
 		

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -117,7 +117,7 @@ public class PendingCheckpoint {
 			if (notYetAcknowledgedTasks.isEmpty()) {
 				CompletedCheckpoint completed =  new CompletedCheckpoint(jobId, checkpointId,
 						checkpointTimestamp, new ArrayList<StateForTask>(collectedStates));
-				discard(null, false);
+				dispose(null, false);
 				
 				return completed;
 			}
@@ -150,11 +150,15 @@ public class PendingCheckpoint {
 	/**
 	 * Discards the pending checkpoint, releasing all held resources.
 	 */
-	public void discard(ClassLoader userClassLoader, boolean discardStateHandle) {
+	public void discard(ClassLoader userClassLoader) {
+		dispose(userClassLoader, true);
+	}
+
+	private void dispose(ClassLoader userClassLoader, boolean releaseState) {
 		synchronized (lock) {
 			discarded = true;
 			numAcknowledgedTasks = -1;
-			if (discardStateHandle) {
+			if (releaseState) {
 				for (StateForTask state : collectedStates) {
 					state.discard(userClassLoader);
 				}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -913,6 +913,8 @@ class JobManager(
           executionGraph.enableSnapshotCheckpointing(
             snapshotSettings.getCheckpointInterval,
             snapshotSettings.getCheckpointTimeout,
+            snapshotSettings.getMinPauseBetweenCheckpoints,
+            snapshotSettings.getMaxConcurrentCheckpoints,
             triggerVertices,
             ackVertices,
             confirmVertices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -80,7 +80,7 @@ public class CheckpointStateRestoreTest {
 			map.put(statelessId, stateless);
 
 
-			CheckpointCoordinator coord = new CheckpointCoordinator(jid, 200000L,
+			CheckpointCoordinator coord = new CheckpointCoordinator(jid, 200000L, 200000L,
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
 					new ExecutionVertex[0], cl,
@@ -151,7 +151,7 @@ public class CheckpointStateRestoreTest {
 			map.put(statelessId, stateless);
 
 
-			CheckpointCoordinator coord = new CheckpointCoordinator(jid, 200000L,
+			CheckpointCoordinator coord = new CheckpointCoordinator(jid, 200000L, 200000L,
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
 					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
 					new ExecutionVertex[0], cl,
@@ -193,7 +193,7 @@ public class CheckpointStateRestoreTest {
 	@Test
 	public void testNoCheckpointAvailable() {
 		try {
-			CheckpointCoordinator coord = new CheckpointCoordinator(new JobID(), 200000L,
+			CheckpointCoordinator coord = new CheckpointCoordinator(new JobID(), 200000L, 200000L,
 					new ExecutionVertex[] { mock(ExecutionVertex.class) },
 					new ExecutionVertex[] { mock(ExecutionVertex.class) },
 					new ExecutionVertex[0], cl,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
@@ -61,7 +61,8 @@ public class CoordinatorShutdownTest {
 			List<JobVertexID> vertexIdList = Collections.singletonList(vertex.getID());
 			
 			JobGraph testGraph = new JobGraph("test job", vertex);
-			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList, 5000));
+			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList, 
+					5000, 60000, 0L, Integer.MAX_VALUE));
 			
 			ActorGateway jmGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
 
@@ -112,7 +113,8 @@ public class CoordinatorShutdownTest {
 			List<JobVertexID> vertexIdList = Collections.singletonList(vertex.getID());
 
 			JobGraph testGraph = new JobGraph("test job", vertex);
-			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList, 5000));
+			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList,
+					5000, 60000, 0L, Integer.MAX_VALUE));
 			
 			ActorGateway jmGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.environment;
+
+import org.apache.flink.streaming.api.CheckpointingMode;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Configuration that captures all checkpointing related settings.
+ */
+public class CheckpointConfig implements java.io.Serializable {
+
+	private static final long serialVersionUID = -750378776078908147L;
+
+	/** The default checkpoint mode: exactly once */
+	public static final CheckpointingMode DEFAULT_MODE = CheckpointingMode.EXACTLY_ONCE;
+
+	/** The default timeout of a checkpoint attempt: 10 minutes */
+	public static final long DEFAULT_TIMEOUT = 10 * 60 * 1000;
+
+	/** The default minimum pause to be made between checkpoints: none */
+	public static final long DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS = 0;
+
+	/** The default limit of concurrently happening checkpoints: one */
+	public static final int DEFAULT_MAX_CONCURRENT_CHECKPOINTS = 1;
+
+	// ------------------------------------------------------------------------
+
+	/** Checkpointing mode (exactly-once vs. at-least-once). */
+	private CheckpointingMode checkpointingMode = DEFAULT_MODE;
+
+	/** Periodic checkpoint triggering interval */
+	private long checkpointInterval = -1; // disabled
+
+	/** Maximum time checkpoint may take before being discarded */
+	private long checkpointTimeout = DEFAULT_TIMEOUT;
+
+	/** Minimal pause between checkpointing attempts */
+	private long minPauseBetweenCheckpoints = DEFAULT_MIN_PAUSE_BETWEEN_CHECKPOINTS;
+
+	/** Maximum number of checkpoint attempts in progress at the same time */
+	private int maxConcurrentCheckpoints = DEFAULT_MAX_CONCURRENT_CHECKPOINTS;
+
+	/** Flag to force checkpointing in iterative jobs */
+	private boolean forceCheckpointing;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Checks whether checkpointing is enabled.
+	 * 
+	 * @return True if checkpointing is enables, false otherwise.
+	 */
+	public boolean isCheckpointingEnabled() {
+		return checkpointInterval > 0;
+	}
+	
+	/**
+	 * Gets the checkpointing mode (exactly-once vs. at-least-once).
+	 * 
+	 * @return The checkpointing mode.
+	 */
+	public CheckpointingMode getCheckpointingMode() {
+		return checkpointingMode;
+	}
+
+	/**
+	 * Sets the checkpointing mode (exactly-once vs. at-least-once).
+	 * 
+	 * @param checkpointingMode The checkpointing mode.
+	 */
+	public void setCheckpointingMode(CheckpointingMode checkpointingMode) {
+		this.checkpointingMode = requireNonNull(checkpointingMode);
+	}
+
+	/**
+	 * Gets the interval in which checkpoints are periodically scheduled.
+	 * 
+	 * <p>This setting defines the base interval. Checkpoint triggering may be delayed by the settings
+	 * {@link #getMaxConcurrentCheckpoints()} and {@link #getMinPauseBetweenCheckpoints()}.
+	 * 
+	 * @return The checkpoint interval, in milliseconds.
+	 */
+	public long getCheckpointInterval() {
+		return checkpointInterval;
+	}
+
+	/**
+	 * Sets the interval in which checkpoints are periodically scheduled.
+	 *
+	 * <p>This setting defines the base interval. Checkpoint triggering may be delayed by the settings
+	 * {@link #setMaxConcurrentCheckpoints(int)} and {@link #setMinPauseBetweenCheckpoints(long)}.
+	 *
+	 * @param checkpointInterval The checkpoint interval, in milliseconds.
+	 */
+	public void setCheckpointInterval(long checkpointInterval) {
+		if (checkpointInterval <= 0) {
+			throw new IllegalArgumentException("Checkpoint interval must be larger than zero");
+		}
+		this.checkpointInterval = checkpointInterval;
+	}
+
+	/**
+	 * Gets the maximum time that a checkpoint may take before being discarded.
+	 * 
+	 * @return The checkpoint timeout, in milliseconds.
+	 */
+	public long getCheckpointTimeout() {
+		return checkpointTimeout;
+	}
+
+	/**
+	 * Sets the maximum time that a checkpoint may take before being discarded.
+	 * 
+	 * @param checkpointTimeout The checkpoint timeout, in milliseconds.
+	 */
+	public void setCheckpointTimeout(long checkpointTimeout) {
+		if (checkpointInterval <= 0) {
+			throw new IllegalArgumentException("Checkpoint timeout must be larger than zero");
+		}
+		this.checkpointTimeout = checkpointTimeout;
+	}
+
+	/**
+	 * Gets the minimal pause between checkpointing attempts. This setting defines how soon the
+	 * checkpoint coordinator may trigger another checkpoint after it becomes possible to trigger
+	 * another checkpoint with respect to the maximum number of concurrent checkpoints
+	 * (see {@link #getMaxConcurrentCheckpoints()}).
+	 *
+	 * @return The minimal pause before the next checkpoint is triggered.
+	 */
+	public long getMinPauseBetweenCheckpoints() {
+		return minPauseBetweenCheckpoints;
+	}
+
+//	/**
+//	 * Sets the minimal pause between checkpointing attempts. This setting defines how soon the
+//	 * checkpoint coordinator may trigger another checkpoint after it becomes possible to trigger
+//	 * another checkpoint with respect to the maximum number of concurrent checkpoints
+//	 * (see {@link #setMaxConcurrentCheckpoints(int)}).
+//	 * 
+//	 * <p>If the maximum number of concurrent checkpoints is set to one, this setting makes effectively sure
+//	 * that a minimum amount of time passes where no checkpoint is in progress at all.
+//	 * 
+//	 * @param minPauseBetweenCheckpoints The minimal pause before the next checkpoint is triggered.
+//	 */
+//	public void setMinPauseBetweenCheckpoints(long minPauseBetweenCheckpoints) {
+//		if (minPauseBetweenCheckpoints < 0) {
+//			throw new IllegalArgumentException("Pause value must be zero or positive");
+//		}
+//		this.minPauseBetweenCheckpoints = minPauseBetweenCheckpoints;
+//	}
+
+	/**
+	 * Gets the maximum number of checkpoint attempts that may be in progress at the same time. If this
+	 * value is <i>n</i>, then no checkpoints will be triggered while <i>n</i> checkpoint attempts are
+	 * currently in flight. For the next checkpoint to be triggered, one checkpoint attempt would need
+	 * to finish or expire.
+	 * 
+	 * @return The maximum number of concurrent checkpoint attempts.
+	 */
+	public int getMaxConcurrentCheckpoints() {
+		return maxConcurrentCheckpoints;
+	}
+
+	/**
+	 * Sets the maximum number of checkpoint attempts that may be in progress at the same time. If this
+	 * value is <i>n</i>, then no checkpoints will be triggered while <i>n</i> checkpoint attempts are
+	 * currently in flight. For the next checkpoint to be triggered, one checkpoint attempt would need
+	 * to finish or expire.
+	 * 
+	 * @param maxConcurrentCheckpoints The maximum number of concurrent checkpoint attempts.
+	 */
+	public void setMaxConcurrentCheckpoints(int maxConcurrentCheckpoints) {
+		if (maxConcurrentCheckpoints < 1) {
+			throw new IllegalArgumentException("The maximum number of concurrent attempts must be at least one.");
+		}
+		this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
+	}
+
+	/**
+	 * Checks whether checkpointing is forced, despite currently non-checkpointable iteration feedback.
+	 * 
+	 * @return True, if checkpointing is forced, false otherwise.
+	 * 
+	 * @deprecated This will be removed once iterations properly participate in checkpointing.
+	 */
+	@Deprecated
+	public boolean isForceCheckpointing() {
+		return forceCheckpointing;
+	}
+
+	/**
+	 * Checks whether checkpointing is forced, despite currently non-checkpointable iteration feedback.
+	 * 
+	 * @param forceCheckpointing The flag to force checkpointing. 
+	 * 
+	 * @deprecated This will be removed once iterations properly participate in checkpointing.
+	 */
+	@Deprecated
+	public void setForceCheckpointing(boolean forceCheckpointing) {
+		this.forceCheckpointing = forceCheckpointing;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -98,17 +98,6 @@ public class StreamGraphGenerator {
 	private StreamGraphGenerator(StreamExecutionEnvironment env) {
 		this.streamGraph = new StreamGraph(env);
 		this.streamGraph.setChaining(env.isChainingEnabled());
-		
-		if (env.getCheckpointInterval() > 0) {
-			this.streamGraph.setCheckpointingEnabled(true);
-			this.streamGraph.setCheckpointingInterval(env.getCheckpointInterval());
-			this.streamGraph.setCheckpointingMode(env.getCheckpointingMode());
-		}
-		this.streamGraph.setStateBackend(env.getStateBackend());
-		if (env.isForceCheckpointing()) {
-			this.streamGraph.forceCheckpoint();
-		}
-		
 		this.env = env;
 		this.alreadyTransformed = new HashMap<>();
 	}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -96,6 +96,13 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   // ------------------------------------------------------------------------
   //  Checkpointing Settings
   // ------------------------------------------------------------------------
+  
+  /**
+   * Gets the checkpoint config, which defines values like checkpoint interval, delay between
+   * checkpoints, etc.
+   */
+  def getCheckpointConfig = javaEnv.getCheckpointConfig()
+  
   /**
    * Enables checkpointing for the streaming job. The distributed state of the streaming
    * dataflow will be periodically snapshotted. In case of a failure, the streaming


### PR DESCRIPTION
This change introduces a parameter that lets users control at most how many checkpoints
should be in progress at any given point in time. This is very useful for
cases where the best checkpoint interval is not easy to determine, or where once in
a while checkpoints may take long. Previously, such situations lead to checkpoint
queue-up, where the system ended up being more busy with checkpoints than with processing.

After this change, the checkpoint rate will by default sort of self-regulate: The checkpoint interval is the most frequent time at which checkpoints will occur, but they will occur slower if they take longer than that interval.

### Checkpoint Config

This also introduces the CheckpointConfig class that holds all checkpointing related parameters to more simply pass them between environment, streamgraph, etc...

### Default number of concurrent checkpoints

Previously, the maximum number of concurrent checkpoints was implicitly infinite.
I would suspect that most people will want to run the system such that only one checkpoint is ever concurrently active, so I set the default value for this to 1.

In some corner cases, it may be interesting to set that value higher.

### WIP for delay between checkpoints

This also contains some WIP to define a minimum time between checkpoint attempts. That flag would tell the system not only to not do more than one checkpoint concurrently, but to leave at least a certain time between completion of one checkpoint, and the triggering of the next. It basically defines a guaranteed time that is "work only" between checkpoints.
