### PR TITLE
[FLINK-3087] [Table-API] support multi count in aggregation

### DIFF
--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionCodeGenerator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionCodeGenerator.scala
@@ -123,14 +123,17 @@ abstract class ExpressionCodeGenerator[R](
       }
     }
 
-    val cleanedExpr = expr match {
-      case expressions.Naming(namedExpr, _) => namedExpr
-      case _ => expr
+    def cleanedExpr(e: Expression): Expression =  {
+      e match {
+        case expressions.Naming(namedExpr, _) => cleanedExpr(namedExpr)
+        case _ => e
+      }
     }
-    
-    val resultTpe = typeTermForTypeInfo(cleanedExpr.typeInfo)
 
-    val code: String = cleanedExpr match {
+    val cleanedExpression = cleanedExpr(expr)
+    val resultTpe = typeTermForTypeInfo(cleanedExpression.typeInfo)
+
+    val code: String = cleanedExpression match {
 
       case expressions.Literal(null, typeInfo) =>
         if (nullCheck) {

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
@@ -137,6 +137,29 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 		compareResultAsText(results, expected);
 	}
 
+	@Test
+	public void testAggregationWithTwoCount() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		DataSource<Tuple2<Float, String>> input =
+			env.fromElements(
+				new Tuple2<>(1f, "Hello"),
+				new Tuple2<>(2f, "Ciao"));
+
+		Table table =
+			tableEnv.fromDataSet(input);
+
+		Table result =
+			table.select("f0.count, f1.count");
+
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "2,2";
+		compareResultAsText(results, expected);
+	}
+
 	@Test(expected = ExpressionException.class)
 	public void testNonWorkingDataTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();

--- a/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/AggregationsITCase.scala
+++ b/flink-staging/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/AggregationsITCase.scala
@@ -80,6 +80,17 @@ class AggregationsITCase(mode: TestExecutionMode) extends MultipleProgramsTestBa
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
+  @Test
+  def testAggregationWithTwoCount(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val ds = env.fromElements((1f, "Hello"), (2f, "Ciao")).toTable
+      .select('_1.count, '_2.count).toDataSet[Row]
+    val expected = "2,2"
+    val results = ds.collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
   @Test(expected = classOf[ExpressionException])
   def testNonWorkingAggregationDataTypes(): Unit = {
 


### PR DESCRIPTION
The `Literal(1)` is used as the IntermediateField of `Count` aggregation, so multi `Count` looks the same in `ExpandAggregations`.