### PR TITLE
[FLINK-3088] [serialization] Fix copy method of TypeSerializers which use Kryo

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -279,9 +279,16 @@ public final class InstantiationUtil {
 		}
 
 		InputViewDataInputStreamWrapper inputViewWrapper = new InputViewDataInputStreamWrapper(new DataInputStream(new ByteArrayInputStream(buf)));
+		return serializer.deserialize(inputViewWrapper);
+	}
 
-		T record = serializer.createInstance();
-		return serializer.deserialize(record, inputViewWrapper);
+	public static <T> T deserializeFromByteArray(TypeSerializer<T> serializer, T reuse, byte[] buf) throws IOException {
+		if (buf == null) {
+			throw new NullPointerException("Byte array to deserialize from must not be null.");
+		}
+
+		InputViewDataInputStreamWrapper inputViewWrapper = new InputViewDataInputStreamWrapper(new DataInputStream(new ByteArrayInputStream(buf)));
+		return serializer.deserialize(reuse, inputViewWrapper);
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
@@ -18,13 +18,9 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import com.esotericsoftware.kryo.KryoException;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
 import com.google.common.base.Preconditions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.reflect.ReflectDatumReader;
@@ -37,6 +33,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
 
 import com.esotericsoftware.kryo.Kryo;
+import org.objenesis.strategy.StdInstantiatorStrategy;
 
 
 /**
@@ -96,27 +93,38 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 	@Override
 	public T copy(T from) {
 		checkKryoInitialized();
-		return this.kryo.copy(from);
+
+		try {
+			return kryo.copy(from);
+		} catch (KryoException ke) {
+			// Kryo could not copy the object --> try to serialize/deserialize the object
+			try {
+				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
+
+				return InstantiationUtil.deserializeFromByteArray(this, byteArray);
+			} catch (IOException ioe) {
+				throw new RuntimeException("Could not copy object by serializing/deserializing" +
+					"it.", ioe);
+			}
+		}
 	}
 	
 	@Override
 	public T copy(T from, T reuse) {
 		checkKryoInitialized();
+
 		try {
-			return this.kryo.copy(from);
-		} catch(KryoException ke) {
-			// kryo was unable to copy it, so we do it through serialization:
-			ByteArrayOutputStream baout = new ByteArrayOutputStream();
-			Output output = new Output(baout);
+			return kryo.copy(from);
+		} catch (KryoException ke) {
+			// Kryo could not copy the object --> try to serialize/deserialize the object
+			try {
+				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
 
-			kryo.writeObject(output, from);
-
-			output.close();
-
-			ByteArrayInputStream bain = new ByteArrayInputStream(baout.toByteArray());
-			Input input = new Input(bain);
-
-			return (T)kryo.readObject(input, from.getClass());
+				return InstantiationUtil.deserializeFromByteArray(this, reuse, byteArray);
+			} catch (IOException ioe) {
+				throw new RuntimeException("Could not copy object by serializing/deserializing" +
+					"it.", ioe);
+			}
 		}
 	}
 
@@ -174,6 +182,11 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 	private void checkKryoInitialized() {
 		if (this.kryo == null) {
 			this.kryo = new Kryo();
+
+			Kryo.DefaultInstantiatorStrategy instantiatorStrategy = new Kryo.DefaultInstantiatorStrategy();
+			instantiatorStrategy.setFallbackInstantiatorStrategy(new StdInstantiatorStrategy());
+			kryo.setInstantiatorStrategy(instantiatorStrategy);
+
 			// register Avro types.
 			this.kryo.register(GenericData.Array.class, new Serializers.SpecificInstanceCollectionSerializerForArrayList());
 			this.kryo.register(Utf8.class);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
-import com.esotericsoftware.kryo.KryoException;
 import com.google.common.base.Preconditions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.reflect.ReflectDatumReader;
@@ -94,38 +93,14 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 	public T copy(T from) {
 		checkKryoInitialized();
 
-		try {
-			return kryo.copy(from);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
-
-				return InstantiationUtil.deserializeFromByteArray(this, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not copy object by serializing/deserializing" +
-					"it.", ioe);
-			}
-		}
+		return KryoUtils.copy(from, kryo, this);
 	}
 	
 	@Override
 	public T copy(T from, T reuse) {
 		checkKryoInitialized();
 
-		try {
-			return kryo.copy(from);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
-
-				return InstantiationUtil.deserializeFromByteArray(this, reuse, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not copy object by serializing/deserializing" +
-					"it.", ioe);
-			}
-		}
+		return KryoUtils.copy(from, reuse, kryo, this);
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoUtils.java
@@ -30,6 +30,17 @@ import java.io.IOException;
  */
 public class KryoUtils {
 
+	/**
+	 * Tries to copy the given record from using the provided Kryo instance. If this fails, then
+	 * the record from is copied by serializing it into a byte buffer and deserializing it from
+	 * there.
+	 *
+	 * @param from Element to copy
+	 * @param kryo Kryo instance to use
+	 * @param serializer TypeSerializer which is used in case of a Kryo failure
+	 * @param <T> Type of the element to be copied
+	 * @return Copied element
+	 */
 	public static <T> T copy(T from, Kryo kryo, TypeSerializer<T> serializer) {
 		try {
 			return kryo.copy(from);
@@ -46,6 +57,18 @@ public class KryoUtils {
 		}
 	}
 
+	/**
+	 * Tries to copy the given record from using the provided Kryo instance. If this fails, then
+	 * the record from is copied by serializing it into a byte buffer and deserializing it from
+	 * there.
+	 *
+	 * @param from Element to copy
+	 * @param reuse Reuse element for the deserialization
+	 * @param kryo Kryo instance to use
+	 * @param serializer TypeSerializer which is used in case of a Kryo failure
+	 * @param <T> Type of the element to be copied
+	 * @return Copied element
+	 */
 	public static <T> T copy(T from, T reuse, Kryo kryo, TypeSerializer<T> serializer) {
 		try {
 			return kryo.copy(from);

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+
+/**
+ * Convenience methods for Kryo
+ */
+public class KryoUtils {
+
+	public static <T> T copy(T from, Kryo kryo, TypeSerializer<T> serializer) {
+		try {
+			return kryo.copy(from);
+		} catch (KryoException ke) {
+			// Kryo could not copy the object --> try to serialize/deserialize the object
+			try {
+				byte[] byteArray = InstantiationUtil.serializeToByteArray(serializer, from);
+
+				return InstantiationUtil.deserializeFromByteArray(serializer, byteArray);
+			} catch (IOException ioe) {
+				throw new RuntimeException("Could not copy object by serializing/deserializing" +
+					" it.", ioe);
+			}
+		}
+	}
+
+	public static <T> T copy(T from, T reuse, Kryo kryo, TypeSerializer<T> serializer) {
+		try {
+			return kryo.copy(from);
+		} catch (KryoException ke) {
+			// Kryo could not copy the object --> try to serialize/deserialize the object
+			try {
+				byte[] byteArray = InstantiationUtil.serializeToByteArray(serializer, from);
+
+				return InstantiationUtil.deserializeFromByteArray(serializer, reuse, byteArray);
+			} catch (IOException ioe) {
+				throw new RuntimeException("Could not copy object by serializing/deserializing" +
+					" it.", ioe);
+			}
+		}
+	}
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueComparator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueComparator.java
@@ -20,9 +20,7 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
-import com.esotericsoftware.kryo.KryoException;
 import org.apache.flink.api.common.typeutils.TypeComparator;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -67,21 +65,7 @@ public class ValueComparator<T extends Value & Comparable<T>> extends TypeCompar
 	public void setReference(T toCompare) {
 		checkKryoInitialized();
 
-		try {
-			reference = kryo.copy(toCompare);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				TypeSerializer<T> serializer = new ValueSerializer<>(type);
-
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(serializer, toCompare);
-
-				reference = InstantiationUtil.deserializeFromByteArray(serializer, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not set the reference, because the reference " +
-					"object could not be copied.", ioe);
-			}
-		}
+		reference = KryoUtils.copy(toCompare, kryo, new ValueSerializer<T>(type));
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
-import com.esotericsoftware.kryo.KryoException;
 import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
@@ -74,38 +73,14 @@ public class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 	public T copy(T from) {
 		checkKryoInitialized();
 
-		try {
-			return kryo.copy(from);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
-
-				return InstantiationUtil.deserializeFromByteArray(this, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not copy object by serializing/deserializing" +
-					"it.", ioe);
-			}
-		}
+		return KryoUtils.copy(from, kryo, this);
 	}
 	
 	@Override
 	public T copy(T from, T reuse) {
 		checkKryoInitialized();
 
-		try {
-			return kryo.copy(from);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
-
-				return InstantiationUtil.deserializeFromByteArray(this, reuse, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not copy object by serializing/deserializing" +
-					"it.", ioe);
-			}
-		}
+		return KryoUtils.copy(from, reuse, kryo, this);
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableComparator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableComparator.java
@@ -20,9 +20,7 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
-import com.esotericsoftware.kryo.KryoException;
 import org.apache.flink.api.common.typeutils.TypeComparator;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -64,21 +62,7 @@ public class WritableComparator<T extends Writable & Comparable<T>> extends Type
 	public void setReference(T toCompare) {
 		checkKryoInitialized();
 
-		try {
-			reference = kryo.copy(toCompare);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				TypeSerializer<T> serializer = new WritableSerializer<>(type);
-
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(serializer, toCompare);
-
-				reference = InstantiationUtil.deserializeFromByteArray(serializer, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not set the reference, because the reference " +
-					"object could not be copied.", ioe);
-			}
-		}
+		reference = KryoUtils.copy(toCompare, kryo, new WritableSerializer<T>(type));
 	}
 	
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.java.typeutils.runtime;
 
 
-import com.esotericsoftware.kryo.KryoException;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -61,38 +60,14 @@ public class WritableSerializer<T extends Writable> extends TypeSerializer<T> {
 	public T copy(T from) {
 		checkKryoInitialized();
 
-		try {
-			return kryo.copy(from);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
-
-				return InstantiationUtil.deserializeFromByteArray(this, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not copy object by serializing/deserializing" +
-					"it.", ioe);
-			}
-		}
+		return KryoUtils.copy(from, kryo, this);
 	}
 	
 	@Override
 	public T copy(T from, T reuse) {
 		checkKryoInitialized();
 
-		try {
-			return kryo.copy(from);
-		} catch (KryoException ke) {
-			// Kryo could not copy the object --> try to serialize/deserialize the object
-			try {
-				byte[] byteArray = InstantiationUtil.serializeToByteArray(this, from);
-
-				return InstantiationUtil.deserializeFromByteArray(this, reuse, byteArray);
-			} catch (IOException ioe) {
-				throw new RuntimeException("Could not copy object by serializing/deserializing" +
-					"it.", ioe);
-			}
-		}
+		return KryoUtils.copy(from, reuse, kryo, this);
 	}
 	
 	@Override

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueComparatorUUIDTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueComparatorUUIDTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.UUID;
+
+public class ValueComparatorUUIDTest extends ComparatorTestBase<ValueID> {
+	@Override
+	protected TypeComparator<ValueID> createComparator(boolean ascending) {
+		return new ValueComparator<>(ascending, ValueID.class);
+	}
+
+	@Override
+	protected TypeSerializer<ValueID> createSerializer() {
+		return new ValueSerializer<>(ValueID.class);
+	}
+
+	@Override
+	protected ValueID[] getSortedTestData() {
+		return new ValueID[] {
+			new ValueID(new UUID(0, 0)),
+			new ValueID(new UUID(1, 0)),
+			new ValueID(new UUID(1, 1))
+		};
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueID.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueID.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.types.Value;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class ValueID implements Value, Comparable<ValueID> {
+	private static final long serialVersionUID = -562791433077971752L;
+
+	private UUID id;
+
+	public ValueID() {
+		id = UUID.randomUUID();
+	}
+
+	public ValueID(UUID id) {
+		this.id = id;
+	}
+
+	@Override
+	public int compareTo(ValueID o) {
+		return id.compareTo(o.id);
+	}
+
+	@Override
+	public void write(DataOutputView out) throws IOException {
+		out.writeLong(id.getMostSignificantBits());
+		out.writeLong(id.getLeastSignificantBits());
+	}
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		id = new UUID(in.readLong(), in.readLong());
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof ValueID) {
+			ValueID other = (ValueID) obj;
+
+			return id.equals(other.id);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return id.hashCode();
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUUIDTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUUIDTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.UUID;
+
+public class ValueSerializerUUIDTest extends SerializerTestBase<ValueID> {
+	@Override
+	protected TypeSerializer<ValueID> createSerializer() {
+		return new ValueSerializer<>(ValueID.class);
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<ValueID> getTypeClass() {
+		return ValueID.class;
+	}
+
+	@Override
+	protected ValueID[] getTestData() {
+		return new ValueID[] {
+			new ValueID(new UUID(0, 0)),
+			new ValueID(new UUID(1, 0)),
+			new ValueID(new UUID(1, 1))
+		};
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableComparatorUUIDTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableComparatorUUIDTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.UUID;
+
+public class WritableComparatorUUIDTest extends ComparatorTestBase<WritableID> {
+	@Override
+	protected TypeComparator<WritableID> createComparator(boolean ascending) {
+		return new WritableComparator<>(ascending, WritableID.class);
+	}
+
+	@Override
+	protected TypeSerializer<WritableID> createSerializer() {
+		return new WritableSerializer<>(WritableID.class);
+	}
+
+	@Override
+	protected WritableID[] getSortedTestData() {
+		return new WritableID[] {
+			new WritableID(new UUID(0, 0)),
+			new WritableID(new UUID(1, 0)),
+			new WritableID(new UUID(1, 1))
+		};
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableID.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableID.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.hadoop.io.WritableComparable;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.UUID;
+
+public class WritableID implements WritableComparable<WritableID> {
+	private UUID uuid;
+
+	public WritableID() {
+		this.uuid = UUID.randomUUID();
+	}
+
+	public WritableID(UUID uuid) {
+		this.uuid = uuid;
+	}
+
+	@Override
+	public int compareTo(WritableID o) {
+		return this.uuid.compareTo(o.uuid);
+	}
+
+	@Override
+	public void write(DataOutput dataOutput) throws IOException {
+		dataOutput.writeLong(uuid.getMostSignificantBits());
+		dataOutput.writeLong(uuid.getLeastSignificantBits());
+	}
+
+	@Override
+	public void readFields(DataInput dataInput) throws IOException {
+		this.uuid = new UUID(dataInput.readLong(), dataInput.readLong());
+	}
+
+	@Override
+	public String toString() {
+		return uuid.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		WritableID id = (WritableID) o;
+
+		return !(uuid != null ? !uuid.equals(id.uuid) : id.uuid != null);
+	}
+
+	@Override
+	public int hashCode() {
+		return uuid != null ? uuid.hashCode() : 0;
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerTest.java
@@ -47,5 +47,4 @@ public class WritableSerializerTest {
 		
 		testInstance.testAll();
 	}
-	
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUUIDTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUUIDTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.UUID;
+
+public class WritableSerializerUUIDTest extends SerializerTestBase<WritableID> {
+	@Override
+	protected TypeSerializer<WritableID> createSerializer() {
+		return new WritableSerializer<>(WritableID.class);
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<WritableID> getTypeClass() {
+		return WritableID.class;
+	}
+
+	@Override
+	protected WritableID[] getTestData() {
+		return new WritableID[] {
+			new WritableID(new UUID(0, 0)),
+			new WritableID(new UUID(1, 0)),
+			new WritableID(new UUID(1, 1))
+		};
+	}
+}


### PR DESCRIPTION
Some TypeSerializer, WritableSerializer, ValueSerializer, and AvroSerializer, and
comparators, WritableComparator and ValueComparator, use Kryo to copy records.
In case where the Kryo serializer cannot copy the record, the copy method fails.
This is however not necessary, because one can copy the element by serializing
the record to a byte array and deserializing it from this array. This PR adds
this behaviour to the respective classes.