### PR TITLE
[FLINK-3084] FsStateBackend backs up very small state directly with the metadata

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamStateHandle.java
@@ -18,11 +18,19 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.runtime.state.StateHandle;
-
 import java.io.InputStream;
+import java.io.Serializable;
 
 /**
  * A state handle that produces an input stream when resolved.
  */
-public interface StreamStateHandle extends StateHandle<InputStream> {}
+public interface StreamStateHandle extends StateHandle<InputStream> {
+
+	/**
+	 * Converts this stream state handle into a state handle that de-serializes
+	 * the stream into an object using Java's serialization mechanism.
+	 *
+	 * @return The state handle that automatically de-serializes.
+	 */
+	<T extends Serializable> StateHandle<T> toSerializableHandle();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileState.java
@@ -23,6 +23,8 @@ import org.apache.flink.core.fs.Path;
 
 import java.io.IOException;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Base class for state that is stored in a file.
  */
@@ -42,7 +44,7 @@ public abstract class AbstractFileState implements java.io.Serializable {
 	 * @param filePath The path to the file that stores the state.
 	 */
 	protected AbstractFileState(Path filePath) {
-		this.filePath = filePath;
+		this.filePath = requireNonNull(filePath);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileSerializableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileSerializableStateHandle.java
@@ -24,13 +24,14 @@ import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.util.InstantiationUtil;
 
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 
 /**
  * A state handle that points to state stored in a file via Java Serialization.
  * 
  * @param <T> The type of state pointed to by the state handle.
  */
-public class FileSerializableStateHandle<T> extends AbstractFileState implements StateHandle<T> {
+public class FileSerializableStateHandle<T extends Serializable> extends AbstractFileState implements StateHandle<T> {
 
 	private static final long serialVersionUID = -657631394290213622L;
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStreamStateHandle.java
@@ -19,9 +19,11 @@
 package org.apache.flink.runtime.state.filesystem;
 
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 import java.io.InputStream;
+import java.io.Serializable;
 
 /**
  * A state handle that points to state in a file system, accessible as an input stream.
@@ -42,5 +44,10 @@ public class FileStreamStateHandle extends AbstractFileState implements StreamSt
 	@Override
 	public InputStream getState(ClassLoader userCodeClassLoader) throws Exception {
 		return getFileSystem().open(getFilePath());
+	}
+
+	@Override
+	public <T extends Serializable> StateHandle<T> toSerializableHandle() {
+		return new FileSerializableStateHandle<>(getFilePath());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
@@ -31,12 +31,18 @@ public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend
 	
 	/** The key under which the config stores the directory where checkpoints should be stored */
 	public static final String CHECKPOINT_DIRECTORY_URI_CONF_KEY = "state.backend.fs.checkpointdir";
+
+	/** The key under which the config stores the threshold for state to be store in memory,
+	 * rather than in files */
+	public static final String MEMORY_THRESHOLD_CONF_KEY = "state.backend.fs.memory-threshold";
 	
 	
 	@Override
 	public FsStateBackend createFromConfig(Configuration config) throws Exception {
 		String checkpointDirURI = config.getString(CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
-
+		int memoryThreshold = config.getInteger(
+			MEMORY_THRESHOLD_CONF_KEY, FsStateBackend.DEFAULT_FILE_STATE_THRESHOLD);
+		
 		if (checkpointDirURI == null) {
 			throw new IllegalConfigurationException(
 					"Cannot create the file system state backend: The configuration does not specify the " +
@@ -45,7 +51,7 @@ public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend
 		
 		try {
 			Path path = new Path(checkpointDirURI);
-			return new FsStateBackend(path);
+			return new FsStateBackend(path.toUri(), memoryThreshold);
 		}
 		catch (IllegalArgumentException e) {
 			throw new Exception("Cannot initialize File System State Backend with URI '"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.runtime.state.memory;
 
+import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.Serializable;
 
 /**
  * A state handle that contains stream state in a byte array.
@@ -49,4 +51,10 @@ public final class ByteStreamStateHandle implements StreamStateHandle {
 
 	@Override
 	public void discardState() {}
+
+	
+	@Override
+	public <T extends Serializable> StateHandle<T> toSerializableHandle() {
+		return new SerializedStateHandle<T>(data);
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FsCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FsCheckpointStateOutputStreamTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.filesystem.FileStreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class FsCheckpointStateOutputStreamTest {
+	
+	/** The temp dir, obtained in a platform neutral way */
+	private static final Path TEMP_DIR_PATH = new Path(new File(System.getProperty("java.io.tmpdir")).toURI());
+	
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testWrongParameters() {
+		// this should fail
+		new FsStateBackend.FsCheckpointStateOutputStream(
+			TEMP_DIR_PATH, FileSystem.getLocalFileSystem(), 4000, 5000);
+	}
+
+
+	@Test
+	public void testEmptyState() throws Exception {
+		StateBackend.CheckpointStateOutputStream stream = new FsStateBackend.FsCheckpointStateOutputStream(
+			TEMP_DIR_PATH, FileSystem.getLocalFileSystem(), 1024, 512);
+		
+		StreamStateHandle handle = stream.closeAndGetHandle();
+		assertTrue(handle instanceof ByteStreamStateHandle);
+		
+		InputStream inStream = handle.getState(ClassLoader.getSystemClassLoader());
+		assertEquals(-1, inStream.read());
+	}
+	
+	@Test
+	public void testStateBlowMemThreshold() throws Exception {
+		runTest(222, 999, 512, false);
+	}
+
+	@Test
+	public void testStateOneBufferAboveThreshold() throws Exception {
+		runTest(896, 1024, 15, true);
+	}
+
+	@Test
+	public void testStateAboveMemThreshold() throws Exception {
+		runTest(576446, 259, 17, true);
+	}
+	
+	@Test
+	public void testZeroThreshold() throws Exception {
+		runTest(16678, 4096, 0, true);
+	}
+	
+	private void runTest(int numBytes, int bufferSize, int threshold, boolean expectFile) throws Exception {
+		StateBackend.CheckpointStateOutputStream stream = 
+			new FsStateBackend.FsCheckpointStateOutputStream(
+				TEMP_DIR_PATH, FileSystem.getLocalFileSystem(), bufferSize, threshold);
+		
+		Random rnd = new Random();
+		byte[] original = new byte[numBytes];
+		byte[] bytes = new byte[original.length];
+
+		rnd.nextBytes(original);
+		System.arraycopy(original, 0, bytes, 0, original.length);
+
+		// the test writes a mixture of writing individual bytes and byte arrays
+		int pos = 0;
+		while (pos < bytes.length) {
+			boolean single = rnd.nextBoolean();
+			if (single) {
+				stream.write(bytes[pos++]);
+			}
+			else {
+				int num = rnd.nextInt(Math.min(10, bytes.length - pos));
+				stream.write(bytes, pos, num);
+				pos += num;
+			}
+		}
+
+		StreamStateHandle handle = stream.closeAndGetHandle();
+		if (expectFile) {
+			assertTrue(handle instanceof FileStreamStateHandle);
+		} else {
+			assertTrue(handle instanceof ByteStreamStateHandle);
+		}
+
+		// make sure the writing process did not alter the original byte array
+		assertArrayEquals(original, bytes);
+
+		InputStream inStream = handle.getState(ClassLoader.getSystemClassLoader());
+		byte[] validation = new byte[bytes.length];
+		int bytesRead = inStream.read(validation);
+
+		assertEquals(numBytes, bytesRead);
+		assertEquals(-1, inStream.read());
+
+		assertArrayEquals(bytes, validation);
+		
+		handle.discardState();
+	}
+}

--- a/flink-staging/flink-fs-tests/src/test/resources/log4j-test.properties
+++ b/flink-staging/flink-fs-tests/src/test/resources/log4j-test.properties
@@ -1,0 +1,31 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Tachyon's test-jar dependency adds a log4j.properties file to classpath.
+# Until the issue is resolved (see https://github.com/amplab/tachyon/pull/571)
+# we provide a log4j.properties file ourselves.
+
+log4j.rootLogger=OFF, testlogger
+
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger


### PR DESCRIPTION
For the File State Backend (`FsStateBackend`), this change avoids the very small files (few bytes) frequently created for small states, like Kafka Offsets, or individual counters.

State whose size is below a certain size (512 bytes) is stored in the state handle directly, rather than in files.