### PR TITLE
[FLINK-3093] Introduce annotations for interface stability

### DIFF
--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-parent</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-annotations</artifactId>
+	<name>flink-annotations</name>
+
+	<packaging>jar</packaging>
+
+</project>

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/PublicExperimental.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/PublicExperimental.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.flink.annotation;
+
+import java.lang.annotation.Documented;
+
+/**
+ * Interface to mark methods within stable, public APIs as experimental.
+ *
+ * An experimental API might change between minor releases.
+ */
+@Documented
+public @interface PublicExperimental {
+}

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/PublicInterface.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/PublicInterface.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.flink.annotation;
+
+import java.lang.annotation.Documented;
+
+/**
+ * Annotation for marking classes as public, stable interfaces.
+ *
+ * Classes, methods and fields with this annotation are stable across minor releases (1.0, 1.1, 1.2). In other words,
+ * applications using @PublicInterface annotated classes will compile against newer versions of the same major release.
+ *
+ * Only major releases (1.0, 2.0, 3.0) can break interfaces with this annotation.
+ */
+@Documented
+public @interface PublicInterface {}

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -37,6 +37,12 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-annotations</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>${shading-artifact.name}</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-core/src/main/java/org/apache/flink/api/common/CodeAnalysisMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/CodeAnalysisMode.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Specifies to which extent user-defined functions are analyzed in order
  * to give the Flink optimizer an insight of UDF internals and inform
@@ -31,6 +33,7 @@ package org.apache.flink.api.common;
  *  - Warnings if a tuple access uses a wrong index
  *  - Information about the number of object creations (for manual optimization)
  */
+@PublicInterface
 public enum CodeAnalysisMode {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common;
 
 import com.esotericsoftware.kryo.Serializer;
+import org.apache.flink.annotation.PublicInterface;
 
 import java.io.Serializable;
 import java.util.LinkedHashMap;
@@ -51,6 +52,7 @@ import java.util.Objects;
  *         automatically applied.</li>
  * </ul>
  */
+@PublicInterface
 public class ExecutionConfig implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -673,6 +675,7 @@ public class ExecutionConfig implements Serializable {
 	 * This user config is accessible at runtime through
 	 * getRuntimeContext().getExecutionConfig().GlobalJobParameters()
 	 */
+	@PublicInterface
 	public static class GlobalJobParameters implements Serializable {
 		private static final long serialVersionUID = 1L;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionMode.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.api.common;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * The execution mode specifies how a batch program is executed in terms
  * of data exchange: pipelining or batched.
  */
+@PublicInterface
 public enum ExecutionMode {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +28,7 @@ import java.util.concurrent.TimeUnit;
  * The result of a job execution. Gives access to the execution time of the job,
  * and to all accumulators created by this job.
  */
+@PublicInterface
 public class JobExecutionResult extends JobSubmissionResult {
 
 	private long netRuntime;

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobID.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobID.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.AbstractID;
 import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
@@ -30,6 +31,7 @@ import java.nio.ByteBuffer;
  * incrementally in different parts. Newer fragments of a graph can be attached to existing
  * graphs, thereby extending the current data flow graphs.</p>
  */
+@PublicInterface
 public final class JobID extends AbstractID {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobSubmissionResult.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobSubmissionResult.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.api.common;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * The result of submitting a job to a JobManager.
  */
+@PublicInterface
 public class JobSubmissionResult {
 	
 	private JobID jobID;

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/Accumulator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/Accumulator.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -39,6 +41,7 @@ import java.io.Serializable;
  *            Type of the accumulator result as it will be reported to the
  *            client
  */
+@PublicInterface
 public interface Accumulator<V, R extends Serializable> extends Serializable, Cloneable {
 	/**
 	 * @param value

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.SerializedValue;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@PublicInterface
 public class AccumulatorHelper {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AverageAccumulator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AverageAccumulator.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An accumulator that computes the average value.
  * Input can be {@code long}, {@code integer}, or {@code double} and the result is {@code double}.
  */
+@PublicInterface
 public class AverageAccumulator implements SimpleAccumulator<Double> {
 
 	private static final long serialVersionUID = 3672555084179165255L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleCounter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleCounter.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An accumulator that sums up {@code double} values.
  */
+@PublicInterface
 public class DoubleCounter implements SimpleAccumulator<Double> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/Histogram.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/Histogram.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -29,6 +31,7 @@ import java.util.TreeMap;
  * This class does not extend to continuous values later, because it makes no
  * attempt to put the data in bins.
  */
+@PublicInterface
 public class Histogram implements Accumulator<Integer, TreeMap<Integer, Integer>> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntCounter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntCounter.java
@@ -19,9 +19,12 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An accumulator that sums up {@code Integer} values.
  */
+@PublicInterface
 public class IntCounter implements SimpleAccumulator<Integer> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/ListAccumulator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/ListAccumulator.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.util.ArrayList;
 
 /**
@@ -25,6 +27,7 @@ import java.util.ArrayList;
  *
  * @param <T> The type of the accumulated objects
  */
+@PublicInterface
 public class ListAccumulator<T> implements Accumulator<T, ArrayList<T>> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongCounter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongCounter.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An accumulator that sums up {@code long} values.
  */
+@PublicInterface
 public class LongCounter implements SimpleAccumulator<Long> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/SimpleAccumulator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/SimpleAccumulator.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.api.common.accumulators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
  * Similar to Accumulator, but the type of items to add and the result value
  * must be the same.
  */
+@PublicInterface
 public interface SimpleAccumulator<T extends Serializable> extends Accumulator<T,T> {}

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/Aggregator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/Aggregator.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.aggregators;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.Value;
 
 /**
@@ -73,6 +74,7 @@ import org.apache.flink.types.Value;
  * 
  * @param <T> The type of the aggregated value.
  */
+@PublicInterface
 public interface Aggregator<T extends Value> extends Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/AggregatorRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/AggregatorRegistry.java
@@ -23,11 +23,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.Value;
 
 /**
  * A registry for iteration {@link Aggregator}s.
  */
+@PublicInterface
 public class AggregatorRegistry {
 	
 	private final Map<String, Aggregator<?>> registry = new HashMap<String, Aggregator<?>>();

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/AggregatorWithName.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/AggregatorWithName.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.api.common.aggregators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.Value;
 
 /**
  * Simple utility class holding an {@link Aggregator} with the name it is registered under.
  */
+@PublicInterface
 public class AggregatorWithName<T extends Value> {
 
 	private final String name;

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/ConvergenceCriterion.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/ConvergenceCriterion.java
@@ -21,11 +21,13 @@ package org.apache.flink.api.common.aggregators;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.Value;
 
 /**
  * Used to check for convergence.
  */
+@PublicInterface
 public interface ConvergenceCriterion<T extends Value> extends Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/DoubleSumAggregator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/DoubleSumAggregator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.aggregators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.DoubleValue;
 
 
@@ -25,6 +26,7 @@ import org.apache.flink.types.DoubleValue;
  * An {@link Aggregator} that sums up {@link DoubleValue} values.
  */
 @SuppressWarnings("serial")
+@PublicInterface
 public class DoubleSumAggregator implements Aggregator<DoubleValue> {
 
 	private DoubleValue wrapper = new DoubleValue();

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/DoubleZeroConvergence.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/DoubleZeroConvergence.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.aggregators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.DoubleValue;
 
 /**
@@ -25,6 +26,7 @@ import org.apache.flink.types.DoubleValue;
  * holds the value zero. The aggregated data type is a {@link DoubleValue}.
  */
 @SuppressWarnings("serial")
+@PublicInterface
 public class DoubleZeroConvergence implements ConvergenceCriterion<DoubleValue> {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/LongSumAggregator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/LongSumAggregator.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.api.common.aggregators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.LongValue;
 
 /**
  * An {@link Aggregator} that sums up long values.
  */
 @SuppressWarnings("serial")
+@PublicInterface
 public class LongSumAggregator implements Aggregator<LongValue> {
 
 	private long sum;	// the sum

--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/LongZeroConvergence.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/LongZeroConvergence.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.aggregators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.LongValue;
 
 /**
@@ -25,6 +26,7 @@ import org.apache.flink.types.LongValue;
  * holds the value zero. The aggregated data type is a {@link LongValue}.
  */
 @SuppressWarnings("serial")
+@PublicInterface
 public class LongZeroConvergence implements ConvergenceCriterion<LongValue> {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -15,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.apache.flink.api.common.cache;
 
 
@@ -29,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 
@@ -36,6 +35,7 @@ import org.apache.flink.core.fs.Path;
  * DistributedCache provides static methods to write the registered cache files into job configuration or decode
  * them from job configuration. It also provides user access to the file locally.
  */
+@PublicInterface
 public class DistributedCache {
 	
 	public static class DistributedCacheEntry {

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/AbstractRichFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/AbstractRichFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.functions;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.configuration.Configuration;
 
 /**
@@ -28,6 +29,7 @@ import org.apache.flink.configuration.Configuration;
  * teardown ({@link #close()}), as well as access to their runtime execution context via
  * {@link #getRuntimeContext()}.
  */
+@PublicInterface
 public abstract class AbstractRichFunction implements RichFunction, Serializable {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/BroadcastVariableInitializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/BroadcastVariableInitializer.java
@@ -15,9 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
+@PublicInterface
 public interface BroadcastVariableInitializer<T, O> {
 	
 	O initializeBroadcastVariable(Iterable<T> data);

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/CoGroupFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/CoGroupFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.functions;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -44,6 +45,7 @@ import org.apache.flink.util.Collector;
  * @param <IN2> The data type of the second input data set.
  * @param <O> The data type of the returned elements.
  */
+@PublicInterface
 public interface CoGroupFunction<IN1, IN2, O> extends Function, Serializable {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/CombineFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/CombineFunction.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -34,6 +36,7 @@ import java.io.Serializable;
  * @param <IN> The data type processed by the combine function.
  * @param <OUT> The data type emitted by the combine function.
  */
+@PublicInterface
 public interface CombineFunction<IN, OUT> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/CrossFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/CrossFunction.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -41,6 +43,7 @@ import java.io.Serializable;
  * @param <IN2> The type of the elements in the second input.
  * @param <OUT> The type of the result elements.
  */
+@PublicInterface
 public interface CrossFunction<IN1, IN2, OUT> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/FilterFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/FilterFunction.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -37,6 +39,7 @@ import java.io.Serializable;
  * 
  * @param <T> The type of the filtered elements.
  */
+@PublicInterface
 public interface FilterFunction<T> extends Function, Serializable {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/FlatJoinFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/FlatJoinFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
@@ -53,6 +54,7 @@ import java.io.Serializable;
  * @param <IN2> The type of the elements in the second input.
  * @param <OUT> The type of the result elements.
  */
+@PublicInterface
 public interface FlatJoinFunction<IN1, IN2, OUT> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/FlatMapFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/FlatMapFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
@@ -38,6 +39,7 @@ import java.io.Serializable;
  * @param <T> Type of the input elements.
  * @param <O> Type of the returned elements.
  */
+@PublicInterface
 public interface FlatMapFunction<T, O> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/FoldFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/FoldFunction.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -37,6 +39,7 @@ import java.io.Serializable;
  * @param <T> Type of the initial input and the returned element
  * @param <O> Type of the elements that the group/list/stream contains
  */
+@PublicInterface
 public interface FoldFunction<O,T> extends Function, Serializable {
 	/**
 	 * The core method of FoldFunction, combining two values into one value of the same type.

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/Function.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/Function.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * The base interface for all user-defined functions.
  * 
  * <p>This interface is empty in order to allow extending interfaces to
  * be SAM (single abstract method) interfaces that can be implemented via Java 8 lambdas.</p>
  */
+@PublicInterface
 public interface Function extends java.io.Serializable {
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/GroupCombineFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/GroupCombineFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.functions;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -36,6 +37,7 @@ import org.apache.flink.util.Collector;
  * @param <IN> The data type processed by the combine function.
  * @param <OUT> The data type emitted by the combine function.
  */
+@PublicInterface
 public interface GroupCombineFunction<IN, OUT> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/GroupReduceFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/GroupReduceFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.functions;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -41,6 +42,7 @@ import org.apache.flink.util.Collector;
  * @param <T> Type of the elements that this function processes.
  * @param <O> The type of the elements returned by the user-defined function.
  */
+@PublicInterface
 public interface GroupReduceFunction<T, O> extends Function, Serializable {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/InvalidTypesException.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/InvalidTypesException.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 
 /**
  * A special case of the {@link InvalidProgramException}, indicating that the types used in
  * an operation are invalid or inconsistent. 
  */
+@PublicInterface
 public class InvalidTypesException extends InvalidProgramException {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/IterationRuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/IterationRuntimeContext.java
@@ -18,12 +18,11 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.aggregators.Aggregator;
 import org.apache.flink.types.Value;
 
-/**
- * 
- */
+@PublicInterface
 public interface IterationRuntimeContext extends RuntimeContext {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/JoinFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/JoinFunction.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -48,6 +50,7 @@ import java.io.Serializable;
  * @param <IN2> The type of the elements in the second input.
  * @param <OUT> The type of the result elements.
  */
+@PublicInterface
 public interface JoinFunction<IN1, IN2, OUT> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/MapFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/MapFunction.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -37,6 +39,7 @@ import java.io.Serializable;
  * @param <T> Type of the input elements.
  * @param <O> Type of the returned elements.
  */
+@PublicInterface
 public interface MapFunction<T, O> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/MapPartitionFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/MapPartitionFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
@@ -40,6 +41,7 @@ import java.io.Serializable;
  * @param <T> Type of the input elements.
  * @param <O> Type of the returned elements.
  */
+@PublicInterface
 public interface MapPartitionFunction<T, O> extends Function, Serializable {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/Partitioner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/Partitioner.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Function to implement a custom partition assignment for keys.
  * 
  * @param <K> The type of the key to be partitioned.
  */
+@PublicInterface
 public interface Partitioner<K> extends java.io.Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/ReduceFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/ReduceFunction.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -42,6 +44,7 @@ import java.io.Serializable;
  * 
  * @param <T> Type of the elements that this function processes.
  */
+@PublicInterface
 public interface ReduceFunction<T> extends Function, Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichCoGroupFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichCoGroupFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.CoGroupFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -33,6 +31,7 @@ import org.apache.flink.util.Collector;
  * @param <IN2> The type of the elements in the second input.
  * @param <OUT> The type of the result elements.
  */
+@PublicInterface
 public abstract class RichCoGroupFunction<IN1, IN2, OUT> extends AbstractRichFunction implements CoGroupFunction<IN1, IN2, OUT> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichCrossFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichCrossFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.CrossFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 
 /**
  * Rich variant of the {@link CrossFunction}. As a {@link RichFunction}, it gives access to the
@@ -32,6 +30,7 @@ import org.apache.flink.api.common.functions.RichFunction;
  * @param <IN2> The type of the elements in the second input.
  * @param <OUT> The type of the result elements.
  */
+@PublicInterface
 public abstract class RichCrossFunction<IN1, IN2, OUT> extends AbstractRichFunction implements CrossFunction<IN1, IN2, OUT> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFilterFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFilterFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.FilterFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 
 /**
  * Rich variant of the {@link FilterFunction}. As a {@link RichFunction}, it gives access to the
@@ -30,6 +28,7 @@ import org.apache.flink.api.common.functions.RichFunction;
  * 
  * @param <T> The type of the filtered elements.
  */
+@PublicInterface
 public abstract class RichFilterFunction<T> extends AbstractRichFunction implements FilterFunction<T> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFlatJoinFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFlatJoinFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.FlatJoinFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -33,6 +31,7 @@ import org.apache.flink.util.Collector;
  * @param <IN2> The type of the elements in the second input.
  * @param <OUT> The type of the result elements.
  */
+@PublicInterface
 public abstract class RichFlatJoinFunction<IN1, IN2, OUT> extends AbstractRichFunction implements FlatJoinFunction<IN1, IN2, OUT> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFlatMapFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFlatMapFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -32,6 +30,7 @@ import org.apache.flink.util.Collector;
  * @param <IN> Type of the input elements.
  * @param <OUT> Type of the returned elements.
  */
+@PublicInterface
 public abstract class RichFlatMapFunction<IN, OUT> extends AbstractRichFunction implements FlatMapFunction<IN, OUT> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFoldFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFoldFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.FoldFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 
 /**
  * Rich variant of the {@link FoldFunction}. As a {@link RichFunction}, it gives access to the
@@ -31,6 +29,7 @@ import org.apache.flink.api.common.functions.RichFunction;
  * @param <T> Type of the initial input and the returned element
  * @param <O> Type of the elements that the group/list/stream contains
  */
+@PublicInterface
 public abstract class RichFoldFunction<O, T> extends AbstractRichFunction implements FoldFunction<O, T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.configuration.Configuration;
 
 /**
@@ -25,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
  * the life cycle of the functions, as well as methods to access the context in which the functions
  * are executed.
  */
+@PublicInterface
 public interface RichFunction extends Function {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichGroupCombineFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichGroupCombineFunction.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.functions;
 
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -30,6 +31,7 @@ import org.apache.flink.util.Collector;
  * @param <IN> The data type of the elements to be combined.
  * @param <OUT> The resulting data type of the elements to be combined.
  */
+@PublicInterface
 public abstract class RichGroupCombineFunction<IN, OUT> extends AbstractRichFunction implements GroupCombineFunction<IN, OUT> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichGroupReduceFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichGroupReduceFunction.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -34,6 +35,7 @@ import org.apache.flink.util.Collector;
  * @param <IN> Type of the elements that this function processes.
  * @param <OUT> The type of the elements returned by the user-defined function.
  */
+@PublicInterface
 public abstract class RichGroupReduceFunction<IN, OUT> extends AbstractRichFunction implements GroupReduceFunction<IN, OUT>, GroupCombineFunction<IN, IN> {
 	
 	private static final long serialVersionUID = 1L;
@@ -83,5 +85,6 @@ public abstract class RichGroupReduceFunction<IN, OUT> extends AbstractRichFunct
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
+	@PublicInterface
 	public static @interface Combinable {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichJoinFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichJoinFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.JoinFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 
 /**
  * Rich variant of the {@link JoinFunction}. As a {@link RichFunction}, it gives access to the
@@ -32,6 +30,7 @@ import org.apache.flink.api.common.functions.RichFunction;
  * @param <IN2> The type of the elements in the second input.
  * @param <OUT> The type of the result elements.
  */
+@PublicInterface
 public abstract class RichJoinFunction<IN1,IN2,OUT> extends AbstractRichFunction implements JoinFunction<IN1,IN2,OUT> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichMapFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichMapFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 
 /**
  * Rich variant of the {@link MapFunction}. As a {@link RichFunction}, it gives access to the
@@ -31,6 +29,7 @@ import org.apache.flink.api.common.functions.RichFunction;
  * @param <IN> Type of the input elements.
  * @param <OUT> Type of the returned elements.
  */
+@PublicInterface
 public abstract class RichMapFunction<IN, OUT> extends AbstractRichFunction implements MapFunction<IN, OUT> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichMapPartitionFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichMapPartitionFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.Collector;
 
 /**
@@ -29,6 +30,7 @@ import org.apache.flink.util.Collector;
  * @param <I> Type of the input elements.
  * @param <O> Type of the returned elements.
  */
+@PublicInterface
 public abstract class RichMapPartitionFunction<I, O> extends AbstractRichFunction implements MapPartitionFunction<I, O> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichReduceFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichReduceFunction.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
-import org.apache.flink.api.common.functions.ReduceFunction;
-import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.annotation.PublicInterface;
 
 /**
  * Rich variant of the {@link ReduceFunction}. As a {@link RichFunction}, it gives access to the
@@ -30,6 +28,7 @@ import org.apache.flink.api.common.functions.RichFunction;
  * 
  * @param <T> Type of the elements that this function processes.
  */
+@PublicInterface
 public abstract class RichReduceFunction<T> extends AbstractRichFunction implements ReduceFunction<T> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
@@ -40,6 +42,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
  * A function can, during runtime, obtain the RuntimeContext via a call to
  * {@link AbstractRichFunction#getRuntimeContext()}.
  */
+@PublicInterface
 public interface RuntimeContext {
 
 	/**
@@ -100,6 +103,7 @@ public interface RuntimeContext {
 	 * @deprecated Use getAccumulator(..) to obtain the value of an accumulator.
 	 */
 	@Deprecated
+	@PublicExperimental
 	Map<String, Accumulator<?, ?>> getAllAccumulators();
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
@@ -43,6 +44,7 @@ import org.apache.flink.util.StringUtils;
  * Base class for all input formats that use blocks of fixed size. The input splits are aligned to these blocks. Without
  * configuration, these block sizes equal the native block sizes of the HDFS.
  */
+@PublicInterface
 public abstract class BinaryInputFormat<T> extends FileInputFormat<T> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryOutputFormat.java
@@ -23,10 +23,12 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
 
+@PublicInterface
 public abstract class BinaryOutputFormat<T> extends FileOutputFormat<T> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BlockInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BlockInfo.java
@@ -20,10 +20,12 @@ package org.apache.flink.api.common.io;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
+@PublicInterface
 public class BlockInfo implements IOReadableWritable {
 
 	private long recordCount;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/CleanupWhenUnsuccessful.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/CleanupWhenUnsuccessful.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * {@link OutputFormat}s may implement this interface to run a cleanup hook when the execution is not successful.
  */
+@PublicInterface
 public interface CleanupWhenUnsuccessful {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.core.io.InputSplit;
@@ -32,6 +33,7 @@ import org.apache.flink.core.io.InputSplitAssigner;
  * This is the default implementation of the {@link InputSplitAssigner} interface. The default input split assigner
  * simply returns all input splits of an input vertex in the order they were originally computed.
  */
+@PublicInterface
 public class DefaultInputSplitAssigner implements InputSplitAssigner {
 
 	/** The logging object used to report information and errors. */

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.io;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
@@ -41,6 +42,7 @@ import com.google.common.base.Charsets;
  * 
  * <p>The default delimiter is the newline character {@code '\n'}.</p>
  */
+@PublicInterface
 public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.compression.DeflateInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.GzipInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
@@ -53,6 +54,7 @@ import org.apache.flink.core.fs.Path;
  * <p>After the {@link #open(FileInputSplit)} method completed, the file input data is available
  * from the {@link #stream} field.</p>
  */
+@PublicInterface
 public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputSplit> {
 	
 	// -------------------------------------- Constants -------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.io;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.configuration.ConfigConstants;
@@ -36,6 +37,7 @@ import org.apache.flink.core.fs.FileSystem.WriteMode;
  * open/close the target
  * file streams.
  */
+@PublicInterface
 public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT> implements InitializeOnMaster, CleanupWhenUnsuccessful {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FinalizeOnMaster.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FinalizeOnMaster.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.IOException;
 
 /**
  * This interface may be implemented by {@link OutputFormat}s to have the master finalize them globally.
  * 
  */
+@PublicInterface
 public interface FinalizeOnMaster {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -23,6 +23,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.types.parser.FieldParser;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
 
+@PublicInterface
 public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(GenericCsvInputFormat.class);

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericInputFormat.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.io;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.GenericInputSplit;
@@ -28,6 +29,7 @@ import org.apache.flink.core.io.GenericInputSplit;
 /**
  * Generic base class for all Rich inputs that are not based on files.
  */
+@PublicInterface
 public abstract class GenericInputFormat<OT> extends RichInputFormat<OT, GenericInputSplit> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InitializeOnMaster.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InitializeOnMaster.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.IOException;
 
 /**
@@ -26,6 +28,7 @@ import java.io.IOException;
  * For example, the {@link FileOutputFormat} implements this behavior for distributed file systems and
  * creates/deletes target directories if necessary.
  */
+@PublicInterface
 public interface InitializeOnMaster {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputFormat.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.io;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplit;
@@ -60,6 +61,7 @@ import org.apache.flink.core.io.InputSplitSource;
  * @param <OT> The type of the produced records.
  * @param <T> The type of input split.
  */
+@PublicInterface
 public interface InputFormat<OT, T extends InputSplit> extends InputSplitSource<T>, Serializable {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.fs.FSDataInputStream;
 
 import java.io.EOFException;
@@ -29,6 +30,7 @@ import java.io.InputStream;
  * <br>
  * <i>NB: {@link #seek(long)} and {@link #getPos()} are currently not supported.</i>
  */
+@PublicInterface
 public class InputStreamFSInputWrapper extends FSDataInputStream {
 
 	private final InputStream inStream;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.core.io.InputSplitAssigner;
@@ -35,6 +36,7 @@ import org.apache.flink.util.NetUtils;
  * The locatable input split assigner assigns to each host splits that are local, before assigning
  * splits that are not local.
  */
+@PublicInterface
 public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LocatableInputSplitAssigner.class);

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/NonParallelInput.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/NonParallelInput.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * This interface acts as a marker for input formats for inputs which cannot be split.
  * Data sources with a non-parallel input formats are always executed with a parallelism
@@ -25,5 +27,6 @@ package org.apache.flink.api.common.io;
  * 
  * @see InputFormat
  */
+@PublicInterface
 public interface NonParallelInput {
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormat.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.io;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.configuration.Configuration;
 
 /**
@@ -38,6 +39,7 @@ import org.apache.flink.configuration.Configuration;
  * 
  * @param <IT> The type of the consumed records. 
  */
+@PublicInterface
 public interface OutputFormat<IT> extends Serializable {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/RichInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/RichInputFormat.java
@@ -18,6 +18,7 @@ c * Licensed to the Apache Software Foundation (ASF) under one
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.core.io.InputSplit;
 
@@ -25,6 +26,7 @@ import org.apache.flink.core.io.InputSplit;
  * An abstract stub implementation for Rich input formats.
  * Rich formats have access to their runtime execution context via {@link #getRuntimeContext()}.
  */
+@PublicInterface
 public abstract class RichInputFormat<OT, T extends InputSplit> implements InputFormat<OT, T> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/RichOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/RichOutputFormat.java
@@ -18,12 +18,14 @@ c * Licensed to the Apache Software Foundation (ASF) under one
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.RuntimeContext;
 
 /**
  * An abstract stub implementation for Rich output formats.
  * Rich formats have access to their runtime execution context via {@link #getRuntimeContext()}.
  */
+@PublicInterface
 public abstract class RichOutputFormat<IT> implements OutputFormat<IT> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/SerializedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/SerializedInputFormat.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.io;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 
@@ -28,6 +29,7 @@ import org.apache.flink.core.memory.DataInputView;
  * 
  * @see SerializedOutputFormat
  */
+@PublicInterface
 public class SerializedInputFormat<T extends IOReadableWritable> extends BinaryInputFormat<T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/SerializedOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/SerializedOutputFormat.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.io;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -28,6 +29,7 @@ import org.apache.flink.core.memory.DataOutputView;
  * 
  * @see SerializedInputFormat
  */
+@PublicInterface
 public class SerializedOutputFormat<T extends IOReadableWritable> extends BinaryOutputFormat<T> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/StrictlyLocalAssignment.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/StrictlyLocalAssignment.java
@@ -18,4 +18,7 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
+@PublicInterface
 public interface StrictlyLocalAssignment {}

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/statistics/BaseStatistics.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/statistics/BaseStatistics.java
@@ -19,9 +19,12 @@
 
 package org.apache.flink.api.common.io.statistics;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Interface describing the basic statistics that can be obtained from the input.
  */
+@PublicInterface
 public interface BaseStatistics {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/AbstractUdfOperator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/AbstractUdfOperator.java
@@ -73,7 +73,7 @@ public abstract class AbstractUdfOperator<OUT, FT extends Function> extends Oper
 		return userFunction;
 	}
 
-// --------------------------------------------------------------------------------------------
+	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Returns the input, or null, if none is set.

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/Order.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/Order.java
@@ -19,9 +19,12 @@
 
 package org.apache.flink.api.common.operators;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Enumeration representing order. May represent no order, an ascending order or a descending order.
  */
+@PublicInterface
 public enum Order {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/SemanticProperties.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/SemanticProperties.java
@@ -21,12 +21,14 @@ package org.apache.flink.api.common.operators;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.operators.util.FieldSet;
 
 /**
  * Container for the semantic properties associated to an operator.
  */
+@PublicInterface
 public interface SemanticProperties extends Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/SingleInputSemanticProperties.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/SingleInputSemanticProperties.java
@@ -21,11 +21,13 @@ package org.apache.flink.api.common.operators;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.operators.util.FieldSet;
 
 /**
  * Container for the semantic properties associated to a single input operator.
  */
+@PublicInterface
 public class SingleInputSemanticProperties implements SemanticProperties {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/OperatorState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/OperatorState.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.state;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.IOException;
 
 /**
@@ -32,6 +34,7 @@ import java.io.IOException;
  * 
  * @param <T> Type of the value in the operator state
  */
+@PublicInterface
 public interface OperatorState<T> {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeinfo;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -67,6 +68,7 @@ import java.util.List;
  *
  * @param <T> The type represented by this type information.
  */
+@PublicInterface
 public abstract class TypeInformation<T> implements Serializable {
 	
 	private static final long serialVersionUID = -7742311969684489493L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeComparator.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.typeutils;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -47,6 +48,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @param <T> The data type that the comparator works on.
  */
+@PublicInterface
 public abstract class TypeComparator<T> implements Serializable {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.typeutils;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -34,6 +35,7 @@ import org.apache.flink.core.memory.DataOutputView;
  * 
  * @param <T> The data type that the serializer serializes.
  */
+@PublicInterface
 public abstract class TypeSerializer<T> implements Serializable {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.configuration;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * This class contains all constants for the configuration. That includes the configuration keys and
  * the default values.
  */
+@PublicInterface
 public final class ConfigConstants {
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Lightweight configuration object which stores key/value pairs.
  */
+@PublicInterface
 public class Configuration extends ExecutionConfig.GlobalJobParameters 
 		implements IOReadableWritable, java.io.Serializable, Cloneable {
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.configuration;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Unmodifiable version of the Configuration class.
  */
+@PublicInterface
 public class UnmodifiableConfiguration extends Configuration {
 	
 	private static final long serialVersionUID = -8151292629158972280L;

--- a/flink-core/src/main/java/org/apache/flink/core/fs/BlockLocation.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/BlockLocation.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.IOException;
 
 /**
  * A BlockLocation lists hosts, offset and length of block.
  */
+@PublicInterface
 public interface BlockLocation extends Comparable<BlockLocation> {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FSDataInputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FSDataInputStream.java
@@ -25,6 +25,8 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -32,6 +34,7 @@ import java.io.InputStream;
  * Interface for a data input stream to a file on a {@link FileSystem}.
  * 
  */
+@PublicInterface
 public abstract class FSDataInputStream extends InputStream {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.IOException;
 import java.io.OutputStream;
 
 /**
  * Interface for a data output stream to a file on a {@link FileSystem}.
  */
+@PublicInterface
 public abstract class FSDataOutputStream extends OutputStream {
 
 	public abstract void flush() throws IOException;

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.LocatableInputSplit;
 
 /**
  * A file input split provides information on a particular part of a file, possibly
  * hosted on a distributed file system and replicated among several hosts. 
  */
+@PublicInterface
 public class FileInputSplit extends LocatableInputSplit {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileStatus.java
@@ -25,11 +25,14 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Interface that represents the client side information for a file
  * independent of the file system.
  * 
  */
+@PublicInterface
 public interface FileStatus {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -34,6 +34,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.ClassUtils;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.StringUtils;
@@ -43,6 +44,7 @@ import org.apache.flink.util.StringUtils;
  * may be implemented as a distributed file system, or as a local
  * one that reflects the locally-connected disk.
  */
+@PublicInterface
 public abstract class FileSystem {
 
 	private static final String LOCAL_FILESYSTEM_CLASS = "org.apache.flink.core.fs.local.LocalFileSystem";
@@ -61,6 +63,7 @@ public abstract class FileSystem {
 	 * Enumeration for write modes. 
 	 *
 	 */
+	@PublicInterface
 	public static enum WriteMode {
 		
 		/** Creates write path if it does not exist. Does not overwrite existing files and directories. */
@@ -73,6 +76,7 @@ public abstract class FileSystem {
 	/**
 	 * An auxiliary class to identify a file system by its scheme and its authority.
 	 */
+	@PublicInterface
 	public static class FSKey {
 
 		/**

--- a/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -38,6 +39,7 @@ import org.apache.flink.util.StringUtils;
  *
  * Tailing slashes are removed from the path.
  */
+@PublicInterface
 public class Path implements IOReadableWritable, Serializable {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/core/io/IOReadableWritable.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/IOReadableWritable.java
@@ -20,6 +20,7 @@ package org.apache.flink.core.io;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -30,6 +31,7 @@ import org.apache.flink.core.memory.DataOutputView;
  * to a binary representation.
  * When implementing this Interface make sure that the implementing class has a default (zero-argument) constructor!
  */
+@PublicInterface
 public interface IOReadableWritable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/io/InputSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/InputSplit.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.core.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -26,6 +28,7 @@ import java.io.Serializable;
  * <p>Input splits are transferred in serialized form via the messages, so they need to be serializable
  * as defined by {@link java.io.Serializable}.</p>
  */
+@PublicInterface
 public interface InputSplit extends Serializable {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/io/InputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/InputSplitAssigner.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.core.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An input split assigner distributes the {@link InputSplit}s among the instances on which a
  * data source exists.
  */
+@PublicInterface
 public interface InputSplitAssigner {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/io/InputSplitSource.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/InputSplitSource.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.core.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -26,6 +28,7 @@ import java.io.Serializable;
  *
  * @param <T> The type of the input splits created by the source.
  */
+@PublicInterface
 public interface InputSplitSource<T extends InputSplit> extends Serializable {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/io/LocatableInputSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/LocatableInputSplit.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.core.io;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.util.Arrays;
 
 /**
  * A locatable input split is an input split referring to input data which is located on one or more hosts.
  */
+@PublicInterface
 public class LocatableInputSplit implements InputSplit, java.io.Serializable {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
@@ -20,6 +20,8 @@
 package org.apache.flink.core.memory;
 
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.DataInput;
 import java.io.IOException;
 
@@ -28,6 +30,7 @@ import java.io.IOException;
  * This interface defines a view over some memory that can be used to sequentially read the contents of the memory.
  * The view is typically backed by one or more {@link org.apache.flink.core.memory.MemorySegment}.
  */
+@PublicInterface
 public interface DataInputView extends DataInput {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputView.java
@@ -20,6 +20,8 @@
 package org.apache.flink.core.memory;
 
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.DataOutput;
 import java.io.IOException;
 
@@ -28,6 +30,7 @@ import java.io.IOException;
  * This interface defines a view over some memory that can be used to sequentially write contents to the memory.
  * The view is typically backed by one or more {@link org.apache.flink.core.memory.MemorySegment}.
  */
+@PublicInterface
 public interface DataOutputView extends DataOutput {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/BooleanValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/BooleanValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -31,6 +32,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class BooleanValue implements NormalizableKey<BooleanValue>, ResettableValue<BooleanValue>, CopyableValue<BooleanValue> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/types/ByteValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/ByteValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -31,6 +32,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class ByteValue implements NormalizableKey<ByteValue>, ResettableValue<ByteValue>, CopyableValue<ByteValue> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/CharValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/CharValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -31,6 +32,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class CharValue implements NormalizableKey<CharValue>, ResettableValue<CharValue>, CopyableValue<CharValue> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/CopyableValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/CopyableValue.java
@@ -20,12 +20,14 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 /**
  * Interface to be implemented by basic types that support to be copied efficiently.
  */
+@PublicInterface
 public interface CopyableValue<T> extends Value {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/DeserializationException.java
+++ b/flink-core/src/main/java/org/apache/flink/types/DeserializationException.java
@@ -20,9 +20,12 @@
 package org.apache.flink.types;
 
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An exception specifying that the deserialization caused an error.
  */
+@PublicInterface
 public class DeserializationException extends RuntimeException
 {
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/DoubleValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/DoubleValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -30,6 +31,7 @@ import org.apache.flink.core.memory.DataOutputView;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class DoubleValue implements Key<DoubleValue>, ResettableValue<DoubleValue>, CopyableValue<DoubleValue> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-core/src/main/java/org/apache/flink/types/FloatValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/FloatValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -30,6 +31,7 @@ import org.apache.flink.core.memory.DataOutputView;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class FloatValue implements Key<FloatValue>, ResettableValue<FloatValue>, CopyableValue<FloatValue> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-core/src/main/java/org/apache/flink/types/IntValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/IntValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -31,6 +32,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class IntValue implements NormalizableKey<IntValue>, ResettableValue<IntValue>, CopyableValue<IntValue> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/Key.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Key.java
@@ -19,6 +19,8 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * This interface has to be implemented by all data types that act as key. Keys are used to establish
  * relationships between values. A key must always be {@link java.lang.Comparable} to other keys of
@@ -32,6 +34,7 @@ package org.apache.flink.types;
  * @see org.apache.flink.core.io.IOReadableWritable
  * @see java.lang.Comparable
  */
+@PublicInterface
 public interface Key<T> extends Value, Comparable<T> {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/KeyFieldOutOfBoundsException.java
+++ b/flink-core/src/main/java/org/apache/flink/types/KeyFieldOutOfBoundsException.java
@@ -20,9 +20,12 @@
 package org.apache.flink.types;
 
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An exception specifying that a required key field was not set in a record, i.e. was <code>null</code>.
  */
+@PublicInterface
 public class KeyFieldOutOfBoundsException extends RuntimeException
 {
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/ListValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/ListValue.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.ReflectionUtil;
@@ -42,6 +43,7 @@ import org.apache.flink.util.ReflectionUtil;
  * 
  * 
  */
+@PublicInterface
 public abstract class ListValue<V extends Value> implements Value, List<V> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/LongValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/LongValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -31,6 +32,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class LongValue implements NormalizableKey<LongValue>, ResettableValue<LongValue>, CopyableValue<LongValue> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-core/src/main/java/org/apache/flink/types/MapValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/MapValue.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.ReflectionUtil;
@@ -42,6 +43,7 @@ import org.apache.flink.util.ReflectionUtil;
  * 
  * 
  */
+@PublicInterface
 public abstract class MapValue<K extends Value, V extends Value> implements Value, Map<K, V> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/NormalizableKey.java
+++ b/flink-core/src/main/java/org/apache/flink/types/NormalizableKey.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.MemorySegment;
 
 
@@ -34,6 +35,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * key. A normalized key is considered a prefix, if its length is less than the maximal normalized
  * key length.
  */
+@PublicInterface
 public interface NormalizableKey<T> extends Key<T> {
 	
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/Nothing.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Nothing.java
@@ -19,9 +19,12 @@
 
 package org.apache.flink.types;
 
-/**
+import org.apache.flink.annotation.PublicInterface;
+
+ /**
  * A type for (synthetic) operators that do not output data. For example, data sinks.
  */
+@PublicInterface
 public class Nothing {
 	private Nothing() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/NullFieldException.java
+++ b/flink-core/src/main/java/org/apache/flink/types/NullFieldException.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * An exception specifying that a required field was not set in a record, i.e. was <code>null</code>.
  */
+@PublicInterface
 public class NullFieldException extends RuntimeException
 {
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/NullKeyFieldException.java
+++ b/flink-core/src/main/java/org/apache/flink/types/NullKeyFieldException.java
@@ -15,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.apache.flink.types;
 
 

--- a/flink-core/src/main/java/org/apache/flink/types/NullValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/NullValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -30,6 +31,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public final class NullValue implements NormalizableKey<NullValue>, CopyableValue<NullValue> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/Pair.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Pair.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.ReflectionUtil;
@@ -33,6 +34,7 @@ import org.apache.flink.util.ReflectionUtil;
  * @param <U> Type of the pair's first element.
  * @param <V> Type of the pair's second element.
  */
+@PublicInterface
 public abstract class Pair<U extends Key<U>, V extends Key<V>> implements Key<Pair<U, V>> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/Record.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Record.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.io.UTFDataFormatException;
 import java.nio.ByteOrder;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemoryUtils;
@@ -51,6 +52,7 @@ import org.apache.flink.util.InstantiationUtil;
  * <p>
  * This class is NOT thread-safe!
  */
+@PublicInterface
 public final class Record implements Value, CopyableValue<Record> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/ResettableValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/ResettableValue.java
@@ -19,6 +19,9 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.annotation.PublicInterface;
+
+@PublicInterface
 public interface ResettableValue<T extends Value> extends Value {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/types/ShortValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/ShortValue.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -31,6 +32,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * 
  * @see org.apache.flink.types.Key
  */
+@PublicInterface
 public class ShortValue implements NormalizableKey<ShortValue>, ResettableValue<ShortValue>, CopyableValue<ShortValue> {
 	private static final long serialVersionUID = 1L;
 	

--- a/flink-core/src/main/java/org/apache/flink/types/StringValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/StringValue.java
@@ -23,6 +23,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.CharBuffer;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
@@ -42,6 +43,7 @@ import com.google.common.base.Preconditions;
  * @see java.lang.String
  * @see java.lang.CharSequence
  */
+@PublicInterface
 public class StringValue implements NormalizableKey<StringValue>, CharSequence, ResettableValue<StringValue>, 
 		CopyableValue<StringValue>, Appendable
 {

--- a/flink-core/src/main/java/org/apache/flink/types/Value.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Value.java
@@ -21,6 +21,7 @@ package org.apache.flink.types;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.IOReadableWritable;
 
 /**
@@ -31,5 +32,6 @@ import org.apache.flink.core.io.IOReadableWritable;
  * 
  * @see org.apache.flink.core.io.IOReadableWritable
  */
+@PublicInterface
 public interface Value extends IOReadableWritable, Serializable {
 }

--- a/flink-core/src/main/java/org/apache/flink/util/Collector.java
+++ b/flink-core/src/main/java/org/apache/flink/util/Collector.java
@@ -19,10 +19,13 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Collects a record and forwards it. The collector is the "push" counterpart of the
  * {@link java.util.Iterator}, which "pulls" data in.
  */
+@PublicInterface
 public interface Collector<T> {
 	
 	/**

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -115,9 +115,9 @@ under the License.
 		
 	</dependencies>
 
-	<!-- Because flink-scala and flink-avro uses it in tests -->
 	<build>
 		<plugins>
+			<!-- Because flink-scala and flink-avro uses it in tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.api.java;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.operators.CollectionExecutor;
 
+@PublicInterface
 public class CollectionEnvironment extends ExecutionEnvironment {
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -19,6 +19,8 @@
 package org.apache.flink.api.java;
 
 import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
@@ -103,6 +105,8 @@ import java.util.List;
  *
  * @param <T> The type of the DataSet, i.e., the type of the elements of the DataSet.
  */
+
+@PublicInterface
 public abstract class DataSet<T> {
 	
 	protected final ExecutionEnvironment context;
@@ -1595,6 +1599,7 @@ public abstract class DataSet<T> {
 	 * @deprecated Use {@link #printOnTaskManager(String)} instead.
 	 */
 	@Deprecated
+	@PublicExperimental
 	public DataSink<T> print(String sinkIdentifier) {
 		return output(new PrintingOutputFormat<T>(sinkIdentifier, false));
 	}
@@ -1611,6 +1616,7 @@ public abstract class DataSet<T> {
 	 *             {@link PrintingOutputFormat} instead.
 	 */
 	@Deprecated
+	@PublicExperimental
 	public DataSink<T> printToErr(String sinkIdentifier) {
 		return output(new PrintingOutputFormat<T>(sinkIdentifier, true));
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -92,6 +93,7 @@ import com.google.common.base.Preconditions;
  * @see LocalEnvironment
  * @see RemoteEnvironment
  */
+@PublicInterface
 public abstract class ExecutionEnvironment {
 
 	/** The logger used by the environment and its subclasses */

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironmentFactory.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironmentFactory.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.api.java;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Factory class for execution environments.
  */
+@PublicInterface
 public interface ExecutionEnvironmentFactory {
 	
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
@@ -36,6 +37,7 @@ import org.apache.flink.configuration.Configuration;
  * and {@link ExecutionEnvironment#createLocalEnvironment(int)}. The former version will pick a
  * default parallelism equal to the number of hardware contexts in the local machine.
  */
+@PublicInterface
 public class LocalEnvironment extends ExecutionEnvironment {
 	
 	/** The user-defined configuration for the local execution */

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
@@ -39,6 +40,7 @@ import java.net.URL;
  * must be attached to the remote environment as JAR files, to allow the environment to ship the
  * classes into the cluster for the distributed execution.
  */
+@PublicInterface
 public class RemoteEnvironment extends ExecutionEnvironment {
 	
 	/** The hostname of the JobManager */

--- a/flink-java/src/main/java/org/apache/flink/api/java/aggregation/Aggregations.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/aggregation/Aggregations.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.api.java.aggregation;
 
-/**
- *
- */
+import org.apache.flink.annotation.PublicInterface;
+
+@PublicInterface
 public enum Aggregations {
 	
 	SUM (new SumAggregationFunction.SumAggregationFunctionFactory()),

--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/KeySelector.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/KeySelector.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 
 import java.io.Serializable;
@@ -31,6 +32,7 @@ import java.io.Serializable;
  * @param <IN> Type of objects to extract the key from.
  * @param <KEY> Type of key.
  */
+@PublicInterface
 public interface KeySelector<IN, KEY> extends Function, Serializable {
 	
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormat.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.hadoop.mapred;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -35,6 +36,7 @@ import org.apache.hadoop.mapred.JobConf;
  * @param <K> Type of the key
  * @param <V> Type of the value.
  */
+@PublicInterface
 public class HadoopInputFormat<K, V> extends HadoopInputFormatBase<K, V, Tuple2<K,V>> implements ResultTypeQueryable<Tuple2<K,V>> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormat.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.hadoop.mapred;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCommitter;
@@ -32,6 +33,7 @@ import org.apache.hadoop.mapred.OutputCommitter;
  * @param <K> Type of the key
  * @param <V> Type of the value.
  */
+@PublicInterface
 public class HadoopOutputFormat<K,V> extends HadoopOutputFormatBase<K, V, Tuple2<K, V>> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.LocatableInputSplit;
 
@@ -34,6 +35,7 @@ import org.apache.hadoop.mapred.JobConfigurable;
  * A wrapper that represents an input split from the Hadoop mapred API as
  * a Flink {@link InputSplit}.
  */
+@PublicInterface
 public class HadoopInputSplit extends LocatableInputSplit {
 
 	private static final long serialVersionUID = -6990336376163226160L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopInputFormat.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.hadoop.mapreduce;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -33,6 +34,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
  * @param <K> Key Type
  * @param <V> Value Type
  */
+@PublicInterface
 public class HadoopInputFormat<K, V> extends HadoopInputFormatBase<K, V, Tuple2<K, V>> implements ResultTypeQueryable<Tuple2<K,V>> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopOutputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopOutputFormat.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.hadoop.mapreduce;
 
 import java.io.IOException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.hadoop.mapreduce.Job;
 
@@ -29,6 +30,7 @@ import org.apache.hadoop.mapreduce.Job;
  * @param <K> Key Type
  * @param <V> Value Type
  */
+@PublicInterface
 public class HadoopOutputFormat<K, V> extends HadoopOutputFormatBase<K, V, Tuple2<K, V>> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/wrapper/HadoopInputSplit.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/wrapper/HadoopInputSplit.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.LocatableInputSplit;
 
@@ -33,6 +34,7 @@ import org.apache.hadoop.mapreduce.JobContext;
  * A wrapper that represents an input split from the Hadoop mapreduce API as
  * a Flink {@link InputSplit}.
  */
+@PublicInterface
 public class HadoopInputSplit extends LocatableInputSplit {
 
 	private static final long serialVersionUID = 6119153593707857235L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/AggregateOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/AggregateOperator.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
@@ -47,6 +48,7 @@ import com.google.common.base.Preconditions;
  * 
  * @param <IN> The type of the data set aggregated by the operator.
  */
+@PublicInterface
 public class AggregateOperator<IN> extends SingleInputOperator<IN, IN, AggregateOperator<IN>> {
 	
 	private final List<AggregationFunction<?>> aggregationFunctions = new ArrayList<AggregationFunction<?>>(4);

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.java.operators;
 
 import java.util.Arrays;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.CrossFunction;
 import org.apache.flink.api.common.operators.BinaryOperatorInformation;
@@ -48,6 +50,7 @@ import com.google.common.base.Preconditions;
  *
  * @see DataSet
  */
+@PublicInterface
 public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT, CrossOperator<I1, I2, OUT>> {
 
 	private final CrossFunction<I1, I2, OUT> function;
@@ -117,6 +120,7 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 	 * @see Tuple2
 	 * @see DataSet
 	 */
+	@PublicInterface
 	public static final class DefaultCross<I1, I2> extends CrossOperator<I1, I2, Tuple2<I1, I2>>  {
 
 		private final DataSet<I1> input1;
@@ -220,6 +224,7 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 	 * @see Tuple
 	 * @see DataSet
 	 */
+	@PublicInterface
 	public static final class ProjectCross<I1, I2, OUT extends Tuple> extends CrossOperator<I1, I2, OUT> {
 		
 		private CrossProjection<I1, I2> crossProjection;
@@ -308,6 +313,7 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 		 */
 		@SuppressWarnings({ "hiding", "unchecked" })
 		@Deprecated
+		@PublicExperimental
 		public <OUT extends Tuple> CrossOperator<I1, I2, OUT> types(Class<?>... types) {
 			TupleTypeInfo<OUT> typeInfo = (TupleTypeInfo<OUT>)this.getResultType();
 
@@ -341,6 +347,7 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 		}
 	}
 
+	@PublicInterface
 	public static final class ProjectCrossFunction<T1, T2, R extends Tuple> implements CrossFunction<T1, T2, R> {
 
 		private static final long serialVersionUID = 1L;
@@ -398,6 +405,7 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 		
 	}
 
+	@PublicInterface
 	public static final class CrossProjection<I1, I2> {
 		
 		private final DataSet<I1> ds1;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.GenericDataSinkBase;
@@ -35,7 +36,7 @@ import org.apache.flink.api.java.DataSet;
 
 import java.util.Arrays;
 
-
+@PublicInterface
 public class DataSink<T> {
 	
 	private final OutputFormat<T> format;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSource.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.NonParallelInput;
 import org.apache.flink.api.common.operators.GenericDataSourceBase;
@@ -34,6 +35,7 @@ import org.apache.flink.configuration.Configuration;
  * 
  * @param <OUT> The type of the elements produced by this data source.
  */
+@PublicInterface
 public class DataSource<OUT> extends Operator<OUT, DataSource<OUT>> {
 
 	private final InputFormat<OUT, ?> inputFormat;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 
@@ -27,6 +28,7 @@ import org.apache.flink.api.java.DataSet;
  * @param <IN> The data type of the input data set.
  * @param <OUT> The data type of the returned data set.
  */
+@PublicInterface
 public abstract class SingleInputOperator<IN, OUT, O extends SingleInputOperator<IN, OUT, O>> extends Operator<OUT, O> {
 	
 	private final DataSet<IN> input;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputUdfOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SingleInputUdfOperator.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.operators.SemanticProperties;
@@ -47,6 +48,7 @@ import org.apache.flink.configuration.Configuration;
  * @param <IN> The data type of the input data set.
  * @param <OUT> The data type of the returned data set.
  */
+@PublicInterface
 public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOperator<IN, OUT, O>>
 	extends SingleInputOperator<IN, OUT, O> implements UdfOperator<O>
 {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/join/JoinType.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/join/JoinType.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.api.java.operators.join;
 
+import org.apache.flink.annotation.PublicInterface;
+
+@PublicInterface
 public enum JoinType {
 
 	INNER, LEFT_OUTER, RIGHT_OUTER, FULL_OUTER;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.types.NullFieldException;
 
 
@@ -33,6 +34,7 @@ import org.apache.flink.types.NullFieldException;
  * Tuples are in principle serializable. However, they may contain non-serializable fields,
  * in which case serialization will fail.
  */
+@PublicInterface
 public abstract class Tuple implements java.io.Serializable {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple0.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple0.java
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.ObjectStreamException;
 
 /**
@@ -27,6 +29,7 @@ import java.io.ObjectStreamException;
  * 
  * @see Tuple
  */
+@PublicInterface
 public class Tuple0 extends Tuple {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -39,6 +40,7 @@ import org.apache.flink.util.StringUtils;
  *
  * @param <T0> The type of field 0
  */
+@PublicInterface
 public class Tuple1<T0> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -48,6 +49,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T8> The type of field 8
  * @param <T9> The type of field 9
  */
+@PublicInterface
 public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -49,6 +50,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T9> The type of field 9
  * @param <T10> The type of field 10
  */
+@PublicInterface
 public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -50,6 +51,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T10> The type of field 10
  * @param <T11> The type of field 11
  */
+@PublicInterface
 public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -51,6 +52,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T11> The type of field 11
  * @param <T12> The type of field 12
  */
+@PublicInterface
 public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -52,6 +53,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T12> The type of field 12
  * @param <T13> The type of field 13
  */
+@PublicInterface
 public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -53,6 +54,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T13> The type of field 13
  * @param <T14> The type of field 14
  */
+@PublicInterface
 public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -54,6 +55,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T14> The type of field 14
  * @param <T15> The type of field 15
  */
+@PublicInterface
 public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -55,6 +56,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T15> The type of field 15
  * @param <T16> The type of field 16
  */
+@PublicInterface
 public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -56,6 +57,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T16> The type of field 16
  * @param <T17> The type of field 17
  */
+@PublicInterface
 public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -57,6 +58,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T17> The type of field 17
  * @param <T18> The type of field 18
  */
+@PublicInterface
 public class Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -40,6 +41,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T0> The type of field 0
  * @param <T1> The type of field 1
  */
+@PublicInterface
 public class Tuple2<T0, T1> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -58,6 +59,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T18> The type of field 18
  * @param <T19> The type of field 19
  */
+@PublicInterface
 public class Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -59,6 +60,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T19> The type of field 19
  * @param <T20> The type of field 20
  */
+@PublicInterface
 public class Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -60,6 +61,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T20> The type of field 20
  * @param <T21> The type of field 21
  */
+@PublicInterface
 public class Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -61,6 +62,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T21> The type of field 21
  * @param <T22> The type of field 22
  */
+@PublicInterface
 public class Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -62,6 +63,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T22> The type of field 22
  * @param <T23> The type of field 23
  */
+@PublicInterface
 public class Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -63,6 +64,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T23> The type of field 23
  * @param <T24> The type of field 24
  */
+@PublicInterface
 public class Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -41,6 +42,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T1> The type of field 1
  * @param <T2> The type of field 2
  */
+@PublicInterface
 public class Tuple3<T0, T1, T2> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -42,6 +43,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T2> The type of field 2
  * @param <T3> The type of field 3
  */
+@PublicInterface
 public class Tuple4<T0, T1, T2, T3> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -43,6 +44,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T3> The type of field 3
  * @param <T4> The type of field 4
  */
+@PublicInterface
 public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -44,6 +45,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T4> The type of field 4
  * @param <T5> The type of field 5
  */
+@PublicInterface
 public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -45,6 +46,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T5> The type of field 5
  * @param <T6> The type of field 6
  */
+@PublicInterface
 public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -46,6 +47,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T6> The type of field 6
  * @param <T7> The type of field 7
  */
+@PublicInterface
 public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.api.java.tuple;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.util.StringUtils;
 
 /**
@@ -47,6 +48,7 @@ import org.apache.flink.util.StringUtils;
  * @param <T7> The type of field 7
  * @param <T8> The type of field 8
  */
+@PublicInterface
 public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -521,6 +521,7 @@ class TupleGenerator {
 		// package and imports
 		w.println("package " + PACKAGE + ';');
 		w.println();
+		w.println("import PublicInterface;");
 		w.println("import org.apache.flink.util.StringUtils;");
 		w.println();
 
@@ -539,6 +540,7 @@ class TupleGenerator {
 			w.println(" * @param <" + GEN_TYPE_PREFIX + i + "> The type of field " + i);
 		}
 		w.println(" */");
+		w.println("@PublicInterface");
 		w.print("public class " + className + "<");
 		for (int i = 0; i < numFields; i++) {
 			if (i > 0) {
@@ -797,10 +799,12 @@ class TupleGenerator {
 		w.println("import java.util.ArrayList;");
 		w.println("import java.util.List;");
 		w.println();
+		w.println("import PublicInterface;");
 		w.println("import " + PACKAGE + ".Tuple" + numFields + ";");
 		w.println();
 
 		// class declaration
+		w.println("@PublicInterface");
 		w.print("public class " + className);
 		printGenericsString(w, numFields);
 		w.println(" {");

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple0Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple0Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple0;
 
+@PublicInterface
 public class Tuple0Builder {
 
 	private List<Tuple0> tuples = new ArrayList<Tuple0>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple10Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple10Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple10;
 
+@PublicInterface
 public class Tuple10Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> {
 
 	private List<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> tuples = new ArrayList<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple11Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple11Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple11;
 
+@PublicInterface
 public class Tuple11Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
 
 	private List<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> tuples = new ArrayList<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple12Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple12Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple12;
 
+@PublicInterface
 public class Tuple12Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> {
 
 	private List<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> tuples = new ArrayList<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple13Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple13Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple13;
 
+@PublicInterface
 public class Tuple13Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> {
 
 	private List<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> tuples = new ArrayList<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple14Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple14Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple14;
 
+@PublicInterface
 public class Tuple14Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> {
 
 	private List<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> tuples = new ArrayList<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple15Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple15Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple15;
 
+@PublicInterface
 public class Tuple15Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> {
 
 	private List<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> tuples = new ArrayList<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple16Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple16Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple16;
 
+@PublicInterface
 public class Tuple16Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> {
 
 	private List<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> tuples = new ArrayList<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple17Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple17Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple17;
 
+@PublicInterface
 public class Tuple17Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> {
 
 	private List<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> tuples = new ArrayList<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple18Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple18Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple18;
 
+@PublicInterface
 public class Tuple18Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> {
 
 	private List<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> tuples = new ArrayList<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple19Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple19Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple19;
 
+@PublicInterface
 public class Tuple19Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> {
 
 	private List<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> tuples = new ArrayList<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple1Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple1Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple1;
 
+@PublicInterface
 public class Tuple1Builder<T0> {
 
 	private List<Tuple1<T0>> tuples = new ArrayList<Tuple1<T0>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple20Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple20Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple20;
 
+@PublicInterface
 public class Tuple20Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> {
 
 	private List<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> tuples = new ArrayList<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple21Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple21Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple21;
 
+@PublicInterface
 public class Tuple21Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> {
 
 	private List<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> tuples = new ArrayList<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple22Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple22Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple22;
 
+@PublicInterface
 public class Tuple22Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> {
 
 	private List<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> tuples = new ArrayList<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple23Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple23Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple23;
 
+@PublicInterface
 public class Tuple23Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> {
 
 	private List<Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>> tuples = new ArrayList<Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple24Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple24Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple24;
 
+@PublicInterface
 public class Tuple24Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> {
 
 	private List<Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>> tuples = new ArrayList<Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple25Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple25Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple25;
 
+@PublicInterface
 public class Tuple25Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> {
 
 	private List<Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>> tuples = new ArrayList<Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple2Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple2Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple2;
 
+@PublicInterface
 public class Tuple2Builder<T0, T1> {
 
 	private List<Tuple2<T0, T1>> tuples = new ArrayList<Tuple2<T0, T1>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple3Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple3Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple3;
 
+@PublicInterface
 public class Tuple3Builder<T0, T1, T2> {
 
 	private List<Tuple3<T0, T1, T2>> tuples = new ArrayList<Tuple3<T0, T1, T2>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple4Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple4Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple4;
 
+@PublicInterface
 public class Tuple4Builder<T0, T1, T2, T3> {
 
 	private List<Tuple4<T0, T1, T2, T3>> tuples = new ArrayList<Tuple4<T0, T1, T2, T3>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple5Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple5Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple5;
 
+@PublicInterface
 public class Tuple5Builder<T0, T1, T2, T3, T4> {
 
 	private List<Tuple5<T0, T1, T2, T3, T4>> tuples = new ArrayList<Tuple5<T0, T1, T2, T3, T4>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple6Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple6Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple6;
 
+@PublicInterface
 public class Tuple6Builder<T0, T1, T2, T3, T4, T5> {
 
 	private List<Tuple6<T0, T1, T2, T3, T4, T5>> tuples = new ArrayList<Tuple6<T0, T1, T2, T3, T4, T5>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple7Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple7Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple7;
 
+@PublicInterface
 public class Tuple7Builder<T0, T1, T2, T3, T4, T5, T6> {
 
 	private List<Tuple7<T0, T1, T2, T3, T4, T5, T6>> tuples = new ArrayList<Tuple7<T0, T1, T2, T3, T4, T5, T6>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple8Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple8Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple8;
 
+@PublicInterface
 public class Tuple8Builder<T0, T1, T2, T3, T4, T5, T6, T7> {
 
 	private List<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> tuples = new ArrayList<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple9Builder.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple9Builder.java
@@ -28,8 +28,10 @@ package org.apache.flink.api.java.tuple.builder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple9;
 
+@PublicInterface
 public class Tuple9Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8> {
 
 	private List<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> tuples = new ArrayList<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>();

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/AvroTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/AvroTypeInfo.java
@@ -20,6 +20,7 @@
 package org.apache.flink.api.java.typeutils;
 
 import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import java.lang.reflect.Type;
@@ -39,6 +40,7 @@ import java.util.List;
  * This class is checked by the AvroPojoTest.
  * @param <T>
  */
+@PublicInterface
 public class AvroTypeInfo<T extends SpecificRecordBase> extends PojoTypeInfo<T> {
 	public AvroTypeInfo(Class<T> typeClass) {
 		super(typeClass, generateFieldsFromAvroSchema(typeClass));

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
@@ -26,12 +26,14 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.EnumComparator;
 import org.apache.flink.api.common.typeutils.base.EnumSerializer;
+import org.apache.flink.annotation.PublicInterface;
 
 /**
  * A {@link TypeInformation} for java enumeration types. 
  *
  * @param <T> The type represented by this type information.
  */
+@PublicInterface
 public class EnumTypeInfo<T extends Enum<T>> extends TypeInformation<T> implements AtomicType<T> {
 
 	private static final long serialVersionUID = 8936740290137178660L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.typeutils;
 
 import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.AtomicType;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -28,6 +29,7 @@ import org.apache.flink.api.java.typeutils.runtime.GenericTypeComparator;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 
 
+@PublicInterface
 public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType<T> {
 
 	private static final long serialVersionUID = -7959114120287706504L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/InputTypeConfigurable.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/InputTypeConfigurable.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.typeutils;
 
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
@@ -29,6 +30,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
  * called when the output format is used with an output method such as
  * {@link org.apache.flink.api.java.DataSet#output(org.apache.flink.api.common.io.OutputFormat)}.
  */
+@PublicInterface
 public interface InputTypeConfigurable {
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -27,6 +28,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * A special type information signifying that the type extraction failed. It contains
  * additional error information.
  */
+@PublicInterface
 public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
 
 	private static final long serialVersionUID = -4212082837126702723L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
@@ -28,6 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
@@ -53,6 +54,7 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
  * 
  * @param <T> The type represented by this type information.
  */
+@PublicInterface
 public class PojoTypeInfo<T> extends CompositeType<T> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/RecordTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/RecordTypeInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -27,6 +28,7 @@ import org.apache.flink.types.Record;
 /**
  * Type information for the {@link Record} data type.
  */
+@PublicInterface
 public class RecordTypeInfo extends TypeInformation<Record> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ResultTypeQueryable.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ResultTypeQueryable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 /**
@@ -26,6 +27,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
  * that is otherwise performed and is useful in situations where the produced data type may vary
  * depending on parameterization.
  */
+@PublicInterface
 public interface ResultTypeQueryable<T> {
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -43,6 +44,7 @@ import org.apache.flink.types.Value;
  *
  * @param <T> The type of the tuple.
  */
+@PublicInterface
 public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -24,10 +24,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.operators.Keys.ExpressionKeys;
 
+@PublicInterface
 public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.CrossFunction;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
@@ -66,6 +67,7 @@ import com.google.common.base.Preconditions;
  * A utility for reflection analysis on classes, to determine the return type of implementations of transformation
  * functions.
  */
+@PublicInterface
 public class TypeExtractor {
 
 	/*

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeInfoParser.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/TypeInfoParser.java
@@ -24,13 +24,14 @@ import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.types.Value;
 
-
+@PublicInterface
 public class TypeInfoParser {
 	private static final String TUPLE_PACKAGE = "org.apache.flink.api.java.tuple";
 	private static final String VALUE_PACKAGE = "org.apache.flink.types";

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.typeutils;
 
 import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.AtomicType;
@@ -48,6 +49,7 @@ import org.apache.flink.types.Value;
  *
  * @param <T> The type of the class represented by this type information.
  */
+@PublicInterface
 public class ValueTypeInfo<T extends Value> extends TypeInformation<T> implements AtomicType<T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/WritableTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/WritableTypeInfo.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.typeutils;
 
 import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.AtomicType;
@@ -35,6 +36,7 @@ import org.apache.hadoop.io.Writable;
  *
  * @param <T> The type of the class represented by this type information.
  */
+@PublicInterface
 public class WritableTypeInfo<T extends Writable> extends TypeInformation<T> implements AtomicType<T> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.utils;
 
 import com.google.common.collect.Lists;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
 import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.api.java.DataSet;
@@ -40,6 +41,7 @@ import java.util.List;
  * This class provides simple utility methods for zipping elements in a data set with an index
  * or with a unique identifier.
  */
+@PublicInterface
 public final class DataSetUtils {
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.utils;
 import com.google.common.base.Preconditions;
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.hadoop.util.GenericOptionsParser;
@@ -38,6 +39,7 @@ import java.util.Properties;
 /**
  * This class provides simple utility methods for reading and parsing program arguments from different sources
  */
+@PublicInterface
 public class ParameterTool extends ExecutionConfig.GlobalJobParameters implements Serializable, Cloneable {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/InputSplitProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/InputSplitProvider.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.runtime.jobgraph.tasks;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.core.io.InputSplit;
 
 /**
  * An input split provider can be successively queried to provide a series of {@link InputSplit} objects a
  * task is supposed to consume in the course of its execution.
  */
+@PublicInterface
 public interface InputSplitProvider {
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -35,6 +36,7 @@ import java.io.Serializable;
  * @param <Backend> The type of backend itself. This generic parameter is used to refer to the
  *                  type of backend when creating state backed by this backend.
  */
+@PublicInterface
 public abstract class StateBackend<Backend extends StateBackend<Backend>> implements java.io.Serializable {
 
 	private static final long serialVersionUID = 4620413814639220247L;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandle.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -25,6 +27,7 @@ import java.io.Serializable;
  * A StateHandle implementation can for example include the state itself in cases where the state 
  * is lightweight or fetching it lazily from some external storage when the state is too large.
  */
+@PublicInterface
 public interface StateHandle<T> extends Serializable {
 
 	/**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/AggregateDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/AggregateDataSet.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.java.aggregation.Aggregations
 import org.apache.flink.api.scala.operators.ScalaAggregateOperator
 
@@ -28,6 +29,7 @@ import scala.reflect.ClassTag
  *
  * @tparam T The type of the DataSet, i.e., the type of the elements of the DataSet.
  */
+@PublicInterface
 class AggregateDataSet[T: ClassTag](set: ScalaAggregateOperator[T])
   extends DataSet[T](set) {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.commons.lang3.tuple.{ImmutablePair, Pair}
 import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.functions.{CoGroupFunction, Partitioner, RichCoGroupFunction}
@@ -59,6 +60,7 @@ import scala.reflect.ClassTag
  * @tparam L Type of the left input of the coGroup.
  * @tparam R Type of the right input of the coGroup.
  */
+@PublicInterface
 class CoGroupDataSet[L, R](
     defaultCoGroup: CoGroupOperator[L, R, (Array[L], Array[R])],
     leftInput: DataSet[L],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.{CrossFunction, RichCrossFunction}
 import org.apache.flink.api.common.operators.base.CrossOperatorBase.CrossHint
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -43,6 +44,7 @@ import scala.reflect.ClassTag
  * @tparam L Type of the left input of the cross.
  * @tparam R Type of the right input of the cross.
  */
+@PublicInterface
 class CrossDataSet[L, R](
     defaultCross: CrossOperator[L, R, (L, R)],
     leftInput: DataSet[L],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.{PublicExperimental, PublicInterface}
 import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.accumulators.SerializedListAccumulator
 import org.apache.flink.api.common.aggregators.Aggregator
@@ -83,6 +84,7 @@ import scala.reflect.ClassTag
  *
  * @tparam T The type of the DataSet, i.e., the type of the elements of the DataSet.
  */
+@PublicInterface
 class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   require(set != null, "Java DataSet must not be null.")
 
@@ -1573,7 +1575,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    * @deprecated Use [[printOnTaskManager(String)]] instead.
    */
   @Deprecated
-  @deprecated
+  @PublicExperimental
   def print(sinkIdentifier: String): DataSink[T] = {
     output(new PrintingOutputFormat[T](sinkIdentifier, false))
   }
@@ -1586,7 +1588,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
    * @deprecated Use [[printOnTaskManager(String)]] instead.
    */
   @Deprecated
-  @deprecated
+  @PublicExperimental
   def printToErr(sinkIdentifier: String): DataSink[T] = {
       output(new PrintingOutputFormat[T](sinkIdentifier, true))
   }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import com.esotericsoftware.kryo.Serializer
 import com.google.common.base.Preconditions
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
@@ -61,6 +62,7 @@ import scala.reflect.ClassTag
  *  created. If the program is submitted to a cluster a remote execution environment will
  *  be created.
  */
+@PublicInterface
 class ExecutionEnvironment(javaEnv: JavaEnv) {
 
   /**
@@ -630,6 +632,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   }
 }
 
+@PublicInterface
 object ExecutionEnvironment {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.functions.{GroupCombineFunction, GroupReduceFunction, Partitioner, ReduceFunction}
 import org.apache.flink.api.common.operators.Order
@@ -38,6 +39,7 @@ import scala.reflect.ClassTag
  * A secondary sort order can be added with sortGroup, but this is only used when using one
  * of the group-at-a-time operations, i.e. `reduceGroup`.
  */
+@PublicInterface
 class GroupedDataSet[T: ClassTag](
     private val set: DataSet[T],
     private val keys: Keys[T]) {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.operators.Order
 import org.apache.flink.api.java.operators.SortPartitionOperator
 
@@ -28,6 +29,7 @@ import scala.reflect.ClassTag
  *
  * @tparam T The type of the DataSet, i.e., the type of the elements of the DataSet.
  */
+@PublicInterface
 class PartitionSortedDataSet[T: ClassTag](set: SortPartitionOperator[T])
   extends DataSet[T](set) {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopInputFormat.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopInputFormat.scala
@@ -17,9 +17,11 @@
  */
 package org.apache.flink.api.scala.hadoop.mapred
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.java.hadoop.mapred.HadoopInputFormatBase
 import org.apache.hadoop.mapred.{JobConf, InputFormat}
 
+@PublicInterface
 class HadoopInputFormat[K, V](
     mapredInputFormat: InputFormat[K, V],
     keyClass: Class[K],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopOutputFormat.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopOutputFormat.scala
@@ -17,9 +17,11 @@
  */
 package org.apache.flink.api.scala.hadoop.mapred
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormatBase
 import org.apache.hadoop.mapred.{OutputCommitter, JobConf, OutputFormat}
 
+@PublicInterface
 class HadoopOutputFormat[K, V](mapredOutputFormat: OutputFormat[K, V], job: JobConf)
   extends HadoopOutputFormatBase[K, V, (K, V)](mapredOutputFormat, job) {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopInputFormat.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopInputFormat.scala
@@ -18,9 +18,11 @@
 
 package org.apache.flink.api.scala.hadoop.mapreduce
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.java.hadoop.mapreduce.HadoopInputFormatBase
 import org.apache.hadoop.mapreduce.{InputFormat, Job}
 
+@PublicInterface
 class HadoopInputFormat[K, V](
     mapredInputFormat: InputFormat[K, V],
     keyClass: Class[K],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopOutputFormat.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopOutputFormat.scala
@@ -18,9 +18,11 @@
 
 package org.apache.flink.api.scala.hadoop.mapreduce
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.java.hadoop.mapreduce.HadoopOutputFormatBase
 import org.apache.hadoop.mapreduce.{Job, OutputFormat}
 
+@PublicInterface
 class HadoopOutputFormat[K, V](mapredOutputFormat: OutputFormat[K, V], job: Job)
   extends HadoopOutputFormatBase[K, V, (K, V)](mapredOutputFormat, job) {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.operators.Operator
 import org.apache.flink.api.common.operators.base.JoinOperatorBase
 import org.apache.flink.api.common.functions.{FlatJoinFunction, JoinFunction, Partitioner, RichFlatJoinFunction}
@@ -57,6 +58,7 @@ import scala.reflect.ClassTag
  * @tparam L Type of the left input of the join.
  * @tparam R Type of the right input of the join.
  */
+@PublicInterface
 class JoinDataSet[L, R](
     defaultJoin: EquiJoin[L, R, (L, R)],
     leftInput: DataSet[L],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
@@ -18,12 +18,14 @@
 
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.Utils
 import org.apache.flink.api.java.utils.{DataSetUtils => jutils}
 
 import _root_.scala.language.implicitConversions
 import _root_.scala.reflect.ClassTag
+
 
 package object utils {
 
@@ -33,6 +35,7 @@ package object utils {
    *
    * @param self Data Set
    */
+  @PublicInterface
   implicit class DataSetUtils[T: TypeInformation : ClassTag](val self: DataSet[T]) {
 
     /**

--- a/flink-shaded-curator/pom.xml
+++ b/flink-shaded-curator/pom.xml
@@ -1,40 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-	<modelVersion>4.0.0</modelVersion>
+  http://www.apache.org/licenses/LICENSE-2.0
 
-	<parent>
-		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-parent</artifactId>
-		<version>1.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
-	</parent>
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<modules>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <modules>
         <module>flink-shaded-curator-recipes</module>
-		<module>flink-shaded-curator-test</module>
-	</modules>
+        <module>flink-shaded-curator-test</module>
+    </modules>
 
-	<artifactId>flink-shaded-curator</artifactId>
-	<name>flink-shaded-curator</name>
+    <artifactId>flink-shaded-curator</artifactId>
+    <name>flink-shaded-curator</name>
 
-	<packaging>pom</packaging>
+    <packaging>pom</packaging>
+
 </project>

--- a/flink-staging/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroInputFormat.java
+++ b/flink-staging/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroInputFormat.java
@@ -27,6 +27,7 @@ import org.apache.avro.file.SeekableInput;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.flink.annotation.PublicInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.api.avro.FSDataInputStreamWrapper;
@@ -38,7 +39,7 @@ import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.InstantiationUtil;
 
-
+@PublicInterface
 public class AvroInputFormat<E> extends FileInputFormat<E> implements ResultTypeQueryable<E> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-staging/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroOutputFormat.java
+++ b/flink-staging/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroOutputFormat.java
@@ -26,11 +26,13 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.ReflectDatumWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.FileOutputFormat;
 import org.apache.flink.core.fs.Path;
 
 import java.io.IOException;
 
+@PublicInterface
 public class AvroOutputFormat<E> extends FileOutputFormat<E> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopMapFunction.java
+++ b/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopMapFunction.java
@@ -23,6 +23,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -42,6 +43,7 @@ import org.apache.hadoop.mapred.Reporter;
  * This wrapper maps a Hadoop Mapper (mapred API) to a Flink FlatMapFunction. 
  */
 @SuppressWarnings("rawtypes")
+@PublicInterface
 public final class HadoopMapFunction<KEYIN, VALUEIN, KEYOUT, VALUEOUT> 
 					extends RichFlatMapFunction<Tuple2<KEYIN,VALUEIN>, Tuple2<KEYOUT,VALUEOUT>> 
 					implements ResultTypeQueryable<Tuple2<KEYOUT,VALUEOUT>>, Serializable {

--- a/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopReduceCombineFunction.java
+++ b/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopReduceCombineFunction.java
@@ -23,6 +23,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -44,6 +45,7 @@ import org.apache.hadoop.mapred.Reporter;
  * This wrapper maps a Hadoop Reducer and Combiner (mapred API) to a combinable Flink GroupReduceFunction.
  */
 @SuppressWarnings("rawtypes")
+@PublicInterface
 @org.apache.flink.api.common.functions.RichGroupReduceFunction.Combinable
 public final class HadoopReduceCombineFunction<KEYIN, VALUEIN, KEYOUT, VALUEOUT> 
 					extends RichGroupReduceFunction<Tuple2<KEYIN,VALUEIN>,Tuple2<KEYOUT,VALUEOUT>> 

--- a/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopReduceFunction.java
+++ b/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/HadoopReduceFunction.java
@@ -23,6 +23,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -44,6 +45,7 @@ import org.apache.hadoop.mapred.Reporter;
  * This wrapper maps a Hadoop Reducer (mapred API) to a non-combinable Flink GroupReduceFunction. 
  */
 @SuppressWarnings("rawtypes")
+@PublicInterface
 public final class HadoopReduceFunction<KEYIN, VALUEIN, KEYOUT, VALUEOUT> 
 					extends RichGroupReduceFunction<Tuple2<KEYIN,VALUEIN>,Tuple2<KEYOUT,VALUEOUT>> 
 					implements ResultTypeQueryable<Tuple2<KEYOUT,VALUEOUT>>, Serializable {

--- a/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/wrapper/HadoopOutputCollector.java
+++ b/flink-staging/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/mapred/wrapper/HadoopOutputCollector.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.hadoopcompatibility.mapred.wrapper;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.apache.hadoop.mapred.OutputCollector;
@@ -30,6 +31,7 @@ import java.io.IOException;
  * 
  */
 @SuppressWarnings("rawtypes")
+@PublicInterface
 public final class HadoopOutputCollector<KEY,VALUE>
 		implements OutputCollector<KEY,VALUE> {
 

--- a/flink-streaming-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSink.java
+++ b/flink-streaming-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.elasticsearch;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -86,6 +87,7 @@ import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
  *
  * @param <T> Type of the elements emitted by this sink
  */
+@PublicInterface
 public class ElasticsearchSink<T> extends RichSinkFunction<T> {
 
 	public static final String CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS = "bulk.flush.max.actions";

--- a/flink-streaming-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/IndexRequestBuilder.java
+++ b/flink-streaming-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/IndexRequestBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.connectors.elasticsearch;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.elasticsearch.action.index.IndexRequest;
@@ -52,6 +53,7 @@ import java.io.Serializable;
  *
  * @param <T> The type of the element handled by this {@code IndexRequestBuilder}
  */
+@PublicInterface
 public interface IndexRequestBuilder<T> extends Function, Serializable {
 
 	/**

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Bucketer.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Bucketer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.hadoop.fs.Path;
 
 import java.io.Serializable;
@@ -31,6 +32,7 @@ import java.io.Serializable;
  * the old one closed. The {@code Bucketer} can, for example, decide to start new buckets
  * based on system time.
  */
+@PublicInterface
 public interface Bucketer extends Serializable {
 
 	/**

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Clock.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Clock.java
@@ -17,12 +17,15 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * A clock that can provide the current time.
  *
  * <p>
  * Normally this would be system time, but for testing a custom {@code Clock} can be provided.
  */
+@PublicInterface
 public interface Clock {
 
 	/**

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/DateTimeBucketer.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/DateTimeBucketer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,7 @@ import java.util.Date;
  * {@code /base/1976-12-31-14/}
  *
  */
+@PublicInterface
 public class DateTimeBucketer implements Bucketer {
 
 	private static Logger LOG = LoggerFactory.getLogger(DateTimeBucketer.class);

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/NonRollingBucketer.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/NonRollingBucketer.java
@@ -17,12 +17,14 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.hadoop.fs.Path;
 
 /**
  * A {@link org.apache.flink.streaming.connectors.fs.Bucketer} that does not perform any
  * rolling of files. All files are written to the base path.
  */
+@PublicInterface
 public class NonRollingBucketer implements Bucketer {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.fs;
 
 import org.apache.commons.lang3.time.StopWatch;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
@@ -119,6 +120,7 @@ import java.util.UUID;
  *
  * @param <T> Type of the elements emitted by this sink
  */
+@PublicInterface
 public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConfigurable, Checkpointed<RollingSink.BucketState>, CheckpointNotifier {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriter.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriter.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.fs;
 
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -41,6 +42,7 @@ import java.io.IOException;
  * @param <K> The type of the first tuple field.
  * @param <V> The type of the second tuple field.
  */
+@PublicInterface
 public class SequenceFileWriter<K extends Writable, V extends Writable> implements Writer<Tuple2<K, V>>, InputTypeConfigurable {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.fs;
 
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.hadoop.fs.FSDataOutputStream;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.nio.charset.UnsupportedCharsetException;
  *
  * @param <T> The type of the elements that are being written by the sink.
  */
+@PublicInterface
 public class StringWriter<T> implements Writer<T> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SystemClock.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SystemClock.java
@@ -17,9 +17,12 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * A {@link Clock} that uses {@code System.currentTimeMillis()} to determine the system time.
  */
+@PublicInterface
 public class SystemClock implements Clock {
 	@Override
 	public long currentTimeMillis() {

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Writer.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Writer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.hadoop.fs.FSDataOutputStream;
 
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.io.Serializable;
  *
  * @param <T> The type of the elements that are being written by the sink.
  */
+@PublicInterface
 public interface Writer<T> extends Serializable {
 
 	/**

--- a/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer081.java
+++ b/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer081.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 
 import java.util.Properties;
@@ -37,6 +38,7 @@ import java.util.Properties;
  * 
  * @param <T> The type of elements produced by this consumer.
  */
+@PublicInterface
 public class FlinkKafkaConsumer081<T> extends FlinkKafkaConsumer<T> {
 
 	private static final long serialVersionUID = -5649906773771949146L;

--- a/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer082.java
+++ b/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer082.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 
@@ -32,6 +33,7 @@ import java.util.Properties;
  *
  * @param <T> The type of elements produced by this consumer.
  */
+@PublicInterface
 public class FlinkKafkaConsumer082<T> extends FlinkKafkaConsumer<T> {
 
 	private static final long serialVersionUID = -8450689820627198228L;

--- a/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.configuration.Configuration;
@@ -52,6 +53,7 @@ import java.util.Properties;
  *
  * @param <IN> Type of the messages to write into Kafka.
  */
+@PublicInterface
 public class FlinkKafkaProducer<IN> extends RichSinkFunction<IN>  {
 
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkKafkaProducer.class);

--- a/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/KafkaPartitioner.java
+++ b/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/KafkaPartitioner.java
@@ -18,6 +18,7 @@ package org.apache.flink.streaming.connectors.kafka.partitioner;
 
 
 import kafka.producer.Partitioner;
+import org.apache.flink.annotation.PublicInterface;
 
 import java.io.Serializable;
 
@@ -26,6 +27,7 @@ import java.io.Serializable;
  * It contains a open() method which is called on each parallel instance.
  * Partitioners have to be serializable!
  */
+@PublicInterface
 public abstract class KafkaPartitioner implements Partitioner, Serializable {
 
 	private static final long serialVersionUID = -1974260817778593473L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/CheckpointingMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/CheckpointingMode.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.api;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * The checkpointing mode defines what consistency guarantees the system gives in the presence of
  * failures.
@@ -29,6 +31,7 @@ package org.apache.flink.streaming.api;
  * in a simpler fashion that typically encounteres some duplicates upon recovery
  * ({@link #AT_LEAST_ONCE})</p> 
  */
+@PublicInterface
 public enum CheckpointingMode {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimeCharacteristic.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimeCharacteristic.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.streaming.api;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * The time characteristic defines how the system determines time for time-dependent
  * order and operations that depend on time (such as time windows).
  */
+@PublicInterface
 public enum TimeCharacteristic {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointNotifier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointNotifier.java
@@ -17,11 +17,14 @@
  */
 package org.apache.flink.streaming.api.checkpoint;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * This interface must be implemented by functions/operations that want to receive
  * a commit notification once a checkpoint has been completely acknowledged by all
  * participants.
  */
+@PublicInterface
 public interface CheckpointNotifier {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/Checkpointed.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/Checkpointed.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.api.checkpoint;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -34,6 +36,7 @@ import java.io.Serializable;
  * 
  * @param <T> The type of the operator state.
  */
+@PublicInterface
 public interface Checkpointed<T extends Serializable> {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.api.checkpoint;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -34,4 +36,5 @@ import java.io.Serializable;
  * {@link #snapshotState(long, long)} method is typically a copy or shadow copy
  * of the actual state.</p>
  */
+@PublicInterface
 public interface CheckpointedAsynchronously<T extends Serializable> extends Checkpointed<T> {}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.ReduceFunction;
@@ -63,6 +65,7 @@ import org.apache.flink.streaming.runtime.operators.windowing.buffers.PreAggrega
  * @param <T> The type of elements in the stream.
  * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns the elements to.
  */
+@PublicInterface
 public class AllWindowedStream<T, W extends Window> {
 
 	/** The data stream that is windowed by this stream */
@@ -88,6 +91,7 @@ public class AllWindowedStream<T, W extends Window> {
 	/**
 	 * Sets the {@code Trigger} that should be used to trigger window emission.
 	 */
+	@PublicExperimental
 	public AllWindowedStream<T, W> trigger(Trigger<? super T, ? super W> trigger) {
 		this.trigger = trigger;
 		return this;
@@ -100,6 +104,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * Note: When using an evictor window performance will degrade significantly, since
 	 * pre-aggregation of window results cannot be used.
 	 */
+	@PublicExperimental
 	public AllWindowedStream<T, W> evictor(Evictor<? super T, ? super W> evictor) {
 		this.evictor = evictor;
 		return this;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -66,6 +67,7 @@ import static java.util.Objects.requireNonNull;
  *     .apply(new MyCoGroupFunction());
  * } </pre>
  */
+@PublicInterface
 public class CoGroupedStreams<T1, T2> {
 
 	/** The first input stream */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -37,6 +38,7 @@ import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
  * @param <IN1> Type of the first input data steam.
  * @param <IN2> Type of the second input data stream.
  */
+@PublicInterface
 public class ConnectedStreams<IN1, IN2> {
 
 	protected StreamExecutionEnvironment environment;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.FlatMapFunction;
@@ -95,6 +97,7 @@ import com.google.common.base.Preconditions;
  * 
  * @param <T> The type of the elements in this Stream
  */
+@PublicInterface
 public class DataStream<T> {
 
 	protected final StreamExecutionEnvironment environment;
@@ -725,6 +728,7 @@ public class DataStream<T> {
 	 * @param assigner The {@code WindowAssigner} that assigns elements to windows.
 	 * @return The trigger windows data stream.
 	 */
+	@PublicExperimental
 	public <W extends Window> AllWindowedStream<T, W> windowAll(WindowAssigner<? super T, W> assigner) {
 		return new AllWindowedStream<>(this, assigner);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
@@ -26,6 +27,7 @@ import org.apache.flink.streaming.api.transformations.SinkTransformation;
  *
  * @param <T> The type of the elements in the Stream
  */
+@PublicInterface
 public class DataStreamSink<T> {
 
 	SinkTransformation<T> transformation;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.StreamSource;
@@ -27,6 +28,7 @@ import org.apache.flink.streaming.api.transformations.SourceTransformation;
  * 
  * @param <T> Type of the elements in the DataStream created from the this source.
  */
+@PublicInterface
 public class DataStreamSource<T> extends SingleOutputStreamOperator<T, DataStreamSource<T>> {
 
 	boolean isParallel;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/IterativeStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/IterativeStream.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -32,6 +33,7 @@ import java.util.Collection;
  * 
  * @param <T> Type of the elements in this Stream
  */
+@PublicInterface
 public class IterativeStream<T> extends SingleOutputStreamOperator<T, IterativeStream<T>> {
 
 	// We store these so that we can create a co-iteration if we need to
@@ -142,6 +144,7 @@ public class IterativeStream<T> extends SingleOutputStreamOperator<T, IterativeS
 	 * @param <F>
 	 *            Type of the feedback of the iteration
 	 */
+	@PublicInterface
 	public static class ConnectedIterativeStreams<I, F> extends ConnectedStreams<I, F> {
 
 		private CoFeedbackTransformation<F> coFeedbackTransformation;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
@@ -59,6 +61,7 @@ import static java.util.Objects.requireNonNull;
  *     .apply(new MyJoinFunction());
  * } </pre>
  */
+@PublicInterface
 public class JoinedStreams<T1, T2> {
 
 	/** The first input stream */
@@ -93,6 +96,7 @@ public class JoinedStreams<T1, T2> {
 	 *
 	 * @param <KEY> The type of the key.
 	 */
+	@PublicInterface
 	public class Where<KEY> {
 
 		private final KeySelector<T1, KEY> keySelector1;
@@ -149,6 +153,7 @@ public class JoinedStreams<T1, T2> {
 	 * @param <KEY> Type of the key. This must be the same for both inputs
 	 * @param <W> Type of {@link Window} on which the join operation works.
 	 */
+	@PublicInterface
 	public static class WithWindow<T1, T2, KEY, W extends Window> {
 		
 		private final DataStream<T1> input1;
@@ -189,6 +194,7 @@ public class JoinedStreams<T1, T2> {
 		/**
 		 * Sets the {@code Trigger} that should be used to trigger window emission.
 		 */
+		@PublicExperimental
 		public WithWindow<T1, T2, KEY, W> trigger(Trigger<? super TaggedUnion<T1, T2>, ? super W> newTrigger) {
 			return new WithWindow<>(input1, input2, keySelector1, keySelector2, keyType,
 					windowAssigner, newTrigger, evictor);
@@ -201,6 +207,7 @@ public class JoinedStreams<T1, T2> {
 		 * Note: When using an evictor window performance will degrade significantly, since
 		 * pre-aggregation of window results cannot be used.
 		 */
+		@PublicExperimental
 		public WithWindow<T1, T2, KEY, W> evictor(Evictor<? super TaggedUnion<T1, T2>, ? super W> newEvictor) {
 			return new WithWindow<>(input1, input2, keySelector1, keySelector2, keyType,
 					windowAssigner, trigger, newEvictor);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -59,6 +60,7 @@ import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
  * @param <T> The type of the elements in the Keyed Stream.
  * @param <KEY> The type of the key in the Keyed Stream.
  */
+@PublicInterface
 public class KeyedStream<T, KEY> extends DataStream<T> {
 
 	/** The key selector that can get the key by which the stream if partitioned from the elements */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -35,6 +36,7 @@ import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
  * @param <T> The type of the elements in this Stream
  * @param <O> Type of the operator.
  */
+@PublicInterface
 public class SingleOutputStreamOperator<T, O extends SingleOutputStreamOperator<T, O>> extends DataStream<T> {
 
 	protected SingleOutputStreamOperator(StreamExecutionEnvironment environment, StreamTransformation<T> transformation) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SplitStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SplitStream.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.datastream;
 
 import com.google.common.collect.Lists;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.transformations.SelectTransformation;
 import org.apache.flink.streaming.api.transformations.SplitTransformation;
@@ -30,6 +31,7 @@ import org.apache.flink.streaming.api.transformations.SplitTransformation;
  *
  * @param <OUT> The type of the elements in the Stream
  */
+@PublicInterface
 public class SplitStream<OUT> extends DataStream<OUT> {
 
 	protected SplitStream(DataStream<OUT> dataStream, OutputSelector<OUT> outputSelector) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/StreamProjection.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/StreamProjection.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple1;
@@ -49,6 +50,7 @@ import org.apache.flink.streaming.api.operators.StreamProject;
 
 import com.google.common.base.Preconditions;
 
+@PublicInterface
 public class StreamProjection<IN> {
 
 	private DataStream<IN> dataStream;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.ReduceFunction;
@@ -74,6 +76,7 @@ import org.apache.flink.streaming.runtime.operators.windowing.buffers.PreAggrega
  * @param <K> The type of the key by which elements are grouped.
  * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns the elements to.
  */
+@PublicInterface
 public class WindowedStream<T, K, W extends Window> {
 
 	/** The keyed data stream that is windowed by this stream */
@@ -99,6 +102,7 @@ public class WindowedStream<T, K, W extends Window> {
 	/**
 	 * Sets the {@code Trigger} that should be used to trigger window emission.
 	 */
+	@PublicExperimental
 	public WindowedStream<T, K, W> trigger(Trigger<? super T, ? super W> trigger) {
 		this.trigger = trigger;
 		return this;
@@ -111,6 +115,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 * Note: When using an evictor window performance will degrade significantly, since
 	 * pre-aggregation of window results cannot be used.
 	 */
+	@PublicExperimental
 	public WindowedStream<T, K, W> evictor(Evictor<? super T, ? super W> evictor) {
 		this.evictor = evictor;
 		return this;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.environment;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * and {@link StreamExecutionEnvironment#createLocalEnvironment(int)}. The former version will pick a
  * default parallelism equal to the number of hardware contexts in the local machine.
  */
+@PublicInterface
 public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStreamEnvironment.class);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -39,6 +40,7 @@ import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@PublicInterface
 public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(RemoteStreamEnvironment.class);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.api.environment;
 import com.esotericsoftware.kryo.Serializer;
 import com.google.common.base.Preconditions;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -92,6 +94,7 @@ import static java.util.Objects.requireNonNull;
  * @see org.apache.flink.streaming.api.environment.LocalStreamEnvironment
  * @see org.apache.flink.streaming.api.environment.RemoteStreamEnvironment
  */
+@PublicInterface
 public abstract class StreamExecutionEnvironment {
 
 	/** The default name to use for a streaming job if no other name has been specified */
@@ -314,6 +317,7 @@ public abstract class StreamExecutionEnvironment {
 	 */
 	@Deprecated
 	@SuppressWarnings("deprecation")
+	@PublicExperimental
 	public StreamExecutionEnvironment enableCheckpointing(long interval, CheckpointingMode mode, boolean force) {
 		checkpointCfg.setCheckpointingMode(mode);
 		checkpointCfg.setCheckpointInterval(interval);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
@@ -17,12 +17,15 @@
  */
 package org.apache.flink.streaming.api.functions;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * Interface for user functions that extract timestamps from elements. The extracting timestamps
  * must be monotonically increasing.
  *
  * @param <T> The type of the elements that this function can extract timestamps from
  */
+@PublicInterface
 public abstract class AscendingTimestampExtractor<T> implements TimestampExtractor<T> {
 
 	long currentTimestamp = 0;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimestampExtractor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimestampExtractor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.api.functions;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 
 /**
@@ -35,6 +36,7 @@ import org.apache.flink.api.common.functions.Function;
  *
  * @param <T> The type of the elements that this function can extract timestamps from
  */
+@PublicInterface
 public interface TimestampExtractor<T> extends Function {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/RichSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/RichSinkFunction.java
@@ -17,8 +17,10 @@
 
 package org.apache.flink.streaming.api.functions.sink;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 
+@PublicInterface
 public abstract class RichSinkFunction<IN> extends AbstractRichFunction implements SinkFunction<IN> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.api.functions.sink;
 
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 
 /**
@@ -26,6 +27,7 @@ import org.apache.flink.api.common.functions.Function;
  *
  * @param <IN> Input type parameter.
  */
+@PublicInterface
 public interface SinkFunction<IN> extends Function, Serializable {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/AllWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/AllWindowFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.functions.windowing;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Collector;
@@ -30,6 +31,7 @@ import java.io.Serializable;
  * @param <IN> The type of the input value.
  * @param <OUT> The type of the output value.
  */
+@PublicInterface
 public interface AllWindowFunction<IN, OUT,  W extends Window> extends Function, Serializable {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/RichAllWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/RichAllWindowFunction.java
@@ -17,9 +17,11 @@
  */
 package org.apache.flink.streaming.api.functions.windowing;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
+@PublicInterface
 public abstract class RichAllWindowFunction<IN, OUT, W extends Window> extends AbstractRichFunction implements AllWindowFunction<IN, OUT, W> {
 	private static final long serialVersionUID = 1L;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/RichWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/RichWindowFunction.java
@@ -17,9 +17,11 @@
  */
 package org.apache.flink.streaming.api.functions.windowing;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
+@PublicInterface
 public abstract class RichWindowFunction<IN, OUT, KEY, W extends Window> extends AbstractRichFunction implements WindowFunction<IN, OUT, KEY, W> {
 	private static final long serialVersionUID = 1L;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/WindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/WindowFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.functions.windowing;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Collector;
@@ -31,6 +32,7 @@ import java.io.Serializable;
  * @param <OUT> The type of the output value.
  * @param <KEY> The type of the key.
  */
+@PublicInterface
 public interface WindowFunction<IN, OUT, KEY, W extends Window> extends Function, Serializable {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
 import org.apache.flink.api.common.functions.util.AbstractRuntimeUDFContext;
@@ -40,6 +41,7 @@ import static java.util.Objects.requireNonNull;
  * Implementation of the {@link org.apache.flink.api.common.functions.RuntimeContext},
  * for streaming operators.
  */
+@PublicInterface
 public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 
 	/** The operator to which this function belongs */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.streaming.api.windowing.assigners;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -39,6 +41,7 @@ import java.util.Collection;
  * @param <T> The type of elements that this WindowAssigner can assign windows to.
  * @param <W> The type of {@code Window} that this assigner assigns.
  */
+@PublicInterface
 public abstract class WindowAssigner<T, W extends Window> implements Serializable {
 	private static final long serialVersionUID = 1L;
 
@@ -53,6 +56,7 @@ public abstract class WindowAssigner<T, W extends Window> implements Serializabl
 	/**
 	 * Returns the default trigger associated with this {@code WindowAssigner}.
 	 */
+	@PublicExperimental
 	public abstract Trigger<T, W> getDefaultTrigger(StreamExecutionEnvironment env);
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.api.windowing.evictors;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
@@ -25,6 +26,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  *
  * @param <W> The type of {@link Window Windows} on which this {@code Evictor} can operate.
  */
+@PublicInterface
 public class CountEvictor<W extends Window> implements Evictor<Object, W> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/Evictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/Evictor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.api.windowing.evictors;
 
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import java.io.Serializable;
@@ -36,6 +37,7 @@ import java.io.Serializable;
  * @param <T> The type of elements that this {@code Evictor} can evict.
  * @param <W> The type of {@link Window Windows} on which this {@code Evictor} can operate.
  */
+@PublicExperimental
 public interface Evictor<T, W extends Window> extends Serializable {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/time/AbstractTime.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/time/AbstractTime.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.windowing.time;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 
 import java.util.concurrent.TimeUnit;
@@ -27,6 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Base class for {@link Time} implementations.
  */
+@PublicInterface
 public abstract class AbstractTime {
 
 	/** The time unit for this policy's time interval */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.api.windowing.triggers;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.state.OperatorState;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
@@ -27,6 +28,7 @@ import java.io.IOException;
  *
  * @param <W> The type of {@link Window Windows} on which this trigger can operate.
  */
+@PublicInterface
 public class CountTrigger<W extends Window> implements Trigger<Object, W> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.streaming.api.windowing.triggers;
 
+import org.apache.flink.annotation.PublicExperimental;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.state.OperatorState;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
@@ -41,6 +43,7 @@ import java.io.Serializable;
  * @param <T> The type of elements on which this {@code Trigger} works.
  * @param <W> The type of {@link Window Windows} on which this {@code Trigger} can operate.
  */
+@PublicExperimental
 public interface Trigger<T, W extends Window> extends Serializable {
 
 	/**
@@ -80,6 +83,7 @@ public interface Trigger<T, W extends Window> extends Serializable {
 	 * are purged. On {@code CONTINUE} nothing happens, processing continues. On {@code PURGE}
 	 * the contents of the window are discarded and now result is emitted for the window.
 	 */
+	@PublicInterface
 	enum TriggerResult {
 		CONTINUE(false, false), FIRE_AND_PURGE(true, true), FIRE(true, false), PURGE(false, true);
 
@@ -128,6 +132,7 @@ public interface Trigger<T, W extends Window> extends Serializable {
 	 * A context object that is given to {@code Trigger} methods to allow them to register timer
 	 * callbacks and deal with state.
 	 */
+	@PublicInterface
 	interface TriggerContext {
 
 		/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/GlobalWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/GlobalWindow.java
@@ -17,12 +17,14 @@
  */
 package org.apache.flink.streaming.api.windowing.windows;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 import java.io.IOException;
 
+@PublicInterface
 public class GlobalWindow extends Window {
 
 	private static GlobalWindow INSTANCE = new GlobalWindow();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.api.windowing.windows;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -27,6 +28,7 @@ import java.io.IOException;
  * A {@link Window} that represents a time interval from {@code start} (inclusive) to
  * {@code start + size} (exclusive).
  */
+@PublicInterface
 public class TimeWindow extends Window {
 
 	private final long start;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/Window.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/Window.java
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.streaming.api.windowing.windows;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * A {@code Window} is a grouping of elements into finite buckets. Windows have a maximum timestamp
  * which means that, at some point, all elements that go into one window will have arrived.
@@ -25,6 +27,7 @@ package org.apache.flink.streaming.api.windowing.windows;
  * Subclasses should implement {@code equals()} and {@code hashCode()} so that logically
  * same windows are treated the same.
  */
+@PublicInterface
 public abstract class Window {
 
 	public abstract long maxTimestamp();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
@@ -17,11 +17,14 @@
 
 package org.apache.flink.streaming.runtime.streamrecord;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * One value in a data stream. This stores the value and the associated timestamp.
  * 
  * @param <T> The type encapsulated with the stream record.
  */
+@PublicInterface
 public class StreamRecord<T> extends StreamElement {
 	
 	/** The actual value held by this record */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/DeserializationSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/DeserializationSchema.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.util.serialization;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 
 /**
@@ -29,6 +30,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
  * 
  * @param <T> The type created by the deserialization schema.
  */
+@PublicInterface
 public interface DeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/SerializationSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/SerializationSchema.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.util.serialization;
 
+import org.apache.flink.annotation.PublicInterface;
+
 import java.io.Serializable;
 
 /**
@@ -26,6 +28,7 @@ import java.io.Serializable;
  * 
  * @param <T> The type to be serialized.
  */
+@PublicInterface
 public interface SerializationSchema<T> extends Serializable {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/TypeInformationSerializationSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/TypeInformationSerializationSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.util.serialization;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -34,6 +35,7 @@ import java.io.IOException;
  * 
  * @param <T> The type to be serialized.
  */
+@PublicInterface
 public class TypeInformationSerializationSchema<T> implements DeserializationSchema<T>, SerializationSchema<T> {
 	
 	private static final long serialVersionUID = -5359448468131559102L;

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.{FoldFunction, ReduceFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{AllWindowedStream => JavaAllWStream}
@@ -54,6 +55,7 @@ import scala.collection.JavaConverters._
  *           [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]]
  *           assigns the elements to.
  */
+@PublicInterface
 class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.CoGroupFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
@@ -56,6 +57,7 @@ import scala.reflect.ClassTag
  *     .apply(new MyCoGroupFunction())
  * } }}}
  */
+@PublicInterface
 object CoGroupedStreams {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
@@ -32,6 +33,7 @@ import scala.reflect.ClassTag
  * can be used to apply transformations such as [[CoMapFunction]] on two
  * [[DataStream]]s.
  */
+@PublicInterface
 class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.{FilterFunction, FlatMapFunction, MapFunction, Partitioner}
 import org.apache.flink.api.common.io.OutputFormat
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -39,6 +40,7 @@ import org.apache.flink.util.Collector
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
+@PublicInterface
 class DataStream[T](javaStream: JavaStream[T]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.{FlatJoinFunction, JoinFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
@@ -54,6 +55,7 @@ import scala.reflect.ClassTag
  *     .apply(new MyJoinFunction())
  * } }}}
  */
+@PublicInterface
 object JoinedStreams {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions._
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream, KeyedStream => KeyedJavaStream, WindowedStream => WindowedJavaStream}
@@ -32,7 +33,7 @@ import org.apache.flink.util.Collector
 
 import scala.reflect.ClassTag
 
-
+@PublicInterface
 class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T](javaStream) {
 
   // ------------------------------------------------------------------------

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SplitStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SplitStream.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.streaming.api.datastream.{ SplitStream => SplitJavaStream }
 
 /**
@@ -27,6 +28,7 @@ import org.apache.flink.streaming.api.datastream.{ SplitStream => SplitJavaStrea
  * the appropriate method on this stream.
  *
  */
+@PublicInterface
 class SplitStream[T](javaStream: SplitJavaStream[T]) extends DataStream[T](javaStream){
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.scala
 
 import com.esotericsoftware.kryo.Serializer
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -37,6 +38,7 @@ import scala.reflect.ClassTag
 
 import _root_.scala.language.implicitConversions
 
+@PublicInterface
 class StreamExecutionEnvironment(javaEnv: JavaEnv) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.{FoldFunction, ReduceFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{WindowedStream => JavaWStream}
@@ -57,6 +58,7 @@ import scala.collection.JavaConverters._
  *           [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]]
  *           assigns the elements to.
  */
+@PublicInterface
 class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.scala.function
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.RichFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.configuration.Configuration
@@ -28,6 +29,7 @@ import org.apache.flink.api.common.state.OperatorState
  * RichFunctions without exposing the OperatorStates to the user. The user should
  * call the applyWithState method in his own RichFunction implementation.
  */
+@PublicInterface
 trait StatefulFunction[I, O, S] extends RichFunction {
   
   var state: OperatorState[S] = _

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@ under the License.
 	</scm>
 
 	<modules>
+		<module>flink-annotations</module>
 		<module>flink-shaded-hadoop</module>
 		<module>flink-shaded-curator</module>
 		<module>flink-core</module>
@@ -500,7 +501,6 @@ under the License.
 			<build>
 
 				<plugins>
-
 					<!-- We need to clean compiled classes to make sure that genjavadoc
 					is called to generate our fake Java source from Scala source. -->
 					<plugin>
@@ -701,6 +701,7 @@ under the License.
 
 	<build>
 		<plugins>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
With this pull request, I'm introducing annotations for marking the stability of certain Flink interfaces.

The annotations are in the `flink-annotations` module. I needed to create a new module because the maven plugin I'm intending to use needs to have access to the annotations at runtime.
My first idea was to add them to `flink-core`, but that lead to circular dependencies.

Speaking of maven plugins: I did not yet include the infrastructure to enforce interface stability. I'm currently trying to find a maven plugin which will allow us to automatically verify the stability.
The problem is that the plugin needs some additional features until we can use it. But I hope we get it in place with the 1.0.0 release.