### PR TITLE
[FLINK-3097] [table] Add support for custom functions in Table API

### DIFF
--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
@@ -33,13 +33,14 @@ import org.apache.flink.api.table.plan._
 import org.apache.flink.api.table.runtime.{ExpressionAggregateFunction, ExpressionFilterFunction, ExpressionJoinFunction, ExpressionSelectFunction}
 import org.apache.flink.api.table.expressions._
 import org.apache.flink.api.table.typeinfo.{RenameOperator, RenamingProxyTypeInfo, RowTypeInfo}
-import org.apache.flink.api.table.{ExpressionException, Row, Table}
+import org.apache.flink.api.table.{TableConfig, ExpressionException, Row, Table}
 
 /**
  * [[PlanTranslator]] for creating [[Table]]s from Java [[org.apache.flink.api.java.DataSet]]s and
  * translating them back to Java [[org.apache.flink.api.java.DataSet]]s.
  */
-class JavaBatchTranslator extends PlanTranslator {
+class JavaBatchTranslator(config: TableConfig = TableConfig.DEFAULT)
+  extends PlanTranslator(config) {
 
   type Representation[A] = JavaDataSet[A]
 
@@ -51,7 +52,7 @@ class JavaBatchTranslator extends PlanTranslator {
 
     val rowDataSet = createSelect(expressions, repr, inputType)
 
-    Table(Root(rowDataSet, resultFields))
+    Table(config, Root(rowDataSet, resultFields))
   }
 
   override def translate[A](op: PlanNode)(implicit tpe: TypeInformation[A]): JavaDataSet[A] = {
@@ -105,7 +106,8 @@ class JavaBatchTranslator extends PlanTranslator {
     val function = new ExpressionSelectFunction(
       resultSet.getType.asInstanceOf[RowTypeInfo],
       outputType,
-      outputFields)
+      outputFields,
+      config)
 
     val opName = s"select(${outputFields.mkString(",")})"
     val operator = new MapOperator(resultSet, outputType, function, opName)
@@ -134,7 +136,7 @@ class JavaBatchTranslator extends PlanTranslator {
 
       case sel@Select(Filter(Join(leftInput, rightInput), predicate), selection) =>
 
-        val expandedInput = ExpandAggregations(sel)
+        val expandedInput = ExpandAggregations(config, sel)
 
         if (expandedInput.eq(sel)) {
           val translatedLeftInput = translateInternal(leftInput)
@@ -176,7 +178,7 @@ class JavaBatchTranslator extends PlanTranslator {
 
       case sel@Select(input, selection) =>
 
-        val expandedInput = ExpandAggregations(sel)
+        val expandedInput = ExpandAggregations(config, sel)
 
         if (expandedInput.eq(sel)) {
           // no expansions took place
@@ -250,7 +252,7 @@ class JavaBatchTranslator extends PlanTranslator {
       case Filter(input, predicate) =>
         val translatedInput = translateInternal(input)
         val inType = translatedInput.getType.asInstanceOf[CompositeType[Row]]
-        val filter = new ExpressionFilterFunction[Row](predicate, inType)
+        val filter = new ExpressionFilterFunction[Row](predicate, inType, config)
         translatedInput.filter(filter).name(predicate.toString)
 
       case uni@UnionAll(left, right) =>
@@ -275,7 +277,7 @@ class JavaBatchTranslator extends PlanTranslator {
 
     val resultType = new RowTypeInfo(fields)
 
-    val function = new ExpressionSelectFunction(inputType, resultType, fields)
+    val function = new ExpressionSelectFunction(inputType, resultType, fields, config)
 
     val opName = s"select(${fields.mkString(",")})"
     val operator = new MapOperator(input, resultType, function, opName)
@@ -310,7 +312,8 @@ class JavaBatchTranslator extends PlanTranslator {
       leftType,
       rightType,
       resultType,
-      fields)
+      fields,
+      config)
 
     new EquiJoin[L, R, Row](
       leftInput,

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
@@ -20,7 +20,7 @@ package org.apache.flink.api.java.table
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.api.table.Table
+import org.apache.flink.api.table.{TableConfig, Table}
 import org.apache.flink.streaming.api.datastream.DataStream
 
 /**
@@ -30,6 +30,13 @@ import org.apache.flink.streaming.api.datastream.DataStream
  * can also use the provided methods to create a [[Table]] directly from a data source.
  */
 class TableEnvironment {
+
+  private val config = new TableConfig()
+
+  /**
+   * Returns the table config to define the runtime behavior of the Table API.
+   */
+  def getConfig = config
 
   /**
    * Transforms the given DataSet to a [[org.apache.flink.api.table.Table]].
@@ -45,7 +52,7 @@ class TableEnvironment {
    * are named a and b.
    */
   def fromDataSet[T](set: DataSet[T], fields: String): Table = {
-    new JavaBatchTranslator().createTable(set, fields)
+    new JavaBatchTranslator(config).createTable(set, fields)
   }
 
   /**
@@ -54,7 +61,7 @@ class TableEnvironment {
    * [[org.apache.flink.api.table.Table]] fields.
    */
   def fromDataSet[T](set: DataSet[T]): Table = {
-    new JavaBatchTranslator().createTable(set)
+    new JavaBatchTranslator(config).createTable(set)
   }
 
   /**
@@ -71,7 +78,7 @@ class TableEnvironment {
    * are named a and b.
    */
   def fromDataStream[T](set: DataStream[T], fields: String): Table = {
-    new JavaStreamingTranslator().createTable(set, fields)
+    new JavaStreamingTranslator(config).createTable(set, fields)
   }
 
   /**
@@ -80,7 +87,7 @@ class TableEnvironment {
    * [[org.apache.flink.api.table.Table]] fields.
    */
   def fromDataStream[T](set: DataStream[T]): Table = {
-    new JavaStreamingTranslator().createTable(set)
+    new JavaStreamingTranslator(config).createTable(set)
   }
 
   /**
@@ -91,7 +98,7 @@ class TableEnvironment {
    */
   @SuppressWarnings(Array("unchecked"))
   def toDataSet[T](table: Table, clazz: Class[T]): DataSet[T] = {
-    new JavaBatchTranslator().translate[T](table.operation)(
+    new JavaBatchTranslator(config).translate[T](table.operation)(
       TypeExtractor.createTypeInfo(clazz).asInstanceOf[TypeInformation[T]])
   }
 
@@ -103,7 +110,7 @@ class TableEnvironment {
    */
   @SuppressWarnings(Array("unchecked"))
   def toDataStream[T](table: Table, clazz: Class[T]): DataStream[T] = {
-    new JavaStreamingTranslator().translate[T](table.operation)(
+    new JavaStreamingTranslator(config).translate[T](table.operation)(
       TypeExtractor.createTypeInfo(clazz).asInstanceOf[TypeInformation[T]])
 
   }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaBatchTranslator.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.java.table.JavaBatchTranslator
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.api.scala.wrap
 import org.apache.flink.api.table.plan._
-import org.apache.flink.api.table.Table
+import org.apache.flink.api.table.{TableConfig, Table}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.DataSet
 
@@ -35,9 +35,10 @@ import scala.reflect.ClassTag
  * [[PlanTranslator]] for creating [[Table]]s from Scala [[DataSet]]s and
  * translating them back to Scala [[DataSet]]s.
  */
-class ScalaBatchTranslator extends PlanTranslator {
+class ScalaBatchTranslator(config: TableConfig = TableConfig.DEFAULT)
+  extends PlanTranslator(config) {
 
-  private val javaTranslator = new JavaBatchTranslator
+  private val javaTranslator = new JavaBatchTranslator(config)
 
   type Representation[A] = DataSet[A]
 
@@ -47,7 +48,7 @@ class ScalaBatchTranslator extends PlanTranslator {
 
     val result = javaTranslator.createTable(repr.javaSet, fields)
 
-    new Table(result.operation)
+    new Table(config, result.operation)
   }
 
   override def translate[O](op: PlanNode)(implicit tpe: TypeInformation[O]): DataSet[O] = {
@@ -63,6 +64,6 @@ class ScalaBatchTranslator extends PlanTranslator {
 
     val result = javaTranslator.createTable(repr.javaSet, inputType, expressions, resultFields)
 
-    Table(result.operation)
+    Table(config, result.operation)
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/scala/table/ScalaStreamingTranslator.scala
@@ -21,7 +21,7 @@ package org.apache.flink.api.scala.table
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.java.table.JavaStreamingTranslator
-import org.apache.flink.api.table.Table
+import org.apache.flink.api.table.{TableConfig, Table}
 import org.apache.flink.api.table.plan._
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.streaming.api.scala.{DataStream, javaToScalaStream}
@@ -33,9 +33,10 @@ import org.apache.flink.streaming.api.scala.{DataStream, javaToScalaStream}
  * This is very limited right now. Only select and filter are implemented. Also, the expression
  * operations must be extended to allow windowing operations.
  */
-class ScalaStreamingTranslator extends PlanTranslator {
+class ScalaStreamingTranslator(config: TableConfig = TableConfig.DEFAULT)
+  extends PlanTranslator(config) {
 
-  private val javaTranslator = new JavaStreamingTranslator
+  private val javaTranslator = new JavaStreamingTranslator(config)
 
   override type Representation[A] = DataStream[A]
 
@@ -53,6 +54,6 @@ class ScalaStreamingTranslator extends PlanTranslator {
     val result =
       javaTranslator.createTable(repr.getJavaStream, inputType, expressions, resultFields)
 
-    new Table(result.operation)
+    new Table(config, result.operation)
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/RowFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/RowFunction.scala
@@ -15,24 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.expressions.analysis
-
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.table.TableConfig
-import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.trees.Analyzer
+package org.apache.flink.api.table
 
 /**
- * Analyzer for predicates, i.e. filter operations and where clauses of joins.
+ * General interface for implementing custom row functions.
+ *
+ * @tparam R return type of the function
  */
-class PredicateAnalyzer(config: TableConfig, inputFields: Seq[(String, TypeInformation[_])])
-  extends Analyzer[Expression] {
+trait RowFunction[R] extends Serializable {
 
-  def rules = Seq(
-    new ResolveFieldReferences(inputFields),
-    new ResolveRowFunctionCalls(config),
-    new InsertAutoCasts,
-    new TypeCheck,
-    new VerifyNoAggregates,
-    new VerifyBoolean)
+  def call(args: Array[Any]): R
+
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/Table.scala
@@ -46,7 +46,7 @@ import org.apache.flink.api.table.plan._
  * in a Scala DSL or as an expression String. Please refer to the documentation for the expression
  * syntax.
  */
-case class Table(private[flink] val operation: PlanNode) {
+case class Table(private[flink] val config: TableConfig, private[flink] val operation: PlanNode) {
 
   /**
    * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
@@ -59,7 +59,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def select(fields: Expression*): Table = {
-    val analyzer = new SelectionAnalyzer(operation.outputFields)
+    val analyzer = new SelectionAnalyzer(config, operation.outputFields)
     val analyzedFields = fields.map(analyzer.analyze)
     val fieldNames = analyzedFields map(_.name)
     if (fieldNames.toSet.size != fieldNames.size) {
@@ -130,7 +130,7 @@ case class Table(private[flink] val operation: PlanNode) {
    * }}}
    */
   def filter(predicate: Expression): Table = {
-    val analyzer = new PredicateAnalyzer(operation.outputFields)
+    val analyzer = new PredicateAnalyzer(config, operation.outputFields)
     val analyzedPredicate = analyzer.analyze(predicate)
     this.copy(operation = Filter(operation, analyzedPredicate))
   }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionCodeGenerator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionCodeGenerator.scala
@@ -27,7 +27,7 @@ import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.api.table.expressions._
 import org.apache.flink.api.table.typeinfo.{RenamingProxyTypeInfo, RowTypeInfo}
-import org.apache.flink.api.table.{ExpressionException, TableConfig, expressions}
+import org.apache.flink.api.table.{ExpressionException, FunctionSignature, TableConfig, expressions}
 import org.codehaus.janino.SimpleCompiler
 import org.slf4j.LoggerFactory
 
@@ -59,9 +59,13 @@ abstract class ExpressionCodeGenerator[R](
   val compiler = new SimpleCompiler()
   compiler.setParentClassLoader(cl)
 
-  protected val reusableMemberStatements = mutable.Set[String]()
+  // set of member statements that will be added only once
+  // we use a LinkedHashSet to keep the insertion order
+  protected val reusableMemberStatements = mutable.LinkedHashSet[String]()
 
-  protected val reusableInitStatements = mutable.Set[String]()
+  // set of constructor statements that will be added only once
+  // we use a LinkedHashSet to keep the insertion order
+  protected val reusableInitStatements = mutable.LinkedHashSet[String]()
 
   protected def reuseMemberCode(): String = {
     reusableMemberStatements.mkString("", "\n", "\n")
@@ -136,11 +140,11 @@ abstract class ExpressionCodeGenerator[R](
         if (nullCheck) {
           s"""
             |boolean $nullTerm = true;
-            |$resultTpe resultTerm = null;
+            |$resultTpe $resultTerm = null;
           """.stripMargin
         } else {
           s"""
-            |$resultTpe resultTerm = null;
+            |$resultTpe $resultTerm = null;
           """.stripMargin
         }
 
@@ -218,10 +222,7 @@ abstract class ExpressionCodeGenerator[R](
         }
 
       case expressions.Literal(dateValue: Date, DATE_TYPE_INFO) =>
-        val dateName = s"""date_${dateValue.getTime}"""
-        val dateStmt = s"""static java.util.Date $dateName
-             |= new java.util.Date(${dateValue.getTime});""".stripMargin
-        reusableMemberStatements.add(dateStmt)
+        val dateName = addDate(dateValue)
 
         if (nullCheck) {
           s"""
@@ -341,9 +342,9 @@ abstract class ExpressionCodeGenerator[R](
         if child.typeInfo == BasicTypeInfo.STRING_TYPE_INFO =>
         val childGen = generateExpression(child)
 
-        addDateFormatter()
-        addTimeFormatter()
-        addTimestampFormatter()
+        val dateFormatterName = addDateFormatter()
+        val timeFormatterName = addTimeFormatter()
+        val timestampFormatterName = addTimestampFormatter()
 
         // tries to parse
         // "2011-05-03 15:51:36.234"
@@ -355,13 +356,13 @@ abstract class ExpressionCodeGenerator[R](
           s"""
             |java.util.Date $parsedName = null;
             |try {
-            |  $parsedName = timestampFormatter.parse(${childGen.resultTerm});
+            |  $parsedName = $timestampFormatterName.parse(${childGen.resultTerm});
             |} catch (java.text.ParseException e1) {
             |  try {
-            |    $parsedName = dateFormatter.parse(${childGen.resultTerm});
+            |    $parsedName = $dateFormatterName.parse(${childGen.resultTerm});
             |  } catch (java.text.ParseException e2) {
             |    try {
-            |      $parsedName = timeFormatter.parse(${childGen.resultTerm});
+            |      $parsedName = $timeFormatterName.parse(${childGen.resultTerm});
             |    } catch (java.text.ParseException e3) {
             |      $parsedName = new java.util.Date(Long.valueOf(${childGen.resultTerm}));
             |    }
@@ -661,6 +662,43 @@ abstract class ExpressionCodeGenerator[R](
             """.stripMargin
         }
 
+      case ResolvedRowFunctionCall(name, typeInfo, args) =>
+        val childrenCode = args.map(generateExpression(_))
+
+        val rowFunctions = config.getRegisteredRowFunctions.toIndexedSeq
+        val signature = FunctionSignature(name, args.map(_.typeInfo))
+        val index = rowFunctions
+          .zipWithIndex
+          .find(_._1._1 == signature)
+          .getOrElse(throw new ExpressionException("Invalid signature."))
+          ._2
+
+        val rowFunctionName = addRowFunction(index, args.size)
+
+        val arguments = childrenCode
+          .zipWithIndex
+          .map(codeWithIndex => s"""
+              |${rowFunctionName}_args[${codeWithIndex._2}] = ${codeWithIndex._1.resultTerm};
+            """.stripMargin
+          )
+          .mkString("\n", "\n", "")
+
+        val resultTermCode = childrenCode.map(_.code).mkString("\n") +
+          arguments +
+          s"""
+            |$resultTpe $resultTerm = ($resultTpe) $rowFunctionName
+            |  .call(${rowFunctionName}_args);
+          """.stripMargin
+
+        if (nullCheck) {
+          resultTermCode +
+            s"""
+              |boolean $nullTerm = $resultTerm == null;
+            """.stripMargin
+        } else {
+          resultTermCode
+        }
+
       case _ => throw new ExpressionException("Could not generate code for expression " + expr)
     }
 
@@ -791,36 +829,94 @@ abstract class ExpressionCodeGenerator[R](
 
   }
 
-  def addDateFormatter(): Unit = {
+  // ----------------------------------------------------------------------------------------------
+
+  def addDateFormatter(): String = {
+    val name = s"dateFormatter"
+
     reusableMemberStatements.add(s"""
-    |java.text.SimpleDateFormat dateFormatter =
-    |  new java.text.SimpleDateFormat("yyyy-MM-dd");
-    |""".stripMargin)
+      |java.text.SimpleDateFormat $name =
+      |  new java.text.SimpleDateFormat("yyyy-MM-dd");
+      """.stripMargin)
 
     reusableInitStatements.add(s"""
-    |dateFormatter.setTimeZone(config.getTimeZone());
-    |""".stripMargin)
+      |$name.setTimeZone(config.getTimeZone());
+      """.stripMargin)
+
+    name
   }
 
-  def addTimeFormatter(): Unit = {
+  def addTimeFormatter(): String = {
+    val name = s"timeFormatter"
+
     reusableMemberStatements.add(s"""
-    |java.text.SimpleDateFormat timeFormatter =
-    |  new java.text.SimpleDateFormat("HH:mm:ss");
-    |""".stripMargin)
+      |java.text.SimpleDateFormat $name =
+      |  new java.text.SimpleDateFormat("HH:mm:ss");
+      """.stripMargin)
 
     reusableInitStatements.add(s"""
-    |timeFormatter.setTimeZone(config.getTimeZone());
-    |""".stripMargin)
+      |$name.setTimeZone(config.getTimeZone());
+      """.stripMargin)
+
+    name
   }
 
-  def addTimestampFormatter(): Unit = {
+  def addTimestampFormatter(): String = {
+    val name = s"timestampFormatter"
+
     reusableMemberStatements.add(s"""
-    |java.text.SimpleDateFormat timestampFormatter =
-    |  new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    |""".stripMargin)
+      |java.text.SimpleDateFormat $name =
+      |  new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      """.stripMargin)
 
     reusableInitStatements.add(s"""
-    |timestampFormatter.setTimeZone(config.getTimeZone());
-    |""".stripMargin)
+      |$name.setTimeZone(config.getTimeZone());
+      """.stripMargin)
+
+    name
+  }
+
+  def addDate(date: Date): String = {
+    val name = s"date_${date.getTime}"
+
+    reusableMemberStatements.add(s"""
+      |java.util.Date $name
+      |  = new java.util.Date(${date.getTime});
+      """.stripMargin)
+
+    name
+  }
+
+  def addRowFunction(index: Int, numberOfArgs: Int): String = {
+    val name = s"rowFunction_$index"
+
+    // add global index of row functions
+    reusableMemberStatements.add(s"""
+      |scala.collection.immutable.IndexedSeq rowFunctions = null;
+      """.stripMargin)
+
+    reusableInitStatements.add(s"""
+      |rowFunctions = config
+      |  .getRegisteredRowFunctions()
+      |  .values()
+      |  .toIndexedSeq();
+      """.stripMargin)
+
+    // add shortcut for called row function
+    reusableMemberStatements.add(s"""
+      |org.apache.flink.api.table.RowFunction $name = null;
+      """.stripMargin)
+
+    reusableInitStatements.add(s"""
+      |$name = ((org.apache.flink.api.table.RowFunctionInfo) rowFunctions.apply($index))
+      |  .rowFunction();
+      """.stripMargin)
+
+    // add array for parameters
+    reusableMemberStatements.add(s"""
+      |java.lang.Object[] ${name}_args = new Object[$numberOfArgs];
+      """.stripMargin)
+
+    name
   }
 }

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/ResolveRowFunctionCalls.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/ResolveRowFunctionCalls.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table.expressions.analysis
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.table.expressions._
+import org.apache.flink.api.table.trees.Rule
+import org.apache.flink.api.table.{ExpressionException, FunctionSignature, TableConfig}
+
+import scala.collection.mutable
+
+/**
+ * Rule that resolves row function calls. It casts arguments if necessary.
+ * This rule verifies that the function's signature points to an existing function and
+ * creates [[org.apache.flink.api.table.expressions.ResolvedRowFunctionCall]]s that holds the
+ * function's return type information in addition to the function name and casted arguments.
+ */
+class ResolveRowFunctionCalls(config: TableConfig) extends Rule[Expression] {
+
+  def apply(expr: Expression) = {
+    val errors = mutable.MutableList[String]()
+
+    val result = expr.transformPost {
+      case call@Call(functionName, argExprs@_*) =>
+        val argsTypeInfo = argExprs.map(_.typeInfo)
+
+        val functions = config.getRegisteredRowFunctions
+        
+        // try to find exact signature
+        val exactSig = FunctionSignature(functionName, argsTypeInfo)
+        if (functions.contains(exactSig)) {
+          ResolvedRowFunctionCall(functionName, functions(exactSig).returnType, argExprs)
+        }
+        // try to find same number of arguments and check if casting is possible
+        else {
+          val similarFunctions = functions.filterKeys((sig) =>
+            sig.name == functionName && sig.args.size == argExprs.size)
+          // function name and number of arguments is unique
+          if (similarFunctions.size == 1) {
+            val similarFunction = similarFunctions.head
+            val similarSig = similarFunction._1
+            val similarInfo = similarFunction._2
+
+            val castedArgExprs = similarSig.args.zip(argExprs).map(expectedInfoAndExpr => {
+              val expectedType = expectedInfoAndExpr._1
+              val actualExpr = expectedInfoAndExpr._2
+              val actualType = actualExpr.typeInfo
+
+              // no casting necessary
+              if (expectedType == actualType) {
+                actualExpr
+              }
+              // casting of basic types
+              else if (expectedType != actualType
+                  && expectedType.isBasicType && actualType.isBasicType) {
+                // do casting
+                if (actualType.asInstanceOf[BasicTypeInfo[_]].shouldAutocastTo(
+                    expectedType.asInstanceOf[BasicTypeInfo[_]])) {
+                  Cast(actualExpr, expectedType)
+                }
+                // casting not possible
+                else {
+                  errors += s"Incompatible types for '$functionName'. " +
+                    s"Expected: $expectedType, Actual: $actualType"
+                  actualExpr
+                }
+              }
+              // casting not possible
+              else {
+                errors += s"Incompatible types for '$functionName'. " +
+                    s"Expected: $expectedType, Actual: $actualType"
+                actualExpr
+              }
+            })
+            ResolvedRowFunctionCall(functionName, similarInfo.returnType, castedArgExprs)
+          }
+          // not unique
+          else if (similarFunctions.size > 1) {
+            errors += s"Function call '$functionName' is ambiguous."
+            call
+          }
+          // not existing
+          else {
+            errors += s"Function call '$functionName' is invalid: ${argExprs.mkString(" ")}."
+            call
+          }
+        }
+    }
+
+    if (errors.length > 0) {
+      throw new ExpressionException(
+        s"""Invalid expression "$expr": ${errors.mkString(" ")}""")
+    }
+
+    result
+
+  }
+}

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/SelectionAnalyzer.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/expressions/analysis/SelectionAnalyzer.scala
@@ -18,17 +18,19 @@
 package org.apache.flink.api.table.expressions.analysis
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.api.table.trees.Analyzer
 
 /**
  * This analyzes selection expressions.
  */
-class SelectionAnalyzer(inputFields: Seq[(String, TypeInformation[_])])
+class SelectionAnalyzer(config: TableConfig, inputFields: Seq[(String, TypeInformation[_])])
   extends Analyzer[Expression] {
 
   def rules = Seq(
     new ResolveFieldReferences(inputFields),
+    new ResolveRowFunctionCalls(config),
     new VerifyNoNestedAggregates,
     new InsertAutoCasts,
     new TypeCheck)

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/parser/ExpressionParser.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/parser/ExpressionParser.scala
@@ -17,12 +17,11 @@
  */
 package org.apache.flink.api.table.parser
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.api.table.ExpressionException
-import org.apache.flink.api.table.plan.As
 import org.apache.flink.api.table.expressions._
 
-import scala.util.parsing.combinator.{PackratParsers, JavaTokenParsers}
+import scala.util.parsing.combinator.{JavaTokenParsers, PackratParsers}
 
 /**
  * Parser for expressions inside a String. This parses exactly the same expressions that
@@ -136,10 +135,18 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
 
     }
 
+  lazy val functionCall = ident ~ "(" ~ rep1sep(expression, ",") ~ ")" ^^ {
+    case name ~ _ ~ args ~ _ => Call(name, args: _*)
+  }
+
+  lazy val functionCallWithoutArgs = ident ~ "()" ^^ {
+    case name ~ _ => Call(name)
+  }
+
   lazy val suffix =
     isNull | isNotNull |
       abs | sum | min | max | count | avg | cast |
-      substring | substringWithoutEnd | atom
+      substring | substringWithoutEnd | functionCall | functionCallWithoutArgs | atom
 
 
   // unary ops

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/ExpandAggregations.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/ExpandAggregations.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.table.plan
 
+import org.apache.flink.api.table.TableConfig
 import org.apache.flink.api.table.expressions.analysis.SelectionAnalyzer
 import org.apache.flink.api.table.expressions._
 import org.apache.flink.api.java.aggregation.Aggregations
@@ -43,7 +44,7 @@ import scala.collection.mutable
  * If the input of the [[Select]] is a [[GroupBy]] this is preserved before the aggregation.
  */
 object ExpandAggregations {
-  def apply(select: Select): PlanNode = select match {
+  def apply(config: TableConfig, select: Select): PlanNode = select match {
     case Select(input, selection) =>
 
       val aggregations = mutable.HashMap[(Expression, Aggregations), String]()
@@ -111,11 +112,12 @@ object ExpandAggregations {
         }
       }
 
-      val intermediateAnalyzer = new SelectionAnalyzer(input.outputFields)
+      val intermediateAnalyzer = new SelectionAnalyzer(config, input.outputFields)
       val analyzedIntermediates = intermediateFields.toSeq.map(intermediateAnalyzer.analyze)
 
       val finalAnalyzer =
-        new SelectionAnalyzer(analyzedIntermediates.map(e => (e.name, e.typeInfo)))
+        new SelectionAnalyzer(config: TableConfig,
+          analyzedIntermediates.map(e => (e.name, e.typeInfo)))
       val analyzedFinals = finalFields.map(finalAnalyzer.analyze)
 
       val result = input match {

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/PlanTranslator.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/plan/PlanTranslator.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.table.parser.ExpressionParser
 import org.apache.flink.api.table.expressions.{Expression, Naming, ResolvedFieldReference, UnresolvedFieldReference}
 import org.apache.flink.api.table.typeinfo.RowTypeInfo
-import org.apache.flink.api.table.{ExpressionException, Table}
+import org.apache.flink.api.table.{TableConfig, ExpressionException, Table}
 
 import scala.language.reflectiveCalls
 
@@ -32,7 +32,7 @@ import scala.language.reflectiveCalls
  * Base class for translators that transform the logical plan in a [[Table]] to an executable
  * Flink plan and also for creating a [[Table]] from a DataSet or DataStream.
  */
-abstract class PlanTranslator {
+abstract class PlanTranslator(config: TableConfig) {
 
   type Representation[A] <: { def getType(): TypeInformation[A] }
 
@@ -98,8 +98,7 @@ abstract class PlanTranslator {
         val expressions = rowTypeInfo.getFieldNames map {
           name => (name, rowTypeInfo.getTypeAt(name))
         }
-        new Table(
-          Root(repr, expressions))
+        new Table(config, Root(repr, expressions))
 
       case c: CompositeType[A] => // us ok
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionFilterFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionFilterFunction.scala
@@ -31,7 +31,7 @@ import org.apache.flink.configuration.Configuration
 class ExpressionFilterFunction[T](
     predicate: Expression,
     inputType: CompositeType[T],
-    config: TableConfig = TableConfig.DEFAULT) extends RichFilterFunction[T] {
+    config: TableConfig) extends RichFilterFunction[T] {
 
   var compiledFilter: FilterFunction[T] = null
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionJoinFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionJoinFunction.scala
@@ -35,7 +35,7 @@ class ExpressionJoinFunction[L, R, O](
     rightType: CompositeType[R],
     resultType: CompositeType[O],
     outputFields: Seq[Expression],
-    config: TableConfig = TableConfig.DEFAULT) extends RichFlatJoinFunction[L, R, O] {
+    config: TableConfig) extends RichFlatJoinFunction[L, R, O] {
 
   var compiledJoin: FlatJoinFunction[L, R, O] = null
 

--- a/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionSelectFunction.scala
+++ b/flink-staging/flink-table/src/main/scala/org/apache/flink/api/table/runtime/ExpressionSelectFunction.scala
@@ -32,7 +32,7 @@ class ExpressionSelectFunction[I, O](
      inputType: CompositeType[I],
      resultType: CompositeType[O],
      outputFields: Seq[Expression],
-     config: TableConfig = TableConfig.DEFAULT) extends RichMapFunction[I, O] {
+     config: TableConfig) extends RichMapFunction[I, O] {
 
   var compiledSelect: MapFunction[I, O] = null
 

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
@@ -55,7 +55,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class AggregationsITCase extends MultipleProgramsTestBase {
 
-
 	public AggregationsITCase(TestExecutionMode mode){
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/AsITCase.java
@@ -35,7 +35,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class AsITCase extends MultipleProgramsTestBase {
 
-
 	public AsITCase(TestExecutionMode mode){
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CastingITCase.java
@@ -37,7 +37,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class CastingITCase extends MultipleProgramsTestBase {
 
-
 	public CastingITCase(TestExecutionMode mode){
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CustomRowFunctionsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/CustomRowFunctionsITCase.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.java.table.test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.DataSource;
+import org.apache.flink.api.java.table.TableEnvironment;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.RowFunction;
+import org.apache.flink.api.table.Table;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class CustomRowFunctionsITCase extends MultipleProgramsTestBase {
+
+	public CustomRowFunctionsITCase(TestExecutionMode mode){
+		super(mode);
+	}
+
+	@Test
+	public void testOneArgFunction() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		RowFunction<String> rf = new RowFunction<String>() {
+			@Override
+			public String call(Object[] args) {
+				return ((String) args[0]).trim();
+			}
+		};
+
+		tableEnv.getConfig().registerRowFunction("TRIM", rf, BasicTypeInfo.STRING_TYPE_INFO);
+
+		DataSource<Tuple1<String>> input = env.fromElements(
+				new Tuple1<>(" 1 "),
+				new Tuple1<>(" 	2 "),
+				new Tuple1<>(" 		3 "));
+
+		Table table = tableEnv.fromDataSet(input);
+
+		Table result = table.select("TRIM(f0)");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "1\n2\n3";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testZeroArgFunction() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		RowFunction<Long> rf = new RowFunction<Long>() {
+			@Override
+			public Long call(Object[] args) {
+				return 654654654L;
+			}
+		};
+
+		tableEnv.getConfig().registerRowFunction("SYSTEM_TIME", rf);
+
+		DataSource<Tuple1<String>> input = env.fromElements(new Tuple1<>(" 1 "));
+
+		Table table = tableEnv.fromDataSet(input);
+
+		Table result = table.select("SYSTEM_TIME(), SYSTEM_TIME(), SYSTEM_TIME()");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "654654654,654654654,654654654";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testMultiArgFunction() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		RowFunction<String> rf = new RowFunction<String>() {
+			@Override
+			public String call(Object[] args) {
+				return ((String) args[0]).substring((Integer) args[1], (Integer) args[2]);
+			}
+		};
+
+		tableEnv.getConfig().registerRowFunction(
+				"SUBSTRING",
+				rf,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO);
+
+		DataSource<Tuple1<String>> input = env.fromElements(new Tuple1<>("Hello World"));
+
+		Table table = tableEnv.fromDataSet(input);
+
+		Table result = table.select("SUBSTRING(SUBSTRING(f0, 2, 5), 0, 1)");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "l";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testFunctionWithCasting() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+		RowFunction<Date> rf = new RowFunction<Date>() {
+			@Override
+			public Date call(Object[] args) {
+				return new Date((Long) args[0]);
+			}
+		};
+
+		tableEnv.getConfig().registerRowFunction("LONG2DATE", rf, BasicTypeInfo.LONG_TYPE_INFO);
+
+		DataSource<Tuple1<Integer>> input = env.fromElements(new Tuple1<>(1000));
+
+		Table table = tableEnv.fromDataSet(input);
+
+		Table result = table.select("LONG2DATE(f0)");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "Thu Jan 01 00:00:01 UTC 1970";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testFunctionOverloading() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		RowFunction<String> rf = new RowFunction<String>() {
+			@Override
+			public String call(Object[] args) {
+				if (args.length == 2) {
+					return ((String) args[0]).substring((Integer) args[1]);
+				}
+				return ((String) args[0]).substring((Integer) args[1], (Integer) args[2]);
+			}
+		};
+
+		tableEnv.getConfig().registerRowFunction(
+				"SUBSTRING",
+				rf,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO);
+
+		tableEnv.getConfig().registerRowFunction(
+				"SUBSTRING",
+				rf,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO);
+
+		DataSource<Tuple1<String>> input = env.fromElements(new Tuple1<>("Hello World"));
+
+		Table table = tableEnv.fromDataSet(input);
+
+		Table result = table.select("SUBSTRING(f0, 1), SUBSTRING(f0, 2, 5)");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "ello World,llo";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testFunctionWithNull() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = new TableEnvironment();
+
+		RowFunction<String> rf = new RowFunction<String>() {
+			@Override
+			public String call(Object[] args) {
+				return ((String) args[0]).trim();
+			}
+		};
+
+		tableEnv.getConfig().registerRowFunction("TRIM", rf, BasicTypeInfo.STRING_TYPE_INFO);
+
+		DataSource<Tuple1<String>> input = env.fromElements(
+				new Tuple1<>(" 1 "),
+				new Tuple1<>(" 	2 "),
+				new Tuple1<>(" 		3 "));
+
+		Table table = tableEnv.fromDataSet(input);
+
+		Table result = table.select("TRIM(f0)");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "1\n2\n3";
+		compareResultAsText(results, expected);
+	}
+
+}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
@@ -37,7 +37,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class ExpressionsITCase extends MultipleProgramsTestBase {
 
-
 	public ExpressionsITCase(TestExecutionMode mode){
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FilterITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/FilterITCase.java
@@ -35,7 +35,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class FilterITCase extends MultipleProgramsTestBase {
 
-
 	public FilterITCase(TestExecutionMode mode){
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/GroupedAggregationsITCase.java
@@ -36,7 +36,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class GroupedAggregationsITCase extends MultipleProgramsTestBase {
 
-
 	public GroupedAggregationsITCase(TestExecutionMode mode){
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/JoinITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/JoinITCase.java
@@ -37,7 +37,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class JoinITCase extends MultipleProgramsTestBase {
 
-
 	public JoinITCase(TestExecutionMode mode) {
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/SelectITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/SelectITCase.java
@@ -36,7 +36,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class SelectITCase extends MultipleProgramsTestBase {
 
-
 	public SelectITCase(TestExecutionMode mode) {
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/StringExpressionsITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/StringExpressionsITCase.java
@@ -35,7 +35,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class StringExpressionsITCase extends MultipleProgramsTestBase {
 
-
 	public StringExpressionsITCase(TestExecutionMode mode) {
 		super(mode);
 	}

--- a/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
+++ b/flink-staging/flink-table/src/test/java/org/apache/flink/api/java/table/test/UnionITCase.java
@@ -37,7 +37,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class UnionITCase extends MultipleProgramsTestBase {
 
-
 	public UnionITCase(TestExecutionMode mode) {
 		super(mode);
 	}


### PR DESCRIPTION
As described in FLINK-3097, this PR implements the possibility of adding custom row functions for the Table API.

In the tests you can find some examples how custom functions can look like:
```
table.select("TRIM(f0)")
table.select("SYSTEM_TIME()")
table.select("SUBSTRING(SUBSTRING(f0, 2, 5), 0, 1)")
table.select("SUBSTRING(f0, 1), SUBSTRING(f0, 2, 5)")
```

The Scala Table API is not supported yet, since I'm still waiting for #1237.