### PR TITLE
[FLINK-3057][py] Bidirectional Connection

### DIFF
--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/functions/PythonCoGroup.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/functions/PythonCoGroup.java
@@ -14,7 +14,7 @@ package org.apache.flink.python.api.functions;
 
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.python.api.streaming.PythonStreamer;
+import org.apache.flink.python.api.streaming.data.PythonStreamer;
 import org.apache.flink.util.Collector;
 import java.io.IOException;
 import org.apache.flink.api.common.functions.RichCoGroupFunction;

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/functions/PythonCombineIdentity.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/functions/PythonCombineIdentity.java
@@ -13,7 +13,7 @@
 package org.apache.flink.python.api.functions;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.python.api.streaming.PythonStreamer;
+import org.apache.flink.python.api.streaming.data.PythonStreamer;
 import org.apache.flink.util.Collector;
 import java.io.IOException;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/functions/PythonMapPartition.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/functions/PythonMapPartition.java
@@ -17,7 +17,7 @@ import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.python.api.streaming.PythonStreamer;
+import org.apache.flink.python.api.streaming.data.PythonStreamer;
 import org.apache.flink.util.Collector;
 
 /**

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonSender.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonSender.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.flink.python.api.streaming;
+package org.apache.flink.python.api.streaming.data;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -23,7 +23,6 @@ import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.java.tuple.Tuple;
 import static org.apache.flink.python.api.PythonPlanBinder.FLINK_TMP_DATA_DIR;
 import static org.apache.flink.python.api.PythonPlanBinder.MAPPED_FILE_SIZE;
@@ -32,7 +31,7 @@ import org.apache.flink.python.api.types.CustomTypeWrapper;
 /**
  * General-purpose class to write data to memory-mapped files.
  */
-public class Sender implements Serializable {
+public class PythonSender implements Serializable {
 	public static final byte TYPE_TUPLE = (byte) 11;
 	public static final byte TYPE_BOOLEAN = (byte) 10;
 	public static final byte TYPE_BYTE = (byte) 9;
@@ -46,8 +45,6 @@ public class Sender implements Serializable {
 	public static final byte TYPE_BYTES = (byte) 1;
 	public static final byte TYPE_NULL = (byte) 0;
 
-	private final AbstractRichFunction function;
-
 	private File outputFile;
 	private RandomAccessFile outputRAF;
 	private FileChannel outputChannel;
@@ -56,10 +53,6 @@ public class Sender implements Serializable {
 	private final ByteBuffer[] saved = new ByteBuffer[2];
 
 	private final Serializer[] serializer = new Serializer[2];
-
-	public Sender(AbstractRichFunction function) {
-		this.function = function;
-	}
 
 	//=====Setup========================================================================================================
 	public void open(String path) throws IOException {

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonStreamer.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonStreamer.java
@@ -10,8 +10,9 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.flink.python.api.streaming;
+package org.apache.flink.python.api.streaming.data;
 
+import org.apache.flink.python.api.streaming.util.StreamPrinter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -66,8 +67,8 @@ public class PythonStreamer implements Serializable {
 	protected OutputStream out;
 	protected int port;
 
-	protected Sender sender;
-	protected Receiver receiver;
+	protected PythonSender sender;
+	protected PythonReceiver receiver;
 
 	protected StringBuilder msg = new StringBuilder();
 
@@ -78,8 +79,8 @@ public class PythonStreamer implements Serializable {
 		this.usePython3 = PythonPlanBinder.usePython3;
 		this.debug = DEBUG;
 		planArguments = PythonPlanBinder.arguments.toString();
-		sender = new Sender(function);
-		receiver = new Receiver(function);
+		sender = new PythonSender();
+		receiver = new PythonReceiver();
 		this.function = function;
 	}
 

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanReceiver.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanReceiver.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.flink.python.api.streaming.plan;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import org.apache.flink.api.java.tuple.Tuple;
+import static org.apache.flink.python.api.streaming.data.PythonReceiver.createTuple;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_BOOLEAN;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_BYTE;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_BYTES;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_DOUBLE;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_FLOAT;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_INTEGER;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_LONG;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_NULL;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_SHORT;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_STRING;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_TUPLE;
+import org.apache.flink.python.api.types.CustomTypeWrapper;
+
+/**
+ * Instances of this class can be used to receive data from the plan process.
+ */
+public class PythonPlanReceiver implements Serializable {
+	private final DataInputStream input;
+
+	public PythonPlanReceiver(InputStream input) {
+		this.input = new DataInputStream(input);
+	}
+
+	public Object getRecord() throws IOException {
+		return getRecord(false);
+	}
+
+	public Object getRecord(boolean normalized) throws IOException {
+		return receiveField(normalized);
+	}
+
+	private Object receiveField(boolean normalized) throws IOException {
+		byte type = (byte) input.readByte();
+		switch (type) {
+			case TYPE_TUPLE:
+				int tupleSize = input.readByte();
+				Tuple tuple = createTuple(tupleSize);
+				for (int x = 0; x < tupleSize; x++) {
+					tuple.setField(receiveField(normalized), x);
+				}
+				return tuple;
+			case TYPE_BOOLEAN:
+				return input.readByte() == 1;
+			case TYPE_BYTE:
+				return (byte) input.readByte();
+			case TYPE_SHORT:
+				if (normalized) {
+					return (int) input.readShort();
+				} else {
+					return input.readShort();
+				}
+			case TYPE_INTEGER:
+				return input.readInt();
+			case TYPE_LONG:
+				if (normalized) {
+					return new Long(input.readLong()).intValue();
+				} else {
+					return input.readLong();
+				}
+			case TYPE_FLOAT:
+				if (normalized) {
+					return (double) input.readFloat();
+				} else {
+					return input.readFloat();
+				}
+			case TYPE_DOUBLE:
+				return input.readDouble();
+			case TYPE_STRING:
+				int stringSize = input.readInt();
+				byte[] string = new byte[stringSize];
+				input.readFully(string);
+				return new String(string);
+			case TYPE_BYTES:
+				int bytessize = input.readInt();
+				byte[] bytes = new byte[bytessize];
+				input.readFully(bytes);
+				return bytes;
+			case TYPE_NULL:
+				return null;
+			default:
+				int size = input.readInt();
+				byte[] data = new byte[size];
+				input.readFully(data);
+				return new CustomTypeWrapper(type, data);
+		}
+	}
+}

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanSender.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanSender.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.flink.python.api.streaming.plan;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import org.apache.flink.api.java.tuple.Tuple;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_BOOLEAN;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_BYTE;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_BYTES;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_DOUBLE;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_FLOAT;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_INTEGER;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_LONG;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_NULL;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_SHORT;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_STRING;
+import static org.apache.flink.python.api.streaming.data.PythonSender.TYPE_TUPLE;
+import org.apache.flink.python.api.types.CustomTypeWrapper;
+
+/**
+ * Instances of this class can be used to send data to the plan process.
+ */
+public class PythonPlanSender implements Serializable {
+	private final DataOutputStream output;
+
+	public PythonPlanSender(OutputStream output) {
+		this.output = new DataOutputStream(output);
+	}
+
+	public void sendRecord(Object record) throws IOException {
+		String className = record.getClass().getSimpleName().toUpperCase();
+		if (className.startsWith("TUPLE")) {
+			className = "TUPLE";
+		}
+		if (className.startsWith("BYTE[]")) {
+			className = "BYTES";
+		}
+		SupportedTypes type = SupportedTypes.valueOf(className);
+		switch (type) {
+			case TUPLE:
+				output.write(TYPE_TUPLE);
+				int arity = ((Tuple) record).getArity();
+				output.writeInt(arity);
+				for (int x = 0; x < arity; x++) {
+					sendRecord(((Tuple) record).getField(x));
+				}
+				return;
+			case BOOLEAN:
+				output.write(TYPE_BOOLEAN);
+				output.write(((Boolean) record) ? (byte) 1 : (byte) 0);
+				return;
+			case BYTE:
+				output.write(TYPE_BYTE);
+				output.write((Byte) record);
+				return;
+			case BYTES:
+				output.write(TYPE_BYTES);
+				output.write((byte[]) record, 0, ((byte[]) record).length);
+				return;
+			case CHARACTER:
+				output.write(TYPE_STRING);
+				output.writeChars(((Character) record) + "");
+				return;
+			case SHORT:
+				output.write(TYPE_SHORT);
+				output.writeShort((Short) record);
+				return;
+			case INTEGER:
+				output.write(TYPE_INTEGER);
+				output.writeInt((Integer) record);
+				return;
+			case LONG:
+				output.write(TYPE_LONG);
+				output.writeLong((Long) record);
+				return;
+			case STRING:
+				output.write(TYPE_STRING);
+				output.writeBytes((String) record);
+				return;
+			case FLOAT:
+				output.write(TYPE_FLOAT);
+				output.writeFloat((Float) record);
+				return;
+			case DOUBLE:
+				output.write(TYPE_DOUBLE);
+				output.writeDouble((Double) record);
+				return;
+			case NULL:
+				output.write(TYPE_NULL);
+				return;
+			case CUSTOMTYPEWRAPPER:
+				output.write(((CustomTypeWrapper) record).getType());
+				output.write(((CustomTypeWrapper) record).getData());
+				return;
+			default:
+				throw new IllegalArgumentException("Unknown Type encountered: " + type);
+		}
+	}
+	
+	private enum SupportedTypes {
+		TUPLE, BOOLEAN, BYTE, BYTES, CHARACTER, SHORT, INTEGER, LONG, FLOAT, DOUBLE, STRING, OTHER, NULL, CUSTOMTYPEWRAPPER
+	}
+}

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanStreamer.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanStreamer.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.flink.python.api.streaming.plan;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.ServerSocket;
+import java.net.Socket;
+import org.apache.flink.python.api.streaming.util.StreamPrinter;
+import static org.apache.flink.python.api.PythonPlanBinder.FLINK_PYTHON2_BINARY_PATH;
+import static org.apache.flink.python.api.PythonPlanBinder.FLINK_PYTHON3_BINARY_PATH;
+import static org.apache.flink.python.api.PythonPlanBinder.FLINK_PYTHON_PLAN_NAME;
+import static org.apache.flink.python.api.PythonPlanBinder.usePython3;
+
+/**
+ * Generic class to exchange data during the plan phase.
+ */
+public class PythonPlanStreamer implements Serializable {
+	protected PythonPlanSender sender;
+	protected PythonPlanReceiver receiver;
+
+	private Process process;
+	private ServerSocket server;
+	private Socket socket;
+
+	public Object getRecord() throws IOException {
+		return getRecord(false);
+	}
+
+	public Object getRecord(boolean normalize) throws IOException {
+		return receiver.getRecord(normalize);
+	}
+
+	public void sendRecord(Object record) throws IOException {
+		sender.sendRecord(record);
+	}
+
+	public void open(String tmpPath, String args) throws IOException {
+		server = new ServerSocket(0);
+		startPython(tmpPath, args);
+		socket = server.accept();
+		sender = new PythonPlanSender(socket.getOutputStream());
+		receiver = new PythonPlanReceiver(socket.getInputStream());
+	}
+
+	private void startPython(String tmpPath, String args) throws IOException {
+		String pythonBinaryPath = usePython3 ? FLINK_PYTHON3_BINARY_PATH : FLINK_PYTHON2_BINARY_PATH;
+
+		try {
+			Runtime.getRuntime().exec(pythonBinaryPath);
+		} catch (IOException ex) {
+			throw new RuntimeException(pythonBinaryPath + " does not point to a valid python binary.");
+		}
+		process = Runtime.getRuntime().exec(pythonBinaryPath + " -B " + tmpPath + FLINK_PYTHON_PLAN_NAME + args);
+
+		new StreamPrinter(process.getInputStream()).start();
+		new StreamPrinter(process.getErrorStream()).start();
+
+		try {
+			Thread.sleep(2000);
+		} catch (InterruptedException ex) {
+		}
+
+		try {
+			int value = process.exitValue();
+			if (value != 0) {
+				throw new RuntimeException("Plan file caused an error. Check log-files for details.");
+			}
+			if (value == 0) {
+				throw new RuntimeException("Plan file exited prematurely without an error.");
+			}
+		} catch (IllegalThreadStateException ise) {//Process still running
+		}
+
+		process.getOutputStream().write("plan\n".getBytes());
+		process.getOutputStream().write((server.getLocalPort() + "\n").getBytes());
+		process.getOutputStream().flush();
+	}
+
+	public void close() {
+		try {
+			process.exitValue();
+		} catch (NullPointerException npe) { //exception occurred before process was started
+		} catch (IllegalThreadStateException ise) { //process still active
+			process.destroy();
+		}
+	}
+}

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/util/StreamPrinter.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/util/StreamPrinter.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.flink.python.api.streaming;
+package org.apache.flink.python.api.streaming.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;


### PR DESCRIPTION
This PR allows bidirectional data exchange during the plan phase.
To do this the following changes were made:
* replaced OneWayMappedFileConnection with a simple TCP connection
* added an iterator to the python ExEnv to deserialize data during the plan phase 
* added a new java Streamer class, providing the PlanBinder with a single access point to both send and receive data

A proof-of-concept JobExecutionResult was added as well, providing access to getNetRuntime()

Most of the changes in this PR ended up as a refactoring of related classes. The data exchange code was residing completely within the PythonStreamer, Sender and Receiver classes, regardless of the phase(plan or runtime)they are used. All these classes are now split into classes for the respective phase: PythonSender/-Receiver/-Streamer are used at runtime, PythonPlanSender/-Receiver/-Streamer during the plan phase. Additionally, these classes were renamed to be more consistent, and moved into separate packages.

These changes are mostly about consistency. Process spawning is **always** handled within a Streamer class, which is also **always** used as the access point for both sending and receiving data. There is also no longer a (non-obvious) overlap in methods used in both phases, which frequently caused issues when these were modified.

This PR also includes a fix for FLINK-3014, switching from InputStream.read() to DataInputStream.readFully().