### PR TITLE
[contrib, connector-wikiedits] Add WikipediaEditsSource

### DIFF
--- a/flink-contrib/flink-connector-wikiedits/README.md
+++ b/flink-contrib/flink-connector-wikiedits/README.md
@@ -1,0 +1,38 @@
+# flink-connector-wikiedits
+
+A non-parallel source that parses a live stream of Wikipedia edits.
+
+Meta data about the edits is mirrored to the IRC channel `#en.wikipedia`. The
+source establishes a connection to this IRC channel and parses the messages
+into `WikipediaEditEvent` instances.
+
+The purpose of this source is to ease the setup of demos of the `DataStream`
+API with live data.
+
+The original idea is from the [Hello Samza](https://samza.apache.org/startup/hello-samza/latest/)
+project of [Apache Samza](http://samza.apache.org). The Samza code for this is located in the
+[samza-hello-samza](https://github.com/apache/samza-hello-samza) repository.
+
+## Example
+
+Add the following dependency to your project:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-connector-wikiedits</artifactId>
+  <version>1.0-SNAPSHOT</version>
+</dependency>
+```
+
+You can use the source like regular sources:
+
+```java
+StreamExecutionEnvironment env = StreamExecutionEnvironment
+    .getExecutionEnvironment();
+
+DataStream<WikipediaEditEvent> edits = env
+    .addSource(new WikipediaEditsSource());
+```
+Remember that it is *non-parallel* source and as such it will run with
+parallelism 1.

--- a/flink-contrib/flink-connector-wikiedits/pom.xml
+++ b/flink-contrib/flink-connector-wikiedits/pom.xml
@@ -16,33 +16,35 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-parent</artifactId>
+		<artifactId>flink-contrib-parent</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
-	<modules>
-		<module>flink-storm</module>
-		<module>flink-storm-examples</module>
-		<module>flink-streaming-contrib</module>
-		<module>flink-tweet-inputformat</module>
-		<module>flink-operator-stats</module>
-		<module>flink-connector-wikiedits</module>
-	</modules>
+	<artifactId>flink-connector-wikiedits</artifactId>
+	<name>flink-connector-wikiedits</name>
 
-	<artifactId>flink-contrib-parent</artifactId>
-	<name>flink-contrib</name>
+	<packaging>jar</packaging>
 
-	<packaging>pom</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
+		<dependency>
+			<groupId>org.schwering</groupId>
+			<artifactId>irclib</artifactId>
+			<version>1.10</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditEvent.java
+++ b/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditEvent.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.wikiedits;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WikipediaEditEvent {
+
+	// Metadata
+	private final long timestamp;
+	private final String channel;
+
+	// Edit attributes
+	private final String title;
+	private final String diffUrl;
+	private final String user;
+	private final int byteDiff;
+	private final String summary;
+	private final int flags;
+
+	public WikipediaEditEvent(
+			long timestamp,
+			String channel,
+			String title,
+			String diffUrl,
+			String user,
+			int byteDiff,
+			String summary,
+			boolean isMinor,
+			boolean isNew,
+			boolean isUnpatrolled,
+			boolean isBotEdit,
+			boolean isSpecial,
+			boolean isTalk) {
+
+		if (channel == null || title == null || diffUrl == null ||
+				user == null || summary == null) {
+			throw new NullPointerException();
+		}
+
+		this.timestamp = timestamp;
+		this.channel = channel;
+
+		this.title = title;
+		this.diffUrl = diffUrl;
+		this.user = user;
+		this.byteDiff = byteDiff;
+		this.summary = summary;
+		this.flags = getFlags(
+				isMinor,
+				isNew,
+				isUnpatrolled,
+				isBotEdit,
+				isSpecial,
+				isTalk);
+	}
+
+	/**
+	 * Returns the timestamp when this event arrived at the source.
+	 *
+	 * @return The timestamp assigned at the source.
+	 */
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	public String getChannel() {
+		return channel;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getDiffUrl() {
+		return diffUrl;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public int getByteDiff() {
+		return byteDiff;
+	}
+
+	public String getSummary() {
+		return summary;
+	}
+
+	public boolean isMinor() {
+		return (flags & IS_MINOR) > 0;
+	}
+
+	public boolean isNew() {
+		return (flags & IS_NEW) > 0;
+	}
+
+	public boolean isUnpatrolled() {
+		return (flags & IS_UNPATROLLED) > 0;
+	}
+
+	public boolean isBotEdit() {
+		return (flags & IS_BOT_EDIT) > 0;
+	}
+
+	public boolean isSpecial() {
+		return (flags & IS_SPECIAL) > 0;
+	}
+
+	public boolean isTalk() {
+		return (flags & IS_TALK) > 0;
+	}
+
+	@Override
+	public String toString() {
+		return "WikipediaEditEvent{" +
+				"timestamp=" + timestamp +
+				", channel='" + channel + '\'' +
+				", title='" + title + '\'' +
+				", diffUrl='" + diffUrl + '\'' +
+				", user='" + user + '\'' +
+				", byteDiff=" + byteDiff +
+				", summary='" + summary + '\'' +
+				", flags=" + flags +
+				'}';
+	}
+
+	// - Flags ----------------------------------------------------------------
+
+	private static final byte IS_MINOR = 0B000001;
+	private static final byte IS_NEW = 0B000010;
+	private static final byte IS_UNPATROLLED = 0B000100;
+	private static final byte IS_BOT_EDIT = 0B001000;
+	private static final byte IS_SPECIAL = 0B010000;
+	private static final byte IS_TALK = 0B100000;
+
+	private byte getFlags(
+			boolean isMinor,
+			boolean isNew,
+			boolean isUnpatrolled,
+			boolean isBotEdit,
+			boolean isSpecial,
+			boolean isTalk) {
+
+		byte flag = 0;
+		flag |= isMinor ? IS_MINOR : flag;
+		flag |= isNew ? IS_NEW : flag;
+		flag |= isUnpatrolled ? IS_UNPATROLLED : flag;
+		flag |= isBotEdit ? IS_BOT_EDIT : flag;
+		flag |= isSpecial ? IS_SPECIAL : flag;
+		flag |= isTalk ? IS_TALK : flag;
+
+		return flag;
+	}
+
+	// - Parser ---------------------------------------------------------------
+
+	/** Expected pattern of raw events. */
+	private static final Pattern p = Pattern.compile("\\[\\[(.*)\\]\\]\\s(.*)\\s(.*)\\s\\*\\s(.*)\\s\\*\\s\\(\\+?(.\\d*)\\)\\s(.*)");
+
+	public static WikipediaEditEvent fromRawEvent(
+			long timestamp,
+			String channel,
+			String rawEvent) {
+		final Matcher m = p.matcher(rawEvent);
+
+		if (m.find() && m.groupCount() == 6) {
+			String title = m.group(1);
+			String flags = m.group(2);
+			String diffUrl = m.group(3);
+			String user = m.group(4);
+			int byteDiff = Integer.parseInt(m.group(5));
+			String summary = m.group(6);
+
+			boolean isMinor = flags.contains("M");
+			boolean isNew = flags.contains("N");
+			boolean isUnpatrolled = flags.contains("!");
+			boolean isBotEdit = flags.contains("B");
+			boolean isSpecial = title.startsWith("Special:");
+			boolean isTalk = title.startsWith("Talk:");
+
+			return new WikipediaEditEvent(
+					timestamp,
+					channel,
+					title,
+					diffUrl,
+					user,
+					byteDiff,
+					summary,
+					isMinor,
+					isNew,
+					isUnpatrolled,
+					isBotEdit,
+					isSpecial,
+					isTalk);
+		}
+
+		return null;
+	}
+}

--- a/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditEventIrcStream.java
+++ b/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditEventIrcStream.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.wikiedits;
+
+import org.schwering.irc.lib.IRCConnection;
+import org.schwering.irc.lib.IRCEventListener;
+import org.schwering.irc.lib.IRCModeParser;
+import org.schwering.irc.lib.IRCUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+class WikipediaEditEventIrcStream {
+
+	private static final Logger LOG = LoggerFactory.getLogger(WikipediaEditEventIrcStream.class);
+
+	/** Bounded queue of edit events from the channel. */
+	private final BlockingQueue<WikipediaEditEvent> edits =
+			new ArrayBlockingQueue<>(128);
+
+	/** IRC connection (Thread). */
+	private IRCConnection conn;
+
+	WikipediaEditEventIrcStream(String host, int port) {
+		final String nick = "flink-bot-" + (int) (Math.random() * 1000);
+		this.conn = new IRCConnection(host, new int[] { port}, "", nick, nick, nick);
+		conn.addIRCEventListener(new WikipediaIrcChannelListener(edits));
+		conn.setEncoding("UTF-8");
+		conn.setPong(true);
+		conn.setColors(false);
+		conn.setDaemon(true);
+		conn.setName("WikipediaEditEventIrcStreamThread");
+	}
+
+	void start() throws IOException {
+		if (!conn.isConnected()) {
+			conn.connect();
+		}
+	}
+
+	void stop() throws InterruptedException {
+		if (conn.isConnected()) {
+		}
+
+		conn.interrupt();
+		conn.join(5 * 1000);
+	}
+
+	BlockingQueue<WikipediaEditEvent> getEdits() {
+		return edits;
+	}
+
+	void join(String channel) {
+		conn.send("JOIN " + channel);
+	}
+
+	void leave(String channel) {
+		conn.send("PART " + channel);
+	}
+
+	// ------------------------------------------------------------------------
+	// IRC channel listener
+	// ------------------------------------------------------------------------
+
+	private static class WikipediaIrcChannelListener implements IRCEventListener {
+
+		private final BlockingQueue<WikipediaEditEvent> edits;
+
+		public WikipediaIrcChannelListener(BlockingQueue<WikipediaEditEvent> edits) {
+			if (edits == null) {
+				throw new NullPointerException();
+			}
+
+			this.edits = edits;
+		}
+
+		@Override
+		public void onPrivmsg(String target, IRCUser user, String msg) {
+			LOG.debug("[{}] {}: {}.", target, user.getNick(), msg);
+
+			WikipediaEditEvent event = WikipediaEditEvent.fromRawEvent(
+					System.currentTimeMillis(),
+					target,
+					msg);
+
+			if (event != null) {
+				if (!edits.offer(event)) {
+					LOG.debug("Dropping message, because of full queue.");
+				}
+			}
+		}
+
+		@Override
+		public void onRegistered() {
+			LOG.debug("Connected.");
+		}
+
+		@Override
+		public void onDisconnected() {
+			LOG.debug("Disconnected.");
+		}
+
+		@Override
+		public void onError(String msg) {
+			LOG.error("Error: '{}'.", msg);
+		}
+
+		@Override
+		public void onError(int num, String msg) {
+			LOG.error("Error #{}: '{}'.", num, msg);
+		}
+
+		@Override
+		public void onInvite(String chan, IRCUser user, String passiveNick) {
+			LOG.debug("[{}]: {} invites {}.", chan, user.getNick(), passiveNick);
+		}
+
+		@Override
+		public void onJoin(String chan, IRCUser user) {
+			LOG.debug("[{}]: {} joins.", chan, user.getNick());
+		}
+
+		@Override
+		public void onKick(String chan, IRCUser user, String passiveNick, String msg) {
+			LOG.debug("[{}]: {} kicks {}.", chan, user.getNick(), passiveNick);
+		}
+
+		@Override
+		public void onMode(String chan, IRCUser user, IRCModeParser modeParser) {
+			LOG.debug("[{}]: mode '{}'.", chan, modeParser.getLine());
+		}
+
+		@Override
+		public void onMode(IRCUser user, String passiveNick, String mode) {
+			LOG.debug("{} sets modes {} ({}).", user.getNick(), mode, passiveNick);
+		}
+
+		@Override
+		public void onNick(IRCUser user, String newNick) {
+			LOG.debug("{} is now known as {}.", user.getNick(), newNick);
+		}
+
+		@Override
+		public void onNotice(String target, IRCUser user, String msg) {
+			LOG.debug("[{}] {} (notice): {}.", target, user.getNick(), msg);
+		}
+
+		@Override
+		public void onPart(String chan, IRCUser user, String msg) {
+			LOG.debug("[{}] {} parts.", chan, user.getNick(), msg);
+		}
+
+		@Override
+		public void onPing(String ping) {
+		}
+
+		@Override
+		public void onQuit(IRCUser user, String msg) {
+			LOG.debug("Quit: {}.", user.getNick());
+		}
+
+		@Override
+		public void onReply(int num, String value, String msg) {
+			LOG.debug("Reply #{}: {} {}.", num, value, msg);
+		}
+
+		@Override
+		public void onTopic(String chan, IRCUser user, String topic) {
+			LOG.debug("[{}] {} changes topic into {}.", chan, user.getNick(), topic);
+		}
+
+		@Override
+		public void unknown(String prefix, String command, String middle, String trailing) {
+			LOG.warn("UNKNOWN: " + prefix + " " + command + " " + middle + " " + trailing);
+		}
+	}
+}

--- a/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
+++ b/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.wikiedits;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+
+import java.util.concurrent.TimeUnit;
+
+public class WikipediaEditsSource extends RichSourceFunction<WikipediaEditEvent> {
+
+	/** Hostname of the server to connect to. */
+	public static final String DEFAULT_HOST = "irc.wikimedia.org";
+
+	/** Port of the server to connect to. */
+	public static final int DEFAULT_PORT = 6667;
+
+	/** IRC channel to join */
+	public static final String DEFAULT_CHANNEL = "#en.wikipedia";
+
+	private final String host;
+	private final int port;
+	private final String channel;
+
+	private volatile boolean isRunning = true;
+
+	private WikipediaEditEventIrcStream ircStream;
+
+	/**
+	 * Creates a source reading {@link WikipediaEditEvent} instances from the
+	 * IRC channel <code>#en.wikipedia</code>.
+	 *
+	 * <p>This creates a separate Thread for the IRC connection.
+	 */
+	public WikipediaEditsSource() {
+		this(DEFAULT_HOST, DEFAULT_PORT, DEFAULT_CHANNEL);
+	}
+
+	/**
+	 * Creates a source reading {@link WikipediaEditEvent} instances from the
+	 * specified IRC channel.
+	 *
+	 * <p>In most cases, you want to use the default {@link #WikipediaEditsSource}
+	 * constructor. This constructor is meant to be used only if there is a
+	 * problem with the default constructor.
+	 *
+	 * @param host    The IRC server to connect to.
+	 * @param port    The port of the IRC server to connect to.
+	 * @param channel The channel to join. Messages not matching the expected
+	 *                format will be ignored.
+	 */
+	public WikipediaEditsSource(String host, int port, String channel) {
+		this.host = host;
+		this.port = port;
+		this.channel = channel;
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		ircStream = new WikipediaEditEventIrcStream(host, port);
+		ircStream.start();
+		ircStream.join(channel);
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (ircStream != null) {
+			ircStream.leave(channel);
+			ircStream.stop();
+		}
+	}
+
+	@Override
+	public void run(SourceContext ctx) throws Exception {
+		while (isRunning) {
+			// Query for the next edit event
+			WikipediaEditEvent edit = ircStream.getEdits()
+					.poll(100, TimeUnit.MILLISECONDS);
+
+			if (edit != null) {
+				ctx.collect(edit);
+			}
+		}
+	}
+
+	@Override
+	public void cancel() {
+		isRunning = false;
+	}
+}

--- a/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
+++ b/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.wikiedits;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class WikipediaEditsSourceTest {
+
+	@Test(timeout = 120 * 1000)
+	public void testWikipediaEditsSource() throws Exception {
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
+
+		DataStream<WikipediaEditEvent> edits = env.addSource(new WikipediaEditsSource());
+
+		edits.addSink(new SinkFunction<WikipediaEditEvent>() {
+			@Override
+			public void invoke(WikipediaEditEvent value) throws Exception {
+				throw new Exception("Expected test exception");
+			}
+		});
+
+		try {
+			env.execute();
+			fail("Did not throw expected Exception.");
+		}
+		catch (Exception e) {
+			assertNotNull(e.getCause());
+			assertEquals("Expected test exception", e.getCause().getMessage());
+		}
+	}
+}


### PR DESCRIPTION
A non-parallel source that parses a live stream of Wikipedia edits.

Meta data about the edits is mirrored to the IRC channel `#en.wikipedia`. The source establishes a connection to this IRC channel and parses the messages into `WikipediaEditEvent` instances.

The purpose of this source is to ease the setup of demos of the `DataStream` API with live data.

The original idea is from the [Hello Samza](https://samza.apache.org/startup/hello-samza/latest/) project of [Apache Samza](http://samza.apache.org). The Samza code for this is located in the [samza-hello-samza](https://github.com/apache/samza-hello-samza) repository.

## Example

Add the following dependency to your project:

```xml
<dependency>
  <groupId>org.apache.flink</groupId>
  <artifactId>flink-connector-wikiedits</artifactId>
  <version>1.0-SNAPSHOT</version>
</dependency>
```

You can use the source like regular sources:

```java
StreamExecutionEnvironment env = StreamExecutionEnvironment
    .getExecutionEnvironment();

DataStream<WikipediaEditEvent> edits = env
    .addSource(new WikipediaEditsSource());
```