### PR TITLE
[FLINK-3147] HadoopOutputFormatBase should expose mutexes for subclasses

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormatBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormatBase.java
@@ -58,15 +58,15 @@ public abstract class HadoopOutputFormatBase<K, V, T> extends HadoopOutputFormat
 	// Hadoop parallelizes tasks across JVMs which is why they might rely on this JVM isolation.
 	// In contrast, Flink parallelizes using Threads, so multiple Hadoop OutputFormat instances
 	// might be used in the same JVM.
-	private static final Object OPEN_MUTEX = new Object();
-	private static final Object CONFIGURE_MUTEX = new Object();
-	private static final Object CLOSE_MUTEX = new Object();
+	protected static final Object OPEN_MUTEX = new Object();
+	protected static final Object CONFIGURE_MUTEX = new Object();
+	protected static final Object CLOSE_MUTEX = new Object();
 
-	private JobConf jobConf;
-	private org.apache.hadoop.mapred.OutputFormat<K,V> mapredOutputFormat;
+	protected JobConf jobConf;
+	protected org.apache.hadoop.mapred.OutputFormat<K,V> mapredOutputFormat;
 	protected transient RecordWriter<K,V> recordWriter;
-	private transient OutputCommitter outputCommitter;
-	private transient TaskAttemptContext context;
+	protected transient OutputCommitter outputCommitter;
+	protected transient TaskAttemptContext context;
 
 	public HadoopOutputFormatBase(org.apache.hadoop.mapred.OutputFormat<K, V> mapredOutputFormat, JobConf job) {
 		super(job.getCredentials());

--- a/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopOutputFormatBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopOutputFormatBase.java
@@ -53,16 +53,16 @@ public abstract class HadoopOutputFormatBase<K, V, T> extends HadoopOutputFormat
 	// Hadoop parallelizes tasks across JVMs which is why they might rely on this JVM isolation.
 	// In contrast, Flink parallelizes using Threads, so multiple Hadoop OutputFormat instances
 	// might be used in the same JVM.
-	private static final Object OPEN_MUTEX = new Object();
-	private static final Object CONFIGURE_MUTEX = new Object();
-	private static final Object CLOSE_MUTEX = new Object();
+	protected static final Object OPEN_MUTEX = new Object();
+	protected static final Object CONFIGURE_MUTEX = new Object();
+	protected static final Object CLOSE_MUTEX = new Object();
 
-	private org.apache.hadoop.conf.Configuration configuration;
-	private org.apache.hadoop.mapreduce.OutputFormat<K,V> mapreduceOutputFormat;
+	protected org.apache.hadoop.conf.Configuration configuration;
+	protected org.apache.hadoop.mapreduce.OutputFormat<K,V> mapreduceOutputFormat;
 	protected transient RecordWriter<K,V> recordWriter;
-	private transient OutputCommitter outputCommitter;
-	private transient TaskAttemptContext context;
-	private transient int taskNumber;
+	protected transient OutputCommitter outputCommitter;
+	protected transient TaskAttemptContext context;
+	protected transient int taskNumber;
 
 	public HadoopOutputFormatBase(org.apache.hadoop.mapreduce.OutputFormat<K, V> mapreduceOutputFormat, Job job) {
 		super(job.getCredentials());


### PR DESCRIPTION
Simple patch.