### PR TITLE
[FLINK-3143] update Closure Cleaner's ASM references to ASM5

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -105,7 +105,7 @@ class This0AccessFinder extends ClassVisitor {
 	private String this0Name;
 
 	public This0AccessFinder(String this0Name) {
-		super(Opcodes.ASM4);
+		super(Opcodes.ASM5);
 		this.this0Name = this0Name;
 	}
 
@@ -115,7 +115,7 @@ class This0AccessFinder extends ClassVisitor {
 
 	@Override
 	public MethodVisitor visitMethod(int access, String name, String desc, String sig, String[] exceptions) {
-		return new MethodVisitor(Opcodes.ASM4) {
+		return new MethodVisitor(Opcodes.ASM5) {
 
 			@Override
 			public void visitFieldInsn(int op, String owner, String name, String desc) {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
@@ -253,11 +253,11 @@ object ClosureCleaner {
 }
 
 private[flink]
-class ReturnStatementFinder extends ClassVisitor(ASM4) {
+class ReturnStatementFinder extends ClassVisitor(ASM5) {
   override def visitMethod(access: Int, name: String, desc: String,
                            sig: String, exceptions: Array[String]): MethodVisitor = {
     if (name.contains("apply")) {
-      new MethodVisitor(ASM4) {
+      new MethodVisitor(ASM5) {
         override def visitTypeInsn(op: Int, tp: String) {
           if (op == NEW && tp.contains("scala/runtime/NonLocalReturnControl")) {
             throw new InvalidProgramException("Return statements aren't allowed in Flink closures")
@@ -265,16 +265,16 @@ class ReturnStatementFinder extends ClassVisitor(ASM4) {
         }
       }
     } else {
-      new MethodVisitor(ASM4) {}
+      new MethodVisitor(ASM5) {}
     }
   }
 }
 
 private[flink]
-class FieldAccessFinder(output: Map[Class[_], Set[String]]) extends ClassVisitor(ASM4) {
+class FieldAccessFinder(output: Map[Class[_], Set[String]]) extends ClassVisitor(ASM5) {
   override def visitMethod(access: Int, name: String, desc: String,
                            sig: String, exceptions: Array[String]): MethodVisitor = {
-    new MethodVisitor(ASM4) {
+    new MethodVisitor(ASM5) {
       override def visitFieldInsn(op: Int, owner: String, name: String, desc: String) {
         if (op == GETFIELD) {
           for (cl <- output.keys if cl.getName == owner.replace('/', '.')) {
@@ -297,7 +297,7 @@ class FieldAccessFinder(output: Map[Class[_], Set[String]]) extends ClassVisitor
   }
 }
 
-private[flink] class InnerClosureFinder(output: Set[Class[_]]) extends ClassVisitor(ASM4) {
+private[flink] class InnerClosureFinder(output: Set[Class[_]]) extends ClassVisitor(ASM5) {
   var myName: String = null
 
   override def visit(version: Int, access: Int, name: String, sig: String,
@@ -307,7 +307,7 @@ private[flink] class InnerClosureFinder(output: Set[Class[_]]) extends ClassVisi
 
   override def visitMethod(access: Int, name: String, desc: String,
                            sig: String, exceptions: Array[String]): MethodVisitor = {
-    new MethodVisitor(ASM4) {
+    new MethodVisitor(ASM5) {
       override def visitMethodInsn(op: Int, owner: String, name: String,
                                    desc: String) {
         val argTypes = Type.getArgumentTypes(desc)


### PR DESCRIPTION
- This solves errors with reflectasm using Scala 2.11 and Java 8