### PR TITLE
[FLINK-2936] Fix ClassCastException for Event-Time source

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceFunctionUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceFunctionUtil.java
@@ -62,7 +62,7 @@ public class SourceFunctionUtil<T> {
 			final Object lockingObject = new Object();
 			SourceFunction.SourceContext<T> ctx;
 			if (sourceFunction instanceof EventTimeSourceFunction) {
-				ctx = new StreamSource.ManualWatermarkContext<T>(lockingObject, collector);
+				ctx = new StreamSource.ManualWatermarkContext<T>(lockingObject, collector, true);
 			} else {
 				ctx = new StreamSource.NonWatermarkContext<T>(lockingObject, collector);
 			}


### PR DESCRIPTION
Before, would throw a ClassCastException when emitting watermarks with
timestamp/watermark multiplexing disabled.