### PR TITLE
[FLINK-3165] [py] Windows OS support

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/pyflink2.bat
+++ b/flink-dist/src/main/flink-bin/bin/pyflink2.bat
@@ -1,0 +1,25 @@
+::###############################################################################
+::  Licensed to the Apache Software Foundation (ASF) under one
+::  or more contributor license agreements.  See the NOTICE file
+::  distributed with this work for additional information
+::  regarding copyright ownership.  The ASF licenses this file
+::  to you under the Apache License, Version 2.0 (the
+::  "License"); you may not use this file except in compliance
+::  with the License.  You may obtain a copy of the License at
+::
+::      http://www.apache.org/licenses/LICENSE-2.0
+::
+::  Unless required by applicable law or agreed to in writing, software
+::  distributed under the License is distributed on an "AS IS" BASIS,
+::  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+::  See the License for the specific language governing permissions and
+:: limitations under the License.
+::###############################################################################
+
+@echo off
+setlocal EnableDelayedExpansion
+
+SET bin=%~dp0
+SET FLINK_ROOT_DIR=%bin%..
+
+%FLINK_ROOT_DIR%\bin\flink run -v %FLINK_ROOT_DIR%\lib\flink-python*.jar 2 %*

--- a/flink-dist/src/main/flink-bin/bin/pyflink3.bat
+++ b/flink-dist/src/main/flink-bin/bin/pyflink3.bat
@@ -1,0 +1,25 @@
+::###############################################################################
+::  Licensed to the Apache Software Foundation (ASF) under one
+::  or more contributor license agreements.  See the NOTICE file
+::  distributed with this work for additional information
+::  regarding copyright ownership.  The ASF licenses this file
+::  to you under the Apache License, Version 2.0 (the
+::  "License"); you may not use this file except in compliance
+::  with the License.  You may obtain a copy of the License at
+::
+::      http://www.apache.org/licenses/LICENSE-2.0
+::
+::  Unless required by applicable law or agreed to in writing, software
+::  distributed under the License is distributed on an "AS IS" BASIS,
+::  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+::  See the License for the specific language governing permissions and
+:: limitations under the License.
+::###############################################################################
+
+@echo off
+setlocal EnableDelayedExpansion
+
+SET bin=%~dp0
+SET FLINK_ROOT_DIR=%bin%..
+
+%FLINK_ROOT_DIR%\bin\flink run -v %FLINK_ROOT_DIR%\lib\flink-python*.jar 3 %*

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/Function.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/Function.py
@@ -59,6 +59,7 @@ class Function(object):
 
     def _close(self):
         self._collector._close()
+        self._connection.close()
 
     def _go(self):
         self._receive_broadcast_variables()


### PR DESCRIPTION
This PR allows the usage of the Python API on the Windows Operating System.

Essentially, 4 changes were made:
* pyflinkX.bat start scripts were added
* all paths were adjusted to work with both Unix and Windows systems
* python files on the jobmanager are stored in a randomized folder
  * overlapping python jobs used the same directory, causing data corruption
* usages of socket.recv(\<toRead\>, socket.MSG_WAITALL) were replaced with a new method
  * MSG_WAITALL flag is not available on windows
  * Note: the flag ensured that recv() returned exactly n bytes, opposed to the default of *up to* n bytes

In addition, several resources are now properly closed in python and error reporting has been improved.