### PR TITLE
[FLINK-2882] [core] Improve performance of string conversions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
@@ -48,6 +48,12 @@ public class AbstractID implements IOReadableWritable, Comparable<AbstractID>, j
 	/** The lower part of the actual ID */
 	protected long lowerPart;
 
+	/** The memoized value returned by toString() */
+	private String toString;
+
+	/** The memoized value returned by toShortString() */
+	private String toShortString;
+
 	// --------------------------------------------------------------------------------------------
 	
 	/**
@@ -137,6 +143,9 @@ public class AbstractID implements IOReadableWritable, Comparable<AbstractID>, j
 	public void read(DataInputView in) throws IOException {
 		this.lowerPart = in.readLong();
 		this.upperPart = in.readLong();
+
+		this.toString = null;
+		this.toShortString = null;
 	}
 
 	@Override
@@ -169,16 +178,26 @@ public class AbstractID implements IOReadableWritable, Comparable<AbstractID>, j
 	
 	@Override
 	public String toString() {
-		final byte[] ba = new byte[SIZE];
-		longToByteArray(this.lowerPart, ba, 0);
-		longToByteArray(this.upperPart, ba, SIZE_OF_LONG);
-		return StringUtils.byteToHexString(ba);
+		if (this.toString == null) {
+			final byte[] ba = new byte[SIZE];
+			longToByteArray(this.lowerPart, ba, 0);
+			longToByteArray(this.upperPart, ba, SIZE_OF_LONG);
+
+			this.toString = StringUtils.byteToHexString(ba);
+		}
+
+		return this.toString;
 	}
 
 	public String toShortString() {
-		final byte[] ba = new byte[SIZE_OF_LONG];
-		longToByteArray(upperPart, ba, 0);
-		return StringUtils.byteToHexString(ba);
+		if (this.toShortString == null) {
+			final byte[] ba = new byte[SIZE_OF_LONG];
+			longToByteArray(upperPart, ba, 0);
+
+			this.toShortString = StringUtils.byteToHexString(ba);
+		}
+
+		return this.toShortString;
 	}
 	
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -58,17 +58,25 @@ public final class StringUtils {
 	 * @param end
 	 *        end index, exclusively
 	 * @return hex string representation of the byte array
+	 *
+	 * @see org.apache.commons.codec.binary.Hex#encodeHexString(byte[])
 	 */
 	public static String byteToHexString(final byte[] bytes, final int start, final int end) {
 		if (bytes == null) {
 			throw new IllegalArgumentException("bytes == null");
 		}
 		
-		final StringBuilder s = new StringBuilder();
-		for (int i = start; i < end; i++) {
-			s.append(String.format("%02x", bytes[i]));
+		final char[] HEX_CHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+		int length = end - start;
+		char[] out = new char[length * 2];
+
+		for (int i = start, j = 0; i < end; i++) {
+			out[j++] = HEX_CHARS[(0xF0 & bytes[i]) >>> 4];
+			out[j++] = HEX_CHARS[0x0F & bytes[i]];
 		}
-		return s.toString();
+
+		return new String(out);
 	}
 
 	/**


### PR DESCRIPTION
Memoize string representations of AbstractID.

Use lookup table for byte-to-hex conversion in StringUtils.