### PR TITLE
[FLINK-3173] Bump httpclient and httpcore to version 4.2.6 to solve bug in http client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,13 +343,13 @@ under the License.
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpcore</artifactId>
-				<version>4.2</version>
+				<version>4.2.5</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.2</version>
+				<version>4.2.6</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
The bug prevents the `TwitterStream` example from working.