### PR TITLE
Set current class loader to user-class loader and disable class initialization.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -574,8 +574,11 @@ public class PackagedProgram {
 	}
 	
 	private static Class<?> loadMainClass(String className, ClassLoader cl) throws ProgramInvocationException {
+		ClassLoader contextCl = null;
 		try {
-			return Class.forName(className, true, cl);
+			contextCl = Thread.currentThread().getContextClassLoader();
+			Thread.currentThread().setContextClassLoader(cl);
+			return Class.forName(className, false, cl);
 		}
 		catch (ClassNotFoundException e) {
 			throw new ProgramInvocationException("The program's entry point class '" + className
@@ -592,6 +595,10 @@ public class PackagedProgram {
 		catch (Throwable t) {
 			throw new ProgramInvocationException("The program's entry point class '" + className
 				+ "' caused an exception during initialization: "+ t.getMessage(), t);
+		} finally {
+			if (contextCl != null) {
+				Thread.currentThread().setContextClassLoader(contextCl);
+			}
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes class loading issues with regard to Clojure. It is required to execute a Clojure example via `bin/flink run`.

The Clojure example can be found here: https://github.com/mjsax/flink-external/tree/master/flink-clojure