### PR TITLE
[FLINK-3172] Specify JobManager port in HA mode

### DIFF
--- a/docs/setup/jobmanager_high_availability.md
+++ b/docs/setup/jobmanager_high_availability.md
@@ -55,6 +55,8 @@ jobManagerAddress1:webUIPort1
 jobManagerAddressX:webUIPortX
   </pre>
 
+By default, the job manager will pick a *random port* for inter process communication. You can change this via the **`recovery.jobmanager.port`** key. This key accepts single ports (e.g. `50010`), ranges (`50000-50025`), or a combination of both (`50010,50011,50020-50025,50050-50075`).
+
 #### Config File (flink-conf.yaml)
 
 In order to start an HA-cluster add the following configuration keys to `conf/flink-conf.yaml`:

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -452,6 +452,9 @@ public final class ConfigConstants {
 	/** Defines recovery mode used for the cluster execution ("standalone", "zookeeper") */
 	public static final String RECOVERY_MODE = "recovery.mode";
 
+	/** Ports used by the job manager if not in standalone recovery mode */
+	public static final String RECOVERY_JOB_MANAGER_PORT = "recovery.jobmanager.port";
+
 	// --------------------------- ZooKeeper ----------------------------------
 
 	/** ZooKeeper servers. */
@@ -727,6 +730,12 @@ public final class ConfigConstants {
   	// --------------------------- Recovery ---------------------------------
 
 	public static String DEFAULT_RECOVERY_MODE = "standalone";
+
+	/**
+	 * Default port used by the job manager if not in standalone recovery mode. If <code>0</code>
+	 * the OS picks a random port port.
+	 */
+	public static final String DEFAULT_RECOVERY_JOB_MANAGER_PORT = "0";
 
 	// --------------------------- ZooKeeper ----------------------------------
 

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -22,9 +22,8 @@ USAGE="Usage: jobmanager.sh (start (local|cluster) [host] [webui-port]|stop|stop
 
 STARTSTOP=$1
 EXECUTIONMODE=$2
-STREAMINGMODE=$3
-HOST=$4 # optional when starting multiple instances
-WEBUIPORT=$5 # optinal when starting multiple instances
+HOST=$3 # optional when starting multiple instances
+WEBUIPORT=$4 # optinal when starting multiple instances
 
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterBase.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/ApplicationMasterBase.scala
@@ -180,7 +180,7 @@ abstract class ApplicationMasterBase {
       }
 
       // try starting the actor system
-      val result = retry(startActorSystem(portsIterator), {portsIterator.hasNext})
+      val result = retry(startActorSystem(portsIterator), {!portsIterator.hasNext})
 
       val (actorSystem, jmActor, archiveActor, webMonitor) = result match {
         case Success(r) => r


### PR DESCRIPTION
- Adds support for job manager port configuration for standalone HA clusters
- Re-uses everthing introduced in #1416, but moves the `retry` method to the JobManager and adds an optional sleep time between retries.
- Configuration via `recovery.jobmanager.port` (takes single ports, ranges, or mix)
- This doesn't work with standalone clusters. It would be possible to activate, but then the task managers will have to try each port in the range to connect to a job manager (because in standalone mode there is no ZooKeeper invovled)

---

Starting multiple job managers locally with the default configuration (none) works as expected by picking random ports:
```bash
$ grep ".*Remoting started; listening on addresses.*" -r log
jobmanager-0.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:51132]
jobmanager-1.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:51131]
jobmanager-2.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:51134]
jobmanager-3.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:51136]
jobmanager-4.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:51133]
jobmanager-5.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:51135]
```

After configuring a port range via `recovery.jobmanager.port: 6123-6133`:

```bash
jobmanager-0.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:6125]
jobmanager-1.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:6123]
jobmanager-2.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:6124]
jobmanager-3.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:6128]
jobmanager-4.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:6127]
jobmanager-5.log:...Remoting started; listening on addresses :[akka.tcp://flink@127.0.0.1:6126]
```