### PR TITLE
[FLINK-3174] Add merging WindowAssigner

### DIFF
--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -2216,7 +2216,7 @@ stream.window(TumblingTimeWindows.of(Time.of(1, TimeUnit.SECONDS)));
         <td><strong>Sliding time windows</strong><br>KeyedStream &rarr; WindowedStream</td>
         <td>
           <p>
-            Incoming elements are assigned to a window of a certain size (5 seconds below) based on
+            Incoming elements are assigned to a window of a certain size (5 seconds in the example below) based on
             their timestamp. Windows "slide" by the provided value (1 second in the example), and hence
             overlap. The window comes with a default trigger. For event/ingestion time, a window is triggered when a
 	    watermark with value higher than its end-value is received, whereas for processing time
@@ -2224,6 +2224,23 @@ stream.window(TumblingTimeWindows.of(Time.of(1, TimeUnit.SECONDS)));
           </p>
     {% highlight java %}
 stream.window(SlidingTimeWindows.of(Time.of(5, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS)));
+    {% endhighlight %}
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Session windows</strong><br>KeyedStream &rarr; WindowedStream</td>
+        <td>
+          <p>
+            Incoming elements are assigned to sessions based on a session gap interval (5 seconds in the example below).
+            Elements whose timestamp differs by more than the session gap are assigned to different sessions. If there are
+            consecutive elements which are less than the session gap apart then these will also be put into the same session, i.e. elements
+            can be connected into a session by intermediate elements.
+            The window comes with a default trigger. For event/ingestion time, a window is triggered when a
+            watermark with value higher than its end-value is received, whereas for processing time
+            when the current processing time exceeds its current end value.
+          </p>
+    {% highlight java %}
+stream.window(SessionWindows.withGap(Time.seconds(5)));
     {% endhighlight %}
         </td>
       </tr>
@@ -2281,6 +2298,23 @@ stream.window(TumblingTimeWindows.of(Time.of(1, TimeUnit.SECONDS)))
           </p>
     {% highlight scala %}
 stream.window(SlidingTimeWindows.of(Time.of(5, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS)))
+    {% endhighlight %}
+        </td>
+      </tr>
+       <tr>
+        <td><strong>Session windows</strong><br>KeyedStream &rarr; WindowedStream</td>
+        <td>
+          <p>
+            Incoming elements are assigned to sessions based on a session gap interval (5 seconds in the example below).
+            Elements whose timestamp differs by more than the session gap are assigned to different sessions. If there are
+            consecutive elements which are less than the session gap apart then these will also be put into the same session, i.e. elements
+            can be connected into a session by intermediate elements.
+            The window comes with a default trigger. For event/ingestion time, a window is triggered when a
+            watermark with value higher than its end-value is received, whereas for processing time
+            when the current processing time exceeds its current end value.
+          </p>
+    {% highlight scala %}
+stream.window(SessionWindows.withGap(Time.seconds(5)))
     {% endhighlight %}
         </td>
       </tr>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
@@ -34,7 +34,7 @@ import java.util.Collections;
  * {@link org.apache.flink.streaming.api.windowing.evictors.Evictor} to do flexible, policy based
  * windows.
  */
-public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
+public class GlobalWindows extends NonMergingWindowAssigner<Object, GlobalWindow> {
 	private static final long serialVersionUID = 1L;
 
 	private GlobalWindows() {}
@@ -85,6 +85,14 @@ public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
 
 		@Override
 		public TriggerResult onProcessingTime(long time, GlobalWindow window, TriggerContext ctx) {
+			return TriggerResult.CONTINUE;
+		}
+
+		@Override
+		public TriggerResult onMerge(Collection<GlobalWindow> oldWindows,
+			Collection<TriggerContext> oldTriggerCtxs,
+			GlobalWindow mergedWindow,
+			TriggerContext ctx) {
 			return TriggerResult.CONTINUE;
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/NonMergingWindowAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/NonMergingWindowAssigner.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+
+import java.util.Collection;
+
+
+/**
+ * A {@code WindowAssigner} assigns zero or more {@link Window Windows} to an element.
+ *
+ * <p>
+ * In a window operation, elements are grouped by their key (if available) and by the windows to
+ * which it was assigned. The set of elements with the same key and window is called a pane.
+ * When a {@link Trigger} decides that a certain pane should fire the
+ * {@link org.apache.flink.streaming.api.functions.windowing.WindowFunction} is applied
+ * to produce output elements for that pane.
+ *
+ * @param <T> The type of elements that this WindowAssigner can assign windows to.
+ * @param <W> The type of {@code Window} that this assigner assigns.
+ */
+public abstract class NonMergingWindowAssigner<T, W extends Window> extends WindowAssigner<T, W> {
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public final boolean isMerging() {
+		return false;
+	}
+
+	@Override
+	public final void mergeWindows(Collection<W> windows, MergeCallback<W> callback) {}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingTimeWindows.java
@@ -44,7 +44,7 @@ import java.util.List;
  *   keyed.window(SlidingTimeWindows.of(Time.of(1, MINUTES), Time.of(10, SECONDS));
  * } </pre>
  */
-public class SlidingTimeWindows extends WindowAssigner<Object, TimeWindow> {
+public class SlidingTimeWindows extends NonMergingWindowAssigner<Object, TimeWindow> {
 	private static final long serialVersionUID = 1L;
 
 	private final long size;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
@@ -60,4 +60,29 @@ public abstract class WindowAssigner<T, W extends Window> implements Serializabl
 	 * this {@code WindowAssigner}.
 	 */
 	public abstract TypeSerializer<W> getWindowSerializer(ExecutionConfig executionConfig);
+
+	/**
+	 * Returns {@code true} if the {@code Window}s assigned by this {@code WindowAssigner} can
+	 * be merged}.
+	 */
+	public abstract boolean isMerging();
+
+	/**
+	 * Determines which windows (if any) should be merged.
+	 * @param windows The window candidates.
+	 * @param callback A callback that can be invoked to signal which windows should be merged.
+	 */
+	public abstract void mergeWindows(Collection<W> windows, MergeCallback<W> callback);
+
+	/**
+	 * Callback to be used in {@link #mergeWindows(Collection, MergeCallback)} for specifying which
+	 * windows should be merged.
+	 */
+	public interface MergeCallback<W> {
+
+		/**
+		 * Specifies that the given windows should be merged into the result window.
+		 */
+		void merge(Collection<W> toBeMerged, W mergeResult);
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.state.OperatorState;
 import org.apache.flink.streaming.api.windowing.time.AbstractTime;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
+import java.util.Collection;
+
 /**
  * A {@link Trigger} that continuously fires based on a given time interval. This fires based
  * on {@link org.apache.flink.streaming.api.watermark.Watermark Watermarks}.
@@ -64,6 +66,14 @@ public class ContinuousEventTimeTrigger<W extends Window> implements Trigger<Obj
 
 	@Override
 	public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) throws Exception {
+		return TriggerResult.CONTINUE;
+	}
+
+	@Override
+	public TriggerResult onMerge(Collection<W> oldWindows,
+		Collection<TriggerContext> oldTriggerCtxs,
+		W mergedWindow,
+		TriggerContext ctx) {
 		return TriggerResult.CONTINUE;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.state.OperatorState;
 import org.apache.flink.streaming.api.windowing.time.AbstractTime;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
+import java.util.Collection;
+
 /**
  * A {@link Trigger} that continuously fires based on a given time interval. The time is the current
  * system time.
@@ -80,6 +82,14 @@ public class ContinuousProcessingTimeTrigger<W extends Window> implements Trigge
 			fireState.update(start + interval);
 			return TriggerResult.FIRE;
 		}
+		return TriggerResult.CONTINUE;
+	}
+
+	@Override
+	public TriggerResult onMerge(Collection<W> oldWindows,
+		Collection<TriggerContext> oldTriggerCtxs,
+		W mergedWindow,
+		TriggerContext ctx) {
 		return TriggerResult.CONTINUE;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.state.OperatorState;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * A {@link Trigger} that fires once the count of elements in a pane reaches the given count.
@@ -55,6 +56,14 @@ public class CountTrigger<W extends Window> implements Trigger<Object, W> {
 
 	@Override
 	public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) throws Exception {
+		return TriggerResult.CONTINUE;
+	}
+
+	@Override
+	public TriggerResult onMerge(Collection<W> oldWindows,
+		Collection<TriggerContext> oldTriggerCtxs,
+		W mergedWindow,
+		TriggerContext ctx) {
 		return TriggerResult.CONTINUE;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.api.functions.windowing.delta.DeltaFunction;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
 import java.io.Serializable;
+import java.util.Collection;
 
 /**
  * A {@link Trigger} that fires based on a {@link DeltaFunction} and a threshold.
@@ -65,6 +66,14 @@ public class DeltaTrigger<T extends Serializable, W extends Window> implements T
 
 	@Override
 	public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) throws Exception {
+		return TriggerResult.CONTINUE;
+	}
+
+	@Override
+	public TriggerResult onMerge(Collection<W> oldWindows,
+		Collection<TriggerContext> oldTriggerCtxs,
+		W mergedWindow,
+		TriggerContext ctx) {
 		return TriggerResult.CONTINUE;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
@@ -19,6 +19,8 @@ package org.apache.flink.streaming.api.windowing.triggers;
 
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 
+import java.util.Collection;
+
 /**
  * A {@link Trigger} that fires once the watermark passes the end of the window
  * to which a pane belongs.
@@ -43,6 +45,15 @@ public class EventTimeTrigger implements Trigger<Object, TimeWindow> {
 
 	@Override
 	public TriggerResult onProcessingTime(long time, TimeWindow window, TriggerContext ctx) throws Exception {
+		return TriggerResult.CONTINUE;
+	}
+
+	@Override
+	public TriggerResult onMerge(Collection<TimeWindow> oldWindows,
+		Collection<TriggerContext> oldTriggerCtxs,
+		TimeWindow mergedWindow,
+		TriggerContext ctx) {
+		ctx.registerEventTimeTimer(mergedWindow.maxTimestamp());
 		return TriggerResult.CONTINUE;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
@@ -19,6 +19,8 @@ package org.apache.flink.streaming.api.windowing.triggers;
 
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 
+import java.util.Collection;
+
 /**
  * A {@link Trigger} that fires once the current system time passes the end of the window
  * to which a pane belongs.
@@ -42,6 +44,15 @@ public class ProcessingTimeTrigger implements Trigger<Object, TimeWindow> {
 	@Override
 	public TriggerResult onProcessingTime(long time, TimeWindow window, TriggerContext ctx) {
 		return TriggerResult.FIRE_AND_PURGE;
+	}
+
+	@Override
+	public TriggerResult onMerge(Collection<TimeWindow> oldWindows,
+		Collection<TriggerContext> oldTriggerCtxs,
+		TimeWindow mergedWindow,
+		TriggerContext ctx) {
+		ctx.registerProcessingTimeTimer(mergedWindow.maxTimestamp());
+		return TriggerResult.CONTINUE;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/PurgingTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/PurgingTrigger.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.api.windowing.triggers;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
+import java.util.Collection;
+
 /**
  * A trigger that can turn any {@link Trigger} into a purging {@code Trigger}.
  *
@@ -68,6 +70,22 @@ public class PurgingTrigger<T, W extends Window> implements Trigger<T, W> {
 	@Override
 	public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) throws Exception {
 		TriggerResult triggerResult = nestedTrigger.onProcessingTime(time, window, ctx);
+		switch (triggerResult) {
+			case FIRE:
+				return TriggerResult.FIRE_AND_PURGE;
+			case FIRE_AND_PURGE:
+				return TriggerResult.FIRE_AND_PURGE;
+			default:
+				return TriggerResult.CONTINUE;
+		}
+	}
+
+	@Override
+	public TriggerResult onMerge(Collection<W> oldWindows,
+		Collection<TriggerContext> oldTriggerCtxs,
+		W mergedWindow,
+		TriggerContext ctx) {
+		TriggerResult triggerResult = nestedTrigger.onMerge(oldWindows, oldTriggerCtxs, mergedWindow, ctx);
 		switch (triggerResult) {
 			case FIRE:
 				return TriggerResult.FIRE_AND_PURGE;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.state.OperatorState;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 
 import java.io.Serializable;
+import java.util.Collection;
 
 /**
  * A {@code Trigger} determines when a pane of a window should be evaluated to emit the
@@ -70,6 +71,16 @@ public interface Trigger<T, W extends Window> extends Serializable {
 	 */
 	TriggerResult onEventTime(long time, W window, TriggerContext ctx) throws Exception;
 
+	/**
+	 * Called when several windows have been merged into one window by the
+	 * {@link org.apache.flink.streaming.api.windowing.assigners.WindowAssigner}.
+	 *
+	 * @param oldWindows The windows that were merged.
+	 * @param oldTriggerCtxs The contexts of the windows that were merged.
+	 * @param mergedWindow The newly merged window.
+	 * @param ctx A context object that can be used to register timer callbacks.
+	 */
+	TriggerResult onMerge(Collection<W> oldWindows, Collection<TriggerContext> oldTriggerCtxs, W mergedWindow, TriggerContext ctx);
 
 	/**
 	 * Result type for trigger methods. This determines what happens which the window.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
@@ -79,6 +79,20 @@ public class TimeWindow extends Window {
 				'}';
 	}
 
+	/**
+	 * Returns {@code true} if this window intersects the given window.
+	 */
+	public boolean intersects(TimeWindow other) {
+		return this.start <= other.end && this.end >= other.start;
+	}
+
+	/**
+	 * Returns the minimal window covers both this window and the given window.
+	 */
+	public TimeWindow cover(TimeWindow other) {
+		return new TimeWindow(Math.min(start, other.start), Math.max(end, other.end));
+	}
+
 	public static class Serializer extends TypeSerializer<TimeWindow> {
 		private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -22,10 +22,13 @@ import org.apache.flink.api.common.functions.RichReduceFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
+import org.apache.flink.streaming.api.windowing.assigners.SessionWindows;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
@@ -42,6 +45,7 @@ import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.Collector;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,6 +53,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
@@ -110,35 +115,35 @@ public class WindowOperatorTest {
 		testHarness.processWatermark(new Watermark(initialTime + 999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), initialTime + 999));
 		expectedOutput.add(new Watermark(999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 
 		testHarness.processWatermark(new Watermark(initialTime + 1999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), initialTime + 1999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 3), initialTime + 1999));
 		expectedOutput.add(new Watermark(1999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 2999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), initialTime + 2999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 3), initialTime + 2999));
 		expectedOutput.add(new Watermark(2999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 3999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 5), initialTime + 3999));
 		expectedOutput.add(new Watermark(3999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 4999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), initialTime + 4999));
 		expectedOutput.add(new Watermark(4999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 5999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), initialTime + 5999));
 		expectedOutput.add(new Watermark(5999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 
 		// those don't have any effect...
@@ -147,7 +152,7 @@ public class WindowOperatorTest {
 		expectedOutput.add(new Watermark(6999));
 		expectedOutput.add(new Watermark(7999));
 
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.close();
 		if (windowBufferFactory instanceof PreAggregatingHeapWindowBuffer.Factory) {
@@ -199,31 +204,31 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(initialTime + 999));
 		expectedOutput.add(new Watermark(999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 
 		testHarness.processWatermark(new Watermark(initialTime + 1999));
 		expectedOutput.add(new Watermark(1999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 2999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), initialTime + 2999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 3), initialTime + 2999));
 		expectedOutput.add(new Watermark(2999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 3999));
 		expectedOutput.add(new Watermark(3999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 4999));
 		expectedOutput.add(new Watermark(4999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 5999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), initialTime + 5999));
 		expectedOutput.add(new Watermark(5999));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 
 		// those don't have any effect...
@@ -232,13 +237,139 @@ public class WindowOperatorTest {
 		expectedOutput.add(new Watermark(6999));
 		expectedOutput.add(new Watermark(7999));
 
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.close();
 		if (windowBufferFactory instanceof PreAggregatingHeapWindowBuffer.Factory) {
 			Assert.assertEquals("Close was not called.", 2, closeCalled.get());
 		} else {
 			Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSessionWindows() throws Exception {
+		closeCalled.set(0);
+
+		final int SESSION_SIZE = 3;
+
+		WindowOperator<String, Tuple2<String, Integer>, Tuple3<String, Long, Long>, TimeWindow> operator = new WindowOperator<>(
+			SessionWindows.withGap(Time.seconds(SESSION_SIZE)),
+			new TimeWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			windowBufferFactory,
+			new SessionWindowFunction(),
+			EventTimeTrigger.create());
+
+		operator.setInputType(TypeInfoParser.<Tuple2<String, Integer>>parse("Tuple2<String, Integer>"), new ExecutionConfig());
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
+			new OneInputStreamOperatorTestHarness<>(operator);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 0));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 2), initialTime + 1000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 3), initialTime + 2500));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 10));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 2), initialTime + 1000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 3), initialTime + 2500));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 4), initialTime + 5501));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 5), initialTime + 6000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 5), initialTime + 6000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 6), initialTime + 6050));
+
+		testHarness.processWatermark(new Watermark(initialTime + 12000));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key1-6", 10L, 5500L), initialTime + 5499));
+		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key2-6", 0L, 5500L), initialTime + 5499));
+		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key2-20", 5501L, 9050L), initialTime + 9049));
+		expectedOutput.add(new Watermark(initialTime + 12000));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 10), initialTime + 15000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 20), initialTime + 15000));
+
+		testHarness.processWatermark(new Watermark(initialTime + 17999));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key2-30", 15000L, 18000L), initialTime + 17999));
+		expectedOutput.add(new Watermark(initialTime + 17999));
+
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple3ResultSortComparator());
+
+		testHarness.close();
+
+		if (windowBufferFactory instanceof PreAggregatingHeapWindowBuffer.Factory) {
+			Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+		} else {
+			Assert.assertEquals("Close was not called.", 0, closeCalled.get());
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	/**
+	 * This tests a custom Session window assigner that assigns some elements to "point windows",
+	 * windows that have the same timestamp for start and end.
+	 *
+	 * <p> In this test, elements that have 33 as the second tuple field will be put into a point
+	 * window.
+	 */
+	public void testPointSessions() throws Exception {
+		closeCalled.set(0);
+
+		WindowOperator<String, Tuple2<String, Integer>, Tuple3<String, Long, Long>, TimeWindow> operator = new WindowOperator<>(
+			new PointSessionWindows(3000),
+			new TimeWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			windowBufferFactory,
+			new SessionWindowFunction(),
+			EventTimeTrigger.create());
+
+		operator.setInputType(TypeInfoParser.<Tuple2<String, Integer>>parse("Tuple2<String, Integer>"), new ExecutionConfig());
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
+			new OneInputStreamOperatorTestHarness<>(operator);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 0));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 33), initialTime + 1000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 33), initialTime + 2500));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 10));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 2), initialTime + 1000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 33), initialTime + 2500));
+
+		testHarness.processWatermark(new Watermark(initialTime + 12000));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key1-36", 10L, 4000L), initialTime + 3999));
+		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key2-67", 0L, 3000L), initialTime + 2999));
+		expectedOutput.add(new Watermark(initialTime + 12000));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple3ResultSortComparator());
+
+		testHarness.close();
+
+		if (windowBufferFactory instanceof PreAggregatingHeapWindowBuffer.Factory) {
+			Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+		} else {
+			Assert.assertEquals("Close was not called.", 0, closeCalled.get());
 		}
 	}
 
@@ -286,31 +417,31 @@ public class WindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(initialTime + 1000));
 		expectedOutput.add(new Watermark(1000));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 
 		testHarness.processWatermark(new Watermark(initialTime + 2000));
 		expectedOutput.add(new Watermark(2000));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 3000));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), Long.MAX_VALUE));
 		expectedOutput.add(new Watermark(3000));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 4000));
 		expectedOutput.add(new Watermark(4000));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 5000));
 		expectedOutput.add(new Watermark(5000));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processWatermark(new Watermark(initialTime + 6000));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), Long.MAX_VALUE));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 5), Long.MAX_VALUE));
 		expectedOutput.add(new Watermark(6000));
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 
 		// those don't have any effect...
@@ -319,7 +450,7 @@ public class WindowOperatorTest {
 		expectedOutput.add(new Watermark(7000));
 		expectedOutput.add(new Watermark(8000));
 
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.close();
 		if (windowBufferFactory instanceof PreAggregatingHeapWindowBuffer.Factory) {
@@ -373,7 +504,7 @@ public class WindowOperatorTest {
 
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 4), Long.MAX_VALUE));
 
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 10999));
 
@@ -384,7 +515,7 @@ public class WindowOperatorTest {
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 4), Long.MAX_VALUE));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 4), Long.MAX_VALUE));
 
-		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.close();
 		if (windowBufferFactory instanceof PreAggregatingHeapWindowBuffer.Factory) {
@@ -425,6 +556,54 @@ public class WindowOperatorTest {
 			return new Tuple2<>(value2.f0, value1.f1 + value2.f1);
 		}
 	}
+
+	public static class TupleKeySelector implements KeySelector<Tuple2<String, Integer>, String> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String getKey(Tuple2<String, Integer> value) throws Exception {
+			return value.f0;
+		}
+	}
+
+	public static class SessionWindowFunction implements WindowFunction<Tuple2<String, Integer>, Tuple3<String, Long, Long>, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void apply(String key,
+			TimeWindow window,
+			Iterable<Tuple2<String, Integer>> values,
+			Collector<Tuple3<String, Long, Long>> out) throws Exception {
+			int sum = 0;
+			for (Tuple2<String, Integer> i: values) {
+				sum += i.f1;
+			}
+			String resultString = key + "-" + sum;
+			out.collect(new Tuple3<>(resultString, window.getStart(), window.getEnd()));
+		}
+	}
+
+	public static class PointSessionWindows extends SessionWindows {
+		private static final long serialVersionUID = 1L;
+
+
+		private PointSessionWindows(long sessionTimeout) {
+			super(sessionTimeout);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
+			if (element instanceof Tuple2) {
+				Tuple2<String, Integer> t2 = (Tuple2<String, Integer>) element;
+				if (t2.f1 == 33) {
+					return Collections.singletonList(new TimeWindow(timestamp, timestamp));
+				}
+			}
+			return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionTimeout));
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Parametrization for testing different window buffers
 	// ------------------------------------------------------------------------
@@ -438,7 +617,7 @@ public class WindowOperatorTest {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static class ResultSortComparator implements Comparator<Object> {
+	private static class Tuple2ResultSortComparator implements Comparator<Object> {
 		@Override
 		public int compare(Object o1, Object o2) {
 			if (o1 instanceof Watermark || o2 instanceof Watermark) {
@@ -459,12 +638,29 @@ public class WindowOperatorTest {
 		}
 	}
 
-	private static class TupleKeySelector implements KeySelector<Tuple2<String, Integer>, String> {
-		private static final long serialVersionUID = 1L;
-
+	@SuppressWarnings("unchecked")
+	private static class Tuple3ResultSortComparator implements Comparator<Object> {
 		@Override
-		public String getKey(Tuple2<String, Integer> value) throws Exception {
-			return value.f0;
+		public int compare(Object o1, Object o2) {
+			if (o1 instanceof Watermark || o2 instanceof Watermark) {
+				return 0;
+			} else {
+				StreamRecord<Tuple3<String, Long, Long>> sr0 = (StreamRecord<Tuple3<String, Long, Long>>) o1;
+				StreamRecord<Tuple3<String, Long, Long>> sr1 = (StreamRecord<Tuple3<String, Long, Long>>) o2;
+				if (sr0.getTimestamp() != sr1.getTimestamp()) {
+					return (int) (sr0.getTimestamp() - sr1.getTimestamp());
+				}
+				int comparison = sr0.getValue().f0.compareTo(sr1.getValue().f0);
+				if (comparison != 0) {
+					return comparison;
+				} else {
+					comparison = (int) (sr0.getValue().f1 - sr1.getValue().f1);
+					if (comparison != 0) {
+						return comparison;
+					}
+					return (int) (sr0.getValue().f1 - sr1.getValue().f1);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
After triggering and before emitting the window contents the window
assigner is given the change to merge existing windows. The trigger is
then given a chance to react in the new Trigger.onMerge() call.

This adds new method WindowAssigner.isMerging() that allows window
assigners to specify whether they can merge windows. All existing
assigners are now derived from NonMergingWindowAssigner that returns
false for isMerging(). Only of a WindowAssigners announces that it can
merge is the more costly merging logic used in the WindowOperator.

For triggers there is new method Trigger.onMerge() that notifies the
trigger of the new merged window as well as the old windows and old
trigger contexts. This allows the trigger to set a timer for the newly
merged window.

This enables proper support for session windows.

This also adds the SessionWindows window assigner and adapts an existing
session example and adds test cases.