### PR TITLE
[FLINK-3166] [runtime] The first program in ObjectReuseITCase has the wrong expected result, and it succeeds

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -151,14 +151,20 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 					final Collector<OT> output = this.output;
 
 					if (objectReuseEnabled) {
-						OT reuse = serializer.createInstance();
+						OT reuse1 = serializer.createInstance();
+						OT reuse2 = serializer.createInstance();
+						OT reuse3 = serializer.createInstance();
 
 						// as long as there is data to read
 						while (!this.taskCanceled && !format.reachedEnd()) {
 
 							OT returned;
-							if ((returned = format.nextRecord(reuse)) != null) {
+							if ((returned = format.nextRecord(reuse1)) != null) {
 								output.collect(returned);
+
+								reuse1 = reuse2;
+								reuse2 = reuse3;
+								reuse3 = returned;
 							}
 						}
 					} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceCombineDriver.java
@@ -219,6 +219,11 @@ public class ReduceCombineDriver<T> implements Driver<ReduceFunction<T>, T> {
 						if (comparator.equalToReference(value)) {
 							// same group, reduce
 							res = function.reduce(res, value);
+							if (res == reuse2) {
+								T tmp = reuse1;
+								reuse1 = reuse2;
+								reuse2 = tmp;
+							}
 						} else {
 							// new key group
 							break;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
@@ -135,6 +135,11 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 					if (comparator.equalToReference(value)) {
 						// same group, reduce
 						res = function.reduce(res, value);
+						if (res == reuse2) {
+							T tmp = reuse1;
+							reuse1 = reuse2;
+							reuse2 = tmp;
+						}
 					} else {
 						// new key group
 						break;

--- a/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -49,8 +49,19 @@ public class TestEnvironment extends ExecutionEnvironment {
 	public TestEnvironment(ForkableFlinkMiniCluster executor, int parallelism) {
 		this.executor = executor;
 		setParallelism(parallelism);
+
 		// disabled to improve build time
 		getConfig().setCodeAnalysisMode(CodeAnalysisMode.DISABLE);
+	}
+
+	public TestEnvironment(ForkableFlinkMiniCluster executor, int parallelism, boolean isObjectReuseEnabled) {
+		this(executor, parallelism);
+
+		if (isObjectReuseEnabled) {
+			getConfig().enableObjectReuse();
+		} else {
+			getConfig().disableObjectReuse();
+		}
 	}
 
 	@Override
@@ -89,7 +100,7 @@ public class TestEnvironment extends ExecutionEnvironment {
 		ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 			@Override
 			public ExecutionEnvironment createExecutionEnvironment() {
-				lastEnv = new TestEnvironment(executor, getParallelism());
+				lastEnv = new TestEnvironment(executor, getParallelism(), getConfig().isObjectReuseEnabled());
 				return lastEnv;
 			}
 		};


### PR DESCRIPTION
- TestEnvironment now honors configuration of object reuse
- Fixed reduce transformations to allow the user to modify and return either input

This is neither clean nor complete but I wanted to get some feedback before continuing.

ObjectReuseITCase was forcing object reuse, this was fixed by updating TestEnvironment.

ReduceCombineDriver and ReduceDriver both requests the next record and call the user's reduce() and so can handle whichever of the two inputs objects the user might write to.

In the second test case DataSourceTask (which requests the next record) calls ChainedAllReduceDriver.collect (which calls the user's reduce()). There is no feedback so DataSourceTask must cycle through `n`+1 reusable objects for unknown `n`.