### PR TITLE
[FLINK-3187] Introduce RestartStrategy to decouple restarting behaviour from ExecutionGraph

### DIFF
--- a/docs/apis/streaming/fault_tolerance.md
+++ b/docs/apis/streaming/fault_tolerance.md
@@ -194,3 +194,171 @@ state updates) of Flink coupled with bundled sinks:
 </table>
 
 {% top %}
+
+Restart Strategies
+------------------
+
+Flink supports different restart strategies which control how the jobs are restarted in case of a failure.
+The cluster can be started with a default restart strategy which is always used when no job specific restart strategy has been defined.
+In case that the job is submitted with a restart strategy, this strategy overrides the cluster's default setting.
+ 
+The default restart strategy is set via Flink's configuration file `flink-conf.yaml`.
+The configuration parameter *restart-strategy* defines which strategy is taken.
+Per default, the no-restart strategy is used.
+See the following list of available restart strategies to learn what values are supported.
+
+Each restart strategy comes with its own set of parameters which control its behaviour.
+These values are also set in the configuration file.
+The description of each restart strategy contains more information about the respective configuration values.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 50%">Restart Strategy</th>
+      <th class="text-left">Value for restart-strategy</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td>Fixed delay</td>
+        <td>fixed-delay</td>
+    </tr>
+    <tr>
+        <td>No restart</td>
+        <td>none</td>
+    </tr>
+  </tbody>
+</table>
+
+Apart from defining a default restart strategy, it is possible to define for each Flink job a specific restart strategy.
+This restart strategy is set programmatically by calling the `setRestartStrategy` method on the `ExecutionEnvironment`.
+Note that this also works for the `StreamExecutionEnvironment`.
+
+The following example shows how we can set a fixed delay restart strategy for our job.
+In case of a failure the system tries to restart the job 3 times and waits 10 seconds in-between successive restart attempts.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+env.setRestartStrategy(RestartStrategies.fixedDelay(
+  3, // number of restart attempts 
+  10000 // delay in milliseconds
+));
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val env = ExecutionEnvironment.getExecutionEnvironment()
+env.setRestartStrategy(RestartStrategies.fixedDelay(
+  3, // number of restart attempts 
+  10000 // delay in milliseconds
+))
+{% endhighlight %}
+</div>
+</div>
+
+## Fixed Delay Restart Strategy
+
+The fixed delay restart strategy attempts a given number of times to restart the job.
+If the maximum number of attempts is exceeded, the job eventually fails.
+In-between two consecutive restart attempts, the restart strategy waits a fixed amount of time.
+
+This strategy is enabled as default by setting the following configuration parameter in `flink-conf.yaml`.
+
+~~~
+restart-strategy: fixed-delay
+~~~
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Configuration Parameter</th>
+      <th class="text-left" style="width: 40%">Description</th>
+      <th class="text-left">Default Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td><it>restart-strategy.fixed-delay.attempts</it></td>
+        <td>Number of restart attempts</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td><it>restart-strategy.fixed-delay.delay</it></td>
+        <td>Delay between two consecutive restart attempts</td>
+        <td><it>akka.ask.timeout</it></td>
+    </tr>
+  </tbody>
+</table>
+
+~~~
+restart-strategy.fixed-delay.attempts: 3
+restart-strategy.fixed-delay.delay: 10 s
+~~~
+
+The fixed delay restart strategy can also be set programmatically:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+env.setRestartStrategy(RestartStrategies.fixedDelay(
+  3, // number of restart attempts 
+  10000 // delay in milliseconds
+));
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val env = ExecutionEnvironment.getExecutionEnvironment()
+env.setRestartStrategy(RestartStrategies.fixedDelay(
+  3, // number of restart attempts 
+  10000 // delay in milliseconds
+))
+{% endhighlight %}
+</div>
+</div>
+
+### Restart Attempts
+
+The number of times that Flink retries the execution before the job is declared as failed is configurable via the *restart-strategy.fixed-delay.attempts* parameter.
+
+The default value is **1**.
+
+### Retry Delays
+
+Execution retries can be configured to be delayed. Delaying the retry means that after a failed execution, the re-execution does not start immediately, but only after a certain delay.
+
+Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted.
+
+The default value is the value of *akka.ask.timeout*.
+
+## No Restart Strategy
+
+The job fails directly and no restart is attempted.
+
+~~~
+restart-strategy: none
+~~~
+
+The no restart strategy can also be set programmatically:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+env.setRestartStrategy(RestartStrategies.noRestart());
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val env = ExecutionEnvironment.getExecutionEnvironment()
+env.setRestartStrategy(RestartStrategies.noRestart())
+{% endhighlight %}
+</div>
+</div>
+
+[Back to top](#top)
+
+

--- a/docs/internals/monitoring_rest_api.md
+++ b/docs/internals/monitoring_rest_api.md
@@ -244,7 +244,7 @@ Sample Result:
   "name": "WordCount Example",
   "execution-config": {
     "execution-mode": "PIPELINED",
-    "max-execution-retries": -1,
+    "restart-strategy": "Restart deactivated",
     "job-parallelism": -1,
     "object-reuse-mode": false
   }

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -118,9 +118,17 @@ If you are on YARN, then it is sufficient to authenticate the client with Kerber
 
 - `blob.server.port`: Port definition for the blob server (serving user jar's) on the Taskmanagers. By default the port is set to 0, which means that the operating system is picking an ephemeral port. Flink also accepts a list of ports ("50100,50101"), ranges ("50100-50200") or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple JobManagers are running on the same machine.
 
-- `execution-retries.delay`: Delay between execution retries. Default value "5 s". Note that values have to be specified as strings with a unit.
+- `restart-strategy`: Default restart strategy to use in case that no restart strategy has been specified for the submitted job.
+Currently, it can be chosen between using a fixed delay restart strategy and to turn it off.
+To use the fixed delay strategy you have to specify "fixed-delay".
+To turn the restart behaviour off you have to specify "none".
+Default value "none".
 
-- `execution-retries.default`: Default number of execution retries, used by jobs that do not explicitly specify that value on the execution environment. Default value is zero.
+- `restart-strategy.fixed-delay.attempts`: Number of restart attempts, used if the default restart strategy is set to "fixed-delay". 
+Default value is 1.
+ 
+- `restart-strategy.fixed-delay.delay`: Delay between restart attempts, used if the default restart strategy is set to "fixed-delay". 
+Default value is the `akka.ask.timeout`. 
 
 ## Full Reference
 
@@ -246,6 +254,8 @@ For example when running Flink on YARN on an environment with a restrictive fire
 - `recovery.zookeeper.client.retry-wait`: (Default '5000') Defines the pause between consecutive retries in ms.
 
 - `recovery.zookeeper.client.max-retry-attempts`: (Default '3') Defines the number of connection retries before the client gives up.
+
+- `recovery.job.delay`: (Default 'akka.ask.timeout') Defines the delay before persisted jobs are recovered in case of a recovery situation. 
 
 ## Background
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common;
 import com.esotericsoftware.kryo.Serializer;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 
 import java.io.Serializable;
 import java.util.LinkedHashMap;
@@ -76,7 +77,11 @@ public class ExecutionConfig implements Serializable {
 
 	private int parallelism = -1;
 
-	private int numberOfExecutionRetries = -1;
+	/**
+	 * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
+	 */
+	@Deprecated
+	private int numberOfExecutionRetries = 0;
 
 	private boolean forceKryo = false;
 
@@ -96,9 +101,15 @@ public class ExecutionConfig implements Serializable {
 	private long autoWatermarkInterval = 0;
 
 	private boolean timestampsEnabled = false;
-	
-	private long executionRetryDelay = -1;
 
+	/**
+	 * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
+	 */
+	@Deprecated
+	private long executionRetryDelay = 0;
+
+	private RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration;
+	
 	// Serializers and types registered with Kryo and the PojoSerializer
 	// we store them in linked maps/sets to ensure they are registered in order in all kryo instances.
 
@@ -245,19 +256,64 @@ public class ExecutionConfig implements Serializable {
 	}
 
 	/**
+	 * Sets the restart strategy to be used for recovery.
+	 *
+	 * <pre>{@code
+	 * ExecutionConfig config = env.getConfig();
+	 *
+	 * config.setRestartStrategy(RestartStrategies.fixedDelayRestart(
+	 * 	10,  // number of retries
+	 * 	1000 // delay between retries));
+	 * }</pre>
+	 *
+	 * @param restartStrategyConfiguration Configuration defining the restart strategy to use
+	 */
+	@PublicEvolving
+	public void setRestartStrategy(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+		this.restartStrategyConfiguration = restartStrategyConfiguration;
+	}
+
+	/**
+	 * Returns the restart strategy which has been set for the current job.
+	 *
+	 * @return The specified restart configuration
+	 */
+	@PublicEvolving
+	public RestartStrategies.RestartStrategyConfiguration getRestartStrategy() {
+		if (restartStrategyConfiguration == null) {
+			// support the old API calls by creating a restart strategy from them
+			if (getNumberOfExecutionRetries() > 0 && getExecutionRetryDelay() >= 0) {
+				return RestartStrategies.fixedDelayRestart(getNumberOfExecutionRetries(), getExecutionRetryDelay());
+			} else {
+				return null;
+			}
+		} else {
+			return restartStrategyConfiguration;
+		}
+	}
+
+	/**
 	 * Gets the number of times the system will try to re-execute failed tasks. A value
 	 * of {@code -1} indicates that the system default value (as defined in the configuration)
 	 * should be used.
 	 *
 	 * @return The number of times the system will try to re-execute failed tasks.
+	 *
+	 * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
 	 */
+	@Deprecated
 	public int getNumberOfExecutionRetries() {
 		return numberOfExecutionRetries;
 	}
 
 	/**
 	 * Returns the delay between execution retries.
+	 *
+	 * @return The delay between successive execution retries in milliseconds.
+	 *
+	 * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
 	 */
+	@Deprecated
 	public long getExecutionRetryDelay() {
 		return executionRetryDelay;
 	}
@@ -268,11 +324,18 @@ public class ExecutionConfig implements Serializable {
 	 * default value (as defined in the configuration) should be used.
 	 *
 	 * @param numberOfExecutionRetries The number of times the system will try to re-execute failed tasks.
+	 *
+	 * @return The current execution configuration
+	 *
+	 * @deprecated This method will be replaced by {@link #setRestartStrategy}. The
+	 * {@link RestartStrategies.FixedDelayRestartStrategyConfiguration} contains the number of
+	 * execution retries.
 	 */
+	@Deprecated
 	public ExecutionConfig setNumberOfExecutionRetries(int numberOfExecutionRetries) {
 		if (numberOfExecutionRetries < -1) {
 			throw new IllegalArgumentException(
-					"The number of execution retries must be non-negative, or -1 (use system default)");
+				"The number of execution retries must be non-negative, or -1 (use system default)");
 		}
 		this.numberOfExecutionRetries = numberOfExecutionRetries;
 		return this;
@@ -282,15 +345,23 @@ public class ExecutionConfig implements Serializable {
 	 * Sets the delay between executions. A value of {@code -1} indicates that the default value
 	 * should be used.
 	 * @param executionRetryDelay The number of milliseconds the system will wait to retry.
+	 *
+	 * @return The current execution configuration
+	 *
+	 * @deprecated This method will be replaced by {@link #setRestartStrategy}. The
+	 * {@link RestartStrategies.FixedDelayRestartStrategyConfiguration} contains the delay between
+	 * successive execution attempts.
 	 */
+	@Deprecated
 	public ExecutionConfig setExecutionRetryDelay(long executionRetryDelay) {
 		if (executionRetryDelay < -1 ) {
 			throw new IllegalArgumentException(
-					"The delay between reties must be non-negative, or -1 (use system default)");
+				"The delay between reties must be non-negative, or -1 (use system default)");
 		}
 		this.executionRetryDelay = executionRetryDelay;
 		return this;
 	}
+
 	/**
 	 * Sets the execution mode to execute the program. The execution mode defines whether
 	 * data exchanges are performed in a batch or on a pipelined manner.
@@ -614,7 +685,7 @@ public class ExecutionConfig implements Serializable {
 				Objects.equals(executionMode, other.executionMode) &&
 				useClosureCleaner == other.useClosureCleaner &&
 				parallelism == other.parallelism &&
-				numberOfExecutionRetries == other.numberOfExecutionRetries &&
+				restartStrategyConfiguration.equals(other.restartStrategyConfiguration) &&
 				forceKryo == other.forceKryo &&
 				objectReuse == other.objectReuse &&
 				autoTypeRegistrationEnabled == other.autoTypeRegistrationEnabled &&
@@ -640,7 +711,7 @@ public class ExecutionConfig implements Serializable {
 			executionMode,
 			useClosureCleaner,
 			parallelism,
-			numberOfExecutionRetries,
+			restartStrategyConfiguration,
 			forceKryo,
 			objectReuse,
 			autoTypeRegistrationEnabled,

--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -38,6 +38,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.operators.GenericDataSinkBase;
 import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Visitable;
@@ -292,24 +293,15 @@ public class Plan implements Visitable<Operator<?>> {
 		
 		this.defaultParallelism = defaultParallelism;
 	}
-	
+
 	/**
-	 * Gets the number of times the system will try to re-execute failed tasks. A value
-	 * of {@code -1} indicates that the system default value (as defined in the configuration)
-	 * should be used.
-	 * 
-	 * @return The number of times the system will try to re-execute failed tasks.
+	 * Returns the specified restart strategy configuration. This configuration defines the used
+	 * restart strategy to be used at runtime.
+	 *
+	 * @return The specified restart strategy configuration
 	 */
-	public int getNumberOfExecutionRetries() {
-		return getExecutionConfig().getNumberOfExecutionRetries();
-	}
-	
-	/**
-	 * Gets the delay between retry failed task.
-	 * @return The delay the system will wait to retry.
-	 */
-	public long getExecutionRetryDelay() {
-		return getExecutionConfig().getExecutionRetryDelay();
+	public RestartStrategies.RestartStrategyConfiguration getRestartStrategyConfiguration() {
+		return getExecutionConfig().getRestartStrategy();
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.restartstrategy;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+
+/**
+ * This class defines methods to generate RestartStrategyConfigurations. These configurations are
+ * used to create RestartStrategies at runtime.
+ *
+ * The RestartStrategyConfigurations are used to decouple the core module from the runtime module.
+ */
+@PublicEvolving
+public class RestartStrategies {
+
+	/**
+	 * Generates NoRestartStrategyConfiguration
+	 *
+	 * @return NoRestartStrategyConfiguration
+	 */
+	public static RestartStrategyConfiguration noRestart() {
+		return new NoRestartStrategyConfiguration();
+	}
+
+	/**
+	 * Generates a FixedDelayRestartStrategyConfiguration.
+	 *
+	 * @param restartAttempts Number of restart attempts for the FixedDelayRestartStrategy
+	 * @param delayBetweenAttempts Delay in-between restart attempts for the FixedDelayRestartStrategy
+	 * @return FixedDelayRestartStrategy
+	 */
+	public static RestartStrategyConfiguration fixedDelayRestart(
+		int restartAttempts,
+		long delayBetweenAttempts) {
+
+		return new FixedDelayRestartStrategyConfiguration(restartAttempts, delayBetweenAttempts);
+	}
+
+	public abstract static class RestartStrategyConfiguration implements Serializable {
+		private static final long serialVersionUID = 6285853591578313960L;
+
+		private RestartStrategyConfiguration() {}
+
+		/**
+		 * Returns a description which is shown in the web interface
+		 *
+		 * @return Description of the restart strategy
+		 */
+		public abstract String getDescription();
+	}
+
+	final public static class NoRestartStrategyConfiguration extends RestartStrategyConfiguration {
+		private static final long serialVersionUID = -5894362702943349962L;
+
+		@Override
+		public String getDescription() {
+			return "Restart deactivated.";
+		}
+	}
+
+	final public static class FixedDelayRestartStrategyConfiguration extends RestartStrategyConfiguration {
+		private static final long serialVersionUID = 4149870149673363190L;
+
+		private final int restartAttempts;
+		private final long delayBetweenAttempts;
+
+		FixedDelayRestartStrategyConfiguration(int restartAttempts, long delayBetweenAttempts) {
+			this.restartAttempts = restartAttempts;
+			this.delayBetweenAttempts = delayBetweenAttempts;
+		}
+
+		public int getRestartAttempts() {
+			return restartAttempts;
+		}
+
+		public long getDelayBetweenAttempts() {
+			return delayBetweenAttempts;
+		}
+
+		@Override
+		public int hashCode() {
+			return 31 * restartAttempts + (int)(delayBetweenAttempts ^ (delayBetweenAttempts >>> 32));
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof FixedDelayRestartStrategyConfiguration) {
+				FixedDelayRestartStrategyConfiguration other = (FixedDelayRestartStrategyConfiguration) obj;
+
+				return restartAttempts == other.restartAttempts && delayBetweenAttempts == other.delayBetweenAttempts;
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public String getDescription() {
+			return "Restart with fixed delay (" + delayBetweenAttempts + " ms). #"
+				+ restartAttempts + " restart attempts.";
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -19,6 +19,7 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 
 /**
  * This class contains all constants for the configuration. That includes the configuration keys and
@@ -38,16 +39,50 @@ public final class ConfigConstants {
 	 */
 	public static final String DEFAULT_PARALLELISM_KEY = "parallelism.default";
 
+	// ---------------------------- Restart strategies ------------------------
+
+	/**
+	 * Defines the restart strategy to be used. It can be "off", "none", "disable" to be disabled or
+	 * it can be "fixeddelay", "fixed-delay" to use the FixedDelayRestartStrategy. You can also
+	 * specify a class name which implements the RestartStrategy interface and has a static
+	 * create method which takes a Configuration object.
+	 */
+	@PublicEvolving
+	public static final String RESTART_STRATEGY = "restart-strategy";
+
+	/**
+	 * Maximum number of attempts the fixed delay restart strategy will try before failing a job.
+	 */
+	@PublicEvolving
+	public static final String RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS = "restart-strategy.fixed-delay.attempts";
+
+	/**
+	 * Delay between two consecutive restart attempts. It can be specified using Scala's
+	 * FiniteDuration notation: "1 min", "20 s"
+	 */
+	@PublicEvolving
+	public static final String RESTART_STRATEGY_FIXED_DELAY_DELAY = "restart-strategy.fixed-delay.delay";
+
 	/**
 	 * Config parameter for the number of re-tries for failed tasks. Setting this
 	 * value to 0 effectively disables fault tolerance.
+	 *
+	 * @deprecated The configuration value will be replaced by {@link #RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS}
+	 * and the corresponding FixedDelayRestartStrategy.
 	 */
+	@Deprecated
+	@PublicEvolving
 	public static final String EXECUTION_RETRIES_KEY = "execution-retries.default";
 
 	/**
 	 * Config parameter for the delay between execution retries. The value must be specified in the
 	 * notation "10 s" or "1 min" (style of Scala Finite Durations)
+	 *
+	 * @deprecated The configuration value will be replaced by {@link #RESTART_STRATEGY_FIXED_DELAY_DELAY}
+	 * and the corresponding FixedDelayRestartStrategy.
 	 */
+	@Deprecated
+	@PublicEvolving
 	public static final String EXECUTION_RETRY_DELAY_KEY = "execution-retries.delay";
 	
 	// -------------------------------- Runtime -------------------------------
@@ -268,8 +303,6 @@ public final class ConfigConstants {
 	 */
 	public static final String YARN_TASK_MANAGER_ENV_PREFIX = "yarn.taskmanager.env.";
 
-
-
 	 /**
 	 * The config parameter defining the Akka actor system port for the ApplicationMaster and
 	 * JobManager
@@ -471,6 +504,9 @@ public final class ConfigConstants {
 	/** Ports used by the job manager if not in standalone recovery mode */
 	public static final String RECOVERY_JOB_MANAGER_PORT = "recovery.jobmanager.port";
 
+	/** The time before the JobManager recovers persisted jobs */
+	public static final String RECOVERY_JOB_DELAY = "recovery.job.delay";
+
 	// --------------------------- ZooKeeper ----------------------------------
 
 	/** ZooKeeper servers. */
@@ -521,7 +557,7 @@ public final class ConfigConstants {
 	 * The default number of execution retries.
 	 */
 	public static final int DEFAULT_EXECUTION_RETRIES = 0;
-	
+
 	// ------------------------------ Runtime ---------------------------------
 
 	/**

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/ReadFromKafka.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/ReadFromKafka.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.examples.kafka;
 
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -45,7 +46,7 @@ public class ReadFromKafka {
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.getConfig().disableSysoutLogging();
-		env.setNumberOfExecutionRetries(3); // retry if job fails
+		env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(4, 10000));
 		env.enableCheckpointing(5000); // create a checkpoint every 5 secodns
 		env.getConfig().setGlobalJobParameters(parameterTool); // make parameters available in the web interface
 

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/WriteIntoKafka.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/WriteIntoKafka.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.examples.kafka;
 
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -43,7 +44,7 @@ public class WriteIntoKafka {
 
 		StreamExecutionEnvironment env =StreamExecutionEnvironment.getExecutionEnvironment();
 		env.getConfig().disableSysoutLogging();
-		env.setNumberOfExecutionRetries(3);
+		env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(4, 10000));
 
 		// very simple data generator
 		DataStream<String> messageStream = env.addSource(new SourceFunction<String>() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -35,6 +35,7 @@ import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.operators.OperatorInformation;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.hadoop.mapred.HadoopInputFormat;
@@ -182,12 +183,38 @@ public abstract class ExecutionEnvironment {
 	}
 
 	/**
+	 * Sets the restart strategy configuration. The configuration specifies which restart strategy
+	 * will be used for the execution graph in case of a restart.
+	 *
+	 * @param restartStrategyConfiguration Restart strategy configuration to be set
+	 */
+	@PublicEvolving
+	public void setRestartStrategy(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+		config.setRestartStrategy(restartStrategyConfiguration);
+	}
+
+	/**
+	 * Returns the specified restart strategy configuration.
+	 *
+	 * @return The restart strategy configuration to be used
+	 */
+	@PublicEvolving
+	public RestartStrategies.RestartStrategyConfiguration getRestartStrategy() {
+		return config.getRestartStrategy();
+	}
+
+	/**
 	 * Sets the number of times that failed tasks are re-executed. A value of zero
 	 * effectively disables fault tolerance. A value of {@code -1} indicates that the system
 	 * default value (as defined in the configuration) should be used.
 	 *
 	 * @param numberOfExecutionRetries The number of times the system will try to re-execute failed tasks.
+	 *
+	 * @deprecated This method will be replaced by {@link #setRestartStrategy}. The
+	 * {@link RestartStrategies.FixedDelayRestartStrategyConfiguration} contains the number of
+	 * execution retries.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
 		config.setNumberOfExecutionRetries(numberOfExecutionRetries);
@@ -199,7 +226,12 @@ public abstract class ExecutionEnvironment {
 	 * should be used.
 	 *
 	 * @return The number of times the system will try to re-execute failed tasks.
+	 *
+	 * @deprecated This method will be replaced by {@link #getRestartStrategy}. The
+	 * {@link RestartStrategies.FixedDelayRestartStrategyConfiguration} contains the number of
+	 * execution retries.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public int getNumberOfExecutionRetries() {
 		return config.getNumberOfExecutionRetries();

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonPlanBinder.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonPlanBinder.java
@@ -19,7 +19,9 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Random;
+
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.LocalEnvironment;
@@ -262,7 +264,7 @@ public class PythonPlanBinder {
 					break;
 				case RETRY:
 					int retry = (Integer) value.getField(1);
-					env.setNumberOfExecutionRetries(retry);
+					env.setRestartStrategy(RestartStrategies.fixedDelayRestart(retry, 10000L));
 					break;
 				case DEBUG:
 					DEBUG = (Boolean) value.getField(1);

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -218,8 +218,8 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		
 		// create the job graph object
 		JobGraph graph = new JobGraph(jobId, program.getJobName());
-		graph.setNumberOfExecutionRetries(program.getOriginalPlan().getNumberOfExecutionRetries());
-		graph.setExecutionRetryDelay(program.getOriginalPlan().getExecutionRetryDelay());
+
+		graph.setRestartStrategyConfiguration(program.getOriginalPlan().getRestartStrategyConfiguration());
 		graph.setAllowQueuedScheduling(false);
 		graph.setSessionTimeout(program.getOriginalPlan().getSessionTimeout());
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
@@ -50,7 +50,9 @@ public class JobConfigHandler extends AbstractExecutionGraphRequestHandler {
 			gen.writeObjectFieldStart("execution-config");
 			
 			gen.writeStringField("execution-mode", ec.getExecutionMode().name());
-			gen.writeNumberField("max-execution-retries", ec.getNumberOfExecutionRetries());
+
+			final String restartStrategyDescription = ec.getRestartStrategy() != null ? ec.getRestartStrategy().getDescription() : "default";
+			gen.writeStringField("restart-strategy", restartStrategyDescription);
 			gen.writeNumberField("job-parallelism", ec.getParallelism());
 			gen.writeBooleanField("object-reuse-mode", ec.isObjectReuseEnabled());
 

--- a/flink-runtime-web/web-dashboard/app/partials/jobs/job.config.jade
+++ b/flink-runtime-web/web-dashboard/app/partials/jobs/job.config.jade
@@ -28,7 +28,7 @@ table.table.table-properties(ng-if="job['execution-config']")
 
     tr
       td Max. number of execution retries
-      td {{ job['execution-config']['max-execution-retries'] === -1 ? 'deactivated' : job['execution-config']['max-execution-retries'] }}
+      td {{ job['execution-config']['restart-strategy'] }}
 
     tr
       td Job parallelism

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.restart;
+
+import com.google.common.base.Preconditions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.duration.Duration;
+
+import java.util.concurrent.Callable;
+
+import static akka.dispatch.Futures.future;
+
+/**
+ * Restart strategy which tries to restart the given {@link ExecutionGraph} a fixed number of times
+ * with a fixed time delay in between.
+ */
+public class FixedDelayRestartStrategy implements RestartStrategy {
+	private static final Logger LOG = LoggerFactory.getLogger(FixedDelayRestartStrategy.class);
+
+
+	private final int maxNumberRestartAttempts;
+	private final long delayBetweenRestartAttempts;
+	private int currentRestartAttempt;
+
+	public FixedDelayRestartStrategy(
+		int maxNumberRestartAttempts,
+		long delayBetweenRestartAttempts) {
+
+		Preconditions.checkArgument(maxNumberRestartAttempts >= 0, "Maximum number of restart attempts must be positive.");
+		Preconditions.checkArgument(delayBetweenRestartAttempts >= 0, "Delay between restart attempts must be positive");
+
+		this.maxNumberRestartAttempts = maxNumberRestartAttempts;
+		this.delayBetweenRestartAttempts = delayBetweenRestartAttempts;
+		currentRestartAttempt = 0;
+	}
+
+	public int getCurrentRestartAttempt() {
+		return currentRestartAttempt;
+	}
+
+	@Override
+	public boolean canRestart() {
+		return currentRestartAttempt < maxNumberRestartAttempts;
+	}
+
+	@Override
+	public void restart(final ExecutionGraph executionGraph) {
+		currentRestartAttempt++;
+
+		future(new Callable<Object>() {
+			@Override
+			public Object call() throws Exception {
+				try {
+					LOG.info("Delaying retry of job execution for {} ms ...", delayBetweenRestartAttempts);
+					// do the delay
+					Thread.sleep(delayBetweenRestartAttempts);
+				} catch(InterruptedException e) {
+					// should only happen on shutdown
+				}
+				executionGraph.restart();
+				return null;
+			}
+		}, executionGraph.getExecutionContext());
+	}
+
+	/**
+	 * Creates a FixedDelayRestartStrategy from the given Configuration.
+	 *
+	 * @param configuration Configuration containing the parameter values for the restart strategy
+	 * @return Initialized instance of FixedDelayRestartStrategy
+	 * @throws Exception
+	 */
+	public static FixedDelayRestartStrategy create(Configuration configuration) throws Exception {
+		int maxAttempts = configuration.getInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+
+		String timeoutString = configuration.getString(
+			ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL,
+			ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT);
+
+		String delayString = configuration.getString(
+			ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
+			timeoutString
+		);
+
+		long delay;
+
+		try {
+			delay = Duration.apply(delayString).toMillis();
+		} catch (NumberFormatException nfe) {
+			throw new Exception("Invalid config value for " + ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY +
+				": " + delayString + ". Value must be a valid duration (such as 100 s or 1 min).");
+		}
+
+		return new FixedDelayRestartStrategy(maxAttempts, delay);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoRestartStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.restart;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+
+/**
+ * Restart strategy which does not restart an {@link ExecutionGraph}.
+ */
+public class NoRestartStrategy implements RestartStrategy {
+
+	@Override
+	public boolean canRestart() {
+		return false;
+	}
+
+	@Override
+	public void restart(ExecutionGraph executionGraph) {
+		throw new RuntimeException("NoRestartStrategy does not support restart.");
+	}
+
+	/**
+	 * Creates a NoRestartStrategy instance.
+	 *
+	 * @param configuration Configuration object which is ignored
+	 * @return NoRestartStrategy instance
+	 */
+	public static NoRestartStrategy create(Configuration configuration) {
+		return new NoRestartStrategy();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.restart;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+
+/**
+ * Strategy for {@link ExecutionGraph} restarts.
+ */
+public interface RestartStrategy {
+
+	/**
+	 * True if the restart strategy can be applied to restart the {@link ExecutionGraph}.
+	 *
+	 * @return true if restart is possible, otherwise false
+	 */
+	boolean canRestart();
+
+	/**
+	 * Restarts the given {@link ExecutionGraph}.
+	 *
+	 * @param executionGraph The ExecutionGraph to be restarted
+	 */
+	void restart(ExecutionGraph executionGraph);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/RestartStrategyFactory.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.restart;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.duration.Duration;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class RestartStrategyFactory {
+	private static final Logger LOG = LoggerFactory.getLogger(RestartStrategyFactory.class);
+	private static final String CREATE_METHOD = "create";
+
+	/**
+	 * Creates a {@link RestartStrategy} instance from the given {@link org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration}.
+	 *
+	 * @param restartStrategyConfiguration Restart strategy configuration which specifies which
+	 *                                     restart strategy to instantiate
+	 * @return RestartStrategy instance
+	 */
+	public static RestartStrategy createRestartStrategy(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+		if (restartStrategyConfiguration instanceof RestartStrategies.NoRestartStrategyConfiguration) {
+			return new NoRestartStrategy();
+		} else if (restartStrategyConfiguration instanceof RestartStrategies.FixedDelayRestartStrategyConfiguration) {
+			RestartStrategies.FixedDelayRestartStrategyConfiguration fixedDelayConfig =
+				(RestartStrategies.FixedDelayRestartStrategyConfiguration) restartStrategyConfiguration;
+
+			return new FixedDelayRestartStrategy(
+				fixedDelayConfig.getRestartAttempts(),
+				fixedDelayConfig.getDelayBetweenAttempts());
+		} else {
+			throw new IllegalArgumentException("Unknown restart strategy configuration " +
+				restartStrategyConfiguration + ".");
+		}
+	}
+
+	/**
+	 * Creates a {@link RestartStrategy} instance from the given {@link Configuration}.
+	 *
+	 * @param configuration Configuration object containing the configuration values.
+	 * @return RestartStrategy instance
+	 * @throws Exception which indicates that the RestartStrategy could not be instantiated.
+	 */
+	public static RestartStrategy createFromConfig(Configuration configuration) throws Exception {
+		String restartStrategyName = configuration.getString(ConfigConstants.RESTART_STRATEGY, "none").toLowerCase();
+
+		switch (restartStrategyName) {
+			case "none":
+				// support deprecated ConfigConstants values
+				final int numberExecutionRetries = configuration.getInteger(ConfigConstants.EXECUTION_RETRIES_KEY,
+					ConfigConstants.DEFAULT_EXECUTION_RETRIES);
+				String pauseString = configuration.getString(ConfigConstants.AKKA_WATCH_HEARTBEAT_PAUSE,
+					ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT);
+				String delayString = configuration.getString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY,
+					pauseString);
+
+				long delay;
+
+				try {
+					delay = Duration.apply(delayString).toMillis();
+				} catch (NumberFormatException nfe) {
+					throw new Exception("Invalid config value for " + ConfigConstants.EXECUTION_RETRY_DELAY_KEY +
+						": " + delayString + ". Value must be a valid duration (such as 100 s or 1 min).");
+				}
+
+				if (numberExecutionRetries > 0 && delay >= 0) {
+					return new FixedDelayRestartStrategy(numberExecutionRetries, delay);
+				} else {
+					return NoRestartStrategy.create(configuration);
+				}
+			case "off":
+			case "disable":
+				return NoRestartStrategy.create(configuration);
+			case "fixeddelay":
+			case "fixed-delay":
+				return FixedDelayRestartStrategy.create(configuration);
+			default:
+				try {
+					Class<?> clazz = Class.forName(restartStrategyName);
+
+					if (clazz != null) {
+						Method method = clazz.getMethod(CREATE_METHOD, Configuration.class);
+
+						if (method != null) {
+							Object result = method.invoke(null, configuration);
+
+							if (result != null) {
+								return (RestartStrategy) result;
+							}
+						}
+					}
+				} catch (ClassNotFoundException cnfe) {
+					LOG.warn("Could not find restart strategy class {}.", restartStrategyName);
+				} catch (NoSuchMethodException nsme) {
+					LOG.warn("Class {} does not has static method {}.", restartStrategyName, CREATE_METHOD);
+				} catch (InvocationTargetException ite) {
+					LOG.warn("Cannot call static method {} from class {}.", CREATE_METHOD, restartStrategyName);
+				} catch (IllegalAccessException iae) {
+					LOG.warn("Illegal access while calling method {} from class {}.", CREATE_METHOD, restartStrategyName);
+				}
+
+				// fallback in case of an error
+				return NoRestartStrategy.create(configuration);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 /**
  * The JobGraph represents a Flink dataflow program, at the low level that the JobManager accepts.
  * All programs from higher level APIs are transformed into JobGraphs.
@@ -78,10 +79,8 @@ public class JobGraph implements Serializable {
 	/** Name of this job. */
 	private final String jobName;
 
-	/** The number of times that failed tasks should be re-executed */
-	private int numExecutionRetries;
-
-	private long executionRetryDelay;
+	/** Configuration which defines which restart strategy to use for the job recovery */
+	private RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration;
 
 	/** The number of seconds after which the corresponding ExecutionGraph is removed at the
 	 * job manager after it has been executed. */
@@ -193,54 +192,22 @@ public class JobGraph implements Serializable {
 	}
 
 	/**
-	 * Sets the number of times that failed tasks are re-executed. A value of zero
-	 * effectively disables fault tolerance. A value of {@code -1} indicates that the system
-	 * default value (as defined in the configuration) should be used.
+	 * Sets the restart strategy configuration. This configuration specifies the restart strategy
+	 * to be used by the ExecutionGraph in case of a restart.
 	 *
-	 * @param numberOfExecutionRetries The number of times the system will try to re-execute failed tasks.
+	 * @param restartStrategyConfiguration Restart strategy configuration to be set
 	 */
-	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
-		if (numberOfExecutionRetries < -1) {
-			throw new IllegalArgumentException(
-					"The number of execution retries must be non-negative, or -1 (use system default)");
-		}
-		this.numExecutionRetries = numberOfExecutionRetries;
+	public void setRestartStrategyConfiguration(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+		this.restartStrategyConfiguration = restartStrategyConfiguration;
 	}
 
 	/**
-	 * Gets the number of times the system will try to re-execute failed tasks. A value
-	 * of {@code -1} indicates that the system default value (as defined in the configuration)
-	 * should be used.
+	 * Gets the restart strategy configuration
 	 *
-	 * @return The number of times the system will try to re-execute failed tasks.
+	 * @return Restart strategy configuration to be used
 	 */
-	public int getNumberOfExecutionRetries() {
-		return numExecutionRetries;
-	}
-
-	/**
-	 * Gets the delay of time the system will try to re-execute failed tasks. A value of
-	 * {@code -1} indicates the system default value (as defined in the configuration)
-	 * should be used.
-	 * @return The delay of time in milliseconds the system will try to re-execute failed tasks.
-	 */
-	public long getExecutionRetryDelay() {
-		return executionRetryDelay;
-	}
-
-	/**
-	 * Sets the delay that failed tasks are re-executed. A value of zero
-	 * effectively disables fault tolerance. A value of {@code -1} indicates that the system
-	 * default value (as defined in the configuration) should be used.
-	 *
-	 * @param executionRetryDelay The delay of time the system will wait to re-execute failed tasks.
-	 */
-	public void setExecutionRetryDelay(long executionRetryDelay){
-		if (executionRetryDelay < -1) {
-			throw new IllegalArgumentException(
-					"The delay between reties must be non-negative, or -1 (use system default)");
-		}
-		this.executionRetryDelay = executionRetryDelay;
+	public RestartStrategies.RestartStrategyConfiguration getRestartStrategyConfiguration() {
+		return restartStrategyConfiguration;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
@@ -43,14 +44,15 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 	@Test
 	public void testCheckpointAndSavepointCoordinatorShareCheckpointIDCounter() throws Exception {
 		ExecutionGraph executionGraph = new ExecutionGraph(
-				TestingUtils.defaultExecutionContext(),
-				new JobID(),
-				"test",
-				new Configuration(),
-				new FiniteDuration(1, TimeUnit.DAYS),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				ClassLoader.getSystemClassLoader());
+			TestingUtils.defaultExecutionContext(),
+			new JobID(),
+			"test",
+			new Configuration(),
+			new FiniteDuration(1, TimeUnit.DAYS),
+			new NoRestartStrategy(),
+			Collections.<BlobKey>emptyList(),
+			Collections.<URL>emptyList(),
+			ClassLoader.getSystemClassLoader());
 
 		ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
@@ -105,7 +106,8 @@ public class ExecutionGraphConstructionTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -148,7 +150,8 @@ public class ExecutionGraphConstructionTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -214,7 +217,8 @@ public class ExecutionGraphConstructionTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -467,7 +471,8 @@ public class ExecutionGraphConstructionTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -522,7 +527,8 @@ public class ExecutionGraphConstructionTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 			fail("Attached wrong jobgraph");
@@ -582,7 +588,8 @@ public class ExecutionGraphConstructionTest {
 					jobId,
 					jobName,
 					cfg,
-					AkkaUtils.getDefaultTimeout());
+					AkkaUtils.getDefaultTimeout(),
+					new NoRestartStrategy());
 			try {
 				eg.attachJobGraph(ordered);
 			}
@@ -626,7 +633,8 @@ public class ExecutionGraphConstructionTest {
 					jobId,
 					jobName,
 					cfg,
-					AkkaUtils.getDefaultTimeout());
+					AkkaUtils.getDefaultTimeout(),
+					new NoRestartStrategy());
 
 			try {
 				eg.attachJobGraph(ordered);
@@ -696,7 +704,8 @@ public class ExecutionGraphConstructionTest {
 					jobId,
 					jobName,
 					cfg,
-					AkkaUtils.getDefaultTimeout());
+					AkkaUtils.getDefaultTimeout(),
+					new NoRestartStrategy());
 			eg.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 			
 			// check the v1 / v2 co location hints ( assumes parallelism(v1) >= parallelism(v2) )

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -83,7 +84,8 @@ public class ExecutionGraphDeploymentTest {
 					jobId,
 					"some job",
 					new Configuration(),
-					AkkaUtils.getDefaultTimeout());
+					AkkaUtils.getDefaultTimeout(),
+					new NoRestartStrategy());
 
 			List<JobVertex> ordered = Arrays.asList(v1, v2, v3, v4);
 
@@ -285,7 +287,8 @@ public class ExecutionGraphDeploymentTest {
 				jobId,
 				"some job",
 				new Configuration(),
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		eg.setQueuedSchedulingAllowed(false);
 
 		List<JobVertex> ordered = Arrays.asList(v1, v2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.BaseTestingActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
@@ -173,7 +174,8 @@ public class ExecutionGraphTestUtils {
 				new JobID(),
 				"test job",
 				new Configuration(),
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 
 		ExecutionJobVertex ejv = spy(new ExecutionJobVertex(graph, ajv, 1,
 				AkkaUtils.getDefaultTimeout()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.api.common.JobID;
@@ -52,7 +53,8 @@ public class ExecutionStateProgressTest {
 					jid,
 					"test job",
 					new Configuration(),
-					AkkaUtils.getDefaultTimeout());
+					AkkaUtils.getDefaultTimeout(),
+					new NoRestartStrategy());
 
 			graph.attachJobGraph(Arrays.asList(ajv));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LocalInputSplitsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LocalInputSplitsTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.core.io.LocatableInputSplit;
 import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceConnectionInfo;
@@ -270,7 +271,8 @@ public class LocalInputSplitsTest {
 					jobGraph.getJobID(),
 					jobGraph.getName(),
 					jobGraph.getJobConfiguration(),
-					TIMEOUT);
+					TIMEOUT,
+					new NoRestartStrategy());
 			
 			eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 			eg.setQueuedSchedulingAllowed(false);
@@ -333,7 +335,8 @@ public class LocalInputSplitsTest {
 				jobGraph.getJobID(),
 				jobGraph.getName(),
 				jobGraph.getJobConfiguration(),
-				TIMEOUT);
+				TIMEOUT,
+				new NoRestartStrategy());
 		eg.setQueuedSchedulingAllowed(false);
 		
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Test;
 
@@ -62,7 +63,8 @@ public class PointwisePatternTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -102,7 +104,8 @@ public class PointwisePatternTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -143,7 +146,8 @@ public class PointwisePatternTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -185,7 +189,8 @@ public class PointwisePatternTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -225,7 +230,8 @@ public class PointwisePatternTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -285,7 +291,8 @@ public class PointwisePatternTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -336,7 +343,8 @@ public class PointwisePatternTest {
 				jobId,
 				jobName,
 				cfg,
-				AkkaUtils.getDefaultTimeout());
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy());
 		try {
 			eg.attachJobGraph(ordered);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
@@ -124,9 +125,7 @@ public class TerminalStateDeadlockTest {
 			for (int i = 0; i < 20000; i++) {
 				final TestExecGraph eg = new TestExecGraph(jobId);
 				eg.attachJobGraph(vertices);
-				eg.setDelayBeforeRetrying(0);
-				eg.setNumberOfRetriesLeft(1);
-				
+
 				final Execution e1 = eg.getJobVertex(vid1).getTaskVertices()[0].getCurrentExecutionAttempt();
 				final Execution e2 = eg.getJobVertex(vid2).getTaskVertices()[0].getCurrentExecutionAttempt();
 
@@ -181,7 +180,13 @@ public class TerminalStateDeadlockTest {
 		private volatile boolean done;
 
 		TestExecGraph(JobID jobId) {
-			super(TestingUtils.defaultExecutionContext(), jobId, "test graph", EMPTY_CONFIG, TIMEOUT);
+			super(
+				TestingUtils.defaultExecutionContext(),
+				jobId,
+				"test graph",
+				EMPTY_CONFIG,
+				TIMEOUT,
+				new FixedDelayRestartStrategy(1, 0));
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
@@ -80,7 +81,8 @@ public class VertexLocationConstraintTest {
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
-					timeout);
+					timeout,
+					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -151,7 +153,8 @@ public class VertexLocationConstraintTest {
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
-					timeout);
+					timeout,
+					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -226,7 +229,8 @@ public class VertexLocationConstraintTest {
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
-					timeout);
+					timeout,
+					new NoRestartStrategy());
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex1.getID());
@@ -292,7 +296,8 @@ public class VertexLocationConstraintTest {
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
-					timeout);
+					timeout,
+					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex.getID());
@@ -360,7 +365,8 @@ public class VertexLocationConstraintTest {
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
-					timeout);
+					timeout,
+					new NoRestartStrategy());
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
 			
 			ExecutionJobVertex ejv = eg.getAllVertices().get(jobVertex1.getID());
@@ -398,7 +404,8 @@ public class VertexLocationConstraintTest {
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
-					timeout);
+					timeout,
+					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(vertex));
 			
 			ExecutionVertex ev = eg.getAllVertices().get(vertex.getID()).getTaskVertices()[0];

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.api.common.JobID;
@@ -74,7 +75,8 @@ public class VertexSlotSharingTest {
 					new JobID(),
 					"test job",
 					new Configuration(),
-					AkkaUtils.getDefaultTimeout());
+					AkkaUtils.getDefaultTimeout(),
+					new NoRestartStrategy());
 			eg.attachJobGraph(vertices);
 			
 			// verify that the vertices are all in the same slot sharing group

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.restart;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.junit.Test;
+import org.mockito.Mockito;
+import scala.concurrent.ExecutionContext$;
+
+public class FixedDelayRestartStrategyTest {
+
+	@Test
+	public void testFixedDelayRestartStrategy() {
+		int numberRestarts = 10;
+		long restartDelay = 10;
+
+		FixedDelayRestartStrategy fixedDelayRestartStrategy = new FixedDelayRestartStrategy(
+			numberRestarts,
+			restartDelay);
+
+		ExecutionGraph executionGraph = mock(ExecutionGraph.class);
+		when(executionGraph.getExecutionContext())
+			.thenReturn(ExecutionContext$.MODULE$.fromExecutor(MoreExecutors.directExecutor()));
+
+		while(fixedDelayRestartStrategy.canRestart()) {
+			fixedDelayRestartStrategy.restart(executionGraph);
+		}
+
+		Mockito.verify(executionGraph, Mockito.times(numberRestarts)).restart();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -18,14 +18,11 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.event.AbstractEvent;
-import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
-import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.io.network.util.TestConsumerCallback;
 import org.apache.flink.runtime.io.network.util.TestNotificationListener;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
@@ -39,7 +36,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode.ASYNC;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.checkpoint.SavepointStore;
 import org.apache.flink.runtime.checkpoint.SavepointStoreFactory;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.InstanceManager;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.runtime.jobmanager.StandaloneSubmittedJobGraphStore;
@@ -191,13 +192,13 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 				new Scheduler(TestingUtils.defaultExecutionContext()),
 				new BlobLibraryCacheManager(new BlobServer(configuration), 10L),
 				ActorRef.noSender(),
-				1,
-				1L,
+				new NoRestartStrategy(),
 				AkkaUtils.getDefaultTimeout(),
 				leaderElectionService,
 				submittedJobGraphStore,
 				checkpointRecoveryFactory,
-				savepointStore
+				savepointStore,
+				AkkaUtils.getDefaultTimeout()
 		);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -88,7 +88,7 @@ public class ZooKeeperTestUtils {
 		config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_PAUSE, "6 s");
 		config.setInteger(ConfigConstants.AKKA_WATCH_THRESHOLD, 9);
 		config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, "100 s");
-		config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "10 s");
+		config.setString(ConfigConstants.RECOVERY_JOB_DELAY, "10 s");
 
 		return config;
 	}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.SimpleActorGateway
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy
 import org.apache.flink.runtime.jobgraph.{JobStatus, JobGraph, JobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
@@ -56,8 +57,9 @@ class TaskManagerLossFailsTasksTest extends WordSpecLike with Matchers {
           new JobID(),
           "test job",
           new Configuration(),
-          AkkaUtils.getDefaultTimeout)
-        eg.setNumberOfRetriesLeft(0)
+          AkkaUtils.getDefaultTimeout,
+          new NoRestartStrategy())
+
         eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources)
 
         eg.getState should equal(JobStatus.CREATED)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
@@ -33,6 +33,8 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import org.scalatest.junit.JUnitRunner
 import scala.concurrent.duration._
 
+import language.postfixOps
+
 @RunWith(classOf[JUnitRunner])
 class RecoveryITCase(_system: ActorSystem)
   extends TestKit(_system)
@@ -57,7 +59,9 @@ class RecoveryITCase(_system: ActorSystem)
     config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots)
     config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTaskManagers)
     config.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_PAUSE, heartbeatTimeout)
-    config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, heartbeatTimeout)
+    config.setString(ConfigConstants.RESTART_STRATEGY, "fixeddelay")
+    config.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1)
+    config.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, heartbeatTimeout)
     new TestingCluster(config)
   }
 
@@ -79,7 +83,6 @@ class RecoveryITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
       val jobGraph = new JobGraph("Pointwise job", sender, receiver)
-      jobGraph.setNumberOfExecutionRetries(1)
 
       val cluster = createTestClusterWithHeartbeatTimeout(2 * NUM_TASKS, 1, "2 s")
       cluster.start()
@@ -124,7 +127,6 @@ class RecoveryITCase(_system: ActorSystem)
       receiver.setSlotSharingGroup(sharingGroup)
 
       val jobGraph = new JobGraph("Pointwise job", sender, receiver)
-      jobGraph.setNumberOfExecutionRetries(1)
 
       val cluster = createTestClusterWithHeartbeatTimeout(NUM_TASKS, 1, "2 s")
       cluster.start()
@@ -169,7 +171,6 @@ class RecoveryITCase(_system: ActorSystem)
       receiver.setSlotSharingGroup(sharingGroup)
 
       val jobGraph = new JobGraph("Pointwise job", sender, receiver)
-      jobGraph.setNumberOfExecutionRetries(1)
 
       val cluster = createTestClusterWithHeartbeatTimeout(NUM_TASKS, 2, "2 s")
       cluster.start()

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -96,14 +96,14 @@ class TestingCluster(
     instanceManager,
     scheduler,
     libraryCacheManager,
-    executionRetries,
-    delayBetweenRetries,
+    restartStrategy,
     timeout,
     archiveCount,
     leaderElectionService,
     submittedJobsGraphs,
     checkpointRecoveryFactory,
-    savepointStore) = JobManager.createJobManagerComponents(
+    savepointStore,
+    jobRecoveryTimeout) = JobManager.createJobManagerComponents(
       config,
       createLeaderElectionService())
 
@@ -118,13 +118,13 @@ class TestingCluster(
         scheduler,
         libraryCacheManager,
         archive,
-        executionRetries,
-        delayBetweenRetries,
+        restartStrategy,
         timeout,
         leaderElectionService,
         submittedJobsGraphs,
         checkpointRecoveryFactory,
-        savepointStore))
+        savepointStore,
+        jobRecoveryTimeout))
 
     val dispatcherJobManagerProps = if (synchronousDispatcher) {
       // disable asynchronous futures (e.g. accumulator update in Heartbeat)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -23,6 +23,7 @@ import akka.actor.ActorRef
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.checkpoint.{SavepointStore, CheckpointRecoveryFactory}
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
+import org.apache.flink.runtime.executiongraph.restart.RestartStrategy
 import org.apache.flink.runtime.instance.InstanceManager
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
 import org.apache.flink.runtime.jobmanager.{JobManager, SubmittedJobGraphStore}
@@ -43,13 +44,13 @@ class TestingJobManager(
     scheduler: Scheduler,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
-    defaultExecutionRetries: Int,
-    delayBetweenRetries: Long,
+    restartStrategy: RestartStrategy,
     timeout: FiniteDuration,
     leaderElectionService: LeaderElectionService,
     submittedJobGraphs : SubmittedJobGraphStore,
     checkpointRecoveryFactory : CheckpointRecoveryFactory,
-    savepointStore : SavepointStore)
+    savepointStore : SavepointStore,
+    jobRecoveryTimeout: FiniteDuration)
   extends JobManager(
     flinkConfiguration,
       executorService,
@@ -57,11 +58,11 @@ class TestingJobManager(
     scheduler,
     libraryCacheManager,
     archive,
-    defaultExecutionRetries,
-    delayBetweenRetries,
+    restartStrategy,
     timeout,
     leaderElectionService,
     submittedJobGraphs,
     checkpointRecoveryFactory,
-    savepointStore)
+    savepointStore,
+    jobRecoveryTimeout)
   with TestingJobManagerLike {}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -323,14 +323,14 @@ object TestingUtils {
     instanceManager,
     scheduler,
     libraryCacheManager,
-    executionRetries,
-    delayBetweenRetries,
+    restartStrategy,
     timeout,
     archiveCount,
     leaderElectionService,
     submittedJobGraphs,
     checkpointRecoveryFactory,
-    savepointStore) = JobManager.createJobManagerComponents(
+    savepointStore,
+    jobRecoveryTimeout) = JobManager.createJobManagerComponents(
       configuration,
       None
     )
@@ -347,12 +347,12 @@ object TestingUtils {
       scheduler,
       libraryCacheManager,
       archive,
-      executionRetries,
-      delayBetweenRetries,
+      restartStrategy,
       timeout,
       leaderElectionService,
       submittedJobGraphs,
-      checkpointRecoveryFactory)
+      checkpointRecoveryFactory,
+      jobRecoveryTimeout)
 
     val jobManager: ActorRef = actorSystem.actorOf(jobManagerProps, JobManager.JOB_MANAGER_NAME)
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -21,6 +21,7 @@ import com.esotericsoftware.kryo.Serializer
 import com.google.common.base.Preconditions
 import org.apache.flink.annotation.{PublicEvolving, Public}
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
+import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult, JobID}
@@ -93,20 +94,49 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   def getParallelism = javaEnv.getParallelism
 
   /**
-   * Sets the number of times that failed tasks are re-executed. A value of zero
-   * effectively disables fault tolerance. A value of "-1" indicates that the system
-   * default value (as defined in the configuration) should be used.
-   */
+    * Sets the restart strategy configuration. The configuration specifies which restart strategy
+    * will be used for the execution graph in case of a restart.
+    *
+    * @param restartStrategyConfiguration Restart strategy configuration to be set
+    */
+  @PublicEvolving
+  def setRestartStrategy(restartStrategyConfiguration: RestartStrategyConfiguration): Unit = {
+    javaEnv.setRestartStrategy(restartStrategyConfiguration)
+  }
+
+  /**
+    * Returns the specified restart strategy configuration.
+    *
+    * @return The restart strategy configuration to be used
+    */
+  @PublicEvolving
+  def getRestartStrategy: RestartStrategyConfiguration = {
+    javaEnv.getRestartStrategy()
+  }
+
+  /**
+    * Sets the number of times that failed tasks are re-executed. A value of zero
+    * effectively disables fault tolerance. A value of "-1" indicates that the system
+    * default value (as defined in the configuration) should be used.
+    *
+    * @deprecated This method will be replaced by [[setRestartStrategy()]]. The
+    *            FixedDelayRestartStrategyConfiguration contains the number of execution retries.
+    */
+  @Deprecated
   @PublicEvolving
   def setNumberOfExecutionRetries(numRetries: Int): Unit = {
     javaEnv.setNumberOfExecutionRetries(numRetries)
   }
 
   /**
-   * Gets the number of times the system will try to re-execute failed tasks. A value
-   * of "-1" indicates that the system default value (as defined in the configuration)
-   * should be used.
-   */
+    * Gets the number of times the system will try to re-execute failed tasks. A value
+    * of "-1" indicates that the system default value (as defined in the configuration)
+    * should be used.
+    *
+    * @deprecated This method will be replaced by [[getRestartStrategy]]. The
+    *            FixedDelayRestartStrategyConfiguration contains the number of execution retries.
+    */
+  @Deprecated
   @PublicEvolving
   def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
 

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
@@ -18,21 +18,14 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.api.java.functions.FlatMapIterator;
-import org.apache.flink.api.java.operators.DataSource;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
-import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kafka.internals.ZookeeperOffsetHandler;
 import org.junit.Test;
 
-import java.util.Iterator;
 import java.util.Properties;
 
 import static org.junit.Assert.assertTrue;
-
 
 public class Kafka08ITCase extends KafkaConsumerTestBase {
 
@@ -166,19 +159,19 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 		StreamExecutionEnvironment env1 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env1.getConfig().disableSysoutLogging();
 		env1.enableCheckpointing(50);
-		env1.setNumberOfExecutionRetries(0);
+		env1.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env1.setParallelism(parallelism);
 
 		StreamExecutionEnvironment env2 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env2.getConfig().disableSysoutLogging();
 		env2.enableCheckpointing(50);
-		env2.setNumberOfExecutionRetries(0);
+		env2.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env2.setParallelism(parallelism);
 
 		StreamExecutionEnvironment env3 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env3.getConfig().disableSysoutLogging();
 		env3.enableCheckpointing(50);
-		env3.setNumberOfExecutionRetries(0);
+		env3.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env3.setParallelism(parallelism);
 
 		// write a sequence from 0 to 99 to each of the 3 partitions.
@@ -222,13 +215,13 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 
 		StreamExecutionEnvironment env1 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env1.getConfig().disableSysoutLogging();
-		env1.setNumberOfExecutionRetries(0);
+		env1.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env1.setParallelism(parallelism);
 
 		StreamExecutionEnvironment env2 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		// NOTE: We are not enabling the checkpointing!
 		env2.getConfig().disableSysoutLogging();
-		env2.setNumberOfExecutionRetries(0);
+		env2.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env2.setParallelism(parallelism);
 
 

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -136,7 +137,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 			StreamExecutionEnvironment see = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 			see.getConfig().disableSysoutLogging();
-			see.setNumberOfExecutionRetries(0);
+			see.setRestartStrategy(RestartStrategies.noRestart());
 			see.setParallelism(1);
 
 			// use wrong ports for the consumers
@@ -255,7 +256,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 				StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(500);
-		env.setNumberOfExecutionRetries(0); // fail immediately
+		env.setRestartStrategy(RestartStrategies.noRestart()); // fail immediately
 		env.getConfig().disableSysoutLogging();
 
 		TypeInformation<Tuple2<Long, String>> longStringType = TypeInfoParser.parse("Tuple2<Long, String>");
@@ -385,7 +386,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.enableCheckpointing(500);
 		env.setParallelism(parallelism);
-		env.setNumberOfExecutionRetries(3);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 1000));
 		env.getConfig().disableSysoutLogging();
 
 		FlinkKafkaConsumerBase<Integer> kafkaSource = kafkaServer.getConsumer(topic, schema, standardProps);
@@ -430,7 +431,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.enableCheckpointing(500);
 		env.setParallelism(parallelism);
-		env.setNumberOfExecutionRetries(3);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 1000));
 		env.getConfig().disableSysoutLogging();
 
 		FlinkKafkaConsumerBase<Integer> kafkaSource = kafkaServer.getConsumer(topic, schema, standardProps);
@@ -475,7 +476,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.enableCheckpointing(500);
 		env.setParallelism(parallelism);
-		env.setNumberOfExecutionRetries(3);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 1000));
 		env.getConfig().disableSysoutLogging();
 		env.setBufferTimeout(0);
 
@@ -781,7 +782,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 				new TypeInformationSerializationSchema<>(longBytesInfo, new ExecutionConfig());
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
-		env.setNumberOfExecutionRetries(0);
+		env.setRestartStrategy(RestartStrategies.noRestart());
 		env.getConfig().disableSysoutLogging();
 		env.enableCheckpointing(100);
 		env.setParallelism(parallelism);
@@ -895,7 +896,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(500);
-		env.setNumberOfExecutionRetries(3);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 1000));
 		env.getConfig().disableSysoutLogging();
 
 
@@ -923,7 +924,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(1);
-		env.setNumberOfExecutionRetries(0);
+		env.setRestartStrategy(RestartStrategies.noRestart());
 		env.getConfig().disableSysoutLogging();
 
 		DataStream<Tuple2<Long, PojoValue>> kvStream = env.addSource(new SourceFunction<Tuple2<Long, PojoValue>>() {
@@ -953,7 +954,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 		env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(1);
-		env.setNumberOfExecutionRetries(0);
+		env.setRestartStrategy(RestartStrategies.noRestart());
 		env.getConfig().disableSysoutLogging();
 
 
@@ -1005,7 +1006,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(1);
-		env.setNumberOfExecutionRetries(0);
+		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env.getConfig().disableSysoutLogging();
 
 		DataStream<Tuple2<byte[], PojoValue>> kvStream = env.addSource(new SourceFunction<Tuple2<byte[], PojoValue>>() {
@@ -1038,7 +1039,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 		env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(1);
-		env.setNumberOfExecutionRetries(0);
+		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env.getConfig().disableSysoutLogging();
 
 		DataStream<Tuple2<byte[], PojoValue>> fromKafka = env.addSource(kafkaServer.getConsumer(topic, schema, standardProps));
@@ -1076,7 +1077,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		// write some data
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(1);
-		env.setNumberOfExecutionRetries(0);
+		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env.getConfig().disableSysoutLogging();
 
 		writeSequence(env, topic, ELEMENT_COUNT, 1);
@@ -1084,7 +1085,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		// read using custom schema
 		final StreamExecutionEnvironment env1 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env1.setParallelism(1);
-		env1.setNumberOfExecutionRetries(0);
+		env1.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		env1.getConfig().disableSysoutLogging();
 
 		DataStream<Tuple2<Integer, Integer>> fromKafka = env.addSource(kafkaServer.getConsumer(topic, new FixedNumberDeserializationSchema(ELEMENT_COUNT), standardProps));

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
@@ -70,7 +71,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 			TypeInformation<Tuple2<Long, String>> longStringInfo = TypeInfoParser.parse("Tuple2<Long, String>");
 
 			StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
-			env.setNumberOfExecutionRetries(0);
+			env.setRestartStrategy(RestartStrategies.noRestart());
 			env.getConfig().disableSysoutLogging();
 
 			TypeInformationSerializationSchema<Tuple2<Long, String>> serSchema =

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -104,7 +104,7 @@ public abstract class KafkaTestBase extends TestLogger {
 		flinkConfig.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
 		flinkConfig.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 8);
 		flinkConfig.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 16);
-		flinkConfig.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 s");
+		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		flink = new ForkableFlinkMiniCluster(flinkConfig, false);
 		flink.start();

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka.testutils;
 
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -48,7 +49,7 @@ public class DataGenerators {
 
 		env.setParallelism(numPartitions);
 		env.getConfig().disableSysoutLogging();
-		env.setNumberOfExecutionRetries(0);
+		env.setRestartStrategy(RestartStrategies.noRestart());
 		
 		DataStream<Tuple2<Integer, Integer>> stream =env.addSource(
 				new RichParallelSourceFunction<Tuple2<Integer, Integer>>() {
@@ -90,7 +91,7 @@ public class DataGenerators {
 														 final boolean randomizeOrder) throws Exception {
 		env.setParallelism(numPartitions);
 		env.getConfig().disableSysoutLogging();
-		env.setNumberOfExecutionRetries(0);
+		env.setRestartStrategy(RestartStrategies.noRestart());
 
 		DataStream<Integer> stream = env.addSource(
 				new RichParallelSourceFunction<Integer>() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -424,6 +425,27 @@ public abstract class StreamExecutionEnvironment {
 	}
 
 	/**
+	 * Sets the restart strategy configuration. The configuration specifies which restart strategy
+	 * will be used for the execution graph in case of a restart.
+	 *
+	 * @param restartStrategyConfiguration Restart strategy configuration to be set
+	 */
+	@PublicEvolving
+	public void setRestartStrategy(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+		config.setRestartStrategy(restartStrategyConfiguration);
+	}
+
+	/**
+	 * Returns the specified restart strategy configuration.
+	 *
+	 * @return The restart strategy configuration to be used
+	 */
+	@PublicEvolving
+	public RestartStrategies.RestartStrategyConfiguration getRestartStrategy() {
+		return config.getRestartStrategy();
+	}
+
+	/**
 	 * Sets the number of times that failed tasks are re-executed. A value of
 	 * zero effectively disables fault tolerance. A value of {@code -1}
 	 * indicates that the system default value (as defined in the configuration)
@@ -431,7 +453,12 @@ public abstract class StreamExecutionEnvironment {
 	 *
 	 * @param numberOfExecutionRetries
 	 * 		The number of times the system will try to re-execute failed tasks.
+	 *
+	 * @deprecated This method will be replaced by {@link #setRestartStrategy}. The
+	 * {@link RestartStrategies.FixedDelayRestartStrategyConfiguration} contains the number of
+	 * execution retries.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
 		config.setNumberOfExecutionRetries(numberOfExecutionRetries);
@@ -443,7 +470,12 @@ public abstract class StreamExecutionEnvironment {
 	 * in the configuration) should be used.
 	 *
 	 * @return The number of times the system will try to re-execute failed tasks.
+	 *
+	 * @deprecated This method will be replaced by {@link #getRestartStrategy}. The
+	 * {@link RestartStrategies.FixedDelayRestartStrategyConfiguration} contains the number of
+	 * execution retries.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public int getNumberOfExecutionRetries() {
 		return config.getNumberOfExecutionRetries();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionEdge;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
@@ -133,7 +134,11 @@ public class RescalePartitionerTest extends TestLogger {
 			jobId,
 			jobName,
 			cfg,
-			AkkaUtils.getDefaultTimeout(),new ArrayList<BlobKey>(), new ArrayList<URL>(), ExecutionGraph.class.getClassLoader());
+			AkkaUtils.getDefaultTimeout(),
+			new NoRestartStrategy(),
+			new ArrayList<BlobKey>(),
+			new ArrayList<URL>(),
+			ExecutionGraph.class.getClassLoader());
 		try {
 			eg.attachJobGraph(jobVertices);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/state/StateBackendITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/state/StateBackendITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.state;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -56,7 +57,7 @@ public class StateBackendITCase extends StreamingMultipleProgramsTestBase {
 		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
 		see.setParallelism(1);
 
-		see.setNumberOfExecutionRetries(0);
+		see.getConfig().setRestartStrategy(RestartStrategies.noRestart());
 		see.setStateBackend(new FailingStateBackend());
 
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/timestamp/TimestampITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/timestamp/TimestampITCase.java
@@ -79,7 +79,6 @@ public class TimestampITCase {
 			Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TASK_MANAGERS);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, NUM_TASK_SLOTS);
-			config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 ms");
 			config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 12);
 
 			cluster = new ForkableFlinkMiniCluster(config, false);

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.scala
 import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.annotation.{Internal, PublicEvolving, Public}
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
+import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
@@ -186,8 +187,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * operator states. Time interval between state checkpoints is specified in in millis.
    *
    * Setting this option assumes that the job is used in production and thus if not stated
-   * explicitly otherwise with calling with the
-   * [[setNumberOfExecutionRetries(int)]] method in case of
+   * explicitly otherwise with calling the [[setRestartStrategy]] method in case of
    * failure the job will be resubmitted to the cluster indefinitely.
    */
   @deprecated
@@ -229,22 +229,49 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   @PublicEvolving
   def getStateBackend: AbstractStateBackend = javaEnv.getStateBackend()
-  
+
   /**
-   * Sets the number of times that failed tasks are re-executed. A value of zero
-   * effectively disables fault tolerance. A value of "-1" indicates that the system
-   * default value (as defined in the configuration) should be used.
-   */
+    * Sets the restart strategy configuration. The configuration specifies which restart strategy
+    * will be used for the execution graph in case of a restart.
+    *
+    * @param restartStrategyConfiguration Restart strategy configuration to be set
+    */
+  @PublicEvolving
+  def setRestartStrategy(restartStrategyConfiguration: RestartStrategyConfiguration): Unit = {
+    javaEnv.setRestartStrategy(restartStrategyConfiguration)
+  }
+
+  /**
+    * Returns the specified restart strategy configuration.
+    *
+    * @return The restart strategy configuration to be used
+    */
+  @PublicEvolving
+  def getRestartStrategy: RestartStrategyConfiguration = {
+    javaEnv.getRestartStrategy()
+  }
+
+  /**
+    * Sets the number of times that failed tasks are re-executed. A value of zero
+    * effectively disables fault tolerance. A value of "-1" indicates that the system
+    * default value (as defined in the configuration) should be used.
+    *
+    * @deprecated This method will be replaced by [[setRestartStrategy()]]. The
+    *            FixedDelayRestartStrategyConfiguration contains the number of execution retries.
+    */
   @PublicEvolving
   def setNumberOfExecutionRetries(numRetries: Int): Unit = {
     javaEnv.setNumberOfExecutionRetries(numRetries)
   }
 
   /**
-   * Gets the number of times the system will try to re-execute failed tasks. A value
-   * of "-1" indicates that the system default value (as defined in the configuration)
-   * should be used.
-   */
+    * Gets the number of times the system will try to re-execute failed tasks. A value
+    * of "-1" indicates that the system default value (as defined in the configuration)
+    * should be used.
+    *
+    * @deprecated This method will be replaced by [[getRestartStrategy]]. The
+    *            FixedDelayRestartStrategyConfiguration contains the number of execution retries.
+    */
   @PublicEvolving
   def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.ConfigConstants;
@@ -67,7 +68,6 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, PARALLELISM / 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 48);
-		config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 ms");
 
 		cluster = new ForkableFlinkMiniCluster(config, false);
 		cluster.start();
@@ -96,7 +96,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env
@@ -160,7 +160,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env
@@ -221,7 +221,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env
@@ -289,7 +289,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.java.tuple.Tuple;
@@ -70,7 +71,7 @@ import static org.apache.flink.test.util.TestUtils.tryExecute;
 import static org.junit.Assert.*;
 
 /**
- * This verfies that checkpointing works correctly with event time windows. This is more
+ * This verifies that checkpointing works correctly with event time windows. This is more
  * strict than {@link WindowCheckpointingITCase} because for event-time the contents
  * of the emitted windows are deterministic.
  */
@@ -98,7 +99,6 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, PARALLELISM / 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 48);
-		config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 ms");
 
 		cluster = new ForkableFlinkMiniCluster(config, false);
 		cluster.start();
@@ -149,7 +149,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
 
@@ -213,7 +213,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
 
@@ -282,7 +282,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
 
@@ -346,7 +346,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
 
@@ -414,7 +414,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointNotifierITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointNotifierITCase.java
@@ -84,7 +84,7 @@ public class StreamCheckpointNotifierITCase {
 			Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TASK_MANAGERS);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, NUM_TASK_SLOTS);
-			config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 ms");
+			config.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 ms");
 			config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 12);
 
 			cluster = new ForkableFlinkMiniCluster(config, false);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
@@ -49,7 +49,6 @@ public abstract class StreamFaultToleranceTestBase extends TestLogger {
 			Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TASK_MANAGERS);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, NUM_TASK_SLOTS);
-			config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 ms");
 			config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 12);
 			
 			cluster = new ForkableFlinkMiniCluster(config, false);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -81,7 +82,6 @@ public class WindowCheckpointingITCase extends TestLogger {
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, PARALLELISM / 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 48);
-		config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 ms");
 
 		cluster = new ForkableFlinkMiniCluster(config, false);
 		cluster.start();
@@ -109,7 +109,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(timeCharacteristic);
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env
@@ -167,7 +167,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(timeCharacteristic);
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env
@@ -225,7 +225,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(timeCharacteristic);
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env
@@ -273,7 +273,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 			env.setStreamTimeCharacteristic(timeCharacteristic);
 			env.getConfig().setAutoWatermarkInterval(10);
 			env.enableCheckpointing(100);
-			env.setNumberOfExecutionRetries(3);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 
 			env

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -54,7 +54,6 @@ public class ClassLoaderITCase {
 			Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 2);
-			config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "0 s");
 
 			// we need to use the "filesystem" state backend to ensure FLINK-2543 is not happening again.
 			config.setString(ConfigConstants.STATE_BACKEND, "filesystem");

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
@@ -19,6 +19,7 @@
 package org.apache.flink.test.classloading.jar;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -45,7 +46,7 @@ public class CheckpointedStreamingProgram {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment(host, port, jarFile);
 		env.getConfig().disableSysoutLogging();
 		env.enableCheckpointing(CHECKPOINT_INTERVALL);
-		env.setNumberOfExecutionRetries(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 10000));
 		env.disableOperatorChaining();
 		
 		DataStream<String> text = env.addSource(new SimpleStringGenerator());

--- a/flink-tests/src/test/java/org/apache/flink/test/failingPrograms/TaskFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/failingPrograms/TaskFailureITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.failingPrograms;
 import java.util.List;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.test.util.JavaProgramTestBase;
@@ -63,8 +64,7 @@ public class TaskFailureITCase extends JavaProgramTestBase {
 
 	private void executeTask(MapFunction<Long, Long> mapper, int retries) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().setNumberOfExecutionRetries(retries);
-		env.getConfig().setExecutionRetryDelay(0);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(retries, 0));
 		List<Long> result = env.generateSequence(1, 9)
 				.map(mapper)
 				.collect();

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -122,7 +122,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 			jmConfig.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL, "1000 ms");
 			jmConfig.setString(ConfigConstants.AKKA_WATCH_HEARTBEAT_PAUSE, "6 s");
 			jmConfig.setInteger(ConfigConstants.AKKA_WATCH_THRESHOLD, 9);
-			jmConfig.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "10 s");
+			jmConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "10 s");
 			jmConfig.setString(ConfigConstants.AKKA_ASK_TIMEOUT, "100 s");
 
 			jmActorSystem = AkkaUtils.createActorSystem(jmConfig, new Some<Tuple2<String, Object>>(localAddress));

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/FastFailuresITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/FastFailuresITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.test.recovery;
 
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -29,6 +30,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.test.util.ForkableFlinkMiniCluster;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("serial")
-public class FastFailuresITCase {
+public class FastFailuresITCase extends TestLogger {
 
 	static final AtomicInteger FAILURES_SO_FAR = new AtomicInteger();
 	static final int NUM_FAILURES = 200;
@@ -54,9 +56,9 @@ public class FastFailuresITCase {
 				"localhost", cluster.getLeaderRPCPort());
 
 		env.getConfig().disableSysoutLogging();
-		env.getConfig().setExecutionRetryDelay(0);
 		env.setParallelism(4);
 		env.enableCheckpointing(1000);
+		env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(200, 0));
 		
 		DataStream<Tuple2<Integer, Integer>> input = env.addSource(new RichSourceFunction<Tuple2<Integer, Integer>>() {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerProcessFailureBatchRecoveryITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionMode;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
@@ -75,7 +76,7 @@ public class JobManagerProcessFailureBatchRecoveryITCase extends AbstractJobMana
 		ExecutionEnvironment env = ExecutionEnvironment.createRemoteEnvironment(
 				"leader", 1, config);
 		env.setParallelism(PARALLELISM);
-		env.setNumberOfExecutionRetries(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000));
 		env.getConfig().setExecutionMode(executionMode);
 		env.getConfig().disableSysoutLogging();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -25,6 +25,7 @@ import akka.util.Timeout;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -134,7 +135,7 @@ public class ProcessFailureCancelingITCase {
 					try {
 						ExecutionEnvironment env = ExecutionEnvironment.createRemoteEnvironment("localhost", jobManagerPort);
 						env.setParallelism(2);
-						env.setNumberOfExecutionRetries(0);
+						env.setRestartStrategy(RestartStrategies.noRestart());
 						env.getConfig().disableSysoutLogging();
 
 						env.generateSequence(0, Long.MAX_VALUE)

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.recovery;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -51,7 +52,9 @@ public class SimpleRecoveryITCase {
 		Configuration config = new Configuration();
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 2);
-		config.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, "100 ms");
+		config.setString(ConfigConstants.RESTART_STRATEGY, "fixed-delay");
+		config.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+		config.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "100 ms");
 
 		cluster = new ForkableFlinkMiniCluster(config, false);
 
@@ -82,7 +85,7 @@ public class SimpleRecoveryITCase {
 						"localhost", cluster.getLeaderRPCPort());
 
 				env.setParallelism(4);
-				env.setNumberOfExecutionRetries(0);
+				env.setRestartStrategy(RestartStrategies.noRestart());
 				env.getConfig().disableSysoutLogging();
 
 				env.generateSequence(1, 10)
@@ -112,7 +115,7 @@ public class SimpleRecoveryITCase {
 						"localhost", cluster.getLeaderRPCPort());
 
 				env.setParallelism(4);
-				env.setNumberOfExecutionRetries(0);
+				env.setRestartStrategy(RestartStrategies.noRestart());
 				env.getConfig().disableSysoutLogging();
 
 				env.generateSequence(1, 10)
@@ -159,7 +162,7 @@ public class SimpleRecoveryITCase {
 					"localhost", cluster.getLeaderRPCPort());
 
 			env.setParallelism(4);
-			env.setNumberOfExecutionRetries(1);
+			// the default restart strategy should be taken
 			env.getConfig().disableSysoutLogging();
 
 			env.generateSequence(1, 10)
@@ -204,7 +207,7 @@ public class SimpleRecoveryITCase {
 					"localhost", cluster.getLeaderRPCPort());
 
 			env.setParallelism(4);
-			env.setNumberOfExecutionRetries(5);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, 100));
 			env.getConfig().disableSysoutLogging();
 
 			env.generateSequence(1, 10)

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerFailureRecoveryITCase.java
@@ -24,6 +24,7 @@ import akka.actor.PoisonPill;
 import akka.pattern.Patterns;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.apache.flink.configuration.ConfigConstants;
@@ -88,7 +89,7 @@ public class TaskManagerFailureRecoveryITCase {
 					"localhost", cluster.getLeaderRPCPort());
 
 			env.setParallelism(PARALLELISM);
-			env.setNumberOfExecutionRetries(1);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000));
 			env.getConfig().disableSysoutLogging();
 
 			env.generateSequence(1, 10)

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.recovery;
 import org.apache.flink.api.common.ExecutionMode;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.junit.runner.RunWith;
@@ -65,7 +66,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase extends AbstractTaskMa
 
 		ExecutionEnvironment env = ExecutionEnvironment.createRemoteEnvironment("localhost", jobManagerPort);
 		env.setParallelism(PARALLELISM);
-		env.setNumberOfExecutionRetries(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000));
 		env.getConfig().setExecutionMode(executionMode);
 		env.getConfig().disableSysoutLogging();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
@@ -69,7 +70,7 @@ public class TaskManagerProcessFailureStreamingRecoveryITCase extends AbstractTa
 				.createRemoteEnvironment("localhost", jobManagerPort);
 		env.setParallelism(PARALLELISM);
 		env.getConfig().disableSysoutLogging();
-		env.setNumberOfExecutionRetries(1);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000));
 		env.enableCheckpointing(200);
 		
 		env.setStateBackend(new FsStateBackend(tempCheckpointDir.getAbsoluteFile().toURI()));

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -148,7 +148,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 
 		// we "effectively" disable the automatic RecoverAllJobs message and sent it manually to make
 		// sure that all TMs have registered to the JM prior to issueing the RecoverAllJobs message
-		configuration.setString(ConfigConstants.EXECUTION_RETRY_DELAY_KEY, AkkaUtils.INF_TIMEOUT().toString());
+		configuration.setString(ConfigConstants.AKKA_ASK_TIMEOUT, AkkaUtils.INF_TIMEOUT().toString());
 
 		Tasks.BlockingOnceReceiver$.MODULE$.blocking_$eq(true);
 

--- a/flink-yarn-tests/src/main/scala/org/apache/flink/yarn/TestingYarnJobManager.scala
+++ b/flink-yarn-tests/src/main/scala/org/apache/flink/yarn/TestingYarnJobManager.scala
@@ -24,6 +24,7 @@ import akka.actor.ActorRef
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.checkpoint.{SavepointStore, CheckpointRecoveryFactory}
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
+import org.apache.flink.runtime.executiongraph.restart.RestartStrategy
 import org.apache.flink.runtime.instance.InstanceManager
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
@@ -45,8 +46,7 @@ import scala.concurrent.duration.FiniteDuration
   * @param scheduler Scheduler to schedule Flink jobs
   * @param libraryCacheManager Manager to manage uploaded jar files
   * @param archive Archive for finished Flink jobs
-  * @param defaultExecutionRetries Number of default execution retries
-  * @param delayBetweenRetries Delay between retries
+  * @param restartStrategy Default restart strategy for job restarts
   * @param timeout Timeout for futures
   * @param leaderElectionService LeaderElectionService to participate in the leader election
   */
@@ -57,13 +57,13 @@ class TestingYarnJobManager(
     scheduler: Scheduler,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
-    defaultExecutionRetries: Int,
-    delayBetweenRetries: Long,
+    restartStrategy: RestartStrategy,
     timeout: FiniteDuration,
     leaderElectionService: LeaderElectionService,
     submittedJobGraphs : SubmittedJobGraphStore,
     checkpointRecoveryFactory : CheckpointRecoveryFactory,
-    savepointStore: SavepointStore)
+    savepointStore: SavepointStore,
+    jobRecoveryTimeout: FiniteDuration)
   extends YarnJobManager(
     flinkConfiguration,
     executorService,
@@ -71,13 +71,13 @@ class TestingYarnJobManager(
     scheduler,
     libraryCacheManager,
     archive,
-    defaultExecutionRetries,
-    delayBetweenRetries,
+    restartStrategy,
     timeout,
     leaderElectionService,
     submittedJobGraphs,
     checkpointRecoveryFactory,
-    savepointStore)
+    savepointStore,
+    jobRecoveryTimeout)
   with TestingJobManagerLike {
 
   override val taskManagerRunnerClass = classOf[TestingYarnTaskManagerRunner]

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
@@ -33,6 +33,7 @@ import org.apache.flink.api.common.JobID
 import org.apache.flink.configuration.{Configuration => FlinkConfiguration, ConfigConstants}
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.checkpoint.{SavepointStore, CheckpointRecoveryFactory}
+import org.apache.flink.runtime.executiongraph.restart.RestartStrategy
 import org.apache.flink.runtime.jobgraph.JobStatus
 import org.apache.flink.runtime.jobmanager.{SubmittedJobGraphStore, JobManager}
 import org.apache.flink.runtime.leaderelection.LeaderElectionService
@@ -74,8 +75,7 @@ import scala.util.Try
   * @param scheduler Scheduler to schedule Flink jobs
   * @param libraryCacheManager Manager to manage uploaded jar files
   * @param archive Archive for finished Flink jobs
-  * @param defaultExecutionRetries Number of default execution retries
-  * @param delayBetweenRetries Delay between retries
+  * @param restartStrategy Restart strategy to be used in case of a job recovery
   * @param timeout Timeout for futures
   * @param leaderElectionService LeaderElectionService to participate in the leader election
   */
@@ -86,13 +86,13 @@ class YarnJobManager(
     scheduler: FlinkScheduler,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
-    defaultExecutionRetries: Int,
-    delayBetweenRetries: Long,
+    restartStrategy: RestartStrategy,
     timeout: FiniteDuration,
     leaderElectionService: LeaderElectionService,
     submittedJobGraphs : SubmittedJobGraphStore,
     checkpointRecoveryFactory : CheckpointRecoveryFactory,
-    savepointStore: SavepointStore)
+    savepointStore: SavepointStore,
+    jobRecoveryTimeout: FiniteDuration)
   extends JobManager(
     flinkConfiguration,
     executorService,
@@ -100,13 +100,13 @@ class YarnJobManager(
     scheduler,
     libraryCacheManager,
     archive,
-    defaultExecutionRetries,
-    delayBetweenRetries,
+    restartStrategy,
     timeout,
     leaderElectionService,
     submittedJobGraphs,
     checkpointRecoveryFactory,
-    savepointStore) {
+    savepointStore,
+    jobRecoveryTimeout) {
 
   import context._
   import scala.collection.JavaConverters._


### PR DESCRIPTION
Disclaimer: This PR is based on PR #1468.

## Description

This PR decouples the restart behaviour from the `ExecutionGraph` by introducing the strategy pattern `RestartStrategy`. The `RestartStrategy` encapsulates what will be done in case of a restart.

Currently, the following two `RestartStrategies` are supported:

* `FixedDelayRestartStrategy`: Tries to restart the job a fixed number times with a fixed waiting time in between. This constitutes the ist state.
* `NoRestartStrategy`: No restart, direct failing of job

Having such a decoupling allows us also to set a restart strategy on a per job basis. This renders the necessity to restart the cluster in case of changing the restart delay obsolete. Furthermore, different restart strategies can be used for concurrently running jobs.

Additionally, it is still possible to define a default restart strategy for the cluster. This default strategy is used when there is no other `RestartStrategy` defined for a submitted job.

## API Changes

A `RestartStrategy` can be set using the `setRestartStrategy` method of `(Stream)ExecutionEnvironment`. It looks as follows:

```
ExecutionEnvironment env = ...
env.setRestartStrategy(RestartStrategies.fixedDelay(
  3, // number retry attempts
  1000 // retry delay in milliseconds
));

env.setRestartStrategy(RestartStrategies.noRestart());
```

The default restart strategy is configured using the `restart-strategy` configuration parameter. Depending on the `RestartStrategy` several other configuration parameters can be set. At the moment only the `FixedDelayRestartStrategy` takes more parameters. Those are `restart-strategy.fixed-delay.attempts` and `restart-strategy.fixed-delay.delay`.

In order to configure the `FixedDelayRestartStrategy` as the default strategy, insert the following into the `flink-conf.yaml`.

```
restart-strategy: fixed-delay
restart-strategy.fixed-delay.attempts: 3
restart-strategy.fixed-delay.delay: 10 s
```

 This PR removes the old configuration parameters `execution-retries.default` and `execution-retries.delay` and is thus **API-breaking**.