### PR TITLE
[FLINK-3188] Pass deletes to KeyedDeserializationSchema

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/LegacyFetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/LegacyFetcher.java
@@ -448,19 +448,18 @@ public class LegacyFetcher implements Fetcher {
 
 								final long offset = msg.offset();
 
-								// put value into byte array
 								ByteBuffer payload = msg.message().payload();
+
+								// If the message value is null, this represents a delete command for the message key.
+								// Log this and pass it on to the client who might want to also receive delete messages.
+								byte[] valueBytes;
 								if (payload == null) {
-									// This message has no value (which means it has been deleted from the Kafka topic)
 									deletedMessages++;
-									// advance offset in state to avoid re-reading the message
-									synchronized (sourceContext.getCheckpointLock()) {
-										offsetsState.put(topicPartition, offset);
-									}
-									continue;
+									valueBytes = null;
+								} else {
+									valueBytes = new byte[payload.remaining()];
+									payload.get(valueBytes);
 								}
-								byte[] valueBytes = new byte[payload.remaining()];
-								payload.get(valueBytes);
 
 								// put key into byte array
 								byte[] keyBytes = null;

--- a/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 
 import org.junit.Test;
 
@@ -28,7 +28,7 @@ import java.util.Properties;
 public class KafkaITCase extends KafkaConsumerTestBase {
 	
 	@Override
-	protected <T> FlinkKafkaConsumer<T> getConsumer(List<String> topics, DeserializationSchema<T> deserializationSchema, Properties props) {
+	protected <T> FlinkKafkaConsumer<T> getConsumer(List<String> topics, KeyedDeserializationSchema<T> deserializationSchema, Properties props) {
 		return new FlinkKafkaConsumer082<>(topics, deserializationSchema, props);
 	}
 	
@@ -123,6 +123,11 @@ public class KafkaITCase extends KafkaConsumerTestBase {
 	@Test
 	public void testMultipleTopics() throws Exception {
 		runConsumeMultipleTopics();
+	}
+
+	@Test
+	public void testAllDeletes() throws Exception {
+		runAllDeletesTest();
 	}
 
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
@@ -35,7 +35,7 @@ public interface KeyedDeserializationSchema<T> extends Serializable, ResultTypeQ
 	 * Deserializes the byte message.
 	 *
 	 * @param messageKey the key as a byte array (null if no key has been set)
-	 * @param message The message, as a byte array.
+	 * @param message The message, as a byte array. (null if the message was empty or deleted)
 	 * @param offset the offset of the message in the original source (for example the Kafka offset)
 	 * @return The deserialized message as an object.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/TypeInformationKeyValueSerializationSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/TypeInformationKeyValueSerializationSchema.java
@@ -84,7 +84,10 @@ public class TypeInformationKeyValueSerializationSchema<K, V> implements KeyedDe
 		if(messageKey != null) {
 			key = keySerializer.deserialize(new ByteArrayInputView(messageKey));
 		}
-		V value = valueSerializer.deserialize(new ByteArrayInputView(message));
+		V value = null;
+		if(message != null) {
+			value = valueSerializer.deserialize(new ByteArrayInputView(message));
+		}
 		return new Tuple2<>(key, value);
 	}
 
@@ -128,6 +131,11 @@ public class TypeInformationKeyValueSerializationSchema<K, V> implements KeyedDe
 
 	@Override
 	public byte[] serializeValue(Tuple2<K, V> element) {
+		// if the value is null, its serialized value is null as well.
+		if(element.f1 == null) {
+			return null;
+		}
+
 		if (valueOutputSerializer == null) {
 			valueOutputSerializer = new DataOutputSerializer(16);
 		}


### PR DESCRIPTION
I've converted the two patches from https://issues.apache.org/jira/browse/FLINK-3188 into this pull request.
I removed the manual serializer creation from the patches and replaced them by a `TypeInformationKeyValueSerializationSchema`.