### PR TITLE
[FLINK-2586] Unstable Storm Compatibility Tests

### DIFF
--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/exclamation/ExclamationLocal.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/exclamation/ExclamationLocal.java
@@ -19,7 +19,6 @@ package org.apache.flink.storm.exclamation;
 
 import backtype.storm.Config;
 import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.utils.Utils;
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
 import org.apache.flink.storm.exclamation.operators.ExclamationBolt;
@@ -63,11 +62,10 @@ public class ExclamationLocal {
 		// execute program locally
 		Config conf = new Config();
 		conf.put(ExclamationBolt.EXCLAMATION_COUNT, ExclamationTopology.getExclamation());
+		conf.put(FlinkLocalCluster.SUBMIT_BLOCKING, true); // only required to stabilize integration test
 
 		final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
 		cluster.submitTopology(topologyId, conf, FlinkTopology.createTopology(builder));
-
-		Utils.sleep(10 * 1000);
 		cluster.shutdown();
 	}
 

--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/print/PrintSampleStream.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/print/PrintSampleStream.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 /**
  * Prints incoming tweets. Tweets can be filtered by keywords.
  */
-public class PrintSampleStream {        
+public class PrintSampleStream {
 	public static void main(String[] args) throws Exception {
 		String consumerKey = args[0];
 		String consumerSecret = args[1];

--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/split/operators/VerifyAndEnrichBolt.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/split/operators/VerifyAndEnrichBolt.java
@@ -34,6 +34,8 @@ public class VerifyAndEnrichBolt extends BaseRichBolt {
 	private final String token;
 	private OutputCollector collector;
 
+	public static boolean errorOccured = false;
+
 	public VerifyAndEnrichBolt(boolean evenOrOdd) {
 		this.evenOrOdd = evenOrOdd;
 		this.token = evenOrOdd ? "even" : "odd";
@@ -48,7 +50,7 @@ public class VerifyAndEnrichBolt extends BaseRichBolt {
 	@Override
 	public void execute(Tuple input) {
 		if ((input.getInteger(0) % 2 == 0) != this.evenOrOdd) {
-			throw new RuntimeException("Invalid number detected.");
+			errorOccured = true;
 		}
 		this.collector.emit(new Values(this.token, input.getInteger(0)));
 	}

--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountLocal.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountLocal.java
@@ -17,10 +17,11 @@
 
 package org.apache.flink.storm.wordcount;
 
+import backtype.storm.Config;
 import backtype.storm.LocalCluster;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.utils.Utils;
+
 import org.apache.flink.examples.java.wordcount.util.WordCountData;
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
@@ -60,10 +61,9 @@ public class WordCountLocal {
 		final TopologyBuilder builder = WordCountTopology.buildTopology();
 
 		final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
-		cluster.submitTopology(topologyId, null, FlinkTopology.createTopology(builder));
-
-		Utils.sleep(10 * 1000);
-
+		Config conf = new Config();
+		conf.put(FlinkLocalCluster.SUBMIT_BLOCKING, true); // only required to stabilize integration test
+		cluster.submitTopology(topologyId, conf, FlinkTopology.createTopology(builder));
 		cluster.shutdown();
 	}
 

--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountLocalByName.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountLocalByName.java
@@ -17,10 +17,11 @@
 
 package org.apache.flink.storm.wordcount;
 
+import backtype.storm.Config;
 import backtype.storm.LocalCluster;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.utils.Utils;
+
 import org.apache.flink.examples.java.wordcount.util.WordCountData;
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
@@ -61,11 +62,9 @@ public class WordCountLocalByName {
 		final TopologyBuilder builder = WordCountTopology.buildTopology(false);
 
 		final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
-		cluster.submitTopology(topologyId, null, FlinkTopology.createTopology(builder));
-
-		Utils.sleep(10 * 1000);
-
+		Config conf = new Config();
+		conf.put(FlinkLocalCluster.SUBMIT_BLOCKING, true); // only required to stabilize integration test
+		cluster.submitTopology(topologyId, conf, FlinkTopology.createTopology(builder));
 		cluster.shutdown();
-
 	}
 }

--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountTopology.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountTopology.java
@@ -20,9 +20,11 @@ package org.apache.flink.storm.wordcount;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.tuple.Fields;
+
 import org.apache.flink.examples.java.wordcount.util.WordCountData;
 import org.apache.flink.storm.util.BoltFileSink;
 import org.apache.flink.storm.util.BoltPrintSink;
+import org.apache.flink.storm.util.NullTerminatingSpout;
 import org.apache.flink.storm.util.OutputFormatter;
 import org.apache.flink.storm.util.TupleOutputFormatter;
 import org.apache.flink.storm.wordcount.operators.BoltCounter;
@@ -67,7 +69,8 @@ public class WordCountTopology {
 			// read the text file from given input path
 			final String[] tokens = textPath.split(":");
 			final String inputFile = tokens[tokens.length - 1];
-			builder.setSpout(spoutId, new WordCountFileSpout(inputFile));
+			// inserting NullTerminatingSpout only required to stabilize integration test
+			builder.setSpout(spoutId, new NullTerminatingSpout(new WordCountFileSpout(inputFile)));
 		} else {
 			builder.setSpout(spoutId, new WordCountInMemorySpout());
 		}

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/BoltSplitITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/BoltSplitITCase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.flink.storm.split;
 
+import org.apache.flink.storm.split.operators.VerifyAndEnrichBolt;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class BoltSplitITCase {
@@ -23,6 +25,7 @@ public class BoltSplitITCase {
 	@Test
 	public void testTopology() throws Exception {
 		SplitStreamBoltLocal.main(new String[] { "0", "/dev/null" });
+		Assert.assertFalse(VerifyAndEnrichBolt.errorOccured);
 	}
 
 }

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitBoltTopology.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitBoltTopology.java
@@ -49,10 +49,10 @@ public class SplitBoltTopology {
 			final String[] tokens = outputPath.split(":");
 			final String outputFile = tokens[tokens.length - 1];
 			builder.setBolt(sinkId, new BoltFileSink(outputFile, formatter))
-			.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
+				.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
 		} else {
 			builder.setBolt(sinkId, new BoltPrintSink(formatter), 4)
-			.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
+				.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
 		}
 
 		return builder;

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitSpoutTopology.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitSpoutTopology.java
@@ -47,10 +47,10 @@ public class SplitSpoutTopology {
 			final String[] tokens = outputPath.split(":");
 			final String outputFile = tokens[tokens.length - 1];
 			builder.setBolt(sinkId, new BoltFileSink(outputFile, formatter))
-			.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
+				.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
 		} else {
 			builder.setBolt(sinkId, new BoltPrintSink(formatter), 4)
-			.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
+				.shuffleGrouping(evenVerifierId).shuffleGrouping(oddVerifierId);
 		}
 
 		return builder;

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitStreamBoltLocal.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitStreamBoltLocal.java
@@ -20,7 +20,6 @@ import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.utils.Utils;
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 public class SplitStreamBoltLocal {
 	public final static String topologyId = "Bolt split stream example";
@@ -41,7 +40,8 @@ public class SplitStreamBoltLocal {
 		final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
 		cluster.submitTopology(topologyId, null, FlinkTopology.createTopology(builder));
 
-		Utils.sleep(10 * 1000);
+		// run topology for 5 seconds
+		Utils.sleep(5 * 1000);
 
 		cluster.shutdown();
 	}

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitStreamSpoutLocal.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SplitStreamSpoutLocal.java
@@ -20,7 +20,6 @@ import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.utils.Utils;
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 public class SplitStreamSpoutLocal {
 	public final static String topologyId = "Spout split stream example";
@@ -41,7 +40,8 @@ public class SplitStreamSpoutLocal {
 		final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
 		cluster.submitTopology(topologyId, null, FlinkTopology.createTopology(builder));
 
-		Utils.sleep(10 * 1000);
+		// run topology for 5 seconds
+		Utils.sleep(5 * 1000);
 
 		cluster.shutdown();
 	}

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SpoutSplitITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/split/SpoutSplitITCase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.flink.storm.split;
 
+import org.apache.flink.storm.split.operators.VerifyAndEnrichBolt;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class SpoutSplitITCase {
@@ -23,6 +25,7 @@ public class SpoutSplitITCase {
 	@Test
 	public void testTopology() throws Exception {
 		SplitStreamSpoutLocal.main(new String[] { "0", "/dev/null" });
+		Assert.assertFalse(VerifyAndEnrichBolt.errorOccured);
 	}
 
 }

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
@@ -17,9 +17,9 @@
  */
 package org.apache.flink.storm.tests;
 
+import backtype.storm.Config;
 import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.tuple.Fields;
-import backtype.storm.utils.Utils;
 
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
@@ -61,12 +61,9 @@ public class StormFieldsGroupingITCase extends StreamingProgramTestBase {
 		builder.setBolt(sinkId, new BoltFileSink(outputFile)).shuffleGrouping(boltId);
 
 		final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
-		cluster.submitTopology(topologyId, null, FlinkTopology.createTopology(builder));
-
-		Utils.sleep(10 * 1000);
-
-		// TODO kill does no do anything so far
-		cluster.killTopology(topologyId);
+		Config conf = new Config();
+		conf.put(FlinkLocalCluster.SUBMIT_BLOCKING, true); // only required to stabilize integration test
+		cluster.submitTopology(topologyId, conf, FlinkTopology.createTopology(builder));
 		cluster.shutdown();
 	}
 

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormUnionITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormUnionITCase.java
@@ -17,8 +17,8 @@
  */
 package org.apache.flink.storm.tests;
 
+import backtype.storm.Config;
 import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.utils.Utils;
 
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
@@ -26,7 +26,6 @@ import org.apache.flink.storm.tests.operators.FiniteRandomSpout;
 import org.apache.flink.storm.tests.operators.MergerBolt;
 import org.apache.flink.storm.util.BoltFileSink;
 import org.apache.flink.streaming.util.StreamingProgramTestBase;
-
 
 public class StormUnionITCase extends StreamingProgramTestBase {
 
@@ -76,12 +75,9 @@ public class StormUnionITCase extends StreamingProgramTestBase {
 
 		// execute program locally
 		final FlinkLocalCluster cluster = FlinkLocalCluster.getLocalCluster();
-		cluster.submitTopology(topologyId, null, FlinkTopology.createTopology(builder));
-
-		Utils.sleep(10 * 1000);
-
-		// TODO kill does no do anything so far
-		cluster.killTopology(topologyId);
+		Config conf = new Config();
+		conf.put(FlinkLocalCluster.SUBMIT_BLOCKING, true); // only required to stabilize integration test
+		cluster.submitTopology(topologyId, conf, FlinkTopology.createTopology(builder));
 		cluster.shutdown();
 	}
 

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/wordcount/WordCountLocalITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/wordcount/WordCountLocalITCase.java
@@ -39,7 +39,7 @@ public class WordCountLocalITCase extends StreamingProgramTestBase {
 
 	@Override
 	protected void testProgram() throws Exception {
-		WordCountLocal.main(new String[]{this.textPath, this.resultPath});
+		WordCountLocal.main(new String[] { this.textPath, this.resultPath });
 	}
 
 }

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/util/NullTerminatingSpout.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/util/NullTerminatingSpout.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.storm.util;
+
+import java.util.Map;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.OutputFieldsDeclarer;
+
+/**
+ * {@link NullTerminatingSpout} in a finite spout (ie, implements {@link FiniteSpout} interface) that wraps an
+ * infinite spout, and returns {@code true} in {@link #reachedEnd()} when the wrapped spout does not emit a tuple
+ * in {@code nextTuple()} for the first time.
+ */
+public class NullTerminatingSpout implements FiniteSpout {
+	private static final long serialVersionUID = -6976210409932076066L;
+
+	/** The original infinite Spout. */
+	private final IRichSpout spout;
+	/** The observer that checks if the given spouts emit a tuple or not on nextTuple(). */
+	private SpoutOutputCollectorObserver observer;
+
+
+
+	public NullTerminatingSpout(IRichSpout spout) {
+		this.spout = spout;
+	}
+
+
+
+	@Override
+	public void open(@SuppressWarnings("rawtypes") Map conf, TopologyContext context, SpoutOutputCollector collector) {
+		this.observer = new SpoutOutputCollectorObserver(collector);
+		this.observer.emitted = true;
+		this.spout.open(conf, context, this.observer);
+	}
+
+	@Override
+	public void close() {
+		this.spout.close();
+	}
+
+	@Override
+	public void activate() {
+		this.spout.activate();
+	}
+
+	@Override
+	public void deactivate() {
+		this.spout.deactivate();
+	}
+
+	@Override
+	public void nextTuple() {
+		this.observer.emitted = false;
+		this.spout.nextTuple();
+	}
+
+	@Override
+	public void ack(Object msgId) {
+		this.spout.ack(msgId);
+	}
+
+	@Override
+	public void fail(Object msgId) {
+		this.spout.fail(msgId);
+	}
+
+	@Override
+	public void declareOutputFields(OutputFieldsDeclarer declarer) {
+		this.spout.declareOutputFields(declarer);
+	}
+
+	@Override
+	public Map<String, Object> getComponentConfiguration() {
+		return this.spout.getComponentConfiguration();
+	}
+
+	@Override
+	public boolean reachedEnd() {
+		return this.observer.emitted == false;
+	}
+
+}

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/util/SpoutOutputCollectorObserver.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/util/SpoutOutputCollectorObserver.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.storm.util;
+
+import java.util.List;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.utils.Utils;
+
+/**
+ * Observes if a call to any {@code emit(...)} or {@code emitDirect(...)} method is made.
+ * The internal flag {@link #emitted} must be reset by the user manually.
+ */
+class SpoutOutputCollectorObserver extends SpoutOutputCollector {
+
+	/** The collector to be observed. */
+	private final SpoutOutputCollector delegate;
+	/** The internal flag that it set to {@code true} if a tuple gets emitted. */
+	boolean emitted;
+
+
+
+	public SpoutOutputCollectorObserver(SpoutOutputCollector delegate) {
+		super(null);
+		this.delegate = delegate;
+	}
+
+
+
+	@Override
+	public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
+		emitted = true;
+		return this.delegate.emit(streamId, tuple, messageId);
+	}
+
+	@Override
+	public List<Integer> emit(List<Object> tuple, Object messageId) {
+		return emit(Utils.DEFAULT_STREAM_ID, tuple, messageId);
+	}
+
+	@Override
+	public List<Integer> emit(List<Object> tuple) {
+		return emit(tuple, null);
+	}
+
+	@Override
+	public List<Integer> emit(String streamId, List<Object> tuple) {
+		return emit(streamId, tuple, null);
+	}
+
+	@Override
+	public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
+		emitted = true;
+		delegate.emitDirect(taskId, streamId, tuple, messageId);
+	}
+
+	@Override
+	public void emitDirect(int taskId, List<Object> tuple, Object messageId) {
+		emitDirect(taskId, Utils.DEFAULT_STREAM_ID, tuple, messageId);
+	}
+
+	@Override
+	public void emitDirect(int taskId, String streamId, List<Object> tuple) {
+		emitDirect(taskId, streamId, tuple, null);
+	}
+
+	@Override
+	public void emitDirect(int taskId, List<Object> tuple) {
+		emitDirect(taskId, tuple, null);
+	}
+
+	@Override
+	public void reportError(Throwable error) {
+		delegate.reportError(error);
+	}
+
+}

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/api/FlinkTopologyTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/api/FlinkTopologyTest.java
@@ -16,15 +16,12 @@
  */
 package org.apache.flink.storm.api;
 
-
-import backtype.storm.generated.StormTopology;
 import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.tuple.Fields;
 import org.apache.flink.storm.util.TestDummyBolt;
 import org.apache.flink.storm.util.TestDummySpout;
 import org.apache.flink.storm.util.TestSink;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class FlinkTopologyTest {

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/util/NullTerminatingSpoutTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/util/NullTerminatingSpoutTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.storm.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.OutputFieldsDeclarer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.any;
+
+public class NullTerminatingSpoutTest {
+
+	@Test
+	public void testMethodCalls() {
+		Map<String, Object> compConfig = new HashMap<String, Object>();
+
+		IRichSpout spoutMock = mock(IRichSpout.class);
+		when(spoutMock.getComponentConfiguration()).thenReturn(compConfig);
+
+		Map<?,?> conf = mock(Map.class);
+		TopologyContext context = mock(TopologyContext.class);
+		Object msgId = mock(Object.class);
+		OutputFieldsDeclarer declarer = mock(OutputFieldsDeclarer.class);
+
+		NullTerminatingSpout spout = new NullTerminatingSpout(spoutMock);
+
+		spout.open(conf, context, null);
+		spout.close();
+		spout.activate();
+		spout.deactivate();
+		spout.ack(msgId);
+		spout.fail(msgId);
+		spout.declareOutputFields(declarer);
+		Map<String, Object> c = spoutMock.getComponentConfiguration();
+
+		verify(spoutMock).open(same(conf), same(context), any(SpoutOutputCollector.class));
+		verify(spoutMock).close();
+		verify(spoutMock).activate();
+		verify(spoutMock).deactivate();
+		verify(spoutMock).ack(same(msgId));
+		verify(spoutMock).fail(same(msgId));
+		verify(spoutMock).declareOutputFields(same(declarer));
+		Assert.assertSame(compConfig, c);
+	}
+
+	@Test
+	public void testReachedEnd() {
+		NullTerminatingSpout finiteSpout = new NullTerminatingSpout(new TestDummySpout());
+		finiteSpout.open(null, null, mock(SpoutOutputCollector.class));
+
+		Assert.assertFalse(finiteSpout.reachedEnd());
+
+		finiteSpout.nextTuple();
+		Assert.assertFalse(finiteSpout.reachedEnd());
+		finiteSpout.nextTuple();
+		Assert.assertTrue(finiteSpout.reachedEnd());
+	}
+
+}

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/util/SpoutOutputCollectorObserverTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/util/SpoutOutputCollectorObserverTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.storm.util;
+
+import backtype.storm.spout.SpoutOutputCollector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class SpoutOutputCollectorObserverTest {
+
+	@Test
+	public void testFlag() {
+		SpoutOutputCollectorObserver observer = new SpoutOutputCollectorObserver(mock(SpoutOutputCollector.class));
+
+		observer.emitted = false;
+		observer.emit(null);
+		Assert.assertTrue(observer.emitted);
+
+		observer.emitted = false;
+		observer.emit(null, (Object)null);
+		Assert.assertTrue(observer.emitted);
+
+		observer.emitted = false;
+		observer.emit((String)null, null);
+		Assert.assertTrue(observer.emitted);
+
+		observer.emitted = false;
+		observer.emit(null, null, null);
+		Assert.assertTrue(observer.emitted);
+
+		observer.emitted = false;
+		observer.emitDirect(0, null);
+		Assert.assertTrue(observer.emitted);
+
+		observer.emitted = false;
+		observer.emitDirect(0, null, (Object)null);
+		Assert.assertTrue(observer.emitted);
+
+		observer.emitted = false;
+		observer.emitDirect(0, (String)null, null);
+		Assert.assertTrue(observer.emitted);
+
+		observer.emitted = false;
+		observer.emitDirect(0, null, null, null);
+		Assert.assertTrue(observer.emitted);
+	}
+
+}

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/StormTupleTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/StormTupleTest.java
@@ -616,7 +616,7 @@ public class StormTupleTest extends AbstractTest {
 	@Test
 	public void testGetSourceGlobalStreamid() {
 		GlobalStreamId globalStreamid =
-			new StormTuple<>(new Tuple1(), null, 0, "streamId", "componentID").getSourceGlobalStreamid();
+			new StormTuple<>(new Tuple1<>(), null, 0, "streamId", "componentID").getSourceGlobalStreamid();
 		Assert.assertEquals("streamId", globalStreamid.get_streamId());
 		Assert.assertEquals("componentID", globalStreamid.get_componentId());
 	}
@@ -624,21 +624,21 @@ public class StormTupleTest extends AbstractTest {
 	@Test
 	public void testGetSourceComponent() {
 		String sourceComponent =
-			new StormTuple<>(new Tuple1(), null, 0, "streamId", "componentID").getSourceComponent();
+			new StormTuple<>(new Tuple1<>(), null, 0, "streamId", "componentID").getSourceComponent();
 		Assert.assertEquals("componentID", sourceComponent);
 	}
 
 	@Test
 	public void testGetSourceTask() {
 		String sourceStreamId =
-			new StormTuple<>(new Tuple1(), null, 0, "streamId", "componentID").getSourceStreamId();
+			new StormTuple<>(new Tuple1<>(), null, 0, "streamId", "componentID").getSourceStreamId();
 		Assert.assertEquals("streamId", sourceStreamId);
 	}
 
 	@Test
 	public void testGetSourceStreamId() {
 		String sourceStreamId =
-			new StormTuple<>(new Tuple1(), null, 0, "streamId", "componentID").getSourceStreamId();
+			new StormTuple<>(new Tuple1<>(), null, 0, "streamId", "componentID").getSourceStreamId();
 		Assert.assertEquals("streamId", sourceStreamId);
 	}
 

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/WrapperSetupHelperTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/WrapperSetupHelperTest.java
@@ -178,6 +178,8 @@ public class WrapperSetupHelperTest extends AbstractTest {
 		builder.setBolt("bolt2", (IRichBolt) operators.get("bolt2"), dops.get("bolt2")).allGrouping("spout2");
 		builder.setBolt("sink", (IRichBolt) operators.get("sink"), dops.get("sink"))
 				.shuffleGrouping("bolt1", TestDummyBolt.groupingStreamId)
+				.shuffleGrouping("bolt1", TestDummyBolt.shuffleStreamId)
+				.shuffleGrouping("bolt2", TestDummyBolt.groupingStreamId)
 				.shuffleGrouping("bolt2", TestDummyBolt.shuffleStreamId);
 
 		int counter = 0;
@@ -185,24 +187,15 @@ public class WrapperSetupHelperTest extends AbstractTest {
 			LocalCluster cluster = new LocalCluster();
 			Config c = new Config();
 			c.setNumAckers(0);
+			c.setDebug(true);
 			cluster.submitTopology("test", c, builder.createTopology());
-			Utils.sleep(++counter * 10000);
+			Utils.sleep(++counter * 3000);
 			cluster.shutdown();
 
-			if (TestSink.result.size() == 5) {
+			if (TestSink.result.size() == 8) {
 				break;
 			}
 		}
-
-		TopologyBuilder stormBuilder = new TopologyBuilder();
-
-		stormBuilder.setSpout("spout1", (IRichSpout) operators.get("spout1"), dops.get("spout1"));
-		stormBuilder.setSpout("spout2", (IRichSpout) operators.get("spout2"), dops.get("spout2"));
-		stormBuilder.setBolt("bolt1", (IRichBolt) operators.get("bolt1"), dops.get("bolt1")).shuffleGrouping("spout1");
-		stormBuilder.setBolt("bolt2", (IRichBolt) operators.get("bolt2"), dops.get("bolt2")).allGrouping("spout2");
-		stormBuilder.setBolt("sink", (IRichBolt) operators.get("sink"), dops.get("sink"))
-				.shuffleGrouping("bolt1", TestDummyBolt.groupingStreamId)
-				.shuffleGrouping("bolt2", TestDummyBolt.shuffleStreamId);
 
 		final FlinkTopology flinkBuilder = FlinkTopology.createTopology(builder);
 		StormTopology stormTopology = flinkBuilder.getStormTopology();


### PR DESCRIPTION
 - added BLOCKING flag to FlinkLocalCluster
 - added NullTerminatingSpout and SpoutOutputCollectorObserver plus tests
 - reworked test accordingly
   - set BLOCKING flag for ITCases
   - make infinite spouts finite using NullTerminatingSpout
   - removed sleep time to get stable
 - fixed bug in BoltSplitITCase and SpoutSplitITCase
   - exception in VerifyAndEnrichBolt is swallowed and test would not fail (replaced by errorFlag)
 - reduced sleep-time in BoltSplitITCase and SpoutSplitITCase to reduce testing time
 - fixed WrapperSetupHelperTest
   - reworked to origianl version with more than two inputs
     (was limite to two inputs because more the two inputs per bolt was not supported in between, which is now fixed)
minor code cleanup (removed unused imports, indenting, etc.)