### PR TITLE
[FLINK-3232] Add option to eagerly deploy channels

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
@@ -48,11 +48,20 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 	/** The number of subpartitions. */
 	private final int numberOfSubpartitions;
 
+	/**
+	 * Flag indicating whether to eagerly deploy consumers.
+	 *
+	 * <p>If <code>true</code>, the consumers are deployed as soon as the
+	 * runtime result is registered at the result manager of the task manager.
+	 */
+	private final boolean eagerlyDeployConsumers;
+
 	public ResultPartitionDeploymentDescriptor(
 			IntermediateDataSetID resultId,
 			IntermediateResultPartitionID partitionId,
 			ResultPartitionType partitionType,
-			int numberOfSubpartitions) {
+			int numberOfSubpartitions,
+			boolean eagerlyDeployConsumers) {
 
 		this.resultId = checkNotNull(resultId);
 		this.partitionId = checkNotNull(partitionId);
@@ -60,6 +69,7 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 
 		checkArgument(numberOfSubpartitions >= 1);
 		this.numberOfSubpartitions = numberOfSubpartitions;
+		this.eagerlyDeployConsumers = eagerlyDeployConsumers;
 	}
 
 	public IntermediateDataSetID getResultId() {
@@ -76,6 +86,16 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 
 	public int getNumberOfSubpartitions() {
 		return numberOfSubpartitions;
+	}
+
+	/**
+	 * Returns whether consumers should be deployed eagerly (as soon as they
+	 * are registered at the result manager of the task manager).
+	 *
+	 * @return Whether consumers should be deployed eagerly
+	 */
+	public boolean getEagerlyDeployConsumers() {
+		return eagerlyDeployConsumers;
 	}
 
 	@Override
@@ -109,6 +129,7 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 		}
 
 		return new ResultPartitionDeploymentDescriptor(
-				resultId, partitionId, partitionType, numberOfSubpartitions);
+				resultId, partitionId, partitionType, numberOfSubpartitions,
+				partition.getIntermediateResult().getEagerlyDeployConsumers());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -128,7 +128,11 @@ public class ExecutionJobVertex implements Serializable {
 			final IntermediateDataSet result = jobVertex.getProducedDataSets().get(i);
 
 			this.producedDataSets[i] = new IntermediateResult(
-					result.getId(), this, numTaskVertices, result.getResultType());
+					result.getId(),
+					this,
+					numTaskVertices,
+					result.getResultType(),
+					result.getEagerlyDeployConsumers());
 		}
 
 		// create all task vertices

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -46,11 +46,14 @@ public class IntermediateResult {
 
 	private final ResultPartitionType resultType;
 
+	private final boolean eagerlyDeployConsumers;
+
 	public IntermediateResult(
 			IntermediateDataSetID id,
 			ExecutionJobVertex producer,
 			int numParallelProducers,
-			ResultPartitionType resultType) {
+			ResultPartitionType resultType,
+			boolean eagerlyDeployConsumers) {
 
 		this.id = checkNotNull(id);
 		this.producer = checkNotNull(producer);
@@ -68,6 +71,8 @@ public class IntermediateResult {
 
 		// The runtime type for this produced result
 		this.resultType = checkNotNull(resultType);
+
+		this.eagerlyDeployConsumers = eagerlyDeployConsumers;
 	}
 
 	public void setPartition(int partitionNumber, IntermediateResultPartition partition) {
@@ -101,6 +106,10 @@ public class IntermediateResult {
 
 	public ResultPartitionType getResultType() {
 		return resultType;
+	}
+
+	public boolean getEagerlyDeployConsumers() {
+		return eagerlyDeployConsumers;
 	}
 
 	public int registerConsumer() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -86,6 +86,14 @@ public class ResultPartition implements BufferPoolOwner {
 	/** Type of this partition. Defines the concrete subpartition implementation to use. */
 	private final ResultPartitionType partitionType;
 
+	/**
+	 * Flag indicating whether to eagerly deploy consumers.
+	 *
+	 * <p>If <code>true</code>, the consumers are deployed as soon as the
+	 * runtime result is registered at the result manager of the task manager.
+	 */
+	private final boolean eagerlyDeployConsumers;
+
 	/** The subpartitions of this partition. At least one. */
 	private final ResultSubpartition[] subpartitions;
 
@@ -125,6 +133,7 @@ public class ResultPartition implements BufferPoolOwner {
 			JobID jobId,
 			ResultPartitionID partitionId,
 			ResultPartitionType partitionType,
+			boolean eagerlyDeployConsumers,
 			int numberOfSubpartitions,
 			ResultPartitionManager partitionManager,
 			ResultPartitionConsumableNotifier partitionConsumableNotifier,
@@ -135,6 +144,7 @@ public class ResultPartition implements BufferPoolOwner {
 		this.jobId = checkNotNull(jobId);
 		this.partitionId = checkNotNull(partitionId);
 		this.partitionType = checkNotNull(partitionType);
+		this.eagerlyDeployConsumers = eagerlyDeployConsumers;
 		this.subpartitions = new ResultSubpartition[numberOfSubpartitions];
 		this.partitionManager = checkNotNull(partitionManager);
 		this.partitionConsumableNotifier = checkNotNull(partitionConsumableNotifier);
@@ -199,6 +209,16 @@ public class ResultPartition implements BufferPoolOwner {
 
 	public int getNumberOfSubpartitions() {
 		return subpartitions.length;
+	}
+
+	/**
+	 * Returns whether consumers should be deployed eagerly (as soon as they
+	 * are registered at the result manager of the task manager).
+	 *
+	 * @return Whether consumers should be deployed eagerly
+	 */
+	public boolean getEagerlyDeployConsumers() {
+		return eagerlyDeployConsumers;
 	}
 
 	public BufferProvider getBufferProvider() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSet.java
@@ -45,6 +45,14 @@ public class IntermediateDataSet implements java.io.Serializable {
 
 	// The type of partition to use at runtime
 	private final ResultPartitionType resultType;
+
+	/**
+	 * Flag indicating whether to eagerly deploy consumers.
+	 *
+	 * <p>If <code>true</code>, the consumers are deployed as soon as the
+	 * runtime result is registered at the result manager of the task manager.
+	 */
+	private boolean eagerlyDeployConsumers;
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -78,6 +86,29 @@ public class IntermediateDataSet implements java.io.Serializable {
 
 	public ResultPartitionType getResultType() {
 		return resultType;
+	}
+
+	/**
+	 * Sets the flag indicating whether to eagerly deploy consumers (default:
+	 * <code>false</code>).
+	 *
+	 * @param eagerlyDeployConsumers If <code>true</code>, the consumers are
+	 *                               deployed as soon as the runtime result is
+	 *                               registered at the result manager of the
+	 *                               task manager. Default is <code>false</code>.
+	 */
+	public void setEagerlyDeployConsumers(boolean eagerlyDeployConsumers) {
+		this.eagerlyDeployConsumers = eagerlyDeployConsumers;
+	}
+
+	/**
+	 * Returns whether consumers should be deployed eagerly (as soon as they
+	 * are registered at the result manager of the task manager).
+	 *
+	 * @return Whether consumers should be deployed eagerly
+	 */
+	public boolean getEagerlyDeployConsumers() {
+		return eagerlyDeployConsumers;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -352,7 +352,7 @@ public class JobVertex implements java.io.Serializable {
 	}
 
 	public JobEdge connectNewDataSetAsInput(JobVertex input, DistributionPattern distPattern) {
-		return connectNewDataSetAsInput(input, distPattern, ResultPartitionType.PIPELINED);
+		return connectNewDataSetAsInput(input, distPattern, ResultPartitionType.PIPELINED, false);
 	}
 
 	public JobEdge connectNewDataSetAsInput(
@@ -360,7 +360,18 @@ public class JobVertex implements java.io.Serializable {
 			DistributionPattern distPattern,
 			ResultPartitionType partitionType) {
 
+		return connectNewDataSetAsInput(input, distPattern, partitionType, false);
+	}
+
+	public JobEdge connectNewDataSetAsInput(
+			JobVertex input,
+			DistributionPattern distPattern,
+			ResultPartitionType partitionType,
+			boolean eagerlyDeployConsumers) {
+
 		IntermediateDataSet dataSet = input.createAndAddResultDataSet(partitionType);
+		dataSet.setEagerlyDeployConsumers(eagerlyDeployConsumers);
+
 		JobEdge edge = new JobEdge(dataSet, this, distPattern);
 		this.inputs.add(edge);
 		dataSet.addConsumer(edge);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -284,6 +284,7 @@ public class Task implements Runnable {
 					jobId,
 					partitionId,
 					desc.getPartitionType(),
+					desc.getEagerlyDeployConsumers(),
 					desc.getNumberOfSubpartitions(),
 					networkEnvironment.getPartitionManager(),
 					networkEnvironment.getPartitionConsumableNotifier(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResultPartitionDeploymentDescriptorTest {
+
+	/**
+	 * Tests simple de/serialization.
+	 */
+	@Test
+	public void testSerialization() throws Exception {
+		// Expected values
+		IntermediateDataSetID resultId = new IntermediateDataSetID();
+		IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
+		ResultPartitionType partitionType = ResultPartitionType.PIPELINED;
+		int numberOfSubpartitions = 24;
+		boolean eagerlyDeployConsumers = true;
+
+		ResultPartitionDeploymentDescriptor orig =
+				new ResultPartitionDeploymentDescriptor(
+						resultId,
+						partitionId,
+						partitionType,
+						numberOfSubpartitions,
+						eagerlyDeployConsumers);
+
+		ResultPartitionDeploymentDescriptor copy =
+				CommonTestUtils.createCopySerializable(orig);
+
+		assertEquals(resultId, copy.getResultId());
+		assertEquals(partitionId, copy.getPartitionId());
+		assertEquals(partitionType, copy.getPartitionType());
+		assertEquals(numberOfSubpartitions, copy.getNumberOfSubpartitions());
+		assertEquals(eagerlyDeployConsumers, copy.getEagerlyDeployConsumers());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -118,6 +118,7 @@ public class LocalInputChannelTest {
 					jobId,
 					partitionIds[i],
 					ResultPartitionType.PIPELINED,
+					false,
 					parallelism,
 					partitionManager,
 					partitionConsumableNotifier,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -499,7 +499,7 @@ public class TaskManagerTest {
 				IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
 
 				List<ResultPartitionDeploymentDescriptor> irpdd = new ArrayList<ResultPartitionDeploymentDescriptor>();
-				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1));
+				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, false));
 
 				InputGateDeploymentDescriptor ircdd =
 						new InputGateDeploymentDescriptor(
@@ -643,7 +643,7 @@ public class TaskManagerTest {
 				IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
 
 				List<ResultPartitionDeploymentDescriptor> irpdd = new ArrayList<ResultPartitionDeploymentDescriptor>();
-				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1));
+				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, false));
 
 				InputGateDeploymentDescriptor ircdd =
 						new InputGateDeploymentDescriptor(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.util.UserCodeObjectWrapper;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.InputFormatVertex;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -358,9 +359,17 @@ public class StreamingJobGraphGenerator {
 
 		StreamPartitioner<?> partitioner = edge.getPartitioner();
 		if (partitioner instanceof ForwardPartitioner) {
-			downStreamVertex.connectNewDataSetAsInput(headVertex, DistributionPattern.POINTWISE);
+			downStreamVertex.connectNewDataSetAsInput(
+					headVertex,
+					DistributionPattern.POINTWISE,
+					ResultPartitionType.PIPELINED,
+					true);
 		} else {
-			downStreamVertex.connectNewDataSetAsInput(headVertex, DistributionPattern.ALL_TO_ALL);
+			downStreamVertex.connectNewDataSetAsInput(
+					headVertex,
+					DistributionPattern.ALL_TO_ALL,
+					ResultPartitionType.PIPELINED,
+					true);
 		}
 
 		if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
Adds a flag to the ExecutionGraph's IntermediateResult class indicating whether the result consumers should be deployed eagerly. If true, the consumers are deployed as soon as the partition is registered at the ResultPartitionManager of the task manager. In practice, the deployment boils down to updating unknown input channels of the consumers (because the actual tasks are actually deployed all at once).

This behaviour is configured in the JobGraph generator and only activated for streaming programs (StreamingJobGraphGenerator). It only makes sense for pipelined results.

The motivation is to get down the latency of the first records passing a pipeline. The initial update of the input channels causes a higher latency.

You can see this effect in the StreamingScalabilityAndLatency class (manual test).

At the moment, this results in duplicate Akka messages when the first record is produced (the message travels from the task to the job manager and from the job manager to task manager, which then will be ignored at the InputGate).

You can verify the decreased latency by adding a `Thread.sleep(2000)` to `StreamingScalabilityAndLatency.TimeStampingSource`. In order to compare to the old solution, uncomment lines 348--354 in `NetworkEnvironment`.