### PR TITLE
[FLINK-2984] [ml] Extend libSVM file format support

### DIFF
--- a/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/MLUtilsSuite.scala
+++ b/flink-staging/flink-ml/src/test/scala/org/apache/flink/ml/MLUtilsSuite.scala
@@ -40,9 +40,9 @@ class MLUtilsSuite extends FlatSpec with Matchers with FlinkTestBase {
 
     val content =
       """
-        |1 2:10.0 4:4.5 8:4.2 # foo
+        |1  2:10.0 4:4.5 8:4.2 # foo
         |-1 1:9.0 4:-4.5 7:2.4 # bar
-        |0.4 3:1.0 8:-5.6 10:1.0
+        |0.4  3:1.0 8:-5.6 10:1.0
         |-42.1 2:2.0 4:-6.1 3:5.1 # svm
       """.stripMargin
 


### PR DESCRIPTION
Currently, FlinkML libSVM file reader cannot read some datasets (such as splice-site) in libSVM official site. This PR extends libSVM file format to liblinear equivalent. To avoid re-compiling regex pattern in every line, I changed the mapper from scala lambda function to `RichFlatMapFunction`.