### PR TITLE
Fix to class loader to ensure tasks receive the appropriate classpath…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -315,7 +315,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	private static class FlinkUserCodeClassLoader extends URLClassLoader {
 
 		public FlinkUserCodeClassLoader(URL[] urls) {
-			super(urls);
+			super(urls, FlinkUserCodeClassLoader.class.getClassLoader());
 		}
 	}
 }


### PR DESCRIPTION
… (for the 0.9.1 release branch)

**Note**: This is a hotfix request for release-0.9.1 with the same change as in pull request #1506.  Not sure how you guys usually take these (if at all), but this issue goes back as far as `FlinkUserCodeClassLoader` has been a part of the project.


ClassNotFoundException thrown by task runners after Maven emits a fat-jar instrumented with Spring Boot.  

Here's a [gist](https://gist.github.com/revprez/2c1fb01c40e5d6790247), and here's the [report, discussion and solution](http://mail-archives.apache.org/mod_mbox/flink-user/201601.mbox/browser).  H/t to Stephan Ewen; I just did what he told me to do.