### PR TITLE
[Refactor] [DataSet] Refactor key selector translation in DataSet API.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
@@ -19,31 +19,28 @@
 package org.apache.flink.api.java.operators;
 
 import org.apache.flink.api.common.functions.GroupReduceFunction;
-import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.SingleInputSemanticProperties;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
 import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase;
-import org.apache.flink.api.common.operators.base.MapOperatorBase;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
-import org.apache.flink.api.java.operators.translation.KeyExtractingMapper;
+import org.apache.flink.api.java.operators.Keys.SelectorFunctionKeys;
 import org.apache.flink.api.java.operators.translation.PlanUnwrappingReduceGroupOperator;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.util.Collector;
 import org.apache.flink.api.java.DataSet;
 
 /**
  * This operator represents the application of a "distinct" function on a data set, and the
  * result data set produced by the function.
- * 
+ *
  * @param <T> The type of the data set made distinct by the operator.
  */
 public class DistinctOperator<T> extends SingleInputOperator<T, T, DistinctOperator<T>> {
-	
+
 	private final Keys<T> keys;
-	
+
 	private final String distinctLocationName;
 
 	public DistinctOperator(DataSet<T> input, Keys<T> keys, String distinctLocationName) {
@@ -53,7 +50,7 @@ public class DistinctOperator<T> extends SingleInputOperator<T, T, DistinctOpera
 
 		// if keys is null distinction is done on all fields
 		if (keys == null) {
-			keys = new Keys.ExpressionKeys<T>(new String[] {Keys.ExpressionKeys.SELECT_ALL_CHAR }, input.getType());
+			keys = new Keys.ExpressionKeys<>(new String[] {Keys.ExpressionKeys.SELECT_ALL_CHAR }, input.getType());
 		}
 
 		this.keys = keys;
@@ -61,79 +58,71 @@ public class DistinctOperator<T> extends SingleInputOperator<T, T, DistinctOpera
 
 	@Override
 	protected org.apache.flink.api.common.operators.base.GroupReduceOperatorBase<?, T, ?> translateToDataFlow(Operator<T> input) {
-		
-		final RichGroupReduceFunction<T, T> function = new DistinctFunction<T>();
+
+		final RichGroupReduceFunction<T, T> function = new DistinctFunction<>();
 
 		String name = getName() != null ? getName() : "Distinct at " + distinctLocationName;
-		
+
 		if (keys instanceof Keys.ExpressionKeys) {
 
 			int[] logicalKeyPositions = keys.computeLogicalKeyPositions();
-			UnaryOperatorInformation<T, T> operatorInfo = new UnaryOperatorInformation<T, T>(getInputType(), getResultType());
+			UnaryOperatorInformation<T, T> operatorInfo = new UnaryOperatorInformation<>(getInputType(), getResultType());
 			GroupReduceOperatorBase<T, T, GroupReduceFunction<T, T>> po =
 					new GroupReduceOperatorBase<T, T, GroupReduceFunction<T, T>>(function, operatorInfo, logicalKeyPositions, name);
 
 			po.setCombinable(true);
 			po.setInput(input);
 			po.setParallelism(getParallelism());
-			
+
 			// make sure that distinct preserves the partitioning for the fields on which they operate
 			if (getType().isTupleType()) {
 				SingleInputSemanticProperties sProps = new SingleInputSemanticProperties();
-				
+
 				for (int field : keys.computeLogicalKeyPositions()) {
 					sProps.addForwardedField(field, field);
 				}
-				
+
 				po.setSemanticProperties(sProps);
 			}
-			
-			
+
 			return po;
 		}
-		else if (keys instanceof Keys.SelectorFunctionKeys) {
-		
-			@SuppressWarnings("unchecked")
-			Keys.SelectorFunctionKeys<T, ?> selectorKeys = (Keys.SelectorFunctionKeys<T, ?>) keys;
+		else if (keys instanceof SelectorFunctionKeys) {
 
+			@SuppressWarnings("unchecked")
+			SelectorFunctionKeys<T, ?> selectorKeys = (SelectorFunctionKeys<T, ?>) keys;
 
 			PlanUnwrappingReduceGroupOperator<T, T, ?> po = translateSelectorFunctionDistinct(
-							selectorKeys, function, getInputType(), getResultType(), name, input);
-			
+							selectorKeys, function, getResultType(), name, input);
+
 			po.setParallelism(this.getParallelism());
-			
+
 			return po;
 		}
 		else {
 			throw new UnsupportedOperationException("Unrecognized key type.");
 		}
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	private static <IN, OUT, K> PlanUnwrappingReduceGroupOperator<IN, OUT, K> translateSelectorFunctionDistinct(
-			Keys.SelectorFunctionKeys<IN, ?> rawKeys, RichGroupReduceFunction<IN, OUT> function,
-			TypeInformation<IN> inputType, TypeInformation<OUT> outputType, String name, Operator<IN> input)
+			SelectorFunctionKeys<IN, ?> rawKeys,
+			RichGroupReduceFunction<IN, OUT> function,
+			TypeInformation<OUT> outputType,
+			String name,
+			Operator<IN> input)
 	{
 		@SuppressWarnings("unchecked")
-		final Keys.SelectorFunctionKeys<IN, K> keys = (Keys.SelectorFunctionKeys<IN, K>) rawKeys;
+		final SelectorFunctionKeys<IN, K> keys = (SelectorFunctionKeys<IN, K>) rawKeys;
 		
-		TypeInformation<Tuple2<K, IN>> typeInfoWithKey = new TupleTypeInfo<Tuple2<K, IN>>(keys.getKeyType(), inputType);
+		TypeInformation<Tuple2<K, IN>> typeInfoWithKey = SelectorFunctionKeys.createTypeWithKey(keys);
+		Operator<Tuple2<K, IN>> keyedInput = SelectorFunctionKeys.appendKeyExtractor(input, keys);
 		
-		KeyExtractingMapper<IN, K> extractor = new KeyExtractingMapper<IN, K>(keys.getKeyExtractor());
-
-
 		PlanUnwrappingReduceGroupOperator<IN, OUT, K> reducer =
-				new PlanUnwrappingReduceGroupOperator<IN, OUT, K>(function, keys, name, outputType, typeInfoWithKey, true);
-		
-		MapOperatorBase<IN, Tuple2<K, IN>, MapFunction<IN, Tuple2<K, IN>>> mapper = new MapOperatorBase<IN, Tuple2<K, IN>, MapFunction<IN, Tuple2<K, IN>>>(extractor, new UnaryOperatorInformation<IN, Tuple2<K, IN>>(inputType, typeInfoWithKey), "Key Extractor");
+				new PlanUnwrappingReduceGroupOperator<>(function, keys, name, outputType, typeInfoWithKey, true);
+		reducer.setInput(keyedInput);
 
-		reducer.setInput(mapper);
-		mapper.setInput(input);
-		
-		// set the mapper's parallelism to the input parallelism to make sure it is chained
-		mapper.setParallelism(input.getParallelism());
-		
 		return reducer;
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
@@ -20,24 +20,20 @@ package org.apache.flink.api.java.operators;
 
 import org.apache.flink.api.common.functions.GroupCombineFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
-import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.operators.Ordering;
 import org.apache.flink.api.common.operators.SingleInputSemanticProperties;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
 import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase;
-import org.apache.flink.api.common.operators.base.MapOperatorBase;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.api.java.functions.SemanticPropUtil;
-import org.apache.flink.api.java.operators.translation.KeyExtractingMapper;
+import org.apache.flink.api.java.operators.Keys.SelectorFunctionKeys;
 import org.apache.flink.api.java.operators.translation.PlanUnwrappingReduceGroupOperator;
 import org.apache.flink.api.java.operators.translation.PlanUnwrappingSortedReduceGroupOperator;
-import org.apache.flink.api.java.operators.translation.TwoKeyExtractingMapper;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.DataSet;
 
 /**
@@ -132,9 +128,9 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 		// offset semantic information by extracted key fields
 		if(props != null &&
 				this.grouper != null &&
-				this.grouper.keys instanceof Keys.SelectorFunctionKeys) {
+				this.grouper.keys instanceof SelectorFunctionKeys) {
 
-			int offset = ((Keys.SelectorFunctionKeys<?,?>) this.grouper.keys).getKeyType().getTotalFields();
+			int offset = ((SelectorFunctionKeys<?,?>) this.grouper.keys).getKeyType().getTotalFields();
 			if(this.grouper instanceof SortedGrouping) {
 				offset += ((SortedGrouping<?>) this.grouper).getSortSelectionFunctionKey().getKeyType().getTotalFields();
 			}
@@ -156,9 +152,9 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 		// distinguish between grouped reduce and non-grouped reduce
 		if (grouper == null) {
 			// non grouped reduce
-			UnaryOperatorInformation<IN, OUT> operatorInfo = new UnaryOperatorInformation<IN, OUT>(getInputType(), getResultType());
+			UnaryOperatorInformation<IN, OUT> operatorInfo = new UnaryOperatorInformation<>(getInputType(), getResultType());
 			GroupReduceOperatorBase<IN, OUT, GroupReduceFunction<IN, OUT>> po =
-					new GroupReduceOperatorBase<IN, OUT, GroupReduceFunction<IN, OUT>>(function, operatorInfo, new int[0], name);
+					new GroupReduceOperatorBase<>(function, operatorInfo, new int[0], name);
 			
 			po.setCombinable(combinable);
 			po.setInput(input);
@@ -167,34 +163,27 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 			return po;
 		}
 	
-		if (grouper.getKeys() instanceof Keys.SelectorFunctionKeys) {
+		if (grouper.getKeys() instanceof SelectorFunctionKeys) {
 		
 			@SuppressWarnings("unchecked")
-			Keys.SelectorFunctionKeys<IN, ?> selectorKeys = (Keys.SelectorFunctionKeys<IN, ?>) grouper.getKeys();
+			SelectorFunctionKeys<IN, ?> selectorKeys = (SelectorFunctionKeys<IN, ?>) grouper.getKeys();
 
 			if (grouper instanceof SortedGrouping) {
-				SortedGrouping<IN> sortedGrouper = (SortedGrouping<IN>) grouper;
-				Keys.SelectorFunctionKeys<IN, ?> sortKeys = sortedGrouper.getSortSelectionFunctionKey();
+				SortedGrouping<IN> sortedGrouping = (SortedGrouping<IN>) grouper;
+				SelectorFunctionKeys<IN, ?> sortKeys = sortedGrouping.getSortSelectionFunctionKey();
+				Ordering groupOrder = sortedGrouping.getGroupOrdering();
 
-				PlanUnwrappingSortedReduceGroupOperator<IN, OUT, ?, ?> po = translateSelectorFunctionSortedReducer(
-						selectorKeys, sortKeys, function, getInputType(), getResultType(), name, input, isCombinable());
-
-				// set group order
-				int[] sortKeyPositions = sortedGrouper.getGroupSortKeyPositions();
-				Order[] sortOrders = sortedGrouper.getGroupSortOrders();
-
-				Ordering o = new Ordering();
-				for(int i=0; i < sortKeyPositions.length; i++) {
-					o.appendOrdering(sortKeyPositions[i], null, sortOrders[i]);
-				}
-				po.setGroupOrder(o);
+				PlanUnwrappingSortedReduceGroupOperator<IN, OUT, ?, ?> po =
+					translateSelectorFunctionSortedReducer(
+						selectorKeys, sortKeys, groupOrder, function, getResultType(), name, input, isCombinable()
+					);
 
 				po.setParallelism(this.getParallelism());
 				po.setCustomPartitioner(grouper.getCustomPartitioner());
 				return po;
 			} else {
 				PlanUnwrappingReduceGroupOperator<IN, OUT, ?> po = translateSelectorFunctionReducer(
-							selectorKeys, function, getInputType(), getResultType(), name, input, isCombinable());
+							selectorKeys, function, getResultType(), name, input, isCombinable());
 
 				po.setParallelism(this.getParallelism());
 				po.setCustomPartitioner(grouper.getCustomPartitioner());
@@ -204,9 +193,9 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 		else if (grouper.getKeys() instanceof Keys.ExpressionKeys) {
 
 			int[] logicalKeyPositions = grouper.getKeys().computeLogicalKeyPositions();
-			UnaryOperatorInformation<IN, OUT> operatorInfo = new UnaryOperatorInformation<IN, OUT>(getInputType(), getResultType());
+			UnaryOperatorInformation<IN, OUT> operatorInfo = new UnaryOperatorInformation<>(getInputType(), getResultType());
 			GroupReduceOperatorBase<IN, OUT, GroupReduceFunction<IN, OUT>> po =
-					new GroupReduceOperatorBase<IN, OUT, GroupReduceFunction<IN, OUT>>(function, operatorInfo, logicalKeyPositions, name);
+					new GroupReduceOperatorBase<>(function, operatorInfo, logicalKeyPositions, name);
 
 			po.setCombinable(combinable);
 			po.setInput(input);
@@ -216,7 +205,7 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 			// set group order
 			if (grouper instanceof SortedGrouping) {
 				SortedGrouping<IN> sortedGrouper = (SortedGrouping<IN>) grouper;
-								
+
 				int[] sortKeyPositions = sortedGrouper.getGroupSortKeyPositions();
 				Order[] sortOrders = sortedGrouper.getGroupSortOrders();
 				
@@ -236,56 +225,50 @@ public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 	
 	
 	// --------------------------------------------------------------------------------------------
-	
+
+	@SuppressWarnings("unchecked")
 	private static <IN, OUT, K> PlanUnwrappingReduceGroupOperator<IN, OUT, K> translateSelectorFunctionReducer(
-			Keys.SelectorFunctionKeys<IN, ?> rawKeys, GroupReduceFunction<IN, OUT> function,
-			TypeInformation<IN> inputType, TypeInformation<OUT> outputType, String name, Operator<IN> input,
+			SelectorFunctionKeys<IN, ?> rawKeys,
+			GroupReduceFunction<IN, OUT> function,
+			TypeInformation<OUT> outputType,
+			String name,
+			Operator<IN> input,
 			boolean combinable)
 	{
-		@SuppressWarnings("unchecked")
-		final Keys.SelectorFunctionKeys<IN, K> keys = (Keys.SelectorFunctionKeys<IN, K>) rawKeys;
-		
-		TypeInformation<Tuple2<K, IN>> typeInfoWithKey = new TupleTypeInfo<Tuple2<K, IN>>(keys.getKeyType(), inputType);
-		
-		KeyExtractingMapper<IN, K> extractor = new KeyExtractingMapper<IN, K>(keys.getKeyExtractor());
-		
-		PlanUnwrappingReduceGroupOperator<IN, OUT, K> reducer = new PlanUnwrappingReduceGroupOperator<IN, OUT, K>(function, keys, name, outputType, typeInfoWithKey, combinable);
-		
-		MapOperatorBase<IN, Tuple2<K, IN>, MapFunction<IN, Tuple2<K, IN>>> mapper = new MapOperatorBase<IN, Tuple2<K, IN>, MapFunction<IN, Tuple2<K, IN>>>(extractor, new UnaryOperatorInformation<IN, Tuple2<K, IN>>(inputType, typeInfoWithKey), "Key Extractor");
+		SelectorFunctionKeys<IN, K> keys = (SelectorFunctionKeys<IN, K>) rawKeys;
+		TypeInformation<Tuple2<K, IN>> typeInfoWithKey = SelectorFunctionKeys.createTypeWithKey(keys);
 
-		reducer.setInput(mapper);
-		mapper.setInput(input);
-		
-		// set the mapper's parallelism to the input parallelism to make sure it is chained
-		mapper.setParallelism(input.getParallelism());
-		
+		Operator<Tuple2<K, IN>> keyedInput = SelectorFunctionKeys.appendKeyExtractor(input, keys);
+
+		PlanUnwrappingReduceGroupOperator<IN, OUT, K> reducer =
+			new PlanUnwrappingReduceGroupOperator(function, keys, name, outputType, typeInfoWithKey, combinable);
+		reducer.setInput(keyedInput);
+
 		return reducer;
 	}
 
+	@SuppressWarnings("unchecked")
 	private static <IN, OUT, K1, K2> PlanUnwrappingSortedReduceGroupOperator<IN, OUT, K1, K2> translateSelectorFunctionSortedReducer(
-		Keys.SelectorFunctionKeys<IN, ?> rawGroupingKey, Keys.SelectorFunctionKeys<IN, ?> rawSortingKey, GroupReduceFunction<IN, OUT> function,
-		TypeInformation<IN> inputType, TypeInformation<OUT> outputType, String name, Operator<IN> input,
+		SelectorFunctionKeys<IN, ?> rawGroupingKey,
+		SelectorFunctionKeys<IN, ?> rawSortingKey,
+		Ordering groupOrdering,
+		GroupReduceFunction<IN, OUT> function,
+		TypeInformation<OUT> outputType,
+		String name,
+		Operator<IN> input,
 		boolean combinable)
 	{
-		@SuppressWarnings("unchecked")
-		final Keys.SelectorFunctionKeys<IN, K1> groupingKey = (Keys.SelectorFunctionKeys<IN, K1>) rawGroupingKey;
+		final SelectorFunctionKeys<IN, K1> groupingKey = (SelectorFunctionKeys<IN, K1>) rawGroupingKey;
+		final SelectorFunctionKeys<IN, K2> sortingKey = (SelectorFunctionKeys<IN, K2>) rawSortingKey;
+		TypeInformation<Tuple3<K1, K2, IN>> typeInfoWithKey = SelectorFunctionKeys.createTypeWithKey(groupingKey,sortingKey);
 
-		@SuppressWarnings("unchecked")
-		final Keys.SelectorFunctionKeys<IN, K2> sortingKey = (Keys.SelectorFunctionKeys<IN, K2>) rawSortingKey;
+		Operator<Tuple3<K1, K2, IN>> inputWithKey = SelectorFunctionKeys.appendKeyExtractor(input, groupingKey, sortingKey);
 
-		TypeInformation<Tuple3<K1, K2, IN>> typeInfoWithKey = new TupleTypeInfo<Tuple3<K1, K2, IN>>(groupingKey.getKeyType(), sortingKey.getKeyType(), inputType);
-
-		TwoKeyExtractingMapper<IN, K1, K2> extractor = new TwoKeyExtractingMapper<IN, K1, K2>(groupingKey.getKeyExtractor(), sortingKey.getKeyExtractor());
-
-		PlanUnwrappingSortedReduceGroupOperator<IN, OUT, K1, K2> reducer = new PlanUnwrappingSortedReduceGroupOperator<IN, OUT, K1, K2>(function, groupingKey, sortingKey, name, outputType, typeInfoWithKey, combinable);
-
-		MapOperatorBase<IN, Tuple3<K1, K2, IN>, MapFunction<IN, Tuple3<K1, K2, IN>>> mapper = new MapOperatorBase<IN, Tuple3<K1, K2, IN>, MapFunction<IN, Tuple3<K1, K2, IN>>>(extractor, new UnaryOperatorInformation<IN, Tuple3<K1, K2, IN>>(inputType, typeInfoWithKey), "Key Extractor");
-
-		reducer.setInput(mapper);
-		mapper.setInput(input);
-
-		// set the mapper's parallelism to the input parallelism to make sure it is chained
-		mapper.setParallelism(input.getParallelism());
+		PlanUnwrappingSortedReduceGroupOperator<IN, OUT, K1, K2> reducer =
+			new PlanUnwrappingSortedReduceGroupOperator<>(
+				function, groupingKey, sortingKey, name, outputType, typeInfoWithKey, combinable);
+		reducer.setInput(inputWithKey);
+		reducer.setGroupOrder(groupOrdering);
 
 		return reducer;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
@@ -25,17 +25,14 @@ import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
-import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.functions.RichFlatJoinFunction;
 import org.apache.flink.api.common.operators.BinaryOperatorInformation;
 import org.apache.flink.api.common.operators.DualInputSemanticProperties;
 import org.apache.flink.api.common.operators.Operator;
-import org.apache.flink.api.common.operators.UnaryOperatorInformation;
 import org.apache.flink.api.common.operators.base.JoinOperatorBase;
 import org.apache.flink.api.common.operators.base.InnerJoinOperatorBase;
 import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
-import org.apache.flink.api.common.operators.base.MapOperatorBase;
 import org.apache.flink.api.common.operators.base.OuterJoinOperatorBase;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
@@ -47,10 +44,10 @@ import org.apache.flink.api.java.functions.SemanticPropUtil;
 import org.apache.flink.api.java.operators.DeltaIteration.SolutionSetPlaceHolder;
 import org.apache.flink.api.java.operators.Keys.ExpressionKeys;
 import org.apache.flink.api.java.operators.Keys.IncompatibleKeysException;
+import org.apache.flink.api.java.operators.Keys.SelectorFunctionKeys;
 import org.apache.flink.api.java.operators.join.JoinOperatorSetsBase;
 import org.apache.flink.api.java.operators.join.JoinType;
 import org.apache.flink.api.java.operators.join.JoinFunctionAssigner;
-import org.apache.flink.api.java.operators.translation.KeyExtractingMapper;
 import org.apache.flink.api.java.operators.translation.TupleRightUnwrappingJoiner;
 import org.apache.flink.api.java.operators.translation.TupleLeftUnwrappingJoiner;
 import org.apache.flink.api.java.operators.translation.TupleUnwrappingJoiner;
@@ -104,7 +101,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		// sanity check solution set key mismatches
 		if (input1 instanceof SolutionSetPlaceHolder) {
 			if (keys1 instanceof ExpressionKeys) {
-				int[] positions = ((ExpressionKeys<?>) keys1).computeLogicalKeyPositions();
+				int[] positions = keys1.computeLogicalKeyPositions();
 				((SolutionSetPlaceHolder<?>) input1).checkJoinKeyFields(positions);
 			} else {
 				throw new InvalidProgramException("Currently, the solution set may only be joined with using tuple field positions.");
@@ -112,7 +109,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		}
 		if (input2 instanceof SolutionSetPlaceHolder) {
 			if (keys2 instanceof ExpressionKeys) {
-				int[] positions = ((ExpressionKeys<?>) keys2).computeLogicalKeyPositions();
+				int[] positions = keys2.computeLogicalKeyPositions();
 				((SolutionSetPlaceHolder<?>) input2).checkJoinKeyFields(positions);
 			} else {
 				throw new InvalidProgramException("Currently, the solution set may only be joined with using tuple field positions.");
@@ -260,15 +257,15 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 
 			// offset semantic information by extracted key fields
 			if(props != null &&
-					(this.keys1 instanceof Keys.SelectorFunctionKeys ||
-							this.keys2 instanceof Keys.SelectorFunctionKeys)) {
+					(this.keys1 instanceof SelectorFunctionKeys ||
+							this.keys2 instanceof SelectorFunctionKeys)) {
 
 				int numFields1 = this.getInput1Type().getTotalFields();
 				int numFields2 = this.getInput2Type().getTotalFields();
-				int offset1 = (this.keys1 instanceof Keys.SelectorFunctionKeys) ?
-						((Keys.SelectorFunctionKeys<?,?>) this.keys1).getKeyType().getTotalFields() : 0;
-				int offset2 = (this.keys2 instanceof Keys.SelectorFunctionKeys) ?
-						((Keys.SelectorFunctionKeys<?,?>) this.keys2).getKeyType().getTotalFields() : 0;
+				int offset1 = (this.keys1 instanceof SelectorFunctionKeys) ?
+						((SelectorFunctionKeys<?,?>) this.keys1).getKeyType().getTotalFields() : 0;
+				int offset2 = (this.keys2 instanceof SelectorFunctionKeys) ?
+						((SelectorFunctionKeys<?,?>) this.keys2).getKeyType().getTotalFields() : 0;
 
 				props = SemanticPropUtil.addSourceFieldOffsets(props, numFields1, numFields2, offset1, offset2);
 			}
@@ -315,40 +312,40 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 					.withJoinHint(getJoinHint())
 					.withResultType(getResultType());
 
-			final boolean requiresTupleUnwrapping = keys1 instanceof Keys.SelectorFunctionKeys || keys2 instanceof Keys.SelectorFunctionKeys;
+			final boolean requiresTupleUnwrapping = keys1 instanceof SelectorFunctionKeys || keys2 instanceof SelectorFunctionKeys;
 			if (requiresTupleUnwrapping) {
-				if (keys1 instanceof Keys.SelectorFunctionKeys && keys2 instanceof Keys.SelectorFunctionKeys) {
+				if (keys1 instanceof SelectorFunctionKeys && keys2 instanceof SelectorFunctionKeys) {
 					// Both join sides have a key selector function, so we need to do the
 					// tuple wrapping/unwrapping on both sides.
 
 					@SuppressWarnings("unchecked")
-					Keys.SelectorFunctionKeys<I1, ?> selectorKeys1 = (Keys.SelectorFunctionKeys<I1, ?>) keys1;
+					SelectorFunctionKeys<I1, ?> selectorKeys1 = (SelectorFunctionKeys<I1, ?>) keys1;
 					@SuppressWarnings("unchecked")
-					Keys.SelectorFunctionKeys<I2, ?> selectorKeys2 = (Keys.SelectorFunctionKeys<I2, ?>) keys2;
+					SelectorFunctionKeys<I2, ?> selectorKeys2 = (SelectorFunctionKeys<I2, ?>) keys2;
 
 					builder = builder
 							.withUdf(new TupleUnwrappingJoiner<>(function))
-							.withWrappedInput1(input1, selectorKeys1, getInput1Type())
-							.withWrappedInput2(input2, selectorKeys2, getInput2Type());
-				} else if (keys2 instanceof Keys.SelectorFunctionKeys) {
+							.withWrappedInput1(input1, selectorKeys1)
+							.withWrappedInput2(input2, selectorKeys2);
+				} else if (keys2 instanceof SelectorFunctionKeys) {
 					// The right side of the join needs the tuple wrapping/unwrapping
 
 					@SuppressWarnings("unchecked")
-					Keys.SelectorFunctionKeys<I2, ?> selectorKeys2 = (Keys.SelectorFunctionKeys<I2, ?>) keys2;
+					SelectorFunctionKeys<I2, ?> selectorKeys2 = (SelectorFunctionKeys<I2, ?>) keys2;
 
 					builder = builder
 							.withUdf(new TupleRightUnwrappingJoiner<>(function))
 							.withInput1(input1, getInput1Type(), keys1)
-							.withWrappedInput2(input2, selectorKeys2, getInput2Type());
+							.withWrappedInput2(input2, selectorKeys2);
 				} else {
 					// The left side of the join needs the tuple wrapping/unwrapping
 
 					@SuppressWarnings("unchecked")
-					Keys.SelectorFunctionKeys<I1, ?> selectorKeys1 = (Keys.SelectorFunctionKeys<I1, ?>) keys1;
+					SelectorFunctionKeys<I1, ?> selectorKeys1 = (SelectorFunctionKeys<I1, ?>) keys1;
 
 					builder = builder
 							.withUdf(new TupleLeftUnwrappingJoiner<>(function))
-							.withWrappedInput1(input1, selectorKeys1, getInput1Type())
+							.withWrappedInput1(input1, selectorKeys1)
 							.withInput2(input2, getInput2Type(), keys2);
 				}
 			} else if (keys1 instanceof Keys.ExpressionKeys && keys2 instanceof Keys.ExpressionKeys) {
@@ -393,24 +390,24 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 
 			public <I1, K> JoinOperatorBaseBuilder<OUT> withWrappedInput1(
 					Operator<I1> input1,
-					Keys.SelectorFunctionKeys<I1, ?> rawKeys1,
-					TypeInformation<I1> inputType1) {
-				TypeInformation<Tuple2<K, I1>> typeInfoWithKey1 = new TupleTypeInfo<>(rawKeys1.getKeyType(), inputType1);
+					SelectorFunctionKeys<I1, ?> rawKeys1) {
 
-				MapOperatorBase<I1, Tuple2<K, I1>, MapFunction<I1, Tuple2<K, I1>>> keyMapper1 =
-						createKeyMapper(rawKeys1, inputType1, input1, "Key Extractor 1");
+				@SuppressWarnings("unchecked")
+				SelectorFunctionKeys<I1, K> keys1 = (SelectorFunctionKeys<I1, K>)rawKeys1;
+				TypeInformation<Tuple2<K, I1>> typeInfoWithKey1 = SelectorFunctionKeys.createTypeWithKey(keys1);
+				Operator<Tuple2<K, I1>> keyMapper1 = SelectorFunctionKeys.appendKeyExtractor(input1, keys1);
 
 				return this.withInput1(keyMapper1, typeInfoWithKey1, rawKeys1);
 			}
 
 			public <I2, K> JoinOperatorBaseBuilder<OUT> withWrappedInput2(
 					Operator<I2> input2,
-					Keys.SelectorFunctionKeys<I2, ?> rawKeys2,
-					TypeInformation<I2> inputType2) {
-				TypeInformation<Tuple2<K, I2>> typeInfoWithKey2 = new TupleTypeInfo<>(rawKeys2.getKeyType(), inputType2);
+					SelectorFunctionKeys<I2, ?> rawKeys2) {
 
-				MapOperatorBase<I2, Tuple2<K, I2>, MapFunction<I2, Tuple2<K, I2>>> keyMapper2 =
-						createKeyMapper(rawKeys2, inputType2, input2, "Key Extractor 2");
+				@SuppressWarnings("unchecked")
+				SelectorFunctionKeys<I2, K> keys2 = (SelectorFunctionKeys<I2, K>)rawKeys2;
+				TypeInformation<Tuple2<K, I2>> typeInfoWithKey2 = SelectorFunctionKeys.createTypeWithKey(keys2);
+				Operator<Tuple2<K, I2>> keyMapper2 = SelectorFunctionKeys.appendKeyExtractor(input2, keys2);
 
 				return withInput2(keyMapper2, typeInfoWithKey2, rawKeys2);
 			}
@@ -500,27 +497,6 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 						throw new UnsupportedOperationException();
 				}
 			}
-
-			private static <I, K> MapOperatorBase<I, Tuple2<K, I>, MapFunction<I, Tuple2<K, I>>> createKeyMapper(
-					Keys.SelectorFunctionKeys<I, ?> rawKeys,
-					TypeInformation<I> inputType,
-					Operator<I> input,
-					String mapperName) {
-
-				@SuppressWarnings("unchecked")
-				final Keys.SelectorFunctionKeys<I, K> keys = (Keys.SelectorFunctionKeys<I, K>) rawKeys;
-				final TypeInformation<Tuple2<K, I>> typeInfoWithKey = new TupleTypeInfo<>(keys.getKeyType(), inputType);
-				final KeyExtractingMapper<I, K> extractor = new KeyExtractingMapper<>(keys.getKeyExtractor());
-
-				final MapOperatorBase<I, Tuple2<K, I>, MapFunction<I, Tuple2<K, I>>> keyMapper =
-						new MapOperatorBase<I, Tuple2<K, I>, MapFunction<I, Tuple2<K, I>>>(
-								extractor,
-								new UnaryOperatorInformation<>(inputType, typeInfoWithKey),
-								mapperName);
-				keyMapper.setInput(input);
-				keyMapper.setParallelism(input.getParallelism());
-				return keyMapper;
-			}
 		}
 	}
 	
@@ -607,7 +583,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		 * @see org.apache.flink.api.java.operators.JoinOperator.ProjectJoin
 		 */
 		public <OUT extends Tuple> ProjectJoin<I1, I2, OUT> projectFirst(int... firstFieldIndexes) {
-			JoinProjection<I1, I2> joinProjection = new JoinProjection<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint(), firstFieldIndexes, null);
+			JoinProjection<I1, I2> joinProjection = new JoinProjection<>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint(), firstFieldIndexes, null);
 
 			return joinProjection.projectTupleX();
 		}
@@ -633,7 +609,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		 * @see org.apache.flink.api.java.operators.JoinOperator.ProjectJoin
 		 */
 		public <OUT extends Tuple> ProjectJoin<I1, I2, OUT> projectSecond(int... secondFieldIndexes) {
-			JoinProjection<I1, I2> joinProjection = new JoinProjection<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint(), null, secondFieldIndexes);
+			JoinProjection<I1, I2> joinProjection = new JoinProjection<>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint(), null, secondFieldIndexes);
 			
 			return joinProjection.projectTupleX();
 		}
@@ -901,7 +877,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		@Override
 		public <K> JoinOperatorSetsPredicate where(KeySelector<I1, K> keySelector) {
 			TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keySelector, input1.getType());
-			return new JoinOperatorSetsPredicate(new Keys.SelectorFunctionKeys<>(keySelector, input1.getType(), keyType));
+			return new JoinOperatorSetsPredicate(new SelectorFunctionKeys<>(keySelector, input1.getType(), keyType));
 		}
 
 
@@ -965,7 +941,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			@Override
 			public <K> DefaultJoin<I1, I2> equalTo(KeySelector<I2, K> keySelector) {
 				TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keySelector, input2.getType());
-				return createDefaultJoin(new Keys.SelectorFunctionKeys<>(keySelector, input2.getType(), keyType));
+				return createDefaultJoin(new SelectorFunctionKeys<>(keySelector, input2.getType(), keyType));
 			}
 		}
 	}
@@ -980,7 +956,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 	public static final class DefaultFlatJoinFunction<T1, T2> extends RichFlatJoinFunction<T1, T2, Tuple2<T1, T2>> {
 
 		private static final long serialVersionUID = 1L;
-		private final Tuple2<T1, T2> outTuple = new Tuple2<T1, T2>();
+		private final Tuple2<T1, T2> outTuple = new Tuple2<>();
 
 		@Override
 		public void join(T1 first, T2 second, Collector<Tuple2<T1,T2>> out) throws Exception {
@@ -1071,14 +1047,14 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			boolean isSecondTuple;
 			
 			if(ds1.getType() instanceof TupleTypeInfo) {
-				numFieldsDs1 = ((TupleTypeInfo<?>)ds1.getType()).getArity();
+				numFieldsDs1 = ds1.getType().getArity();
 				isFirstTuple = true;
 			} else {
 				numFieldsDs1 = 1;
 				isFirstTuple = false;
 			}
 			if(ds2.getType() instanceof TupleTypeInfo) {
-				numFieldsDs2 = ((TupleTypeInfo<?>)ds2.getType()).getArity();
+				numFieldsDs2 = ds2.getType().getArity();
 				isSecondTuple = true;
 			} else {
 				numFieldsDs2 = 1;
@@ -1162,12 +1138,8 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		protected JoinProjection<I1, I2> projectFirst(int... firstFieldIndexes) {
 			
 			boolean isFirstTuple;
-			
-			if(ds1.getType() instanceof TupleTypeInfo && firstFieldIndexes.length > 0) {
-				isFirstTuple = true;
-			} else {
-				isFirstTuple = false;
-			}
+
+			isFirstTuple = ds1.getType() instanceof TupleTypeInfo && firstFieldIndexes.length > 0;
 			
 			if(!isFirstTuple && firstFieldIndexes.length != 0) {
 				// field index provided for non-Tuple input
@@ -1226,12 +1198,8 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		protected JoinProjection<I1, I2> projectSecond(int... secondFieldIndexes) {
 			
 			boolean isSecondTuple;
-			
-			if(ds2.getType() instanceof TupleTypeInfo && secondFieldIndexes.length > 0) {
-				isSecondTuple = true;
-			} else {
-				isSecondTuple = false;
-			}
+
+			isSecondTuple = ds2.getType() instanceof TupleTypeInfo && secondFieldIndexes.length > 0;
 			
 			if(!isSecondTuple && secondFieldIndexes.length != 0) {
 				// field index provided for non-Tuple input

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/PartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/PartitionOperator.java
@@ -20,20 +20,16 @@ package org.apache.flink.api.java.operators;
 
 import com.google.common.base.Preconditions;
 
-import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
-import org.apache.flink.api.common.operators.base.MapOperatorBase;
 import org.apache.flink.api.common.operators.base.PartitionOperatorBase;
 import org.apache.flink.api.common.operators.base.PartitionOperatorBase.PartitionMethod;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.api.java.operators.translation.KeyExtractingMapper;
-import org.apache.flink.api.java.operators.translation.KeyRemovingMapper;
+import org.apache.flink.api.java.operators.Keys.SelectorFunctionKeys;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 
 /**
  * This operator represents a partitioning.
@@ -113,34 +109,31 @@ public class PartitionOperator<T> extends SingleInputOperator<T, T, PartitionOpe
 		// distinguish between partition types
 		if (pMethod == PartitionMethod.REBALANCE) {
 			
-			UnaryOperatorInformation<T, T> operatorInfo = new UnaryOperatorInformation<T, T>(getType(), getType());
-			PartitionOperatorBase<T> noop = new PartitionOperatorBase<T>(operatorInfo, pMethod, name);
+			UnaryOperatorInformation<T, T> operatorInfo = new UnaryOperatorInformation<>(getType(), getType());
+			PartitionOperatorBase<T> rebalancedInput = new PartitionOperatorBase<>(operatorInfo, pMethod, name);
+			rebalancedInput.setInput(input);
+			rebalancedInput.setParallelism(getParallelism());
 			
-			noop.setInput(input);
-			noop.setParallelism(getParallelism());
-			
-			return noop;
+			return rebalancedInput;
 		} 
 		else if (pMethod == PartitionMethod.HASH || pMethod == PartitionMethod.CUSTOM || pMethod == PartitionMethod.RANGE) {
 			
 			if (pKeys instanceof Keys.ExpressionKeys) {
 				
 				int[] logicalKeyPositions = pKeys.computeLogicalKeyPositions();
-				UnaryOperatorInformation<T, T> operatorInfo = new UnaryOperatorInformation<T, T>(getType(), getType());
-				PartitionOperatorBase<T> noop = new PartitionOperatorBase<T>(operatorInfo, pMethod, logicalKeyPositions, name);
+				UnaryOperatorInformation<T, T> operatorInfo = new UnaryOperatorInformation<>(getType(), getType());
+				PartitionOperatorBase<T> partitionedInput = new PartitionOperatorBase<>(operatorInfo, pMethod, logicalKeyPositions, name);
+				partitionedInput.setInput(input);
+				partitionedInput.setParallelism(getParallelism());
+				partitionedInput.setCustomPartitioner(customPartitioner);
 				
-				noop.setInput(input);
-				noop.setParallelism(getParallelism());
-				noop.setCustomPartitioner(customPartitioner);
-				
-				return noop;
+				return partitionedInput;
 			}
 			else if (pKeys instanceof Keys.SelectorFunctionKeys) {
 				
 				@SuppressWarnings("unchecked")
 				Keys.SelectorFunctionKeys<T, ?> selectorKeys = (Keys.SelectorFunctionKeys<T, ?>) pKeys;
-				MapOperatorBase<?, T, ?> po = translateSelectorFunctionPartitioner(selectorKeys, pMethod, getType(), name, input, getParallelism(), customPartitioner);
-				return po;
+				return translateSelectorFunctionPartitioner(selectorKeys, pMethod, name, input, getParallelism(), customPartitioner);
 			}
 			else {
 				throw new UnsupportedOperationException("Unrecognized key type.");
@@ -151,34 +144,28 @@ public class PartitionOperator<T> extends SingleInputOperator<T, T, PartitionOpe
 			throw new UnsupportedOperationException("Unsupported partitioning method: " + pMethod.name());
 		}
 	}
-	
-	private static <T, K> MapOperatorBase<Tuple2<K, T>, T, ?> translateSelectorFunctionPartitioner(Keys.SelectorFunctionKeys<T, ?> rawKeys,
-			PartitionMethod pMethod, TypeInformation<T> inputType, String name, Operator<T> input, int partitionDop, Partitioner<?> customPartitioner)
-	{
-		@SuppressWarnings("unchecked")
-		final Keys.SelectorFunctionKeys<T, K> keys = (Keys.SelectorFunctionKeys<T, K>) rawKeys;
-		
-		TypeInformation<Tuple2<K, T>> typeInfoWithKey = new TupleTypeInfo<Tuple2<K, T>>(keys.getKeyType(), inputType);
-		UnaryOperatorInformation<Tuple2<K, T>, Tuple2<K, T>> operatorInfo = new UnaryOperatorInformation<Tuple2<K, T>, Tuple2<K, T>>(typeInfoWithKey, typeInfoWithKey);
-		
-		KeyExtractingMapper<T, K> extractor = new KeyExtractingMapper<T, K>(keys.getKeyExtractor());
-		
-		MapOperatorBase<T, Tuple2<K, T>, MapFunction<T, Tuple2<K, T>>> keyExtractingMap = new MapOperatorBase<T, Tuple2<K, T>, MapFunction<T, Tuple2<K, T>>>(extractor, new UnaryOperatorInformation<T, Tuple2<K, T>>(inputType, typeInfoWithKey), "Key Extractor");
-		PartitionOperatorBase<Tuple2<K, T>> noop = new PartitionOperatorBase<Tuple2<K, T>>(operatorInfo, pMethod, new int[]{0}, name);
-		MapOperatorBase<Tuple2<K, T>, T, MapFunction<Tuple2<K, T>, T>> keyRemovingMap = new MapOperatorBase<Tuple2<K, T>, T, MapFunction<Tuple2<K, T>, T>>(new KeyRemovingMapper<T, K>(), new UnaryOperatorInformation<Tuple2<K, T>, T>(typeInfoWithKey, inputType), "Key Extractor");
 
-		keyExtractingMap.setInput(input);
-		noop.setInput(keyExtractingMap);
-		keyRemovingMap.setInput(noop);
-		
-		noop.setCustomPartitioner(customPartitioner);
-		
-		// set parallelism
-		keyExtractingMap.setParallelism(input.getParallelism());
-		noop.setParallelism(partitionDop);
-		keyRemovingMap.setParallelism(partitionDop);
-		
-		return keyRemovingMap;
+	@SuppressWarnings("unchecked")
+	private static <T, K> org.apache.flink.api.common.operators.SingleInputOperator<?, T, ?> translateSelectorFunctionPartitioner(
+		SelectorFunctionKeys<T, ?> rawKeys,
+		PartitionMethod pMethod,
+		String name,
+		Operator<T> input,
+		int partitionDop,
+		Partitioner<?> customPartitioner)
+	{
+		final SelectorFunctionKeys<T, K> keys = (SelectorFunctionKeys<T, K>) rawKeys;
+		TypeInformation<Tuple2<K, T>> typeInfoWithKey = SelectorFunctionKeys.createTypeWithKey(keys);
+
+		Operator<Tuple2<K, T>> keyedInput = SelectorFunctionKeys.appendKeyExtractor(input, keys);
+
+		PartitionOperatorBase<Tuple2<K, T>> keyedPartitionedInput =
+			new PartitionOperatorBase<>(new UnaryOperatorInformation<>(typeInfoWithKey, typeInfoWithKey), pMethod, new int[]{0}, name);
+		keyedPartitionedInput.setInput(keyedInput);
+		keyedPartitionedInput.setCustomPartitioner(customPartitioner);
+		keyedPartitionedInput.setParallelism(partitionDop);
+
+		return SelectorFunctionKeys.appendKeyRemover(keyedPartitionedInput, keys);
 	}
 
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SortedGrouping.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SortedGrouping.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.operators;
 
 import org.apache.flink.api.common.functions.GroupCombineFunction;
+import org.apache.flink.api.common.operators.Ordering;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.Utils;
@@ -123,6 +124,16 @@ public class SortedGrouping<T> extends Grouping<T> {
 	
 	protected Order[] getGroupSortOrders() {
 		return this.groupSortOrders;
+	}
+
+	protected Ordering getGroupOrdering() {
+
+		Ordering o = new Ordering();
+		for(int i=0; i < this.groupSortKeyPositions.length; i++) {
+			o.appendOrdering(this.groupSortKeyPositions[i], null, this.groupSortOrders[i]);
+		}
+
+		return o;
 	}
 	
 	/**


### PR DESCRIPTION
This PR refactors the translation of `SelectorFunctionKey`s in the DataSet API. 

It removes a lot of duplicate code to create key extracting mappers and key removal mappers and reformats overlong lines.
It also cleans up most compiler warnings in the touched classes.