### PR TITLE
[FLINK-3208] [gelly] rename vertex-centric iteration model to scatter-gather

### DIFF
--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.graph._
 import org.apache.flink.graph.validation.GraphValidator
 import org.apache.flink.graph.gsa.{ApplyFunction, GSAConfiguration, GatherFunction, SumFunction}
-import org.apache.flink.graph.spargel.{MessagingFunction, VertexCentricConfiguration, VertexUpdateFunction}
+import org.apache.flink.graph.spargel.{MessagingFunction, ScatterGatherConfiguration, VertexUpdateFunction}
 import org.apache.flink.{graph => jg}
 import _root_.scala.collection.JavaConverters._
 import _root_.scala.reflect.ClassTag
@@ -1027,39 +1027,39 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
   }
 
   /**
-   * Runs a Vertex-Centric iteration on the graph.
+   * Runs a scatter-gather iteration on the graph.
    * No configuration options are provided.
    *
    * @param vertexUpdateFunction the vertex update function
    * @param messagingFunction the messaging function
    * @param maxIterations maximum number of iterations to perform
    *
-   * @return the updated Graph after the vertex-centric iteration has converged or
+   * @return the updated Graph after the scatter-gather iteration has converged or
    *         after maximumNumberOfIterations.
    */
-  def runVertexCentricIteration[M](vertexUpdateFunction: VertexUpdateFunction[K, VV, M],
+  def runScatterGatherIteration[M](vertexUpdateFunction: VertexUpdateFunction[K, VV, M],
                                    messagingFunction: MessagingFunction[K, VV, M, EV],
                                    maxIterations: Int): Graph[K, VV, EV] = {
-    wrapGraph(jgraph.runVertexCentricIteration(vertexUpdateFunction, messagingFunction,
+    wrapGraph(jgraph.runScatterGatherIteration(vertexUpdateFunction, messagingFunction,
       maxIterations))
   }
 
   /**
-   * Runs a Vertex-Centric iteration on the graph with configuration options.
+   * Runs a scatter-gather iteration on the graph with configuration options.
    *
    * @param vertexUpdateFunction the vertex update function
    * @param messagingFunction the messaging function
    * @param maxIterations maximum number of iterations to perform
    * @param parameters the iteration configuration parameters
    *
-   * @return the updated Graph after the vertex-centric iteration has converged or
+   * @return the updated Graph after the scatter-gather iteration has converged or
    *         after maximumNumberOfIterations.
    */
-  def runVertexCentricIteration[M](vertexUpdateFunction: VertexUpdateFunction[K, VV, M],
+  def runScatterGatherIteration[M](vertexUpdateFunction: VertexUpdateFunction[K, VV, M],
                                    messagingFunction: MessagingFunction[K, VV, M, EV],
-                                   maxIterations: Int, parameters: VertexCentricConfiguration):
+                                   maxIterations: Int, parameters: ScatterGatherConfiguration):
   Graph[K, VV, EV] = {
-    wrapGraph(jgraph.runVertexCentricIteration(vertexUpdateFunction, messagingFunction,
+    wrapGraph(jgraph.runScatterGatherIteration(vertexUpdateFunction, messagingFunction,
       maxIterations, parameters))
   }
 

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/example/SingleSourceShortestPaths.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/example/SingleSourceShortestPaths.scala
@@ -31,7 +31,7 @@ import org.apache.flink.graph.scala.utils.Tuple3ToEdgeMap
 import org.apache.flink.graph.example.utils.SingleSourceShortestPathsData
 
 /**
- * This example shows how to use Gelly's vertex-centric iterations.
+ * This example shows how to use Gelly's scatter-gather iterations.
  * 
  * It is an implementation of the Single-Source-Shortest-Paths algorithm. 
  *
@@ -54,8 +54,8 @@ object SingleSourceShortestPaths {
     val edges: DataSet[Edge[Long, Double]] = getEdgesDataSet(env)
     val graph = Graph.fromDataSet[Long, Double, Double](edges, new InitVertices(srcVertexId), env)
 
-    // Execute the vertex-centric iteration
-    val result = graph.runVertexCentricIteration(new VertexDistanceUpdater,
+    // Execute the scatter-gather iteration
+    val result = graph.runScatterGatherIteration(new VertexDistanceUpdater,
       new MinDistanceMessenger, maxIterations)
 
     // Extract the vertices as the result

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -52,8 +52,8 @@ import org.apache.flink.graph.gsa.GatherFunction;
 import org.apache.flink.graph.gsa.GatherSumApplyIteration;
 import org.apache.flink.graph.gsa.SumFunction;
 import org.apache.flink.graph.spargel.MessagingFunction;
-import org.apache.flink.graph.spargel.VertexCentricConfiguration;
-import org.apache.flink.graph.spargel.VertexCentricIteration;
+import org.apache.flink.graph.spargel.ScatterGatherConfiguration;
+import org.apache.flink.graph.spargel.ScatterGatherIteration;
 import org.apache.flink.graph.spargel.VertexUpdateFunction;
 import org.apache.flink.graph.utils.EdgeToTuple3Map;
 import org.apache.flink.graph.utils.Tuple2ToVertexMap;
@@ -1585,42 +1585,42 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
-	 * Runs a Vertex-Centric iteration on the graph.
+	 * Runs a ScatterGather iteration on the graph.
 	 * No configuration options are provided.
 	 *
 	 * @param vertexUpdateFunction the vertex update function
 	 * @param messagingFunction the messaging function
 	 * @param maximumNumberOfIterations maximum number of iterations to perform
 	 * 
-	 * @return the updated Graph after the vertex-centric iteration has converged or
+	 * @return the updated Graph after the scatter-gather iteration has converged or
 	 * after maximumNumberOfIterations.
 	 */
-	public <M> Graph<K, VV, EV> runVertexCentricIteration(
+	public <M> Graph<K, VV, EV> runScatterGatherIteration(
 			VertexUpdateFunction<K, VV, M> vertexUpdateFunction,
 			MessagingFunction<K, VV, M, EV> messagingFunction,
 			int maximumNumberOfIterations) {
 
-		return this.runVertexCentricIteration(vertexUpdateFunction, messagingFunction,
+		return this.runScatterGatherIteration(vertexUpdateFunction, messagingFunction,
 				maximumNumberOfIterations, null);
 	}
 
 	/**
-	 * Runs a Vertex-Centric iteration on the graph with configuration options.
+	 * Runs a ScatterGather iteration on the graph with configuration options.
 	 * 
 	 * @param vertexUpdateFunction the vertex update function
 	 * @param messagingFunction the messaging function
 	 * @param maximumNumberOfIterations maximum number of iterations to perform
 	 * @param parameters the iteration configuration parameters
 	 * 
-	 * @return the updated Graph after the vertex-centric iteration has converged or
+	 * @return the updated Graph after the scatter-gather iteration has converged or
 	 * after maximumNumberOfIterations.
 	 */
-	public <M> Graph<K, VV, EV> runVertexCentricIteration(
+	public <M> Graph<K, VV, EV> runScatterGatherIteration(
 			VertexUpdateFunction<K, VV, M> vertexUpdateFunction,
 			MessagingFunction<K, VV, M, EV> messagingFunction,
-			int maximumNumberOfIterations, VertexCentricConfiguration parameters) {
+			int maximumNumberOfIterations, ScatterGatherConfiguration parameters) {
 
-		VertexCentricIteration<K, VV, M, EV> iteration = VertexCentricIteration.withEdges(
+		ScatterGatherIteration<K, VV, M, EV> iteration = ScatterGatherIteration.withEdges(
 				edges, vertexUpdateFunction, messagingFunction, maximumNumberOfIterations);
 
 		iteration.configure(parameters);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/GraphCsvReader.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/GraphCsvReader.java
@@ -154,7 +154,6 @@ public class GraphCsvReader {
 			throw new RuntimeException("The edges input file cannot be null!");
 		}
 
-		@SuppressWarnings("serial")
 		DataSet<Tuple3<K, K, NullValue>> edges = edgeReader.types(vertexKey, vertexKey)
 				.map(new MapFunction<Tuple2<K, K>, Tuple3<K, K, NullValue>>() {
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/IncrementalSSSP.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/IncrementalSSSP.java
@@ -29,14 +29,14 @@ import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.example.utils.IncrementalSSSPData;
 import org.apache.flink.graph.spargel.MessageIterator;
 import org.apache.flink.graph.spargel.MessagingFunction;
-import org.apache.flink.graph.spargel.VertexCentricConfiguration;
+import org.apache.flink.graph.spargel.ScatterGatherConfiguration;
 import org.apache.flink.graph.spargel.VertexUpdateFunction;
 
 /**
  * This example illustrates how to 
  * <ul>
  *  <li> create a Graph directly from CSV files
- *  <li> use the vertex-centric iteration's messaging direction configuration option
+ *  <li> use the scatter-gather iteration's messaging direction configuration option
  * </ul>
  * 
  * Incremental Single Sink Shortest Paths Example. Shortest Paths are incrementally updated
@@ -89,15 +89,15 @@ public class IncrementalSSSP implements ProgramDescription {
 		graph.removeEdge(edgeToBeRemoved);
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		if(isInSSSP(edgeToBeRemoved, ssspGraph.getEdges())) {
 
 			parameters.setDirection(EdgeDirection.IN);
 			parameters.setOptDegrees(true);
 
-			// run the vertex centric iteration to propagate info
-			Graph<Long, Double, Double> result = ssspGraph.runVertexCentricIteration(new VertexDistanceUpdater(),
+			// run the scatter-gather iteration to propagate info
+			Graph<Long, Double, Double> result = ssspGraph.runScatterGatherIteration(new VertexDistanceUpdater(),
 					new InvalidateMessenger(edgeToBeRemoved), maxIterations, parameters);
 
 			DataSet<Vertex<Long, Double>> resultedVertices = result.getVertices();

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/SingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/example/SingleSourceShortestPaths.java
@@ -32,7 +32,7 @@ import org.apache.flink.graph.spargel.VertexUpdateFunction;
 import org.apache.flink.graph.utils.Tuple3ToEdgeMap;
 
 /**
- * This example shows how to use Gelly's vertex-centric iterations.
+ * This example shows how to use Gelly's scatter-gather iterations.
  * 
  * It is an implementation of the Single-Source-Shortest-Paths algorithm.
  * For a gather-sum-apply implementation of the same algorithm, please refer to {@link GSASingleSourceShortestPaths}. 
@@ -60,8 +60,8 @@ public class SingleSourceShortestPaths implements ProgramDescription {
 
 		Graph<Long, Double, Double> graph = Graph.fromDataSet(edges, new InitVertices(srcVertexId), env);
 
-		// Execute the vertex-centric iteration
-		Graph<Long, Double, Double> result = graph.runVertexCentricIteration(
+		// Execute the scatter-gather iteration
+		Graph<Long, Double, Double> result = graph.runScatterGatherIteration(
 				new VertexDistanceUpdater(), new MinDistanceMessenger(), maxIterations);
 
 		// Extract the vertices as the result
@@ -196,6 +196,6 @@ public class SingleSourceShortestPaths implements ProgramDescription {
 
 	@Override
 	public String getDescription() {
-		return "Vertex-centric Single Source Shortest Paths";
+		return "Scatter-gather Single Source Shortest Paths";
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/CommunityDetection.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/CommunityDetection.java
@@ -78,7 +78,7 @@ public class CommunityDetection<K> implements GraphAlgorithm<K, Long, Double, Gr
 		Graph<K, Tuple2<Long, Double>, Double> graphWithScoredVertices =
 				Graph.fromDataSet(initializedVertices, graph.getEdges(), graph.getContext()).getUndirected();
 
-		return graphWithScoredVertices.runVertexCentricIteration(new VertexLabelUpdater<K>(delta),
+		return graphWithScoredVertices.runScatterGatherIteration(new VertexLabelUpdater<K>(delta),
 				new LabelMessenger<K>(), maxIterations)
 				.mapVertices(new RemoveScoreFromVertexValuesMapper<K>());
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/ConnectedComponents.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/ConnectedComponents.java
@@ -29,7 +29,7 @@ import org.apache.flink.graph.utils.NullValueEdgeMapper;
 import org.apache.flink.types.NullValue;
 
 /**
- * A vertex-centric implementation of the Weakly Connected Components algorithm.
+ * A scatter-gather implementation of the Weakly Connected Components algorithm.
  *
  * This implementation assumes that the vertex values of the input Graph are initialized with Long component IDs.
  * The vertices propagate their current component ID in iterations.
@@ -66,8 +66,8 @@ public class ConnectedComponents<K, EV> implements GraphAlgorithm<K, Long, EV, D
 		Graph<K, Long, NullValue> undirectedGraph = graph.mapEdges(new NullValueEdgeMapper<K, EV>())
 				.getUndirected();
 
-		// initialize vertex values and run the Vertex Centric Iteration
-		return undirectedGraph.runVertexCentricIteration(
+		// initialize vertex values and run the Scatter-Gather Iteration
+		return undirectedGraph.runScatterGatherIteration(
 				new CCUpdater<K>(), new CCMessenger<K>(), maxIterations)
 				.getVertices();
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/LabelPropagation.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/LabelPropagation.java
@@ -77,7 +77,7 @@ public class LabelPropagation<K, VV extends Comparable<VV>, EV>
 		// iteratively adopt the most frequent label among the neighbors of each vertex
 		return input
 			.mapEdges(new NullValueEdgeMapper<K, EV>())
-			.runVertexCentricIteration(
+			.runScatterGatherIteration(
 				new UpdateVertexLabel<K, VV>(), new SendNewLabelToNeighbors<K, VV>(valueType), maxIterations)
 			.getVertices();
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/PageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/PageRank.java
@@ -30,7 +30,7 @@ import org.apache.flink.graph.spargel.MessagingFunction;
 import org.apache.flink.graph.spargel.VertexUpdateFunction;
 
 /**
- * This is an implementation of a simple PageRank algorithm, using a vertex-centric iteration.
+ * This is an implementation of a simple PageRank algorithm, using a scatter-gather iteration.
  * The user can define the damping factor and the maximum number of iterations.
  * If the number of vertices of the input graph is known, it should be provided as a parameter
  * to speed up computation. Otherwise, the algorithm will first execute a job to count the vertices.
@@ -88,7 +88,7 @@ public class PageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet<Ve
 		Graph<K, Double, Double> networkWithWeights = network
 				.joinWithEdgesOnSource(vertexOutDegrees, new InitWeights());
 
-		return networkWithWeights.runVertexCentricIteration(new VertexRankUpdater<K>(beta, numberOfVertices),
+		return networkWithWeights.runScatterGatherIteration(new VertexRankUpdater<K>(beta, numberOfVertices),
 				new RankMessenger<K>(numberOfVertices), maxIterations)
 				.getVertices();
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/SingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/SingleSourceShortestPaths.java
@@ -29,7 +29,7 @@ import org.apache.flink.graph.spargel.MessagingFunction;
 import org.apache.flink.graph.spargel.VertexUpdateFunction;
 
 /**
- * This is an implementation of the Single-Source-Shortest Paths algorithm, using a vertex-centric iteration.
+ * This is an implementation of the Single-Source-Shortest Paths algorithm, using a scatter-gather iteration.
  */
 @SuppressWarnings("serial")
 public class SingleSourceShortestPaths<K> implements GraphAlgorithm<K, Double, Double, DataSet<Vertex<K, Double>>> {
@@ -52,7 +52,7 @@ public class SingleSourceShortestPaths<K> implements GraphAlgorithm<K, Double, D
 	public DataSet<Vertex<K, Double>> run(Graph<K, Double, Double> input) {
 
 		return input.mapVertices(new InitVerticesMapper<K>(srcVertexId))
-				.runVertexCentricIteration(new VertexDistanceUpdater<K>(), new MinDistanceMessenger<K>(),
+				.runScatterGatherIteration(new VertexDistanceUpdater<K>(), new MinDistanceMessenger<K>(),
 				maxIterations).getVertices();
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/MessagingFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/MessagingFunction.java
@@ -33,7 +33,7 @@ import org.apache.flink.types.Value;
 import org.apache.flink.util.Collector;
 
 /**
- * The base class for functions that produce messages between vertices as a part of a {@link VertexCentricIteration}.
+ * The base class for functions that produce messages between vertices as a part of a {@link ScatterGatherIteration}.
  * 
  * @param <K> The type of the vertex key (the vertex identifier).
  * @param <VV> The type of the vertex value (the state of the vertex).
@@ -66,7 +66,7 @@ public abstract class MessagingFunction<K, VV, Message, EV> implements Serializa
 
 	// --------------------------------------------------------------------------------------------
 	//  Attribute that allows the user to choose the neighborhood type(in/out/all) on which to run
-	//  the vertex centric iteration.
+	//  the scatter gather iteration.
 	// --------------------------------------------------------------------------------------------
 
 	private EdgeDirection direction;
@@ -233,7 +233,7 @@ public abstract class MessagingFunction<K, VV, Message, EV> implements Serializa
 	/**
 	 * Gets the broadcast data set registered under the given name. Broadcast data sets
 	 * are available on all parallel instances of a function. They can be registered via
-	 * {@link org.apache.flink.graph.spargel.VertexCentricConfiguration#addBroadcastSetForMessagingFunction(String, org.apache.flink.api.java.DataSet)}.
+	 * {@link org.apache.flink.graph.spargel.ScatterGatherConfiguration#addBroadcastSetForMessagingFunction(String, org.apache.flink.api.java.DataSet)}.
 	 * 
 	 * @param name The name under which the broadcast set is registered.
 	 * @return The broadcast data set.

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherConfiguration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherConfiguration.java
@@ -27,16 +27,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A VertexCentricConfiguration object can be used to set the iteration name and
+ * A ScatterGatherConfiguration object can be used to set the iteration name and
  * degree of parallelism, to register aggregators and use broadcast sets in
  * the {@link org.apache.flink.graph.spargel.VertexUpdateFunction} and {@link org.apache.flink.graph.spargel.MessagingFunction}
  *
  * The VertexCentricConfiguration object is passed as an argument to
- * {@link org.apache.flink.graph.Graph#runVertexCentricIteration (
+ * {@link org.apache.flink.graph.Graph#runScatterGatherIteration (
  * org.apache.flink.graph.spargel.VertexUpdateFunction, org.apache.flink.graph.spargel.MessagingFunction, int,
- * VertexCentricConfiguration)}.
+ * ScatterGatherConfiguration)}.
  */
-public class VertexCentricConfiguration extends IterationConfiguration {
+public class ScatterGatherConfiguration extends IterationConfiguration {
 
 	/** the broadcast variables for the update function **/
 	private List<Tuple2<String, DataSet<?>>> bcVarsUpdate = new ArrayList<Tuple2<String,DataSet<?>>>();
@@ -50,7 +50,7 @@ public class VertexCentricConfiguration extends IterationConfiguration {
 	/** the direction in which the messages should be sent **/
 	private EdgeDirection direction = EdgeDirection.OUT;
 
-	public VertexCentricConfiguration() {}
+	public ScatterGatherConfiguration() {}
 
 	/**
 	 * Adds a data set as a broadcast set to the messaging function.

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/VertexUpdateFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/VertexUpdateFunction.java
@@ -157,7 +157,7 @@ public abstract class VertexUpdateFunction<K, VV, Message> implements Serializab
 	/**
 	 * Gets the broadcast data set registered under the given name. Broadcast data sets
 	 * are available on all parallel instances of a function. They can be registered via
-	 * {@link org.apache.flink.graph.spargel.VertexCentricConfiguration#addBroadcastSetForUpdateFunction(String, org.apache.flink.api.java.DataSet)}.
+	 * {@link org.apache.flink.graph.spargel.ScatterGatherConfiguration#addBroadcastSetForUpdateFunction(String, org.apache.flink.api.java.DataSet)}.
 	 * 
 	 * @param name The name under which the broadcast set is registered.
 	 * @return The broadcast data set.
@@ -230,7 +230,7 @@ public abstract class VertexUpdateFunction<K, VV, Message> implements Serializab
 
 	/**
 	 * In order to hide the Tuple3(actualValue, inDegree, OutDegree) vertex value from the user,
-	 * another function will be called from {@link org.apache.flink.graph.spargel.VertexCentricIteration}.
+	 * another function will be called from {@link org.apache.flink.graph.spargel.ScatterGatherIteration}.
 	 *
 	 * This function will retrieve the vertex from the vertexState and will set its degrees, afterwards calling
 	 * the regular updateVertex function.
@@ -240,7 +240,7 @@ public abstract class VertexUpdateFunction<K, VV, Message> implements Serializab
 	 * @throws Exception
 	 */
 	@SuppressWarnings("unchecked")
-	<VertexWithDegree> void updateVertexFromVertexCentricIteration(Vertex<K, VertexWithDegree> vertexState,
+	<VertexWithDegree> void updateVertexFromScatterGatherIteration(Vertex<K, VertexWithDegree> vertexState,
 												MessageIterator<Message> inMessages) throws Exception {
 
 		Vertex<K, VV> vertex = new Vertex<K, VV>(vertexState.f0,

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelCompilerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelCompilerTest.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.graph.spargel;
 
 import static org.junit.Assert.assertEquals;
@@ -74,7 +73,7 @@ public class SpargelCompilerTest extends CompilerTestBase {
 
 				Graph<Long, Long, NullValue> graph = Graph.fromDataSet(initialVertices, edges, env);
 				
-				DataSet<Vertex<Long, Long>> result = graph.runVertexCentricIteration(
+				DataSet<Vertex<Long, Long>> result = graph.runScatterGatherIteration(
 						new ConnectedComponents.CCUpdater<Long>(),
 						new ConnectedComponents.CCMessenger<Long>(), 100)
 						.getVertices();
@@ -156,11 +155,11 @@ public class SpargelCompilerTest extends CompilerTestBase {
 
 				Graph<Long, Long, NullValue> graph = Graph.fromDataSet(initialVertices, edges, env);
 
-				VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+				ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 				parameters.addBroadcastSetForMessagingFunction(BC_VAR_NAME, bcVar);
 				parameters.addBroadcastSetForUpdateFunction(BC_VAR_NAME, bcVar);
 
-				DataSet<Vertex<Long, Long>> result = graph.runVertexCentricIteration(
+				DataSet<Vertex<Long, Long>> result = graph.runScatterGatherIteration(
 						new ConnectedComponents.CCUpdater<Long>(),
 						new ConnectedComponents.CCMessenger<Long>(), 100)
 						.getVertices();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelTranslationTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelTranslationTest.java
@@ -81,7 +81,7 @@ public class SpargelTranslationTest {
 							}
 						}), env);
 
-				VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+				ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 				parameters.addBroadcastSetForMessagingFunction(BC_SET_MESSAGES_NAME, bcMessaging);
 				parameters.addBroadcastSetForUpdateFunction(BC_SET_UPDATES_NAME, bcUpdate);
@@ -89,7 +89,7 @@ public class SpargelTranslationTest {
 				parameters.setParallelism(ITERATION_parallelism);
 				parameters.registerAggregator(AGGREGATOR_NAME, new LongSumAggregator());
 
-				result = graph.runVertexCentricIteration(new UpdateFunction(), new MessageFunctionNoEdgeValue(),
+				result = graph.runScatterGatherIteration(new UpdateFunction(), new MessageFunctionNoEdgeValue(),
 						NUM_ITERATIONS, parameters).getVertices();
 
 				result.output(new DiscardingOutputFormat<Vertex<String, Double>>());
@@ -167,7 +167,7 @@ public class SpargelTranslationTest {
 							}
 						}), env);
 
-				VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+				ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 				parameters.addBroadcastSetForMessagingFunction(BC_SET_MESSAGES_NAME, bcVar);
 				parameters.addBroadcastSetForUpdateFunction(BC_SET_UPDATES_NAME, bcVar);
@@ -175,7 +175,7 @@ public class SpargelTranslationTest {
 				parameters.setParallelism(ITERATION_parallelism);
 				parameters.registerAggregator(AGGREGATOR_NAME, new LongSumAggregator());
 				
-				result = graph.runVertexCentricIteration(new UpdateFunction(), new MessageFunctionNoEdgeValue(),
+				result = graph.runScatterGatherIteration(new UpdateFunction(), new MessageFunctionNoEdgeValue(),
 						NUM_ITERATIONS, parameters).getVertices();
 
 				result.output(new DiscardingOutputFormat<Vertex<String, Double>>());

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/CollectionModeSuperstepITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/CollectionModeSuperstepITCase.java
@@ -47,7 +47,7 @@ public class CollectionModeSuperstepITCase {
 		Graph<Long, Long, Long> graph = Graph.fromCollection(TestGraphUtils.getLongLongVertices(), 
 				TestGraphUtils.getLongLongEdges(), env).mapVertices(new AssignOneMapper());
 		
-		Graph<Long, Long, Long> result = graph.runVertexCentricIteration(
+		Graph<Long, Long, Long> result = graph.runScatterGatherIteration(
 				new UpdateFunction(), new MessageFunction(), 10);
 
 		result.getVertices().map(

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/ScatterGatherConfigurationITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/ScatterGatherConfigurationITCase.java
@@ -33,8 +33,8 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.spargel.MessageIterator;
 import org.apache.flink.graph.spargel.MessagingFunction;
-import org.apache.flink.graph.spargel.VertexCentricConfiguration;
-import org.apache.flink.graph.spargel.VertexCentricIteration;
+import org.apache.flink.graph.spargel.ScatterGatherConfiguration;
+import org.apache.flink.graph.spargel.ScatterGatherIteration;
 import org.apache.flink.graph.spargel.VertexUpdateFunction;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
 import org.apache.flink.types.LongValue;
@@ -45,9 +45,9 @@ import org.junit.runners.Parameterized;
 import org.apache.flink.graph.utils.VertexToTuple2Map;
 
 @RunWith(Parameterized.class)
-public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
+public class ScatterGatherConfigurationITCase extends MultipleProgramsTestBase {
 
-	public VertexCentricConfigurationITCase(TestExecutionMode mode){
+	public ScatterGatherConfigurationITCase(TestExecutionMode mode){
 		super(mode);
 	}
 
@@ -56,7 +56,7 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testRunWithConfiguration() throws Exception {
 		/*
-		 * Test Graph's runVertexCentricIteration when configuration parameters are provided
+		 * Test Graph's runScatterGatherIteration when configuration parameters are provided
 		 */
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		
@@ -64,14 +64,14 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				TestGraphUtils.getLongLongEdges(), env).mapVertices(new AssignOneMapper());
 
 		// create the configuration object
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.addBroadcastSetForUpdateFunction("updateBcastSet", env.fromElements(1, 2, 3));
 		parameters.addBroadcastSetForMessagingFunction("messagingBcastSet", env.fromElements(4, 5, 6));
 		parameters.registerAggregator("superstepAggregator", new LongSumAggregator());
 		parameters.setOptNumVertices(true);
 
-		Graph<Long, Long, Long> res = graph.runVertexCentricIteration(
+		Graph<Long, Long, Long> res = graph.runScatterGatherIteration(
 				new UpdateFunction(), new MessageFunction(), 10, parameters);
 
 		DataSet<Vertex<Long,Long>> data = res.getVertices();
@@ -94,11 +94,11 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 		 */
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-		VertexCentricIteration<Long, Long, Long, Long> iteration = VertexCentricIteration
+		ScatterGatherIteration<Long, Long, Long, Long> iteration = ScatterGatherIteration
 				.withEdges(TestGraphUtils.getLongLongEdgeData(env), new DummyUpdateFunction(), 
 						new DummyMessageFunction(), 10);
 		
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 		parameters.setName("gelly iteration");
 		parameters.setParallelism(2);
 		parameters.setSolutionSetUnmanagedMemory(true);
@@ -124,7 +124,7 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testDefaultConfiguration() throws Exception {
 		/*
-		 * Test Graph's runVertexCentricIteration when configuration parameters are not provided
+		 * Test Graph's runScatterGatherIteration when configuration parameters are not provided
 		 * i.e. degrees and numVertices will be -1, EdgeDirection will be OUT.
 		 */
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
@@ -132,7 +132,7 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 		Graph<Long, Long, Long> graph = Graph.fromCollection(TestGraphUtils.getLongLongVertices(), 
 				TestGraphUtils.getLongLongEdges(), env).mapVertices(new AssignOneMapper());
 
-		Graph<Long, Long, Long> res = graph.runVertexCentricIteration(
+		Graph<Long, Long, Long> res = graph.runScatterGatherIteration(
 				new UpdateFunctionDefault(), new MessageFunctionDefault(), 5);
 
 		
@@ -162,7 +162,7 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				.mapVertices(new InitialiseHashSetMapper());
 
 		DataSet<Vertex<Long, HashSet<Long>>> resultedVertices = graph
-				.runVertexCentricIteration(new VertexUpdateDirection(), new IdMessengerTrg(), 5)
+				.runScatterGatherIteration(new VertexUpdateDirection(), new IdMessengerTrg(), 5)
 				.getVertices();
 
         List<Vertex<Long, HashSet<Long>>> result= resultedVertices.collect();
@@ -190,12 +190,12 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				.mapVertices(new InitialiseHashSetMapper());
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setDirection(EdgeDirection.IN);
 
 		DataSet<Vertex<Long, HashSet<Long>>> resultedVertices = graph
-				.runVertexCentricIteration(new VertexUpdateDirection(), new IdMessengerSrc(), 5, parameters)
+				.runScatterGatherIteration(new VertexUpdateDirection(), new IdMessengerSrc(), 5, parameters)
 				.getVertices();
 
         List<Vertex<Long, HashSet<Long>>> result= resultedVertices.collect();
@@ -223,12 +223,12 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				.mapVertices(new InitialiseHashSetMapper());
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setDirection(EdgeDirection.ALL);
 
 		DataSet<Vertex<Long, HashSet<Long>>> resultedVertices = graph
-				.runVertexCentricIteration(new VertexUpdateDirection(), new IdMessengerAll(), 5, parameters)
+				.runScatterGatherIteration(new VertexUpdateDirection(), new IdMessengerAll(), 5, parameters)
 				.getVertices();
 
 		List<Vertex<Long, HashSet<Long>>> result= resultedVertices.collect();
@@ -256,12 +256,12 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				.mapVertices(new InitialiseHashSetMapper());
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setDirection(EdgeDirection.IN);
 
 		DataSet<Vertex<Long, HashSet<Long>>> resultedVertices = graph
-				.runVertexCentricIteration(new VertexUpdateDirection(), new SendMsgToAll(), 5, parameters)
+				.runScatterGatherIteration(new VertexUpdateDirection(), new SendMsgToAll(), 5, parameters)
 				.getVertices();
 
 		List<Vertex<Long, HashSet<Long>>> result = resultedVertices.collect();
@@ -289,12 +289,12 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				.mapVertices(new InitialiseHashSetMapper());
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setDirection(EdgeDirection.OUT);
 
 		DataSet<Vertex<Long, HashSet<Long>>> resultedVertices = graph
-				.runVertexCentricIteration(new VertexUpdateDirection(), new SendMsgToAll(), 5, parameters)
+				.runScatterGatherIteration(new VertexUpdateDirection(), new SendMsgToAll(), 5, parameters)
 				.getVertices();
 
 		List<Vertex<Long, HashSet<Long>>> result = resultedVertices.collect();
@@ -322,12 +322,12 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				.mapVertices(new InitialiseHashSetMapper());
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setDirection(EdgeDirection.ALL);
 
 		DataSet<Vertex<Long, HashSet<Long>>> resultedVertices = graph
-				.runVertexCentricIteration(new VertexUpdateDirection(), new SendMsgToAll(), 5, parameters)
+				.runScatterGatherIteration(new VertexUpdateDirection(), new SendMsgToAll(), 5, parameters)
 				.getVertices();
 
 		List<Vertex<Long, HashSet<Long>>> result = resultedVertices.collect();
@@ -353,7 +353,7 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 		Graph<Long, Long, Long> graph = Graph.fromCollection(TestGraphUtils.getLongLongVertices(),
 				TestGraphUtils.getLongLongEdges(), env);
 
-		DataSet<Vertex<Long, Long>> verticesWithNumVertices = graph.runVertexCentricIteration(new UpdateFunctionNumVertices(),
+		DataSet<Vertex<Long, Long>> verticesWithNumVertices = graph.runScatterGatherIteration(new UpdateFunctionNumVertices(),
 				new DummyMessageFunction(), 2).getVertices();
 
 		List<Vertex<Long, Long>> result= verticesWithNumVertices.collect();
@@ -381,11 +381,11 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				TestGraphUtils.getLongLongEdges(), env);
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setOptDegrees(true);
 
-		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runVertexCentricIteration(
+		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runScatterGatherIteration(
 				new UpdateFunctionInDegrees(), new DegreesMessageFunction(), 5, parameters).getVertices();
 
 		List<Vertex<Long, Long>> result= verticesWithDegrees.collect();
@@ -410,7 +410,7 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 		Graph<Long, Long, Long> graph = Graph.fromCollection(TestGraphUtils.getLongLongVertices(),
 				TestGraphUtils.getLongLongEdges(), env);
 
-		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runVertexCentricIteration(
+		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runScatterGatherIteration(
 				new UpdateFunctionInDegrees(), new DummyMessageFunction(), 2).getVertices();
 
 		List<Vertex<Long, Long>> result= verticesWithDegrees.collect();
@@ -438,11 +438,11 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				TestGraphUtils.getLongLongEdges(), env);
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setOptDegrees(true);
 
-		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runVertexCentricIteration(
+		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runScatterGatherIteration(
 				new UpdateFunctionOutDegrees(), new DegreesMessageFunction(), 5, parameters).getVertices();
 
 		List<Vertex<Long, Long>> result= verticesWithDegrees.collect();
@@ -467,7 +467,7 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 		Graph<Long, Long, Long> graph = Graph.fromCollection(TestGraphUtils.getLongLongVertices(),
 				TestGraphUtils.getLongLongEdges(), env);
 
-		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runVertexCentricIteration(
+		DataSet<Vertex<Long, Long>> verticesWithDegrees = graph.runScatterGatherIteration(
 				new UpdateFunctionInDegrees(), new DummyMessageFunction(), 2).getVertices();
 
 		List<Vertex<Long, Long>> result= verticesWithDegrees.collect();
@@ -494,12 +494,12 @@ public class VertexCentricConfigurationITCase extends MultipleProgramsTestBase {
 				TestGraphUtils.getLongLongEdges(), env);
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		parameters.setOptDegrees(true);
 		parameters.setDirection(EdgeDirection.ALL);
 
-		DataSet<Vertex<Long, Boolean>> verticesWithNumNeighbors = graph.runVertexCentricIteration(
+		DataSet<Vertex<Long, Boolean>> verticesWithNumNeighbors = graph.runScatterGatherIteration(
 				new VertexUpdateNumNeighbors(), new IdMessenger(), 1, parameters).getVertices();
 
 		List<Vertex<Long, Boolean>> result= verticesWithNumNeighbors.collect();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/example/IncrementalSSSPITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/example/IncrementalSSSPITCase.java
@@ -28,7 +28,7 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.example.IncrementalSSSP;
 import org.apache.flink.graph.example.utils.IncrementalSSSPData;
-import org.apache.flink.graph.spargel.VertexCentricConfiguration;
+import org.apache.flink.graph.spargel.ScatterGatherConfiguration;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
 import org.junit.After;
 import org.junit.Before;
@@ -101,15 +101,15 @@ public class IncrementalSSSPITCase extends MultipleProgramsTestBase {
 		graph.removeEdge(edgeToBeRemoved);
 
 		// configure the iteration
-		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
 		if(IncrementalSSSP.isInSSSP(edgeToBeRemoved, edgesInSSSP)) {
 
 			parameters.setDirection(EdgeDirection.IN);
 			parameters.setOptDegrees(true);
 
-			// run the vertex centric iteration to propagate info
-			Graph<Long, Double, Double> result = ssspGraph.runVertexCentricIteration(
+			// run the scatter gather iteration to propagate info
+			Graph<Long, Double, Double> result = ssspGraph.runScatterGatherIteration(
 					new IncrementalSSSP.VertexDistanceUpdater(),
 					new IncrementalSSSP.InvalidateMessenger(edgeToBeRemoved),
 					IncrementalSSSPData.NUM_VERTICES, parameters);


### PR DESCRIPTION
This is the first step to introducing a Pregel abstraction in Gelly.