### PR TITLE
[FLINK-3246] Remove unnecessary '-parent' suffix from some projects

### DIFF
--- a/flink-contrib/flink-connector-wikiedits/pom.xml
+++ b/flink-contrib/flink-connector-wikiedits/pom.xml
@@ -24,7 +24,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-contrib-parent</artifactId>
+		<artifactId>flink-contrib</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-contrib/flink-operator-stats/pom.xml
+++ b/flink-contrib/flink-operator-stats/pom.xml
@@ -23,7 +23,7 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-contrib-parent</artifactId>
+        <artifactId>flink-contrib</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>

--- a/flink-contrib/flink-storm-examples/pom.xml
+++ b/flink-contrib/flink-storm-examples/pom.xml
@@ -24,7 +24,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-contrib-parent</artifactId>
+		<artifactId>flink-contrib</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-contrib/flink-storm/pom.xml
+++ b/flink-contrib/flink-storm/pom.xml
@@ -24,7 +24,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-contrib-parent</artifactId>
+		<artifactId>flink-contrib</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-contrib/flink-streaming-contrib/pom.xml
+++ b/flink-contrib/flink-streaming-contrib/pom.xml
@@ -26,7 +26,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-contrib-parent</artifactId>
+		<artifactId>flink-contrib</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-contrib/flink-tweet-inputformat/pom.xml
+++ b/flink-contrib/flink-tweet-inputformat/pom.xml
@@ -26,7 +26,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-contrib-parent</artifactId>
+		<artifactId>flink-contrib</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-contrib/pom.xml
+++ b/flink-contrib/pom.xml
@@ -31,8 +31,8 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-contrib-parent</artifactId>
-	<name>flink-contrib-parent</name>
+	<artifactId>flink-contrib</artifactId>
+	<name>flink-contrib</name>
 
 	<packaging>pom</packaging>
 

--- a/flink-streaming-connectors/flink-connector-elasticsearch/pom.xml
+++ b/flink-streaming-connectors/flink-connector-elasticsearch/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-streaming-connectors-parent</artifactId>
+		<artifactId>flink-streaming-connectors</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-streaming-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-streaming-connectors/flink-connector-filesystem/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-streaming-connectors-parent</artifactId>
+		<artifactId>flink-streaming-connectors</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-streaming-connectors/flink-connector-flume/pom.xml
+++ b/flink-streaming-connectors/flink-connector-flume/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-streaming-connectors-parent</artifactId>
+		<artifactId>flink-streaming-connectors</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-streaming-connectors/flink-connector-kafka/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-streaming-connectors-parent</artifactId>
+		<artifactId>flink-streaming-connectors</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-streaming-connectors/flink-connector-nifi/pom.xml
+++ b/flink-streaming-connectors/flink-connector-nifi/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-streaming-connectors-parent</artifactId>
+		<artifactId>flink-streaming-connectors</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-streaming-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-streaming-connectors/flink-connector-rabbitmq/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-streaming-connectors-parent</artifactId>
+		<artifactId>flink-streaming-connectors</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-streaming-connectors/flink-connector-twitter/pom.xml
+++ b/flink-streaming-connectors/flink-connector-twitter/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-streaming-connectors-parent</artifactId>
+		<artifactId>flink-streaming-connectors</artifactId>
 		<version>1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-streaming-connectors/pom.xml
+++ b/flink-streaming-connectors/pom.xml
@@ -30,7 +30,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-streaming-connectors-parent</artifactId>
+	<artifactId>flink-streaming-connectors</artifactId>
 	<name>flink-streaming-connectors</name>
 
 	<packaging>pom</packaging>


### PR DESCRIPTION
Remove unnecessary '-parent' suffix from projects 'flink-contrib' and 'flink-streaming-connectors'.

The projects `flink-streaming-connectors-parent` and `flink-contrib-parent` carry the unnecessary `-parent ` suffix.
I suspect that was mistakenly added when looking at the root project called `flink-parent`. The suffix was added there to not have a project with an unqualified name flink. However, for the projects mentioned here, that suffix is not necessary and can be dropped.