### PR TITLE
[FLINK-3267] Disable reference tracking in Kryo fallback serializer

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -306,6 +306,10 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 		if (this.kryo == null) {
 			this.kryo = getKryoInstance();
 
+			// disable reference tracking. reference tracking is costly, usually unnecessary, and
+			// inconsistent with Flink's own serialization (which does not do reference tracking)
+			kryo.setReferences(false);
+			
 			// Throwable and all subclasses should be serialized via java serialization
 			kryo.addDefaultSerializer(Throwable.class, new JavaSerializer());
 


### PR DESCRIPTION
Before this commit, Kryo runs extra logic to track and resolve repeated references to
the same object (similar as JavaSerialization)

This disables reference tracking because
  - reference tracking is costly
  - it is virtually always unnecessary in the datatypes used in Flink
  - it is inconsistent with Flink's own serialization (which does not do reference tracking)
  - it may have problems if elements are read in a different order than they are written.