### PR TITLE
FLINK-3135 Add chainable driver for UNARY_NO_OP strategy(Ram)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DriverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DriverStrategy.java
@@ -35,7 +35,7 @@ public enum DriverStrategy {
 	// no local strategy, as for sources and sinks
 	NONE(null, null, PIPELINED, 0),
 	// a unary no-op operator
-	UNARY_NO_OP(NoOpDriver.class, null, PIPELINED, PIPELINED, 0),
+	UNARY_NO_OP(NoOpDriver.class, NoOpChainedDriver.class, PIPELINED, PIPELINED, 0),
 	// a binary no-op operator. non implementation available
 	BINARY_NO_OP(null, null, PIPELINED, PIPELINED, 0),
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpChainedDriver.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.operators;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.operators.chaining.ChainedDriver;
+import org.apache.flink.runtime.operators.chaining.ExceptionInChainedStubException;
+
+/**
+ * A chained driver that just passes on the input as the output
+ * @param <IT> The type of the input
+ */
+public class NoOpChainedDriver<IT> extends ChainedDriver<IT, IT> {
+
+	@Override
+	public void setup(AbstractInvokable parent) {
+
+	}
+
+	@Override
+	public void openTask() throws Exception {
+
+	}
+
+	@Override
+	public void closeTask() throws Exception {
+
+	}
+
+	@Override
+	public void cancelTask() {
+
+	}
+
+	@Override
+	public Function getStub() {
+		return null;
+	}
+
+	@Override
+	public String getTaskName() {
+		return this.taskName;
+	}
+
+	@Override
+	public void collect(IT record) {
+		try {
+			this.outputCollector.collect(record);
+		} catch (Exception ex) {
+			throw new ExceptionInChainedStubException(this.taskName, ex);
+		}
+	}
+
+	@Override
+	public void close() {
+		this.outputCollector.close();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpDriver.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NoOpDriver<T> implements Driver<AbstractRichFunction, T> {
 
-	private static final Logger LOG = LoggerFactory.getLogger(MapPartitionDriver.class);
+	private static final Logger LOG = LoggerFactory.getLogger(NoOpDriver.class);
 
 	private TaskContext<AbstractRichFunction, T> taskContext;
 	


### PR DESCRIPTION
My first flink PR. A simple way to add a Chainable Driver for UNARY_NO_OP. Just followed the existing code pieces and also reading the NoOpDriver created the NoOpChainedDriver. Just trying to learn and happy to work on feedbacks/comments.
Since here the input just needs to be passed to the output there is no need for any class to be loaded I felt. Hence most of the abstract APIs have empty implementations.