### PR TITLE
[hotfix] Fix interaction of Async calls/checkpointing/canceling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -882,7 +882,11 @@ public class Task implements Runnable {
 							}
 						}
 						catch (Throwable t) {
-							failExternally(new RuntimeException("Error while triggering checkpoint for " + taskName, t));
+							if (getExecutionState() == ExecutionState.RUNNING) {
+								failExternally(new RuntimeException(
+									"Error while triggering checkpoint for " + taskName,
+									t));
+							}
 						}
 					}
 				};
@@ -915,8 +919,12 @@ public class Task implements Runnable {
 							statefulTask.notifyCheckpointComplete(checkpointID);
 						}
 						catch (Throwable t) {
-							// fail task if checkpoint confirmation failed.
-							failExternally(new RuntimeException("Error while confirming checkpoint", t));
+							if (getExecutionState() == ExecutionState.RUNNING) {
+								// fail task if checkpoint confirmation failed.
+								failExternally(new RuntimeException(
+									"Error while confirming checkpoint",
+									t));
+							}
 						}
 					}
 				};


### PR DESCRIPTION
Before, it could happen that a Task is canceled during snapshotting.
Some State Backends would silently swallow exceptions resulting from
this and the Task would get stuck until the cleanup logic gets to it.

Now, we rethrow a CancelTaskException if isRunning is false in
StreamTask after performing snapshots.

This also moves the logic that swallows exceptions in case a task is not
running anymore from StreamTask to the async caller in Task.