### PR TITLE
[FLINK-2972] remove Chill dependency from the test scope

### DIFF
--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -104,14 +104,6 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>com.twitter</groupId>
-			<artifactId>chill_${scala.binary.version}</artifactId>
-			<version>${chill.version}</version>
-			<!-- For execution, Chill is added to the classpath through flink-runtime. -->
-			<scope>test</scope>
-		</dependency>
 		
 	</dependencies>
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoGenericTypeSerializerTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoGenericTypeSerializerTest.java
@@ -36,6 +36,8 @@ import java.util.Random;
 
 @SuppressWarnings("unchecked")
 public class KryoGenericTypeSerializerTest extends AbstractGenericTypeSerializerTest {
+
+	ExecutionConfig ec = new ExecutionConfig();
 	
 	@Test
 	public void testJavaList(){
@@ -82,7 +84,7 @@ public class KryoGenericTypeSerializerTest extends AbstractGenericTypeSerializer
 		coll.add(49);
 		coll.add(1);
 	}
-	ExecutionConfig ec = new ExecutionConfig();
+
 	@Override
 	protected <T> TypeSerializer<T> createSerializer(Class<T> type) {
 		return new KryoSerializer<T>(type, ec);


### PR DESCRIPTION
This eliminates the last bit of the Scala dependency of `flink-java`. If the Chill library can't be found it is replaced by one of the default Kryo serializers which support all test cases in `flink-java`. This is important for merging #1529.