### PR TITLE
[FLINK-2021] Rework examples to use ParameterTool (K-Means)

### DIFF
--- a/docs/quickstart/run_example_quickstart.md
+++ b/docs/quickstart/run_example_quickstart.md
@@ -100,9 +100,9 @@ The Flink web interface allows to submit Flink programs using a graphical user i
 		5. Enter the arguments and options in the lower box: <br>
 		    Leave the <i>Entry Class</i> and <i>Parallelism</i> form empty<br>
 		    Enter the following program arguments: <br>
-		    (KMeans expects the following args: <code>&lt;points path&gt; &lt;centers path&gt; &lt;result path&gt; &lt;num iterations&gt;</code>
+		    (KMeans expects the following args: <code>--points &lt;points path&gt; --centroids &lt;centers path&gt; --output &lt;result path&gt; --iterations &lt;num iterations&gt;</code>
 			{% highlight bash %}
-            /tmp/kmeans/points /tmp/kmeans/centers /tmp/kmeans/result 10
+            --points /tmp/kmeans/points --centroids /tmp/kmeans/centers --output /tmp/kmeans/result --iterations 10
 			{% endhighlight %} <br>
 		6. Press <b>Submit</b> to start the job
 	</div>

--- a/docs/quickstart/run_example_quickstart.md
+++ b/docs/quickstart/run_example_quickstart.md
@@ -100,7 +100,7 @@ The Flink web interface allows to submit Flink programs using a graphical user i
 		5. Enter the arguments and options in the lower box: <br>
 		    Leave the <i>Entry Class</i> and <i>Parallelism</i> form empty<br>
 		    Enter the following program arguments: <br>
-		    (KMeans expects the following args: <code>--points &lt;points path&gt; --centroids &lt;centers path&gt; --output &lt;result path&gt; --iterations &lt;num iterations&gt;</code>
+		    (KMeans expects the following args: <code>--points &lt;path&gt; --centroids &lt;path&gt; --output &lt;path&gt; --iterations &lt;n&gt;</code>
 			{% highlight bash %}
             --points /tmp/kmeans/points --centroids /tmp/kmeans/centers --output /tmp/kmeans/result --iterations 10
 			{% endhighlight %} <br>

--- a/docs/quickstart/run_example_quickstart.md
+++ b/docs/quickstart/run_example_quickstart.md
@@ -101,9 +101,7 @@ The Flink web interface allows to submit Flink programs using a graphical user i
 		    Leave the <i>Entry Class</i> and <i>Parallelism</i> form empty<br>
 		    Enter the following program arguments: <br>
 		    (KMeans expects the following args: <code>--points &lt;path&gt; --centroids &lt;path&gt; --output &lt;path&gt; --iterations &lt;n&gt;</code>
-			{% highlight bash %}
-            --points /tmp/kmeans/points --centroids /tmp/kmeans/centers --output /tmp/kmeans/result --iterations 10
-			{% endhighlight %} <br>
+			{% highlight bash %}--points /tmp/kmeans/points --centroids /tmp/kmeans/centers --output /tmp/kmeans/result --iterations 10{% endhighlight %}<br>
 		6. Press <b>Submit</b> to start the job
 	</div>
 </div>

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
@@ -299,13 +299,13 @@ public class KMeans {
 	private static int numIterations = 10;
 
 	private static final Option POINTS_PATH_OPTION =
-		new Option("pointsPath").alt("P").help("The path to the input points");
+		new Option("points").alt("P").help("The path to the input points");
 	private static final Option CENTERS_PATH_OPTION =
-		new Option("centersPath").alt("C").help("The path to the input centroids");
+		new Option("centroids").alt("C").help("The path to the input centroids");
 	private static final Option OUTPUT_PATH_OPTION =
-		new Option("outputPath").alt("O").help("The path where the output will be written");
+		new Option("output").alt("O").help("The path where the output will be written");
 	private static final Option NUM_ITERATIONS_OPTION =
-		new Option("numIterations").alt("N").help("The number of iteration performed by the K-Means algorithm");
+		new Option("iterations").alt("I").help("The number of iteration performed by the K-Means algorithm");
 
 	private static boolean parseParameters(final ParameterTool params) throws RequiredParametersException {
 

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
@@ -329,9 +329,8 @@ public class KMeans {
 			if (params.getNumberOfParameters() == 0) {
 				printRunWithDefaultParams();
 				parseStatus = true;
-			} else {
-				System.out.println(requiredParameters.getHelp(e.getMissingArguments()));
 			}
+			System.out.println(requiredParameters.getHelp(e.getMissingArguments()));
 		}
 
 		return parseStatus;
@@ -342,7 +341,6 @@ public class KMeans {
 		System.out.println("  Provide parameters to read input data from files.");
 		System.out.println("  See the documentation for the correct format of input files.");
 		System.out.println("  We provide a data generator to create synthetic input files for this program.");
-		System.out.println("  Usage: KMeans --points <points path> --centroids <centers path> --output <result path> --iterations <num iterations>");
 	}
 
 	private static DataSet<Point> getPointDataSet(ExecutionEnvironment env) {

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
@@ -27,10 +27,7 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.api.java.utils.Option;
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.api.java.utils.RequiredParameters;
-import org.apache.flink.api.java.utils.RequiredParametersException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.examples.java.clustering.util.KMeansData;
 import org.apache.flink.api.java.DataSet;
@@ -39,23 +36,23 @@ import org.apache.flink.api.java.operators.IterativeDataSet;
 
 /**
  * This example implements a basic K-Means clustering algorithm.
- * 
+ *
  * <p>
  * K-Means is an iterative clustering algorithm and works as follows:<br>
  * K-Means is given a set of data points to be clustered and an initial set of <i>K</i> cluster centers.
  * In each iteration, the algorithm computes the distance of each data point to each cluster center.
  * Each point is assigned to the cluster center which is closest to it.
  * Subsequently, each cluster center is moved to the center (<i>mean</i>) of all points that have been assigned to it.
- * The moved cluster centers are fed into the next iteration. 
- * The algorithm terminates after a fixed number of iterations (as in this implementation) 
+ * The moved cluster centers are fed into the next iteration.
+ * The algorithm terminates after a fixed number of iterations (as in this implementation)
  * or if cluster centers do not (significantly) move in an iteration.<br>
  * This is the Wikipedia entry for the <a href="http://en.wikipedia.org/wiki/K-means_clustering">K-Means Clustering algorithm</a>.
- * 
+ *
  * <p>
  * This implementation works on two-dimensional data points. <br>
- * It computes an assignment of data points to cluster centers, i.e., 
+ * It computes an assignment of data points to cluster centers, i.e.,
  * each data point is annotated with the id of the final cluster (center) it belongs to.
- * 
+ *
  * <p>
  * Input files are plain text files and must be formatted as follows:
  * <ul>
@@ -65,11 +62,11 @@ import org.apache.flink.api.java.operators.IterativeDataSet;
  * <li>Cluster centers are represented by an integer id and a point value.<br>
  * For example <code>"1 6.2 3.2\n2 2.9 5.7\n"</code> gives two centers (id=1, x=6.2, y=3.2) and (id=2, x=2.9, y=5.7).
  * </ul>
- * 
+ *
  * <p>
- * Usage: <code>KMeans &lt;points path&gt; &lt;centers path&gt; &lt;result path&gt; &lt;num iterations&gt;</code><br>
- * If no parameters are provided, the program is run with default data from {@link org.apache.flink.examples.java.clustering.util.KMeansData} and 10 iterations. 
- * 
+ * Usage: <code>KMeans --points --centroids --output --iterations</code><br>
+ * If no parameters are provided, the program is run with default data from {@link org.apache.flink.examples.java.clustering.util.KMeansData} and 10 iterations.
+ *
  * <p>
  * This example shows how to use:
  * <ul>
@@ -80,56 +77,52 @@ import org.apache.flink.api.java.operators.IterativeDataSet;
  */
 @SuppressWarnings("serial")
 public class KMeans {
-	
-	// *************************************************************************
-	//     PROGRAM
-	// *************************************************************************
-	
+
 	public static void main(String[] args) throws Exception {
 
 		// Checking input parameters
 		final ParameterTool params = ParameterTool.fromArgs(args);
-		final RequiredParameters requiredParameters = new RequiredParameters();
-		boolean paramsOk = false;
-
-		requiredParameters.add(POINTS_PATH_OPTION);
-		requiredParameters.add(CENTERS_PATH_OPTION);
-		requiredParameters.add(OUTPUT_PATH_OPTION);
-		requiredParameters.add(NUM_ITERATIONS_OPTION);
-
-		try {
-			requiredParameters.applyTo(params);
-			pointsPath = params.get(POINTS_PATH_OPTION.getName());
-			centersPath = params.get(CENTERS_PATH_OPTION.getName());
-			outputPath = params.get(OUTPUT_PATH_OPTION.getName());
-			numIterations = params.getInt(NUM_ITERATIONS_OPTION.getName());
-			fileOutput = true;
-			paramsOk = true;
-		} catch (RequiredParametersException e) {
-			if (params.getNumberOfParameters() == 0) {
-				System.out.println("Executing K-Means example with default parameters and built-in default data.");
-				System.out.println("  Provide parameters to read input data from files.");
-				System.out.println("  See the documentation for the correct format of input files.");
-				System.out.println("  We provide a data generator to create synthetic input files for this program.");
-				paramsOk = true;
-			}
-			System.out.println(requiredParameters.getHelp(e.getMissingArguments()));
+		if (params.getNumberOfParameters() < 4) {
+			System.out.println("Executing K-Means example with default parameters and built-in default data.");
+			System.out.println("  Provide parameters to read input data from files.");
+			System.out.println("  See the documentation for the correct format of input files.");
+			System.out.println("  We provide a data generator to create synthetic input files for this program.");
+			System.out.println("  Usage: KMeans --points --centroids --output --iterations");
 		}
 
-		if(!paramsOk) {
-			return;
-		}
-	
 		// set up execution environment
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		
-		// get input data
-		DataSet<Point> points = getPointDataSet(env);
-		DataSet<Centroid> centroids = getCentroidDataSet(env);
-		
+		env.getConfig().setGlobalJobParameters(params); // make parameters available in the web interface
+
+		// get input data:
+		// points
+		DataSet<Point> points;
+		if(params.has("points")) {
+			// read points from CSV file
+			points = env.readCsvFile(params.get("points"))
+				.fieldDelimiter(" ")
+				.includeFields(true, true)
+				.types(Double.class, Double.class)
+				.map(new TuplePointConverter());
+		} else {
+			points = KMeansData.getDefaultPointDataSet(env);
+		}
+
+		// centroids
+		DataSet<Centroid> centroids;
+		if(params.has("centroids")) {
+			centroids = env.readCsvFile(params.get("centroids"))
+				.fieldDelimiter(" ")
+				.includeFields(true, true, true)
+				.types(Integer.class, Double.class, Double.class)
+				.map(new TupleCentroidConverter());
+		} else {
+			centroids = KMeansData.getDefaultCentroidDataSet(env);
+		}
+
 		// set number of bulk iterations for KMeans algorithm
-		IterativeDataSet<Centroid> loop = centroids.iterate(numIterations);
-		
+		IterativeDataSet<Centroid> loop = centroids.iterate(params.getInt("iterations", 10));
+
 		DataSet<Centroid> newCentroids = points
 			// compute closest centroid for each point
 			.map(new SelectNearestCenter()).withBroadcastSet(loop, "centroids")
@@ -138,99 +131,98 @@ public class KMeans {
 			.groupBy(0).reduce(new CentroidAccumulator())
 			// compute new centroids from point counts and coordinate sums
 			.map(new CentroidAverager());
-		
+
 		// feed new centroids back into next iteration
 		DataSet<Centroid> finalCentroids = loop.closeWith(newCentroids);
-		
+
 		DataSet<Tuple2<Integer, Point>> clusteredPoints = points
-				// assign points to final clusters
-				.map(new SelectNearestCenter()).withBroadcastSet(finalCentroids, "centroids");
-		
+			// assign points to final clusters
+			.map(new SelectNearestCenter()).withBroadcastSet(finalCentroids, "centroids");
+
 		// emit result
-		if (fileOutput) {
-			clusteredPoints.writeAsCsv(outputPath, "\n", " ");
+		if (params.has("output")) {
+			clusteredPoints.writeAsCsv(params.get("output"), "\n", " ");
 
 			// since file sinks are lazy, we trigger the execution explicitly
 			env.execute("KMeans Example");
-		}
-		else {
+		} else {
 			clusteredPoints.print();
 		}
 	}
-	
+
 	// *************************************************************************
 	//     DATA TYPES
 	// *************************************************************************
-	
+
 	/**
 	 * A simple two-dimensional point.
 	 */
 	public static class Point implements Serializable {
-		
+
 		public double x, y;
-		
+
 		public Point() {}
 
 		public Point(double x, double y) {
 			this.x = x;
 			this.y = y;
 		}
-		
+
 		public Point add(Point other) {
 			x += other.x;
 			y += other.y;
 			return this;
 		}
-		
+
 		public Point div(long val) {
 			x /= val;
 			y /= val;
 			return this;
 		}
-		
+
 		public double euclideanDistance(Point other) {
 			return Math.sqrt((x-other.x)*(x-other.x) + (y-other.y)*(y-other.y));
 		}
-		
+
 		public void clear() {
 			x = y = 0.0;
 		}
-		
+
 		@Override
 		public String toString() {
 			return x + " " + y;
 		}
 	}
-	
+
 	/**
-	 * A simple two-dimensional centroid, basically a point with an ID. 
+	 * A simple two-dimensional centroid, basically a point with an ID.
 	 */
 	public static class Centroid extends Point {
-		
+
 		public int id;
-		
+
 		public Centroid() {}
-		
+
 		public Centroid(int id, double x, double y) {
 			super(x,y);
 			this.id = id;
 		}
-		
+
 		public Centroid(int id, Point p) {
 			super(p.x, p.y);
 			this.id = id;
 		}
-		
+
 		@Override
 		public String toString() {
 			return id + " " + super.toString();
 		}
 	}
-	
+
 	// *************************************************************************
 	//     USER FUNCTIONS
 	// *************************************************************************
-	
+
 	/** Converts a {@code Tuple2<Double,Double>} into a Point. */
 	@ForwardedFields("0->x; 1->y")
 	public static final class TuplePointConverter implements MapFunction<Tuple2<Double, Double>, Point> {
@@ -240,7 +232,7 @@ public class KMeans {
 			return new Point(t.f0, t.f1);
 		}
 	}
-	
+
 	/** Converts a {@code Tuple3<Integer, Double,Double>} into a Centroid. */
 	@ForwardedFields("0->id; 1->x; 2->y")
 	public static final class TupleCentroidConverter implements MapFunction<Tuple3<Integer, Double, Double>, Centroid> {
@@ -250,7 +242,7 @@ public class KMeans {
 			return new Centroid(t.f0, t.f1, t.f2);
 		}
 	}
-	
+
 	/** Determines the closest cluster center for a data point. */
 	@ForwardedFields("*->1")
 	public static final class SelectNearestCenter extends RichMapFunction<Point, Tuple2<Integer, Point>> {
@@ -261,19 +253,19 @@ public class KMeans {
 		public void open(Configuration parameters) throws Exception {
 			this.centroids = getRuntimeContext().getBroadcastVariable("centroids");
 		}
-		
+
 		@Override
 		public Tuple2<Integer, Point> map(Point p) throws Exception {
-			
+
 			double minDistance = Double.MAX_VALUE;
 			int closestCentroidId = -1;
-			
+
 			// check all cluster centers
 			for (Centroid centroid : centroids) {
 				// compute distance
 				double distance = p.euclideanDistance(centroid);
-				
-				// update nearest cluster if necessary 
+
+				// update nearest cluster if necessary
 				if (distance < minDistance) {
 					minDistance = distance;
 					closestCentroidId = centroid.id;
@@ -281,30 +273,30 @@ public class KMeans {
 			}
 
 			// emit a new record with the center id and the data point.
-			return new Tuple2<Integer, Point>(closestCentroidId, p);
+			return new Tuple2<>(closestCentroidId, p);
 		}
 	}
-	
+
 	/** Appends a count variable to the tuple. */
 	@ForwardedFields("f0;f1")
 	public static final class CountAppender implements MapFunction<Tuple2<Integer, Point>, Tuple3<Integer, Point, Long>> {
 
 		@Override
 		public Tuple3<Integer, Point, Long> map(Tuple2<Integer, Point> t) {
-			return new Tuple3<Integer, Point, Long>(t.f0, t.f1, 1L);
-		} 
+			return new Tuple3<>(t.f0, t.f1, 1L);
+		}
 	}
-	
+
 	/** Sums and counts point coordinates. */
 	@ForwardedFields("0")
 	public static final class CentroidAccumulator implements ReduceFunction<Tuple3<Integer, Point, Long>> {
 
 		@Override
 		public Tuple3<Integer, Point, Long> reduce(Tuple3<Integer, Point, Long> val1, Tuple3<Integer, Point, Long> val2) {
-			return new Tuple3<Integer, Point, Long>(val1.f0, val1.f1.add(val2.f1), val1.f2 + val2.f2);
+			return new Tuple3<>(val1.f0, val1.f1.add(val2.f1), val1.f2 + val2.f2);
 		}
 	}
-	
+
 	/** Computes new centroid from coordinate sum and count of points. */
 	@ForwardedFields("0->id")
 	public static final class CentroidAverager implements MapFunction<Tuple3<Integer, Point, Long>, Centroid> {
@@ -312,50 +304,6 @@ public class KMeans {
 		@Override
 		public Centroid map(Tuple3<Integer, Point, Long> value) {
 			return new Centroid(value.f0, value.f1.div(value.f2));
-		}
-	}
-	
-	// *************************************************************************
-	//     UTIL METHODS
-	// *************************************************************************
-	
-	private static boolean fileOutput = false;
-	private static String pointsPath = null;
-	private static String centersPath = null;
-	private static String outputPath = null;
-	private static int numIterations = 10;
-
-	private static final Option POINTS_PATH_OPTION =
-		new Option("points").alt("P").help("The path to the input points");
-	private static final Option CENTERS_PATH_OPTION =
-		new Option("centroids").alt("C").help("The path to the input centroids");
-	private static final Option OUTPUT_PATH_OPTION =
-		new Option("output").alt("O").help("The path where the output will be written");
-	private static final Option NUM_ITERATIONS_OPTION =
-		new Option("iterations").alt("I").help("The number of iteration performed by the K-Means algorithm");
-
-	private static DataSet<Point> getPointDataSet(ExecutionEnvironment env) {
-		if(fileOutput) {
-			// read points from CSV file
-			return env.readCsvFile(pointsPath)
-						.fieldDelimiter(" ")
-						.includeFields(true, true)
-						.types(Double.class, Double.class)
-						.map(new TuplePointConverter());
-		} else {
-			return KMeansData.getDefaultPointDataSet(env);
-		}
-	}
-	
-	private static DataSet<Centroid> getCentroidDataSet(ExecutionEnvironment env) {
-		if(fileOutput) {
-			return env.readCsvFile(centersPath)
-						.fieldDelimiter(" ")
-						.includeFields(true, true, true)
-						.types(Integer.class, Double.class, Double.class)
-						.map(new TupleCentroidConverter());
-		} else {
-			return KMeansData.getDefaultCentroidDataSet(env);
 		}
 	}
 }

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
@@ -20,8 +20,6 @@ package org.apache.flink.examples.java.clustering;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.List;
-import java.util.function.Consumer;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
@@ -86,8 +86,37 @@ public class KMeans {
 	// *************************************************************************
 	
 	public static void main(String[] args) throws Exception {
-		
-		if(!parseParameters(ParameterTool.fromArgs(args))) {
+
+		// Checking input parameters
+		final ParameterTool params = ParameterTool.fromArgs(args);
+		final RequiredParameters requiredParameters = new RequiredParameters();
+		boolean paramsOk = false;
+
+		requiredParameters.add(POINTS_PATH_OPTION);
+		requiredParameters.add(CENTERS_PATH_OPTION);
+		requiredParameters.add(OUTPUT_PATH_OPTION);
+		requiredParameters.add(NUM_ITERATIONS_OPTION);
+
+		try {
+			requiredParameters.applyTo(params);
+			pointsPath = params.get(POINTS_PATH_OPTION.getName());
+			centersPath = params.get(CENTERS_PATH_OPTION.getName());
+			outputPath = params.get(OUTPUT_PATH_OPTION.getName());
+			numIterations = params.getInt(NUM_ITERATIONS_OPTION.getName());
+			fileOutput = true;
+			paramsOk = true;
+		} catch (RequiredParametersException e) {
+			if (params.getNumberOfParameters() == 0) {
+				System.out.println("Executing K-Means example with default parameters and built-in default data.");
+				System.out.println("  Provide parameters to read input data from files.");
+				System.out.println("  See the documentation for the correct format of input files.");
+				System.out.println("  We provide a data generator to create synthetic input files for this program.");
+				paramsOk = true;
+			}
+			System.out.println(requiredParameters.getHelp(e.getMissingArguments()));
+		}
+
+		if(!paramsOk) {
 			return;
 		}
 	
@@ -304,42 +333,6 @@ public class KMeans {
 		new Option("output").alt("O").help("The path where the output will be written");
 	private static final Option NUM_ITERATIONS_OPTION =
 		new Option("iterations").alt("I").help("The number of iteration performed by the K-Means algorithm");
-
-	private static boolean parseParameters(final ParameterTool params) throws RequiredParametersException {
-
-		final RequiredParameters requiredParameters = new RequiredParameters();
-		boolean parseStatus = false;
-
-		requiredParameters.add(POINTS_PATH_OPTION);
-		requiredParameters.add(CENTERS_PATH_OPTION);
-		requiredParameters.add(OUTPUT_PATH_OPTION);
-		requiredParameters.add(NUM_ITERATIONS_OPTION);
-
-		try {
-			requiredParameters.applyTo(params);
-			pointsPath = params.get(POINTS_PATH_OPTION.getName());
-			centersPath = params.get(CENTERS_PATH_OPTION.getName());
-			outputPath = params.get(OUTPUT_PATH_OPTION.getName());
-			numIterations = params.getInt(NUM_ITERATIONS_OPTION.getName());
-			fileOutput = true;
-			parseStatus = true;
-		} catch (RequiredParametersException e) {
-			if (params.getNumberOfParameters() == 0) {
-				printRunWithDefaultParams();
-				parseStatus = true;
-			}
-			System.out.println(requiredParameters.getHelp(e.getMissingArguments()));
-		}
-
-		return parseStatus;
-	}
-
-	private static void printRunWithDefaultParams() {
-		System.out.println("Executing K-Means example with default parameters and built-in default data.");
-		System.out.println("  Provide parameters to read input data from files.");
-		System.out.println("  See the documentation for the correct format of input files.");
-		System.out.println("  We provide a data generator to create synthetic input files for this program.");
-	}
 
 	private static DataSet<Point> getPointDataSet(ExecutionEnvironment env) {
 		if(fileOutput) {

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
@@ -342,7 +342,7 @@ public class KMeans {
 		System.out.println("  Provide parameters to read input data from files.");
 		System.out.println("  See the documentation for the correct format of input files.");
 		System.out.println("  We provide a data generator to create synthetic input files for this program.");
-		System.out.println("  Usage: KMeans <points path> <centers path> <result path> <num iterations>");
+		System.out.println("  Usage: KMeans --points <points path> --centroids <centers path> --output <result path> --iterations <num iterations>");
 	}
 
 	private static DataSet<Point> getPointDataSet(ExecutionEnvironment env) {

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/clustering/KMeans.java
@@ -135,12 +135,10 @@ public class KMeans {
 
 	private static DataSet<Centroid> getCentroidDataSet(ParameterTool params, ExecutionEnvironment env) {
 		DataSet<Centroid> centroids;
-		if(params.has("centroids")) {
+		if (params.has("centroids")) {
 			centroids = env.readCsvFile(params.get("centroids"))
 				.fieldDelimiter(" ")
-				.includeFields(true, true, true)
-				.types(Integer.class, Double.class, Double.class)
-				.map(new TupleCentroidConverter());
+				.pojoType(Centroid.class, "id", "x", "y");
 		} else {
 			centroids = KMeansData.getDefaultCentroidDataSet(env);
 		}
@@ -149,13 +147,11 @@ public class KMeans {
 
 	private static DataSet<Point> getPointDataSet(ParameterTool params, ExecutionEnvironment env) {
 		DataSet<Point> points;
-		if(params.has("points")) {
+		if (params.has("points")) {
 			// read points from CSV file
 			points = env.readCsvFile(params.get("points"))
 				.fieldDelimiter(" ")
-				.includeFields(true, true)
-				.types(Double.class, Double.class)
-				.map(new TuplePointConverter());
+				.pojoType(Point.class, "x", "y");
 		} else {
 			points = KMeansData.getDefaultPointDataSet(env);
 		}
@@ -234,26 +230,6 @@ public class KMeans {
 	// *************************************************************************
 	//     USER FUNCTIONS
 	// *************************************************************************
-
-	/** Converts a {@code Tuple2<Double,Double>} into a Point. */
-	@ForwardedFields("0->x; 1->y")
-	public static final class TuplePointConverter implements MapFunction<Tuple2<Double, Double>, Point> {
-
-		@Override
-		public Point map(Tuple2<Double, Double> t) throws Exception {
-			return new Point(t.f0, t.f1);
-		}
-	}
-
-	/** Converts a {@code Tuple3<Integer, Double,Double>} into a Centroid. */
-	@ForwardedFields("0->id; 1->x; 2->y")
-	public static final class TupleCentroidConverter implements MapFunction<Tuple3<Integer, Double, Double>, Centroid> {
-
-		@Override
-		public Centroid map(Tuple3<Integer, Double, Double> t) throws Exception {
-			return new Centroid(t.f0, t.f1, t.f2);
-		}
-	}
 
 	/** Determines the closest cluster center for a data point. */
 	@ForwardedFields("*->1")

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
@@ -106,13 +106,13 @@ object KMeans {
   }
 
   private val POINTS_PATH_OPTION: Option =
-    new Option("pointsPath").alt("P").help("The path to the input points")
+    new Option("points").alt("P").help("The path to the input points")
   private val CENTERS_PATH_OPTION: Option =
-    new Option("centersPath").alt("C").help("The path to the input centroids")
+    new Option("centroids").alt("C").help("The path to the input centroids")
   private val OUTPUT_PATH_OPTION: Option =
-    new Option("outputPath").alt("O").help("The path where the output will be written")
+    new Option("output").alt("O").help("The path where the output will be written")
   private val NUM_ITERATIONS_OPTION: Option =
-    new Option("numIterations").alt("N").help("The number of iteration performed by the K-Means algorithm")
+    new Option("iterations").alt("I").help("The number of iteration performed by the K-Means algorithm")
 
   @throws(classOf[RequiredParametersException])
   private def parseParameters(params: ParameterTool): Boolean = {

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
@@ -130,16 +130,13 @@ object KMeans {
       numIterations = params.getInt(NUM_ITERATIONS_OPTION.getName)
       fileOutput = true
       parseStatus = true
-    }
-    catch {
+    } catch {
       case e: RequiredParametersException => {
         if (params.getNumberOfParameters == 0) {
           printRunWithDefaultParams()
           parseStatus = true
         }
-        else {
-          println(requiredParameters.getHelp(e.getMissingArguments))
-        }
+        println(requiredParameters.getHelp(e.getMissingArguments))
       }
     }
     parseStatus
@@ -150,7 +147,6 @@ object KMeans {
     println("  Provide parameters to read input data from files.")
     println("  See the documentation for the correct format of input files.")
     println("  We provide a data generator to create synthetic input files for this program.")
-    println("  Usage: KMeans --points <points path> --centroids <centers path> --output <result path> --iterations <num iterations>")
   }
 
   private def getPointDataSet(env: ExecutionEnvironment): DataSet[Point] = {

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
@@ -27,53 +27,84 @@ import org.apache.flink.examples.java.clustering.util.KMeansData
 import scala.collection.JavaConverters._
 
 /**
- * This example implements a basic K-Means clustering algorithm.
- *
- * K-Means is an iterative clustering algorithm and works as follows:
- * K-Means is given a set of data points to be clustered and an initial set of ''K'' cluster
- * centers.
- * In each iteration, the algorithm computes the distance of each data point to each cluster center.
- * Each point is assigned to the cluster center which is closest to it.
- * Subsequently, each cluster center is moved to the center (''mean'') of all points that have
- * been assigned to it.
- * The moved cluster centers are fed into the next iteration. 
- * The algorithm terminates after a fixed number of iterations (as in this implementation) 
- * or if cluster centers do not (significantly) move in an iteration.
- * This is the Wikipedia entry for the [[http://en.wikipedia
- * .org/wiki/K-means_clustering K-Means Clustering algorithm]].
- *
- * This implementation works on two-dimensional data points.
- * It computes an assignment of data points to cluster centers, i.e., 
- * each data point is annotated with the id of the final cluster (center) it belongs to.
- *
- * Input files are plain text files and must be formatted as follows:
- *
- *  - Data points are represented as two double values separated by a blank character.
- *    Data points are separated by newline characters.
- *    For example `"1.2 2.3\n5.3 7.2\n"` gives two data points (x=1.2, y=2.3) and (x=5.3,
- *    y=7.2).
- *  - Cluster centers are represented by an integer id and a point value.
- *    For example `"1 6.2 3.2\n2 2.9 5.7\n"` gives two centers (id=1, x=6.2,
- *    y=3.2) and (id=2, x=2.9, y=5.7).
- *
- * Usage:
- * {{{
- *   KMeans <points path> <centers path> <result path> <num iterations>
- * }}}
- * If no parameters are provided, the program is run with default data from
- * [[org.apache.flink.examples.java.clustering.util.KMeansData]]
- * and 10 iterations.
- *
- * This example shows how to use:
- *
- *  - Bulk iterations
- *  - Broadcast variables in bulk iterations
- *  - Custom Java objects (PoJos)
- */
+  * This example implements a basic K-Means clustering algorithm.
+  *
+  * K-Means is an iterative clustering algorithm and works as follows:
+  * K-Means is given a set of data points to be clustered and an initial set of ''K'' cluster
+  * centers.
+  * In each iteration, the algorithm computes the distance of each data point to each cluster center.
+  * Each point is assigned to the cluster center which is closest to it.
+  * Subsequently, each cluster center is moved to the center (''mean'') of all points that have
+  * been assigned to it.
+  * The moved cluster centers are fed into the next iteration.
+  * The algorithm terminates after a fixed number of iterations (as in this implementation)
+  * or if cluster centers do not (significantly) move in an iteration.
+  * This is the Wikipedia entry for the [[http://en.wikipedia
+  * .org/wiki/K-means_clustering K-Means Clustering algorithm]].
+  *
+  * This implementation works on two-dimensional data points.
+  * It computes an assignment of data points to cluster centers, i.e.,
+  * each data point is annotated with the id of the final cluster (center) it belongs to.
+  *
+  * Input files are plain text files and must be formatted as follows:
+  *
+  * - Data points are represented as two double values separated by a blank character.
+  * Data points are separated by newline characters.
+  * For example `"1.2 2.3\n5.3 7.2\n"` gives two data points (x=1.2, y=2.3) and (x=5.3,
+  * y=7.2).
+  * - Cluster centers are represented by an integer id and a point value.
+  * For example `"1 6.2 3.2\n2 2.9 5.7\n"` gives two centers (id=1, x=6.2,
+  * y=3.2) and (id=2, x=2.9, y=5.7).
+  *
+  * Usage:
+  * {{{
+  *   KMeans <points path> <centers path> <result path> <num iterations>
+  * }}}
+  * If no parameters are provided, the program is run with default data from
+  * [[org.apache.flink.examples.java.clustering.util.KMeansData]]
+  * and 10 iterations.
+  *
+  * This example shows how to use:
+  *
+  * - Bulk iterations
+  * - Broadcast variables in bulk iterations
+  * - Custom Java objects (PoJos)
+  */
 object KMeans {
 
   def main(args: Array[String]) {
-    if (!parseParameters(ParameterTool.fromArgs(args))) {
+
+    // Checking input parameters
+    val params: ParameterTool = ParameterTool.fromArgs(args)
+    val requiredParameters: RequiredParameters = new RequiredParameters
+    var paramsOk: Boolean = false
+
+    requiredParameters.add(POINTS_PATH_OPTION)
+    requiredParameters.add(CENTERS_PATH_OPTION)
+    requiredParameters.add(OUTPUT_PATH_OPTION)
+    requiredParameters.add(NUM_ITERATIONS_OPTION)
+
+    try {
+      requiredParameters.applyTo(params)
+      pointsPath = params.get(POINTS_PATH_OPTION.getName)
+      centersPath = params.get(CENTERS_PATH_OPTION.getName)
+      outputPath = params.get(OUTPUT_PATH_OPTION.getName)
+      numIterations = params.getInt(NUM_ITERATIONS_OPTION.getName)
+      fileOutput = true
+      paramsOk = true
+    } catch {
+      case e: RequiredParametersException =>
+        if (params.getNumberOfParameters == 0) {
+          println("Executing K-Means example with default parameters and built-in default data.")
+          println("  Provide parameters to read input data from files.")
+          println("  See the documentation for the correct format of input files.")
+          println("  We provide a data generator to create synthetic input files for this program.")
+          paramsOk = true
+        }
+        println(requiredParameters.getHelp(e.getMissingArguments))
+    }
+
+    if (!paramsOk) {
       return
     }
 

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
@@ -142,7 +142,7 @@ object KMeans {
         }
       }
     }
-    return parseStatus
+    parseStatus
   }
 
   private def printRunWithDefaultParams() {
@@ -150,7 +150,7 @@ object KMeans {
     println("  Provide parameters to read input data from files.")
     println("  See the documentation for the correct format of input files.")
     println("  We provide a data generator to create synthetic input files for this program.")
-    println("  Usage: KMeans <points path> <centers path> <result path> <num iterations>")
+    println("  Usage: KMeans --points <points path> --centroids <centers path> --output <result path> --iterations <num iterations>")
   }
 
   private def getPointDataSet(env: ExecutionEnvironment): DataSet[Point] = {

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/clustering/KMeans.scala
@@ -27,49 +27,49 @@ import org.apache.flink.examples.java.clustering.util.KMeansData
 import scala.collection.JavaConverters._
 
 /**
-  * This example implements a basic K-Means clustering algorithm.
-  *
-  * K-Means is an iterative clustering algorithm and works as follows:
-  * K-Means is given a set of data points to be clustered and an initial set of ''K'' cluster
-  * centers.
-  * In each iteration, the algorithm computes the distance of each data point to each cluster center.
-  * Each point is assigned to the cluster center which is closest to it.
-  * Subsequently, each cluster center is moved to the center (''mean'') of all points that have
-  * been assigned to it.
-  * The moved cluster centers are fed into the next iteration.
-  * The algorithm terminates after a fixed number of iterations (as in this implementation)
-  * or if cluster centers do not (significantly) move in an iteration.
-  * This is the Wikipedia entry for the [[http://en.wikipedia
-  * .org/wiki/K-means_clustering K-Means Clustering algorithm]].
-  *
-  * This implementation works on two-dimensional data points.
-  * It computes an assignment of data points to cluster centers, i.e.,
-  * each data point is annotated with the id of the final cluster (center) it belongs to.
-  *
-  * Input files are plain text files and must be formatted as follows:
-  *
-  * - Data points are represented as two double values separated by a blank character.
-  * Data points are separated by newline characters.
-  * For example `"1.2 2.3\n5.3 7.2\n"` gives two data points (x=1.2, y=2.3) and (x=5.3,
-  * y=7.2).
-  * - Cluster centers are represented by an integer id and a point value.
-  * For example `"1 6.2 3.2\n2 2.9 5.7\n"` gives two centers (id=1, x=6.2,
-  * y=3.2) and (id=2, x=2.9, y=5.7).
-  *
-  * Usage:
-  * {{{
-  *   KMeans --points <path> --centroids <path> --output <path> --iterations <n>
-  * }}}
-  * If no parameters are provided, the program is run with default data from
-  * [[org.apache.flink.examples.java.clustering.util.KMeansData]]
-  * and 10 iterations.
-  *
-  * This example shows how to use:
-  *
-  * - Bulk iterations
-  * - Broadcast variables in bulk iterations
-  * - Scala case classes
-  */
+ * This example implements a basic K-Means clustering algorithm.
+ *
+ * K-Means is an iterative clustering algorithm and works as follows:
+ * K-Means is given a set of data points to be clustered and an initial set of ''K'' cluster
+ * centers.
+ * In each iteration, the algorithm computes the distance of each data point to each cluster center.
+ * Each point is assigned to the cluster center which is closest to it.
+ * Subsequently, each cluster center is moved to the center (''mean'') of all points that have
+ * been assigned to it.
+ * The moved cluster centers are fed into the next iteration.
+ * The algorithm terminates after a fixed number of iterations (as in this implementation)
+ * or if cluster centers do not (significantly) move in an iteration.
+ * This is the Wikipedia entry for the [[http://en.wikipedia
+ * .org/wiki/K-means_clustering K-Means Clustering algorithm]].
+ *
+ * This implementation works on two-dimensional data points.
+ * It computes an assignment of data points to cluster centers, i.e.,
+ * each data point is annotated with the id of the final cluster (center) it belongs to.
+ *
+ * Input files are plain text files and must be formatted as follows:
+ *
+ * - Data points are represented as two double values separated by a blank character.
+ * Data points are separated by newline characters.
+ * For example `"1.2 2.3\n5.3 7.2\n"` gives two data points (x=1.2, y=2.3) and (x=5.3,
+ * y=7.2).
+ * - Cluster centers are represented by an integer id and a point value.
+ * For example `"1 6.2 3.2\n2 2.9 5.7\n"` gives two centers (id=1, x=6.2,
+ * y=3.2) and (id=2, x=2.9, y=5.7).
+ *
+ * Usage:
+ * {{{
+ *   KMeans --points <path> --centroids <path> --output <path> --iterations <n>
+ * }}}
+ * If no parameters are provided, the program is run with default data from
+ * [[org.apache.flink.examples.java.clustering.util.KMeansData]]
+ * and 10 iterations.
+ *
+ * This example shows how to use:
+ *
+ * - Bulk iterations
+ * - Broadcast variables in bulk iterations
+ * - Scala case classes
+ */
 object KMeans {
 
   def main(args: Array[String]) {

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/DumpCompiledPlanTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/DumpCompiledPlanTest.java
@@ -80,7 +80,11 @@ public class DumpCompiledPlanTest extends CompilerTestBase {
 		PreviewPlanEnvironment env = new PreviewPlanEnvironment();
 		env.setAsContext();
 		try {
-			KMeans.main(new String[] {IN_FILE, IN_FILE, OUT_FILE, "123"});
+			KMeans.main(new String[] {
+				"--points ", IN_FILE,
+				"--centroids ", IN_FILE,
+				"--output ", OUT_FILE,
+				"--iterations", "123"});
 		} catch(OptimizerPlanEnvironment.ProgramAbortException pae) {
 			// all good.
 		} catch (Exception e) {

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -217,7 +217,7 @@ public class JsonJobGraphGenerationTest {
 	
 	private static interface JsonValidator {
 		
-		void validtateJson(String json) throws Exception;
+		void validateJson(String json) throws Exception;
 	}
 	
 	private static class GenericValidator implements JsonValidator {
@@ -231,7 +231,7 @@ public class JsonJobGraphGenerationTest {
 		}
 
 		@Override
-		public void validtateJson(String json) throws Exception {
+		public void validateJson(String json) throws Exception {
 			final Map<String, JsonNode> idToNode = new HashMap<>();
 			
 			// validate the produced JSON
@@ -334,7 +334,7 @@ public class JsonJobGraphGenerationTest {
 			JsonParser parser = new JsonFactory().createJsonParser(jsonPlan);
 			while (parser.nextToken() != null);
 			
-			validator.validtateJson(jsonPlan);
+			validator.validateJson(jsonPlan);
 			
 			throw new AbortError();
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -165,7 +165,11 @@ public class JsonJobGraphGenerationTest {
 				TestingExecutionEnvironment.setAsNext(validator, parallelism);
 
 				String tmpDir = ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH;
-				KMeans.main(new String[] {tmpDir, tmpDir, tmpDir, "100"});
+				KMeans.main(new String[] {
+					"--points ", tmpDir,
+					"--centroids ", tmpDir,
+					"--output ", tmpDir,
+					"--iterations", "100"});
 			}
 			catch (AbortError ignored) {}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/PreviewPlanDumpTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/PreviewPlanDumpTest.java
@@ -81,7 +81,11 @@ public class PreviewPlanDumpTest extends CompilerTestBase {
 		PreviewPlanEnvironment env = new PreviewPlanEnvironment();
 		env.setAsContext();
 		try {
-			KMeans.main(new String[] {IN_FILE, IN_FILE, OUT_FILE, "123"});
+			KMeans.main(new String[] {
+				"--points ", IN_FILE,
+				"--centroids ", IN_FILE,
+				"--output ", OUT_FILE,
+				"--iterations", "123"});
 		} catch(OptimizerPlanEnvironment.ProgramAbortException pae) {
 			// all good.
 		} catch (Exception e) {


### PR DESCRIPTION
I've reworked the K-Means examples in Java and Scala to get a feeling of what it would mean on the whole examples code base. Just a remark: I've caught the `RequiredParametersException` on the requirements application but not on their definition because I've felt the errors are different in nature (the application depends on user input while the definition should be somehow caught sooner — it would be great to have a way to catch it at compile-time).