### PR TITLE
[FLINK-3261] Allow Task to decline checkpoint request if not ready

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
 import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
 import org.slf4j.Logger;
@@ -502,6 +503,88 @@ public class CheckpointCoordinator {
 			}
 			return false;
 		}
+	}
+
+	/**
+	 * Receives a {@link DeclineCheckpoint} message and returns whether the
+	 * message was associated with a pending checkpoint.
+	 *
+	 * @param message Checkpoint decline from the task manager
+	 *
+	 * @return Flag indicating whether the declined checkpoint was associated
+	 * with a pending checkpoint.
+	 */
+
+	public boolean receiveDeclineMessage(DeclineCheckpoint message) throws Exception {
+		if (shutdown || message == null) {
+			return false;
+		}
+		if (!job.equals(message.getJob())) {
+			LOG.error("Received DeclineCheckpoint message for wrong job: {}", message);
+			return false;
+		}
+
+		final long checkpointId = message.getCheckpointId();
+
+		CompletedCheckpoint completed = null;
+		PendingCheckpoint checkpoint;
+
+		// Flag indicating whether the ack message was for a known pending
+		// checkpoint.
+		boolean isPendingCheckpoint;
+
+		synchronized (lock) {
+			// we need to check inside the lock for being shutdown as well, otherwise we
+			// get races and invalid error log messages
+			if (shutdown) {
+				return false;
+			}
+
+			checkpoint = pendingCheckpoints.get(checkpointId);
+
+			if (checkpoint != null && !checkpoint.isDiscarded()) {
+				isPendingCheckpoint = true;
+
+				LOG.info("Discarding checkpoint " + checkpointId
+					+ " because of checkpoint decline from task " + message.getTaskExecutionId());
+
+				pendingCheckpoints.remove(checkpointId);
+				checkpoint.discard(userClassLoader);
+				rememberRecentCheckpointId(checkpointId);
+
+				boolean haveMoreRecentPending = false;
+				Iterator<Map.Entry<Long, PendingCheckpoint>> entries = pendingCheckpoints.entrySet().iterator();
+				while (entries.hasNext()) {
+					PendingCheckpoint p = entries.next().getValue();
+					if (!p.isDiscarded() && p.getCheckpointTimestamp() >= checkpoint.getCheckpointTimestamp()) {
+						haveMoreRecentPending = true;
+						break;
+					}
+				}
+				if (!haveMoreRecentPending && !triggerRequestQueued) {
+					LOG.info("Triggering new checkpoint because of discarded checkpoint " + checkpointId);
+					triggerCheckpoint(System.currentTimeMillis());
+				} else if (!haveMoreRecentPending) {
+					LOG.info("Promoting queued checkpoint request because of discarded checkpoint " + checkpointId);
+					triggerQueuedRequests();
+				}
+
+			} else if (checkpoint != null) {
+				// this should not happen
+				throw new IllegalStateException(
+					"Received message for discarded but non-removed checkpoint " + checkpointId);
+			} else {
+				// message is for an unknown checkpoint, or comes too late (checkpoint disposed)
+				if (recentPendingCheckpoints.contains(checkpointId)) {
+					isPendingCheckpoint = true;
+					LOG.info("Received another decline checkpoint message for now expired checkpoint attempt " + checkpointId);
+				} else {
+					isPendingCheckpoint = false;
+				}
+			}
+		}
+
+		return isPendingCheckpoint;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
@@ -43,8 +43,10 @@ public interface StatefulTask<T extends StateHandle<?>> {
 	 *
 	 * @param checkpointId The ID of the checkpoint, incrementing.
 	 * @param timestamp The timestamp when the checkpoint was triggered at the JobManager.
+	 *
+	 * @return {@code false} if the checkpoint can not be carried out, {@code true} otherwise
 	 */
-	void triggerCheckpoint(long checkpointId, long timestamp) throws Exception;
+	boolean triggerCheckpoint(long checkpointId, long timestamp) throws Exception;
 
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+
+/**
+ * This message is sent from the {@link org.apache.flink.runtime.taskmanager.TaskManager} to the
+ * {@link org.apache.flink.runtime.jobmanager.JobManager} to tell the checkpoint coordinator
+ * that a checkpoint request could not be heeded. This can happen if a Task is already in
+ * RUNNING state but is internally not yet ready to perform checkpoints.
+ */
+public class DeclineCheckpoint extends AbstractCheckpointMessage implements java.io.Serializable {
+
+	private static final long serialVersionUID = 2094094662279578953L;
+
+	/** The timestamp associated with the checkpoint */
+	private final long timestamp;
+
+	public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, long timestamp) {
+		super(job, taskExecutionId, checkpointId);
+		this.timestamp = timestamp;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		return super.hashCode() + (int) (timestamp ^ (timestamp >>> 32));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		else if (o instanceof DeclineCheckpoint) {
+			DeclineCheckpoint that = (DeclineCheckpoint) o;
+			return this.timestamp == that.timestamp && super.equals(o);
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Declined Checkpoint %d@%d for (%s/%s)",
+				getCheckpointId(), getTimestamp(), getJob(), getTaskExecutionId());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.TaskManagerMessages.FatalError;
 import org.apache.flink.runtime.messages.TaskMessages.TaskInFinalState;
 import org.apache.flink.runtime.messages.TaskMessages.UpdateTaskExecutionState;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StateUtils;
 import org.apache.flink.util.SerializedValue;
@@ -854,7 +855,8 @@ public class Task implements Runnable {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Calls the invokable to trigger a checkpoint, if the invokable implements the interface
+	 * Calls the invokable to trigger a checkpoint, i
+	 * f the invokable implements the interface
 	 * {@link org.apache.flink.runtime.jobgraph.tasks.StatefulTask}.
 	 * 
 	 * @param checkpointID The ID identifying the checkpoint.
@@ -874,7 +876,11 @@ public class Task implements Runnable {
 					@Override
 					public void run() {
 						try {
-							statefulTask.triggerCheckpoint(checkpointID, checkpointTimestamp);
+							boolean success = statefulTask.triggerCheckpoint(checkpointID, checkpointTimestamp);
+							if (!success) {
+								DeclineCheckpoint decline = new DeclineCheckpoint(jobId, getExecutionId(), checkpointID, checkpointTimestamp);
+								jobManager.tell(decline);
+							}
 						}
 						catch (Throwable t) {
 							failExternally(new RuntimeException("Error while triggering checkpoint for " + taskName, t));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -204,7 +204,7 @@ public class TaskAsyncCallTest {
 		}
 
 		@Override
-		public void triggerCheckpoint(long checkpointId, long timestamp) {
+		public boolean triggerCheckpoint(long checkpointId, long timestamp) {
 			lastCheckpointId++;
 			if (checkpointId == lastCheckpointId) {
 				if (lastCheckpointId == NUM_CALLS) {
@@ -217,6 +217,7 @@ public class TaskAsyncCallTest {
 					notifyAll();
 				}
 			}
+			return true;
 		}
 
 		@Override

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -1137,7 +1137,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 								final int sourceParallelism,
 								final String topicName,
 								final int valuesCount, final int startFrom) throws Exception {
-		env.getCheckpointConfig().setCheckpointTimeout(5000); // set timeout for checkpoints to 5 seconds
 
 		final int finalCount = valuesCount * sourceParallelism;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -444,7 +444,7 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 
 	@Override
 	@SuppressWarnings("unchecked,rawtypes")
-	public void triggerCheckpoint(final long checkpointId, final long timestamp) throws Exception {
+	public boolean triggerCheckpoint(final long checkpointId, final long timestamp) throws Exception {
 		LOG.debug("Starting checkpoint {} on task {}", checkpointId, getName());
 		
 		synchronized (lock) {
@@ -526,6 +526,9 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 						throw e;
 					}
 				}
+				return true;
+			} else {
+				return false;
 			}
 		}
 	}


### PR DESCRIPTION
Before, it could happen that a StreamingTask receives a Checkpoint
Trigger message while internally not being ready. The checkpoint
coordinator would then wait the specified timeout interval before
continuing. Now, tasks can signal that they are not ready and the
checkpoint coordinator will dicard a checkpoint for which is this the
case and trigger new checkpoints if necessary.

The newly triggered checkpoints will also release alignment locks in
streaming tasks that are still waiting for barriers from failed
checkpoints.