### PR TITLE
[FLINK-3258] [runtime, streaming-java, tests] Move registerInputOutput code to invoke and remove registerInputOutput

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
@@ -149,8 +149,6 @@ public class ClientConnectionTest {
 	// --------------------------------------------------------------------------------------------
 
 	public static class TestInvokable extends AbstractInvokable {
-		@Override
-		public void registerInputOutput() {}
 
 		@Override
 		public void invoke() {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
 import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
 import org.slf4j.Logger;
@@ -502,6 +503,88 @@ public class CheckpointCoordinator {
 			}
 			return false;
 		}
+	}
+
+	/**
+	 * Receives a {@link DeclineCheckpoint} message and returns whether the
+	 * message was associated with a pending checkpoint.
+	 *
+	 * @param message Checkpoint decline from the task manager
+	 *
+	 * @return Flag indicating whether the declined checkpoint was associated
+	 * with a pending checkpoint.
+	 */
+
+	public boolean receiveDeclineMessage(DeclineCheckpoint message) throws Exception {
+		if (shutdown || message == null) {
+			return false;
+		}
+		if (!job.equals(message.getJob())) {
+			LOG.error("Received DeclineCheckpoint message for wrong job: {}", message);
+			return false;
+		}
+
+		final long checkpointId = message.getCheckpointId();
+
+		CompletedCheckpoint completed = null;
+		PendingCheckpoint checkpoint;
+
+		// Flag indicating whether the ack message was for a known pending
+		// checkpoint.
+		boolean isPendingCheckpoint;
+
+		synchronized (lock) {
+			// we need to check inside the lock for being shutdown as well, otherwise we
+			// get races and invalid error log messages
+			if (shutdown) {
+				return false;
+			}
+
+			checkpoint = pendingCheckpoints.get(checkpointId);
+
+			if (checkpoint != null && !checkpoint.isDiscarded()) {
+				isPendingCheckpoint = true;
+
+				LOG.info("Discarding checkpoint " + checkpointId
+					+ " because of checkpoint decline from task " + message.getTaskExecutionId());
+
+				pendingCheckpoints.remove(checkpointId);
+				checkpoint.discard(userClassLoader);
+				rememberRecentCheckpointId(checkpointId);
+
+				boolean haveMoreRecentPending = false;
+				Iterator<Map.Entry<Long, PendingCheckpoint>> entries = pendingCheckpoints.entrySet().iterator();
+				while (entries.hasNext()) {
+					PendingCheckpoint p = entries.next().getValue();
+					if (!p.isDiscarded() && p.getCheckpointTimestamp() >= checkpoint.getCheckpointTimestamp()) {
+						haveMoreRecentPending = true;
+						break;
+					}
+				}
+				if (!haveMoreRecentPending && !triggerRequestQueued) {
+					LOG.info("Triggering new checkpoint because of discarded checkpoint " + checkpointId);
+					triggerCheckpoint(System.currentTimeMillis());
+				} else if (!haveMoreRecentPending) {
+					LOG.info("Promoting queued checkpoint request because of discarded checkpoint " + checkpointId);
+					triggerQueuedRequests();
+				}
+
+			} else if (checkpoint != null) {
+				// this should not happen
+				throw new IllegalStateException(
+					"Received message for discarded but non-removed checkpoint " + checkpointId);
+			} else {
+				// message is for an unknown checkpoint, or comes too late (checkpoint disposed)
+				if (recentPendingCheckpoints.contains(checkpointId)) {
+					isPendingCheckpoint = true;
+					LOG.info("Received another decline checkpoint message for now expired checkpoint attempt " + checkpointId);
+				} else {
+					isPendingCheckpoint = false;
+				}
+			}
+		}
+
+		return isPendingCheckpoint;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
@@ -68,16 +68,12 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 
 	private final AtomicBoolean terminated = new AtomicBoolean(false);
 
-
 	// --------------------------------------------------------------------------------------------
 	
 	@Override
-	public void registerInputOutput() {
-		this.headEventReader = new MutableRecordReader<IntValue>(getEnvironment().getInputGate(0));
-	}
-
-	@Override
 	public void invoke() throws Exception {
+		this.headEventReader = new MutableRecordReader<IntValue>(getEnvironment().getInputGate(0));
+
 		TaskConfig taskConfig = new TaskConfig(getTaskConfiguration());
 		
 		// store all aggregators

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -27,18 +27,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This is the abstract base class for every task that can be executed by a TaskManager.
- * Concrete tasks like the stream vertices of the batch tasks
- * (see {@link BatchTask}) inherit from this class.
+ * This is the abstract base class for every task that can be executed by a
+ * TaskManager. Concrete tasks like the vertices of batch jobs (see
+ * {@link BatchTask} inherit from this class.
  *
- * The TaskManager invokes the methods {@link #registerInputOutput()} and {@link #invoke()} in
- * this order when executing a task. The first method is responsible for setting up input and
- * output stream readers and writers, the second method contains the task's core operation.
+ * <p>The TaskManager invokes the {@link #invoke()} method when executing a
+ * task. All operations of the task happen in this method (setting up input
+ * output stream readers and writers as well as the task's core operation).
  */
 public abstract class AbstractInvokable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractInvokable.class);
-
 
 	/** The environment assigned to this invokable. */
 	private Environment environment;
@@ -46,15 +45,15 @@ public abstract class AbstractInvokable {
 	/** The execution config, cached from the deserialization from the JobConfiguration */
 	private ExecutionConfig executionConfig;
 
-
 	/**
-	 * Must be overwritten by the concrete task to instantiate the required record reader and record writer.
-	 */
-	public abstract void registerInputOutput() throws Exception;
-
-	/**
-	 * Must be overwritten by the concrete task. This method is called by the task manager
-	 * when the actual execution of the task starts.
+	 * Starts the execution.
+	 *
+	 * <p>Must be overwritten by the concrete task implementation. This method
+	 * is called by the task manager when the actual execution of the task
+	 * starts.
+	 *
+	 * <p>All resources should be cleaned up when the method returns. Make sure
+	 * to guard the code with <code>try-finally</code> blocks where necessary.
 	 * 
 	 * @throws Exception
 	 *         Tasks may forward their exceptions for the TaskManager to handle through failure/recovery.
@@ -88,7 +87,6 @@ public abstract class AbstractInvokable {
 	public ClassLoader getUserCodeClassLoader() {
 		return getEnvironment().getUserClassLoader();
 	}
-
 
 	/**
 	 * Returns the current number of subtasks the respective task is split into.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
@@ -43,8 +43,10 @@ public interface StatefulTask<T extends StateHandle<?>> {
 	 *
 	 * @param checkpointId The ID of the checkpoint, incrementing.
 	 * @param timestamp The timestamp when the checkpoint was triggered at the JobManager.
+	 *
+	 * @return {@code false} if the checkpoint can not be carried out, {@code true} otherwise
 	 */
-	void triggerCheckpoint(long checkpointId, long timestamp) throws Exception;
+	boolean triggerCheckpoint(long checkpointId, long timestamp) throws Exception;
 
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+
+/**
+ * This message is sent from the {@link org.apache.flink.runtime.taskmanager.TaskManager} to the
+ * {@link org.apache.flink.runtime.jobmanager.JobManager} to tell the checkpoint coordinator
+ * that a checkpoint request could not be heeded. This can happen if a Task is already in
+ * RUNNING state but is internally not yet ready to perform checkpoints.
+ */
+public class DeclineCheckpoint extends AbstractCheckpointMessage implements java.io.Serializable {
+
+	private static final long serialVersionUID = 2094094662279578953L;
+
+	/** The timestamp associated with the checkpoint */
+	private final long timestamp;
+
+	public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, long timestamp) {
+		super(job, taskExecutionId, checkpointId);
+		this.timestamp = timestamp;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		return super.hashCode() + (int) (timestamp ^ (timestamp >>> 32));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		else if (o instanceof DeclineCheckpoint) {
+			DeclineCheckpoint that = (DeclineCheckpoint) o;
+			return this.timestamp == that.timestamp && super.equals(o);
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Declined Checkpoint %d@%d for (%s/%s)",
+				getCheckpointId(), getTimestamp(), getJob(), getTaskExecutionId());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -217,13 +217,14 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	//                                  Task Interface
 	// --------------------------------------------------------------------------------------------
 
-
 	/**
-	 * Initialization method. Runs in the execution graph setup phase in the JobManager
-	 * and as a setup method on the TaskManager.
+	 * The main work method.
 	 */
 	@Override
-	public void registerInputOutput() throws Exception {
+	public void invoke() throws Exception {
+		// --------------------------------------------------------------------
+		// Initialize
+		// --------------------------------------------------------------------
 		if (LOG.isDebugEnabled()) {
 			LOG.debug(formatLogString("Start registering input and output."));
 		}
@@ -247,20 +248,13 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		if (LOG.isDebugEnabled()) {
 			LOG.debug(formatLogString("Finished registering input and output."));
 		}
-	}
 
-
-	/**
-	 * The main work method.
-	 */
-	@Override
-	public void invoke() throws Exception {
-
+		// --------------------------------------------------------------------
+		// Invoke
+		// --------------------------------------------------------------------
 		if (LOG.isDebugEnabled()) {
 			LOG.debug(formatLogString("Start task code."));
 		}
-
-		Environment env = getEnvironment();
 
 		this.runtimeUdfContext = createRuntimeContext();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -83,13 +83,15 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 	private volatile boolean cleanupCalled;
 
 	@Override
-	public void registerInputOutput() {
-
+	public void invoke() throws Exception {
+		// --------------------------------------------------------------------
+		// Initialize
+		// --------------------------------------------------------------------
 		LOG.debug(getLogString("Start registering input and output"));
 
 		// initialize OutputFormat
 		initOutputFormat();
-		
+
 		// initialize input readers
 		try {
 			initInputReaders();
@@ -99,12 +101,10 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 		}
 
 		LOG.debug(getLogString("Finished registering input and output"));
-	}
 
-
-	@Override
-	public void invoke() throws Exception
-	{
+		// --------------------------------------------------------------------
+		// Invoke
+		// --------------------------------------------------------------------
 		LOG.debug(getLogString("Starting data sink operator"));
 
 		if(RichOutputFormat.class.isAssignableFrom(this.format.getClass())){

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -77,7 +77,10 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 	private volatile boolean taskCanceled = false;
 
 	@Override
-	public void registerInputOutput() {
+	public void invoke() throws Exception {
+		// --------------------------------------------------------------------
+		// Initialize
+		// --------------------------------------------------------------------
 		initInputFormat();
 
 		LOG.debug(getLogString("Start registering input and output"));
@@ -85,17 +88,15 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 		try {
 			initOutputs(getUserCodeClassLoader());
 		} catch (Exception ex) {
-			throw new RuntimeException("The initialization of the DataSource's outputs caused an error: " + 
-				ex.getMessage(), ex);
+			throw new RuntimeException("The initialization of the DataSource's outputs caused an error: " +
+					ex.getMessage(), ex);
 		}
 
 		LOG.debug(getLogString("Finished registering input and output"));
-	}
 
-
-	@Override
-	public void invoke() throws Exception {
-		
+		// --------------------------------------------------------------------
+		// Invoke
+		// --------------------------------------------------------------------
 		LOG.debug(getLogString("Starting data source operator"));
 
 		if(RichInputFormat.class.isAssignableFrom(this.format.getClass())){

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -504,18 +504,12 @@ public class Task implements Runnable {
 
 			// let the task code create its readers and writers
 			invokable.setEnvironment(env);
-			try {
-				invokable.registerInputOutput();
-			}
-			catch (Exception e) {
-				throw new Exception("Call to registerInputOutput() of invokable failed", e);
-			}
 
 			// the very last thing before the actual execution starts running is to inject
 			// the state into the task. the state is non-empty if this is an execution
 			// of a task that failed but had backuped state from a checkpoint
 
-			// get our private reference onto the stack (be safe against concurrent changes) 
+			// get our private reference onto the stack (be safe against concurrent changes)
 			SerializedValue<StateHandle<?>> operatorState = this.operatorState;
 			long recoveryTs = this.recoveryTs;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
@@ -143,11 +143,6 @@ public class JobClientActorRecoveryITCase extends TestLogger {
 		private static Object waitLock = new Object();
 
 		@Override
-		public void registerInputOutput() throws Exception {
-			// Nothing to do
-		}
-
-		@Override
 		public void invoke() throws Exception {
 			if (BlockExecution > 0) {
 				BlockExecution--;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -108,11 +108,6 @@ public class PartialConsumePipelinedResultTest {
 	public static class SlowBufferSender extends AbstractInvokable {
 
 		@Override
-		public void registerInputOutput() {
-			// Nothing to do
-		}
-
-		@Override
 		public void invoke() throws Exception {
 			final ResultPartitionWriter writer = getEnvironment().getWriter(0);
 
@@ -129,11 +124,6 @@ public class PartialConsumePipelinedResultTest {
 	 * Reads a single buffer and recycles it.
 	 */
 	public static class SingleBufferReceiver extends AbstractInvokable {
-
-		@Override
-		public void registerInputOutput() {
-			// Nothing to do
-		}
 
 		@Override
 		public void invoke() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
@@ -120,18 +120,11 @@ public class SlotCountExceedingParallelismTest {
 
 		public final static String CONFIG_KEY = "number-of-times-to-send";
 
-		private RecordWriter<IntValue> writer;
-
-		private int numberOfTimesToSend;
-
-		@Override
-		public void registerInputOutput() {
-			writer = new RecordWriter<IntValue>(getEnvironment().getWriter(0));
-			numberOfTimesToSend = getTaskConfiguration().getInteger(CONFIG_KEY, 0);
-		}
-
 		@Override
 		public void invoke() throws Exception {
+			RecordWriter<IntValue> writer = new RecordWriter<>(getEnvironment().getWriter(0));
+			final int numberOfTimesToSend = getTaskConfiguration().getInteger(CONFIG_KEY, 0);
+
 			final IntValue subtaskIndex = new IntValue(
 					getEnvironment().getTaskInfo().getIndexOfThisSubtask());
 
@@ -154,26 +147,16 @@ public class SlotCountExceedingParallelismTest {
 
 		public final static String CONFIG_KEY = "number-of-indexes-to-receive";
 
-		private RecordReader<IntValue> reader;
-
-		private int numberOfSubtaskIndexesToReceive;
-
-		/** Each set bit position corresponds to a received subtask index */
-		private BitSet receivedSubtaskIndexes;
-
 		@Override
-		public void registerInputOutput() {
-			reader = new RecordReader<IntValue>(
+		public void invoke() throws Exception {
+			RecordReader<IntValue> reader = new RecordReader<>(
 					getEnvironment().getInputGate(0),
 					IntValue.class);
 
-			numberOfSubtaskIndexesToReceive = getTaskConfiguration().getInteger(CONFIG_KEY, 0);
-			receivedSubtaskIndexes = new BitSet(numberOfSubtaskIndexesToReceive);
-		}
-
-		@Override
-		public void invoke() throws Exception {
 			try {
+				final int numberOfSubtaskIndexesToReceive = getTaskConfiguration().getInteger(CONFIG_KEY, 0);
+				final BitSet receivedSubtaskIndexes = new BitSet(numberOfSubtaskIndexesToReceive);
+
 				IntValue record;
 
 				int numberOfReceivedSubtaskIndexes = 0;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -125,28 +125,23 @@ public class ScheduleOrUpdateConsumersTest {
 
 		public final static String CONFIG_KEY = "number-of-times-to-send";
 
-		private List<RecordWriter<IntValue>> writers = Lists.newArrayListWithCapacity(2);
-
-		private int numberOfTimesToSend;
-
 		@Override
-		public void registerInputOutput() {
+		public void invoke() throws Exception {
+			List<RecordWriter<IntValue>> writers = Lists.newArrayListWithCapacity(2);
+
 			// The order of intermediate result creation in the job graph specifies which produced
 			// result partition is pipelined/blocking.
 			final RecordWriter<IntValue> pipelinedWriter =
-					new RecordWriter<IntValue>(getEnvironment().getWriter(0));
+					new RecordWriter<>(getEnvironment().getWriter(0));
 
 			final RecordWriter<IntValue> blockingWriter =
-					new RecordWriter<IntValue>(getEnvironment().getWriter(1));
+					new RecordWriter<>(getEnvironment().getWriter(1));
 
 			writers.add(pipelinedWriter);
 			writers.add(blockingWriter);
 
-			numberOfTimesToSend = getTaskConfiguration().getInteger(CONFIG_KEY, 0);
-		}
+			final int numberOfTimesToSend = getTaskConfiguration().getInteger(CONFIG_KEY, 0);
 
-		@Override
-		public void invoke() throws Exception {
 			final IntValue subtaskIndex = new IntValue(
 					getEnvironment().getTaskInfo().getIndexOfThisSubtask());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.types.Record;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -142,7 +143,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 
 		super.initEnvironment(MEMORY_MANAGER_SIZE, NETWORK_BUFFER_SIZE);
 
-		IteratorWrappingTestSingleInputGate<?>[] readers = new IteratorWrappingTestSingleInputGate[4];
+		final IteratorWrappingTestSingleInputGate<?>[] readers = new IteratorWrappingTestSingleInputGate[4];
 		readers[0] = super.addInput(new UniformRecordGenerator(keyCnt, valCnt, 0, 0, false), 0, false);
 		readers[1] = super.addInput(new UniformRecordGenerator(keyCnt, valCnt, keyCnt, 0, false), 0, false);
 		readers[2] = super.addInput(new UniformRecordGenerator(keyCnt, valCnt, keyCnt * 2, 0, false), 0, false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyInvokable.java
@@ -28,9 +28,6 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 public class DummyInvokable extends AbstractInvokable {
 
 	@Override
-	public void registerInputOutput() {}
-
-	@Override
 	public void invoke() {}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
@@ -97,23 +97,10 @@ public abstract class TaskTestBase extends TestLogger {
 		config.setStubWrapper(new UserCodeClassWrapper<>(stubClass));
 		
 		task.setEnvironment(this.mockEnv);
-
-		try {
-			task.registerInputOutput();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e.getMessage(), e);
-		}
 	}
 
 	public void registerTask(AbstractInvokable task) {
 		task.setEnvironment(this.mockEnv);
-		try {
-			task.registerInputOutput();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e.getMessage(), e);
-		}
 	}
 
 	public void registerFileOutputTask(AbstractInvokable outTask, Class<? extends FileOutputFormat<Record>> stubClass, String outPath) {
@@ -129,13 +116,6 @@ public abstract class TaskTestBase extends TestLogger {
 		dsConfig.setStubWrapper(new UserCodeObjectWrapper<>(outputFormat));
 
 		outTask.setEnvironment(this.mockEnv);
-
-		try {
-			outTask.registerInputOutput();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e.getMessage(), e);
-		}
 	}
 
 	public void registerFileInputTask(AbstractInvokable inTask,
@@ -158,13 +138,6 @@ public abstract class TaskTestBase extends TestLogger {
 		this.inputSplitProvider.addInputSplits(inPath, 5);
 
 		inTask.setEnvironment(this.mockEnv);
-
-		try {
-			inTask.registerInputOutput();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e.getMessage(), e);
-		}
 	}
 
 	public MemoryManager getMemoryManager() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -179,9 +179,6 @@ public class TaskAsyncCallTest {
 		private volatile Exception error;
 		
 		@Override
-		public void registerInputOutput() {}
-
-		@Override
 		public void invoke() throws Exception {
 			awaitLatch.trigger();
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -201,7 +201,7 @@ public class TaskAsyncCallTest {
 		}
 
 		@Override
-		public void triggerCheckpoint(long checkpointId, long timestamp) {
+		public boolean triggerCheckpoint(long checkpointId, long timestamp) {
 			lastCheckpointId++;
 			if (checkpointId == lastCheckpointId) {
 				if (lastCheckpointId == NUM_CALLS) {
@@ -214,6 +214,7 @@ public class TaskAsyncCallTest {
 					notifyAll();
 				}
 			}
+			return true;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelTest.java
@@ -219,41 +219,35 @@ public class TaskCancelTest {
 
 	public static class InfiniteSource extends AbstractInvokable {
 
-		private RecordWriter<IntValue> writer;
-
-		@Override
-		public void registerInputOutput() {
-			writer = new RecordWriter<IntValue>(getEnvironment().getWriter(0));
-		}
-
 		@Override
 		public void invoke() throws Exception {
+			RecordWriter<IntValue> writer = new RecordWriter<>(getEnvironment().getWriter(0));
+
 			final IntValue val = new IntValue();
 
-			for (int i = 0; true; i++) {
-				if (Thread.interrupted()) {
-					return;
-				}
+			try {
+				for (int i = 0; true; i++) {
+					if (Thread.interrupted()) {
+						return;
+					}
 
-				val.setValue(i);
-				writer.emit(val);
+					val.setValue(i);
+					writer.emit(val);
+				}
+			}
+			finally {
+				writer.clearBuffers();
 			}
 		}
 	}
 
 	public static class AgnosticUnion extends AbstractInvokable {
 
-		private RecordReader<IntValue> reader;
-
-		@Override
-		public void registerInputOutput() {
-			UnionInputGate union = new UnionInputGate(getEnvironment().getAllInputGates());
-
-			reader = new RecordReader<IntValue>(union, IntValue.class);
-		}
-
 		@Override
 		public void invoke() throws Exception {
+			UnionInputGate union = new UnionInputGate(getEnvironment().getAllInputGates());
+			RecordReader<IntValue> reader = new RecordReader<>(union, IntValue.class);
+
 			while (reader.next() != null) {
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -1101,16 +1101,10 @@ public class TaskManagerTest {
 	public static final class TestInvokableCorrect extends AbstractInvokable {
 
 		@Override
-		public void registerInputOutput() {}
-
-		@Override
 		public void invoke() {}
 	}
 	
 	public static final class TestInvokableBlockingCancelable extends AbstractInvokable {
-
-		@Override
-		public void registerInputOutput() {}
 
 		@Override
 		public void invoke() throws Exception {

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -1137,7 +1137,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 								final int sourceParallelism,
 								final String topicName,
 								final int valuesCount, final int startFrom) throws Exception {
-		env.getCheckpointConfig().setCheckpointTimeout(5000); // set timeout for checkpoints to 5 seconds
 
 		final int finalCount = valuesCount * sourceParallelism;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -69,16 +69,13 @@ import org.slf4j.LoggerFactory;
  *
  * The life cycle of the task is set up as follows: 
  * <pre>{@code
- *  -- registerInputOutput()
- *         |
- *         +----> Create basic utils (config, etc) and load the chain of operators
- *         +----> operators.setup()
- *         +----> task specific init()
- *  
  *  -- restoreState() -> restores state of all operators in the chain
  *  
  *  -- invoke()
  *        |
+ *        +----> Create basic utils (config, etc) and load the chain of operators
+ *        +----> operators.setup()
+ *        +----> task specific init()
  *        +----> open-operators()
  *        +----> run()
  *        +----> close-operators()
@@ -168,8 +165,11 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 	// ------------------------------------------------------------------------
 	
 	@Override
-	public final void registerInputOutput() throws Exception {
-		LOG.debug("registerInputOutput for {}", getName());
+	public final void invoke() throws Exception {
+		// --------------------------------------------------------------------
+		// Initialize
+		// --------------------------------------------------------------------
+		LOG.debug("Initializing {}", getName());
 
 		boolean initializationCompleted = false;
 		try {
@@ -193,7 +193,7 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 
 			// task specific initialization
 			init();
-			
+
 			initializationCompleted = true;
 		}
 		finally {
@@ -206,10 +206,10 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 				}
 			}
 		}
-	}
-	
-	@Override
-	public final void invoke() throws Exception {
+
+		// --------------------------------------------------------------------
+		// Invoke
+		// --------------------------------------------------------------------
 		LOG.debug("Invoking {}", getName());
 		
 		boolean disposed = false;
@@ -297,6 +297,10 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 	public final void cancel() throws Exception {
 		isRunning = false;
 		cancelTask();
+	}
+
+	public final boolean isRunning() {
+		return isRunning;
 	}
 	
 	private void openAllOperators() throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -448,7 +448,7 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 
 	@Override
 	@SuppressWarnings("unchecked,rawtypes")
-	public void triggerCheckpoint(final long checkpointId, final long timestamp) throws Exception {
+	public boolean triggerCheckpoint(final long checkpointId, final long timestamp) throws Exception {
 		LOG.debug("Starting checkpoint {} on task {}", checkpointId, getName());
 		
 		synchronized (lock) {
@@ -530,6 +530,9 @@ public abstract class StreamTask<OUT, Operator extends StreamOperator<OUT>>
 						throw e;
 					}
 				}
+				return true;
+			} else {
+				return false;
 			}
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -49,7 +49,8 @@ public class StreamTaskTimerTest {
 	public void testOpenCloseAndTimestamps() throws Exception {
 		final OneInputStreamTask<String, String> mapTask = new OneInputStreamTask<>();
 		
-		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(mapTask, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
+		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
+				mapTask, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
 
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 		
@@ -57,11 +58,13 @@ public class StreamTaskTimerTest {
 		streamConfig.setStreamOperator(mapOperator);
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		// first one spawns thread
 		mapTask.registerTimer(System.currentTimeMillis(), new Triggerable() {
 			@Override
-			public void trigger(long timestamp) {}
+			public void trigger(long timestamp) {
+			}
 		});
 
 		assertEquals(1, StreamTask.TRIGGER_THREAD_GROUP.activeCount());
@@ -91,6 +94,7 @@ public class StreamTaskTimerTest {
 			streamConfig.setStreamOperator(mapOperator);
 
 			testHarness.invoke();
+			testHarness.waitForTaskRunning();
 
 			final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -69,6 +69,7 @@ public class OneInputStreamTaskTest {
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<Object>();
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processElement(new StreamRecord<String>("Hello", initialTime + 1));
 		testHarness.processElement(new StreamRecord<String>("Ciao", initialTime + 2));
@@ -105,6 +106,7 @@ public class OneInputStreamTaskTest {
 		long initialTime = 0L;
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processElement(new Watermark(initialTime), 0, 0);
 		testHarness.processElement(new Watermark(initialTime), 0, 1);
@@ -180,6 +182,7 @@ public class OneInputStreamTaskTest {
 		long initialTime = 0L;
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processEvent(new CheckpointBarrier(0, 0), 0, 0);
 
@@ -237,6 +240,7 @@ public class OneInputStreamTaskTest {
 		long initialTime = 0L;
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processEvent(new CheckpointBarrier(0, 0), 0, 0);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -95,7 +95,6 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 			this.mockEnv.addInputGate(inputGates[i].getInputGate());
 		}
 
-
 		streamConfig.setNumberOfInputs(1);
 		streamConfig.setTypeSerializerIn1(inputSerializer);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -159,8 +159,6 @@ public class StreamTaskTestHarness<OUT> {
 		initializeInputs();
 		initializeOutput();
 
-		task.registerInputOutput();
-
 		taskThread = new TaskThread(task);
 		taskThread.start();
 	}
@@ -180,8 +178,6 @@ public class StreamTaskTestHarness<OUT> {
 		initializeInputs();
 		initializeOutput();
 
-		task.registerInputOutput();
-
 		taskThread = new TaskThread(task);
 		taskThread.start();
 	}
@@ -194,6 +190,23 @@ public class StreamTaskTestHarness<OUT> {
 		taskThread.join();
 		if (taskThread.getError() != null) {
 			throw new Exception("error in task", taskThread.getError());
+		}
+	}
+
+	public void waitForTaskRunning() throws Exception {
+		if (taskThread == null) {
+			throw new IllegalStateException("Task thread was not started.");
+		}
+		else {
+			if (taskThread.task instanceof StreamTask) {
+				StreamTask streamTask = (StreamTask) taskThread.task;
+				while (!streamTask.isRunning()) {
+					Thread.sleep(100);
+				}
+			}
+			else {
+				throw new IllegalStateException("Not a StreamTask");
+			}
 		}
 	}
 
@@ -315,7 +328,6 @@ public class StreamTaskTestHarness<OUT> {
 		private final AbstractInvokable task;
 		
 		private volatile Throwable error;
-
 
 		TaskThread(AbstractInvokable task) {
 			super("Task Thread");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -71,6 +71,7 @@ public class TwoInputStreamTaskTest {
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<Object>();
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processElement(new StreamRecord<String>("Hello", initialTime + 1), 0, 0);
 		expectedOutput.add(new StreamRecord<String>("Hello", initialTime + 1));
@@ -110,6 +111,7 @@ public class TwoInputStreamTaskTest {
 		long initialTime = 0L;
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processElement(new Watermark(initialTime), 0, 0);
 		testHarness.processElement(new Watermark(initialTime), 0, 1);
@@ -189,6 +191,7 @@ public class TwoInputStreamTaskTest {
 		long initialTime = 0L;
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processEvent(new CheckpointBarrier(0, 0), 0, 0);
 
@@ -255,6 +258,7 @@ public class TwoInputStreamTaskTest {
 		long initialTime = 0L;
 
 		testHarness.invoke();
+		testHarness.waitForTaskRunning();
 
 		testHarness.processEvent(new CheckpointBarrier(0, 0), 0, 0);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
@@ -157,86 +157,78 @@ public class NetworkStackThroughputITCase {
 
 	public static class SpeedTestProducer extends AbstractInvokable {
 
-		private RecordWriter<SpeedTestRecord> writer;
-
-		@Override
-		public void registerInputOutput() {
-			this.writer = new RecordWriter<SpeedTestRecord>(getEnvironment().getWriter(0));
-		}
-
 		@Override
 		public void invoke() throws Exception {
-			// Determine the amount of data to send per subtask
-			int dataVolumeGb = getTaskConfiguration().getInteger(NetworkStackThroughputITCase.DATA_VOLUME_GB_CONFIG_KEY, 1);
+			RecordWriter<SpeedTestRecord> writer = new RecordWriter<>(getEnvironment().getWriter(0));
 
-			long dataMbPerSubtask = (dataVolumeGb * 1024) / getCurrentNumberOfSubtasks();
-			long numRecordsToEmit = (dataMbPerSubtask * 1024 * 1024) / SpeedTestRecord.RECORD_SIZE;
+			try {
+				// Determine the amount of data to send per subtask
+				int dataVolumeGb = getTaskConfiguration().getInteger(NetworkStackThroughputITCase.DATA_VOLUME_GB_CONFIG_KEY, 1);
 
-			LOG.info(String.format("%d/%d: Producing %d records (each record: %d bytes, total: %.2f GB)",
-					getIndexInSubtaskGroup() + 1, getCurrentNumberOfSubtasks(), numRecordsToEmit,
-					SpeedTestRecord.RECORD_SIZE, dataMbPerSubtask / 1024.0));
+				long dataMbPerSubtask = (dataVolumeGb * 1024) / getCurrentNumberOfSubtasks();
+				long numRecordsToEmit = (dataMbPerSubtask * 1024 * 1024) / SpeedTestRecord.RECORD_SIZE;
 
-			boolean isSlow = getTaskConfiguration().getBoolean(IS_SLOW_SENDER_CONFIG_KEY, false);
+				LOG.info(String.format("%d/%d: Producing %d records (each record: %d bytes, total: %.2f GB)",
+						getIndexInSubtaskGroup() + 1, getCurrentNumberOfSubtasks(), numRecordsToEmit,
+						SpeedTestRecord.RECORD_SIZE, dataMbPerSubtask / 1024.0));
 
-			int numRecords = 0;
-			SpeedTestRecord record = new SpeedTestRecord();
-			for (long i = 0; i < numRecordsToEmit; i++) {
-				if (isSlow && (numRecords++ % IS_SLOW_EVERY_NUM_RECORDS) == 0) {
-					Thread.sleep(IS_SLOW_SLEEP_MS);
+				boolean isSlow = getTaskConfiguration().getBoolean(IS_SLOW_SENDER_CONFIG_KEY, false);
+
+				int numRecords = 0;
+				SpeedTestRecord record = new SpeedTestRecord();
+				for (long i = 0; i < numRecordsToEmit; i++) {
+					if (isSlow && (numRecords++ % IS_SLOW_EVERY_NUM_RECORDS) == 0) {
+						Thread.sleep(IS_SLOW_SLEEP_MS);
+					}
+
+					writer.emit(record);
 				}
-
-				this.writer.emit(record);
 			}
-
-			this.writer.flush();
+			finally {
+				writer.flush();
+			}
 		}
 	}
 
 	public static class SpeedTestForwarder extends AbstractInvokable {
 
-		private RecordReader<SpeedTestRecord> reader;
-
-		private RecordWriter<SpeedTestRecord> writer;
-
-		@Override
-		public void registerInputOutput() {
-			this.reader = new RecordReader<SpeedTestRecord>(getEnvironment().getInputGate(0), SpeedTestRecord.class);
-			this.writer = new RecordWriter<SpeedTestRecord>(getEnvironment().getWriter(0));
-		}
-
 		@Override
 		public void invoke() throws Exception {
-			SpeedTestRecord record;
-			while ((record = this.reader.next()) != null) {
-				this.writer.emit(record);
-			}
+			RecordReader<SpeedTestRecord> reader = new RecordReader<>(getEnvironment().getInputGate(0), SpeedTestRecord.class);
+			RecordWriter<SpeedTestRecord> writer = new RecordWriter<>(getEnvironment().getWriter(0));
 
-			this.reader.clearBuffers();
-			this.writer.flush();
+			try {
+				SpeedTestRecord record;
+				while ((record = reader.next()) != null) {
+					writer.emit(record);
+				}
+			}
+			finally {
+				reader.clearBuffers();
+				writer.flush();
+			}
 		}
 	}
 
 	public static class SpeedTestConsumer extends AbstractInvokable {
 
-		private RecordReader<SpeedTestRecord> reader;
-
-		@Override
-		public void registerInputOutput() {
-			this.reader = new RecordReader<SpeedTestRecord>(getEnvironment().getInputGate(0), SpeedTestRecord.class);
-		}
-
 		@Override
 		public void invoke() throws Exception {
-			boolean isSlow = getTaskConfiguration().getBoolean(IS_SLOW_RECEIVER_CONFIG_KEY, false);
+			RecordReader<SpeedTestRecord> reader = new RecordReader<>(getEnvironment().getInputGate(0), SpeedTestRecord.class);
 
-			int numRecords = 0;
-			while (this.reader.next() != null) {
-				if (isSlow && (numRecords++ % IS_SLOW_EVERY_NUM_RECORDS) == 0) {
-					Thread.sleep(IS_SLOW_SLEEP_MS);
+			try {
+				boolean isSlow = getTaskConfiguration().getBoolean(IS_SLOW_RECEIVER_CONFIG_KEY, false);
+
+				int numRecords = 0;
+				while (reader.next() != null) {
+					if (isSlow && (numRecords++ % IS_SLOW_EVERY_NUM_RECORDS) == 0) {
+						Thread.sleep(IS_SLOW_SLEEP_MS);
+					}
 				}
 			}
-
-			this.reader.clearBuffers();
+			finally {
+				reader.clearBuffers();
+			}
 		}
 	}
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
@@ -238,6 +238,5 @@ class StringTupleReader(val reader: BufferedReader) extends MutableObjectIterato
 
 class DummyInvokable extends AbstractInvokable {
 
-  override def registerInputOutput() = {}
   override def invoke() = {}
 }

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerLeaderSessionIDITSuite.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerLeaderSessionIDITSuite.scala
@@ -90,9 +90,6 @@ class JobManagerLeaderSessionIDITSuite(_system: ActorSystem)
 }
 
 class BlockingUntilSignalNoOpInvokable extends AbstractInvokable {
-  override def registerInputOutput(): Unit = {
-
-  }
 
   override def invoke(): Unit = {
     BlockingUntilSignalNoOpInvokable.lock.synchronized{


### PR DESCRIPTION
This removes the `registerInputOutput` method and move the respective code to the `invoke` method. The separation was an artifact of the old Nephele runtime, which has become obsolete now. With this change, the contract for `AbstractInvokable` is easier (`invoke` needs to clean up everything it sets up).

Includes #1537, because it appears more often with initialization in `invoke`.