### PR TITLE
[hotfix] [docs] Add missing licenses to programming guide redirects.

### DIFF
--- a/docs/apis/programming_guide.md
+++ b/docs/apis/programming_guide.md
@@ -4,4 +4,23 @@ title: DataSet API
 
 <meta http-equiv="refresh" content="1; url={{ site.baseurl }}/apis/batch/index.html" />
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 The *DataSet API guide* has been moved. Redirecting to [{{ site.baseurl }}/apis/batch/index.html]({{ site.baseurl }}/apis/batch/index.html) in 1 second.

--- a/docs/apis/streaming_guide.md
+++ b/docs/apis/streaming_guide.md
@@ -4,4 +4,23 @@ title: DataStream API
 
 <meta http-equiv="refresh" content="1; url={{ site.baseurl }}/apis/streaming/index.html" />
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 The *DataStream API guide* has been moved. Redirecting to [{{ site.baseurl }}/apis/streaming/index.html]({{ site.baseurl }}/apis/streaming/index.html) in 1 second.


### PR DESCRIPTION
The recently added files `flink/docs/apis/programming_guide.md` and `flink/docs/apis/streaming_guide.md` (in 1a5ce4da9a6cc92a5a64189378789ef77cde47de) are missing licenses, which breaks the build.