### PR TITLE
FLINK-3179 Combiner is not injected if Reduce or GroupReduce input is explicitly partitioned (Ram)

### DIFF
--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
@@ -66,7 +66,7 @@ public class WordCount {
 
 		DataSet<Tuple2<String, Integer>> counts = 
 				// split up the lines in pairs (2-tuples) containing: (word,1)
-				(text.flatMap(new Tokenizer()))
+				text.flatMap(new Tokenizer())
 				// group by the tuple field "0" and sum up tuple field "1"
 				.groupBy(0)
 				.sum(1);

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
@@ -66,7 +66,7 @@ public class WordCount {
 
 		DataSet<Tuple2<String, Integer>> counts = 
 				// split up the lines in pairs (2-tuples) containing: (word,1)
-				text.flatMap(new Tokenizer())
+				(text.flatMap(new Tokenizer())).partitionByHash(1)
 				// group by the tuple field "0" and sum up tuple field "1"
 				.groupBy(0)
 				.sum(1);

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java
@@ -66,7 +66,7 @@ public class WordCount {
 
 		DataSet<Tuple2<String, Integer>> counts = 
 				// split up the lines in pairs (2-tuples) containing: (word,1)
-				(text.flatMap(new Tokenizer())).partitionByHash(1)
+				(text.flatMap(new Tokenizer()))
 				// group by the tuple field "0" and sum up tuple field "1"
 				.groupBy(0)
 				.sum(1);

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/GroupReduceWithCombineProperties.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/GroupReduceWithCombineProperties.java
@@ -92,76 +92,69 @@ public final class GroupReduceWithCombineProperties extends OperatorDescriptorSi
 		return DriverStrategy.SORTED_GROUP_REDUCE;
 	}
 
-	@Override
 	public SingleInputPlanNode instantiate(Channel in, SingleInputNode node) {
 		if (in.getShipStrategy() == ShipStrategyType.FORWARD) {
 			// adjust a sort (changes grouping, so it must be for this driver to combining sort
-			if (in.getLocalStrategy() == LocalStrategy.SORT) {
-				if (!in.getLocalStrategyKeys().isValidUnorderedPrefix(this.keys)) {
-					throw new RuntimeException("Bug: Inconsistent sort for group strategy.");
+			if(in.getSource().getOptimizerNode() instanceof PartitionNode) {
+				// Inject a combiner before the partition node
+				Channel toCombiner = new Channel(in.getSource());
+				toCombiner.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+				GroupReduceNode combinerNode = ((GroupReduceNode) node).getCombinerUtilityNode();
+				combinerNode.setParallelism(in.getSource().getParallelism());
+				if(toCombiner.getSource().getInputs().iterator().hasNext()) {
+					Channel source = toCombiner.getSource().getInputs().iterator().next();
+					// A combiner plan node is created with the map as the input
+					SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine("+node.getOperator()
+						.getName()+")", source, DriverStrategy.SORTED_GROUP_COMBINE);
+					addCombinerNodeData(in, toCombiner, combiner);
+					Channel combinerChannel = new Channel(combiner);
+					combinerChannel.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+					// Create the partition single input plan node from the existing partition node
+					PlanNode partitionplanNode = in.getSource().getPlanNode();
+					SingleInputPlanNode partition = new SingleInputPlanNode(in.getSource().getOptimizerNode(), partitionplanNode.getNodeName(),
+						combinerChannel, partitionplanNode.getDriverStrategy());
+					partition.setCosts(partitionplanNode.getNodeCosts());
+					partition.initProperties(partitionplanNode.getGlobalProperties(), partitionplanNode.getLocalProperties());
+					// Create a reducer such that the input of the reducer is the partition node
+					Channel toReducer = new Channel(partition);
+					toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
+						in.getShipStrategySortOrder(), in.getDataExchangeMode());
+					return getReducerSingleInputPlanNode(toReducer, node);
+				} else {
+					return getReducerSingleInputPlanNode(in, node);
 				}
-				in.setLocalStrategy(LocalStrategy.COMBININGSORT, in.getLocalStrategyKeys(),
-									in.getLocalStrategySortOrder());
 			}
-			return new SingleInputPlanNode(node, "Reduce("+node.getOperator().getName()+")", in,
-											DriverStrategy.SORTED_GROUP_REDUCE, this.keyList);
+			return getReducerSingleInputPlanNode(in, node);
 		} else {
 			// non forward case. all local properties are killed anyways, so we can safely plug in a combiner
-			// This forms the parition node
-			boolean reducerOperator = node.getOperator() instanceof GroupReduceOperatorBase;
-			boolean injectCombiner = false;
-			if(reducerOperator && node.getOperator().getInput() instanceof PartitionOperatorBase) {
-				// We are sure that we got a partitionoperator as an input to the reducer operator.
-				injectCombiner = true;
-			}
 			Channel toCombiner = new Channel(in.getSource());
 			toCombiner.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+
 			// create an input node for combine with same parallelism as input node
-			// This is same as input node and this is the group reduce node
 			GroupReduceNode combinerNode = ((GroupReduceNode) node).getCombinerUtilityNode();
 			combinerNode.setParallelism(in.getSource().getParallelism());
-			if(injectCombiner) {
-				// Is it right to directly iterate and get the source??
-				toCombiner.getSource().getInputs().iterator().hasNext();
-				Channel source = toCombiner.getSource().getInputs().iterator().next();
-                // Create the combiner node with the Parition node's source as the input
-				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine("+node.getOperator()
-					.getName()+")", source, DriverStrategy.SORTED_GROUP_COMBINE);
-				addCombinerNodeData(in, toCombiner, combiner);
 
-				Channel combinerChannel = new Channel(combiner);
-				combinerChannel.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine("+node.getOperator()
+				.getName()+")", toCombiner, DriverStrategy.SORTED_GROUP_COMBINE);
+			combiner.setCosts(new Costs(0, 0));
+			combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
+			// set sorting comparator key info
+			combiner.setDriverKeyInfo(in.getLocalStrategyKeys(), in.getLocalStrategySortOrder(), 0);
+			// set grouping comparator key info
+			combiner.setDriverKeyInfo(this.keyList, 1);
 
-				// Create the partition single input plan node from the existing partition node
-				PlanNode partitionplanNode = in.getSource().getPlanNode();
-				SingleInputPlanNode partition = new SingleInputPlanNode(combinerNode, partitionplanNode.getNodeName(), combinerChannel, partitionplanNode.getDriverStrategy());
-				partition.setCosts(partitionplanNode.getNodeCosts());
-				partition.initProperties(partitionplanNode.getGlobalProperties(), partitionplanNode.getLocalProperties());
-				// Create a reducer such that the input of the reducer is the partition node
-				return createReducerPlanNode(in, node, partition);
-			} else {
-				// Create the combiner node with the partition node as the input to the combiner
-				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine(" + node.getOperator()
-					.getName() + ")", toCombiner, DriverStrategy.SORTED_GROUP_COMBINE);
-				addCombinerNodeData(in, toCombiner, combiner);
-				// Create a reducer such that the input of the reducer is the combiner node
-				return createReducerPlanNode(in, node, combiner);
+			Channel toReducer = new Channel(combiner);
+			toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
+				in.getShipStrategySortOrder(), in.getDataExchangeMode());
+			if (in.getShipStrategy() == ShipStrategyType.PARTITION_RANGE) {
+				toReducer.setDataDistribution(in.getDataDistribution());
 			}
+			toReducer.setLocalStrategy(LocalStrategy.COMBININGSORT, in.getLocalStrategyKeys(),
+				in.getLocalStrategySortOrder());
+
+			return new SingleInputPlanNode(node, "Reduce ("+node.getOperator().getName()+")",
+				toReducer, DriverStrategy.SORTED_GROUP_REDUCE, this.keyList);
 		}
-	}
-
-	private SingleInputPlanNode createReducerPlanNode(Channel in, SingleInputNode node, SingleInputPlanNode planNode) {
-		Channel toReducer = new Channel(planNode);
-		toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
-            in.getShipStrategySortOrder(), in.getDataExchangeMode());
-		if (in.getShipStrategy() == ShipStrategyType.PARTITION_RANGE) {
-            toReducer.setDataDistribution(in.getDataDistribution());
-        }
-		toReducer.setLocalStrategy(LocalStrategy.COMBININGSORT, in.getLocalStrategyKeys(),
-            in.getLocalStrategySortOrder());
-
-		return new SingleInputPlanNode(node, "Reduce (" + node.getOperator().getName() + ")",
-            toReducer, DriverStrategy.SORTED_GROUP_REDUCE, this.keyList);
 	}
 
 	private void addCombinerNodeData(Channel in, Channel toCombiner, SingleInputPlanNode combiner) {
@@ -171,6 +164,18 @@ public final class GroupReduceWithCombineProperties extends OperatorDescriptorSi
 		combiner.setDriverKeyInfo(in.getLocalStrategyKeys(), in.getLocalStrategySortOrder(), 0);
 		// set grouping comparator key info
 		combiner.setDriverKeyInfo(this.keyList, 1);
+	}
+
+	private SingleInputPlanNode getReducerSingleInputPlanNode(Channel in, SingleInputNode node) {
+		if (in.getLocalStrategy() == LocalStrategy.SORT) {
+            if (!in.getLocalStrategyKeys().isValidUnorderedPrefix(this.keys)) {
+                throw new RuntimeException("Bug: Inconsistent sort for group strategy.");
+            }
+            in.setLocalStrategy(LocalStrategy.COMBININGSORT, in.getLocalStrategyKeys(),
+                                in.getLocalStrategySortOrder());
+        }
+		return new SingleInputPlanNode(node, "Reduce("+node.getOperator().getName()+")", in,
+                                        DriverStrategy.SORTED_GROUP_REDUCE, this.keyList);
 	}
 
 	@Override

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/GroupReduceWithCombineProperties.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/GroupReduceWithCombineProperties.java
@@ -24,9 +24,13 @@ import java.util.List;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.operators.Ordering;
+import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase;
+import org.apache.flink.api.common.operators.base.PartitionOperatorBase;
+import org.apache.flink.api.common.operators.base.ReduceOperatorBase;
 import org.apache.flink.api.common.operators.util.FieldSet;
 import org.apache.flink.optimizer.costs.Costs;
 import org.apache.flink.optimizer.dag.GroupReduceNode;
+import org.apache.flink.optimizer.dag.PartitionNode;
 import org.apache.flink.optimizer.dag.SingleInputNode;
 import org.apache.flink.optimizer.dataproperties.GlobalProperties;
 import org.apache.flink.optimizer.dataproperties.LocalProperties;
@@ -34,6 +38,7 @@ import org.apache.flink.optimizer.dataproperties.PartitioningProperty;
 import org.apache.flink.optimizer.dataproperties.RequestedGlobalProperties;
 import org.apache.flink.optimizer.dataproperties.RequestedLocalProperties;
 import org.apache.flink.optimizer.plan.Channel;
+import org.apache.flink.optimizer.plan.PlanNode;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.runtime.io.network.DataExchangeMode;
 import org.apache.flink.runtime.operators.DriverStrategy;
@@ -102,34 +107,70 @@ public final class GroupReduceWithCombineProperties extends OperatorDescriptorSi
 											DriverStrategy.SORTED_GROUP_REDUCE, this.keyList);
 		} else {
 			// non forward case. all local properties are killed anyways, so we can safely plug in a combiner
+			// This forms the parition node
+			boolean reducerOperator = node.getOperator() instanceof GroupReduceOperatorBase;
+			boolean injectCombiner = false;
+			if(reducerOperator && node.getOperator().getInput() instanceof PartitionOperatorBase) {
+				// We are sure that we got a partitionoperator as an input to the reducer operator.
+				injectCombiner = true;
+			}
 			Channel toCombiner = new Channel(in.getSource());
 			toCombiner.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
-
 			// create an input node for combine with same parallelism as input node
+			// This is same as input node and this is the group reduce node
 			GroupReduceNode combinerNode = ((GroupReduceNode) node).getCombinerUtilityNode();
 			combinerNode.setParallelism(in.getSource().getParallelism());
+			if(injectCombiner) {
+				// Is it right to directly iterate and get the source??
+				toCombiner.getSource().getInputs().iterator().hasNext();
+				Channel source = toCombiner.getSource().getInputs().iterator().next();
+                // Create the combiner node with the Parition node's source as the input
+				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine("+node.getOperator()
+					.getName()+")", source, DriverStrategy.SORTED_GROUP_COMBINE);
+				addCombinerNodeData(in, toCombiner, combiner);
 
-			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine("+node.getOperator()
-					.getName()+")", toCombiner, DriverStrategy.SORTED_GROUP_COMBINE);
-			combiner.setCosts(new Costs(0, 0));
-			combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
-			// set sorting comparator key info
-			combiner.setDriverKeyInfo(in.getLocalStrategyKeys(), in.getLocalStrategySortOrder(), 0);
-			// set grouping comparator key info
-			combiner.setDriverKeyInfo(this.keyList, 1);
-			
-			Channel toReducer = new Channel(combiner);
-			toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
-									in.getShipStrategySortOrder(), in.getDataExchangeMode());
-			if (in.getShipStrategy() == ShipStrategyType.PARTITION_RANGE) {
-				toReducer.setDataDistribution(in.getDataDistribution());
+				Channel combinerChannel = new Channel(combiner);
+				combinerChannel.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+
+				// Create the partition single input plan node from the existing partition node
+				PlanNode partitionplanNode = in.getSource().getPlanNode();
+				SingleInputPlanNode partition = new SingleInputPlanNode(combinerNode, partitionplanNode.getNodeName(), combinerChannel, partitionplanNode.getDriverStrategy());
+				partition.setCosts(partitionplanNode.getNodeCosts());
+				partition.initProperties(partitionplanNode.getGlobalProperties(), partitionplanNode.getLocalProperties());
+				// Create a reducer such that the input of the reducer is the partition node
+				return createReducerPlanNode(in, node, partition);
+			} else {
+				// Create the combiner node with the partition node as the input to the combiner
+				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine(" + node.getOperator()
+					.getName() + ")", toCombiner, DriverStrategy.SORTED_GROUP_COMBINE);
+				addCombinerNodeData(in, toCombiner, combiner);
+				// Create a reducer such that the input of the reducer is the combiner node
+				return createReducerPlanNode(in, node, combiner);
 			}
-			toReducer.setLocalStrategy(LocalStrategy.COMBININGSORT, in.getLocalStrategyKeys(),
-										in.getLocalStrategySortOrder());
-
-			return new SingleInputPlanNode(node, "Reduce ("+node.getOperator().getName()+")",
-											toReducer, DriverStrategy.SORTED_GROUP_REDUCE, this.keyList);
 		}
+	}
+
+	private SingleInputPlanNode createReducerPlanNode(Channel in, SingleInputNode node, SingleInputPlanNode planNode) {
+		Channel toReducer = new Channel(planNode);
+		toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
+            in.getShipStrategySortOrder(), in.getDataExchangeMode());
+		if (in.getShipStrategy() == ShipStrategyType.PARTITION_RANGE) {
+            toReducer.setDataDistribution(in.getDataDistribution());
+        }
+		toReducer.setLocalStrategy(LocalStrategy.COMBININGSORT, in.getLocalStrategyKeys(),
+            in.getLocalStrategySortOrder());
+
+		return new SingleInputPlanNode(node, "Reduce (" + node.getOperator().getName() + ")",
+            toReducer, DriverStrategy.SORTED_GROUP_REDUCE, this.keyList);
+	}
+
+	private void addCombinerNodeData(Channel in, Channel toCombiner, SingleInputPlanNode combiner) {
+		combiner.setCosts(new Costs(0, 0));
+		combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
+		// set sorting comparator key info
+		combiner.setDriverKeyInfo(in.getLocalStrategyKeys(), in.getLocalStrategySortOrder(), 0);
+		// set grouping comparator key info
+		combiner.setDriverKeyInfo(this.keyList, 1);
 	}
 
 	@Override

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/ReduceProperties.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/ReduceProperties.java
@@ -22,6 +22,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.common.operators.base.GroupReduceOperatorBase;
+import org.apache.flink.api.common.operators.base.PartitionOperatorBase;
+import org.apache.flink.api.common.operators.base.ReduceOperatorBase;
 import org.apache.flink.api.common.operators.util.FieldSet;
 import org.apache.flink.optimizer.costs.Costs;
 import org.apache.flink.optimizer.dag.ReduceNode;
@@ -32,6 +35,7 @@ import org.apache.flink.optimizer.dataproperties.PartitioningProperty;
 import org.apache.flink.optimizer.dataproperties.RequestedGlobalProperties;
 import org.apache.flink.optimizer.dataproperties.RequestedLocalProperties;
 import org.apache.flink.optimizer.plan.Channel;
+import org.apache.flink.optimizer.plan.PlanNode;
 import org.apache.flink.optimizer.plan.SingleInputPlanNode;
 import org.apache.flink.runtime.io.network.DataExchangeMode;
 import org.apache.flink.runtime.operators.DriverStrategy;
@@ -66,28 +70,60 @@ public final class ReduceProperties extends OperatorDescriptorSingle {
 		}
 		else {
 			// non forward case. all local properties are killed anyways, so we can safely plug in a combiner
+			boolean reducerOperator = node.getOperator() instanceof ReduceOperatorBase;
+			boolean injectCombiner = false;
+			if(reducerOperator && node.getOperator().getInput() instanceof PartitionOperatorBase) {
+				// We are sure that we got a partitionoperator as an input to the reducer operator.
+				injectCombiner = true;
+			}
 			Channel toCombiner = new Channel(in.getSource());
 			toCombiner.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
-			
+
 			// create an input node for combine with same parallelism as input node
 			ReduceNode combinerNode = ((ReduceNode) node).getCombinerUtilityNode();
 			combinerNode.setParallelism(in.getSource().getParallelism());
+			if(injectCombiner) {
+				toCombiner.getSource().getInputs().iterator().hasNext();
+				Channel source = toCombiner.getSource().getInputs().iterator().next();
+				// Create the combiner node with the Parition node's source as the input
+				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode,
+					"Combine ("+node.getOperator().getName()+")", source,
+					DriverStrategy.SORTED_PARTIAL_REDUCE, this.keyList);
+				addCombinerNodeData(in, toCombiner, combiner);
 
-			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode,
-								"Combine ("+node.getOperator().getName()+")", toCombiner,
-								DriverStrategy.SORTED_PARTIAL_REDUCE, this.keyList);
+				Channel combinerChannel = new Channel(combiner);
+				combinerChannel.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
 
-			combiner.setCosts(new Costs(0, 0));
-			combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
-			
-			Channel toReducer = new Channel(combiner);
-			toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
-										in.getShipStrategySortOrder(), in.getDataExchangeMode());
-			toReducer.setLocalStrategy(LocalStrategy.SORT, in.getLocalStrategyKeys(), in.getLocalStrategySortOrder());
-
-			return new SingleInputPlanNode(node, "Reduce("+node.getOperator().getName()+")", toReducer,
-											DriverStrategy.SORTED_REDUCE, this.keyList);
+				// Create the partition single input plan node from the existing partition node
+				PlanNode partitionplanNode = in.getSource().getPlanNode();
+				SingleInputPlanNode partition = new SingleInputPlanNode(combinerNode, partitionplanNode.getNodeName(), combinerChannel, partitionplanNode.getDriverStrategy());
+				partition.setCosts(partitionplanNode.getNodeCosts());
+				partition.initProperties(partitionplanNode.getGlobalProperties(), partitionplanNode.getLocalProperties());
+				// Create a reducer such that the input of the reducer is the partition node
+				return createReducerPlanNode(in, node, partition);
+			} else {
+				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode,
+					"Combine ("+node.getOperator().getName()+")", toCombiner,
+					DriverStrategy.SORTED_PARTIAL_REDUCE, this.keyList);
+				addCombinerNodeData(in, toCombiner, combiner);
+				return createReducerPlanNode(in, node, combiner);
+			}
 		}
+	}
+
+	private SingleInputPlanNode createReducerPlanNode(Channel in, SingleInputNode node, SingleInputPlanNode planNode) {
+		Channel toReducer = new Channel(planNode);
+		toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
+			in.getShipStrategySortOrder(), in.getDataExchangeMode());
+		toReducer.setLocalStrategy(LocalStrategy.SORT, in.getLocalStrategyKeys(), in.getLocalStrategySortOrder());
+
+		return new SingleInputPlanNode(node, "Reduce("+node.getOperator().getName()+")", toReducer,
+			DriverStrategy.SORTED_REDUCE, this.keyList);
+	}
+
+	private void addCombinerNodeData(Channel in, Channel toCombiner, SingleInputPlanNode combiner) {
+		combiner.setCosts(new Costs(0, 0));
+		combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
 	}
 
 	@Override

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/ReduceProperties.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/ReduceProperties.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.operators.base.PartitionOperatorBase;
 import org.apache.flink.api.common.operators.base.ReduceOperatorBase;
 import org.apache.flink.api.common.operators.util.FieldSet;
 import org.apache.flink.optimizer.costs.Costs;
+import org.apache.flink.optimizer.dag.GroupReduceNode;
+import org.apache.flink.optimizer.dag.PartitionNode;
 import org.apache.flink.optimizer.dag.ReduceNode;
 import org.apache.flink.optimizer.dag.SingleInputNode;
 import org.apache.flink.optimizer.dataproperties.GlobalProperties;
@@ -63,65 +65,65 @@ public final class ReduceProperties extends OperatorDescriptorSingle {
 	@Override
 	public SingleInputPlanNode instantiate(Channel in, SingleInputNode node) {
 		if (in.getShipStrategy() == ShipStrategyType.FORWARD ||
-				(node.getBroadcastConnections() != null && !node.getBroadcastConnections().isEmpty()))
+			(node.getBroadcastConnections() != null && !node.getBroadcastConnections().isEmpty()))
 		{
+			// adjust a sort (changes grouping, so it must be for this driver to combining sort
+			if(in.getSource().getOptimizerNode() instanceof PartitionNode) {
+				Channel toCombiner = new Channel(in.getSource());
+				toCombiner.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+				// create an input node for combine with same parallelism as input node
+				ReduceNode combinerNode = ((ReduceNode) node).getCombinerUtilityNode();
+				combinerNode.setParallelism(in.getSource().getParallelism());
+				if(toCombiner.getSource().getInputs().iterator().hasNext()) {
+					Channel source = toCombiner.getSource().getInputs().iterator().next();
+					SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode,
+						"Combine ("+node.getOperator().getName()+")", source,
+						DriverStrategy.SORTED_PARTIAL_REDUCE, this.keyList);
+					addCombinerProperties(toCombiner, combiner);
+					Channel combinerChannel = new Channel(combiner);
+					combinerChannel.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+					// Create the partition single input plan node from the existing partition node
+					PlanNode partitionplanNode = in.getSource().getPlanNode();
+					SingleInputPlanNode partition = new SingleInputPlanNode(in.getSource().getOptimizerNode(), partitionplanNode.getNodeName(),
+						combinerChannel, partitionplanNode.getDriverStrategy());
+					partition.setCosts(partitionplanNode.getNodeCosts());
+					partition.initProperties(partitionplanNode.getGlobalProperties(), partitionplanNode.getLocalProperties());
+					// Create a reducer such that the input of the reducer is the partition node
+					Channel toReducer = new Channel(partition);
+					toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
+						in.getShipStrategySortOrder(), in.getDataExchangeMode());
+					return new SingleInputPlanNode(node, "Reduce ("+node.getOperator().getName()+")", toReducer,
+						DriverStrategy.SORTED_REDUCE, this.keyList);
+				}
+			}
 			return new SingleInputPlanNode(node, "Reduce ("+node.getOperator().getName()+")", in,
-											DriverStrategy.SORTED_REDUCE, this.keyList);
+				DriverStrategy.SORTED_REDUCE, this.keyList);
 		}
 		else {
 			// non forward case. all local properties are killed anyways, so we can safely plug in a combiner
-			boolean reducerOperator = node.getOperator() instanceof ReduceOperatorBase;
-			boolean injectCombiner = false;
-			if(reducerOperator && node.getOperator().getInput() instanceof PartitionOperatorBase) {
-				// We are sure that we got a partitionoperator as an input to the reducer operator.
-				injectCombiner = true;
-			}
 			Channel toCombiner = new Channel(in.getSource());
 			toCombiner.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
 
 			// create an input node for combine with same parallelism as input node
 			ReduceNode combinerNode = ((ReduceNode) node).getCombinerUtilityNode();
 			combinerNode.setParallelism(in.getSource().getParallelism());
-			if(injectCombiner) {
-				toCombiner.getSource().getInputs().iterator().hasNext();
-				Channel source = toCombiner.getSource().getInputs().iterator().next();
-				// Create the combiner node with the Parition node's source as the input
-				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode,
-					"Combine ("+node.getOperator().getName()+")", source,
-					DriverStrategy.SORTED_PARTIAL_REDUCE, this.keyList);
-				addCombinerNodeData(in, toCombiner, combiner);
 
-				Channel combinerChannel = new Channel(combiner);
-				combinerChannel.setShipStrategy(ShipStrategyType.FORWARD, DataExchangeMode.PIPELINED);
+			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode,
+				"Combine ("+node.getOperator().getName()+")", toCombiner,
+				DriverStrategy.SORTED_PARTIAL_REDUCE, this.keyList);
 
-				// Create the partition single input plan node from the existing partition node
-				PlanNode partitionplanNode = in.getSource().getPlanNode();
-				SingleInputPlanNode partition = new SingleInputPlanNode(combinerNode, partitionplanNode.getNodeName(), combinerChannel, partitionplanNode.getDriverStrategy());
-				partition.setCosts(partitionplanNode.getNodeCosts());
-				partition.initProperties(partitionplanNode.getGlobalProperties(), partitionplanNode.getLocalProperties());
-				// Create a reducer such that the input of the reducer is the partition node
-				return createReducerPlanNode(in, node, partition);
-			} else {
-				SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode,
-					"Combine ("+node.getOperator().getName()+")", toCombiner,
-					DriverStrategy.SORTED_PARTIAL_REDUCE, this.keyList);
-				addCombinerNodeData(in, toCombiner, combiner);
-				return createReducerPlanNode(in, node, combiner);
-			}
+			addCombinerProperties(toCombiner, combiner);
+			Channel toReducer = new Channel(combiner);
+			toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
+				in.getShipStrategySortOrder(), in.getDataExchangeMode());
+			toReducer.setLocalStrategy(LocalStrategy.SORT, in.getLocalStrategyKeys(), in.getLocalStrategySortOrder());
+
+			return new SingleInputPlanNode(node, "Reduce("+node.getOperator().getName()+")", toReducer,
+				DriverStrategy.SORTED_REDUCE, this.keyList);
 		}
 	}
 
-	private SingleInputPlanNode createReducerPlanNode(Channel in, SingleInputNode node, SingleInputPlanNode planNode) {
-		Channel toReducer = new Channel(planNode);
-		toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(),
-			in.getShipStrategySortOrder(), in.getDataExchangeMode());
-		toReducer.setLocalStrategy(LocalStrategy.SORT, in.getLocalStrategyKeys(), in.getLocalStrategySortOrder());
-
-		return new SingleInputPlanNode(node, "Reduce("+node.getOperator().getName()+")", toReducer,
-			DriverStrategy.SORTED_REDUCE, this.keyList);
-	}
-
-	private void addCombinerNodeData(Channel in, Channel toCombiner, SingleInputPlanNode combiner) {
+	private void addCombinerProperties(Channel toCombiner, SingleInputPlanNode combiner) {
 		combiner.setCosts(new Costs(0, 0));
 		combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/ReduceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/ReduceITCase.java
@@ -233,6 +233,27 @@ public class ReduceITCase extends MultipleProgramsTestBase {
 	}
 
 	@Test
+	public void testReduceWithPartition() throws Exception {
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		DataSet<Tuple3<Integer, Long, String>> reduceDs = ds.partitionByHash(1).
+			groupBy(1).reduce(new Tuple3Reduce("replace"));
+
+		List<Tuple3<Integer, Long, String>> result = reduceDs.collect();
+
+		String expected = "1,1,Hi\n" +
+			"5,2,replace\n" +
+			"15,3,replace\n" +
+			"34,4,replace\n" +
+			"65,5,replace\n" +
+			"111,6,replace\n";
+
+		compareResultAsTuples(result, expected);
+	}
+
+	@Test
 	public void testReduceATupleReturningKeySelector() throws Exception {
 		/*
 		 * Reduce with a Tuple-returning KeySelector


### PR DESCRIPTION
Followed the guidance given in the description in order to fix this. Is the approach correct here?  Also using this to learn the code. 
Once we see that a partition node is the input of a reduce node or group reduce node -  we try to inject the combiner to the source node (the data source node) and the reducer node will take the actual partition node as the input. 
So now the structure would be DataSource->Combine->Partition->Reduce. 
Suggestions and feedback welcome as am not sure if I have covered all the cases here. 