### PR TITLE
[Flink-3226] Implement project and filter translator.

### DIFF
--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/DataSetRelNodeRule.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/DataSetRelNodeRule.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table.sql.calcite;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+
+public abstract class DataSetRelNodeRule extends ConverterRule {
+	public static RelTrait FLINK_CONVENTION = new Convention.Impl("FLINK", RelNode.class);
+	
+	private boolean exprCodeGen = false;
+	
+	public DataSetRelNodeRule(Class<? extends RelNode> clazz, RelTrait in, String description, boolean exprCodeGen) {
+		super(clazz, in, FLINK_CONVENTION, description);
+		this.exprCodeGen = exprCodeGen;
+	}
+	
+	protected boolean isExprCodeGen() {
+		return this.exprCodeGen;
+	}
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/FlinkUtils.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/FlinkUtils.java
@@ -15,41 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.api.table.sql.calcite.node;
+package org.apache.flink.api.table.sql.calcite;
 
-import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelOptTable;
-import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.DataSet;
-import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
+import org.apache.flink.api.table.typeinfo.RowTypeInfo;
+import scala.collection.JavaConversions;
 
-/**
- * Flink RelNode which matches along with DataSource.
- *
- * @param <T>
- */
-public class DataSetSource<T> extends TableScan implements DataSetRelNode<T> {
+import java.util.LinkedList;
+import java.util.List;
+
+public class FlinkUtils {
 	
-	public DataSetSource(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table) {
-		super(cluster, traitSet, table);
-	}
-	
-	private TypeInformation<T> getType() {
-		return null;
-	}
-	
-	private String getName() {
-		return null;
-	}
-	
-	private DataSet<T> getDatSource() {
-		return null;
-	}
-	
-	@Override
-	public DataSet<T> translateToPlan() {
-		return null;
+	public static RowTypeInfo getRowTypeInfoFromRelDataType(RelDataType rowType) {
+		List<TypeInformation<?>> outputFieldTypes = new LinkedList<>();
+		for (RelDataTypeField relField : rowType.getFieldList()) {
+			RelDataType sqlType = relField.getType();
+			TypeInformation<?> typeInformation = TypeConverter.sqlTypeToTypeInfo(sqlType.getSqlTypeName());
+			outputFieldTypes.add(typeInformation);
+		}
+		return new RowTypeInfo(JavaConversions.asScalaBuffer(outputFieldTypes).toSeq(),
+			JavaConversions.asScalaBuffer(rowType.getFieldNames()).toSeq());
 	}
 }

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/flinkFunction/FilterFunction.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/flinkFunction/FilterFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table.sql.calcite.flinkFunction;
+
+import org.apache.flink.api.common.functions.RichMapPartitionFunction;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.expressions.Expression;
+import org.apache.flink.api.table.typeinfo.RowTypeInfo;
+import org.apache.flink.util.Collector;
+
+public class FilterFunction extends RichMapPartitionFunction<Row, Row> {
+	
+	private RowTypeInfo outputType;
+	private Expression filterExpression;
+	
+	public FilterFunction(RowTypeInfo outputType, Expression filterExpression) {
+		this.outputType = outputType;
+		this.filterExpression = filterExpression;
+	}
+	
+	@Override
+	public void mapPartition(Iterable<Row> values, Collector<Row> out) throws Exception {
+		 for (Row record : values) {
+			 //if (filterExpression.eval(record)), miss 'eval' support from expression.
+			 out.collect(record);
+		 }
+	}
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/flinkFunction/ProjectFunction.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/flinkFunction/ProjectFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table.sql.calcite.flinkFunction;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.expressions.Expression;
+import org.apache.flink.api.table.expressions.Naming;
+import org.apache.flink.api.table.typeinfo.RowTypeInfo;
+
+import java.util.List;
+
+public class ProjectFunction extends RichMapFunction<Row, Row> {
+	
+	private RowTypeInfo outputType;
+	private List<Naming> expressions;
+	
+	public ProjectFunction(RowTypeInfo outputType, List<Naming> expressions) {
+		this.outputType = outputType;
+		this.expressions = expressions;
+	}
+	
+	@Override
+	public Row map(Row input) throws Exception {
+		Row result = new Row(outputType.getTotalFields());
+		for (Naming naming : expressions) {
+			Expression expression = naming.child();
+			String outputFieldName = naming.name();
+			Object evaluated = null; // evaluated = expression.eval(input); missing 'eval' support from Expression.
+			result.setField(outputType.getFieldIndex(outputFieldName), evaluated);
+		}
+		return result;
+	}
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetFlatMap.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetFlatMap.java
@@ -21,7 +21,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
-import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
@@ -29,15 +29,14 @@ import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
 /**
  * Flink RelNode which matches along with FlatMapOperator.
  *
- * @param <T>
  */
-public class DataSetFlatMap<T> extends SingleRel implements DataSetRelNode<T> {
+public class DataSetFlatMap<IN, OUT> extends SingleRel implements DataSetRelNode<OUT> {
 	
 	protected DataSetFlatMap(RelOptCluster cluster, RelTraitSet traits, RelNode input) {
 		super(cluster, traits, input);
 	}
 	
-	private TypeInformation<T> getType() {
+	private TypeInformation<OUT> getType() {
 		return null;
 	}
 	
@@ -45,12 +44,12 @@ public class DataSetFlatMap<T> extends SingleRel implements DataSetRelNode<T> {
 		return null;
 	}
 	
-	private RichFlatMapFunction<T, T> getFlatMapFunction() {
+	private FlatMapFunction<IN, OUT> getFlatMapFunction() {
 		return null;
 	}
 	
 	@Override
-	public DataSet<T> translateToPlan() {
+	public DataSet<OUT> translateToPlan() {
 		return null;
 	}
 }

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetJoin.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetJoin.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.operators.join.JoinType;
 import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
 
 /**
  * Flink RelNode which matches along with JoinOperator and its related operations.
@@ -37,15 +39,15 @@ public class DataSetJoin<L, R, OUT> extends BiRel implements DataSetRelNode<OUT>
 		super(cluster, traitSet, left, right);
 	}
 	
+	private TypeInformation<OUT> getType() {
+		return null;
+	}
+	
 	private TypeInformation<L> getLeftInputType() {
 		return null;
 	}
 	
 	private TypeInformation<R> getRightInputType() {
-		return null;
-	}
-	
-	private TypeInformation<OUT> getType() {
 		return null;
 	}
 	

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetMap.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetMap.java
@@ -25,30 +25,35 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
 
 /**
  * Flink RelNode which matches along with MapOperator.
  */
 public class DataSetMap<IN, OUT> extends SingleRel implements DataSetRelNode<OUT> {
 	
-	protected DataSetMap(RelOptCluster cluster, RelTraitSet traits, RelNode input) {
-		super(cluster, traits, input);
-	}
+	private final static String NAME = "DataSetMap";
+	private TypeInformation<OUT> outputType;
+	private RichMapFunction<IN, OUT> mapFunction;
 	
-	private TypeInformation<IN> getInputType() {
-		return null;
+	public DataSetMap(RelOptCluster cluster, RelTraitSet traits, RelNode input, 
+		TypeInformation<OUT> outputType, RichMapFunction<IN, OUT> mapFunction) {
+		super(cluster, traits, input);
+		this.outputType = outputType;
+		this.mapFunction = mapFunction;
 	}
 	
 	private TypeInformation<OUT> getType() {
-		return null;
+		return this.outputType;
 	}
 	
 	private String getName() {
-		return null;
+		return NAME;
 	}
 	
 	private RichMapFunction<IN, OUT> getMapFunction() {
-		return null;
+		return this.mapFunction;
 	}
 	
 	@Override

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetMapPartition.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetMapPartition.java
@@ -21,38 +21,41 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
-import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
 
-/**
- * Flink RelNode which matches along with ReduceOperator.
- */
-public class DataSetReduce<T> extends SingleRel implements DataSetRelNode<T> {
+public class DataSetMapPartition<IN, OUT> extends SingleRel implements DataSetRelNode<OUT> {
 	
-	public DataSetReduce(RelOptCluster cluster, RelTraitSet traits, RelNode input) {
+	private final static String NAME = "DataSetMapPartition";
+	private TypeInformation<OUT> outputType;
+	private MapPartitionFunction<IN, OUT> mapPartitionFunction;
+	
+	public DataSetMapPartition(RelOptCluster cluster, RelTraitSet traits, RelNode input,
+		TypeInformation<OUT> outputType, MapPartitionFunction<IN, OUT> mapPartitionFunction) {
+		
 		super(cluster, traits, input);
+		this.outputType = outputType;
+		this.mapPartitionFunction = mapPartitionFunction;
 	}
 	
-	private TypeInformation<T> getType() {
-		return null;
+	private MapPartitionFunction<IN, OUT> getMapPartitionFunction() {
+		return this.mapPartitionFunction;
 	}
 	
 	private String getName() {
-		return null;
+		return NAME;
 	}
 	
-	private ReduceFunction<T> getReduceFunction() {
-		return null;
-	}
-	
-	private int[] getGroupingKeys() {
-		return null;
+	private TypeInformation<OUT> getType() {
+		return this.outputType;
 	}
 	
 	@Override
-	public DataSet<T> translateToPlan() {
+	public DataSet<OUT> translateToPlan() {
 		return null;
 	}
 }

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetReduceGroup.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/node/DataSetReduceGroup.java
@@ -21,7 +21,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
-import org.apache.flink.api.common.functions.RichGroupReduceFunction;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.table.sql.calcite.DataSetRelNode;
@@ -47,7 +47,7 @@ public class DataSetReduceGroup<IN, OUT> extends SingleRel implements DataSetRel
 		return null;
 	}
 	
-	private RichGroupReduceFunction<IN, OUT> getGroupReduceFunction() {
+	private GroupReduceFunction<IN, OUT> getGroupReduceFunction() {
 		return null;
 	}
 	

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/rule/LogicalFilterTranslator.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/rule/LogicalFilterTranslator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table.sql.calcite.rule;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNodeRule;
+import org.apache.flink.api.table.sql.calcite.FlinkUtils;
+import org.apache.flink.api.table.sql.calcite.RexToExpr;
+import org.apache.flink.api.table.sql.calcite.flinkFunction.FilterFunction;
+import org.apache.flink.api.table.sql.calcite.node.DataSetMapPartition;
+import org.apache.flink.api.table.expressions.Expression;
+import org.apache.flink.api.table.plan.TypeConverter;
+import org.apache.flink.api.table.sql.calcite.FlinkUtils;
+import org.apache.flink.api.table.sql.calcite.RexToExpr;
+import org.apache.flink.api.table.typeinfo.RowTypeInfo;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class LogicalFilterTranslator extends DataSetRelNodeRule {
+	public LogicalFilterTranslator(boolean exprCodeGen) {
+		super(LogicalFilter.class, Convention.NONE, "FlinkFilterRule2", exprCodeGen);
+	}
+	
+	@Override
+	public RelNode convert(RelNode rel) {
+		LogicalFilter filterRelNode = (LogicalFilter) rel;
+		RelNode input = filterRelNode.getInput();
+		RelDataType inputRowType = input.getRowType();
+		RelDataType rowType = filterRelNode.getRowType();
+		
+		// build program
+		RexBuilder rexBuilder = filterRelNode.getCluster().getRexBuilder();
+		RexProgramBuilder programBuilder = new RexProgramBuilder(inputRowType, rexBuilder);
+		programBuilder.addIdentity();
+		programBuilder.addCondition(filterRelNode.getCondition());
+		RexProgram program = programBuilder.getProgram();
+		
+		RexNode rexCondition = program.expandLocalRef(program.getCondition());
+		List<Tuple2<String, TypeInformation<?>>> inputFieldsInfo = new LinkedList<>();
+		for (RelDataTypeField relField : inputRowType.getFieldList()) {
+			String renamedFieldName = relField.getName();
+			RelDataType sqlType = relField.getType();
+			TypeInformation<?> typeInformation = TypeConverter.sqlTypeToTypeInfo(sqlType.getSqlTypeName());
+			inputFieldsInfo.add(new Tuple2<String, TypeInformation<?>>(renamedFieldName, typeInformation));
+		}
+		// translate to flink expression.
+		Expression filterExpression = RexToExpr.translate(rexCondition,
+			JavaConversions.asScalaBuffer(inputFieldsInfo).toSeq());
+		
+		final RowTypeInfo outputType = FlinkUtils.getRowTypeInfoFromRelDataType(rowType);
+		
+		FilterFunction filterFunction = null;
+		if (isExprCodeGen()) {
+			//TODO generate expression code.
+		} else {
+			filterFunction = new FilterFunction(outputType, filterExpression);
+		}
+		
+		return new DataSetMapPartition<>(rel.getCluster(), rel.getTraitSet(), input, outputType, filterFunction);
+	}
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/rule/LogicalProjectTranslator.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/api/table/sql/calcite/rule/LogicalProjectTranslator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table.sql.calcite.rule;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexLocalRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.util.Pair;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNodeRule;
+import org.apache.flink.api.table.sql.calcite.FlinkUtils;
+import org.apache.flink.api.table.sql.calcite.RexToExpr;
+import org.apache.flink.api.table.sql.calcite.flinkFunction.ProjectFunction;
+import org.apache.flink.api.table.sql.calcite.node.DataSetMap;
+import org.apache.flink.api.table.expressions.Expression;
+import org.apache.flink.api.table.expressions.Naming;
+import org.apache.flink.api.table.plan.TypeConverter;
+import org.apache.flink.api.table.sql.calcite.DataSetRelNodeRule;
+import org.apache.flink.api.table.sql.calcite.FlinkUtils;
+import org.apache.flink.api.table.sql.calcite.RexToExpr;
+import org.apache.flink.api.table.typeinfo.RowTypeInfo;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class LogicalProjectTranslator extends DataSetRelNodeRule {
+	
+	public LogicalProjectTranslator(boolean exprCodeGen) {
+		super(LogicalProject.class, Convention.NONE, "FlinkProjectRule", exprCodeGen);
+	}
+	
+	@Override
+	public RelNode convert(RelNode rel) {
+		LogicalProject project = (LogicalProject) rel;
+		RelNode input = project.getInput();
+		RelDataType inputRowType = input.getRowType();
+		List<RexNode> projects = project.getProjects();
+		RelDataType rowType = project.getRowType();
+		
+		RexProgram projectProgram = RexProgram.create(
+			inputRowType,
+			projects,
+			null,
+			rowType,
+			project.getCluster().getRexBuilder());
+		
+		List<Naming> projectExprs = new LinkedList<>();
+		
+		if (!projectProgram.projectsOnlyIdentity()) {
+			
+			List<Tuple2<String, TypeInformation<?>>> inputFieldsInfo = new LinkedList<>();
+			for (RelDataTypeField relField : inputRowType.getFieldList()) {
+				String renamedFieldName = relField.getName();
+				RelDataType sqlType = relField.getType();
+				TypeInformation<?> typeInformation = TypeConverter.sqlTypeToTypeInfo(sqlType.getSqlTypeName());
+				inputFieldsInfo.add(new Tuple2<String, TypeInformation<?>>(renamedFieldName, typeInformation));
+			}
+			
+			// translate project RexNode to Flink expression.
+			List<Pair<RexLocalRef, String>> namedProjects = projectProgram.getNamedProjects();
+			for (Pair<RexLocalRef, String> rexAndName : namedProjects) {
+				RexNode rexNode = projectProgram.expandLocalRef(rexAndName.getKey());
+				Expression projectExpr = RexToExpr.translate(rexNode, JavaConversions.asScalaBuffer(inputFieldsInfo).toSeq());
+				projectExprs.add(new Naming(projectExpr, rexAndName.getValue()));
+			}
+		}
+		
+		final RowTypeInfo outputType = FlinkUtils.getRowTypeInfoFromRelDataType(rowType);
+		
+		RichMapFunction<Row, Row> mapFunction = null;
+		if (isExprCodeGen()) {
+			// TODO generate expression code.
+		} else {
+			if (projectExprs.isEmpty()) {
+				// no project, just rename, translate to RenameOperator while build Flink program, 
+				// MapFunction is not required.
+			} else {
+				mapFunction = new ProjectFunction(outputType, projectExprs);
+			}
+		}
+		
+		return new DataSetMap<>(rel.getCluster(), rel.getTraitSet(), input, outputType, mapFunction);
+	}
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/sql/calcite/FlinkRules.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/sql/calcite/FlinkRules.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table.sql.calcite
+
+import org.apache.flink.api.table.calcite.rule.LogicalFilterTranslator
+import org.apache.flink.api.table.sql.calcite.rule.{LogicalProjectTranslator, LogicalFilterTranslator}
+
+object FlinkRules {
+  val CONVERTER_RULES = List(
+    new LogicalProjectTranslator(false),
+    new LogicalFilterTranslator(false)
+  )
+
+  // ALL RULES UNTIL FilterToCalcRule HAVE BEEN REVIEWED
+  val OPTIMIZE_RULES = List(
+  )
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/sql/calcite/RexToExpr.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/sql/calcite/RexToExpr.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.sql.calcite
+
+import org.apache.calcite.rex._
+import org.apache.calcite.sql.SqlKind._
+import org.apache.calcite.sql.`type`.SqlTypeName._
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.table.expressions._
+
+import scala.collection.JavaConversions._
+
+class RexToExpr private (
+    input1Fields: Seq[(String, TypeInformation[_])],
+    input2Fields: Seq[(String, TypeInformation[_])] = null)
+  extends RexVisitor[Expression] {
+
+  override def visitInputRef(inputRef: RexInputRef): Expression = {
+    val index = inputRef.getIndex
+    // input 1
+    if (index < input1Fields.size) {
+      val fieldName = input1Fields(index)._1
+      val fieldType = input1Fields(index)._2
+      ResolvedFieldReference(fieldName, fieldType)
+    }
+    // input 2
+    else {
+      val fieldName = input2Fields(index - input1Fields.size)._1
+      val fieldType = input2Fields(index - input1Fields.size)._2
+      ResolvedFieldReference(fieldName, fieldType)
+    }
+  }
+
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): Expression = ???
+
+  override def visitLiteral(literal: RexLiteral): Expression = {
+    literal.getType.getSqlTypeName match {
+      case VARCHAR | CHAR =>
+        Literal(literal.getValue3, BasicTypeInfo.STRING_TYPE_INFO)
+      case BOOLEAN =>
+        Literal(literal.getValue3, BasicTypeInfo.BOOLEAN_TYPE_INFO)
+      case INTEGER =>
+        val decimal = BigDecimal(literal.getValue3.asInstanceOf[java.math.BigDecimal])
+        Literal(decimal.toInt, BasicTypeInfo.INT_TYPE_INFO)
+      case DECIMAL =>
+        val decimal = BigDecimal(literal.getValue3.asInstanceOf[java.math.BigDecimal])
+        // covert decimals to double type info if possible
+        if (decimal.isValidDouble) {
+          Literal(decimal.doubleValue(), BasicTypeInfo.DOUBLE_TYPE_INFO)
+        }
+        else {
+          ???
+        }
+      case DATE => ??? // TODO
+      case _ => ???
+    }
+  }
+
+  override def visitCorrelVariable(correlVariable: RexCorrelVariable): Expression = ???
+
+  override def visitLocalRef(localRef: RexLocalRef): Expression = ???
+
+  override def visitRangeRef(rangeRef: RexRangeRef): Expression = ???
+
+  override def visitDynamicParam(dynamicParam: RexDynamicParam): Expression = ???
+
+  override def visitCall(call: RexCall): Expression = {
+    val operands = call.getOperands.map(_.accept(this))
+    // binary calls
+    if (operands.size == 2) {
+      translateBinaryCall(call, operands(0), operands(1))
+    }
+    // unary calls
+    else if (operands.size == 1) {
+      translateUnaryCall(call, operands(0))
+    }
+    // special case: n-ary AND / OR
+    else if (operands.size > 2
+        && (call.getKind == AND || call.getKind == OR)) {
+      translateNaryAndOr(call, operands)
+    }
+    else ???
+  }
+
+  override def visitOver(over: RexOver): Expression = ???
+
+  // ----------------------------------------------------------------------------------------------
+
+  def translateNaryAndOr(call: RexCall, operands: Seq[Expression]): Expression = call.getKind match {
+    case AND => operands.reduceLeft(And(_ , _))
+    case OR => operands.reduceLeft(Or(_ , _))
+    case _ => throw new IllegalArgumentException()
+  }
+
+  def translateBinaryCall(call: RexCall, left: Expression, right: Expression): Expression = {
+    val autoCasted = autoCast(left, right)
+    call.getKind match {
+      // logic
+      case AND => And(left, right)
+      case OR => Or(left, right)
+      // comparison
+      case EQUALS => EqualTo(autoCasted._1, autoCasted._2)
+      case NOT_EQUALS => NotEqualTo(autoCasted._1, autoCasted._2)
+      case GREATER_THAN => GreaterThan(autoCasted._1, autoCasted._2)
+      case GREATER_THAN_OR_EQUAL => GreaterThanOrEqual(autoCasted._1, autoCasted._2)
+      case LESS_THAN => LessThan(autoCasted._1, autoCasted._2)
+      case LESS_THAN_OR_EQUAL => LessThanOrEqual(autoCasted._1, autoCasted._2)
+      // arithmetic
+      case PLUS => Plus(autoCasted._1, autoCasted._2)
+      case MINUS => Minus(autoCasted._1, autoCasted._2)
+      case TIMES => Mul(autoCasted._1, autoCasted._2)
+      case DIVIDE => Div(autoCasted._1, autoCasted._2)
+      case _ => ???
+    }
+  }
+
+  def translateUnaryCall(call: RexCall, operand: Expression): Expression = call.getKind match {
+    // casting
+    case CAST =>
+      val targetType = TypeConverter.sqlTypeToTypeInfo(call.getType.getSqlTypeName)
+      // only cast if necessary
+      if (targetType == operand.typeInfo) {
+        operand
+      }
+      else {
+        Cast(operand, targetType)
+      }
+    // logic
+    case NOT => Not(operand)
+    case IS_NULL => IsNull(operand)
+    case IS_NOT_NULL => IsNotNull(operand)
+    case _ => ???
+  }
+
+  def autoCast(o1: Expression, o2: Expression): (Expression, Expression) = {
+    if (o1.typeInfo != o2.typeInfo && o1.typeInfo.isBasicType && o2.typeInfo.isBasicType) {
+      if (o1.typeInfo.asInstanceOf[BasicTypeInfo[_]].shouldAutocastTo(
+        o2.typeInfo.asInstanceOf[BasicTypeInfo[_]])) {
+        (Cast(o1, o2.typeInfo), o2)
+      } else if (o2.typeInfo.asInstanceOf[BasicTypeInfo[_]].shouldAutocastTo(
+        o1.typeInfo.asInstanceOf[BasicTypeInfo[_]])) {
+        (o1, Cast(o2, o1.typeInfo))
+      } else {
+        (o1, o2)
+      }
+    }
+    else {
+      (o1, o2)
+    }
+  }
+
+}
+
+object RexToExpr {
+
+  def translate(rexNode: RexNode, inputFields: Seq[(String, TypeInformation[_])]): Expression = {
+    rexNode.accept(new RexToExpr(inputFields))
+  }
+
+  def translate(
+      rexNode: RexNode,
+      input1Fields: Seq[(String, TypeInformation[_])],
+      input2Fields: Seq[(String, TypeInformation[_])]): Expression = {
+    rexNode.accept(new RexToExpr(input1Fields, input2Fields))
+  }
+
+}


### PR DESCRIPTION
This is just prototype implementation to translate Calcite Project and Filter into Flink RelNode. It still miss several parts, which could be done in separate tasks:
1. expression code generation.
2. Flink expression do not support `eval` yet, so expression is not supported in interpreter mode as well.
3. i test these rules based on Timo's prototype, the rule registry and launch part is not ready in this PR. 
4. other Calcite RelNodes translator.

@fhueske and @twalthr , please let me know if you have any suggestion.
 