### PR TITLE
[FLINK-2678]DataSet API does not support multi-dimensional arrays as keys

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ObjectArrayComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ObjectArrayComparator.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+
+
+public class ObjectArrayComparator<T,C> extends TypeComparator<T[]> implements java.io.Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private transient T[] reference;
+
+	protected final boolean ascendingComparison;
+
+	private final TypeSerializer<T[]> serializer;
+
+	private TypeComparator<? super Object> comparatorInfo;
+
+	// For use by getComparators
+	@SuppressWarnings("rawtypes")
+	private final TypeComparator[] comparators = new TypeComparator[] {this};
+
+	public ObjectArrayComparator(boolean ascending, TypeSerializer<T[]> serializer, TypeComparator<? super Object> comparatorInfo) {
+		this.ascendingComparison = ascending;
+		this.serializer = serializer;
+		this.comparatorInfo = comparatorInfo;
+	}
+
+	@Override
+	public void setReference(T[] reference) {
+		this.reference = reference;
+	}
+
+	@Override
+	public boolean equalToReference(T[] candidate) {
+		return compare(this.reference, candidate) == 0;
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<T[]> referencedComparator) {
+		int comp = compare(((ObjectArrayComparator<T,C>) referencedComparator).reference, reference);
+		return comp;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		T[] firstArray = serializer.deserialize(firstSource);
+		T[] secondArray = serializer.deserialize(secondSource);
+
+		int comp = compare(firstArray, secondArray);
+		return comp;
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator[] getFlatComparators() {
+		return comparators;
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return 0;
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void putNormalizedKey(T[] record, MemorySegment target, int offset, int numBytes) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void writeWithKeyNormalization(T[] record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public T[] readWithKeyDenormalization(T[] reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return !ascendingComparison;
+	}
+
+	@Override
+	public int hash(T[] record) {
+		return Arrays.hashCode(record);
+	}
+
+	private int compareValues(Object first, Object second) {
+		/**
+		 * uses the chosen comparator ( of primitive or composite type ) & compares the provided objects as input
+		 */
+		return comparatorInfo.compare(first, second);
+	}
+
+	@SuppressWarnings("unchecked")
+	private int parseGenericArray(Object firstArray, Object secondArray) {
+		int compareResult = 0;
+
+		/**
+		 * logic to determine comparison result due to length difference.
+		 * the length difference cannot fully determine the result of the comparison. Hence, result added to tempResult.
+		 */
+		int min = Array.getLength(firstArray);
+		int tempResult = 0;
+		if (min < Array.getLength(secondArray)) {
+			tempResult = ascendingComparison ? -1: 1;
+		}
+		if (min > Array.getLength(secondArray)) {
+			tempResult = ascendingComparison? 1: -1;
+			min = Array.getLength(secondArray);
+		}
+
+		/**
+		 * comparing the actual content of two arrays.
+		 */
+		for (int i=0;i < min;i++) {
+			int val;
+
+			if (!Array.get(firstArray, i).getClass().isArray() && !Array.get(secondArray, i).getClass().isArray()) {
+				val = compareValues(Array.get(firstArray, i), Array.get(secondArray, i));
+			}
+			else {
+				val = parseGenericArray(Array.get(firstArray, i), Array.get(secondArray, i));
+			}
+
+			if (val != 0) {
+				compareResult = val;
+				break;
+			}
+		}
+
+		/**
+		 * if the actual comparison cannot distinguish between two arrays, then length differences take preference.
+		 */
+		if (compareResult == 0) {
+			compareResult = tempResult;
+		}
+		return compareResult;
+	}
+
+	@Override
+	public int compare(T[] first, T[] second) {
+		return parseGenericArray(first, second);
+	}
+
+	@Override
+	public TypeComparator<T[]> duplicate() {
+		ObjectArrayComparator<T,C> dupe = new ObjectArrayComparator<T,C>(ascendingComparison, serializer, comparatorInfo);
+		dupe.setReference(this.reference);
+		return dupe;
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ObjectArrayComparatorCompositeTypeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ObjectArrayComparatorCompositeTypeTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.junit.Assert;
+
+import java.lang.reflect.Array;
+
+public class ObjectArrayComparatorCompositeTypeTest extends ComparatorTestBase<Tuple2<String, Integer>[][]> {
+	private final TypeInformation<Tuple2<String, Integer>[]> componentInfo;
+
+	public ObjectArrayComparatorCompositeTypeTest() {
+		this.componentInfo = ObjectArrayTypeInfo.getInfoFor(new TupleTypeInfo<Tuple>(BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<Tuple2<String, Integer>[][]> createSerializer() {
+		return (TypeSerializer<Tuple2<String, Integer>[][]>) new GenericArraySerializer<Tuple2<String, Integer>[]>(
+			componentInfo.getTypeClass(),
+			componentInfo.createSerializer(null));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeComparator<Tuple2<String, Integer>[][]> createComparator(boolean ascending) {
+		CompositeType<? extends Object> baseComponentInfo = new TupleTypeInfo<Tuple>(BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+		int componentArity = baseComponentInfo.getArity();
+		int [] logicalKeyFields = new int[componentArity];
+		boolean[] orders = new boolean[componentArity];
+
+		for (int i=0;i < componentArity;i++) {
+			logicalKeyFields[i] = i;
+			orders[i] = ascending;
+		}
+
+		return (TypeComparator<Tuple2<String, Integer>[][]>) new ObjectArrayComparator<Tuple2<String, Integer>[], Character>(ascending,
+			(GenericArraySerializer<Tuple2<String, Integer>[]>) createSerializer(),
+			((CompositeType<? super Object>) baseComponentInfo).createComparator(logicalKeyFields, orders, 0, null)
+		);
+	}
+
+	@Override
+	protected void deepEquals(String message, Tuple2<String, Integer>[][] should, Tuple2<String, Integer>[][] is) {
+		Assert.assertTrue(should.length==is.length);
+		for (int i=0;i < should.length;i++) {
+			Assert.assertTrue(should[i].length==is[i].length);
+			for (int j=0;j < should[i].length;j++) {
+				Assert.assertEquals(should[i][j].f0,is[i][j].f0);
+				Assert.assertEquals(should[i][j].f1,is[i][j].f1);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Tuple2<String, Integer>[][][] getSortedTestData() {
+		Object result = Array.newInstance(Tuple2.class, new int[]{2, 2, 1});
+
+		((Tuple2<String, Integer>[][][]) result)[0][0][0] = new Tuple2<String, Integer>();
+		((Tuple2<String, Integer>[][][]) result)[0][0][0].f0 = "be";
+		((Tuple2<String, Integer>[][][]) result)[0][0][0].f1 = 2;
+
+		((Tuple2<String, Integer>[][][]) result)[0][1][0] = new Tuple2<String, Integer>();
+		((Tuple2<String, Integer>[][][]) result)[0][1][0].f0 = "not";
+		((Tuple2<String, Integer>[][][]) result)[0][1][0].f1 = 3;
+
+
+		((Tuple2<String, Integer>[][][]) result)[1][0][0] = new Tuple2<String, Integer>();
+		((Tuple2<String, Integer>[][][]) result)[1][0][0].f0 = "or";
+		((Tuple2<String, Integer>[][][]) result)[1][0][0].f1 = 2;
+
+		((Tuple2<String, Integer>[][][]) result)[1][1][0] = new Tuple2<String, Integer>();
+		((Tuple2<String, Integer>[][][]) result)[1][1][0].f0 = "to";
+		((Tuple2<String, Integer>[][][]) result)[1][1][0].f1 = 2;
+
+		return (Tuple2<String, Integer>[][][]) result;
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ObjectArrayComparatorPrimitiveTypeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ObjectArrayComparatorPrimitiveTypeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeinfo.AtomicType;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
+import org.junit.Assert;
+
+public class ObjectArrayComparatorPrimitiveTypeTest extends ComparatorTestBase<char[][]> {
+	private final TypeInformation<char[]> componentInfo;
+
+	public ObjectArrayComparatorPrimitiveTypeTest() {
+		this.componentInfo = PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO;
+	}
+
+	@Override
+	protected TypeSerializer<char[][]> createSerializer() {
+		return (TypeSerializer<char[][]>) new GenericArraySerializer<char[]>(
+			componentInfo.getTypeClass(),
+			componentInfo.createSerializer(null));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeComparator<char[][]> createComparator(boolean ascending) {
+		TypeInformation<Character> baseComponentInfo = BasicTypeInfo.CHAR_TYPE_INFO;
+		return (TypeComparator<char[][]>) new ObjectArrayComparator<char[], Character>(ascending,
+			(GenericArraySerializer<char[]>) createSerializer(),
+			((AtomicType<? super Object>) baseComponentInfo).createComparator(ascending, null)
+		);
+	}
+
+	@Override
+	protected void deepEquals(String message, char[][] should, char[][] is) {
+		Assert.assertTrue(should.length==is.length);
+		for (int i=0; i < should.length;i++) {
+			Assert.assertTrue(should[i].length==is[i].length);
+			for (int j=0;j < should[i].length;j++) {
+				Assert.assertEquals(should[i][j], is[i][j]);
+			}
+		}
+	}
+
+	@Override
+	protected char[][][] getSortedTestData() {
+		return new char[][][]{
+			new char[][]{
+				new char[]{'b', 'e'},
+				new char[]{'2'},
+			},
+			new char[][]{
+				new char[]{'n', 'o', 't'},
+				new char[]{'3'}
+			},
+			new char[][]{
+				new char[]{'o', 'r'},
+				new char[]{'2'}
+			},
+			new char[][]{
+				new char[]{'t', 'o'},
+				new char[]{'2'}
+			}
+		};
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/DataSinkTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/DataSinkTest.java
@@ -311,7 +311,7 @@ public class DataSinkTest {
 			.sortLocalOutput("*", Order.ASCENDING);
 	}
 
-	@Test(expected = InvalidProgramException.class)
+	@Test
 	public void testArrayOrderFull() {
 
 		List<Object[]> arrayData = new ArrayList<>();
@@ -321,10 +321,13 @@ public class DataSinkTest {
 				.getExecutionEnvironment();
 		DataSet<Object[]> pojoDs = env
 				.fromCollection(arrayData);
-
-		// must not work
-		pojoDs.writeAsText("/tmp/willNotHappen")
-			.sortLocalOutput("*", Order.ASCENDING);
+		// should work
+		try {
+			pojoDs.writeAsText("/tmp/willNotHappen")
+				.sortLocalOutput("*", Order.ASCENDING);
+		} catch (Exception e) {
+			Assert.fail();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Hello,

@tillrohrmann I have added support for multi-dimensional arrays as keys in Dataset api. Please review & merge.