### PR TITLE
[FLINK-3287]	[FLINK-3247] Fix curator shading for Kafka connector

### DIFF
--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -112,7 +112,9 @@ under the License.
 									Everything else will be packaged into the fat-jar
 									-->
 									<exclude>org.apache.flink:flink-annotations</exclude>
-									<exclude>org.apache.flink:flink-shaded-*</exclude>
+									<exclude>org.apache.flink:flink-shaded-hadoop1</exclude>
+									<exclude>org.apache.flink:flink-shaded-hadoop2</exclude>
+									<exclude>org.apache.flink:flink-shaded-curator-recipes</exclude>
 									<exclude>org.apache.flink:flink-core</exclude>
 									<exclude>org.apache.flink:flink-java</exclude>
 									<exclude>org.apache.flink:flink-scala_2.10</exclude>
@@ -184,7 +186,8 @@ under the License.
 								<filter>
 									<artifact>org.apache.flink:*</artifact>
 									<excludes>
-										<exclude>org/apache/flink/shaded/**</exclude>
+										<!-- exclude shaded google but include shaded curator -->
+										<exclude>org/apache/flink/shaded/com/**</exclude>
 										<exclude>web-docs/**</exclude>
 									</excludes>
 								</filter>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -116,7 +116,9 @@ under the License.
 									Everything else will be packaged into the fat-jar
 									-->
 									<exclude>org.apache.flink:flink-annotations</exclude>
-									<exclude>org.apache.flink:flink-shaded-*</exclude>
+									<exclude>org.apache.flink:flink-shaded-hadoop1</exclude>
+									<exclude>org.apache.flink:flink-shaded-hadoop2</exclude>
+									<exclude>org.apache.flink:flink-shaded-curator-recipes</exclude>
 									<exclude>org.apache.flink:flink-core</exclude>
 									<exclude>org.apache.flink:flink-java</exclude>
 									<exclude>org.apache.flink:flink-scala_2.10</exclude>
@@ -187,7 +189,8 @@ under the License.
 								<filter>
 									<artifact>org.apache.flink:*</artifact>
 									<excludes>
-										<exclude>org/apache/flink/shaded/**</exclude>
+										<!-- exclude shaded google but include shaded curator -->
+										<exclude>org/apache/flink/shaded/com/**</exclude>
 										<exclude>web-docs/**</exclude>
 									</excludes>
 								</filter>

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/pom.xml
@@ -154,6 +154,33 @@ under the License.
 					<forkCount>1</forkCount>
 				</configuration>
 			</plugin>
+			<!-- Relocate curator -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes combine.children="append">
+									<include>org.apache.flink:flink-shaded-curator-recipes</include>
+								</includes>
+							</artifactSet>
+							<relocations combine.children="append">
+								<relocation>
+									<pattern>org.apache.curator</pattern>
+									<shadedPattern>org.apache.flink.shaded.org.apache.curator</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	


### PR DESCRIPTION
Some maven versions are not properly evaluating star * excludes. Therefore, I've manually listed our shaded artifacts in the quickstart pom.

Also, a user reported a version mismatch with curator on HDP. As a fix, I'm shading curator into the kafka connector.