### PR TITLE
[hotfix][yarn] Shutdown JVM when Flink-on-yarn is shutting down

### DIFF
--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
@@ -183,6 +183,9 @@ class YarnJobManager(
       // Shutdown and discard all queued messages
       context.system.shutdown()
 
+      log.info("Shutdown completed. Stopping JVM")
+      System.exit(0)
+
     case RegisterApplicationClient =>
       val client = sender()
 

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
@@ -55,5 +55,8 @@ class YarnTaskManager(
       log.info(s"Stopping YARN TaskManager with final application status $status " +
         s"and diagnostics: $diagnostics")
       context.system.shutdown()
+
+      log.info("Shutdown completed. Stopping JVM")
+      System.exit(0)
   }
 }


### PR DESCRIPTION
With this change, we call System.exit() when the YARN session is shutting down.

On some Linux distributions, YARN is not able to stop containers because the "kill" command has different arguments. For example when running Flink on GCE ("Debian GNU/Linux 7.9 (wheezy)"), YARN containers will not properly shut down.

I propose to apply this change to 0.10 as well.

I tested this on GCE (multiple times, also by externally killing the app)