### PR TITLE
FLINK-3327: ExecutionConfig to JobGraph.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -59,9 +59,6 @@ public class ExecutionConfig implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	// Key for storing it in the Job Configuration
-	public static final String CONFIG_KEY = "runtime.config";
-
 	/**
 	 * The constant to use for the parallelism, if the system should use the number
 	 *  of currently available slots.
@@ -650,7 +647,8 @@ public class ExecutionConfig implements Serializable {
 				Objects.equals(executionMode, other.executionMode) &&
 				useClosureCleaner == other.useClosureCleaner &&
 				parallelism == other.parallelism &&
-				restartStrategyConfiguration.equals(other.restartStrategyConfiguration) &&
+				((restartStrategyConfiguration == null && other.restartStrategyConfiguration == null) ||
+				restartStrategyConfiguration.equals(other.restartStrategyConfiguration)) &&
 				forceKryo == other.forceKryo &&
 				objectReuse == other.objectReuse &&
 				autoTypeRegistrationEnabled == other.autoTypeRegistrationEnabled &&

--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -38,7 +38,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.operators.GenericDataSinkBase;
 import org.apache.flink.api.common.operators.Operator;
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Visitable;
@@ -292,16 +291,6 @@ public class Plan implements Visitable<Operator<?>> {
 			"The default parallelism must be positive, or -1 if the system should use the globally comfigured default.");
 		
 		this.defaultParallelism = defaultParallelism;
-	}
-
-	/**
-	 * Returns the specified restart strategy configuration. This configuration defines the used
-	 * restart strategy to be used at runtime.
-	 *
-	 * @return The specified restart strategy configuration
-	 */
-	public RestartStrategies.RestartStrategyConfiguration getRestartStrategyConfiguration() {
-		return getExecutionConfig().getRestartStrategy();
 	}
 
 	/**

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -20,7 +20,6 @@ package org.apache.flink.optimizer.plantranslate;
 
 import com.fasterxml.jackson.core.JsonFactory;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.aggregators.AggregatorRegistry;
 import org.apache.flink.api.common.aggregators.AggregatorWithName;
@@ -81,11 +80,9 @@ import org.apache.flink.runtime.operators.chaining.ChainedDriver;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.apache.flink.runtime.operators.util.LocalStrategy;
 import org.apache.flink.runtime.operators.util.TaskConfig;
-import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.Visitor;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -218,7 +215,6 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		
 		// create the job graph object
 		JobGraph graph = new JobGraph(jobId, program.getJobName(), program.getOriginalPlan().getExecutionConfig());
-		graph.setRestartStrategyConfiguration(program.getOriginalPlan().getRestartStrategyConfiguration());
 		graph.setAllowQueuedScheduling(false);
 		graph.setSessionTimeout(program.getOriginalPlan().getSessionTimeout());
 
@@ -235,15 +231,6 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		// add registered cache file into job configuration
 		for (Entry<String, DistributedCacheEntry> e : program.getOriginalPlan().getCachedFiles()) {
 			DistributedCache.writeFileInfoToConfig(e.getKey(), e.getValue(), graph.getJobConfiguration());
-		}
-
-		try {
-			InstantiationUtil.writeObjectToConfig(
-					program.getOriginalPlan().getExecutionConfig(),
-					graph.getJobConfiguration(),
-					ExecutionConfig.CONFIG_KEY);
-		} catch (IOException e) {
-			throw new RuntimeException("Config object could not be written to Job Configuration: " + e);
 		}
 
 		// release all references again

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -217,8 +217,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		// ----------- finalize the job graph -----------
 		
 		// create the job graph object
-		JobGraph graph = new JobGraph(jobId, program.getJobName());
-
+		JobGraph graph = new JobGraph(jobId, program.getJobName(), program.getOriginalPlan().getExecutionConfig());
 		graph.setRestartStrategyConfiguration(program.getOriginalPlan().getRestartStrategyConfiguration());
 		graph.setAllowQueuedScheduling(false);
 		graph.setSessionTimeout(program.getOriginalPlan().getSessionTimeout());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor;
 
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
@@ -92,7 +93,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 			final FiniteDuration deadline = new FiniteDuration(60, TimeUnit.SECONDS);
 
 			// The JobGraph
-			final JobGraph jobGraph = new JobGraph();
+			final JobGraph jobGraph = new JobGraph(new ExecutionConfig());
 			final int parallelism = 4;
 
 			final JobVertex task = new JobVertex("Task");

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor;
 
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -76,7 +77,7 @@ public class StackTraceSampleCoordinatorITCase extends TestLogger {
 			final FiniteDuration deadline = new FiniteDuration(60, TimeUnit.SECONDS);
 
 			// The JobGraph
-			final JobGraph jobGraph = new JobGraph();
+			final JobGraph jobGraph = new JobGraph(new ExecutionConfig());
 			final int parallelism = 1;
 
 			final JobVertex task = new JobVertex("Task");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.deployment;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
@@ -88,6 +89,9 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 	private final SerializedValue<StateHandle<?>> operatorState;
 
+	/** The execution configuration (see {@link ExecutionConfig}) related to the specific job. */
+	private final ExecutionConfig executionConfig;
+
 	private long recoveryTimestamp;
 		
 	/**
@@ -95,9 +99,9 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	 */
 	public TaskDeploymentDescriptor(
 			JobID jobID, JobVertexID vertexID, ExecutionAttemptID executionId,
-			String taskName, int indexInSubtaskGroup, int numberOfSubtasks, int attemptNumber,
-			Configuration jobConfiguration, Configuration taskConfiguration, String invokableClassName,
-			List<ResultPartitionDeploymentDescriptor> producedPartitions,
+			ExecutionConfig executionConfig, String taskName, int indexInSubtaskGroup, int numberOfSubtasks,
+			int attemptNumber, Configuration jobConfiguration, Configuration taskConfiguration,
+			String invokableClassName, List<ResultPartitionDeploymentDescriptor> producedPartitions,
 			List<InputGateDeploymentDescriptor> inputGates,
 			List<BlobKey> requiredJarFiles, List<URL> requiredClasspaths,
 			int targetSlotNumber, SerializedValue<StateHandle<?>> operatorState,
@@ -111,6 +115,7 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		this.jobID = checkNotNull(jobID);
 		this.vertexID = checkNotNull(vertexID);
 		this.executionId = checkNotNull(executionId);
+		this.executionConfig = checkNotNull(executionConfig);
 		this.taskName = checkNotNull(taskName);
 		this.indexInSubtaskGroup = indexInSubtaskGroup;
 		this.numberOfSubtasks = numberOfSubtasks;
@@ -129,16 +134,23 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 	public TaskDeploymentDescriptor(
 			JobID jobID, JobVertexID vertexID, ExecutionAttemptID executionId,
-			String taskName, int indexInSubtaskGroup, int numberOfSubtasks, int attemptNumber,
-			Configuration jobConfiguration, Configuration taskConfiguration, String invokableClassName,
-			List<ResultPartitionDeploymentDescriptor> producedPartitions,
+			ExecutionConfig executionConfig, String taskName, int indexInSubtaskGroup, int numberOfSubtasks,
+			int attemptNumber, Configuration jobConfiguration, Configuration taskConfiguration,
+			String invokableClassName, List<ResultPartitionDeploymentDescriptor> producedPartitions,
 			List<InputGateDeploymentDescriptor> inputGates,
 			List<BlobKey> requiredJarFiles, List<URL> requiredClasspaths,
 			int targetSlotNumber) {
 
-		this(jobID, vertexID, executionId, taskName, indexInSubtaskGroup, numberOfSubtasks, attemptNumber,
-				jobConfiguration, taskConfiguration, invokableClassName, producedPartitions,
-				inputGates, requiredJarFiles, requiredClasspaths, targetSlotNumber, null, -1);
+		this(jobID, vertexID, executionId, executionConfig, taskName, indexInSubtaskGroup,
+				numberOfSubtasks, attemptNumber, jobConfiguration, taskConfiguration, invokableClassName,
+				producedPartitions, inputGates, requiredJarFiles, requiredClasspaths, targetSlotNumber, null, -1);
+	}
+
+	/**
+	 * Returns the execution configuration (see {@link ExecutionConfig}) related to the specific job.
+	 */
+	public ExecutionConfig getExecutionConfig() {
+		return executionConfig;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.execution;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
@@ -44,6 +45,13 @@ import java.util.concurrent.Future;
  * memory manager, I/O manager, ...
  */
 public interface Environment {
+
+	/**
+	 * Returns the job specific {@link ExecutionConfig}.
+	 *
+	 * @return The execution configuration associated with the current job.
+	 * */
+	ExecutionConfig getExecutionConfig();
 
 	/**
 	 * Returns the ID of the job that the task belongs to.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
@@ -665,10 +666,11 @@ public class ExecutionVertex implements Serializable {
 			consumedPartitions.add(new InputGateDeploymentDescriptor(resultId, queueToRequest, partitions));
 		}
 
+		ExecutionConfig config = getExecutionGraph().getExecutionConfig();
 		List<BlobKey> jarFiles = getExecutionGraph().getRequiredJarFiles();
 		List<URL> classpaths = getExecutionGraph().getRequiredClasspaths();
 
-		return new TaskDeploymentDescriptor(getJobId(), getJobvertexId(), executionId, getTaskName(),
+		return new TaskDeploymentDescriptor(getJobId(), getJobvertexId(), executionId, config, getTaskName(),
 				subTaskIndex, getTotalNumberOfParallelSubtasks(), attemptNumber, getExecutionGraph().getJobConfiguration(),
 				jobVertex.getJobVertex().getConfiguration(), jobVertex.getJobVertex().getInvokableClassName(),
 				producedPartitions, consumedPartitions, jarFiles, classpaths, targetSlot.getRoot().getSlotNumber(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobgraph;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
@@ -33,13 +34,14 @@ import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
+import java.util.Arrays;
 import java.util.Set;
+import java.util.LinkedHashSet;
+import java.util.Iterator;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 /**
@@ -81,7 +83,13 @@ public class JobGraph implements Serializable {
 
 	/** Configuration which defines which restart strategy to use for the job recovery */
 	private RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration;
-	
+
+	private final ExecutionConfig executionConfig;
+
+	/** The number of times that failed tasks should be re-executed */
+	private int numExecutionRetries;
+
+	private long executionRetryDelay;
 
 	/** The number of seconds after which the corresponding ExecutionGraph is removed at the
 	 * job manager after it has been executed. */
@@ -114,7 +122,20 @@ public class JobGraph implements Serializable {
 	 * @param jobName The name of the job
 	 */
 	public JobGraph(String jobName) {
-		this(null, jobName);
+		this(null, jobName, (ExecutionConfig) null);
+	}
+
+	public JobGraph(JobID jobID, String jobName) {
+		this(jobID, jobName, (ExecutionConfig) null);
+	}
+
+	/**
+	 * Constructs a new job graph with the given name, a random job ID.
+	 *
+	 * @param jobName The name of the job
+	 */
+	public JobGraph(String jobName, ExecutionConfig config) {
+		this(null, jobName, config);
 	}
 
 	/**
@@ -123,9 +144,22 @@ public class JobGraph implements Serializable {
 	 * @param jobId The id of the job. A random ID is generated, if {@code null} is passed.
 	 * @param jobName The name of the job.
 	 */
-	public JobGraph(JobID jobId, String jobName) {
+	public JobGraph(JobID jobId, String jobName, ExecutionConfig config) {
 		this.jobID = jobId == null ? new JobID() : jobId;
 		this.jobName = jobName == null ? "(unnamed job)" : jobName;
+		this.executionConfig = config;
+	}
+
+	public JobGraph(String jobName, JobVertex vertex) {
+		this(jobName, Collections.singletonList(vertex));
+	}
+
+	public JobGraph(String jobName, JobVertex vertex1, JobVertex vertex2) {
+		this(jobName, Arrays.asList(vertex1, vertex2));
+	}
+
+	public JobGraph(JobVertex vertex) {
+		this(null, Collections.singletonList(vertex));
 	}
 
 	/**
@@ -133,7 +167,7 @@ public class JobGraph implements Serializable {
 	 *
 	 * @param vertices The vertices to add to the graph.
 	 */
-	public JobGraph(JobVertex... vertices) {
+	public JobGraph(List<JobVertex> vertices) {
 		this(null, vertices);
 	}
 
@@ -143,7 +177,7 @@ public class JobGraph implements Serializable {
 	 * @param jobName The name of the job.
 	 * @param vertices The vertices to add to the graph.
 	 */
-	public JobGraph(String jobName, JobVertex... vertices) {
+	public JobGraph(String jobName, List<JobVertex> vertices) {
 		this(null, jobName, vertices);
 	}
 
@@ -154,8 +188,8 @@ public class JobGraph implements Serializable {
 	 * @param jobName The name of the job.
 	 * @param vertices The vertices to add to the graph.
 	 */
-	public JobGraph(JobID jobId, String jobName, JobVertex... vertices) {
-		this(jobId, jobName);
+	public  JobGraph(JobID jobId, String jobName, List<JobVertex> vertices) {
+		this(jobId, jobName, (ExecutionConfig) null);
 
 		for (JobVertex vertex : vertices) {
 			addVertex(vertex);
@@ -209,6 +243,57 @@ public class JobGraph implements Serializable {
 	 */
 	public RestartStrategies.RestartStrategyConfiguration getRestartStrategyConfiguration() {
 		return restartStrategyConfiguration;
+	}
+
+	/**
+	 * Sets the number of times that failed tasks are re-executed. A value of zero
+	 * effectively disables fault tolerance. A value of {@code -1} indicates that the system
+	 * default value (as defined in the configuration) should be used.
+	 *
+	 * @param numberOfExecutionRetries The number of times the system will try to re-execute failed tasks.
+	 */
+	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
+		if (numberOfExecutionRetries < -1) {
+			throw new IllegalArgumentException(
+					"The number of execution retries must be non-negative, or -1 (use system default)");
+		}
+		this.numExecutionRetries = numberOfExecutionRetries;
+	}
+
+	/**
+	 * Gets the number of times the system will try to re-execute failed tasks. A value
+	 * of {@code -1} indicates that the system default value (as defined in the configuration)
+	 * should be used.
+	 *
+	 * @return The number of times the system will try to re-execute failed tasks.
+	 */
+	public int getNumberOfExecutionRetries() {
+		return numExecutionRetries;
+	}
+
+	/**
+	 * Gets the delay of time the system will try to re-execute failed tasks. A value of
+	 * {@code -1} indicates the system default value (as defined in the configuration)
+	 * should be used.
+	 * @return The delay of time in milliseconds the system will try to re-execute failed tasks.
+	 */
+	public long getExecutionRetryDelay() {
+		return executionRetryDelay;
+	}
+
+	/**
+	 * Sets the delay that failed tasks are re-executed. A value of zero
+	 * effectively disables fault tolerance. A value of {@code -1} indicates that the system
+	 * default value (as defined in the configuration) should be used.
+	 *
+	 * @param executionRetryDelay The delay of time the system will wait to re-execute failed tasks.
+	 */
+	public void setExecutionRetryDelay(long executionRetryDelay){
+		if (executionRetryDelay < -1) {
+			throw new IllegalArgumentException(
+					"The delay between reties must be non-negative, or -1 (use system default)");
+		}
+		this.executionRetryDelay = executionRetryDelay;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.BatchTask;
-import org.apache.flink.util.InstantiationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,9 +40,6 @@ public abstract class AbstractInvokable {
 
 	/** The environment assigned to this invokable. */
 	private Environment environment;
-
-	/** The execution config, cached from the deserialization from the JobConfiguration */
-	private ExecutionConfig executionConfig;
 
 	/**
 	 * Starts the execution.
@@ -125,29 +121,10 @@ public abstract class AbstractInvokable {
 	}
 
 	/**
-	 * Returns the global ExecutionConfig, obtained from the job configuration.
+	 * Returns the global ExecutionConfig.
 	 */
 	public ExecutionConfig getExecutionConfig() {
-		if (executionConfig != null) {
-			return executionConfig;
-		}
-
-		try {
-			executionConfig = (ExecutionConfig) InstantiationUtil.readObjectFromConfig(
-					getJobConfiguration(),
-					ExecutionConfig.CONFIG_KEY,
-					getUserCodeClassLoader());
-
-			if (executionConfig == null) {
-				LOG.warn("Environment did not contain an ExecutionConfig - using a default config.");
-				executionConfig = new ExecutionConfig();
-			}
-			return executionConfig;
-		}
-		catch (Exception e) {
-			LOG.warn("Could not load ExecutionConfig from Environment, returning default ExecutionConfig", e);
-			return new ExecutionConfig();
-		}
+		return this.environment.getExecutionConfig();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -41,12 +41,9 @@ import org.apache.flink.runtime.operators.util.DistributedRuntimeUDFContext;
 import org.apache.flink.runtime.operators.util.ReaderIterator;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
-import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.MutableObjectIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
  * DataSinkTask which is executed by a task manager. The task hands the data to an output format.
@@ -112,21 +109,8 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 			LOG.debug(getLogString("Rich Sink detected. Initializing runtime context."));
 		}
 
-		ExecutionConfig executionConfig;
-		try {
-			ExecutionConfig c = InstantiationUtil.readObjectFromConfig(
-					getJobConfiguration(),
-					ExecutionConfig.CONFIG_KEY,
-					getUserCodeClassLoader());
-			if (c != null) {
-				executionConfig = c;
-			} else {
-				LOG.warn("The execution config returned by the configuration was null");
-				executionConfig = new ExecutionConfig();
-			}
-		} catch (IOException | ClassNotFoundException e) {
-			throw new RuntimeException("Could not load ExecutionConfig from Job Configuration: " + e);
-		}
+		ExecutionConfig executionConfig = getExecutionConfig();
+
 		boolean objectReuseEnabled = executionConfig.isObjectReuseEnabled();
 		
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -36,11 +36,9 @@ import org.apache.flink.runtime.operators.chaining.ExceptionInChainedStubExcepti
 import org.apache.flink.runtime.operators.util.DistributedRuntimeUDFContext;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.InstantiationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -104,21 +102,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 			LOG.debug(getLogString("Rich Source detected. Initializing runtime context."));
 		}
 
-		ExecutionConfig executionConfig;
-		try {
-			ExecutionConfig c = (ExecutionConfig) InstantiationUtil.readObjectFromConfig(
-					getJobConfiguration(),
-					ExecutionConfig.CONFIG_KEY,
-					getUserCodeClassLoader());
-			if (c != null) {
-				executionConfig = c;
-			} else {
-				LOG.warn("ExecutionConfig from job configuration is null. Creating empty config");
-				executionConfig = new ExecutionConfig();
-			}
-		} catch (IOException | ClassNotFoundException e) {
-			throw new RuntimeException("Could not load ExecutionConfig from Job Configuration: ", e);
-		}
+		ExecutionConfig executionConfig = getExecutionConfig();
 
 		boolean objectReuseEnabled = executionConfig.isObjectReuseEnabled();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
@@ -55,7 +56,8 @@ public class RuntimeEnvironment implements Environment {
 	
 	private final Configuration jobConfiguration;
 	private final Configuration taskConfiguration;
-	
+	private final ExecutionConfig executionConfig;
+
 	private final ClassLoader userCodeClassLoader;
 
 	private final MemoryManager memManager;
@@ -80,6 +82,7 @@ public class RuntimeEnvironment implements Environment {
 			JobID jobId,
 			JobVertexID jobVertexId,
 			ExecutionAttemptID executionId,
+			ExecutionConfig executionConfig,
 			TaskInfo taskInfo,
 			Configuration jobConfiguration,
 			Configuration taskConfiguration,
@@ -99,6 +102,7 @@ public class RuntimeEnvironment implements Environment {
 		this.jobVertexId = checkNotNull(jobVertexId);
 		this.executionId = checkNotNull(executionId);
 		this.taskInfo = checkNotNull(taskInfo);
+		this.executionConfig = checkNotNull(executionConfig);
 		this.jobConfiguration = checkNotNull(jobConfiguration);
 		this.taskConfiguration = checkNotNull(taskConfiguration);
 		this.userCodeClassLoader = checkNotNull(userCodeClassLoader);
@@ -115,6 +119,11 @@ public class RuntimeEnvironment implements Environment {
 	}
 
 	// ------------------------------------------------------------------------
+
+	@Override
+	public ExecutionConfig getExecutionConfig() {
+		return this.executionConfig;
+	}
 
 	@Override
 	public JobID getJobID() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.cache.DistributedCache;
@@ -217,6 +219,9 @@ public class Task implements Runnable {
 
 	private volatile long recoveryTs;
 
+	/** The job specific execution configuration (see {@link ExecutionConfig}). */
+	private final ExecutionConfig executionConfig;
+
 	/**
 	 * <p><b>IMPORTANT:</b> This constructor may not start any work that would need to
 	 * be undone in the case of a failing task deployment.</p>
@@ -245,6 +250,7 @@ public class Task implements Runnable {
 		this.nameOfInvokableClass = checkNotNull(tdd.getInvokableClassName());
 		this.operatorState = tdd.getOperatorState();
 		this.recoveryTs = tdd.getRecoveryTimestamp();
+		this.executionConfig = checkNotNull(tdd.getExecutionConfig());
 
 		this.memoryManager = checkNotNull(memManager);
 		this.ioManager = checkNotNull(ioManager);
@@ -493,8 +499,8 @@ public class Task implements Runnable {
 			TaskInputSplitProvider splitProvider = new TaskInputSplitProvider(jobManager,
 					jobId, vertexId, executionId, userCodeClassLoader, actorAskTimeout);
 
-			Environment env = new RuntimeEnvironment(jobId, vertexId, executionId, taskInfo,
-					jobConfiguration, taskConfiguration,
+			Environment env = new RuntimeEnvironment(jobId, vertexId, executionId,
+					executionConfig, taskInfo, jobConfiguration, taskConfiguration,
 					userCodeClassLoader, memoryManager, ioManager,
 					broadcastVariableManager, accumulatorRegistry,
 					splitProvider, distributedCacheEntries,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -944,7 +944,7 @@ class JobManager(
           throw new JobSubmissionException(jobId, "The given job is empty")
         }
 
-        val restartStrategy = Option(jobGraph.getRestartStrategyConfiguration())
+        val restartStrategy = Option(jobGraph.getExecutionConfig.getRestartStrategy())
           .map(RestartStrategyFactory.createRestartStrategy(_)) match {
             case Some(strategy) => strategy
             case None => defaultRestartStrategy
@@ -963,6 +963,7 @@ class JobManager(
               jobGraph.getJobID,
               jobGraph.getName,
               jobGraph.getJobConfiguration,
+              jobGraph.getExecutionConfig,
               timeout,
               restartStrategy,
               jobGraph.getUserJarBlobKeys,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
@@ -60,7 +61,7 @@ public class CoordinatorShutdownTest {
 			vertex.setInvokableClass(Tasks.NoOpInvokable.class);
 			List<JobVertexID> vertexIdList = Collections.singletonList(vertex.getID());
 			
-			JobGraph testGraph = new JobGraph("test job", vertex);
+			JobGraph testGraph = new JobGraph("test job", new ExecutionConfig(), vertex);
 			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList, 
 					5000, 60000, 0L, Integer.MAX_VALUE));
 			
@@ -112,7 +113,7 @@ public class CoordinatorShutdownTest {
 			vertex.setInvokableClass(Tasks.NoOpInvokable.class);
 			List<JobVertexID> vertexIdList = Collections.singletonList(vertex.getID());
 
-			JobGraph testGraph = new JobGraph("test job", vertex);
+			JobGraph testGraph = new JobGraph("test job", new ExecutionConfig(), vertex);
 			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList,
 					5000, 60000, 0L, Integer.MAX_VALUE));
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import akka.actor.ActorSystem;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -44,15 +45,16 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 	@Test
 	public void testCheckpointAndSavepointCoordinatorShareCheckpointIDCounter() throws Exception {
 		ExecutionGraph executionGraph = new ExecutionGraph(
-			TestingUtils.defaultExecutionContext(),
-			new JobID(),
-			"test",
-			new Configuration(),
-			new FiniteDuration(1, TimeUnit.DAYS),
-			new NoRestartStrategy(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList(),
-			ClassLoader.getSystemClassLoader());
+				TestingUtils.defaultExecutionContext(),
+				new JobID(),
+				"test",
+				new Configuration(),
+				new ExecutionConfig(),
+				new FiniteDuration(1, TimeUnit.DAYS),
+				new NoRestartStrategy(),
+				Collections.<BlobKey>emptyList(),
+				Collections.<URL>emptyList(),
+				ClassLoader.getSystemClassLoader());
 
 		ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.client;
 
 import akka.actor.PoisonPill;
 import org.apache.curator.test.TestingServer;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -94,7 +95,7 @@ public class JobClientActorRecoveryITCase extends TestLogger {
 		JobVertex blockingVertex = new JobVertex("Blocking Vertex");
 		blockingVertex.setInvokableClass(BlockingTask.class);
 		blockingVertex.setParallelism(1);
-		final JobGraph jobGraph = new JobGraph("Blocking Test Job", blockingVertex);
+		final JobGraph jobGraph = new JobGraph("Blocking Test Job", new ExecutionConfig(), blockingVertex);
 		final Promise<JobExecutionResult> promise = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 		Deadline deadline = new FiniteDuration(2, TimeUnit.MINUTES).fromNow();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
@@ -25,6 +25,7 @@ import akka.actor.Props;
 import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
 import akka.util.Timeout;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
@@ -47,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 public class JobClientActorTest extends TestLogger {
 
 	private static ActorSystem system;
-	private static JobGraph testJobGraph = new JobGraph("Test Job");
+	private static JobGraph testJobGraph = new JobGraph("Test Job", new ExecutionConfig());
 
 	@BeforeClass
 	public static void setup() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -54,10 +55,12 @@ public class TaskDeploymentDescriptorTest {
 			final List<InputGateDeploymentDescriptor> inputGates = new ArrayList<InputGateDeploymentDescriptor>(0);
 			final List<BlobKey> requiredJars = new ArrayList<BlobKey>(0);
 			final List<URL> requiredClasspaths = new ArrayList<URL>(0);
-	
-			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(jobID, vertexID, execId, taskName,
-				indexInSubtaskGroup, currentNumberOfSubtasks, attemptNumber, jobConfiguration, taskConfiguration,
-				invokableClass.getName(), producedResults, inputGates, requiredJars, requiredClasspaths, 47);
+			final ExecutionConfig executionConfig = new ExecutionConfig();
+
+			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(jobID, vertexID, execId,
+				executionConfig, taskName, indexInSubtaskGroup, currentNumberOfSubtasks, attemptNumber,
+				jobConfiguration, taskConfiguration, invokableClass.getName(), producedResults, inputGates,
+				requiredJars, requiredClasspaths, 47);
 	
 			final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
 	
@@ -75,6 +78,7 @@ public class TaskDeploymentDescriptorTest {
 			assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
 			assertEquals(orig.getProducedPartitions(), copy.getProducedPartitions());
 			assertEquals(orig.getInputGates(), copy.getInputGates());
+			assertEquals(orig.getExecutionConfig(), copy.getExecutionConfig());
 
 			assertEquals(orig.getRequiredJarFiles(), copy.getRequiredJarFiles());
 			assertEquals(orig.getRequiredClasspaths(), copy.getRequiredClasspaths());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -696,8 +696,9 @@ public class ExecutionGraphConstructionTest {
 			// isolated vertex
 			JobVertex v8 = new JobVertex("vertex8");
 			v8.setParallelism(2);
-			
-			JobGraph jg = new JobGraph(jobId, jobName, v1, v2, v3, v4, v5, v6, v7, v8);
+
+			List<JobVertex> vertices = Arrays.asList(v1, v2, v3, v4, v5, v6, v7, v8);
+			JobGraph jg = new JobGraph(jobId, jobName, vertices);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 				TestingUtils.defaultExecutionContext(), 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -106,6 +107,7 @@ public class ExecutionGraphConstructionTest {
 			jobId, 
 			jobName, 
 			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -149,7 +151,8 @@ public class ExecutionGraphConstructionTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -216,7 +219,8 @@ public class ExecutionGraphConstructionTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -470,7 +474,8 @@ public class ExecutionGraphConstructionTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -526,7 +531,8 @@ public class ExecutionGraphConstructionTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -587,7 +593,8 @@ public class ExecutionGraphConstructionTest {
 				TestingUtils.defaultExecutionContext(), 
 				jobId, 
 				jobName, 
-				cfg, 
+				cfg,
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy());
 			try {
@@ -632,7 +639,8 @@ public class ExecutionGraphConstructionTest {
 				TestingUtils.defaultExecutionContext(), 
 				jobId, 
 				jobName,
-				cfg, 
+				cfg,
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy());
 
@@ -697,14 +705,14 @@ public class ExecutionGraphConstructionTest {
 			JobVertex v8 = new JobVertex("vertex8");
 			v8.setParallelism(2);
 
-			List<JobVertex> vertices = Arrays.asList(v1, v2, v3, v4, v5, v6, v7, v8);
-			JobGraph jg = new JobGraph(jobId, jobName, vertices);
+			JobGraph jg = new JobGraph(jobId, jobName, new ExecutionConfig(), v1, v2, v3, v4, v5, v6, v7, v8);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 				TestingUtils.defaultExecutionContext(), 
 				jobId, 
 				jobName, 
-				cfg, 
+				cfg,
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy());
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -83,7 +84,8 @@ public class ExecutionGraphDeploymentTest {
 				TestingUtils.defaultExecutionContext(), 
 				jobId, 
 				"some job", 
-				new Configuration(), 
+				new Configuration(),
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy());
 
@@ -287,6 +289,7 @@ public class ExecutionGraphDeploymentTest {
 			jobId, 
 			"some job", 
 			new Configuration(),
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
@@ -72,13 +73,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		sender.setInvokableClass(Tasks.NoOpInvokable.class);
 		sender.setParallelism(NUM_TASKS);
 
-		JobGraph jobGraph = new JobGraph("Pointwise job", sender);
+		JobGraph jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender);
 
 		ExecutionGraph eg = new ExecutionGraph(
 				TestingUtils.defaultExecutionContext(),
 				new JobID(),
 				"test job",
 				new Configuration(),
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy());
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
@@ -127,14 +129,15 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		groupVertex.setStrictlyCoLocatedWith(groupVertex2);
 		
 		//initiate and schedule job
-		JobGraph jobGraph = new JobGraph("Pointwise job", groupVertex, groupVertex2);
+		JobGraph jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), groupVertex, groupVertex2);
 		ExecutionGraph eg = new ExecutionGraph(
 			TestingUtils.defaultExecutionContext(),
 			new JobID(),
 			"test job",
 			new Configuration(),
-				AkkaUtils.getDefaultTimeout(),
-				new FixedDelayRestartStrategy(1, 0L));
+			new ExecutionConfig(),
+			AkkaUtils.getDefaultTimeout(),
+			new FixedDelayRestartStrategy(1, 0L));
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
 		assertEquals(JobStatus.CREATED, eg.getState());
@@ -181,13 +184,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		sender.setInvokableClass(Tasks.NoOpInvokable.class);
 		sender.setParallelism(NUM_TASKS);
 
-		JobGraph jobGraph = new JobGraph("Pointwise job", sender);
+		JobGraph jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender);
 
 		ExecutionGraph eg = new ExecutionGraph(
 				TestingUtils.defaultExecutionContext(),
 				new JobID(),
 				"Test job",
 				new Configuration(),
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new FixedDelayRestartStrategy(1, 1000));
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
@@ -216,6 +220,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 				new JobID(),
 				"TestJob",
 				new Configuration(),
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				// We want to manually control the restart and delay
 				new FixedDelayRestartStrategy(Integer.MAX_VALUE, Long.MAX_VALUE));
@@ -224,7 +229,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		jobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
 		jobVertex.setParallelism(NUM_TASKS);
 
-		JobGraph jobGraph = new JobGraph("TestJob", jobVertex);
+		JobGraph jobGraph = new JobGraph("TestJob", new ExecutionConfig(), jobVertex);
 
 		executionGraph.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -274,6 +279,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 				new JobID(),
 				"TestJob",
 				new Configuration(),
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				// We want to manually control the restart and delay
 				new FixedDelayRestartStrategy(Integer.MAX_VALUE, Long.MAX_VALUE));
@@ -289,7 +295,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		jobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
 		jobVertex.setParallelism(NUM_TASKS);
 
-		JobGraph jobGraph = new JobGraph("TestJob", jobVertex);
+		JobGraph jobGraph = new JobGraph("TestJob", new ExecutionConfig(), jobVertex);
 
 		executionGraph.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -349,13 +355,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		sender.setInvokableClass(Tasks.NoOpInvokable.class);
 		sender.setParallelism(NUM_TASKS);
 
-		JobGraph jobGraph = new JobGraph("Pointwise job", sender);
+		JobGraph jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender);
 
 		ExecutionGraph eg = spy(new ExecutionGraph(
 			TestingUtils.defaultExecutionContext(),
 			new JobID(),
 			"Test job",
 			new Configuration(),
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new FixedDelayRestartStrategy(1, 1000)));
 
@@ -419,13 +426,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		receiver.setInvokableClass(Tasks.NoOpInvokable.class);
 		receiver.setParallelism(1);
 
-		JobGraph jobGraph = new JobGraph("Pointwise job", sender, receiver);
+		JobGraph jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender, receiver);
 
 		ExecutionGraph eg = new ExecutionGraph(
 			TestingUtils.defaultExecutionContext(),
 			new JobID(),
 			"test job",
 			new Configuration(),
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new FixedDelayRestartStrategy(1, 1000));
 
@@ -510,8 +518,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		vertex.setInvokableClass(Tasks.NoOpInvokable.class);
 		vertex.setParallelism(1);
 
-		JobGraph jobGraph = new JobGraph("Test Job", vertex);
-		jobGraph.setRestartStrategyConfiguration(RestartStrategies.fixedDelayRestart(
+		JobGraph jobGraph = new JobGraph("Test Job", new ExecutionConfig(), vertex);
+		jobGraph.getExecutionConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(
 				Integer.MAX_VALUE, Integer.MAX_VALUE));
 
 		ExecutionGraph eg = new ExecutionGraph(
@@ -519,6 +527,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 				new JobID(),
 				"test job",
 				new Configuration(),
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new FixedDelayRestartStrategy(1, 1000000));
 
@@ -561,8 +570,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		vertex.setInvokableClass(Tasks.NoOpInvokable.class);
 		vertex.setParallelism(1);
 
-		JobGraph jobGraph = new JobGraph("Test Job", vertex);
-		jobGraph.setRestartStrategyConfiguration(RestartStrategies.fixedDelayRestart(
+		JobGraph jobGraph = new JobGraph("Test Job", new ExecutionConfig(), vertex);
+		jobGraph.getExecutionConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(
 				Integer.MAX_VALUE, Integer.MAX_VALUE));
 
 		ExecutionGraph eg = new ExecutionGraph(
@@ -570,6 +579,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 				new JobID(),
 				"test job",
 				new Configuration(),
+				new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new FixedDelayRestartStrategy(1, 1000000));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSignalsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSignalsTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.StoppingException;
@@ -127,6 +128,7 @@ public class ExecutionGraphSignalsTest {
 			jobId,
 			jobName,
 			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		eg.attachJobGraph(ordered);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.spy;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -173,7 +174,8 @@ public class ExecutionGraphTestUtils {
 			executionContext, 
 			new JobID(), 
 			"test job", 
-			new Configuration(), 
+			new Configuration(),
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -52,7 +53,8 @@ public class ExecutionStateProgressTest {
 				TestingUtils.defaultExecutionContext(), 
 				jid, 
 				"test job", 
-				new Configuration(), 
+				new Configuration(),
+                new ExecutionConfig(),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy());
 			graph.attachJobGraph(Arrays.asList(ajv));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LocalInputSplitsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LocalInputSplitsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.StrictlyLocalAssignment;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.core.io.InputSplitSource;
@@ -264,13 +265,14 @@ public class LocalInputSplitsTest {
 			vertex.setInvokableClass(DummyInvokable.class);
 			vertex.setInputSplitSource(new TestInputSplitSource(splits));
 			
-			JobGraph jobGraph = new JobGraph("test job", vertex);
+			JobGraph jobGraph = new JobGraph("test job", new ExecutionConfig(), vertex);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 				TestingUtils.defaultExecutionContext(), 
 				jobGraph.getJobID(),
 				jobGraph.getName(),  
 				jobGraph.getJobConfiguration(),
+				new ExecutionConfig(),
 				TIMEOUT,
 				new NoRestartStrategy());
 			
@@ -328,13 +330,14 @@ public class LocalInputSplitsTest {
 		vertex.setInvokableClass(DummyInvokable.class);
 		vertex.setInputSplitSource(new TestInputSplitSource(splits));
 		
-		JobGraph jobGraph = new JobGraph("test job", vertex);
+		JobGraph jobGraph = new JobGraph("test job", new ExecutionConfig(), vertex);
 		
 		ExecutionGraph eg = new ExecutionGraph(
 			TestingUtils.defaultExecutionContext(),
 			jobGraph.getJobID(),
 			jobGraph.getName(),  
 			jobGraph.getJobConfiguration(),
+			new ExecutionConfig(),
 			TIMEOUT,
 			new NoRestartStrategy());
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -63,6 +64,7 @@ public class PointwisePatternTest {
 			jobId, 
 			jobName, 
 			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -103,7 +105,8 @@ public class PointwisePatternTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -145,7 +148,8 @@ public class PointwisePatternTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -188,7 +192,8 @@ public class PointwisePatternTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName,
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -229,7 +234,8 @@ public class PointwisePatternTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -290,7 +296,8 @@ public class PointwisePatternTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {
@@ -342,7 +349,8 @@ public class PointwisePatternTest {
 			TestingUtils.defaultExecutionContext(), 
 			jobId, 
 			jobName, 
-			cfg, 
+			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy());
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -185,6 +186,7 @@ public class TerminalStateDeadlockTest {
 				jobId,
 				"test graph",
 				EMPTY_CONFIG,
+				new ExecutionConfig(),
 				TIMEOUT,
 				new FixedDelayRestartStrategy(1, 0));
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
@@ -74,13 +75,14 @@ public class VertexLocationConstraintTest {
 			JobVertex jobVertex = new JobVertex("test vertex", new JobVertexID());
 			jobVertex.setInvokableClass(DummyInvokable.class);
 			jobVertex.setParallelism(2);
-			JobGraph jg = new JobGraph("test job", jobVertex);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), jobVertex);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 					TestingUtils.defaultExecutionContext(),
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
+					new ExecutionConfig(),
 					timeout,
 					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
@@ -146,13 +148,14 @@ public class VertexLocationConstraintTest {
 			JobVertex jobVertex = new JobVertex("test vertex", new JobVertexID());
 			jobVertex.setInvokableClass(DummyInvokable.class);
 			jobVertex.setParallelism(2);
-			JobGraph jg = new JobGraph("test job", jobVertex);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), jobVertex);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 					TestingUtils.defaultExecutionContext(),
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
+					new ExecutionConfig(),
 					timeout,
 					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
@@ -222,13 +225,14 @@ public class VertexLocationConstraintTest {
 			jobVertex1.setSlotSharingGroup(sharingGroup);
 			jobVertex2.setSlotSharingGroup(sharingGroup);
 			
-			JobGraph jg = new JobGraph("test job", jobVertex1, jobVertex2);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), jobVertex1, jobVertex2);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 					TestingUtils.defaultExecutionContext(),
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
+					new ExecutionConfig(),
 					timeout,
 					new NoRestartStrategy());
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
@@ -289,13 +293,14 @@ public class VertexLocationConstraintTest {
 			JobVertex jobVertex = new JobVertex("test vertex", new JobVertexID());
 			jobVertex.setInvokableClass(DummyInvokable.class);
 			jobVertex.setParallelism(1);
-			JobGraph jg = new JobGraph("test job", jobVertex);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), jobVertex);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 					TestingUtils.defaultExecutionContext(),
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
+					new ExecutionConfig(),
 					timeout,
 					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(jobVertex));
@@ -354,7 +359,7 @@ public class VertexLocationConstraintTest {
 			jobVertex1.setParallelism(1);
 			jobVertex2.setParallelism(1);
 			
-			JobGraph jg = new JobGraph("test job", jobVertex1, jobVertex2);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), jobVertex1, jobVertex2);
 			
 			SlotSharingGroup sharingGroup = new SlotSharingGroup();
 			jobVertex1.setSlotSharingGroup(sharingGroup);
@@ -365,6 +370,7 @@ public class VertexLocationConstraintTest {
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
+					new ExecutionConfig(),
 					timeout,
 					new NoRestartStrategy());
 			eg.attachJobGraph(Arrays.asList(jobVertex1, jobVertex2));
@@ -397,13 +403,14 @@ public class VertexLocationConstraintTest {
 	public void testArchivingClearsFields() {
 		try {
 			JobVertex vertex = new JobVertex("test vertex", new JobVertexID());
-			JobGraph jg = new JobGraph("test job", vertex);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), vertex);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 					TestingUtils.defaultExecutionContext(),
 					jg.getJobID(),
 					jg.getName(),
 					jg.getJobConfiguration(),
+					new ExecutionConfig(),
 					timeout,
 					new NoRestartStrategy());
 			eg.attachJobGraph(Collections.singletonList(vertex));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -75,6 +76,7 @@ public class VertexSlotSharingTest {
 					new JobID(),
 					"test job",
 					new Configuration(),
+					new ExecutionConfig(),
 					AkkaUtils.getDefaultTimeout(),
 					new NoRestartStrategy());
 			eg.attachJobGraph(vertices);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.api.reader.BufferReader;
@@ -89,7 +90,7 @@ public class PartialConsumePipelinedResultTest {
 				sender, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
 		final JobGraph jobGraph = new JobGraph(
-				"Partial Consume of Pipelined Result", sender, receiver);
+				"Partial Consume of Pipelined Result", new ExecutionConfig(), sender, receiver);
 
 		final SlotSharingGroup slotSharingGroup = new SlotSharingGroup(
 				sender.getID(), receiver.getID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobgraph;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.flink.api.common.InvalidProgramException;
@@ -89,8 +90,9 @@ public class JobGraphTest {
 			target2.connectNewDataSetAsInput(intermediate2, DistributionPattern.POINTWISE);
 			intermediate2.connectNewDataSetAsInput(intermediate1, DistributionPattern.POINTWISE);
 			intermediate1.connectNewDataSetAsInput(source2, DistributionPattern.POINTWISE);
-			
-			JobGraph graph = new JobGraph("TestGraph", source1, source2, intermediate1, intermediate2, target1, target2);
+
+			List<JobVertex> vertices = Arrays.asList(source1, source2, intermediate1, intermediate2, target1, target2);
+			JobGraph graph = new JobGraph("TestGraph", vertices);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
 			assertEquals(6, sorted.size());
@@ -133,8 +135,9 @@ public class JobGraphTest {
 			l12.connectNewDataSetAsInput(source2, DistributionPattern.POINTWISE);
 			
 			l13.connectNewDataSetAsInput(source2, DistributionPattern.POINTWISE);
-			
-			JobGraph graph = new JobGraph("TestGraph", source1, source2, root, l11, l13, l12, l2);
+
+			List<JobVertex> vertices = Arrays.asList(source1, source2, root, l11, l13, l12, l2);
+			JobGraph graph = new JobGraph("TestGraph", vertices);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
 			assertEquals(7,  sorted.size());
@@ -179,8 +182,9 @@ public class JobGraphTest {
 			op2.connectNewDataSetAsInput(op1, DistributionPattern.POINTWISE);
 			op2.connectNewDataSetAsInput(source, DistributionPattern.POINTWISE);
 			op3.connectNewDataSetAsInput(op2, DistributionPattern.POINTWISE);
-			
-			JobGraph graph = new JobGraph("TestGraph", source, op1, op2, op3);
+
+			List<JobVertex> vertices = Arrays.asList(source, op1, op2, op3);
+			JobGraph graph = new JobGraph("TestGraph", vertices);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
 			assertEquals(4,  sorted.size());
@@ -208,8 +212,9 @@ public class JobGraphTest {
 			v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 			v3.connectNewDataSetAsInput(v2, DistributionPattern.POINTWISE);
 			v4.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE);
-			
-			JobGraph jg = new JobGraph("Cyclic Graph", v1, v2, v3, v4);
+
+			List<JobVertex> vertices = Arrays.asList(v1, v2, v3, v4);
+			JobGraph jg = new JobGraph("Cyclic Graph", vertices);
 			try {
 				jg.getVerticesSortedTopologicallyFromSources();
 				fail("Failed to raise error on topologically sorting cyclic graph.");
@@ -240,8 +245,9 @@ public class JobGraphTest {
 			v3.connectNewDataSetAsInput(v2, DistributionPattern.POINTWISE);
 			v4.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE);
 			target.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE);
-			
-			JobGraph jg = new JobGraph("Cyclic Graph", v1, v2, v3, v4, source, target);
+
+			List<JobVertex> vertices = Arrays.asList(v1, v2, v3, v4, source, target);
+			JobGraph jg = new JobGraph("Cyclic Graph", vertices);
 			try {
 				jg.getVerticesSortedTopologicallyFromSources();
 				fail("Failed to raise error on topologically sorting cyclic graph.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.jobgraph;
 
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
 import java.util.List;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.junit.Test;
@@ -32,7 +32,7 @@ public class JobGraphTest {
 	@Test
 	public void testSerialization() {
 		try {
-			JobGraph jg = new JobGraph("The graph");
+			JobGraph jg = new JobGraph("The graph", new ExecutionConfig());
 			
 			// add some configuration values
 			{
@@ -91,8 +91,8 @@ public class JobGraphTest {
 			intermediate2.connectNewDataSetAsInput(intermediate1, DistributionPattern.POINTWISE);
 			intermediate1.connectNewDataSetAsInput(source2, DistributionPattern.POINTWISE);
 
-			List<JobVertex> vertices = Arrays.asList(source1, source2, intermediate1, intermediate2, target1, target2);
-			JobGraph graph = new JobGraph("TestGraph", vertices);
+			JobGraph graph = new JobGraph("TestGraph", new ExecutionConfig(),
+				source1, source2, intermediate1, intermediate2, target1, target2);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
 			assertEquals(6, sorted.size());
@@ -136,8 +136,8 @@ public class JobGraphTest {
 			
 			l13.connectNewDataSetAsInput(source2, DistributionPattern.POINTWISE);
 
-			List<JobVertex> vertices = Arrays.asList(source1, source2, root, l11, l13, l12, l2);
-			JobGraph graph = new JobGraph("TestGraph", vertices);
+			JobGraph graph = new JobGraph("TestGraph", new ExecutionConfig(),
+				source1, source2, root, l11, l13, l12, l2);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
 			assertEquals(7,  sorted.size());
@@ -183,8 +183,7 @@ public class JobGraphTest {
 			op2.connectNewDataSetAsInput(source, DistributionPattern.POINTWISE);
 			op3.connectNewDataSetAsInput(op2, DistributionPattern.POINTWISE);
 
-			List<JobVertex> vertices = Arrays.asList(source, op1, op2, op3);
-			JobGraph graph = new JobGraph("TestGraph", vertices);
+			JobGraph graph = new JobGraph("TestGraph", new ExecutionConfig(), source, op1, op2, op3);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
 			assertEquals(4,  sorted.size());
@@ -213,8 +212,7 @@ public class JobGraphTest {
 			v3.connectNewDataSetAsInput(v2, DistributionPattern.POINTWISE);
 			v4.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE);
 
-			List<JobVertex> vertices = Arrays.asList(v1, v2, v3, v4);
-			JobGraph jg = new JobGraph("Cyclic Graph", vertices);
+			JobGraph jg = new JobGraph("Cyclic Graph", new ExecutionConfig(), v1, v2, v3, v4);
 			try {
 				jg.getVerticesSortedTopologicallyFromSources();
 				fail("Failed to raise error on topologically sorting cyclic graph.");
@@ -246,8 +244,7 @@ public class JobGraphTest {
 			v4.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE);
 			target.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE);
 
-			List<JobVertex> vertices = Arrays.asList(v1, v2, v3, v4, source, target);
-			JobGraph jg = new JobGraph("Cyclic Graph", vertices);
+			JobGraph jg = new JobGraph("Cyclic Graph", new ExecutionConfig(), v1, v2, v3, v4, source, target);
 			try {
 				jg.getVerticesSortedTopologicallyFromSources();
 				fail("Failed to raise error on topologically sorting cyclic graph.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
@@ -29,7 +29,9 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -65,9 +67,10 @@ public class JsonGeneratorTest {
 			
 			sink1.connectNewDataSetAsInput(join2, DistributionPattern.POINTWISE);
 			sink2.connectNewDataSetAsInput(join1, DistributionPattern.ALL_TO_ALL);
-			
-			JobGraph jg = new JobGraph("my job", source1, source2, source3,
-					intermediate1, intermediate2, join1, join2, sink1, sink2);
+
+			List<JobVertex> vertices = Arrays.asList(source1, source2, source3,
+				intermediate1, intermediate2, join1, join2, sink1, sink2);
+			JobGraph jg = new JobGraph("my job", vertices);
 			
 			String plan = JsonPlanGenerator.generatePlan(jg);
 			assertNotNull(plan);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobgraph.jsonplan;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -29,9 +30,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -68,9 +67,8 @@ public class JsonGeneratorTest {
 			sink1.connectNewDataSetAsInput(join2, DistributionPattern.POINTWISE);
 			sink2.connectNewDataSetAsInput(join1, DistributionPattern.ALL_TO_ALL);
 
-			List<JobVertex> vertices = Arrays.asList(source1, source2, source3,
-				intermediate1, intermediate2, join1, join2, sink1, sink2);
-			JobGraph jg = new JobGraph("my job", vertices);
+			JobGraph jg = new JobGraph("my job", new ExecutionConfig(), source1, source2, source3,
+					intermediate1, intermediate2, join1, join2, sink1, sink2);
 			
 			String plan = JsonPlanGenerator.generatePlan(jg);
 			assertNotNull(plan);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -23,6 +23,7 @@ import akka.testkit.JavaTestKit;
 
 import com.typesafe.config.Config;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -122,7 +123,7 @@ public class JobManagerTest {
 				sender.setInvokableClass(Tasks.BlockingNoOpInvokable.class); // just block
 				sender.createAndAddResultDataSet(rid, PIPELINED);
 
-				final JobGraph jobGraph = new JobGraph("Blocking test job", sender);
+				final JobGraph jobGraph = new JobGraph("Blocking test job", new ExecutionConfig(), sender);
 				final JobID jid = jobGraph.getJobID();
 
 				final ActorGateway jobManagerGateway = cluster.getLeaderGateway(
@@ -246,7 +247,7 @@ public class JobManagerTest {
 				sender.setParallelism(2);
 				sender.setInvokableClass(StoppableInvokable.class);
 
-				final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", sender);
+				final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", new ExecutionConfig(), sender);
 				final JobID jid = jobGraph.getJobID();
 
 				final ActorGateway jobManagerGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
@@ -294,7 +295,7 @@ public class JobManagerTest {
 				sender.setParallelism(1);
 				sender.setInvokableClass(Tasks.BlockingNoOpInvokable.class); // just block
 
-				final JobGraph jobGraph = new JobGraph("Non-Stoppable batching test job", sender);
+				final JobGraph jobGraph = new JobGraph("Non-Stoppable batching test job", new ExecutionConfig(), sender);
 				final JobID jid = jobGraph.getJobID();
 
 				final ActorGateway jobManagerGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -105,7 +106,7 @@ public class JobSubmitTest {
 			// create a simple job graph
 			JobVertex jobVertex = new JobVertex("Test Vertex");
 			jobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
-			JobGraph jg = new JobGraph("test job", jobVertex);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), jobVertex);
 
 			// request the blob port from the job manager
 			Future<Object> future = jmGateway.ask(JobManagerMessages.getRequestBlobManagerPort(), timeout);
@@ -169,7 +170,7 @@ public class JobSubmitTest {
 			};
 
 			jobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
-			JobGraph jg = new JobGraph("test job", jobVertex);
+			JobGraph jg = new JobGraph("test job", new ExecutionConfig(), jobVertex);
 
 			// submit the job
 			Future<Object> submitFuture = jmGateway.ask(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmanager;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.io.network.api.reader.RecordReader;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
@@ -103,7 +104,7 @@ public class SlotCountExceedingParallelismTest {
 				DistributionPattern.ALL_TO_ALL,
 				ResultPartitionType.BLOCKING);
 
-		final JobGraph jobGraph = new JobGraph(jobName, sender, receiver);
+		final JobGraph jobGraph = new JobGraph(jobName, new ExecutionConfig(), sender, receiver);
 
 		// We need to allow queued scheduling, because there are not enough slots available
 		// to run all tasks at once. We queue tasks and then let them finish/consume the blocking

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmanager;
 
 import akka.actor.ActorRef;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -37,7 +38,7 @@ public class StandaloneSubmittedJobGraphStoreTest {
 		StandaloneSubmittedJobGraphStore jobGraphs = new StandaloneSubmittedJobGraphStore();
 
 		SubmittedJobGraph jobGraph = new SubmittedJobGraph(
-				new JobGraph("testNoOps"),
+				new JobGraph("testNoOps", new ExecutionConfig()),
 				new JobInfo(ActorRef.noSender(), ListeningBehaviour.DETACHED, 0, Integer.MAX_VALUE));
 
 		assertEquals(0, jobGraphs.recoverJobGraphs().size());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmanager;
 
 import akka.actor.ActorRef;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -260,7 +261,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 	// ---------------------------------------------------------------------------------------------
 
 	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId, long start) {
-		final JobGraph jobGraph = new JobGraph(jobId, "Test JobGraph");
+		final JobGraph jobGraph = new JobGraph(jobId, "Test JobGraph", new ExecutionConfig());
 
 		final JobVertex jobVertex = new JobVertex("Test JobVertex");
 		jobVertex.setParallelism(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager.scheduler;
 
 import com.google.common.collect.Lists;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -35,7 +36,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.flink.runtime.jobmanager.SlotCountExceedingParallelismTest.SubtaskIndexReceiver.CONFIG_KEY;
@@ -111,13 +111,12 @@ public class ScheduleOrUpdateConsumersTest {
 		pipelinedReceiver.setSlotSharingGroup(slotSharingGroup);
 		blockingReceiver.setSlotSharingGroup(slotSharingGroup);
 
-		List<JobVertex> vertices = Arrays.asList(sender,
-			pipelinedReceiver,
-			blockingReceiver);
-
 		final JobGraph jobGraph = new JobGraph(
 				"Mixed pipelined and blocking result",
-				vertices);
+				new ExecutionConfig(),
+				sender,
+				pipelinedReceiver,
+				blockingReceiver);
 
 		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -35,6 +35,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.flink.runtime.jobmanager.SlotCountExceedingParallelismTest.SubtaskIndexReceiver.CONFIG_KEY;
@@ -110,11 +111,13 @@ public class ScheduleOrUpdateConsumersTest {
 		pipelinedReceiver.setSlotSharingGroup(slotSharingGroup);
 		blockingReceiver.setSlotSharingGroup(slotSharingGroup);
 
+		List<JobVertex> vertices = Arrays.asList(sender,
+			pipelinedReceiver,
+			blockingReceiver);
+
 		final JobGraph jobGraph = new JobGraph(
 				"Mixed pipelined and blocking result",
-				sender,
-				pipelinedReceiver,
-				blockingReceiver);
+				vertices);
 
 		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeStateCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeStateCleanupTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.instance.ActorGateway;
@@ -268,6 +269,6 @@ public class LeaderChangeStateCleanupTest extends TestLogger {
 		sender.setSlotSharingGroup(slotSharingGroup);
 		receiver.setSlotSharingGroup(slotSharingGroup);
 
-		return new JobGraph("Blocking test job", sender, receiver);
+		return new JobGraph("Blocking test job", new ExecutionConfig(), sender, receiver);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Future;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
@@ -44,9 +45,15 @@ public class DummyEnvironment implements Environment {
 	private final TaskInfo taskInfo;
 	private final JobID jobId = new JobID();
 	private final JobVertexID jobVertexId = new JobVertexID();
+	private final ExecutionConfig executionConfig = new ExecutionConfig();
 
 	public DummyEnvironment(String taskName, int numSubTasks, int subTaskIndex) {
 		this.taskInfo = new TaskInfo(taskName, subTaskIndex, numSubTasks, 0);
+	}
+
+	@Override
+	public ExecutionConfig getExecutionConfig() {
+		return executionConfig;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.operators.testutils;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
@@ -64,7 +65,9 @@ import static org.mockito.Mockito.when;
 public class MockEnvironment implements Environment {
 	
 	private final TaskInfo taskInfo;
-	
+
+	private final ExecutionConfig executionConfig;
+
 	private final MemoryManager memManager;
 
 	private final IOManager ioManager;
@@ -96,6 +99,7 @@ public class MockEnvironment implements Environment {
 
 		this.memManager = new MemoryManager(memorySize, 1);
 		this.ioManager = new IOManagerAsync();
+		this.executionConfig = new ExecutionConfig();
 		this.inputSplitProvider = inputSplitProvider;
 		this.bufferSize = bufferSize;
 
@@ -183,6 +187,11 @@ public class MockEnvironment implements Environment {
 	@Override
 	public IOManager getIOManager() {
 		return this.ioManager;
+	}
+
+	@Override
+	public ExecutionConfig getExecutionConfig() {
+		return this.executionConfig;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
@@ -148,7 +149,7 @@ public class TaskAsyncCallTest {
 
 		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
 				new JobID(), new JobVertexID(), new ExecutionAttemptID(),
-				"Test Task", 0, 1, 0,
+				new ExecutionConfig(), "Test Task", 0, 1, 0,
 				new Configuration(), new Configuration(),
 				CheckpointsInOrderInvokable.class.getName(),
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -73,7 +74,7 @@ public class TaskCancelTest {
 			flink.start();
 
 			// Setup
-			final JobGraph jobGraph = new JobGraph("Cancel Big Union");
+			final JobGraph jobGraph = new JobGraph("Cancel Big Union", new ExecutionConfig());
 
 			JobVertex[] sources = new JobVertex[numberOfSources];
 			SlotSharingGroup group = new SlotSharingGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -23,6 +23,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.japi.Creator;
 import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -157,9 +158,11 @@ public class TaskManagerTest extends TestLogger {
 				final JobID jid = new JobID();
 				final JobVertexID vid = new JobVertexID();
 				final ExecutionAttemptID eid = new ExecutionAttemptID();
+				final ExecutionConfig executionConfig = new ExecutionConfig();
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(jid, vid, eid, "TestTask", 2, 7, 0,
-						new Configuration(), new Configuration(), TestInvokableCorrect.class.getName(),
+				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(jid, vid, eid, executionConfig,
+						"TestTask", 2, 7, 0, new Configuration(), new Configuration(),
+						TestInvokableCorrect.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
@@ -258,13 +261,15 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, vid1, eid1, "TestTask1", 1, 5, 0,
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, vid1, eid1,
+						new ExecutionConfig(), "TestTask1", 1, 5, 0,
 						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, vid2, eid2, "TestTask2", 2, 7, 0,
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, vid2, eid2,
+						new ExecutionConfig(), "TestTask2", 2, 7, 0,
 						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
@@ -390,14 +395,14 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, vid1, eid1, "TestTask1", 1, 5, 0,
-						new Configuration(), new Configuration(), StoppableInvokable.class.getName(),
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, vid1, eid1, new ExecutionConfig(),
+						"TestTask1", 1, 5, 0, new Configuration(), new Configuration(), StoppableInvokable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, vid2, eid2, "TestTask2", 2, 7, 0,
-						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, vid2, eid2, new ExecutionConfig(),
+						"TestTask2", 2, 7, 0, new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
@@ -516,13 +521,15 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1, "Sender", 0, 1, 0,
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1,
+						new ExecutionConfig(), "Sender", 0, 1, 0,
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2, "Receiver", 2, 7, 0,
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2,
+						new ExecutionConfig(), "Receiver", 2, 7, 0,
 						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
@@ -615,12 +622,14 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1, "Sender", 0, 1, 0,
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1,
+						new ExecutionConfig(), "Sender", 0, 1, 0,
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(), new ArrayList<BlobKey>(),
 						Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2, "Receiver", 2, 7, 0,
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2,
+						new ExecutionConfig(), "Receiver", 2, 7, 0,
 						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
@@ -754,12 +763,14 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1, "Sender", 0, 1, 0,
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1,
+						new ExecutionConfig(), "Sender", 0, 1, 0,
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2, "Receiver", 2, 7, 0,
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2,
+						new ExecutionConfig(), "Receiver", 2, 7, 0,
 						new Configuration(), new Configuration(), Tasks.BlockingReceiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
@@ -897,7 +908,8 @@ public class TaskManagerTest extends TestLogger {
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
 				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-						jid, vid, eid, "Receiver", 0, 1, 0,
+						jid, vid, eid,
+						new ExecutionConfig(), "Receiver", 0, 1, 0,
 						new Configuration(), new Configuration(),
 						Tasks.AgnosticReceiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
@@ -990,7 +1002,7 @@ public class TaskManagerTest extends TestLogger {
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
 				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-						jid, vid, eid, "Receiver", 0, 1, 0,
+						jid, vid, eid, new ExecutionConfig(), "Receiver", 0, 1, 0,
 						new Configuration(), new Configuration(),
 						Tasks.AgnosticReceiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
@@ -1066,6 +1078,7 @@ public class TaskManagerTest extends TestLogger {
 						new JobID(),
 						new JobVertexID(),
 						new ExecutionAttemptID(),
+						new ExecutionConfig(),
 						"Task",
 						0,
 						1,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.runtime.taskmanager;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
@@ -61,6 +62,7 @@ public class TaskStopTest {
 		when(tddMock.getExecutionId()).thenReturn(mock(ExecutionAttemptID.class));
 		when(tddMock.getJobConfiguration()).thenReturn(mock(Configuration.class));
 		when(tddMock.getTaskConfiguration()).thenReturn(mock(Configuration.class));
+		when(tddMock.getExecutionConfig()).thenReturn(mock(ExecutionConfig.class));
 		when(tddMock.getInvokableClassName()).thenReturn("className");
 
 		task = new Task(tddMock, mock(MemoryManager.class), mock(IOManager.class), mock(NetworkEnvironment.class),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 
 import com.google.common.collect.Maps;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -627,7 +628,7 @@ public class TaskTest {
 	private TaskDeploymentDescriptor createTaskDeploymentDescriptor(Class<? extends AbstractInvokable> invokable) {
 		return new TaskDeploymentDescriptor(
 				new JobID(), new JobVertexID(), new ExecutionAttemptID(),
-				"Test Task", 0, 1, 0,
+				new ExecutionConfig(), "Test Task", 0, 1, 0,
 				new Configuration(), new Configuration(),
 				invokable.getName(),
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph
 
-import org.apache.flink.api.common.JobID
+import org.apache.flink.api.common.{ExecutionConfig, JobID}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.SimpleActorGateway
@@ -50,13 +50,14 @@ class TaskManagerLossFailsTasksTest extends WordSpecLike with Matchers {
         sender.setInvokableClass(classOf[Tasks.NoOpInvokable])
         sender.setParallelism(20)
 
-        val jobGraph = new JobGraph("Pointwise job", sender)
+        val jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender)
 
         val eg = new ExecutionGraph(
           TestingUtils.defaultExecutionContext,
           new JobID(),
           "test job",
           new Configuration(),
+          new ExecutionConfig,
           AkkaUtils.getDefaultTimeout,
           new NoRestartStrategy())
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmanager
 import akka.actor.ActorSystem
 import akka.actor.Status.Success
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.jobgraph.{JobGraph, DistributionPattern, JobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks.{Receiver, Sender}
@@ -67,7 +68,7 @@ class CoLocationConstraintITCase(_system: ActorSystem)
 
       receiver.setStrictlyCoLocatedWith(sender)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -22,7 +22,7 @@ package org.apache.flink.runtime.jobmanager
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
-import org.apache.flink.api.common.JobID
+import org.apache.flink.api.common.{ExecutionConfig, JobID}
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.checkpoint.{CheckpointCoordinator, SavepointCoordinator}
 import org.apache.flink.runtime.client.JobExecutionException
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.{NoResourceAvailableExcepti
 import org.apache.flink.runtime.messages.JobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
+import org.apache.flink.runtime.testutils.JobManagerActorTestUtils
 import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.junit.JUnitRunner
@@ -42,8 +43,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Random
-
-import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class JobManagerITCase(_system: ActorSystem)
@@ -69,7 +68,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(2)
       vertex.setInvokableClass(classOf[BlockingNoOpInvokable])
 
-      val jobGraph = new JobGraph("Test Job", vertex)
+      val jobGraph = new JobGraph("Test Job", new ExecutionConfig(), vertex)
 
       val cluster = TestingUtils.startTestingCluster(1)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -111,7 +110,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(num_tasks)
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph = new JobGraph("Test Job", vertex)
+      val jobGraph = new JobGraph("Test Job", new ExecutionConfig(), vertex)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -146,7 +145,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(num_tasks)
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph = new JobGraph("Test job", vertex)
+      val jobGraph = new JobGraph("Test job", new ExecutionConfig(), vertex)
       jobGraph.setAllowQueuedScheduling(true)
 
       val cluster = TestingUtils.startTestingCluster(10)
@@ -182,7 +181,7 @@ class JobManagerITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(2 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -217,7 +216,7 @@ class JobManagerITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Bipartite Job", sender, receiver)
+      val jobGraph = new JobGraph("Bipartite Job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(2 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -254,8 +253,8 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender1, DistributionPattern.POINTWISE)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL)
 
-      val vertices = (List(sender1, receiver, sender2)).asJava
-      val jobGraph = new JobGraph("Bipartite Job", vertices)
+      val jobGraph = new JobGraph("Bipartite Job", new ExecutionConfig(),
+        sender1, receiver, sender2)
 
       val cluster = TestingUtils.startTestingCluster(6 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -300,8 +299,8 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender1, DistributionPattern.POINTWISE)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL)
 
-      val vertices = (List(sender1, receiver, sender2)).asJava
-      val jobGraph = new JobGraph("Bipartite Job", vertices)
+      val jobGraph = new JobGraph("Bipartite Job", new ExecutionConfig(),
+        sender1, receiver, sender2)
 
       val cluster = TestingUtils.startTestingCluster(6 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -343,8 +342,8 @@ class JobManagerITCase(_system: ActorSystem)
       forwarder.connectNewDataSetAsInput(sender, DistributionPattern.ALL_TO_ALL)
       receiver.connectNewDataSetAsInput(forwarder, DistributionPattern.ALL_TO_ALL)
 
-      val vertices = (List(sender, forwarder, receiver)).asJava
-      val jobGraph = new JobGraph("Forwarding Job", vertices)
+      val jobGraph = new JobGraph("Forwarding Job", new ExecutionConfig(),
+        sender, forwarder, receiver)
 
       jobGraph.setScheduleMode(ScheduleMode.ALL)
 
@@ -380,7 +379,7 @@ class JobManagerITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -428,7 +427,7 @@ class JobManagerITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -473,7 +472,7 @@ class JobManagerITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(2 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -513,7 +512,7 @@ class JobManagerITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -561,7 +560,7 @@ class JobManagerITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -604,7 +603,8 @@ class JobManagerITCase(_system: ActorSystem)
       source.setParallelism(num_tasks)
       sink.setParallelism(num_tasks)
 
-      val jobGraph = new JobGraph("SubtaskInFinalStateRaceCondition", source, sink)
+      val jobGraph = new JobGraph("SubtaskInFinalStateRaceCondition",
+        new ExecutionConfig(), source, sink)
 
       val cluster = TestingUtils.startTestingCluster(2*num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -630,12 +630,12 @@ class JobManagerITCase(_system: ActorSystem)
       val vertex = new JobVertex("Test Vertex")
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph1 = new JobGraph("Test Job", vertex)
+      val jobGraph1 = new JobGraph("Test Job", new ExecutionConfig(), vertex)
 
       val slowVertex = new WaitingOnFinalizeJobVertex("Long running Vertex", 2000)
       slowVertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph2 = new JobGraph("Long running Job", slowVertex)
+      val jobGraph2 = new JobGraph("Long running Job", new ExecutionConfig(), slowVertex)
 
       val cluster = TestingUtils.startTestingCluster(1)
       val jm = cluster.getLeaderGateway(1 seconds)
@@ -684,7 +684,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(1)
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph = new JobGraph("Test Job", vertex)
+      val jobGraph = new JobGraph("Test Job", new ExecutionConfig(), vertex)
 
       val cluster = TestingUtils.startTestingCluster(1)
       val jm = cluster.getLeaderGateway(1 seconds)
@@ -782,7 +782,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           val jobVertex = new JobVertex("Blocking vertex")
           jobVertex.setInvokableClass(classOf[BlockingNoOpInvokable])
-          val jobGraph = new JobGraph(jobVertex)
+          val jobGraph = new JobGraph(new ExecutionConfig(), jobVertex)
 
           // Submit job w/o checkpointing configured
           jobManager.tell(SubmitJob(jobGraph, ListeningBehaviour.DETACHED), testActor)
@@ -815,7 +815,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           val jobVertex = new JobVertex("Blocking vertex")
           jobVertex.setInvokableClass(classOf[BlockingNoOpInvokable])
-          val jobGraph = new JobGraph(jobVertex)
+          val jobGraph = new JobGraph(new ExecutionConfig(), jobVertex)
           jobGraph.setSnapshotSettings(new JobSnapshottingSettings(
             java.util.Collections.emptyList(),
             java.util.Collections.emptyList(),
@@ -868,7 +868,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           val jobVertex = new JobVertex("Blocking vertex")
           jobVertex.setInvokableClass(classOf[BlockingNoOpInvokable])
-          val jobGraph = new JobGraph(jobVertex)
+          val jobGraph = new JobGraph(new ExecutionConfig(), jobVertex)
           jobGraph.setSnapshotSettings(new JobSnapshottingSettings(
             java.util.Collections.emptyList(),
             java.util.Collections.emptyList(),
@@ -926,7 +926,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           val jobVertex = new JobVertex("Blocking vertex")
           jobVertex.setInvokableClass(classOf[BlockingNoOpInvokable])
-          val jobGraph = new JobGraph(jobVertex)
+          val jobGraph = new JobGraph(new ExecutionConfig(), jobVertex)
           jobGraph.setSnapshotSettings(new JobSnapshottingSettings(
             java.util.Collections.emptyList(),
             java.util.Collections.emptyList(),

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.{NoResourceAvailableExcepti
 import org.apache.flink.runtime.messages.JobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
-import org.apache.flink.runtime.testutils.JobManagerActorTestUtils
 import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.junit.JUnitRunner
@@ -43,6 +42,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Random
+
+import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class JobManagerITCase(_system: ActorSystem)
@@ -253,7 +254,8 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender1, DistributionPattern.POINTWISE)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL)
 
-      val jobGraph = new JobGraph("Bipartite Job", sender1, receiver, sender2)
+      val vertices = (List(sender1, receiver, sender2)).asJava
+      val jobGraph = new JobGraph("Bipartite Job", vertices)
 
       val cluster = TestingUtils.startTestingCluster(6 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -298,7 +300,8 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender1, DistributionPattern.POINTWISE)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL)
 
-      val jobGraph = new JobGraph("Bipartite Job", sender1, receiver, sender2)
+      val vertices = (List(sender1, receiver, sender2)).asJava
+      val jobGraph = new JobGraph("Bipartite Job", vertices)
 
       val cluster = TestingUtils.startTestingCluster(6 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -340,7 +343,8 @@ class JobManagerITCase(_system: ActorSystem)
       forwarder.connectNewDataSetAsInput(sender, DistributionPattern.ALL_TO_ALL)
       receiver.connectNewDataSetAsInput(forwarder, DistributionPattern.ALL_TO_ALL)
 
-      val jobGraph = new JobGraph("Forwarding Job", sender, forwarder, receiver)
+      val vertices = (List(sender, forwarder, receiver)).asJava
+      val jobGraph = new JobGraph("Forwarding Job", vertices)
 
       jobGraph.setScheduleMode(ScheduleMode.ALL)
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager
 
 import akka.actor.{PoisonPill, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.configuration.{ConfigConstants, Configuration}
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.jobgraph.{JobStatus, JobGraph, DistributionPattern, JobVertex}
@@ -82,7 +83,10 @@ class RecoveryITCase(_system: ActorSystem)
 
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val executionConfig = new ExecutionConfig()
+      executionConfig.setNumberOfExecutionRetries(1);
+
+      val jobGraph = new JobGraph("Pointwise job", executionConfig, sender, receiver)
 
       val cluster = createTestClusterWithHeartbeatTimeout(2 * NUM_TASKS, 1, "2 s")
       cluster.start()
@@ -126,7 +130,10 @@ class RecoveryITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val executionConfig = new ExecutionConfig()
+      executionConfig.setNumberOfExecutionRetries(1);
+
+      val jobGraph = new JobGraph("Pointwise job", executionConfig, sender, receiver)
 
       val cluster = createTestClusterWithHeartbeatTimeout(NUM_TASKS, 1, "2 s")
       cluster.start()
@@ -170,7 +177,10 @@ class RecoveryITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val executionConfig = new ExecutionConfig()
+      executionConfig.setNumberOfExecutionRetries(1);
+
+      val jobGraph = new JobGraph("Pointwise job", executionConfig, sender, receiver)
 
       val cluster = createTestClusterWithHeartbeatTimeout(NUM_TASKS, 2, "2 s")
       cluster.start()

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmanager
 
 import akka.actor.ActorSystem
-import akka.actor.Status.Success
 import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.jobgraph.{JobVertex, DistributionPattern, JobGraph}
@@ -31,6 +30,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import scala.concurrent.duration._
+import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class SlotSharingITCase(_system: ActorSystem)
@@ -109,7 +109,8 @@ class SlotSharingITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender1, DistributionPattern.POINTWISE)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL)
 
-      val jobGraph = new JobGraph("Bipartite job", sender1, sender2, receiver)
+      val vertices = (List(sender1, sender2, receiver)).asJava
+      val jobGraph = new JobGraph("Bipartite job", vertices)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
@@ -19,7 +19,9 @@
 package org.apache.flink.runtime.jobmanager
 
 import akka.actor.ActorSystem
+import akka.actor.Status.Success
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.jobgraph.{JobVertex, DistributionPattern, JobGraph}
 import org.apache.flink.runtime.jobmanager.Tasks.{Sender, AgnosticBinaryReceiver, Receiver}
@@ -30,7 +32,6 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class SlotSharingITCase(_system: ActorSystem)
@@ -65,7 +66,7 @@ class SlotSharingITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -109,8 +110,8 @@ class SlotSharingITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender1, DistributionPattern.POINTWISE)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL)
 
-      val vertices = (List(sender1, sender2, receiver)).asJava
-      val jobGraph = new JobGraph("Bipartite job", vertices)
+      val jobGraph = new JobGraph("Bipartite job", new ExecutionConfig(),
+        sender1, sender2, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager
 
 import akka.actor.{Kill, ActorSystem, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.client.JobExecutionException
 import org.apache.flink.runtime.jobgraph.{JobVertex, DistributionPattern, JobGraph}
@@ -28,7 +29,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup
 import org.apache.flink.runtime.messages.JobManagerMessages.{JobResultFailure, JobSubmitSuccess, SubmitJob}
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
-import org.apache.flink.runtime.util.SerializedThrowable
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -67,7 +67,7 @@ class TaskManagerFailsWithSlotSharingITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks/2, 2)
@@ -116,7 +116,7 @@ class TaskManagerFailsWithSlotSharingITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks/2, 2)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -24,7 +24,6 @@ import com.google.common.hash.Hashing;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.util.UserCodeObjectWrapper;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -52,12 +51,10 @@ import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationHead;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationTail;
-import org.apache.flink.util.InstantiationUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -112,7 +109,7 @@ public class StreamingJobGraphGenerator {
 	}
 
 	public JobGraph createJobGraph() {
-		jobGraph = new JobGraph(streamGraph.getJobName());
+		jobGraph = new JobGraph(streamGraph.getJobName(), streamGraph.getExecutionConfig());
 
 		// make sure that all vertices start immediately
 		jobGraph.setScheduleMode(ScheduleMode.ALL);
@@ -133,12 +130,6 @@ public class StreamingJobGraphGenerator {
 
 		configureRestartStrategy();
 
-		try {
-			InstantiationUtil.writeObjectToConfig(this.streamGraph.getExecutionConfig(), this.jobGraph.getJobConfiguration(), ExecutionConfig.CONFIG_KEY);
-		} catch (IOException e) {
-			throw new RuntimeException("Config object could not be written to Job Configuration: ", e);
-		}
-		
 		return jobGraph;
 	}
 
@@ -494,7 +485,8 @@ public class StreamingJobGraphGenerator {
 	}
 
 	private void configureRestartStrategy() {
-		jobGraph.setRestartStrategyConfiguration(streamGraph.getExecutionConfig().getRestartStrategy());
+		jobGraph.getExecutionConfig().setRestartStrategy(
+			streamGraph.getExecutionConfig().getRestartStrategy());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -327,7 +327,7 @@ public class StreamingJobGraphGenerator {
 		config.setChainedOutputs(chainableOutputs);
 
 		config.setTimeCharacteristic(streamGraph.getEnvironment().getStreamTimeCharacteristic());
-		
+
 		final CheckpointConfig ceckpointCfg = streamGraph.getCheckpointConfig();
 		
 		config.setStateBackend(streamGraph.getStateBackend());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/RestartStrategyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/RestartStrategyTest.java
@@ -42,7 +42,7 @@ public class RestartStrategyTest {
 		StreamGraph graph = env.getStreamGraph();
 		JobGraph jobGraph = graph.getJobGraph();
 
-		RestartStrategies.RestartStrategyConfiguration restartStrategy = jobGraph.getRestartStrategyConfiguration();
+		RestartStrategies.RestartStrategyConfiguration restartStrategy = jobGraph.getExecutionConfig().getRestartStrategy();
 
 		Assert.assertNotNull(restartStrategy);
 		Assert.assertTrue(restartStrategy instanceof RestartStrategies.FixedDelayRestartStrategyConfiguration);
@@ -64,7 +64,7 @@ public class RestartStrategyTest {
 		StreamGraph graph = env.getStreamGraph();
 		JobGraph jobGraph = graph.getJobGraph();
 
-		RestartStrategies.RestartStrategyConfiguration restartStrategy = jobGraph.getRestartStrategyConfiguration();
+		RestartStrategies.RestartStrategyConfiguration restartStrategy = jobGraph.getExecutionConfig().getRestartStrategy();
 
 		Assert.assertNotNull(restartStrategy);
 		Assert.assertTrue(restartStrategy instanceof RestartStrategies.NoRestartStrategyConfiguration);
@@ -86,7 +86,7 @@ public class RestartStrategyTest {
 		StreamGraph graph = env.getStreamGraph();
 		JobGraph jobGraph = graph.getJobGraph();
 
-		RestartStrategies.RestartStrategyConfiguration restartStrategy = jobGraph.getRestartStrategyConfiguration();
+		RestartStrategies.RestartStrategyConfiguration restartStrategy = jobGraph.getExecutionConfig().getRestartStrategy();
 
 		Assert.assertNotNull(restartStrategy);
 		Assert.assertTrue(restartStrategy instanceof RestartStrategies.FixedDelayRestartStrategyConfiguration);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -44,10 +44,10 @@ public class StreamingJobGraphGeneratorTest {
 
 		StreamGraph streamingJob = new StreamGraph(env);
 		StreamingJobGraphGenerator compiler = new StreamingJobGraphGenerator(streamingJob);
-		
+
 		boolean closureCleanerEnabled = r.nextBoolean(), forceAvroEnabled = r.nextBoolean(), forceKryoEnabled = r.nextBoolean(), objectReuseEnabled = r.nextBoolean(), sysoutLoggingEnabled = r.nextBoolean();
 		int dop = 1 + r.nextInt(10);
-		
+
 		ExecutionConfig config = streamingJob.getExecutionConfig();
 		if(closureCleanerEnabled) {
 			config.enableClosureCleaner();
@@ -75,16 +75,22 @@ public class StreamingJobGraphGeneratorTest {
 			config.disableSysoutLogging();
 		}
 		config.setParallelism(dop);
-		
+
 		JobGraph jobGraph = compiler.createJobGraph();
-		
+
+		final String EXEC_CONFIG_KEY = "runtime.config";
+
+		InstantiationUtil.writeObjectToConfig(jobGraph.getExecutionConfig(),
+			jobGraph.getJobConfiguration(),
+			EXEC_CONFIG_KEY);
+
 		ExecutionConfig executionConfig = InstantiationUtil.readObjectFromConfig(
 				jobGraph.getJobConfiguration(),
-				ExecutionConfig.CONFIG_KEY,
+				EXEC_CONFIG_KEY,
 				Thread.currentThread().getContextClassLoader());
-		
+
 		assertNotNull(executionConfig);
-		
+
 		assertEquals(closureCleanerEnabled, executionConfig.isClosureCleanerEnabled());
 		assertEquals(forceAvroEnabled, executionConfig.isForceAvroEnabled());
 		assertEquals(forceKryoEnabled, executionConfig.isForceKryoEnabled());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.partitioner;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple;
@@ -134,6 +135,7 @@ public class RescalePartitionerTest extends TestLogger {
 			jobId,
 			jobName,
 			cfg,
+			new ExecutionConfig(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
 			new ArrayList<BlobKey>(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -90,8 +91,10 @@ public class StreamMockEnvironment implements Environment {
 
 	private final int bufferSize;
 
-	public StreamMockEnvironment(Configuration jobConfig, Configuration taskConfig, long memorySize,
-									MockInputSplitProvider inputSplitProvider, int bufferSize) {
+	private final ExecutionConfig executionConfig;
+
+	public StreamMockEnvironment(Configuration jobConfig, Configuration taskConfig, ExecutionConfig executionConfig,
+									long memorySize, MockInputSplitProvider inputSplitProvider, int bufferSize) {
 		this.taskInfo = new TaskInfo("", 0, 1, 0);
 		this.jobConfiguration = jobConfig;
 		this.taskConfiguration = taskConfig;
@@ -103,7 +106,13 @@ public class StreamMockEnvironment implements Environment {
 		this.inputSplitProvider = inputSplitProvider;
 		this.bufferSize = bufferSize;
 
+		this.executionConfig = executionConfig;
 		this.accumulatorRegistry = new AccumulatorRegistry(jobID, getExecutionId());
+	}
+
+	public StreamMockEnvironment(Configuration jobConfig, Configuration taskConfig, long memorySize,
+								 MockInputSplitProvider inputSplitProvider, int bufferSize) {
+		this(jobConfig, taskConfig, null, memorySize, inputSplitProvider, bufferSize);
 	}
 
 	public void addInputGate(InputGate gate) {
@@ -203,6 +212,11 @@ public class StreamMockEnvironment implements Environment {
 	@Override
 	public IOManager getIOManager() {
 		return this.ioManager;
+	}
+
+	@Override
+	public ExecutionConfig getExecutionConfig() {
+		return this.executionConfig;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskAsyncCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskAsyncCheckpointTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
@@ -75,6 +76,11 @@ public class StreamTaskAsyncCheckpointTest {
 			testHarness.memorySize,
 			new MockInputSplitProvider(),
 			testHarness.bufferSize) {
+
+			@Override
+			public ExecutionConfig getExecutionConfig() {
+				return testHarness.executionConfig;
+			}
 
 			@Override
 			public void acknowledgeCheckpoint(long checkpointId) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import akka.actor.ActorRef;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
@@ -134,7 +135,7 @@ public class StreamTaskTest {
 
 		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
 				new JobID(), new JobVertexID(), new ExecutionAttemptID(),
-				"Test Task", 0, 1, 0,
+				new ExecutionConfig(), "Test Task", 0, 1, 0,
 				new Configuration(),
 				taskConfig.getConfiguration(),
 				invokable.getName(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -37,7 +37,6 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.MultiplexingStreamRecordSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
-import org.apache.flink.util.InstantiationUtil;
 import org.junit.Assert;
 
 import java.io.IOException;
@@ -104,12 +103,6 @@ public class StreamTaskTestHarness<OUT> {
 		this.jobConfig = new Configuration();
 		this.taskConfig = new Configuration();
 		this.executionConfig = new ExecutionConfig();
-		
-		try {
-			InstantiationUtil.writeObjectToConfig(executionConfig, this.jobConfig, ExecutionConfig.CONFIG_KEY);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
 
 		streamConfig = new StreamConfig(taskConfig);
 		streamConfig.setChainStart();
@@ -156,7 +149,8 @@ public class StreamTaskTestHarness<OUT> {
 	 * Task thread to finish running.
 	 */
 	public void invoke() throws Exception {
-		mockEnv = new StreamMockEnvironment(jobConfig, taskConfig, memorySize, new MockInputSplitProvider(), bufferSize);
+		mockEnv = new StreamMockEnvironment(jobConfig, taskConfig, executionConfig,
+			memorySize, new MockInputSplitProvider(), bufferSize);
 		task.setEnvironment(mockEnv);
 
 		initializeInputs();

--- a/flink-tests/src/test/java/org/apache/flink/test/failingPrograms/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/failingPrograms/JobSubmissionFailsITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.failingPrograms;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -64,7 +65,7 @@ public class JobSubmissionFailsITCase {
 			
 			final JobVertex jobVertex = new JobVertex("Working job vertex.");
 			jobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
-			workingJobGraph = new JobGraph("Working testing job", jobVertex);
+			workingJobGraph = new JobGraph("Working testing job", new ExecutionConfig(), jobVertex);
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -115,7 +116,7 @@ public class JobSubmissionFailsITCase {
 			final JobVertex failingJobVertex = new FailingJobVertex("Failing job vertex");
 			failingJobVertex.setInvokableClass(Tasks.NoOpInvokable.class);
 
-			final JobGraph failingJobGraph = new JobGraph("Failing testing job", failingJobVertex);
+			final JobGraph failingJobGraph = new JobGraph("Failing testing job", new ExecutionConfig(), failingJobVertex);
 
 			try {
 				submitJob(failingJobGraph);
@@ -140,7 +141,7 @@ public class JobSubmissionFailsITCase {
 	@Test
 	public void testSubmitEmptyJobGraph() {
 		try {
-			final JobGraph jobGraph = new JobGraph("Testing job");
+			final JobGraph jobGraph = new JobGraph("Testing job", new ExecutionConfig());
 	
 			try {
 				submitJob(jobGraph);

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/MapITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/MapITCase.java
@@ -68,6 +68,39 @@ public class MapITCase extends MultipleProgramsTestBase {
 		compareResultAsText(result, expected);
 	}
 
+	@Test
+	public void testRuntimeContextAndExecutionConfigParams() throws Exception {
+		/*
+		 * Test identity map with basic type
+		 */
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().setNumberOfExecutionRetries(1000);
+
+		DataSet<String> ds = CollectionDataSets.getStringDataSet(env);
+		DataSet<String> identityMapDs = ds.
+			map(new RichMapFunction<String, String>() {
+				@Override
+				public String map(String value) throws Exception {
+					Assert.assertTrue(1000 == getRuntimeContext().getExecutionConfig().getNumberOfExecutionRetries());
+					return value;
+				}
+			});
+
+		List<String> result = identityMapDs.collect();
+
+		String expected = "Hi\n" +
+			"Hello\n" +
+			"Hello world\n" +
+			"Hello world, how are you?\n" +
+			"I am fine.\n" +
+			"Luke Skywalker\n" +
+			"Random comment\n" +
+			"LOL\n";
+
+		compareResultAsText(result, expected);
+	}
+
 	public static class Mapper1 implements MapFunction<String, String> {
 		private static final long serialVersionUID = 1L;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.recovery;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -366,7 +367,7 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 			// BLocking JobGraph
 			JobVertex blockingVertex = new JobVertex("Blocking vertex");
 			blockingVertex.setInvokableClass(Tasks.BlockingNoOpInvokable.class);
-			JobGraph jobGraph = new JobGraph(blockingVertex);
+			JobGraph jobGraph = new JobGraph(new ExecutionConfig(), blockingVertex);
 
 			// Submit the job in detached mode
 			leader.tell(new SubmitJob(jobGraph, ListeningBehaviour.DETACHED));

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAJobGraphRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAJobGraphRecoveryITCase.java
@@ -25,6 +25,7 @@ import akka.actor.UntypedActor;
 import akka.testkit.TestActorRef;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -428,7 +429,7 @@ public class JobManagerHAJobGraphRecoveryITCase extends TestLogger {
 	 * Creates a simple blocking JobGraph.
 	 */
 	private static JobGraph createBlockingJobGraph() {
-		JobGraph jobGraph = new JobGraph("Blocking program");
+		JobGraph jobGraph = new JobGraph("Blocking program", new ExecutionConfig());
 
 		JobVertex jobVertex = new JobVertex("Blocking Vertex");
 		jobVertex.setInvokableClass(Tasks.BlockingNoOpInvokable.class);

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.runtime;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
@@ -96,7 +97,7 @@ public class NetworkStackThroughputITCase {
 
 		private JobGraph createJobGraph(int dataVolumeGb, boolean useForwarder, boolean isSlowSender,
 										boolean isSlowReceiver, int numSubtasks) {
-			JobGraph jobGraph = new JobGraph("Speed Test");
+			JobGraph jobGraph = new JobGraph("Speed Test", new ExecutionConfig());
 			SlotSharingGroup sharingGroup = new SlotSharingGroup();
 
 			JobVertex producer = new JobVertex("Speed Test Producer");

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -22,6 +22,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Kill;
 import akka.actor.PoisonPill;
 import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -167,7 +168,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 		sender.setSlotSharingGroup(slotSharingGroup);
 		receiver.setSlotSharingGroup(slotSharingGroup);
 
-		final JobGraph graph = new JobGraph("Blocking test job", sender, receiver);
+		final JobGraph graph = new JobGraph("Blocking test job", new ExecutionConfig(), sender, receiver);
 
 		final ForkableFlinkMiniCluster cluster = new ForkableFlinkMiniCluster(configuration);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/web/WebFrontendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/web/WebFrontendITCase.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import org.apache.commons.io.FileUtils;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -178,7 +179,7 @@ public class WebFrontendITCase extends MultipleProgramsTestBase {
 		sender.setParallelism(2);
 		sender.setInvokableClass(StoppableInvokable.class);
 
-		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", sender);
+		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", new ExecutionConfig(), sender);
 		final JobID jid = jobGraph.getJobID();
 
 		cluster.submitJobDetached(jobGraph);
@@ -206,7 +207,7 @@ public class WebFrontendITCase extends MultipleProgramsTestBase {
 		sender.setParallelism(2);
 		sender.setInvokableClass(StoppableInvokable.class);
 
-		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", sender);
+		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", new ExecutionConfig(), sender);
 		final JobID jid = jobGraph.getJobID();
 
 		cluster.submitJobDetached(jobGraph);

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -21,6 +21,7 @@ package org.apache.flink.api.scala.runtime.jobmanager
 import akka.actor.{ActorSystem, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.flink.configuration.{ConfigConstants, Configuration}
+import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.runtime.akka.{AkkaUtils, ListeningBehaviour}
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks.{BlockingNoOpInvokable, NoOpInvokable}
@@ -93,12 +94,12 @@ class JobManagerFailsITCase(_system: ActorSystem)
       val sender = new JobVertex("BlockingSender")
       sender.setParallelism(num_slots)
       sender.setInvokableClass(classOf[BlockingNoOpInvokable])
-      val jobGraph = new JobGraph("Blocking Testjob", sender)
+      val jobGraph = new JobGraph("Blocking Testjob", new ExecutionConfig(), sender)
 
       val noOp = new JobVertex("NoOpInvokable")
       noOp.setParallelism(num_slots)
       noOp.setInvokableClass(classOf[NoOpInvokable])
-      val jobGraph2 = new JobGraph("NoOp Testjob", noOp)
+      val jobGraph2 = new JobGraph("NoOp Testjob", new ExecutionConfig(), noOp)
 
       val cluster = startDeathwatchCluster(num_slots / 2, 2)
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerLeaderSessionIDITSuite.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerLeaderSessionIDITSuite.scala
@@ -23,6 +23,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.actor.Status.Success
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.runtime.akka.{ListeningBehaviour, AkkaUtils}
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobVertex}
@@ -64,7 +65,7 @@ class JobManagerLeaderSessionIDITSuite(_system: ActorSystem)
     val sender = new JobVertex("BlockingSender");
     sender.setParallelism(numSlots)
     sender.setInvokableClass(classOf[BlockingUntilSignalNoOpInvokable])
-    val jobGraph = new JobGraph("TestJob", sender)
+    val jobGraph = new JobGraph("TestJob", new ExecutionConfig(), sender)
 
     val oldSessionID = UUID.randomUUID()
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
@@ -18,9 +18,9 @@
 
 package org.apache.flink.api.scala.runtime.taskmanager
 
-import akka.actor.Status.{Failure, Success}
 import akka.actor.{ActorSystem, Kill, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.flink.api.common.ExecutionConfig
 
 import org.apache.flink.configuration.ConfigConstants
 import org.apache.flink.configuration.Configuration
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.messages.TaskManagerMessages.{RegisteredAtJobMan
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
 import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingUtils}
-import org.apache.flink.runtime.util.SerializedThrowable
 import org.apache.flink.test.util.ForkableFlinkMiniCluster
 
 import org.junit.runner.RunWith
@@ -100,7 +99,7 @@ class TaskManagerFailsITCase(_system: ActorSystem)
       receiver.setParallelism(num_tasks)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = ForkableFlinkMiniCluster.startCluster(num_tasks, 2)
@@ -152,7 +151,7 @@ class TaskManagerFailsITCase(_system: ActorSystem)
       receiver.setParallelism(num_tasks)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", new ExecutionConfig(), sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = ForkableFlinkMiniCluster.startCluster(num_tasks, 2)
@@ -191,12 +190,12 @@ class TaskManagerFailsITCase(_system: ActorSystem)
       val sender = new JobVertex("BlockingSender")
       sender.setParallelism(num_slots)
       sender.setInvokableClass(classOf[BlockingNoOpInvokable])
-      val jobGraph = new JobGraph("Blocking Testjob", sender)
+      val jobGraph = new JobGraph("Blocking Testjob", new ExecutionConfig(), sender)
 
       val noOp = new JobVertex("NoOpInvokable")
       noOp.setParallelism(num_slots)
       noOp.setInvokableClass(classOf[NoOpInvokable])
-      val jobGraph2 = new JobGraph("NoOp Testjob", noOp)
+      val jobGraph2 = new JobGraph("NoOp Testjob", new ExecutionConfig(), noOp)
 
       val cluster = createDeathwatchCluster(num_slots/2, 2)
 


### PR DESCRIPTION
This makes the ExecutionConfig available to the Task. In a nutshell, the ExecutionConfig is attached to the JobGraph which is sent to the JobManager. The JobManager passes it to the ExecutionGraph, and, later on, to the TaskDeploymentDescriptor, and the TaskManager puts it into the Environment, which is visible to the AbstractInvocable.