### PR TITLE
[FLINK-3234] [dataSet] Add KeySelector support to sortPartition operation.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1379,7 +1379,11 @@ public abstract class DataSet<T> {
 
 	/**
 	 * Locally sorts the partitions of the DataSet on the an extracted key in the specified order.
-	 * DataSet can be sorted on multiple values by returning a tuple.
+	 * DataSet can be sorted on multiple values by returning a tuple from the KeySelector.
+	 *
+	 * Note that any key extraction methods cannot be chained with the KeySelector. To sort the
+	 * partition by multiple values using KeySelector, the KeySelector must return a tuple
+	 * consisting of the values.
 	 *
 	 * @param keyExtractor The KeySelector function which extracts the key values from the DataSet
 	 *                     on which the DataSet is sorted.

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1377,6 +1377,20 @@ public abstract class DataSet<T> {
 		return new SortPartitionOperator<>(this, field, order, Utils.getCallLocationName());
 	}
 
+	/**
+	 * Locally sorts the partitions of the DataSet on the specified field in the specified order.
+	 * DataSet can be sorted on multiple fields by chaining sortPartition() calls.
+	 *
+	 * @param keyExtractor The KeySelector function which extracts the key values from the DataSet
+	 *                     on which the DataSet is sorted.
+	 * @param order The order in which the DataSet is sorted.
+	 * @return The DataSet with sorted local partitions.
+	 */
+	public <K> SortPartitionOperator<T> sortPartition(KeySelector<T, K> keyExtractor, Order order) {
+		final TypeInformation<K> keyType = TypeExtractor.getKeySelectorTypes(keyExtractor, getType());
+		return new SortPartitionOperator<>(this, new Keys.SelectorFunctionKeys<>(clean(keyExtractor), getType(), keyType), order, Utils.getCallLocationName());
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Top-K
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1378,11 +1378,11 @@ public abstract class DataSet<T> {
 	}
 
 	/**
-	 * Locally sorts the partitions of the DataSet on the an extracted key in the specified order.
-	 * DataSet can be sorted on multiple values by returning a tuple from the KeySelector.
+	 * Locally sorts the partitions of the DataSet on the extracted key in the specified order.
+	 * The DataSet can be sorted on multiple values by returning a tuple from the KeySelector.
 	 *
-	 * Note that any key extraction methods cannot be chained with the KeySelector. To sort the
-	 * partition by multiple values using KeySelector, the KeySelector must return a tuple
+	 * Note that no additional sort keys can be appended to a KeySelector sort keys. To sort
+	 * the partitions by multiple values using KeySelector, the KeySelector must return a tuple
 	 * consisting of the values.
 	 *
 	 * @param keyExtractor The KeySelector function which extracts the key values from the DataSet

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1378,8 +1378,8 @@ public abstract class DataSet<T> {
 	}
 
 	/**
-	 * Locally sorts the partitions of the DataSet on the specified field in the specified order.
-	 * DataSet can be sorted on multiple fields by chaining sortPartition() calls.
+	 * Locally sorts the partitions of the DataSet on the an extracted key in the specified order.
+	 * DataSet can be sorted on multiple values by returning a tuple.
 	 *
 	 * @param keyExtractor The KeySelector function which extracts the key values from the DataSet
 	 *                     on which the DataSet is sorted.

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SortPartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SortPartitionOperator.java
@@ -77,7 +77,7 @@ public class SortPartitionOperator<T> extends SingleInputOperator<T, T, SortPart
 		orders.add(sortOrder);
 	}
 
-	public SortPartitionOperator(DataSet<T> dataSet, Keys<T> sortKey, Order sortOrder, String sortLocationName) {
+	public <K> SortPartitionOperator(DataSet<T> dataSet, Keys.SelectorFunctionKeys<T, K> sortKey, Order sortOrder, String sortLocationName) {
 		this(dataSet, sortLocationName);
 		this.useKeySelector = true;
 
@@ -151,8 +151,8 @@ public class SortPartitionOperator<T> extends SingleInputOperator<T, T, SortPart
 		}
 	}
 
-	private void ensureSortableKey(Keys<T> sortKey) {
-		if (sortKey instanceof Keys.SelectorFunctionKeys && !((Keys.SelectorFunctionKeys) sortKey).getKeyType().isSortKeyType()) {
+	private <K> void ensureSortableKey(Keys.SelectorFunctionKeys<T, K> sortKey) {
+		if (!sortKey.getKeyType().isSortKeyType()) {
 			throw new InvalidProgramException("Selected sort key is not a sortable type");
 		}
 	}

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
@@ -235,6 +235,22 @@ public class SortPartitionTest {
 		}
 	}
 
+	@Test(expected = InvalidProgramException.class)
+	public void testSortPartitionWithKeySelector5() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// must not work
+		tupleDs
+			.sortPartition(new KeySelector<Tuple4<Integer, Long, CustomType, Long[]>, CustomType>() {
+				@Override
+				public CustomType getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+					return value.f2;
+				}
+			}, Order.ASCENDING)
+			.sortPartition("f1", Order.ASCENDING);
+	}
+
 	public static class CustomType implements Serializable {
 		
 		public static class Nest {

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
@@ -169,6 +169,38 @@ public class SortPartitionTest {
 		tupleDs.sortPartition("f3", Order.ASCENDING);
 	}
 
+	@Test
+	public void testSortPartitionWithKeySelector1() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should work
+		try {
+			tupleDs.sortPartition(new KeySelector<Tuple4<Integer, Long, CustomType, Long[]>, Integer>() {
+				@Override
+				public Integer getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+					return value.f0;
+				}
+			}, Order.ASCENDING);
+		} catch (Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testSortPartitionWithKeySelector2() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// must not work
+		tupleDs.sortPartition(new KeySelector<Tuple4<Integer, Long, CustomType, Long[]>, Long[]>() {
+			@Override
+			public Long[] getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+				return value.f3;
+			}
+		}, Order.ASCENDING);
+	}
+
 	public static class CustomType implements Serializable {
 		
 		public static class Nest {

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/SortPartitionTest.java
@@ -201,6 +201,40 @@ public class SortPartitionTest {
 		}, Order.ASCENDING);
 	}
 
+	@Test(expected = InvalidProgramException.class)
+	public void testSortPartitionWithKeySelector3() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// must not work
+		tupleDs
+			.sortPartition("f1", Order.ASCENDING)
+			.sortPartition(new KeySelector<Tuple4<Integer, Long, CustomType, Long[]>, CustomType>() {
+				@Override
+				public CustomType getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+					return value.f2;
+				}
+			}, Order.ASCENDING);
+	}
+
+	@Test
+	public void testSortPartitionWithKeySelector4() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple4<Integer, Long, CustomType, Long[]>> tupleDs = env.fromCollection(tupleWithCustomData, tupleWithCustomInfo);
+
+		// should work
+		try {
+			tupleDs.sortPartition(new KeySelector<Tuple4<Integer,Long,CustomType,Long[]>, Tuple2<Integer, Long>>() {
+				@Override
+				public Tuple2<Integer, Long> getKey(Tuple4<Integer, Long, CustomType, Long[]> value) throws Exception {
+					return new Tuple2<>(value.f0, value.f1);
+				}
+			}, Order.ASCENDING);
+		} catch (Exception e) {
+			Assert.fail();
+		}
+	}
+
 	public static class CustomType implements Serializable {
 		
 		public static class Nest {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -1509,11 +1509,11 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   }
 
   /**
-    * Locally sorts the partitions of the DataSet on the specified field in the specified order.
-    * The DataSet can be sorted on multiple fields by chaining sortPartition() calls.
+    * Locally sorts the partitions of the DataSet on the extracted key in the specified order.
+    * The DataSet can be sorted on multiple values by returning a tuple from the KeySelector.
     *
-    * Note that any key extraction methods cannot be chained with the KeySelector. To sort the
-    * partition by multiple values using KeySelector, the KeySelector must return a tuple
+    * Note that no additional sort keys can be appended to a KeySelector sort keys. To sort
+    * the partitions by multiple values using KeySelector, the KeySelector must return a tuple
     * consisting of the values.
     */
   def sortPartition[K: TypeInformation](fun: T => K, order: Order): DataSet[T] ={

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -1511,6 +1511,10 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   /**
     * Locally sorts the partitions of the DataSet on the specified field in the specified order.
     * The DataSet can be sorted on multiple fields by chaining sortPartition() calls.
+    *
+    * Note that any key extraction methods cannot be chained with the KeySelector. To sort the
+    * partition by multiple values using KeySelector, the KeySelector must return a tuple
+    * consisting of the values.
     */
   def sortPartition[K: TypeInformation](fun: T => K, order: Order): DataSet[T] ={
     val keyExtractor = new KeySelector[T, K] {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
@@ -38,7 +38,8 @@ class PartitionSortedDataSet[T: ClassTag](set: SortPartitionOperator[T])
    */
   override def sortPartition(field: Int, order: Order): DataSet[T] = {
     if (set.useKeySelector()) {
-      throw new InvalidProgramException("Expression keys cannot be appended after selector function keys")
+      throw new InvalidProgramException("Expression keys cannot be appended after selector " +
+        "function keys")
     }
 
     this.set.sortPartition(field, order)
@@ -50,7 +51,8 @@ class PartitionSortedDataSet[T: ClassTag](set: SortPartitionOperator[T])
    */
   override def sortPartition(field: String, order: Order): DataSet[T] = {
     if (set.useKeySelector()) {
-      throw new InvalidProgramException("Expression keys cannot be appended after selector function keys")
+      throw new InvalidProgramException("Expression keys cannot be appended after selector " +
+        "function keys")
     }
 
     this.set.sortPartition(field, order)

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
@@ -18,6 +18,8 @@
 package org.apache.flink.api.scala
 
 import org.apache.flink.api.common.operators.Order
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.operators.SortPartitionOperator
 
 import scala.reflect.ClassTag
@@ -39,11 +41,24 @@ class PartitionSortedDataSet[T: ClassTag](set: SortPartitionOperator[T])
     this
   }
 
-/**
- * Appends the given field and order to the sort-partition operator.
- */
+  /**
+   * Appends the given field and order to the sort-partition operator.
+   */
   override def sortPartition(field: String, order: Order): DataSet[T] = {
     this.set.sortPartition(field, order)
+    this
+  }
+
+  /**
+    * Appends the given field and order to the sort-partition operator.
+    */
+  override def sortPartition[K: TypeInformation](fun: T => K, order: Order): DataSet[T] = {
+    val keyExtractor = new KeySelector[T, K] {
+      val cleanFun = clean(fun)
+      def getKey(in: T) = cleanFun(in)
+    }
+
+    this.set.sortPartition(keyExtractor, order)
     this
   }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/SortPartitionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/SortPartitionITCase.java
@@ -215,8 +215,8 @@ public class SortPartitionITCase extends MultipleProgramsTestBase {
 				public Long getKey(Tuple3<Integer, Long, String> value) throws Exception {
 					return value.f1;
 				}
-			}, Order.DESCENDING)
-			.mapPartition(new OrderCheckMapper<>(new Tuple3Checker()))
+			}, Order.ASCENDING)
+			.mapPartition(new OrderCheckMapper<>(new Tuple3AscendingChecker()))
 			.distinct().collect();
 
 		String expected = "(true)\n";
@@ -259,6 +259,14 @@ public class SortPartitionITCase extends MultipleProgramsTestBase {
 		@Override
 		public boolean inOrder(Tuple3<Integer, Long, String> t1, Tuple3<Integer, Long, String> t2) {
 			return t1.f1 >= t2.f1;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class Tuple3AscendingChecker implements OrderChecker<Tuple3<Integer, Long, String>> {
+		@Override
+		public boolean inOrder(Tuple3<Integer, Long, String> t1, Tuple3<Integer, Long, String> t2) {
+			return t1.f1 <= t2.f1;
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/SortPartitionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/SortPartitionITCase.java
@@ -210,10 +210,10 @@ public class SortPartitionITCase extends MultipleProgramsTestBase {
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		List<Tuple1<Boolean>> result = ds
 			.map(new IdMapper<Tuple3<Integer, Long, String>>()).setParallelism(4) // parallelize input
-			.sortPartition(new KeySelector<Tuple3<Integer, Long, String>, Integer>() {
+			.sortPartition(new KeySelector<Tuple3<Integer, Long, String>, Long>() {
 				@Override
-				public Integer getKey(Tuple3<Integer, Long, String> value) throws Exception {
-					return value.f0;
+				public Long getKey(Tuple3<Integer, Long, String> value) throws Exception {
+					return value.f1;
 				}
 			}, Order.DESCENDING)
 			.mapPartition(new OrderCheckMapper<>(new Tuple3Checker()))

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SortPartitionITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SortPartitionITCase.scala
@@ -175,8 +175,8 @@ class SortPartitionITCase(mode: TestExecutionMode) extends MultipleProgramsTestB
 
     val result = ds
       .map { x => x }.setParallelism(4)
-      .sortPartition(_._2, Order.DESCENDING)
-      .mapPartition(new OrderCheckMapper(new Tuple3Checker))
+      .sortPartition(_._2, Order.ASCENDING)
+      .mapPartition(new OrderCheckMapper(new Tuple3AscendingChecker))
       .distinct()
       .collect()
 
@@ -228,6 +228,12 @@ trait OrderChecker[T] extends Serializable {
 class Tuple3Checker extends OrderChecker[(Int, Long, String)] {
   def inOrder(t1: (Int, Long, String), t2: (Int, Long, String)): Boolean = {
     t1._2 >= t2._2
+  }
+}
+
+class Tuple3AscendingChecker extends OrderChecker[(Int, Long, String)] {
+  def inOrder(t1: (Int, Long, String), t2: (Int, Long, String)): Boolean = {
+    t1._2 <= t2._2
   }
 }
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SortPartitionITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SortPartitionITCase.scala
@@ -166,6 +166,23 @@ class SortPartitionITCase(mode: TestExecutionMode) extends MultipleProgramsTestB
     TestBaseUtils.compareResultAsText(result.asJava, expected)
   }
 
+  @Test
+  def testSortPartitionWithKeySelector(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(4)
+    val ds = CollectionDataSets.get3TupleDataSet(env)
+
+    val result = ds
+      .map { x => x }.setParallelism(4)
+      .sortPartition(_._2, Order.DESCENDING)
+      .mapPartition(new OrderCheckMapper(new Tuple3Checker))
+      .distinct()
+      .collect()
+
+    val expected: String = "(true)\n"
+    TestBaseUtils.compareResultAsText(result.asJava, expected)
+  }
+
 }
 
 trait OrderChecker[T] extends Serializable {

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SortPartitionITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SortPartitionITCase.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.flink.api.common.functions.MapPartitionFunction
 import org.apache.flink.api.common.operators.Order
+import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
@@ -167,7 +168,7 @@ class SortPartitionITCase(mode: TestExecutionMode) extends MultipleProgramsTestB
   }
 
   @Test
-  def testSortPartitionWithKeySelector(): Unit = {
+  def testSortPartitionWithKeySelector1(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(4)
     val ds = CollectionDataSets.get3TupleDataSet(env)
@@ -175,6 +176,41 @@ class SortPartitionITCase(mode: TestExecutionMode) extends MultipleProgramsTestB
     val result = ds
       .map { x => x }.setParallelism(4)
       .sortPartition(_._2, Order.DESCENDING)
+      .mapPartition(new OrderCheckMapper(new Tuple3Checker))
+      .distinct()
+      .collect()
+
+    val expected: String = "(true)\n"
+    TestBaseUtils.compareResultAsText(result.asJava, expected)
+  }
+
+  @Test
+  def testSortPartitionWithKeySelector2(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(4)
+    val ds = CollectionDataSets.get3TupleDataSet(env)
+
+    val result = ds
+      .map { x => x }.setParallelism(4)
+      .sortPartition(x => (x._2, x._1), Order.DESCENDING)
+      .mapPartition(new OrderCheckMapper(new Tuple3Checker))
+      .distinct()
+      .collect()
+
+    val expected: String = "(true)\n"
+    TestBaseUtils.compareResultAsText(result.asJava, expected)
+  }
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testSortPartitionWithKeySelector3(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(4)
+    val ds = CollectionDataSets.get3TupleDataSet(env)
+
+    val result = ds
+      .map { x => x }.setParallelism(4)
+      .sortPartition(x => (x._2, x._1), Order.DESCENDING)
+      .sortPartition(0, Order.DESCENDING)
       .mapPartition(new OrderCheckMapper(new Tuple3Checker))
       .distinct()
       .collect()


### PR DESCRIPTION
This PR contains following changes:

* Add `sortPartition` methods which receive a `KeySelector` instance or a Scala lambda function
* Add `SortPartitionOperator` constructor which takes `Keys.SelectorFunctionKeys`
* Add `getFlatFields` method to `SortPartitionOperator` class for `Keys.SelectorFunctionKeys`
* Add some test cases