### PR TITLE
[FLINK-3339] Make ValueState.update(null) act as ValueState.clear()

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -102,6 +102,10 @@ public class RocksDBValueState<K, N, V, Backend extends AbstractStateBackend>
 
 	@Override
 	public void update(V value) throws IOException {
+		if (value == null) {
+			clear();
+			return;
+		}
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(baos);
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsValueState.java
@@ -94,6 +94,11 @@ public class FsValueState<K, N, V>
 			throw new RuntimeException("No key available.");
 		}
 
+		if (value == null) {
+			clear();
+			return;
+		}
+
 		if (currentNSState == null) {
 			currentNSState = new HashMap<>();
 			state.put(currentNamespace, currentNSState);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemValueState.java
@@ -69,6 +69,11 @@ public class MemValueState<K, N, V>
 			throw new RuntimeException("No key available.");
 		}
 
+		if (value == null) {
+			clear();
+			return;
+		}
+
 		if (currentNSState == null) {
 			currentNSState = new HashMap<>();
 			state.put(currentNamespace, currentNSState);


### PR DESCRIPTION
This was causing problems with TypeSerializers that choke on null
values, especially in the Scala KeyedStream.*WithState() family of
functions.