### PR TITLE
[FLINK-3337] [runtime] mvn test fails on flink-runtime because curator classes not found

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -323,11 +323,6 @@ under the License.
 						<exclude>**/TestData.java</exclude>
 						<exclude>**/TestInstanceListener.java</exclude>
 					</excludes>
-					<classpathDependencyExcludes>
-						<classpathDependencyExclude>org.apache.curator:curator-recipes</classpathDependencyExclude>
-						<classpathDependencyExclude>org.apache.curator:curator-client</classpathDependencyExclude>
-						<classpathDependencyExclude>org.apache.curator:curator-framework</classpathDependencyExclude>
-					</classpathDependencyExcludes>
 					<systemPropertyVariables>
 						<log.level>WARN</log.level>
 					</systemPropertyVariables>
@@ -341,11 +336,6 @@ under the License.
 					<excludes>
 						<exclude>**/TestData.java</exclude>
 					</excludes>
-					<classpathDependencyExcludes>
-						<classpathDependencyExclude>org.apache.curator:curator-recipes</classpathDependencyExclude>
-						<classpathDependencyExclude>org.apache.curator:curator-client</classpathDependencyExclude>
-						<classpathDependencyExclude>org.apache.curator:curator-framework</classpathDependencyExclude>
-					</classpathDependencyExcludes>
 					<systemPropertyVariables>
 						<log.level>WARN</log.level>
 					</systemPropertyVariables>


### PR DESCRIPTION
Removes curator dependency exclusions from flink-runtime. This resolves
NoClassDefFoundError exceptions when running `mvn test`.

This partialy reverts e31a4d8.