### PR TITLE
[FLINK-3353] CSV-related tests may fail depending on locale

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.util.List;
+import java.util.Locale;
 
 @RunWith(Parameterized.class)
 public class CsvReaderITCase extends MultipleProgramsTestBase {
@@ -136,7 +137,7 @@ public class CsvReaderITCase extends MultipleProgramsTestBase {
 
 		@Override
 		public String toString() {
-			return String.format("%s,%d,%.02f", f1, f2, f3);
+			return String.format(Locale.US, "%s,%d,%.02f", f1, f2, f3);
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/KMeansWithBroadcastSetITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/KMeansWithBroadcastSetITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 import org.apache.flink.test.testdata.KMeansData;
 
 import java.util.List;
+import java.util.Locale;
 
 public class KMeansWithBroadcastSetITCase extends JavaProgramTestBase {
 
@@ -83,7 +84,7 @@ public class KMeansWithBroadcastSetITCase extends JavaProgramTestBase {
 				.map(new MapFunction<Centroid, String>() {
 					@Override
 					public String map(Centroid c) throws Exception {
-						return String.format("%d|%.2f|%.2f|", c.id, c.x, c.y);
+						return String.format(Locale.US, "%d|%.2f|%.2f|", c.id, c.x, c.y);
 					}
 				});
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/io/ScalaCsvReaderWithPOJOITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/io/ScalaCsvReaderWithPOJOITCase.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.scala.io
 
+import java.util.Locale
+
 import com.google.common.base.Charsets
 import com.google.common.io.Files
 import org.apache.flink.api.scala._
@@ -120,5 +122,5 @@ class POJOItem(var f1: String, var f2: Double, var f3: Int) {
     this("", 0.0, 0)
   }
 
-  override def toString: String = "%s,%.02f,%d".format(f1, f2, f3)
+  override def toString: String = "%s,%.02f,%d".formatLocal(Locale.US, f1, f2, f3)
 }


### PR DESCRIPTION
As the results are hard-coded, it makes sense to explicitly pass the US locale to render the results as strings. Should close [FLINK-3353](https://issues.apache.org/jira/browse/FLINK-3353).