### PR TITLE
[FLINK-3357] [core] Drop AbstractID#toShortString()

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -81,11 +81,11 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	}
 
 	private File getDbPath(String stateName) {
-		return new File(new File(new File(new File(dbBasePath), jobId.toShortString()), operatorIdentifier), stateName);
+		return new File(new File(new File(new File(dbBasePath), jobId.toString()), operatorIdentifier), stateName);
 	}
 
 	private String getCheckpointPath(String stateName) {
-		return checkpointDirectory + "/" + jobId.toShortString() + "/" + operatorIdentifier + "/" + stateName;
+		return checkpointDirectory + "/" + jobId.toString() + "/" + operatorIdentifier + "/" + stateName;
 	}
 
 	@Override

--- a/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/state/DbStateBackendTest.java
+++ b/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/state/DbStateBackendTest.java
@@ -136,14 +136,15 @@ public class DbStateBackendTest {
 
 		Environment env = new DummyEnvironment("test", 1, 0);
 		backend.initializeForJob(env, "dummy-setup-ser", StringSerializer.INSTANCE);
+		String appId = env.getApplicationID().toString().substring(0, 16);
 
 		assertNotNull(backend.getConnections());
 		assertTrue(
-				isTableCreated(backend.getConnections().getFirst(), "checkpoints_" + env.getApplicationID().toShortString()));
+				isTableCreated(backend.getConnections().getFirst(), "checkpoints_" + appId));
 
 		backend.disposeAllStateForCurrentJob();
 		assertFalse(
-				isTableCreated(backend.getConnections().getFirst(), "checkpoints_" + env.getApplicationID().toShortString()));
+				isTableCreated(backend.getConnections().getFirst(), "checkpoints_" + appId));
 		backend.close();
 
 		assertTrue(backend.getConnections().getFirst().isClosed());
@@ -153,6 +154,7 @@ public class DbStateBackendTest {
 	public void testSerializableState() throws Exception {
 		Environment env = new DummyEnvironment("test", 1, 0);
 		DbStateBackend backend = new DbStateBackend(conf);
+		String appId = env.getApplicationID().toString().substring(0, 16);
 
 		backend.initializeForJob(env, "dummy-ser-state", StringSerializer.INSTANCE);
 
@@ -173,12 +175,12 @@ public class DbStateBackendTest {
 		assertEquals(state2, handle2.getState(getClass().getClassLoader()));
 		handle2.discardState();
 
-		assertFalse(isTableEmpty(backend.getConnections().getFirst(), "checkpoints_" + env.getApplicationID().toShortString()));
+		assertFalse(isTableEmpty(backend.getConnections().getFirst(), "checkpoints_" + appId));
 
 		assertEquals(state3, handle3.getState(getClass().getClassLoader()));
 		handle3.discardState();
 
-		assertTrue(isTableEmpty(backend.getConnections().getFirst(), "checkpoints_" + env.getApplicationID().toShortString()));
+		assertTrue(isTableEmpty(backend.getConnections().getFirst(), "checkpoints_" + appId));
 
 		backend.close();
 

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
@@ -51,9 +51,6 @@ public class AbstractID implements IOReadableWritable, Comparable<AbstractID>, j
 	/** The memoized value returned by toString() */
 	private String toString;
 
-	/** The memoized value returned by toShortString() */
-	private String toShortString;
-
 	// --------------------------------------------------------------------------------------------
 	
 	/**
@@ -145,7 +142,6 @@ public class AbstractID implements IOReadableWritable, Comparable<AbstractID>, j
 		this.upperPart = in.readLong();
 
 		this.toString = null;
-		this.toShortString = null;
 	}
 
 	@Override
@@ -187,17 +183,6 @@ public class AbstractID implements IOReadableWritable, Comparable<AbstractID>, j
 		}
 
 		return this.toString;
-	}
-
-	public String toShortString() {
-		if (this.toShortString == null) {
-			final byte[] ba = new byte[SIZE_OF_LONG];
-			longToByteArray(upperPart, ba, 0);
-
-			this.toShortString = StringUtils.byteToHexString(ba);
-		}
-
-		return this.toShortString;
 	}
 	
 	@Override

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -48,7 +48,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandler extends AbstractSubtaskA
 
 		gen.writeNumberField("subtask", execAttempt.getVertex().getParallelSubtaskIndex());
 		gen.writeNumberField("attempt", execAttempt.getAttemptNumber());
-		gen.writeStringField("id", execAttempt.getAttemptId().toShortString());
+		gen.writeStringField("id", execAttempt.getAttemptId().toString());
 		
 		gen.writeArrayFieldStart("user-accumulators");
 		for (StringifiedAccumulatorResult acc : accs) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
@@ -83,7 +83,7 @@ public class InputGateDeploymentDescriptor implements Serializable {
 	public String toString() {
 		return String.format("InputGateDeploymentDescriptor [result id: %s, " +
 						"consumed subpartition index: %d, input channels: %s]",
-				consumedResultId.toShortString(), consumedSubpartitionIndex,
+				consumedResultId.toString(), consumedSubpartitionIndex,
 				Arrays.toString(inputChannels));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionID.java
@@ -72,6 +72,6 @@ public final class ResultPartitionID implements Serializable {
 
 	@Override
 	public String toString() {
-		return partitionId.toShortString() + "@" + producerId.toShortString();
+		return partitionId.toString() + "@" + producerId.toString();
 	}
 }


### PR DESCRIPTION
Drops the `toShortString` method in `AbstractID`.

@aljoscha Is that OK in the RocksDB state backend?

@gyfora As discussed offline, I've still shortened the ID in the DB state backend, because this a requirement from certain DBs for table names.