### PR TITLE
[FLINK-3373] [build] Shade away Hadoop's HTTP Components dependency

### DIFF
--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -111,6 +111,11 @@ under the License.
 									<include>io.netty:netty:*</include>
 									<include>org.apache.curator:*</include>
 									<include>org.apache.hadoop:*</include>
+
+									<!-- This dependency needs to be included to properly get rid of the HTTP Components dependency -->
+									<include>net.java.dev.jets3t:jets3t</include>
+									<include>org.apache.httpcomponents:*</include>
+									<include>commons-httpclient:commons-httpclient</include>
 								</includes>
 							</artifactSet>
 							<relocations>
@@ -132,6 +137,14 @@ under the License.
 								<relocation>
 									<pattern>org.apache.curator</pattern>
 									<shadedPattern>org.apache.flink.hadoop.shaded.org.apache.curator</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.http</pattern>
+									<shadedPattern>org.apache.flink.hadoop.shaded.org.apache.http</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.commons.httpclient</pattern>
+									<shadedPattern>org.apache.flink.hadoop.shaded.org.apache.commons.httpclient</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -342,18 +342,6 @@ under the License.
 			</dependency>
 
 			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpcore</artifactId>
-				<version>4.2.5</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>4.2.6</version>
-			</dependency>
-
-			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
 				<version>${jackson.version}</version>


### PR DESCRIPTION
This makes the HTTP Components dependency disappear from the core classpath, allowing users to use their own version of the dependency.

We need shading because we cannot simply bump the HTTP Components version to the newest version. The YARN test for Hadoop version >= 2.6.0 fail in that case.