### PR TITLE
[FLINK-3332] Cassandra connector

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -37,7 +37,7 @@ import java.io.IOException;
  * The {@link ResultPartitionWriter} is the runtime API for producing results. It
  * supports two kinds of data to be sent: buffers and events.
  */
-public final class ResultPartitionWriter implements EventListener<TaskEvent> {
+public class ResultPartitionWriter implements EventListener<TaskEvent> {
 
 	private final ResultPartition partition;
 

--- a/flink-streaming-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-streaming-connectors/flink-connector-cassandra/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-streaming-connectors</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-cassandra_2.10</artifactId>
+	<name>flink-connector-cassandra</name>
+
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<reuseForks>true</reuseForks>
+					<forkCount>1</forkCount>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<!-- Allow users to pass custom connector versions -->
+	<properties>
+		<cassandra.version>2.2.0</cassandra.version>
+		<driver.version>3.0.0</driver.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.datastax.cassandra</groupId>
+			<artifactId>cassandra-driver-core</artifactId>
+			<version>${driver.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.datastax.cassandra</groupId>
+			<artifactId>cassandra-driver-mapping</artifactId>
+			<version>${driver.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cassandra</groupId>
+			<artifactId>cassandra-all</artifactId>
+			<version>${cassandra.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+</project>

--- a/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
@@ -51,6 +51,12 @@ public class CassandraExactlyOnceSink<IN extends Tuple> extends GenericExactlyOn
 	}
 
 	public CassandraExactlyOnceSink(String host, String createQuery, String insertQuery) {
+		if (host == null) {
+			throw new IllegalArgumentException("Host argument must not be null.");
+		}
+		if (insertQuery == null) {
+			throw new IllegalArgumentException("Insert query argument must not be null.");
+		}
 		this.host = host;
 		this.createQuery = createQuery;
 		this.insertQuery = insertQuery;

--- a/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
@@ -36,9 +36,9 @@ import org.apache.flink.streaming.runtime.operators.GenericExactlyOnceSink;
  * @param <IN> Type of the elements emitted by this sink
  */
 public class CassandraExactlyOnceSink<IN extends Tuple> extends GenericExactlyOnceSink<IN> {
-	private String host;
-	private String createQuery;
-	private String insertQuery;
+	private final String host;
+	private final String createQuery;
+	private final String insertQuery;
 
 	private transient Cluster cluster;
 	private transient Session session;

--- a/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.streaming.runtime.operators.GenericExactlyOnceSink;
+
+/**
+ * Sink that emits its input elements into a Cassandra database. This sink is integrated with the checkpointing
+ * mechanism to provide exactly once semantics.
+ *
+ * Incoming records are stored within a {@link org.apache.flink.runtime.state.AbstractStateBackend}, and only committed if a
+ * checkpoint is completed. Should a job fail while the data is being committed, no exactly once guarantee can be made.
+ * @param <IN>
+ */
+public class CassandraExactlyOnceSink<IN extends Tuple> extends GenericExactlyOnceSink<IN> {
+	private String host;
+	private String createQuery;
+	private String insertQuery;
+
+	private transient Cluster cluster;
+	private transient Session session;
+	private transient PreparedStatement preparedStatement;
+
+	private transient Throwable exception = null;
+
+	public CassandraExactlyOnceSink(String host, String insertQuery) {
+		this(host, null, insertQuery);
+	}
+
+	public CassandraExactlyOnceSink(String host, String createQuery, String insertQuery) {
+		this.host = host;
+		this.createQuery = createQuery;
+		this.insertQuery = insertQuery;
+	}
+
+	@Override
+	public void close() {
+		session.close();
+		cluster.close();
+	}
+
+	@Override
+	public void open() {
+		cluster = Cluster.builder().addContactPoint(host).build();
+		session = cluster.connect();
+		if (createQuery != null) {
+			session.execute(createQuery);
+		}
+		preparedStatement = session.prepare(insertQuery);
+	}
+
+	@Override
+	protected void sendValue(IN value) throws Exception {
+		//verify that no query failed until now
+		if (exception != null) {
+			throw new Exception(exception);
+		}
+		//set values for prepared statement
+		Object[] fields = new Object[value.getArity()];
+		for (int x = 0; x < value.getArity(); x++) {
+			fields[x] = value.getField(x);
+		}
+		//insert values and send to cassandra
+		ResultSetFuture result = session.executeAsync(preparedStatement.bind(fields));
+		//add callback to detect errors
+		Futures.addCallback(result, new FutureCallback<ResultSet>() {
+			@Override
+			public void onSuccess(ResultSet resultSet) {
+			}
+
+			@Override
+			public void onFailure(Throwable throwable) {
+				exception = throwable;
+			}
+		});
+	}
+}

--- a/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSink.java
@@ -33,7 +33,7 @@ import org.apache.flink.streaming.runtime.operators.GenericExactlyOnceSink;
  *
  * Incoming records are stored within a {@link org.apache.flink.runtime.state.AbstractStateBackend}, and only committed if a
  * checkpoint is completed. Should a job fail while the data is being committed, no exactly once guarantee can be made.
- * @param <IN>
+ * @param <IN> Type of the elements emitted by this sink
  */
 public class CassandraExactlyOnceSink<IN extends Tuple> extends GenericExactlyOnceSink<IN> {
 	private String host;

--- a/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraExactlyOnceSinkExample.java
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraExactlyOnceSinkExample.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.cassandra.example;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.streaming.api.checkpoint.Checkpointed;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.cassandra.CassandraExactlyOnceSink;
+
+import java.util.UUID;
+
+public class CassandraExactlyOnceSinkExample {
+	public static void main(String[] args) throws Exception {
+
+		class MySource implements SourceFunction<Tuple2<String, Integer>>, Checkpointed<Integer> {
+			private int counter = 0;
+			private boolean stop = false;
+
+			@Override
+			public void run(SourceContext<Tuple2<String, Integer>> ctx) throws Exception {
+				while (!stop) {
+					Thread.sleep(50);
+					ctx.collect(new Tuple2<>("" + UUID.randomUUID(), counter));
+					counter++;
+				}
+			}
+
+			@Override
+			public void cancel() {
+				stop = true;
+			}
+
+			@Override
+			public Integer snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
+				return counter;
+			}
+
+			@Override
+			public void restoreState(Integer state) throws Exception {
+				this.counter = state;
+			}
+		}
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.enableCheckpointing(1000);
+		env.setNumberOfExecutionRetries(1);
+		env.setStateBackend(new FsStateBackend(System.getProperty("java.io.tmpdir") + "/flink/backend"));
+
+		env
+			.addSource(new MySource())
+			.transform(
+				"Cassandra Sink",
+				TypeExtractor.getForObject(new Tuple2<>("", 0)),
+				new CassandraExactlyOnceSink<Tuple2<String, Integer>>(
+					"127.0.0.1",
+					"CREATE TABLE example.entries (id text PRIMARY KEY, counter int);",
+					"INSERT INTO example.entries (id, counter) VALUES (?, ?)"));
+
+		env.execute();
+	}
+}

--- a/flink-streaming-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSinkTest.java
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraExactlyOnceSinkTest.java
@@ -1,0 +1,192 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.service.CassandraDaemon;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.streaming.runtime.operators.ExactlyOnceSinkTestBase;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Scanner;
+import java.util.UUID;
+
+public class CassandraExactlyOnceSinkTest extends ExactlyOnceSinkTestBase<Tuple3<String, Integer, Integer>, CassandraExactlyOnceSink<Tuple3<String, Integer, Integer>>> {
+	private static EmbeddedCassandraService cassandra;
+	private static Cluster cluster;
+	private static Session session;
+
+	private static final String CREATE_KEYSPACE_QUERY = "CREATE KEYSPACE flink WITH replication" + "= {'class':'SimpleStrategy', 'replication_factor':3};";
+	private static final String CREATE_TABLE_QUERY = "CREATE TABLE flink.test (id text PRIMARY KEY, counter int, batch_id int);";
+	private static final String CLEAR_TABLE_QUERY = "TRUNCATE flink.test;";
+	private static final String INSERT_DATA_QUERY = "INSERT INTO flink.test (id, counter, batch_id) VALUES (?, ?, ?)";
+	private static final String SELECT_DATA_QUERY = "SELECT * FROM flink.test;";
+
+	private static class EmbeddedCassandraService {
+		CassandraDaemon cassandraDaemon;
+
+		public void start() throws IOException {
+			this.cassandraDaemon = new CassandraDaemon();
+			this.cassandraDaemon.init(null);
+			this.cassandraDaemon.start();
+		}
+
+		public void stop() {
+			this.cassandraDaemon.stop();
+		}
+	}
+
+	@ClassRule
+	public static TemporaryFolder testFolder = new TemporaryFolder();
+
+	@BeforeClass
+	public static void startCassandra() throws IOException {
+		//generate temporary files
+		ClassLoader classLoader = CassandraExactlyOnceSinkTest.class.getClassLoader();
+		File file = new File(classLoader.getResource("cassandra.yaml").getFile());
+		File tmp = testFolder.newFile("cassandra.yaml");
+		testFolder.newFolder("data");
+		testFolder.newFolder("commit");
+		testFolder.newFolder("cache");
+		BufferedWriter b = new BufferedWriter(new FileWriter(tmp));
+
+		//copy cassandra.yaml; inject absolute paths into cassandra.yaml
+		Scanner scanner = new Scanner(file);
+		while (scanner.hasNextLine()) {
+			String line = scanner.nextLine();
+			line = line.replace("$PATH", "'" + tmp.getParentFile());
+			b.write(line + "\n");
+			b.flush();
+		}
+		scanner.close();
+
+
+		// Tell cassandra where the configuration files are.
+		// Use the test configuration file.
+		System.setProperty("cassandra.config", "file:" + File.separator + File.separator + File.separator + tmp.getAbsolutePath());
+
+		cassandra = new EmbeddedCassandraService();
+		cassandra.start();
+
+		cluster = Cluster.builder().addContactPoint("127.0.0.1").build();
+		session = cluster.connect();
+
+		session.execute(CREATE_KEYSPACE_QUERY);
+		session.execute(CREATE_TABLE_QUERY);
+	}
+
+	@After
+	public void deleteSchema() throws Exception {
+		session.executeAsync(CLEAR_TABLE_QUERY);
+	}
+
+	@AfterClass
+	public static void closeCassandra() {
+		session.close();
+		cluster.close();
+		cassandra.stop();
+	}
+
+	protected CassandraExactlyOnceSink<Tuple3<String, Integer, Integer>> createSink() {
+		return new CassandraExactlyOnceSink<>(
+			"127.0.0.1",
+			INSERT_DATA_QUERY);
+	}
+
+	protected TupleTypeInfo<Tuple3<String, Integer, Integer>> createTypeInfo() {
+		return TupleTypeInfo.getBasicTupleTypeInfo(String.class, Integer.class, Integer.class);
+	}
+
+	@Override
+	protected Tuple3<String, Integer, Integer> generateValue(int counter, int checkpointID) {
+		return new Tuple3<>("" + UUID.randomUUID(), counter, checkpointID);
+	}
+
+	@Override
+	protected void verifyResultsIdealCircumstances(
+		OneInputStreamTaskTestHarness<Tuple3<String, Integer, Integer>, Tuple3<String, Integer, Integer>> harness,
+		OneInputStreamTask<Tuple3<String, Integer, Integer>, Tuple3<String, Integer, Integer>> task,
+		CassandraExactlyOnceSink<Tuple3<String, Integer, Integer>> sink) {
+
+		ResultSet result = session.execute(SELECT_DATA_QUERY);
+		ArrayList<Integer> list = new ArrayList<>();
+		for (int x = 1; x <= 600; x++) {
+			list.add(x);
+		}
+
+		for (Row s : result) {
+			list.remove(new Integer(s.getInt("counter")));
+		}
+		Assert.assertTrue("The following ID's were not found in the ResultSet: " + list.toString(), list.isEmpty());
+	}
+
+	@Override
+	protected void verifyResultsDataPersistenceUponMissedNotify(
+		OneInputStreamTaskTestHarness<Tuple3<String, Integer, Integer>, Tuple3<String, Integer, Integer>> harness,
+		OneInputStreamTask<Tuple3<String, Integer, Integer>, Tuple3<String, Integer, Integer>> task,
+		CassandraExactlyOnceSink<Tuple3<String, Integer, Integer>> sink) {
+
+		ResultSet result = session.execute(SELECT_DATA_QUERY);
+		ArrayList<Integer> list = new ArrayList<>();
+		for (int x = 1; x <= 600; x++) {
+			list.add(x);
+		}
+
+		for (Row s : result) {
+			list.remove(new Integer(s.getInt("counter")));
+		}
+		Assert.assertTrue("The following ID's were not found in the ResultSet: " + list.toString(), list.isEmpty());
+	}
+
+	@Override
+	protected void verifyResultsDataDiscardingUponRestore(
+		OneInputStreamTaskTestHarness<Tuple3<String, Integer, Integer>, Tuple3<String, Integer, Integer>> harness,
+		OneInputStreamTask<Tuple3<String, Integer, Integer>, Tuple3<String, Integer, Integer>> task,
+		CassandraExactlyOnceSink<Tuple3<String, Integer, Integer>> sink) {
+
+		ResultSet result = session.execute(SELECT_DATA_QUERY);
+		ArrayList<Integer> list = new ArrayList<>();
+		for (int x = 1; x <= 200; x++) {
+			list.add(x);
+		}
+		for (int x = 401; x <= 600; x++) {
+			list.add(x);
+		}
+
+		for (Row s : result) {
+			list.remove(new Integer(s.getInt("counter")));
+		}
+		Assert.assertTrue("The following ID's were not found in the ResultSet: " + list.toString(), list.isEmpty());
+	}
+}

--- a/flink-streaming-connectors/flink-connector-cassandra/src/test/resources/cassandra.yaml
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/test/resources/cassandra.yaml
@@ -1,0 +1,40 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+cluster_name: 'Test Cluster'
+commitlog_sync: 'periodic'
+commitlog_sync_period_in_ms: 10000
+partitioner: 'org.apache.cassandra.dht.RandomPartitioner'
+endpoint_snitch: 'org.apache.cassandra.locator.SimpleSnitch'
+commitlog_directory: $PATH\commit'
+data_file_directories:
+    - $PATH\data'
+saved_caches_directory: $PATH\cache'
+listen_address: '127.0.0.1'
+seed_provider:
+    - class_name: 'org.apache.cassandra.locator.SimpleSeedProvider'
+      parameters:
+          - seeds: '127.0.0.1'
+native_transport_port: 9042
+start_native_transport: true
+
+read_request_timeout_in_ms: 60000
+range_request_timeout_in_ms: 60000
+write_request_timeout_in_ms: 40000
+cas_contention_timeout_in_ms: 3000
+truncate_request_timeout_in_ms: 60000
+request_timeout_in_ms: 60000

--- a/flink-streaming-connectors/flink-connector-cassandra/src/test/resources/log4j-test.properties
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/test/resources/log4j-test.properties
@@ -1,0 +1,29 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=ERROR, testlogger
+
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger
+
+

--- a/flink-streaming-connectors/pom.xml
+++ b/flink-streaming-connectors/pom.xml
@@ -44,6 +44,7 @@ under the License.
 		<module>flink-connector-rabbitmq</module>
 		<module>flink-connector-twitter</module>
 		<module>flink-connector-nifi</module>
+		<module>flink-connector-cassandra</module>
 	</modules>
 
 	<!-- See main pom.xml for explanation of profiles -->

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -93,7 +93,6 @@ public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<
 	@Override
 	public void notifyOfCompletedCheckpoint(long checkpointId) throws Exception {
 		super.notifyOfCompletedCheckpoint(checkpointId);
-		saveHandleInState(checkpointId);
 
 		synchronized (state.pendingHandles) {
 			Set<Long> pastCheckpointIds = state.pendingHandles.keySet();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -47,7 +47,7 @@ import java.util.Set;
  * checkpoint is completed. Should a job fail while the data is being committed, no exactly once guarantee can be made.
  * @param <IN>
  */
-public abstract class GenericExactlyOnceSink<IN extends Tuple> extends AbstractStreamOperator<IN> implements OneInputStreamOperator<IN, IN> {
+public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<IN> implements OneInputStreamOperator<IN, IN> {
 	private AbstractStateBackend.CheckpointStateOutputView out;
 	private TypeSerializer<IN> serializer;
 	protected TypeInformation<IN> typeInfo;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -45,7 +45,7 @@ import java.util.Set;
  *
  * Incoming records are stored within a {@link org.apache.flink.runtime.state.AbstractStateBackend}, and only committed if a
  * checkpoint is completed. Should a job fail while the data is being committed, no exactly once guarantee can be made.
- * @param <IN>
+ * @param <IN> Type of the elements emitted by this sink
  */
 public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<IN> implements OneInputStreamOperator<IN, IN> {
 	private AbstractStateBackend.CheckpointStateOutputView out;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -111,7 +111,11 @@ public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<
 				}
 			}
 			for (Long toRemove : checkpointsToRemove) {
+				List<StateHandle<DataInputView>> handles = state.pendingHandles.get(toRemove);
 				state.pendingHandles.remove(toRemove);
+				for (StateHandle<DataInputView> handle : handles) {
+					handle.discardState();
+				}
 			}
 		}
 	}
@@ -161,6 +165,11 @@ public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<
 
 		@Override
 		public void discardState() throws Exception {
+			for (List<StateHandle<DataInputView>> handles : pendingHandles.values()) {
+				for (StateHandle<DataInputView> handle : handles) {
+					handle.discardState();
+				}
+			}
 			pendingHandles = new HashMap<>();
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskState;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generic Sink that emits its input elements into an arbitrary backend. This sink is integrated with the checkpointing
+ * mechanism to provide exactly once semantics.
+ *
+ * Incoming records are stored within a {@link org.apache.flink.runtime.state.AbstractStateBackend}, and only committed if a
+ * checkpoint is completed. Should a job fail while the data is being committed, no exactly once guarantee can be made.
+ * @param <IN>
+ */
+public abstract class GenericExactlyOnceSink<IN extends Tuple> extends AbstractStreamOperator<IN> implements OneInputStreamOperator<IN, IN> {
+	private AbstractStateBackend.CheckpointStateOutputView out;
+	private TypeSerializer<IN> serializer;
+	protected TypeInformation<IN> typeInfo;
+
+	private ExactlyOnceState state = new ExactlyOnceState();
+
+	/**
+	 * Saves a handle in the state.
+	 * @param checkpointId
+	 * @throws IOException
+	 */
+	private void saveHandleInState(final long checkpointId) throws IOException {
+		//only add handle if a new OperatorState was created since the last snapshot/notify
+		if (out != null) {
+			out.writeByte(0); //EOF-byte
+			StateHandle<DataInputView> handle = out.closeAndGetHandle();
+			if (state.pendingHandles.containsKey(checkpointId)) {
+				state.pendingHandles.get(checkpointId).add(handle);
+			} else {
+				ArrayList<StateHandle<DataInputView>> list = new ArrayList<>();
+				list.add(handle);
+				state.pendingHandles.put(checkpointId, list);
+			}
+			out = null;
+		}
+	}
+
+	@Override
+	public StreamTaskState snapshotOperatorState(final long checkpointId, final long timestamp) throws Exception {
+		StreamTaskState taskState = super.snapshotOperatorState(checkpointId, timestamp);
+		saveHandleInState(checkpointId);
+		taskState.setFunctionState(state);
+		return taskState;
+	}
+
+	@Override
+	public void restoreState(StreamTaskState state, long recoveryTimestamp) throws Exception {
+		super.restoreState(state, recoveryTimestamp);
+		this.state = (ExactlyOnceState) state.getFunctionState();
+		out = null;
+	}
+
+	@Override
+	public void notifyOfCompletedCheckpoint(long checkpointId) throws Exception {
+		super.notifyOfCompletedCheckpoint(checkpointId);
+		saveHandleInState(checkpointId);
+
+		synchronized (state.pendingHandles) {
+			Set<Long> pastCheckpointIds = state.pendingHandles.keySet();
+			Set<Long> checkpointsToRemove = new HashSet<>();
+			for (Long pastCheckpointId : pastCheckpointIds) {
+				if (pastCheckpointId <= checkpointId) {
+					List<StateHandle<DataInputView>> handles = state.pendingHandles.get(pastCheckpointId);
+					for (StateHandle<DataInputView> handle : handles) {
+						DataInputView in = handle.getState(getUserCodeClassloader());
+						while (in.readByte() == 1) {
+							IN value = serializer.deserialize(in);
+							sendValue(value);
+						}
+						checkpointsToRemove.add(pastCheckpointId);
+					}
+				}
+			}
+			for (Long toRemove : checkpointsToRemove) {
+				state.pendingHandles.remove(toRemove);
+			}
+		}
+	}
+
+	/**
+	 * Write the given element into the backend.
+	 * @param value value to be written
+	 * @throws Exception
+     */
+	protected abstract void sendValue(IN value) throws Exception;
+
+	@Override
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		IN value = element.getValue();
+		if (serializer == null) {
+			typeInfo = TypeExtractor.getForObject(value);
+			serializer = typeInfo.createSerializer(new ExecutionConfig());
+		}
+		//generate initial operator state
+		if (out == null) {
+			out = getStateBackend().createCheckpointStateOutputView(0, 0);
+		}
+		out.writeByte(1);
+		serializer.serialize(value, out);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		//don't do anything, since no are a sink
+	}
+
+	/**
+	 * This state is used to keep a list of all StateHandles (essentially references to past OperatorStates) that were
+	 * used since the last completed checkpoint.
+	 **/
+	public class ExactlyOnceState implements StateHandle<Serializable> {
+		protected HashMap<Long, ArrayList<StateHandle<DataInputView>>> pendingHandles;
+
+		public ExactlyOnceState() {
+			pendingHandles = new HashMap<>();
+		}
+
+		@Override
+		public HashMap<Long, ArrayList<StateHandle<DataInputView>>> getState(ClassLoader userCodeClassLoader) throws Exception {
+			return pendingHandles;
+		}
+
+		@Override
+		public void discardState() throws Exception {
+			pendingHandles = new HashMap<>();
+		}
+
+		@Override
+		public long getStateSize() throws Exception {
+			return 0;
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -141,7 +141,7 @@ public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<
 
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
-		//don't do anything, since no are a sink
+		//don't do anything, since we are a sink
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -175,7 +175,13 @@ public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<
 
 		@Override
 		public long getStateSize() throws Exception {
-			return 0;
+			int stateSize = 0;
+			for (List<StateHandle<DataInputView>> handles : pendingHandles.values()) {
+				for (StateHandle<DataInputView> handle : handles) {
+					stateSize += handle.getStateSize();
+				}
+			}
+			return stateSize;
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSink.java
@@ -107,8 +107,8 @@ public abstract class GenericExactlyOnceSink<IN> extends AbstractStreamOperator<
 							IN value = serializer.deserialize(in);
 							sendValue(value);
 						}
-						checkpointsToRemove.add(pastCheckpointId);
 					}
+					checkpointsToRemove.add(pastCheckpointId);
 				}
 			}
 			for (Long toRemove : checkpointsToRemove) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ExactlyOnceSinkTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ExactlyOnceSinkTestBase.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskState;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public abstract class ExactlyOnceSinkTestBase<IN extends Tuple, S extends GenericExactlyOnceSink<IN>> {
+
+	protected class OperatorExposingTask<IN> extends OneInputStreamTask<IN, IN> {
+		public OneInputStreamOperator<IN, IN> getOperator() {
+			return this.headOperator;
+		}
+	}
+
+	protected OperatorExposingTask<IN> createTask() {
+		return new OperatorExposingTask<>();
+	}
+
+	protected abstract S createSink();
+
+	protected abstract TupleTypeInfo<IN> createTypeInfo();
+
+	protected abstract IN generateValue(int counter, int checkpointID);
+
+	protected abstract void verifyResultsIdealCircumstances(
+		OneInputStreamTaskTestHarness<IN, IN> harness, OneInputStreamTask<IN, IN> task, S sink) throws Exception;
+
+	protected abstract void verifyResultsDataPersistenceUponMissedNotify(
+		OneInputStreamTaskTestHarness<IN, IN> harness, OneInputStreamTask<IN, IN> task, S sink) throws Exception;
+
+	protected abstract void verifyResultsDataDiscardingUponRestore(
+		OneInputStreamTaskTestHarness<IN, IN> harness, OneInputStreamTask<IN, IN> task, S sink) throws Exception;
+
+	@Test
+	public void testIdealCircumstances() throws Exception {
+		S sink = createSink();
+		OperatorExposingTask<IN> task = createTask();
+		TupleTypeInfo<IN> info = createTypeInfo();
+		OneInputStreamTaskTestHarness<IN, IN> testHarness = new OneInputStreamTaskTestHarness<>(task, 1, 1, info, info);
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(sink);
+
+		int elementCounter = 1;
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		ArrayList<StreamTaskState> states = new ArrayList<>();
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 0)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+		task.notifyCheckpointComplete(states.size() - 1);
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 1)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+		task.notifyCheckpointComplete(states.size() - 1);
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 2)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+		task.notifyCheckpointComplete(states.size() - 1);
+
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+
+		verifyResultsIdealCircumstances(testHarness, task, (S) task.getOperator());
+	}
+
+	@Test
+	public void testDataPersistenceUponMissedNotify() throws Exception {
+		S sink = createSink();
+		OperatorExposingTask<IN> task = createTask();
+		TupleTypeInfo<IN> info = createTypeInfo();
+		OneInputStreamTaskTestHarness<IN, IN> testHarness = new OneInputStreamTaskTestHarness<>(task, 1, 1, info, info);
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(sink);
+
+		int elementCounter = 1;
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		ArrayList<StreamTaskState> states = new ArrayList<>();
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 0)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+		task.notifyCheckpointComplete(states.size() - 1);
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 1)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 2)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+		task.notifyCheckpointComplete(states.size() - 1);
+
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+
+		verifyResultsDataPersistenceUponMissedNotify(testHarness, task, (S) task.getOperator());
+	}
+
+	@Test
+	public void testDataDiscardingUponRestore() throws Exception {
+		S sink = createSink();
+		OperatorExposingTask<IN> task = createTask();
+		TupleTypeInfo<IN> info = createTypeInfo();
+		OneInputStreamTaskTestHarness<IN, IN> testHarness = new OneInputStreamTaskTestHarness<>(task, 1, 1, info, info);
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		streamConfig.setStreamOperator(sink);
+
+		int elementCounter = 1;
+
+		testHarness.invoke();
+		testHarness.waitForTaskRunning();
+
+		ArrayList<StreamTaskState> states = new ArrayList<>();
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 0)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+		task.notifyCheckpointComplete(states.size() - 1);
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 1)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		task.getOperator().restoreState(states.get(states.size() - 1), 0);
+
+		for (int x = 0; x < 200; x++) {
+			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 2)));
+			elementCounter++;
+		}
+		testHarness.waitForInputProcessing();
+
+		states.add(task.getOperator().snapshotOperatorState(states.size(), 0));
+		task.notifyCheckpointComplete(states.size() - 1);
+
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+
+		verifyResultsDataDiscardingUponRestore(testHarness, task, (S) task.getOperator());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ExactlyOnceSinkTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ExactlyOnceSinkTestBase.java
@@ -17,8 +17,7 @@
  */
 package org.apache.flink.streaming.runtime.operators;
 
-import org.apache.flink.api.java.tuple.Tuple;
-import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -29,7 +28,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 
-public abstract class ExactlyOnceSinkTestBase<IN extends Tuple, S extends GenericExactlyOnceSink<IN>> {
+public abstract class ExactlyOnceSinkTestBase<IN, S extends GenericExactlyOnceSink<IN>> {
 
 	protected class OperatorExposingTask<IN> extends OneInputStreamTask<IN, IN> {
 		public OneInputStreamOperator<IN, IN> getOperator() {
@@ -43,7 +42,7 @@ public abstract class ExactlyOnceSinkTestBase<IN extends Tuple, S extends Generi
 
 	protected abstract S createSink();
 
-	protected abstract TupleTypeInfo<IN> createTypeInfo();
+	protected abstract TypeInformation<IN> createTypeInfo();
 
 	protected abstract IN generateValue(int counter, int checkpointID);
 
@@ -60,7 +59,7 @@ public abstract class ExactlyOnceSinkTestBase<IN extends Tuple, S extends Generi
 	public void testIdealCircumstances() throws Exception {
 		S sink = createSink();
 		OperatorExposingTask<IN> task = createTask();
-		TupleTypeInfo<IN> info = createTypeInfo();
+		TypeInformation<IN> info = createTypeInfo();
 		OneInputStreamTaskTestHarness<IN, IN> testHarness = new OneInputStreamTaskTestHarness<>(task, 1, 1, info, info);
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 		streamConfig.setStreamOperator(sink);
@@ -109,7 +108,7 @@ public abstract class ExactlyOnceSinkTestBase<IN extends Tuple, S extends Generi
 	public void testDataPersistenceUponMissedNotify() throws Exception {
 		S sink = createSink();
 		OperatorExposingTask<IN> task = createTask();
-		TupleTypeInfo<IN> info = createTypeInfo();
+		TypeInformation<IN> info = createTypeInfo();
 		OneInputStreamTaskTestHarness<IN, IN> testHarness = new OneInputStreamTaskTestHarness<>(task, 1, 1, info, info);
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 		streamConfig.setStreamOperator(sink);
@@ -157,7 +156,7 @@ public abstract class ExactlyOnceSinkTestBase<IN extends Tuple, S extends Generi
 	public void testDataDiscardingUponRestore() throws Exception {
 		S sink = createSink();
 		OperatorExposingTask<IN> task = createTask();
-		TupleTypeInfo<IN> info = createTypeInfo();
+		TypeInformation<IN> info = createTypeInfo();
 		OneInputStreamTaskTestHarness<IN, IN> testHarness = new OneInputStreamTaskTestHarness<>(task, 1, 1, info, info);
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 		streamConfig.setStreamOperator(sink);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericExactlyOnceSinkTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenericExactlyOnceSinkTest extends ExactlyOnceSinkTestBase<Tuple1<Integer>, GenericExactlyOnceSinkTest.ListSink> {
+	@Override
+	protected ListSink createSink() {
+		return new ListSink();
+	}
+
+	@Override
+	protected TupleTypeInfo<Tuple1<Integer>> createTypeInfo() {
+		return TupleTypeInfo.getBasicTupleTypeInfo(Integer.class);
+	}
+
+	@Override
+	protected Tuple1<Integer> generateValue(int counter, int checkpointID) {
+		return new Tuple1<>(counter);
+	}
+
+	@Override
+	protected void verifyResultsIdealCircumstances(
+		OneInputStreamTaskTestHarness<Tuple1<Integer>, Tuple1<Integer>> harness,
+		OneInputStreamTask<Tuple1<Integer>, Tuple1<Integer>> task, ListSink sink) {
+
+		ArrayList<Integer> list = new ArrayList<>();
+		for (int x = 1; x <= 600; x++) {
+			list.add(x);
+		}
+
+		for (Integer i : sink.values) {
+			list.remove(i);
+		}
+		Assert.assertTrue("The following ID's where not found in the result list: " + list.toString(), list.isEmpty());
+	}
+
+	@Override
+	protected void verifyResultsDataPersistenceUponMissedNotify(
+		OneInputStreamTaskTestHarness<Tuple1<Integer>, Tuple1<Integer>> harness,
+		OneInputStreamTask<Tuple1<Integer>, Tuple1<Integer>> task, ListSink sink) {
+
+		ArrayList<Integer> list = new ArrayList<>();
+		for (int x = 1; x <= 600; x++) {
+			list.add(x);
+		}
+
+		for (Integer i : sink.values) {
+			list.remove(i);
+		}
+		Assert.assertTrue("The following ID's where not found in the result list: " + list.toString(), list.isEmpty());
+	}
+
+	@Override
+	protected void verifyResultsDataDiscardingUponRestore(
+		OneInputStreamTaskTestHarness<Tuple1<Integer>, Tuple1<Integer>> harness,
+		OneInputStreamTask<Tuple1<Integer>, Tuple1<Integer>> task, ListSink sink) {
+
+		ArrayList<Integer> list = new ArrayList<>();
+		for (int x = 1; x <= 200; x++) {
+			list.add(x);
+		}
+		for (int x = 401; x <= 600; x++) {
+			list.add(x);
+		}
+
+		for (Integer i : sink.values) {
+			list.remove(i);
+		}
+		Assert.assertTrue("The following ID's where not found in the result list: " + list.toString(), list.isEmpty());
+	}
+
+	/**
+	 * Simple sink that stores all records in a public list.
+	 */
+	public static class ListSink extends GenericExactlyOnceSink<Tuple1<Integer>> {
+		public List<Integer> values = new ArrayList<>();
+
+		@Override
+		protected void sendValue(Tuple1<Integer> value) throws Exception {
+			values.add(value.f0);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds an Exactly-Once Cassandra Sink.

The Exactly-once guarantee is made by saving incoming records in the OperatorState, and only committing them into Cassandra when a checkpoint completes. Note that a job failure while the data is being committed will cause duplicate data to be committed, but the chance of this happening is much smaller than for a naive At-Least-once implementation.

The CassandraExactlyOnceSink is implemented as a custom operator to get access to the Statebackend. Values are committed with single inserts using a PreparedStatement that is supplied by the user, similiar to the Batch JDBC-Outputformat.

The Exactly-Once logic is completely contained in a GenericExactlyOnceSink class that can be used by virtually every sink, requiring no knowledge about the checkpointing mechamism.

The CassandraExactlyOnceSink and GenericExactlyOnceSink are covered by tests that use the OneInputStreamTaskHarness to generate a task environment, verifying that stored data is discarded when a state is restored; all data is being committed when a notify is missed; and of course that everything works when nothing goes wrong.

Note: This PR currently subsumes #1609 (the change to ResultPartitionWriter), so that the tests run properly.