### PR TITLE
[FLINK-3368][Kafka 0.8] Handle leader changes in Kafka Consumer.

### DIFF
--- a/docs/apis/streaming/connectors/kafka.md
+++ b/docs/apis/streaming/connectors/kafka.md
@@ -203,3 +203,12 @@ stream.addSink(new FlinkKafkaProducer08[String]("localhost:9092", "my-topic", ne
 You can also define a custom Kafka producer configuration for the KafkaSink with the constructor. Please refer to
 the [Apache Kafka documentation](https://kafka.apache.org/documentation.html) for details on how to configure
 Kafka Producers.
+
+**Note**: By default, the number of retries is set to "0". This means that the producer fails immediately on errors,
+including leader changes. The value is set to "0" by default to avoid duplicate messages in the target topic.
+For most production environments with frequent broker changes, we recommend setting the number of retries to a 
+higher value.
+
+There is currently no transactional producer for Kafka, so Flink can not guarantee exactly-once delivery
+into a Kafka topic.
+

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Fetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Fetcher.java
@@ -61,16 +61,7 @@ public interface Fetcher {
 	 */
 	<T> void run(SourceFunction.SourceContext<T> sourceContext, KeyedDeserializationSchema<T> valueDeserializer,
 				HashMap<KafkaTopicPartition, Long> lastOffsets) throws Exception;
-	
-	/**
-	 * Set the next offset to read from for the given partition.
-	 * For example, if the partition <i>i</i> offset is set to <i>n</i>, the Fetcher's next result
-	 * will be the message with <i>offset=n</i>.
-	 * 
-	 * @param topicPartition The partition for which to seek the offset.
-	 * @param offsetToRead To offset to seek to.
-	 */
-	void seek(KafkaTopicPartition topicPartition, long offsetToRead);
+
 
 	/**
 	 * Exit run loop with given error and release all resources.

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/OffsetHandler.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/OffsetHandler.java
@@ -45,7 +45,7 @@ public interface OffsetHandler {
 	 * @param partitions The partitions for which to seeks the fetcher to the beginning.
 	 * @param fetcher The fetcher that will pull data from Kafka and must be positioned.
 	 */
-	void seekFetcherToInitialOffsets(List<KafkaTopicPartitionLeader> partitions, Fetcher fetcher) throws Exception;
+	Map<KafkaTopicPartition, Long> getOffsets(List<KafkaTopicPartition> partitions, Fetcher fetcher) throws Exception;
 
 	/**
 	 * Closes the offset handler, releasing all resources.

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
@@ -318,6 +318,7 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 	public void run(SourceContext<T> sourceContext) throws Exception {
 		if(consumer != null) {
 			consumerThread = new ConsumerThread<>(this, sourceContext);
+			consumerThread.setDaemon(true);
 			consumerThread.start();
 			// wait for the consumer to stop
 			while(consumerThread.isAlive()) {

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartition.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartition.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -84,25 +83,19 @@ public class KafkaTopicPartition implements Serializable {
 
 	// ------------------- Utilities -------------------------------------
 
-	/**
-	 * Returns a unique list of topics from the topic partition map
-	 *
-	 * @param topicPartitionMap A map of KafkaTopicPartition's
-	 * @return A unique list of topics from the input map
-	 */
-	public static List<String> getTopics(Map<KafkaTopicPartition, ?> topicPartitionMap) {
-		HashSet<String> uniqueTopics = new HashSet<>();
-		for (KafkaTopicPartition ktp: topicPartitionMap.keySet()) {
-			uniqueTopics.add(ktp.getTopic());
-		}
-		return new ArrayList<>(uniqueTopics);
-	}
-
 	public static String toString(Map<KafkaTopicPartition, Long> map) {
 		StringBuilder sb = new StringBuilder();
 		for (Map.Entry<KafkaTopicPartition, Long> p: map.entrySet()) {
 			KafkaTopicPartition ktp = p.getKey();
 			sb.append(ktp.getTopic()).append(":").append(ktp.getPartition()).append("=").append(p.getValue()).append(", ");
+		}
+		return sb.toString();
+	}
+
+	public static String toString(List<KafkaTopicPartition> partitions) {
+		StringBuilder sb = new StringBuilder();
+		for (KafkaTopicPartition p: partitions) {
+			sb.append(p.getTopic()).append(":").append(p.getPartition()).append(", ");
 		}
 		return sb.toString();
 	}
@@ -122,7 +115,7 @@ public class KafkaTopicPartition implements Serializable {
 		return false;
 	}
 
-	public static List<KafkaTopicPartition> convertToPartitionInfo(List<KafkaTopicPartitionLeader> partitionInfos) {
+	public static List<KafkaTopicPartition> dropLeaderData(List<KafkaTopicPartitionLeader> partitionInfos) {
 		List<KafkaTopicPartition> ret = new ArrayList<>(partitionInfos.size());
 		for(KafkaTopicPartitionLeader ktpl: partitionInfos) {
 			ret.add(ktpl.getTopicPartition());

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionLeader.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionLeader.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 import org.apache.kafka.common.Node;
 
 import java.io.Serializable;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -62,14 +62,6 @@ public class KafkaTopicPartitionLeader implements Serializable {
 		} else {
 			return new Node(leaderId, leaderHost, leaderPort);
 		}
-	}
-
-	public static Object toString(List<KafkaTopicPartitionLeader> partitions) {
-		StringBuilder sb = new StringBuilder();
-		for (KafkaTopicPartitionLeader p: partitions) {
-			sb.append(p.getTopicPartition().getTopic()).append(":").append(p.getTopicPartition().getPartition()).append(", ");
-		}
-		return sb.toString();
 	}
 
 	@Override
@@ -115,7 +107,8 @@ public class KafkaTopicPartitionLeader implements Serializable {
 	 * @return oldValue the old value (offset)
 	 */
 	public static Long replaceIgnoringLeader(KafkaTopicPartitionLeader newKey, Long newValue, Map<KafkaTopicPartitionLeader, Long> map) {
-		for(Map.Entry<KafkaTopicPartitionLeader, Long> entry: map.entrySet()) {
+		Map<KafkaTopicPartitionLeader, Long> searchMap = new HashMap<>(map); // create copy for the iterator
+		for(Map.Entry<KafkaTopicPartitionLeader, Long> entry: searchMap.entrySet()) {
 			if(entry.getKey().getTopicPartition().equals(newKey.getTopicPartition())) {
 				Long oldValue = map.remove(entry.getKey());
 				if(map.put(newKey, newValue) != null) {

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -888,7 +888,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		LOG.info("Leader to shutdown {}", leaderId);
 
 
-		// run the topology that fails and recovers
+		// run the topology (the consumers must handle the failures)
 
 		DeserializationSchema<Integer> schema =
 				new TypeInformationSerializationSchema<>(BasicTypeInfo.INT_TYPE_INFO, new ExecutionConfig());
@@ -896,7 +896,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
 		env.setParallelism(parallelism);
 		env.enableCheckpointing(500);
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 1000));
+		env.setRestartStrategy(RestartStrategies.noRestart());
 		env.getConfig().disableSysoutLogging();
 
 
@@ -909,7 +909,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 				.addSink(new ValidatingExactlyOnceSink(totalElements)).setParallelism(1);
 
 		BrokerKillingMapper.killedLeaderBefore = false;
-		tryExecute(env, "One-to-one exactly once test");
+		tryExecute(env, "Broker failure once test");
 
 		// start a new broker:
 		kafkaServer.restartBroker(leaderId);


### PR DESCRIPTION
Please see the JIRA for an explanation of the problems.
tl;dr: The Kafka 0.8 consumer now handles broker failures internally, without relying on Flink's checkpointing / job recovery.

The test case which was previously relying on a topology restart is now expecting the consumers to handle the failure.

I also tested this change on a 7 nodes cluster. The job was running for 30 minutes, surviving 4 broker shutdowns.