### PR TITLE
[FLINK-3352] Use HDFS Config in RocksDB Copy Utilities

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/pom.xml
+++ b/flink-contrib/flink-statebackend-rocksdb/pom.xml
@@ -57,7 +57,6 @@ under the License.
 			<artifactId>rocksdbjni</artifactId>
 			<version>4.1.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime_2.10</artifactId>
@@ -65,7 +64,17 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_2.10</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+		</dependency>
 	</dependencies>
-
 </project>

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -156,7 +156,7 @@ public class RocksDBFoldingState<K, N, T, ACC>
 	protected AbstractRocksDBSnapshot<K, N, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>> createRocksDBSnapshot(
 			URI backupUri, long checkpointId) {
 		
-		return new Snapshot<>(dbPath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
+		return new Snapshot<>(basePath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
 	}
 
 	private static class Snapshot<K, N, T, ACC> extends AbstractRocksDBSnapshot<K, N, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>> {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -154,7 +154,7 @@ public class RocksDBListState<K, N, V>
 			URI backupUri,
 			long checkpointId) {
 		
-		return new Snapshot<>(dbPath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
+		return new Snapshot<>(basePath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
 	}
 
 	private static class Snapshot<K, N, V> extends 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -183,12 +183,12 @@ public class RocksDBListState<K, N, V>
 				TypeSerializer<K> keySerializer,
 				TypeSerializer<N> namespaceSerializer,
 				ListStateDescriptor<V> stateDesc,
-				File dbPath,
+				File basePath,
 				String backupPath,
 				String restorePath,
 				Options options) throws Exception {
 			
-			return new RocksDBListState<>(keySerializer, namespaceSerializer, stateDesc, dbPath, 
+			return new RocksDBListState<>(keySerializer, namespaceSerializer, stateDesc, basePath,
 					checkpointPath, restorePath, options);
 		}
 	}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -152,7 +152,7 @@ public class RocksDBReducingState<K, N, V>
 			URI backupUri,
 			long checkpointId) {
 		
-		return new Snapshot<>(dbPath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
+		return new Snapshot<>(basePath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
 	}
 
 	private static class Snapshot<K, N, V> extends 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -181,13 +181,13 @@ public class RocksDBReducingState<K, N, V>
 				TypeSerializer<K> keySerializer,
 				TypeSerializer<N> namespaceSerializer,
 				ReducingStateDescriptor<V> stateDesc,
-				File dbPath,
+				File basePath,
 				String backupPath,
 				String restorePath,
 				Options options) throws Exception {
 			
-			return new RocksDBReducingState<>(keySerializer, namespaceSerializer, stateDesc, 
-					dbPath, checkpointPath, restorePath, options);
+			return new RocksDBReducingState<>(keySerializer, namespaceSerializer, stateDesc,
+					basePath, checkpointPath, restorePath, options);
 		}
 	}
 }

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -68,19 +68,17 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	private static final Logger LOG = LoggerFactory.getLogger(RocksDBStateBackend.class);
 	
 	
-	/** The checkpoint directory that copy the RocksDB backups to. */
+	/** The checkpoint directory that we copy the RocksDB backups to. */
 	private final Path checkpointDirectory;
 
 	/** The state backend that stores the non-partitioned state */
 	private final AbstractStateBackend nonPartitionedStateBackend;
-	
-	
+
 	/** Operator identifier that is used to uniqueify the RocksDB storage path. */
 	private String operatorIdentifier;
 
 	/** JobID for uniquifying backup paths. */
 	private JobID jobId;
-	
 
 	// DB storage directories
 	

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -169,12 +169,12 @@ public class RocksDBValueState<K, N, V>
 				TypeSerializer<K> keySerializer,
 				TypeSerializer<N> namespaceSerializer,
 				ValueStateDescriptor<V> stateDesc,
-				File dbPath,
+				File basePath,
 				String backupPath,
 				String restorePath,
 				Options options) throws Exception {
 			
-			return new RocksDBValueState<>(keySerializer, namespaceSerializer, stateDesc, dbPath, 
+			return new RocksDBValueState<>(keySerializer, namespaceSerializer, stateDesc, basePath,
 					checkpointPath, restorePath, options);
 		}
 	}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -140,7 +140,7 @@ public class RocksDBValueState<K, N, V>
 			URI backupUri,
 			long checkpointId) {
 		
-		return new Snapshot<>(dbPath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
+		return new Snapshot<>(basePath, checkpointPath, backupUri, checkpointId, keySerializer, namespaceSerializer, stateDesc);
 	}
 
 	private static class Snapshot<K, N, V> 

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/HDFSCopyUtilitiesTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/HDFSCopyUtilitiesTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.net.URI;
+
+import static org.junit.Assert.assertTrue;
+
+public class HDFSCopyUtilitiesTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+
+	/**
+	 * This test verifies that a hadoop configuration is correctly read in the external
+	 * process copying tools.
+	 */
+	@Test
+	public void testCopyFromLocal() throws Exception {
+		Configuration config = new Configuration();
+		config.set("fs.default.name", "magic-1337:///");
+
+		File testFolder = tempFolder.newFolder();
+		File hadoopConfPath = new File(testFolder, "hadoop-conf.binary");
+		try (DataOutputStream out = new DataOutputStream(new FileOutputStream(hadoopConfPath))) {
+			config.write(out);
+		}
+
+		File originalFile = new File(testFolder, "original");
+		File copyFile = new File(testFolder, "copy");
+
+		try (DataOutputStream out = new DataOutputStream(new FileOutputStream(originalFile))) {
+			out.writeUTF("Hello there, 42!");
+		}
+
+		try {
+			HDFSCopyFromLocal.copyFromLocal(hadoopConfPath,
+					originalFile,
+					new URI(copyFile.getAbsolutePath()));
+		} catch (Exception e) {
+			// The copying will try to write to filesystem "magic-1337" for which there is no
+			// implementation, the error message will contain the name of the file system and
+			// we check for that.
+			assertTrue(e.getMessage().contains("magic-1337"));
+		}
+
+		config.set("fs.default.name", "file:///");
+
+		hadoopConfPath.delete();
+		try (DataOutputStream out = new DataOutputStream(new FileOutputStream(hadoopConfPath))) {
+			config.write(out);
+		}
+
+		HDFSCopyFromLocal.copyFromLocal(hadoopConfPath,
+				originalFile,
+				new URI(copyFile.getAbsolutePath()));
+
+		try (DataInputStream in = new DataInputStream(new FileInputStream(copyFile))) {
+			assertTrue(in.readUTF().equals("Hello there, 42!"));
+
+		}
+	}
+
+	/**
+	 * This test verifies that a hadoop configuration is correctly read in the external
+	 * process copying tools.
+	 */
+	@Test
+	public void testCopyToLocal() throws Exception {
+		Configuration config = new Configuration();
+		config.set("fs.default.name", "magic-1337:///");
+
+		File testFolder = tempFolder.newFolder();
+		File hadoopConfPath = new File(testFolder, "hadoop-conf.binary");
+		try (DataOutputStream out = new DataOutputStream(new FileOutputStream(hadoopConfPath))) {
+			config.write(out);
+		}
+
+		File originalFile = new File(testFolder, "original");
+		File copyFile = new File(testFolder, "copy");
+
+		try (DataOutputStream out = new DataOutputStream(new FileOutputStream(originalFile))) {
+			out.writeUTF("Hello there, 42!");
+		}
+
+		try {
+			HDFSCopyToLocal.copyToLocal(hadoopConfPath,
+					new URI(originalFile.getAbsolutePath()),
+					copyFile);
+		} catch (Exception e) {
+			// The copying will try to write to filesystem "magic-1337" for which there is no
+			// implementation, the error message will contain the name of the file system and
+			// we check for that.
+			assertTrue(e.getMessage().contains("magic-1337"));
+		}
+
+		config.set("fs.default.name", "file:///");
+
+		hadoopConfPath.delete();
+		try (DataOutputStream out = new DataOutputStream(new FileOutputStream(hadoopConfPath))) {
+			config.write(out);
+		}
+
+		HDFSCopyToLocal.copyToLocal(hadoopConfPath,
+				new URI(originalFile.getAbsolutePath()),
+				copyFile);
+
+		try (DataInputStream in = new DataInputStream(new FileInputStream(copyFile))) {
+			assertTrue(in.readUTF().equals("Hello there, 42!"));
+
+		}
+	}
+
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -37,8 +37,8 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 
 	@Override
 	protected RocksDBStateBackend getStateBackend() throws IOException {
-		dbDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
-		chkDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString());
+		dbDir = new File(new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString()), "state");
+		chkDir = new File(new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString()), "snapshots");
 
 		RocksDBStateBackend backend = new RocksDBStateBackend(chkDir.getAbsoluteFile().toURI(), new MemoryStateBackend());
 		backend.setDbStoragePath(dbDir.getAbsolutePath());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsynchronousKvStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsynchronousKvStateSnapshot.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+/**
+ * {@link KvStateSnapshot} that asynchronously materializes the state that it represents. Instead
+ * of representing a materialized handle to state this would normally hold the (immutable) state
+ * internally and materializes it when {@link #materialize()} is called.
+ *
+ * @param <K> The type of the key
+ * @param <N> The type of the namespace
+ * @param <S> The type of the {@link State}
+ * @param <SD> The type of the {@link StateDescriptor}
+ * @param <Backend> The type of the backend that can restore the state from this snapshot.
+ */
+public abstract class AsynchronousKvStateSnapshot<K, N, S extends State, SD extends StateDescriptor<S, ?>, Backend extends AbstractStateBackend> implements KvStateSnapshot<K, N, S, SD, Backend> {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Materializes the state held by this {@code AsynchronousKvStateSnapshot}.
+	 */
+	public abstract KvStateSnapshot<K, N, S, SD, Backend> materialize() throws Exception;
+
+	@Override
+	public final KvState<K, N, S, SD, Backend> restoreState(
+		Backend stateBackend,
+		TypeSerializer<K> keySerializer,
+		ClassLoader classLoader,
+		long recoveryTimestamp) throws Exception {
+		throw new RuntimeException("This should never be called and probably points to a bug.");
+	}
+
+	@Override
+	public void discardState() throws Exception {
+		throw new RuntimeException("This should never be called and probably points to a bug.");
+	}
+
+	@Override
+	public long getStateSize() throws Exception {
+		throw new RuntimeException("This should never be called and probably points to a bug.");
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskStateList.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskStateList.java
@@ -33,11 +33,35 @@ public class StreamTaskStateList implements StateHandle<StreamTaskState[]> {
 	/** The states for all operator */
 	private final StreamTaskState[] states;
 
-	private final long stateSize;
-	
 	public StreamTaskStateList(StreamTaskState[] states) throws Exception {
 		this.states = states;
+	}
 
+	public boolean isEmpty() {
+		for (StreamTaskState state : states) {
+			if (state != null) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	@Override
+	public StreamTaskState[] getState(ClassLoader userCodeClassLoader) {
+		return states;
+	}
+
+	@Override
+	public void discardState() throws Exception {
+		for (StreamTaskState state : states) {
+			if (state != null) {
+				state.discardState();
+			}
+		}
+	}
+
+	@Override
+	public long getStateSize() throws Exception {
 		long sumStateSize = 0;
 
 		if (states != null) {
@@ -67,34 +91,6 @@ public class StreamTaskStateList implements StateHandle<StreamTaskState[]> {
 		}
 
 		// State size as sum of all state sizes
-		stateSize = sumStateSize;
-	}
-
-	public boolean isEmpty() {
-		for (StreamTaskState state : states) {
-			if (state != null) {
-				return false;
-			}
-		}
-		return true;
-	}
-	
-	@Override
-	public StreamTaskState[] getState(ClassLoader userCodeClassLoader) {
-		return states;
-	}
-
-	@Override
-	public void discardState() throws Exception {
-		for (StreamTaskState state : states) {
-			if (state != null) {
-				state.discardState();
-			}
-		}
-	}
-
-	@Override
-	public long getStateSize() throws Exception {
-		return stateSize;
+		return sumStateSize;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -19,6 +19,8 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 
@@ -99,5 +101,10 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 		streamConfig.setTypeSerializerIn1(inputSerializer);
 	}
 
+	public <K> void configureForKeyedStream(KeySelector<IN, K> keySelector, TypeInformation<K> keyType) {
+		ClosureCleaner.clean(keySelector, false);
+		streamConfig.setStatePartitioner(0, keySelector);
+		streamConfig.setStateKeySerializer(keyType.createSerializer(executionConfig));
+	}
 }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -51,10 +51,16 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.model.Statement;
 
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;


### PR DESCRIPTION
This also moves the utilities (HDFSCopyFromLocal and HDFSCopyToLocal) to
the RocksDB package because we would need a HDFS dependency in
flink-core otherwise.