### PR TITLE
[FLINK-3226] Translate logical joins to physical

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
@@ -32,9 +32,9 @@ import org.apache.flink.api.table.codegen.Indenter.toISC
 import org.apache.flink.api.table.codegen.OperatorCodeGen._
 import org.apache.flink.api.table.plan.TypeConverter.sqlTypeToTypeInfo
 import org.apache.flink.api.table.typeinfo.RowTypeInfo
-
 import scala.collection.JavaConversions._
 import scala.collection.mutable
+import org.apache.flink.api.common.functions.FlatJoinFunction
 
 /**
   * A code generator for generating Flink [[org.apache.flink.api.common.functions.Function]]s.
@@ -148,16 +148,24 @@ class CodeGenerator(
       if (clazz == classOf[FlatMapFunction[_,_]]) {
         val inputTypeTerm = boxedTypeTermForTypeInfo(input1)
         (s"void flatMap(Object _in1, org.apache.flink.util.Collector $collectorTerm)",
-          s"$inputTypeTerm $input1Term = ($inputTypeTerm) _in1;")
+          List(s"$inputTypeTerm $input1Term = ($inputTypeTerm) _in1;"))
       }
 
       // MapFunction
       else if (clazz == classOf[MapFunction[_,_]]) {
         val inputTypeTerm = boxedTypeTermForTypeInfo(input1)
         ("Object map(Object _in1)",
-          s"$inputTypeTerm $input1Term = ($inputTypeTerm) _in1;")
+          List(s"$inputTypeTerm $input1Term = ($inputTypeTerm) _in1;"))
       }
 
+      // FlatJoinFunction
+      else if (clazz == classOf[FlatJoinFunction[_,_,_]]) {
+        val inputTypeTerm1 = boxedTypeTermForTypeInfo(input1)
+        val inputTypeTerm2 = boxedTypeTermForTypeInfo(input2.get) //TODO check this
+        (s"void join(Object _in1, Object _in2, org.apache.flink.util.Collector $collectorTerm)",
+          List(s"$inputTypeTerm1 $input1Term = ($inputTypeTerm1) _in1;",
+          s"$inputTypeTerm2 $input2Term = ($inputTypeTerm2) _in2;"))
+      }
       else {
         // TODO more functions
         throw new CodeGenException("Unsupported Function.")
@@ -175,7 +183,7 @@ class CodeGenerator(
 
         @Override
         public ${samHeader._1} {
-          ${samHeader._2}
+          ${samHeader._2.mkString("\n")}
           ${reuseInputUnboxingCode()}
           $bodyCode
         }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
@@ -161,7 +161,8 @@ class CodeGenerator(
       // FlatJoinFunction
       else if (clazz == classOf[FlatJoinFunction[_,_,_]]) {
         val inputTypeTerm1 = boxedTypeTermForTypeInfo(input1)
-        val inputTypeTerm2 = boxedTypeTermForTypeInfo(input2.get) //TODO check this
+        val inputTypeTerm2 = boxedTypeTermForTypeInfo(input2.getOrElse(
+            throw new CodeGenException("Input 2 for FlatJoinFunction should not be null")))
         (s"void join(Object _in1, Object _in2, org.apache.flink.util.Collector $collectorTerm)",
           List(s"$inputTypeTerm1 $input1Term = ($inputTypeTerm1) _in1;",
           s"$inputTypeTerm2 $input2Term = ($inputTypeTerm2) _in2;"))

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetJoin.scala
@@ -90,36 +90,9 @@ class DataSetJoin(
       config.getNullCheck,
       config.getEfficientTypeUsage)
 
-      if (func == null) {
-        // return the dataset as is
-        val toReturn = leftDataSet.join(rightDataSet)
-        .where(joinKeysLeft: _*).equalTo(joinKeysRight: _*)
-        .map(new Tuple2ToRowMapper).returns(returnType)
-        .asInstanceOf[DataSet[Any]]
-        toReturn
-      }
-      else {
-        val joinFun = func.apply(config, leftDataSet.getType, rightDataSet.getType, returnType)
-        leftDataSet.join(rightDataSet).where(joinKeysLeft: _*).equalTo(joinKeysRight: _*)
-        .`with`(joinFun).asInstanceOf[DataSet[Any]] 
-      }
+    val joinFun = func.apply(config, leftDataSet.getType, rightDataSet.getType, returnType)
+      leftDataSet.join(rightDataSet).where(joinKeysLeft: _*).equalTo(joinKeysRight: _*)
+      .`with`(joinFun).asInstanceOf[DataSet[Any]]
   }
-}
 
-class Tuple2ToRowMapper extends MapFunction[Tuple2[Any, Any], Any] {
-
-  override def map(input: Tuple2[Any, Any]): Any = {
-    val leftRow = input.f0.asInstanceOf[Row]
-    val leftLen = leftRow.productArity
-    val rightRow = input.f1.asInstanceOf[Row]
-    val rightLen = rightRow.productArity
-    val outRow = new Row(leftLen + rightLen)
-    for (i <- 0 until leftLen) {
-      outRow.setField(i, leftRow.productElement(i))
-    }
-    for (i <- 0 until rightLen) {
-      outRow.setField(i + leftLen, rightRow.productElement(i))
-    }
-    outRow
-  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetMap.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetMap.scala
@@ -63,7 +63,7 @@ class DataSetMap(
       config: TableConfig,
       expectedType: Option[TypeInformation[Any]])
     : DataSet[Any] = {
-    val inputDataSet = input.asInstanceOf[DataSetRel].translateToPlan(config)
+    val inputDataSet = input.asInstanceOf[DataSetRel].translateToPlan(config, expectedType)
     val returnType = determineReturnType(
       getRowType,
       expectedType,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetMap.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetMap.scala
@@ -63,7 +63,7 @@ class DataSetMap(
       config: TableConfig,
       expectedType: Option[TypeInformation[Any]])
     : DataSet[Any] = {
-    val inputDataSet = input.asInstanceOf[DataSetRel].translateToPlan(config, expectedType)
+    val inputDataSet = input.asInstanceOf[DataSetRel].translateToPlan(config)
     val returnType = determineReturnType(
       getRowType,
       expectedType,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataset/DataSetJoinRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataset/DataSetJoinRule.scala
@@ -24,6 +24,16 @@ import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.flink.api.java.operators.join.JoinType
 import org.apache.flink.api.table.plan.nodes.dataset.{DataSetConvention, DataSetJoin}
 import org.apache.flink.api.table.plan.nodes.logical.{FlinkJoin, FlinkConvention}
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+import org.apache.flink.api.table.plan.TypeConverter._
+import org.apache.flink.api.table.runtime.FlatJoinRunner
+import org.apache.flink.api.table.TableConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.table.codegen.CodeGenerator
+import org.apache.flink.api.common.functions.FlatJoinFunction
+import org.apache.calcite.rel.core.JoinInfo
+import org.apache.flink.api.table.TableException
 
 class DataSetJoinRule
   extends ConverterRule(
@@ -39,18 +49,80 @@ class DataSetJoinRule
     val convLeft: RelNode = RelOptRule.convert(join.getInput(0), DataSetConvention.INSTANCE)
     val convRight: RelNode = RelOptRule.convert(join.getInput(1), DataSetConvention.INSTANCE)
 
-    new DataSetJoin(
-      rel.getCluster,
-      traitSet,
-      convLeft,
-      convRight,
-      rel.getRowType,
-      join.toString,
-      Array[Int](),
-      Array[Int](),
-      JoinType.INNER,
-      null,
-      null)
+    // get the equality keys
+    val joinInfo = join.analyzeCondition
+    val keyPairs = joinInfo.pairs
+
+    if (keyPairs.isEmpty) { // if no equality keys => not supported
+      throw new TableException("Joins should have at least one equality condition")
+    }
+    else { // at least one equality expression => generate a join function
+      val conditionType = join.getCondition.getType
+      val func = getJoinFunction(join, joinInfo)
+      val leftKeys = ArrayBuffer.empty[Int]
+      val rightKeys = ArrayBuffer.empty[Int]
+
+      keyPairs.foreach(pair => {
+        leftKeys.add(pair.source)
+        rightKeys.add(pair.target)}
+      )
+
+      new DataSetJoin(
+        rel.getCluster,
+        traitSet,
+        convLeft,
+        convRight,
+        rel.getRowType,
+        join.toString,
+        leftKeys.toArray,
+        rightKeys.toArray,
+        JoinType.INNER,
+        null,
+        func)
+    }
+  }
+
+  def getJoinFunction(join: FlinkJoin, joinInfo: JoinInfo):
+      ((TableConfig, TypeInformation[Any], TypeInformation[Any], TypeInformation[Any]) =>
+      FlatJoinFunction[Any, Any, Any]) = {
+
+    if (joinInfo.isEqui) {
+      // only equality condition => no join function necessary
+      null
+    }
+    else {
+      val func = (
+        config: TableConfig,
+        leftInputType: TypeInformation[Any],
+        rightInputType: TypeInformation[Any],
+        returnType: TypeInformation[Any]) => {
+
+      val generator = new CodeGenerator(config, leftInputType, Some(rightInputType))
+      val condition = generator.generateExpression(join.getCondition)
+      val body = {
+        val conversion = generator.generateConverterResultExpression(returnType)
+        s"""
+          |${condition.code}
+          |if (${condition.resultTerm}) {
+          |  ${conversion.code}
+          |  ${generator.collectorTerm}.collect(${conversion.resultTerm});
+          |}
+          |""".stripMargin
+      }
+
+      val genFunction = generator.generateFunction(
+        description,
+        classOf[FlatJoinFunction[Any, Any, Any]],
+        body,
+        returnType)
+
+      new FlatJoinRunner[Any, Any, Any](
+        genFunction.name,
+        genFunction.code,
+        genFunction.returnType)
+      }
+    func
+    }
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/FlatJoinRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/FlatJoinRunner.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.runtime
+
+import org.apache.flink.api.common.functions.{FlatJoinFunction, RichFlatJoinFunction}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.util.Collector
+import org.slf4j.LoggerFactory
+
+class FlatJoinRunner[IN1, IN2, OUT](
+    name: String,
+    code: String,
+    @transient returnType: TypeInformation[OUT])
+  extends RichFlatJoinFunction[IN1, IN2, OUT]
+  with ResultTypeQueryable[OUT]
+  with FunctionCompiler[FlatJoinFunction[IN1, IN2, OUT]] {
+
+  val LOG = LoggerFactory.getLogger(this.getClass)
+
+  private var function: FlatJoinFunction[IN1, IN2, OUT] = null
+
+  override def open(parameters: Configuration): Unit = {
+    LOG.debug(s"Compiling FlatJoinFunction: $name \n\n Code:\n$code")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
+    LOG.debug("Instantiating FlatJoinFunction.")
+    function = clazz.newInstance()
+  }
+
+  override def join(first: IN1, second: IN2, out: Collector[OUT]): Unit =
+    function.join(first, second, out)
+
+  override def getProducedType: TypeInformation[OUT] = returnType
+}


### PR DESCRIPTION
This PR contains the logical to physical translation for joins.
- Joins with equality conditions only do not generate a join function.
- Joins with equality and non-equality conditions evaluate the non-equality conditions inside a `FlatJoinFunction`.
- Joins without any equality conditions e.g. `in1.join.in2.where(a > b)` are currently not supported. We could consider supporting those later by generating a cross function.