### PR TITLE
FLINK-3304: Making the Avro Schema serializable.

### DIFF
--- a/flink-batch-connectors/flink-avro/src/test/java/org/apache/flink/api/avro/AvroOutputFormatITCase.java
+++ b/flink-batch-connectors/flink-avro/src/test/java/org/apache/flink/api/avro/AvroOutputFormatITCase.java
@@ -68,7 +68,9 @@ public class AvroOutputFormatITCase extends JavaProgramTestBase {
 
 		//output the data with AvroOutputFormat for specific user type
 		DataSet<User> specificUser = input.map(new ConvertToUser());
-		specificUser.write(new AvroOutputFormat<User>(User.class), outputPath1);
+		AvroOutputFormat<User> avroOutputFormat = new AvroOutputFormat<User>(User.class);
+		avroOutputFormat.setSchema(User.SCHEMA$);
+		specificUser.write(avroOutputFormat, outputPath1);
 
 		//output the data with AvroOutputFormat for reflect user type
 		DataSet<ReflectiveUser> reflectiveUser = specificUser.map(new ConvertToReflective());


### PR DESCRIPTION
This solves the issue FLINK-3304 by making the Avro Schema serializable. 
This is done by having a custom serializer which transforms the Schema into a JSON string, and the deserializer de-serializes the JSON to re-create the original schema.