### PR TITLE
[FLINK-3400] Move RocksDB Copy Utils to flink-streaming-java

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.state.AsynchronousKvStateSnapshot;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
+import org.apache.flink.streaming.util.HDFSCopyFromLocal;
+import org.apache.flink.streaming.util.HDFSCopyToLocal;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/HDFSCopyFromLocal.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/HDFSCopyFromLocal.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.contrib.streaming.state;
+package org.apache.flink.streaming.util;
 
 import org.apache.flink.util.ExternalProcessRunner;
 import org.apache.hadoop.conf.Configuration;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/HDFSCopyToLocal.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/HDFSCopyToLocal.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.contrib.streaming.state;
+package org.apache.flink.streaming.util;
 
 import org.apache.flink.util.ExternalProcessRunner;
 import org.apache.hadoop.conf.Configuration;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.contrib.streaming.state;
+package org.apache.flink.streaming.util;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Rule;


### PR DESCRIPTION
They are not specific to RocksDB, just utilities for copying local
folders to/from HDFS. Moving them to flink-streaming-java means that
they are always in the classpath of the TaskManager, not only in the
user-code jar when using RocksDB. If they are only in the user-code jar
the external process runner cannot find the class files, leading to
ClassNotFoundExceptions.