### PR TITLE
[FLINK-3379] [FLINK-3415] [streaming] Refactor TimestampExtractor

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/join/WindowJoin.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/join/WindowJoin.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.functions.AscendingTimestampExtractor;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingTimeWindows;
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
  *   <li>write a simple streaming program.
  * </ul>
  */
+@SuppressWarnings("serial")
 public class WindowJoin {
 
 	// *************************************************************************
@@ -211,22 +212,11 @@ public class WindowJoin {
 		}
 	}
 
-	private static class MyTimestampExtractor implements TimestampExtractor<Tuple3<Long, String, Integer>> {
-		private static final long serialVersionUID = 1L;
+	private static class MyTimestampExtractor extends AscendingTimestampExtractor<Tuple3<Long, String, Integer>> {
 
 		@Override
-		public long extractTimestamp(Tuple3<Long, String, Integer> element, long currentTimestamp) {
+		public long extractAscendingTimestamp(Tuple3<Long, String, Integer> element, long currentTimestamp) {
 			return element.f0;
-		}
-
-		@Override
-		public long extractWatermark(Tuple3<Long, String, Integer> element, long currentTimestamp) {
-			return element.f0 - 1;
-		}
-
-		@Override
-		public long getCurrentWatermark() {
-			return Long.MIN_VALUE;
 		}
 	}
 

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/ml/IncrementalLearningSkeleton.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/ml/IncrementalLearningSkeleton.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.examples.ml;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
@@ -69,7 +69,7 @@ public class IncrementalLearningSkeleton {
 
 		// build new model on every second of new data
 		DataStream<Double[]> model = trainingData
-				.assignTimestamps(new LinearTimestamp())
+				.assignTimestampsAndWatermarks(new LinearTimestamp())
 				.timeWindowAll(Time.of(5000, TimeUnit.MILLISECONDS))
 				.apply(new PartialModelBuilder());
 
@@ -145,26 +145,20 @@ public class IncrementalLearningSkeleton {
 		}
 	}
 
-	public static class LinearTimestamp implements TimestampExtractor<Integer> {
+	public static class LinearTimestamp implements AssignerWithPunctuatedWatermarks<Integer> {
 		private static final long serialVersionUID = 1L;
 
 		private long counter = 0L;
 
 		@Override
-		public long extractTimestamp(Integer element, long currentTimestamp) {
+		public long extractTimestamp(Integer element, long previousElementTimestamp) {
 			return counter += 10L;
 		}
 
 		@Override
-		public long extractWatermark(Integer element, long currentTimestamp) {
+		public long checkAndGetNextWatermark(Integer lastElement, long extractedTimestamp) {
 			return counter - 1;
 		}
-
-		@Override
-		public long getCurrentWatermark() {
-			return Long.MIN_VALUE;
-		}
-
 	}
 
 	/**

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/TopSpeedWindowing.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.functions.AscendingTimestampExtractor;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.delta.DeltaFunction;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
@@ -150,8 +150,7 @@ public class TopSpeedWindowing {
 		}
 	}
 
-	private static class ParseCarData extends
-			RichMapFunction<String, Tuple4<Integer, Integer, Double, Long>> {
+	private static class ParseCarData extends RichMapFunction<String, Tuple4<Integer, Integer, Double, Long>> {
 		private static final long serialVersionUID = 1L;
 
 		@Override
@@ -162,24 +161,12 @@ public class TopSpeedWindowing {
 		}
 	}
 
-	private static class CarTimestamp implements TimestampExtractor<Tuple4<Integer, Integer, Double, Long>> {
+	private static class CarTimestamp extends AscendingTimestampExtractor<Tuple4<Integer, Integer, Double, Long>> {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public long extractTimestamp(Tuple4<Integer, Integer, Double, Long> element,
-				long currentTimestamp) {
+		public long extractAscendingTimestamp(Tuple4<Integer, Integer, Double, Long> element, long previous) {
 			return element.f3;
-		}
-
-		@Override
-		public long extractWatermark(Tuple4<Integer, Integer, Double, Long> element,
-				long currentTimestamp) {
-			return element.f3 - 1;
-		}
-
-		@Override
-		public long getCurrentWatermark() {
-			return Long.MIN_VALUE;
 		}
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -27,8 +27,9 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,6 +38,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.Map;
 
+@SuppressWarnings("serial")
 public class CEPITCase extends StreamingMultipleProgramsTestBase {
 
 	private String resultPath;
@@ -77,7 +79,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		);
 
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = 5681493970790509488L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -86,7 +87,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		})
 		.followedBy("middle").subtype(SubEvent.class).where(
 				new FilterFunction<SubEvent>() {
-					private static final long serialVersionUID = 448591738315698540L;
 
 					@Override
 					public boolean filter(SubEvent value) throws Exception {
@@ -95,7 +95,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 				}
 			)
 		.followedBy("end").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = 6080276591060431966L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -104,7 +103,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		});
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Event, String>() {
-			private static final long serialVersionUID = 1447462674590806097L;
 
 			@Override
 			public String select(Map<String, Event> pattern) {
@@ -148,7 +146,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			new Event(2, "end", 1.0),
 			new Event(42, "end", 42.0)
 		).keyBy(new KeySelector<Event, Integer>() {
-			private static final long serialVersionUID = -2112041392652797483L;
 
 			@Override
 			public Integer getKey(Event value) throws Exception {
@@ -157,7 +154,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		});
 
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = 5681493970790509488L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -166,7 +162,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		})
 			.followedBy("middle").subtype(SubEvent.class).where(
 				new FilterFunction<SubEvent>() {
-					private static final long serialVersionUID = 448591738315698540L;
 
 					@Override
 					public boolean filter(SubEvent value) throws Exception {
@@ -175,7 +170,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 				}
 			)
 			.followedBy("end").where(new FilterFunction<Event>() {
-				private static final long serialVersionUID = 6080276591060431966L;
 
 				@Override
 				public boolean filter(Event value) throws Exception {
@@ -184,7 +178,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			});
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Event, String>() {
-			private static final long serialVersionUID = 1447462674590806097L;
 
 			@Override
 			public String select(Map<String, Event> pattern) {
@@ -218,31 +211,21 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			Tuple2.of(new Event(3, "end", 3.0), 3L),
 			Tuple2.of(new Event(4, "end", 4.0), 10L),
 			Tuple2.of(new Event(5, "middle", 5.0), 7L)
-		).assignTimestamps(new TimestampExtractor<Tuple2<Event, Long>>() {
-			private static final long serialVersionUID = 878281782188702293L;
+		).assignTimestampsAndWatermarks(new AssignerWithPeriodicWatermarks<Tuple2<Event,Long>>() {
 
-			private Long currentMaxTimestamp = Long.MIN_VALUE;
+			private long currentMaxTimestamp = -1;
 
 			@Override
-			public long extractTimestamp(Tuple2<Event, Long> element, long currentTimestamp) {
-				if (currentMaxTimestamp < element.f1) {
-					currentMaxTimestamp = element.f1;
-				}
-
+			public long extractTimestamp(Tuple2<Event, Long> element, long previousTimestamp) {
+				currentMaxTimestamp = Math.max(currentMaxTimestamp, element.f1);
 				return element.f1;
 			}
 
 			@Override
-			public long extractWatermark(Tuple2<Event, Long> element, long currentTimestamp) {
+			public long getCurrentWatermark() {
 				return currentMaxTimestamp - 5;
 			}
-
-			@Override
-			public long getCurrentWatermark() {
-				return Long.MIN_VALUE;
-			}
 		}).map(new MapFunction<Tuple2<Event, Long>, Event>() {
-			private static final long serialVersionUID = -5288731103938665328L;
 
 			@Override
 			public Event map(Tuple2<Event, Long> value) throws Exception {
@@ -251,21 +234,18 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		});
 
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = 2601494641888389648L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("start");
 			}
 		}).followedBy("middle").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = -3133506934766766660L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("middle");
 			}
 		}).followedBy("end").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = -8528031731858936269L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -275,7 +255,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(
 			new PatternSelectFunction<Event, String>() {
-				private static final long serialVersionUID = 1447462674590806097L;
 
 				@Override
 				public String select(Map<String, Event> pattern) {
@@ -317,38 +296,27 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			Tuple2.of(new Event(1, "middle", 5.0), 7L),
 			Tuple2.of(new Event(3, "middle", 6.0), 9L),
 			Tuple2.of(new Event(3, "end", 7.0), 7L)
-		).assignTimestamps(new TimestampExtractor<Tuple2<Event, Long>>() {
-			private static final long serialVersionUID = 878281782188702293L;
+		).assignTimestampsAndWatermarks(new AssignerWithPeriodicWatermarks<Tuple2<Event,Long>>() {
 
-			private Long currentMaxTimestamp = Long.MIN_VALUE;
+			private long currentMaxTimestamp = -1L;
 
 			@Override
 			public long extractTimestamp(Tuple2<Event, Long> element, long currentTimestamp) {
-				if (currentMaxTimestamp < element.f1) {
-					currentMaxTimestamp = element.f1;
-				}
-
+				currentMaxTimestamp = Math.max(element.f1, currentMaxTimestamp);
 				return element.f1;
 			}
 
 			@Override
-			public long extractWatermark(Tuple2<Event, Long> element, long currentTimestamp) {
+			public long getCurrentWatermark() {
 				return currentMaxTimestamp - 5;
 			}
-
-			@Override
-			public long getCurrentWatermark() {
-				return Long.MIN_VALUE;
-			}
 		}).map(new MapFunction<Tuple2<Event, Long>, Event>() {
-			private static final long serialVersionUID = -5288731103938665328L;
 
 			@Override
 			public Event map(Tuple2<Event, Long> value) throws Exception {
 				return value.f0;
 			}
 		}).keyBy(new KeySelector<Event, Integer>() {
-			private static final long serialVersionUID = -3282946957177720879L;
 
 			@Override
 			public Integer getKey(Event value) throws Exception {
@@ -357,21 +325,18 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		});
 
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = 2601494641888389648L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("start");
 			}
 		}).followedBy("middle").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = -3133506934766766660L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("middle");
 			}
 		}).followedBy("end").where(new FilterFunction<Event>() {
-			private static final long serialVersionUID = -8528031731858936269L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -381,7 +346,6 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(
 			new PatternSelectFunction<Event, String>() {
-				private static final long serialVersionUID = 1447462674590806097L;
 
 				@Override
 				public String select(Map<String, Event> pattern) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -47,6 +47,8 @@ import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.TimestampExtractor;
 import org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
@@ -73,6 +75,8 @@ import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.operators.ExtractTimestampsOperator;
+import org.apache.flink.streaming.runtime.operators.TimestampsAndPeriodicWatermarksOperator;
+import org.apache.flink.streaming.runtime.operators.TimestampsAndPunctuatedWatermarksOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.CustomPartitionerWrapper;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
@@ -735,6 +739,10 @@ public class DataStream<T> {
 		return new AllWindowedStream<>(this, assigner);
 	}
 
+	// ------------------------------------------------------------------------
+	//  Timestamps and watermarks
+	// ------------------------------------------------------------------------
+	
 	/**
 	 * Extracts a timestamp from an element and assigns it as the internal timestamp of that element.
 	 * The internal timestamps are, for example, used to to event-time window operations.
@@ -745,11 +753,15 @@ public class DataStream<T> {
 	 * you should provide a {@link TimestampExtractor} that also implements
 	 * {@link TimestampExtractor#getCurrentWatermark()} to keep track of watermarks.
 	 *
-	 * @see org.apache.flink.streaming.api.watermark.Watermark
-	 *
 	 * @param extractor The TimestampExtractor that is called for each element of the DataStream.
+	 * 
+	 * @deprecated Please use {@link #assignTimestampsAndWatermarks(AssignerWithPeriodicWatermarks)}
+	 *             of {@link #assignTimestampsAndWatermarks(AssignerWithPunctuatedWatermarks)}
+	 *             instread.
+	 * @see #assignTimestampsAndWatermarks(AssignerWithPeriodicWatermarks)
+	 * @see #assignTimestampsAndWatermarks(AssignerWithPunctuatedWatermarks)
 	 */
-	@PublicEvolving
+	@Deprecated
 	public SingleOutputStreamOperator<T, ?> assignTimestamps(TimestampExtractor<T> extractor) {
 		// match parallelism to input, otherwise dop=1 sources could lead to some strange
 		// behaviour: the watermark will creep along very slowly because the elements
@@ -760,6 +772,95 @@ public class DataStream<T> {
 				.setParallelism(inputParallelism);
 	}
 
+	/**
+	 * Assigns timestamps to the elements in the data stream and periodically creates
+	 * watermarks to signal event time progress.
+	 * 
+	 * <p>This method creates watermarks periodically (for example every second), based
+	 * on the watermarks indicated by the given watermark generator. Even when no new elements
+	 * in the stream arrive, the given watermark generator will be periodically checked for
+	 * new watermarks. The interval in which watermarks are generated is defined in
+	 * {@link ExecutionConfig#setAutoWatermarkInterval(long)}.
+	 * 
+	 * <p>Use this method for the common cases, where some characteristic over all elements
+	 * should generate the watermarks, or where watermarks are simply trailing behind the
+	 * wall clock time by a certain amount.
+	 * 
+	 * <p>For cases where watermarks should be created in an irregular fashion, for example
+	 * based on certain markers that some element carry, use the
+	 * {@link AssignerWithPunctuatedWatermarks}.
+	 * 
+	 * @param timestampAndWatermarkAssigner The implementation of the timestamp assigner and
+	 *                                      watermark generator.   
+	 * @return The stream after the transformation, with assigned timestamps and watermarks.
+	 * 
+	 * @see AssignerWithPeriodicWatermarks
+	 * @see AssignerWithPunctuatedWatermarks
+	 * @see #assignTimestampsAndWatermarks(AssignerWithPunctuatedWatermarks) 
+	 */
+	public SingleOutputStreamOperator<T, ?> assignTimestampsAndWatermarks(
+			AssignerWithPeriodicWatermarks<T> timestampAndWatermarkAssigner) {
+		
+		// match parallelism to input, otherwise dop=1 sources could lead to some strange
+		// behaviour: the watermark will creep along very slowly because the elements
+		// from the source go to each extraction operator round robin.
+		final int inputParallelism = getTransformation().getParallelism();
+		final AssignerWithPeriodicWatermarks<T> cleanedAssigner = clean(timestampAndWatermarkAssigner);
+		
+		TimestampsAndPeriodicWatermarksOperator<T> operator = 
+				new TimestampsAndPeriodicWatermarksOperator<>(cleanedAssigner);
+		
+		return transform("Timestamps/Watermarks", getTransformation().getOutputType(), operator)
+				.setParallelism(inputParallelism);
+	}
+	
+	/**
+	 * Assigns timestamps to the elements in the data stream and periodically creates
+	 * watermarks to signal event time progress.
+	 *
+	 * <p>This method creates watermarks based purely on stream elements. For each element
+	 * that is handled via {@link AssignerWithPunctuatedWatermarks#extractTimestamp(Object, long)},
+	 * the {@link AssignerWithPunctuatedWatermarks#checkAndGetNextWatermark(Object, long)} 
+	 * method is called, and a new watermark is emitted, if the returned watermark value is
+	 * non-negative and greater than the previous watermark.
+	 * 
+	 * <p>This method is useful when the data stream embeds watermark elements, or certain elements
+	 * carry a marker that can be used to determine the current event time watermark. 
+	 * This operation gives the programmer full control over the watermark generation. Users
+	 * should be aware that too aggressive watermark generation (i.e., generating hundreds of
+	 * watermarks every second) can cost some performance.
+	 *
+	 * <p>For cases where watermarks should be created in a regular fashion, for example
+	 * every x milliseconds, use the {@link AssignerWithPeriodicWatermarks}.
+	 *
+	 * @param timestampAndWatermarkAssigner The implementation of the timestamp assigner and
+	 *                                      watermark generator.   
+	 * @return The stream after the transformation, with assigned timestamps and watermarks.
+	 *
+	 * @see AssignerWithPunctuatedWatermarks
+	 * @see AssignerWithPeriodicWatermarks
+	 * @see #assignTimestampsAndWatermarks(AssignerWithPeriodicWatermarks) 
+	 */
+	public SingleOutputStreamOperator<T, ?> assignTimestampsAndWatermarks(
+			AssignerWithPunctuatedWatermarks<T> timestampAndWatermarkAssigner) {
+		
+		// match parallelism to input, otherwise dop=1 sources could lead to some strange
+		// behaviour: the watermark will creep along very slowly because the elements
+		// from the source go to each extraction operator round robin.
+		final int inputParallelism = getTransformation().getParallelism();
+		final AssignerWithPunctuatedWatermarks<T> cleanedAssigner = clean(timestampAndWatermarkAssigner);
+
+		TimestampsAndPunctuatedWatermarksOperator<T> operator = 
+				new TimestampsAndPunctuatedWatermarksOperator<>(cleanedAssigner);
+		
+		return transform("Timestamps/Watermarks", getTransformation().getOutputType(), operator)
+				.setParallelism(inputParallelism);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Data sinks
+	// ------------------------------------------------------------------------
+	
 	/**
 	 * Writes a DataStream to the standard output stream (stdout).
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AssignerWithPeriodicWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AssignerWithPeriodicWatermarks.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions;
+
+import org.apache.flink.api.common.ExecutionConfig;
+
+/**
+ * The {@code AssignerWithPeriodicWatermarks} assigns event time timestamps to elements,
+ * and generates low watermarks that signal event time progress within the stream.
+ * These timestamps and watermarks are used by functions and operators that operate
+ * on event time, for example event time windows.
+ * 
+ * <p>This class is used to generate watermarks in a periodical interval.
+ * At most every {@code i} milliseconds (configured via
+ * {@link ExecutionConfig#getAutoWatermarkInterval()}, the system will call the
+ * {@link #getCurrentWatermark()} method to probe for the next watermark value.
+ * The system will generate a new watermark, if the probed value is larger than
+ * zero and larger than the previous watermark.
+ * 
+ * <p>The system may call the {@link #getCurrentWatermark()} method less often than every
+ * {@code i} milliseconds, of no new elements arrived since the last call to the
+ * method.
+ *
+ * <p>Timestamps and watermarks are defined as {@code longs} that represent the
+ * milliseconds since the Epoch (midnight, January 1, 1970 UTC).
+ * A watermark with a certain value {@code t} indicates that no elements with event
+ * timestamps {@code x}, where {@code x} is lower or equal to {@code t}, will occur any more.
+ * 
+ * @param <T> The type of the elements to which this assigner assigns timestamps.
+ * 
+ * @see org.apache.flink.streaming.api.watermark.Watermark
+ */
+public interface AssignerWithPeriodicWatermarks<T> extends TimestampAssigner<T> {
+
+	/**
+	 * Returns the current watermark. This method is periodically called by the
+	 * system to retrieve the current watermark.
+	 * 
+	 * <p>The current watermark will be emitted only if it is larger than the previously
+	 * emitted watermark. If the current watermark is still identical to the previous
+	 * one, no progress in event time has happened since the previous call to this method.
+	 * 
+	 * <p>If this method returns a value that is smaller than the previously returned watermark,
+	 * then the implementation does not properly handle the event stream timestamps.
+	 * In that case, the returned watermark will not be emitted (to preserve the contract of
+	 * ascending watermarks), and the violation will be logged and registered in the metrics.
+	 *     
+	 * <p>The interval in which this method is called and Watermarks are generated
+	 * depends on {@link ExecutionConfig#getAutoWatermarkInterval()}.
+	 *
+	 * @see org.apache.flink.streaming.api.watermark.Watermark
+	 * @see ExecutionConfig#getAutoWatermarkInterval()
+	 */
+	long getCurrentWatermark();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AssignerWithPunctuatedWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AssignerWithPunctuatedWatermarks.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions;
+
+/**
+ * The {@code AssignerWithPunctuatedWatermarks} assigns event time timestamps to elements,
+ * and generates low watermarks that signal event time progress within the stream.
+ * 
+ * <p>Use these class if certain special elements act as markers that signify event time
+ * progress, and when you want to emit watermarks specifically at certain events.
+ * 
+ * <p>For use cases that should periodically emit watermarks based on element timestamps,
+ * use the {@link AssignerWithPeriodicWatermarks} instead.
+ *
+ * <p>The following example illustrates how to use this timestamp extractor and watermark
+ * generator. It assumes elements carry a timestamp that describes when they were created,
+ * and that some elements carry a flag, marking them as the end of a sequence such that no
+ * elements with smaller timestamps can come any more.
+ * 
+ * <pre>{@code
+ * public class WatermarkOnFlagAssigner implements AssignerWithPunctuatedWatermarks<MyElement> {
+ *
+ *     public long extractTimestamp(MyElement element, long previousElementTimestamp) {
+ *         return element.getSequenceTimestamp();
+ *     }
+ *
+ *     public long checkAndGetNextWatermark(MyElement lastElement, long extractedTimestamp) {
+ *         return lastElement.isEndOfSequence() ? extractedTimestamp : -1L;
+ *     }
+ * }
+ * }</pre>
+ * 
+ * <p>Timestamps and watermarks are defined as {@code longs} that represent the
+ * milliseconds since the Epoch (midnight, January 1, 1970 UTC).
+ * A watermark with a certain value {@code t} indicates that no elements with event
+ * timestamps {@code x}, where {@code x} is lower or equal to {@code t}, will occur any more.
+ * 
+ * @param <T> The type of the elements to which this assigner assigns timestamps.
+ * 
+ * @see org.apache.flink.streaming.api.watermark.Watermark
+ */
+public interface AssignerWithPunctuatedWatermarks<T> extends TimestampAssigner<T> {
+	
+	/**
+	 * Asks this implementation if it wants to emit a watermark. This method is called right after
+	 * the {@link #extractTimestamp(Object, long)} method. If the method returns a positive
+	 * value, a new watermark should be emitted. If a negative value is emitted, no new watermark
+	 * will be generated.
+	 * 
+	 * <p>Note that whenever this method returns a positive value that is larger than the previous
+	 * value, a new watermark is generated. Hence, the implementation has full control how often
+	 * watermarks are generated.
+	 * 
+	 * <p>For an example how to use this method, see the documentation of
+	 * {@link AssignerWithPunctuatedWatermarks this class}.
+	 *
+	 * @return A negative value, if no watermark should be emitted, positive value for
+	 *         emitting this value as a watermark.
+	 */
+	long checkAndGetNextWatermark(T lastElement, long extractedTimestamp);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimestampAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimestampAssigner.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions;
+
+import org.apache.flink.api.common.functions.Function;
+
+/**
+ * A {@code TimestampAssigner} assigns event time timestamps to elements.
+ * These timestamps are used by all functions that operate on event time,
+ * for example event time windows.
+ * 
+ * <p>Timestamps are represented in milliseconds since the Epoch
+ * (midnight, January 1, 1970 UTC).
+ * 
+ * <p>A timestamp assigner that assigns to each element a timestamp via
+ * {@link System#currentTimeMillis()} effectively realizes "ingestion time"
+ * semantics.
+ * 
+ * @param <T> The type of the elements to which this assigner assigns timestamps.
+ */
+public interface TimestampAssigner<T> extends Function {
+
+	/**
+	 * Assigns a timestamp to an element, in milliseconds since the Epoch.
+	 * 
+	 * <p>The method gets the previously assigned timestamp of the element.
+	 * That previous timestamp may have been assigned from a previous assigner,
+	 * by ingestion time, or be simply uninitialized. In the latter case, the
+	 * timestamp will be a negative value.
+	 *
+	 * @param element The element that the timestamp is wil be assigned to.
+	 * @param previousElementTimestamp The previous internal timestamp of the element,
+	 *                                 or a negative value, if no timestamp has been assigned, yet.   
+	 * @return The new timestamp.
+	 */
+	long extractTimestamp(T element, long previousElementTimestamp);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimestampExtractor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimestampExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.streaming.api.functions;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.Function;
 
 /**
@@ -32,11 +32,15 @@ import org.apache.flink.api.common.functions.Function;
  * {@link org.apache.flink.streaming.api.functions.AscendingTimestampExtractor}. This will
  * keep track of watermarks.
  *
- * @see org.apache.flink.streaming.api.watermark.Watermark
- *
  * @param <T> The type of the elements that this function can extract timestamps from
+ *
+ * @deprecated This class has been replaced by {@link AssignerWithPeriodicWatermarks} and
+ *             {@link AssignerWithPunctuatedWatermarks}
+ *             
+ * @see AssignerWithPeriodicWatermarks
+ * @see AssignerWithPunctuatedWatermarks
  */
-@PublicEvolving
+@Deprecated
 public interface TimestampExtractor<T> extends Function {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -187,8 +187,8 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function> extends
 	@Override
 	public void setOutputType(TypeInformation<OUT> outTypeInfo, ExecutionConfig executionConfig) {
 		if (userFunction instanceof OutputTypeConfigurable) {
+			@SuppressWarnings("unchecked")
 			OutputTypeConfigurable<OUT> outputTypeConfigurable = (OutputTypeConfigurable<OUT>) userFunction;
-
 			outputTypeConfigurable.setOutputType(outTypeInfo, executionConfig);
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimestampedCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimestampedCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperator.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.runtime.operators;
 
-import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -25,17 +25,13 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
- * A {@link org.apache.flink.streaming.api.operators.StreamOperator} for extracting timestamps
- * from user elements and assigning them as the internal timestamp of the {@link StreamRecord}.
+ * A stream operator that extracts timestamps from stream elements and
+ * generates periodic watermarks.
  *
  * @param <T> The type of the input elements
- * 
- * @deprecated Subsumed by {@link TimestampsAndPeriodicWatermarksOperator} and
- *             {@link TimestampsAndPunctuatedWatermarksOperator}.
  */
-@Deprecated
-public class ExtractTimestampsOperator<T>
-		extends AbstractUdfStreamOperator<T, TimestampExtractor<T>>
+public class TimestampsAndPeriodicWatermarksOperator<T>
+		extends AbstractUdfStreamOperator<T, AssignerWithPeriodicWatermarks<T>>
 		implements OneInputStreamOperator<T, T>, Triggerable {
 
 	private static final long serialVersionUID = 1L;
@@ -44,51 +40,48 @@ public class ExtractTimestampsOperator<T>
 
 	private transient long currentWatermark;
 
-	public ExtractTimestampsOperator(TimestampExtractor<T> extractor) {
-		super(extractor);
+	
+	public TimestampsAndPeriodicWatermarksOperator(AssignerWithPeriodicWatermarks<T> assigner) {
+		super(assigner);
 		chainingStrategy = ChainingStrategy.ALWAYS;
 	}
 
 	@Override
 	public void open() throws Exception {
 		super.open();
+
+		currentWatermark = -1L;
 		watermarkInterval = getExecutionConfig().getAutoWatermarkInterval();
+		
 		if (watermarkInterval > 0) {
 			registerTimer(System.currentTimeMillis() + watermarkInterval, this);
 		}
-
-		currentWatermark = Long.MIN_VALUE;
 	}
 
 	@Override
 	public void processElement(StreamRecord<T> element) throws Exception {
 		long newTimestamp = userFunction.extractTimestamp(element.getValue(), element.getTimestamp());
 		output.collect(element.replace(element.getValue(), newTimestamp));
-		long watermark = userFunction.extractWatermark(element.getValue(), newTimestamp);
-		if (watermark > currentWatermark) {
-			currentWatermark = watermark;
-			output.emitWatermark(new Watermark(currentWatermark));
-		}
 	}
 
 	@Override
 	public void trigger(long timestamp) throws Exception {
 		// register next timer
-		registerTimer(System.currentTimeMillis() + watermarkInterval, this);
 		long newWatermark = userFunction.getCurrentWatermark();
-
 		if (newWatermark > currentWatermark) {
 			currentWatermark = newWatermark;
 			// emit watermark
 			output.emitWatermark(new Watermark(currentWatermark));
 		}
+
+		registerTimer(System.currentTimeMillis() + watermarkInterval, this);
 	}
 
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
 		// if we receive a Long.MAX_VALUE watermark we forward it since it is used
 		// to signal the end of input and to not block watermark progress downstream
-		if (mark.getTimestamp() == Long.MAX_VALUE && mark.getTimestamp() > currentWatermark) {
+		if (mark.getTimestamp() == Long.MAX_VALUE && currentWatermark != Long.MAX_VALUE) {
 			currentWatermark = Long.MAX_VALUE;
 			output.emitWatermark(mark);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperator.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.runtime.operators;
 
-import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -25,62 +25,41 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
- * A {@link org.apache.flink.streaming.api.operators.StreamOperator} for extracting timestamps
- * from user elements and assigning them as the internal timestamp of the {@link StreamRecord}.
+ * A stream operator that extracts timestamps from stream elements and
+ * generates watermarks based on punctuation elements.
  *
  * @param <T> The type of the input elements
- * 
- * @deprecated Subsumed by {@link TimestampsAndPeriodicWatermarksOperator} and
- *             {@link TimestampsAndPunctuatedWatermarksOperator}.
  */
-@Deprecated
-public class ExtractTimestampsOperator<T>
-		extends AbstractUdfStreamOperator<T, TimestampExtractor<T>>
-		implements OneInputStreamOperator<T, T>, Triggerable {
+public class TimestampsAndPunctuatedWatermarksOperator<T>
+		extends AbstractUdfStreamOperator<T, AssignerWithPunctuatedWatermarks<T>>
+		implements OneInputStreamOperator<T, T> {
 
 	private static final long serialVersionUID = 1L;
 
-	private transient long watermarkInterval;
-
 	private transient long currentWatermark;
 
-	public ExtractTimestampsOperator(TimestampExtractor<T> extractor) {
-		super(extractor);
+	
+	public TimestampsAndPunctuatedWatermarksOperator(AssignerWithPunctuatedWatermarks<T> assigner) {
+		super(assigner);
 		chainingStrategy = ChainingStrategy.ALWAYS;
 	}
 
 	@Override
 	public void open() throws Exception {
 		super.open();
-		watermarkInterval = getExecutionConfig().getAutoWatermarkInterval();
-		if (watermarkInterval > 0) {
-			registerTimer(System.currentTimeMillis() + watermarkInterval, this);
-		}
-
-		currentWatermark = Long.MIN_VALUE;
+		currentWatermark = -1L;
 	}
 
 	@Override
 	public void processElement(StreamRecord<T> element) throws Exception {
-		long newTimestamp = userFunction.extractTimestamp(element.getValue(), element.getTimestamp());
+		final T value = element.getValue();
+		final long newTimestamp = userFunction.extractTimestamp(value, element.getTimestamp());
 		output.collect(element.replace(element.getValue(), newTimestamp));
-		long watermark = userFunction.extractWatermark(element.getValue(), newTimestamp);
-		if (watermark > currentWatermark) {
-			currentWatermark = watermark;
-			output.emitWatermark(new Watermark(currentWatermark));
-		}
-	}
-
-	@Override
-	public void trigger(long timestamp) throws Exception {
-		// register next timer
-		registerTimer(System.currentTimeMillis() + watermarkInterval, this);
-		long newWatermark = userFunction.getCurrentWatermark();
-
-		if (newWatermark > currentWatermark) {
-			currentWatermark = newWatermark;
-			// emit watermark
-			output.emitWatermark(new Watermark(currentWatermark));
+		
+		final long nextWatermark = userFunction.checkAndGetNextWatermark(value, newTimestamp);
+		if (nextWatermark >= 0 && nextWatermark > currentWatermark) {
+			currentWatermark = nextWatermark;
+			output.emitWatermark(new Watermark(nextWatermark));
 		}
 	}
 
@@ -88,7 +67,7 @@ public class ExtractTimestampsOperator<T>
 	public void processWatermark(Watermark mark) throws Exception {
 		// if we receive a Long.MAX_VALUE watermark we forward it since it is used
 		// to signal the end of input and to not block watermark progress downstream
-		if (mark.getTimestamp() == Long.MAX_VALUE && mark.getTimestamp() > currentWatermark) {
+		if (mark.getTimestamp() == Long.MAX_VALUE && currentWatermark != Long.MAX_VALUE) {
 			currentWatermark = Long.MAX_VALUE;
 			output.emitWatermark(mark);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperatorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.Assert.*;
+
+public class TimestampsAndPeriodicWatermarksOperatorTest {
+	
+	@Test
+	public void testTimestampsAndPeriodicWatermarksOperator() throws Exception {
+		
+		final TimestampsAndPeriodicWatermarksOperator<Long> operator = 
+				new TimestampsAndPeriodicWatermarksOperator<Long>(new LongExtractor());
+
+		final ExecutionConfig config = new ExecutionConfig();
+		config.setAutoWatermarkInterval(50);
+		
+		OneInputStreamOperatorTestHarness<Long, Long> testHarness =
+				new OneInputStreamOperatorTestHarness<Long, Long>(operator, config);
+
+		testHarness.open();
+		
+		testHarness.processElement(new StreamRecord<>(1L, 1));
+		testHarness.processElement(new StreamRecord<>(2L, 1));
+		testHarness.processWatermark(new Watermark(2)); // this watermark should be ignored
+		testHarness.processElement(new StreamRecord<>(3L, 3));
+		testHarness.processElement(new StreamRecord<>(4L, 3));
+		
+		// validate first part of the sequence. we poll elements until our
+		// watermark updates to "3", which must be the result of the "4" element.
+		{
+			ConcurrentLinkedQueue<Object> output = testHarness.getOutput();
+			long nextElementValue = 1L;
+			long lastWatermark = -1L;
+			
+			while (lastWatermark < 3) {
+				if (output.size() > 0) {
+					Object next = output.poll();
+					assertNotNull(next);
+					Tuple2<Long, Long> update = validateElement(next, nextElementValue, lastWatermark);
+					nextElementValue = update.f0;
+					lastWatermark = update.f1;
+					
+					// check the invariant
+					assertTrue(lastWatermark < nextElementValue);
+				} else {
+					Thread.sleep(10);
+				}
+			}
+			
+			output.clear();
+		}
+
+		testHarness.processElement(new StreamRecord<>(4L, 4));
+		testHarness.processElement(new StreamRecord<>(5L, 4));
+		testHarness.processElement(new StreamRecord<>(6L, 4));
+		testHarness.processElement(new StreamRecord<>(7L, 4));
+		testHarness.processElement(new StreamRecord<>(8L, 4));
+
+		// validate the next part of the sequence. we poll elements until our
+		// watermark updates to "7", which must be the result of the "8" element.
+		{
+			ConcurrentLinkedQueue<Object> output = testHarness.getOutput();
+			long nextElementValue = 4L;
+			long lastWatermark = 2L;
+
+			while (lastWatermark < 7) {
+				if (output.size() > 0) {
+					Object next = output.poll();
+					assertNotNull(next);
+					Tuple2<Long, Long> update = validateElement(next, nextElementValue, lastWatermark);
+					nextElementValue = update.f0;
+					lastWatermark = update.f1;
+					
+					// check the invariant
+					assertTrue(lastWatermark < nextElementValue);
+				} else {
+					Thread.sleep(10);
+				}
+			}
+
+			output.clear();
+		}
+		
+		testHarness.processWatermark(new Watermark(Long.MAX_VALUE));
+		assertEquals(Long.MAX_VALUE, ((Watermark) testHarness.getOutput().poll()).getTimestamp());
+	}
+
+	// ------------------------------------------------------------------------
+	
+	private Tuple2<Long, Long> validateElement(Object element, long nextElementValue, long currentWatermark) {
+		if (element instanceof StreamRecord) {
+			@SuppressWarnings("unchecked")
+			StreamRecord<Long> record = (StreamRecord<Long>) element;
+			assertEquals(nextElementValue, record.getValue().longValue());
+			assertEquals(nextElementValue, record.getTimestamp());
+			return new Tuple2<>(nextElementValue + 1, currentWatermark);
+		}
+		else if (element instanceof Watermark) {
+			long wt = ((Watermark) element).getTimestamp();
+			assertTrue(wt > currentWatermark);
+			return new Tuple2<>(nextElementValue, wt);
+		}
+		else {
+			throw new IllegalArgumentException("unrecognized element: " + element);
+		}
+	}
+	
+	// ------------------------------------------------------------------------
+
+	private static class LongExtractor implements AssignerWithPeriodicWatermarks<Long> {
+		private static final long serialVersionUID = 1L;
+
+		private long currentTimestamp = -1L;
+
+		@Override
+		public long extractTimestamp(Long element, long previousElementTimestamp) {
+			currentTimestamp = element;
+			return element;
+		}
+
+		@Override
+		public long getCurrentWatermark() {
+			return currentTimestamp - 1;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperatorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimestampsAndPunctuatedWatermarksOperatorTest {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testTimestampsAndPeriodicWatermarksOperator() throws Exception {
+		
+		final TimestampsAndPunctuatedWatermarksOperator<Tuple2<Long, Boolean>> operator = 
+				new TimestampsAndPunctuatedWatermarksOperator<>(new PunctuatedExtractor());
+		
+		OneInputStreamOperatorTestHarness<Tuple2<Long, Boolean>, Tuple2<Long, Boolean>> testHarness =
+				new OneInputStreamOperatorTestHarness<>(operator);
+
+		testHarness.open();
+		
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(3L, true), 0L));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(5L, false), 0L));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(4L, false), 0L));
+		testHarness.processWatermark(new Watermark(10)); // this watermark should be ignored
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(4L, false), 0L));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(4L, true), 0L));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(9L, false), 0L));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(5L, false), 0L));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(7L, true), 0L));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>(10L, false), 0L));
+
+		testHarness.processWatermark(new Watermark(Long.MAX_VALUE));
+
+		ConcurrentLinkedQueue<Object> output = testHarness.getOutput();
+		
+		assertEquals(3L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(3L, ((Watermark) output.poll()).getTimestamp());
+		
+		assertEquals(5L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(4L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(4L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(4L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(4L, ((Watermark) output.poll()).getTimestamp());
+
+		assertEquals(9L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(5L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(7L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(7L, ((Watermark) output.poll()).getTimestamp());
+
+		assertEquals(10L, ((StreamRecord<Tuple2<Long, Boolean>>) output.poll()).getTimestamp());
+		assertEquals(Long.MAX_VALUE, ((Watermark) output.poll()).getTimestamp());
+	}
+	
+	// ------------------------------------------------------------------------
+
+	private static class PunctuatedExtractor implements AssignerWithPunctuatedWatermarks<Tuple2<Long, Boolean>> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public long extractTimestamp(Tuple2<Long, Boolean> element, long previousTimestamp) {
+			return element.f0;
+		}
+
+		@Override
+		public long checkAndGetNextWatermark(Tuple2<Long, Boolean> lastElement, long extractedTimestamp) {
+			return lastElement.f1 ? extractedTimestamp : -1L;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/timestamp/TimestampITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/timestamp/TimestampITCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.streaming.timestamp;
 
 import org.apache.flink.api.common.functions.MapFunction;
@@ -27,7 +28,8 @@ import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.AscendingTimestampExtractor;
-import org.apache.flink.streaming.api.functions.TimestampExtractor;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.source.EventTimeSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -38,6 +40,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.NoOpSink;
 import org.apache.flink.test.util.ForkableFlinkMiniCluster;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -245,8 +248,8 @@ public class TimestampITCase {
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
 			public void run(SourceContext<Integer> ctx) throws Exception {
-				int index = 0;
-				while (index < NUM_ELEMENTS) {
+				int index = 1;
+				while (index <= NUM_ELEMENTS) {
 					ctx.collect(index);
 					latch.await();
 					index++;
@@ -254,9 +257,7 @@ public class TimestampITCase {
 			}
 
 			@Override
-			public void cancel() {
-
-			}
+			public void cancel() {}
 		});
 
 		DataStream<Integer> extractOp = source1.assignTimestamps(
@@ -280,7 +281,7 @@ public class TimestampITCase {
 
 		// verify that we get NUM_ELEMENTS watermarks
 		for (int j = 0; j < NUM_ELEMENTS; j++) {
-			if (!CustomOperator.finalWatermarks[0].get(j).equals(new Watermark(j - 1))) {
+			if (!CustomOperator.finalWatermarks[0].get(j).equals(new Watermark(j))) {
 				Assert.fail("Wrong watermark.");
 			}
 		}
@@ -307,8 +308,8 @@ public class TimestampITCase {
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
 			public void run(SourceContext<Integer> ctx) throws Exception {
-				int index = 0;
-				while (index < NUM_ELEMENTS) {
+				int index = 1;
+				while (index <= NUM_ELEMENTS) {
 					ctx.collect(index);
 					latch.await();
 					index++;
@@ -316,27 +317,22 @@ public class TimestampITCase {
 			}
 
 			@Override
-			public void cancel() {
-
-			}
+			public void cancel() {}
 		});
 
-		source1.assignTimestamps(new TimestampExtractor<Integer>() {
-			@Override
-			public long extractTimestamp(Integer element, long currentTimestamp) {
-				return element;
-			}
+		source1
+				.assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Integer>() {
+					
+					@Override
+					public long extractTimestamp(Integer element, long currentTimestamp) {
+						return element;
+					}
 
-			@Override
-			public long extractWatermark(Integer element, long currentTimestamp) {
-				return element - 1;
-			}
-
-			@Override
-			public long getCurrentWatermark() {
-				return Long.MIN_VALUE;
-			}
-		})
+					@Override
+					public long checkAndGetNextWatermark(Integer element, long extractedTimestamp) {
+						return extractedTimestamp - 1;
+					}
+				})
 				.transform("Watermark Check", BasicTypeInfo.INT_TYPE_INFO, new CustomOperator(true))
 				.transform("Timestamp Check", BasicTypeInfo.INT_TYPE_INFO, new TimestampCheckingOperator());
 
@@ -345,7 +341,7 @@ public class TimestampITCase {
 
 		// verify that we get NUM_ELEMENTS watermarks
 		for (int j = 0; j < NUM_ELEMENTS; j++) {
-			if (!CustomOperator.finalWatermarks[0].get(j).equals(new Watermark(j - 1))) {
+			if (!CustomOperator.finalWatermarks[0].get(j).equals(new Watermark(j))) {
 				Assert.fail("Wrong watermark.");
 			}
 		}
@@ -372,8 +368,8 @@ public class TimestampITCase {
 		DataStream<Integer> source1 = env.addSource(new SourceFunction<Integer>() {
 			@Override
 			public void run(SourceContext<Integer> ctx) throws Exception {
-				int index = 0;
-				while (index < NUM_ELEMENTS) {
+				int index = 1;
+				while (index <= NUM_ELEMENTS) {
 					ctx.collect(index);
 					Thread.sleep(100);
 					ctx.collect(index - 1);
@@ -383,27 +379,22 @@ public class TimestampITCase {
 			}
 
 			@Override
-			public void cancel() {
-
-			}
+			public void cancel() {}
 		});
 
-		source1.assignTimestamps(new TimestampExtractor<Integer>() {
-			@Override
-			public long extractTimestamp(Integer element, long currentTimestamp) {
-				return element;
-			}
+		source1
+				.assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Integer>() {
 
-			@Override
-			public long extractWatermark(Integer element, long currentTimestamp) {
-				return element - 1;
-			}
+					@Override
+					public long extractTimestamp(Integer element, long previousTimestamp) {
+						return element;
+					}
 
-			@Override
-			public long getCurrentWatermark() {
-				return Long.MIN_VALUE;
-			}
-		})
+					@Override
+					public long checkAndGetNextWatermark(Integer element, long extractedTimestamp) {
+						return extractedTimestamp - 1;
+					}
+				})
 				.transform("Watermark Check", BasicTypeInfo.INT_TYPE_INFO, new CustomOperator(true))
 				.transform("Timestamp Check", BasicTypeInfo.INT_TYPE_INFO, new TimestampCheckingOperator());
 
@@ -412,7 +403,7 @@ public class TimestampITCase {
 
 		// verify that we get NUM_ELEMENTS watermarks
 		for (int j = 0; j < NUM_ELEMENTS; j++) {
-			if (!CustomOperator.finalWatermarks[0].get(j).equals(new Watermark(j - 1))) {
+			if (!CustomOperator.finalWatermarks[0].get(j).equals(new Watermark(j))) {
 				Assert.fail("Wrong watermark.");
 			}
 		}
@@ -453,30 +444,84 @@ public class TimestampITCase {
 			}
 
 			@Override
-			public void cancel() {
-
-			}
+			public void cancel() {}
 		});
 
-		source1.assignTimestamps(new TimestampExtractor<Integer>() {
-			@Override
-			public long extractTimestamp(Integer element, long currentTimestamp) {
-				return element;
-			}
+		source1
+				.assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Integer>() {
 
-			@Override
-			public long extractWatermark(Integer element, long currentTimestamp) {
-				return Long.MIN_VALUE;
-			}
+					@Override
+					public long extractTimestamp(Integer element, long currentTimestamp) {
+						return element;
+					}
 
-			@Override
-			public long getCurrentWatermark() {
-				return Long.MIN_VALUE;
-			}
-		})
+					@Override
+					public long checkAndGetNextWatermark(Integer element, long extractedTimestamp) {
+						return -1L;
+					}
+				})
 			.transform("Watermark Check", BasicTypeInfo.INT_TYPE_INFO, new CustomOperator(true));
 
 
+		env.execute();
+
+		Assert.assertTrue(CustomOperator.finalWatermarks[0].size() == 1);
+		Assert.assertTrue(CustomOperator.finalWatermarks[0].get(0).getTimestamp() == Long.MAX_VALUE);
+	}
+
+	/**
+	 * This test verifies that the timestamp extractor forwards Long.MAX_VALUE watermarks.
+	 * 
+	 * Same test as before, but using a different timestamp extractor
+	 */
+	@Test
+	public void testTimestampExtractorWithLongMaxWatermarkFromSource2() throws Exception {
+		final int NUM_ELEMENTS = 10;
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment
+				.createRemoteEnvironment("localhost", cluster.getLeaderRPCPort());
+		
+		env.setParallelism(2);
+		env.getConfig().disableSysoutLogging();
+		env.getConfig().enableTimestamps();
+		env.getConfig().setAutoWatermarkInterval(10);
+
+		DataStream<Integer> source1 = env.addSource(new EventTimeSourceFunction<Integer>() {
+			@Override
+			public void run(SourceContext<Integer> ctx) throws Exception {
+				int index = 0;
+				while (index < NUM_ELEMENTS) {
+					ctx.collectWithTimestamp(index, index);
+					ctx.collectWithTimestamp(index - 1, index - 1);
+					index++;
+					ctx.emitWatermark(new Watermark(index-2));
+				}
+
+				// emit the final Long.MAX_VALUE watermark, do it twice and verify that
+				// we only see one in the result
+				ctx.emitWatermark(new Watermark(Long.MAX_VALUE));
+				ctx.emitWatermark(new Watermark(Long.MAX_VALUE));
+			}
+
+			@Override
+			public void cancel() {}
+		});
+
+		source1
+				.assignTimestampsAndWatermarks(new AssignerWithPeriodicWatermarks<Integer>() {
+
+					@Override
+					public long extractTimestamp(Integer element, long currentTimestamp) {
+						return element;
+					}
+
+					@Override
+					public long getCurrentWatermark() {
+						return -1L;
+					}
+				})
+				.transform("Watermark Check", BasicTypeInfo.INT_TYPE_INFO, new CustomOperator(true));
+		
 		env.execute();
 
 		Assert.assertTrue(CustomOperator.finalWatermarks[0].size() == 1);
@@ -625,8 +670,7 @@ public class TimestampITCase {
 		}
 
 		@Override
-		public void processWatermark(Watermark mark) throws Exception {
-		}
+		public void processWatermark(Watermark mark) throws Exception {}
 	}
 
 	public static class DisabledTimestampCheckingOperator extends AbstractStreamOperator<Integer> implements OneInputStreamOperator<Integer, Integer> {
@@ -640,8 +684,7 @@ public class TimestampITCase {
 		}
 
 		@Override
-		public void processWatermark(Watermark mark) throws Exception {
-		}
+		public void processWatermark(Watermark mark) throws Exception {}
 	}
 
 	public static class IdentityCoMap implements CoMapFunction<Integer, Integer, Integer> {
@@ -682,9 +725,7 @@ public class TimestampITCase {
 		}
 
 		@Override
-		public void cancel() {
-
-		}
+		public void cancel() {}
 	}
 
 	public static class MyNonWatermarkingSource implements SourceFunction<Integer> {
@@ -703,9 +744,7 @@ public class TimestampITCase {
 		}
 
 		@Override
-		public void cancel() {
-
-		}
+		public void cancel() {}
 	}
 
 	// This is a event-time source. This should only emit elements with timestamps. The test should
@@ -720,9 +759,7 @@ public class TimestampITCase {
 		}
 
 		@Override
-		public void cancel() {
-
-		}
+		public void cancel() {}
 	}
 
 	// This is a normal source. This should only emit elements without timestamps. The test should
@@ -737,9 +774,7 @@ public class TimestampITCase {
 		}
 
 		@Override
-		public void cancel() {
-
-		}
+		public void cancel() {}
 	}
 
 	// This is a normal source. This should only emit elements without timestamps. This also
@@ -755,8 +790,6 @@ public class TimestampITCase {
 		}
 
 		@Override
-		public void cancel() {
-
-		}
+		public void cancel() {}
 	}
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -30,7 +30,7 @@ import org.apache.flink.core.fs.{FileSystem, Path}
 import org.apache.flink.streaming.api.collector.selector.OutputSelector
 import org.apache.flink.streaming.api.datastream.{AllWindowedStream => JavaAllWindowedStream, DataStream => JavaStream, KeyedStream => JavaKeyedStream, _}
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
-import org.apache.flink.streaming.api.functions.{AscendingTimestampExtractor, TimestampExtractor}
+import org.apache.flink.streaming.api.functions.{AssignerWithPunctuatedWatermarks, AssignerWithPeriodicWatermarks, AscendingTimestampExtractor, TimestampExtractor}
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.windows.{GlobalWindow, TimeWindow, Window}
@@ -630,6 +630,7 @@ class DataStream[T](stream: JavaStream[T]) {
   def windowAll[W <: Window](assigner: WindowAssigner[_ >: T, W]): AllWindowedStream[T, W] = {
     new AllWindowedStream[T, W](new JavaAllWindowedStream[T, W](stream, assigner))
   }
+  
   /**
    * Extracts a timestamp from an element and assigns it as the internal timestamp of that element.
    * The internal timestamps are, for example, used to to event-time window operations.
@@ -641,21 +642,82 @@ class DataStream[T](stream: JavaStream[T]) {
    *
    * @see org.apache.flink.streaming.api.watermark.Watermark
    */
-  @PublicEvolving
+  @deprecated
   def assignTimestamps(extractor: TimestampExtractor[T]): DataStream[T] = {
     stream.assignTimestamps(clean(extractor))
   }
 
   /**
-   * Extracts a timestamp from an element and assigns it as the internal timestamp of that element.
-   * The internal timestamps are, for example, used to to event-time window operations.
+   * Assigns timestamps to the elements in the data stream and periodically creates
+   * watermarks to signal event time progress.
    *
-   * If you know that the timestamps are strictly increasing you can use an
-   * [[org.apache.flink.streaming.api.functions.AscendingTimestampExtractor]]. Otherwise,
-   * you should provide a [[TimestampExtractor]] that also implements
-   * [[TimestampExtractor#getCurrentWatermark]] to keep track of watermarks.
+   * This method creates watermarks periodically (for example every second), based
+   * on the watermarks indicated by the given watermark generator. Even when no new elements
+   * in the stream arrive, the given watermark generator will be periodically checked for
+   * new watermarks. The interval in which watermarks are generated is defined in
+   * [[org.apache.flink.api.common.ExecutionConfig#setAutoWatermarkInterval(long)]].
    *
-   * @see org.apache.flink.streaming.api.watermark.Watermark
+   * Use this method for the common cases, where some characteristic over all elements
+   * should generate the watermarks, or where watermarks are simply trailing behind the
+   * wall clock time by a certain amount.
+   *
+   * For cases where watermarks should be created in an irregular fashion, for example
+   * based on certain markers that some element carry, use the
+   * [[AssignerWithPunctuatedWatermarks]].
+   *
+   * @see AssignerWithPeriodicWatermarks
+   * @see AssignerWithPunctuatedWatermarks
+   * @see #assignTimestampsAndWatermarks(AssignerWithPunctuatedWatermarks) 
+   */
+  @PublicEvolving
+  def assignTimestampsAndWatermarks(assigner: AssignerWithPeriodicWatermarks[T]) 
+      : DataStream[T] = {
+    
+    stream.assignTimestampsAndWatermarks(assigner)
+  }
+
+  /**
+   * Assigns timestamps to the elements in the data stream and periodically creates
+   * watermarks to signal event time progress.
+   *
+   * This method creates watermarks based purely on stream elements. For each element
+   * that is handled via [[AssignerWithPunctuatedWatermarks#extractTimestamp(Object, long)]],
+   * the [[AssignerWithPunctuatedWatermarks#checkAndGetNextWatermark()]] method is called,
+   * and a new watermark is emitted, if the returned watermark value is larger than the previous
+   * watermark.
+   *
+   * This method is useful when the data stream embeds watermark elements, or certain elements
+   * carry a marker that can be used to determine the current event time watermark. 
+   * This operation gives the programmer full control over the watermark generation. Users
+   * should be aware that too aggressive watermark generation (i.e., generating hundreds of
+   * watermarks every second) can cost some performance.
+   *
+   * For cases where watermarks should be created in a regular fashion, for example
+   * every x milliseconds, use the [[AssignerWithPeriodicWatermarks]].
+   *
+   * @see AssignerWithPunctuatedWatermarks
+   * @see AssignerWithPeriodicWatermarks
+   * @see #assignTimestampsAndWatermarks(AssignerWithPeriodicWatermarks) 
+   */
+  @PublicEvolving
+  def assignTimestampsAndWatermarks(assigner: AssignerWithPunctuatedWatermarks[T])
+      : DataStream[T] = {
+    
+    stream.assignTimestampsAndWatermarks(assigner)
+  }
+
+  /**
+   * Assigns timestamps to the elements in the data stream and periodically creates
+   * watermarks to signal event time progress.
+   * 
+   * This method is a shortcut for data streams where the element timestamp are known
+   * to be monotonously ascending within each parallel stream.
+   * In that case, the system can generate watermarks automatically and perfectly
+   * by tracking the ascending timestamps.
+   * 
+   * For cases where the timestamps are not monotonously increasing, use the more
+   * general methods [[assignTimestampsAndWatermarks(AssignerWithPeriodicWatermarks)]]
+   * and [[assignTimestampsAndWatermarks(AssignerWithPunctuatedWatermarks)]].
    */
   @PublicEvolving
   def assignAscendingTimestamps(extractor: T => Long): DataStream[T] = {


### PR DESCRIPTION
This pull request divides the TimestampExtractor into two separate classes:

### Periodic Watermarks

Watermarks generated every *n* milliseconds, as defined by `ExecutionConfig.getAutoWatermarkInterval()`

```java
public class AscendingTimestampExtractor implements AssignerWithPeriodicWatermarks<MyType> {

    private long currentTimestamp = -1L

    public long extractTimestamp(MyType element, long previousElementTimestamp) {
        currentTimestamp = element.timestamp();
        return element.timestamp();
    }

    public long getCurrentWatermark() {
        return currentTimestamp ;
    }
```

### Punctuated Watermarks

Punctuated Watermarks are for cases where the elements themselves carry information about watermarks.

```java
public class WatermarkOnFlagAssigner implements AssignerWithPunctuatedWatermarks<Event> {

    public long extractTimestamp(Event element, long previousElementTimestamp) {
        return element.getTimestamp();
    }

    public long checkAndGetNextWatermark(Event lastElement, long extractedTimestamp) {
        return lastElement.isWatermark() ? extractedTimestamp : -1L;
    }
}
```

## Other changes / Tests

This also makes sure that any timestamp assigner / watermark generators cannot generate
negative watermarks.

This also adds tests for the operators that run the timestamp extractors.