### PR TITLE
[FLINK-3396] [runtime] Suppress job restart if adding to job graph store fails

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/SuppressRestartsException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/SuppressRestartsException.java
@@ -19,17 +19,17 @@
 package org.apache.flink.runtime.execution;
 
 /**
- * Exception thrown on unrecoverable failures.
+ * Exception thrown in order to suppress job restarts.
  *
  * <p>This exception acts as a wrapper around the real cause and suppresses
  * job restarts. The JobManager will <strong>not</strong> restart a job, which
  * fails with this Exception.
  */
-public class UnrecoverableException extends RuntimeException {
+public class SuppressRestartsException extends RuntimeException {
 
 	private static final long serialVersionUID = 221873676920848349L;
 
-	public UnrecoverableException(Throwable cause) {
+	public SuppressRestartsException(Throwable cause) {
 		super("Unrecoverable failure. This suppresses job restarts. Please check the " +
 				"stack trace for the root cause.", cause);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -42,7 +42,7 @@ import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.stats.DisabledCheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.stats.SimpleCheckpointStatsTracker;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.execution.UnrecoverableException;
+import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -1037,14 +1037,14 @@ public class ExecutionGraph implements Serializable {
 						}
 					}
 					else if (current == JobStatus.FAILING) {
-						boolean isRecoverable = !(failureCause instanceof UnrecoverableException);
+						boolean allowRestart = !(failureCause instanceof SuppressRestartsException);
 
-						if (isRecoverable && restartStrategy.canRestart() &&
+						if (allowRestart && restartStrategy.canRestart() &&
 								transitionState(current, JobStatus.RESTARTING)) {
 							restartStrategy.restart(this);
 							break;
 
-						} else if ((!isRecoverable || !restartStrategy.canRestart()) &&
+						} else if ((!allowRestart || !restartStrategy.canRestart()) &&
 							transitionState(current, JobStatus.FAILED, failureCause)) {
 							postRunCleanup();
 							break;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -38,7 +38,7 @@ import org.apache.flink.runtime.akka.{AkkaUtils, ListeningBehaviour}
 import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint._
 import org.apache.flink.runtime.client._
-import org.apache.flink.runtime.execution.UnrecoverableException
+import org.apache.flink.runtime.execution.SuppressRestartsException
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
 import org.apache.flink.runtime.executiongraph.restart.{RestartStrategy, RestartStrategyFactory}
 import org.apache.flink.runtime.executiongraph.{ExecutionGraph, ExecutionJobVertex}
@@ -1120,12 +1120,10 @@ class JobManager(
                   executionGraph.restoreSavepoint(savepointPath)
                 } catch {
                   case e: Exception =>
-                    throw new UnrecoverableException(e)
+                    throw new SuppressRestartsException(e)
                 }
               }
             }
-
-            submittedJobGraphs.putJobGraph(new SubmittedJobGraph(jobGraph, jobInfo))
           }
 
           jobInfo.client ! decorateMessage(JobSubmitSuccess(jobGraph.getJobID))

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -905,7 +905,6 @@ class JobManager(
    * @param isRecovery Flag indicating whether this is a recovery or initial submission
    */
   private def submitJob(jobGraph: JobGraph, jobInfo: JobInfo, isRecovery: Boolean = false): Unit = {
-
     if (jobGraph == null) {
       jobInfo.client ! decorateMessage(JobResultFailure(
         new SerializedThrowable(
@@ -1080,8 +1079,7 @@ class JobManager(
           executionGraph.registerExecutionListener(gateway)
           executionGraph.registerJobStatusListener(gateway)
         }
-      }
-      catch {
+      } catch {
         case t: Throwable =>
           log.error(s"Failed to submit job $jobId ($jobName)", t)
 
@@ -1108,8 +1106,7 @@ class JobManager(
         try {
           if (isRecovery) {
             executionGraph.restoreLatestCheckpointedState()
-          }
-          else {
+          } else {
             val snapshotSettings = jobGraph.getSnapshotSettings
             if (snapshotSettings != null) {
               val savepointPath = snapshotSettings.getSavepointPath()
@@ -1123,6 +1120,15 @@ class JobManager(
                     throw new SuppressRestartsException(e)
                 }
               }
+            }
+
+            try {
+              submittedJobGraphs.putJobGraph(new SubmittedJobGraph(jobGraph, jobInfo))
+            } catch {
+              case t: Throwable =>
+                // Don't restart the execution if this fails. Otherwise, the
+                // job graph will skip ZooKeeper in case of HA.
+                new SuppressRestartsException(t)
             }
           }
 
@@ -1150,8 +1156,7 @@ class JobManager(
         } catch {
           case t: Throwable => try {
             executionGraph.fail(t)
-          }
-          catch {
+          } catch {
             case tt: Throwable =>
               log.error("Error while marking ExecutionGraph as failed.", tt)
           }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.execution.UnrecoverableException;
+import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
@@ -335,7 +335,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	}
 
 	@Test
-	public void testNoRestartOnUnrecoverableException() throws Exception {
+	public void testNoRestartOnSuppressException() throws Exception {
 		Instance instance = ExecutionGraphTestUtils.getInstance(
 				new SimpleActorGateway(TestingUtils.directExecutionContext()),
 				NUM_TASKS);
@@ -367,7 +367,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		// Fail with unrecoverable Exception
 		eg.getAllExecutionVertices().iterator().next().fail(
-				new UnrecoverableException(new Exception("Test Exception")));
+				new SuppressRestartsException(new Exception("Test Exception")));
 
 		assertEquals(JobStatus.FAILING, eg.getState());
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.checkpoint.Savepoint;
 import org.apache.flink.runtime.checkpoint.SavepointStoreFactory;
 import org.apache.flink.runtime.checkpoint.StateForTask;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
-import org.apache.flink.runtime.execution.UnrecoverableException;
+import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -736,7 +736,7 @@ public class SavepointITCase extends TestLogger {
 				flink.submitJobAndWait(jobGraph, false);
 			}
 			catch (Exception e) {
-				assertEquals(UnrecoverableException.class, e.getCause().getClass());
+				assertEquals(SuppressRestartsException.class, e.getCause().getClass());
 				assertEquals(IllegalArgumentException.class, e.getCause().getCause().getClass());
 			}
 		}


### PR DESCRIPTION
@tillrohrmann, this leaves everything as is, but suppresses the restart in case of a failure to add the job graph to ZooKeeper (the standalone case should never fail). This applies only to the initial job submission.

The behaviour before was possibly leading to restart and the job being submitted w/o being added to ZooKeeper. Furthermore, the submission was not ACK'd in such a case. Now it will simply fail and the user can/has to react.