### PR TITLE
Improve TaskManagerTest#testRemotePartitionNotFound failure message

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -920,7 +920,7 @@ public class TaskManagerTest extends TestLogger {
 						// The task should fail after repeated requests
 						assertEquals(ExecutionState.FAILED, msg.getExecutionState());
 						Throwable t = msg.getError(ClassLoader.getSystemClassLoader());
-						assertEquals("Thrown exception was not a PartitionNodFoundException: " + t.getMessage(), PartitionNotFoundException.class,
+						assertEquals("Thrown exception was not a PartitionNotFoundException: " + t.getMessage(), PartitionNotFoundException.class,
 								t.getClass());
 					}
 				};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -919,8 +919,9 @@ public class TaskManagerTest extends TestLogger {
 
 						// The task should fail after repeated requests
 						assertEquals(ExecutionState.FAILED, msg.getExecutionState());
-						assertEquals(PartitionNotFoundException.class,
-								msg.getError(ClassLoader.getSystemClassLoader()).getClass());
+						Throwable t = msg.getError(ClassLoader.getSystemClassLoader());
+						assertEquals("Thrown exception was not a PartitionNodFoundException: " + t.getMessage(), PartitionNotFoundException.class,
+								t.getClass());
 					}
 				};
 			}


### PR DESCRIPTION
I've observed a failure in TaskManagerTest#testRemotePartitionNotFound, but the exception was essentially swallowed. I've added an error message containing the swallowed exceptions message, in case it occurs again.

Below is the stacktrace i got:

testRemotePartitionNotFound(org.apache.flink.runtime.taskmanager.TaskManagerTest)  Time elapsed: 16.178 sec  <<< FAILURE!
java.lang.AssertionError: expected:\<class org.apache.flink.runtime.io.network.partition.PartitionNotFoundException> but was:\<class java.lang.Exception>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:743)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.apache.flink.runtime.taskmanager.TaskManagerTest$7$1.run(TaskManagerTest.java:922)
        at akka.testkit.JavaTestKit$Within$1.apply(JavaTestKit.java:232)
        at akka.testkit.TestKitBase$class.within(TestKit.scala:296)
        at akka.testkit.TestKit.within(TestKit.scala:718)
        at akka.testkit.TestKitBase$class.within(TestKit.scala:310)
        at akka.testkit.TestKit.within(TestKit.scala:718)
        at akka.testkit.JavaTestKit$Within.<init>(JavaTestKit.java:230)
        at org.apache.flink.runtime.taskmanager.TaskManagerTest$7$1.<init>(TaskManagerTest.java:910)
        at org.apache.flink.runtime.taskmanager.TaskManagerTest$7.<init>(TaskManagerTest.java:910)
        at org.apache.flink.runtime.taskmanager.TaskManagerTest.testRemotePartitionNotFound(TaskManagerTest.java:850)
