### PR TITLE
[FLINK-3438] ExternalProcessRunner fails to detect ClassNotFound exception because of locale settings

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExternalProcessRunner.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExternalProcessRunner.java
@@ -62,6 +62,11 @@ public class ExternalProcessRunner {
 		commandList.add(javaCommand);
 		commandList.add("-classpath");
 		commandList.add(getCurrentClasspath());
+		// FIXME Find a locale-agnostic way to do this
+		// Since the error checking is performed based on the output of the external process
+		// said output must not be localized for the check to be useful (see `run` method)
+		commandList.add("-Duser.country=US");
+		commandList.add("-Duser.language=en");
 		commandList.add(entryPointClassName);
 
 		Collections.addAll(commandList, parameters);
@@ -92,6 +97,9 @@ public class ExternalProcessRunner {
 			pipeForwarder.join();
 
 			if (returnCode != 0) {
+
+				// FIXME Find a locale-agnostic way to perform error checking
+				// See the `ExternalProcessRunner(String, String[])` constructor
 				// determine whether we failed because of a ClassNotFoundException and forward that
 				if (getErrorOutput().toString().contains("Error: Could not find or load main class " + entryPointClassName)) {
 					throw new ClassNotFoundException("Error: Could not find or load main class " + entryPointClassName);

--- a/flink-core/src/main/java/org/apache/flink/util/ExternalProcessRunner.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExternalProcessRunner.java
@@ -91,7 +91,7 @@ public class ExternalProcessRunner {
 
 				final String errorOutput = getErrorOutput().toString();
 				if (!errorOutput.isEmpty()) {
-					throw new Exception(errorOutput);
+					throw new RuntimeException(errorOutput);
 				}
 
 			}

--- a/flink-core/src/test/java/org/apache/flink/util/ExternalProcessRunnerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/ExternalProcessRunnerTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.util;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ExternalProcessRunnerTest {
@@ -71,17 +70,11 @@ public class ExternalProcessRunnerTest {
 		assertEquals(runner.getErrorOutput().toString(), "Hello process hello42\n");
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void testFailing() throws Exception {
 		final ExternalProcessRunner runner = new ExternalProcessRunner(Failing.class.getName(), new String[]{});
-
-		int result = runner.run();
-
-		assertEquals(1, result);
-		// this needs to be adapted if the test changes because it contains the line number
-		assertTrue(runner.getErrorOutput().toString().startsWith("Exception in thread \"main\""));
+		runner.run();
 	}
-
 
 	public static class InfiniteLoop {
 		public static void main(String[] args) {

--- a/flink-core/src/test/java/org/apache/flink/util/ExternalProcessRunnerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/ExternalProcessRunnerTest.java
@@ -27,8 +27,15 @@ public class ExternalProcessRunnerTest {
 
 	@Test(expected = ClassNotFoundException.class)
 	public void testClassNotFound() throws Exception {
-		ExternalProcessRunner runner = new ExternalProcessRunner("MyClassThatDoesNotExist", new String[]{});
-		runner.run();
+		final String nonExistingClassName = "MyClassThatDoesNotExist";
+		ExternalProcessRunner runner = new ExternalProcessRunner(nonExistingClassName, new String[]{});
+		try {
+			runner.run();
+		} catch (final Exception e) {
+			if (e.getMessage().contains(nonExistingClassName)) {
+				throw new ClassNotFoundException();
+			}
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This should be regarded as a temporary solution to this issue in particular. See the discussion going on at [[FLINK-3438]].

[FLINK-3438]: https://issues.apache.org/jira/browse/FLINK-3438