### PR TITLE
[FLINK-3257] Add Exactly-Once Processing Guarantees for Iterative DataStream Jobs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -595,14 +595,6 @@ public class StreamGraph extends StreamingPlan {
 	 */
 	@SuppressWarnings("deprecation")
 	public JobGraph getJobGraph() {
-		// temporarily forbid checkpointing for iterative jobs
-		if (isIterative() && checkpointConfig.isCheckpointingEnabled() && !checkpointConfig.isForceCheckpointing()) {
-			throw new UnsupportedOperationException(
-					"Checkpointing is currently not supported by default for iterative jobs, as we cannot guarantee exactly once semantics. "
-							+ "State checkpoints happen normally, but records in-transit during the snapshot will be lost upon failure. "
-							+ "\nThe user can force enable state checkpoints with the reduced guarantees by calling: env.enableCheckpointing(interval,true)");
-		}
-
 		StreamingJobGraphGenerator jobgraphGenerator = new StreamingJobGraphGenerator(this);
 
 		return jobgraphGenerator.createJobGraph();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -91,7 +91,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		final StreamConfig configuration = containingTask.getConfiguration();
 
 		headOperator = configuration.getStreamOperator(userCodeClassloader);
-
+		
 		// we read the chained configs, and the order of record writer registrations by output name
 		Map<Integer, StreamConfig> chainedConfigs = configuration.getTransitiveChainedTaskConfigs(userCodeClassloader);
 		chainedConfigs.put(configuration.getVertexID(), configuration);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -17,43 +17,80 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.BlockingQueueBroker;
+import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.types.Either;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.LinkedList;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
-import org.apache.flink.streaming.runtime.io.BlockingQueueBroker;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+/**
+ * TODO write javadoc
+ * <p>
+ * - open a list state per snapshot process
+ * - book-keep snapshot logs
+ * - Clean up state when a savepoint is complete - ONLY in-transit records who do NOT belong in other snapshots
+ *
+ * @param <IN>
+ */
 @Internal
-public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
+public class StreamIterationHead<IN> extends OneInputStreamTask<IN, IN> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamIterationHead.class);
 
 	private volatile boolean running = true;
 
-	// ------------------------------------------------------------------------
-	
+	private volatile RecordWriterOutput<IN>[] outputs;
+
+	private UpstreamLogger<IN> upstreamLogger;
+
+	private Object lock;
+
+	@Override
+	public void init() throws Exception {
+		this.lock = getCheckpointLock();
+		getConfiguration().setStreamOperator(new UpstreamLogger(getConfiguration()));
+		operatorChain = new OperatorChain<>(this);
+		this.upstreamLogger = (UpstreamLogger<IN>) operatorChain.getHeadOperator();
+	}
+
 	@Override
 	protected void run() throws Exception {
-		
+
 		final String iterationId = getConfiguration().getIterationId();
 		if (iterationId == null || iterationId.length() == 0) {
 			throw new Exception("Missing iteration ID in the task configuration");
 		}
-		
-		final String brokerID = createBrokerIdString(getEnvironment().getJobID(), iterationId ,
-				getEnvironment().getTaskInfo().getIndexOfThisSubtask());
-		
+		final String brokerID = createBrokerIdString(getEnvironment().getJobID(), iterationId,
+			getEnvironment().getTaskInfo().getIndexOfThisSubtask());
 		final long iterationWaitTime = getConfiguration().getIterationWaitTime();
 		final boolean shouldWait = iterationWaitTime > 0;
 
-		final BlockingQueue<StreamRecord<OUT>> dataChannel = new ArrayBlockingQueue<StreamRecord<OUT>>(1);
+		final BlockingQueue<Either<StreamRecord<IN>, CheckpointBarrier>> dataChannel
+			= new ArrayBlockingQueue<>(1);
 
 		// offer the queue for the tail
 		BlockingQueueBroker.INSTANCE.handIn(brokerID, dataChannel);
@@ -61,56 +98,83 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 
 		// do the work 
 		try {
-			@SuppressWarnings("unchecked")
-			RecordWriterOutput<OUT>[] outputs = (RecordWriterOutput<OUT>[]) getStreamOutputs();
+			outputs = (RecordWriterOutput<IN>[]) getStreamOutputs();
 
 			// If timestamps are enabled we make sure to remove cyclic watermark dependencies
 			if (isSerializingTimestamps()) {
-				for (RecordWriterOutput<OUT> output : outputs) {
+				for (RecordWriterOutput<IN> output : outputs) {
 					output.emitWatermark(new Watermark(Long.MAX_VALUE));
 				}
 			}
 
+			synchronized (lock) {
+				//emit in-flight events in the upstream log upon recovery
+				for (StreamRecord<IN> rec : upstreamLogger.getReplayLog()) {
+					for (RecordWriterOutput<IN> output : outputs) {
+						output.collect(rec);
+					}
+				}
+				upstreamLogger.clearLog();
+			}
+
 			while (running) {
-				StreamRecord<OUT> nextRecord = shouldWait ?
+				Either<StreamRecord<IN>, CheckpointBarrier> nextRecord = shouldWait ?
 					dataChannel.poll(iterationWaitTime, TimeUnit.MILLISECONDS) :
 					dataChannel.take();
 
-				if (nextRecord != null) {
-					for (RecordWriterOutput<OUT> output : outputs) {
-						output.collect(nextRecord);
+				synchronized (lock) {
+
+					if (nextRecord != null) {
+
+						if (nextRecord.isLeft()) {
+							//log in-transit records whose effects are not part of ongoing snapshots
+							upstreamLogger.logRecord(nextRecord.left());
+
+							//always forward records in transit 
+							for (RecordWriterOutput<IN> output : outputs) {
+								output.collect(nextRecord.left());
+							}
+						} else {
+							//upon marker from tail (markers should loop back in FIFO order)
+							checkpointState(new CheckpointMetaData(nextRecord.right().getId(), nextRecord.right().getTimestamp()), nextRecord.right().getCheckpointOptions(), new CheckpointMetrics());
+							upstreamLogger.discardSlice();
+						}
+
+					} else {
+						break;
 					}
 				}
-				else {
-					// done
-					break;
-				}
 			}
-		}
-		finally {
+		} finally {
 			// make sure that we remove the queue from the broker, to prevent a resource leak
 			BlockingQueueBroker.INSTANCE.remove(brokerID);
 			LOG.info("Iteration head {} removed feedback queue under {}", getName(), brokerID);
 		}
 	}
 
+
 	@Override
 	protected void cancelTask() {
 		running = false;
 	}
 
-	// ------------------------------------------------------------------------
-
-	@Override
-	public void init() {
-		// does not hold any resources, no initialization necessary
-	}
-
 	@Override
 	protected void cleanup() throws Exception {
-		// does not hold any resources, no cleanup necessary
+		//nothing to cleanup
 	}
-	
+
+	@Override
+	public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) throws Exception {
+
+		//create a buffer for logging the initiated snapshot and broadcast a barrier for it
+		synchronized (getCheckpointLock()) {
+			upstreamLogger.createSlice(String.valueOf(checkpointMetaData.getCheckpointId()));
+			operatorChain.broadcastCheckpointBarrier(checkpointMetaData.getCheckpointId(), checkpointMetaData.getTimestamp(), checkpointOptions);
+		}
+
+		return true;
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
@@ -119,13 +183,154 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 	 * Creates the identification string with which head and tail task find the shared blocking
 	 * queue for the back channel. The identification string is unique per parallel head/tail pair
 	 * per iteration per job.
-	 * 
-	 * @param jid The job ID.
-	 * @param iterationID The id of the iteration in the job.
+	 *
+	 * @param jid          The job ID.
+	 * @param iterationID  The id of the iteration in the job.
 	 * @param subtaskIndex The parallel subtask number
 	 * @return The identification string.
 	 */
 	public static String createBrokerIdString(JobID jid, String iterationID, int subtaskIndex) {
 		return jid + "-" + iterationID + "-" + subtaskIndex;
 	}
+
+	/**
+	 * An internal operator that solely serves as a state logging facility for persisting,
+	 * partitioning and restoring output logs for dataflow cycles consistently. To support concurrency,
+	 * logs are being sliced proportionally to the number of concurrent snapshots. This allows committed
+	 * output logs to be uniquely identified and cleared after each complete checkpoint.
+	 * <p>
+	 * The design is based on the following assumptions:
+	 * <p>
+	 * - A slice is named after a checkpoint ID. Checkpoint IDs are numerically ordered within an execution.
+	 * - Each checkpoint barrier arrives back in FIFO order, thus we discard log slices in respective FIFO order.
+	 * - Upon restoration the logger sorts sliced logs in the same FIFO order and returns an Iterable that
+	 * gives a singular view of the log.
+	 * <p>
+	 * TODO it seems that ListState.clear does not unregister state. We need to put a hook for that.
+	 *
+	 * @param <IN>
+	 */
+	public static class UpstreamLogger<IN> extends AbstractStreamOperator<IN> implements OneInputStreamOperator<IN, IN> {
+
+		private final StreamConfig config;
+
+		private LinkedList<ListState<StreamRecord<IN>>> slicedLog = new LinkedList<>();
+
+		private UpstreamLogger(StreamConfig config) {
+			this.config = config;
+		}
+
+		public void logRecord(StreamRecord<IN> record) throws Exception {
+			if (!slicedLog.isEmpty()) {
+				slicedLog.getLast().add(record);
+			}
+		}
+
+		public void createSlice(String sliceID) throws Exception {
+			ListState<StreamRecord<IN>> nextSlice =
+				getOperatorStateBackend().getOperatorState(new ListStateDescriptor<>(sliceID,
+					config.<StreamRecord<IN>>getTypeSerializerOut(getUserCodeClassloader())));
+			slicedLog.addLast(nextSlice);
+		}
+
+		public void discardSlice() {
+			ListState<StreamRecord<IN>> logToEvict = slicedLog.pollFirst();
+			logToEvict.clear();
+		}
+
+		public Iterable<StreamRecord<IN>> getReplayLog() throws Exception {
+			final List<String> logSlices = new ArrayList<>(getOperatorStateBackend().getRegisteredStateNames());
+			Collections.sort(logSlices, new Comparator<String>() {
+				@Override
+				public int compare(String o1, String o2) {
+					return Long.valueOf(o1).compareTo(Long.valueOf(o2));
+				}
+			});
+
+			final List<Iterator<StreamRecord<IN>>> wrappedIterators = new ArrayList<>();
+			for (String splitID : logSlices) {
+				wrappedIterators.add(getOperatorStateBackend()
+					.getOperatorState(new ListStateDescriptor<>(splitID,
+						config.<StreamRecord<IN>>getTypeSerializerOut(getUserCodeClassloader()))).get().iterator());
+			}
+
+			if (wrappedIterators.size() == 0) {
+				return new Iterable<StreamRecord<IN>>() {
+					@Override
+					public Iterator<StreamRecord<IN>> iterator() {
+						return Collections.emptyListIterator();
+					}
+				};
+			}
+
+			return new Iterable<StreamRecord<IN>>() {
+				@Override
+				public Iterator<StreamRecord<IN>> iterator() {
+
+					return new Iterator<StreamRecord<IN>>() {
+						int indx = 0;
+						Iterator<StreamRecord<IN>> currentIterator = wrappedIterators.get(0);
+
+						@Override
+						public boolean hasNext() {
+							if (!currentIterator.hasNext()) {
+								progressLog();
+							}
+							return currentIterator.hasNext();
+						}
+
+						@Override
+						public StreamRecord<IN> next() {
+							if (!currentIterator.hasNext() && indx < wrappedIterators.size()) {
+								progressLog();
+							}
+							return currentIterator.next();
+						}
+
+						private void progressLog() {
+							while (!currentIterator.hasNext() && ++indx < wrappedIterators.size()) {
+								currentIterator = wrappedIterators.get(indx);
+							}
+						}
+
+						@Override
+						public void remove() {
+							throw new UnsupportedOperationException();
+						}
+
+					};
+				}
+			};
+		}
+
+		public void clearLog() throws Exception {
+			for (String outputLogs : getOperatorStateBackend().getRegisteredStateNames()) {
+				getOperatorStateBackend().getOperatorState(new ListStateDescriptor<>(outputLogs,
+					config.<StreamRecord<IN>>getTypeSerializerOut(getUserCodeClassloader()))).clear();
+			}
+		}
+
+
+		@Override
+		public void open() throws Exception {
+			super.open();
+		}
+
+		@Override
+		public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<IN>> output) {
+			super.setup(containingTask, config, output);
+		}
+
+		@Override
+		public void processElement(StreamRecord<IN> element) throws Exception {
+			//nothing to do
+		}
+
+		@Override
+		public void processWatermark(Watermark mark) throws Exception {
+			//nothing to do
+		}
+
+	}
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
@@ -21,6 +21,10 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
@@ -28,6 +32,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.BlockingQueueBroker;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.types.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +40,9 @@ import org.slf4j.LoggerFactory;
 public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamIterationTail.class);
+	private
+	@SuppressWarnings("unchecked")
+	BlockingQueue<Either<StreamRecord<IN>, CheckpointBarrier>> dataChannel;
 
 	@Override
 	public void init() throws Exception {
@@ -51,10 +59,8 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 
 		LOG.info("Iteration tail {} trying to acquire feedback queue under {}", getName(), brokerID);
 
-		@SuppressWarnings("unchecked")
-		BlockingQueue<StreamRecord<IN>> dataChannel =
-				(BlockingQueue<StreamRecord<IN>>) BlockingQueueBroker.INSTANCE.get(brokerID);
-
+		dataChannel = (BlockingQueue<Either<StreamRecord<IN>, CheckpointBarrier>>) BlockingQueueBroker.INSTANCE.get(brokerID);
+		
 		LOG.info("Iteration tail {} acquired feedback queue {}", getName(), brokerID);
 
 		this.headOperator = new RecordPusher<>();
@@ -62,6 +68,22 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 
 		// call super.init() last because that needs this.headOperator to be set up
 		super.init();
+	}
+
+	@Override
+	protected boolean performCheckpoint(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, CheckpointMetrics checkpointMetrics) throws Exception {
+		LOG.debug("Starting checkpoint {} on task {}", checkpointMetaData.getCheckpointId(), getName());
+
+		synchronized (getCheckpointLock()) {
+			if (isRunning()) {
+				dataChannel.put(new Either.Right(new CheckpointBarrier(checkpointMetaData.getCheckpointId(), checkpointMetaData.getTimestamp(), checkpointOptions)));
+				getEnvironment().acknowledgeCheckpoint(checkpointMetaData.getCheckpointId(), checkpointMetrics);
+				return true;
+			}
+			else {
+				return super.performCheckpoint(checkpointMetaData, checkpointOptions, checkpointMetrics);
+			}
+		}
 	}
 
 	private static class RecordPusher<IN> extends AbstractStreamOperator<IN> implements OneInputStreamOperator<IN, IN> {
@@ -87,13 +109,13 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 	private static class IterationTailOutput<IN> implements Output<StreamRecord<IN>> {
 
 		@SuppressWarnings("NonSerializableFieldInSerializableClass")
-		private final BlockingQueue<StreamRecord<IN>> dataChannel;
+		private final BlockingQueue<Either<StreamRecord<IN>, CheckpointBarrier>> dataChannel;
 		
 		private final long iterationWaitTime;
 		
 		private final boolean shouldWait;
 
-		IterationTailOutput(BlockingQueue<StreamRecord<IN>> dataChannel, long iterationWaitTime) {
+		IterationTailOutput(BlockingQueue<Either<StreamRecord<IN>, CheckpointBarrier>> dataChannel, long iterationWaitTime) {
 			this.dataChannel = dataChannel;
 			this.iterationWaitTime = iterationWaitTime;
 			this.shouldWait =  iterationWaitTime > 0;
@@ -111,10 +133,10 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 		public void collect(StreamRecord<IN> record) {
 			try {
 				if (shouldWait) {
-					dataChannel.offer(record, iterationWaitTime, TimeUnit.MILLISECONDS);
+					dataChannel.offer(new Either.Left(record), iterationWaitTime, TimeUnit.MILLISECONDS);
 				}
 				else {
-					dataChannel.put(record);
+					dataChannel.put(new Either.Left(record));
 				}
 			} catch (InterruptedException e) {
 				throw new RuntimeException(e);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -569,7 +569,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
-	private boolean performCheckpoint(
+	protected boolean performCheckpoint(
 			CheckpointMetaData checkpointMetaData,
 			CheckpointOptions checkpointOptions,
 			CheckpointMetrics checkpointMetrics) throws Exception {
@@ -643,7 +643,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
-	private void checkpointState(
+	protected void checkpointState(
 			CheckpointMetaData checkpointMetaData,
 			CheckpointOptions checkpointOptions,
 			CheckpointMetrics checkpointMetrics) throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamIterationCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamIterationCheckpointingITCase.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import com.google.common.collect.Lists;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.streaming.api.checkpoint.Checkpointed;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.IterativeStream;
+import org.apache.flink.streaming.api.datastream.SplitStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.util.Collector;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * An integration test that runs an iterative streaming topology with checkpointing enabled.
+ * <p/>
+ * The test triggers a failure after a while and verifies "exactly-once-processing" guarantees.
+ * 
+ * The correctness of the final state relies on whether all records in transit through the iteration cycle
+ * have been processed exactly once by the stateful operator that consumes the feedback stream.
+ * 
+ */
+@SuppressWarnings("serial")
+public class StreamIterationCheckpointingITCase extends StreamFaultToleranceTestBase {
+
+	static volatile long FINISH_POINT = Long.MAX_VALUE; 
+	
+	@Override
+	public void testProgram(StreamExecutionEnvironment env) {
+		env.getCheckpointConfig().setCheckpointInterval(1000);
+		DataStream<ADD> stream = env.addSource(new AddGenerator());
+		IterativeStream.ConnectedIterativeStreams<ADD, SUBTRACT> iter = stream.iterate(2000).withFeedbackType(SUBTRACT.class);
+		SplitStream<Tuple2<String, Long>> step = iter.flatMap(new LoopCounter()).disableChaining().split(new OutputSelector<Tuple2<String, Long>>() {
+			@Override
+			public Iterable<String> select(Tuple2<String, Long> value) {
+				return Lists.newArrayList(value.f0);
+			}
+		});
+		iter.closeWith(step.select(LoopCounter.FEEDBACK).map(new MapFunction<Tuple2<String, Long>, SUBTRACT>() {
+			@Override
+			public SUBTRACT map(Tuple2 value) throws Exception {
+				return new SUBTRACT(1);
+			}
+		}));
+		step.select(LoopCounter.FORWARD).map(new MapFunction<Tuple2<String, Long>, Long>() {
+			@Override
+			public Long map(Tuple2<String, Long> value) throws Exception {
+				return value.f1;
+			}
+		}).disableChaining().addSink(new OnceFailingSink());
+
+	}
+
+	@Override
+	public void postSubmit() {
+		Long[] counters = new Long[PARALLELISM];
+		Long[] states = new Long[PARALLELISM];
+
+		Arrays.fill(counters, FINISH_POINT);
+		Arrays.fill(states, FINISH_POINT);
+
+		assertTrue(OnceFailingSink.hasFailed);
+		assertArrayEquals(counters, AddGenerator.counts);
+		assertArrayEquals(states, LoopCounter.stateVals);
+		assertArrayEquals(counters, OnceFailingSink.stateVals);
+
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Custom Functions
+	// --------------------------------------------------------------------------------------------
+
+
+	private static class AddGenerator extends RichSourceFunction<ADD>
+		implements ParallelSourceFunction<ADD>, Checkpointed<Long> {
+
+		private volatile boolean isRunning = true;
+		static final Long[] counts = new Long[PARALLELISM];
+		private int index;
+		private long state;
+		
+
+		@Override
+		public void open(Configuration parameters) throws IOException {
+			index = getRuntimeContext().getIndexOfThisSubtask();
+		}
+
+		@Override
+		public void close() throws Exception {
+			counts[index] = state;
+		}
+
+		@Override
+		public void run(SourceContext<ADD> ctx) throws Exception {
+			final Object lockingObject = ctx.getCheckpointLock();
+
+			while (isRunning && state < FINISH_POINT) {
+				synchronized (lockingObject) {
+					counts[index] = ++state;
+					ctx.collect(new ADD(2));
+					Thread.sleep(2);
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+
+		@Override
+		public Long snapshotState(long checkpointId, long checkpointTimestamp) {
+			return state;
+		}
+
+		@Override
+		public void restoreState(Long state) {
+			this.state = state;
+		}
+	}
+
+
+	private static class LoopCounter extends RichCoFlatMapFunction<ADD, SUBTRACT, Tuple2<String, Long>> implements Checkpointed<Long> {
+
+		public static final String FEEDBACK = "FEEDBACK";
+		public static final String FORWARD = "FORWARD";
+		static final Long[] stateVals = new Long[PARALLELISM];
+		private long state;
+		private int index;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			this.index = getRuntimeContext().getIndexOfThisSubtask();
+		}
+
+		@Override
+		public void close() throws Exception {
+			stateVals[index] = state;
+		}
+
+		@Override
+		public void flatMap1(ADD toAdd, Collector<Tuple2<String, Long>> out) throws Exception {
+			state += toAdd.val;
+			out.collect(new Tuple2<>(FEEDBACK, state));
+		}
+
+		@Override
+		public void flatMap2(SUBTRACT toSubtract, Collector<Tuple2<String, Long>> out) throws Exception {
+			state -= toSubtract.val;
+			out.collect(new Tuple2<>(FORWARD, state));
+		}
+
+		@Override
+		public Long snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
+			return state;
+		}
+
+		@Override
+		public void restoreState(Long recState) throws Exception {
+			state = recState;
+		}
+	}
+	
+	private static class OnceFailingSink extends RichSinkFunction<Long>
+		implements Checkpointed<Long>, CheckpointListener {
+
+		static final Long[] stateVals = new Long[PARALLELISM];
+		private long state;
+		private static volatile boolean hasFailed = false;
+		private int index;
+		private boolean failNow = false;
+
+		@Override
+		public void open(Configuration parameters) throws IOException {
+			index = getRuntimeContext().getIndexOfThisSubtask();
+		}
+
+		@Override
+		public void close() throws Exception {
+			stateVals[index] = state;
+		}
+
+		@Override
+		public Long snapshotState(long checkpointId, long checkpointTimestamp) {
+			return state;
+		}
+
+		@Override
+		public void restoreState(Long toRestore) {
+			state = toRestore;
+		}
+
+		@Override
+		public void invoke(Long value) throws Exception {
+			state++;
+			if(failNow){
+				long max = Collections.max(Arrays.asList(AddGenerator.counts));
+				FINISH_POINT = (long) (max * 1.5);
+				hasFailed = true;
+				throw new Exception("Intended Exception");
+			}
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) throws Exception {
+			synchronized (OnceFailingSink.class){
+				if(!hasFailed){
+					failNow = true;
+					hasFailed = true;
+				}	
+			}
+		}
+	}
+
+}
+
+class ADD implements Serializable {
+	public long val;
+
+	public ADD() {
+		this(0);
+	}
+
+	public void setVal(long val) {
+		
+		this.val = val;
+	}
+
+	public ADD(int val) {
+		this.val = val;
+	}
+}
+
+class SUBTRACT implements Serializable {
+	public long val;
+
+	public SUBTRACT() {
+		this(0);
+	}
+
+	public void setVal(long val) {
+		this.val = val;
+	}
+
+	public SUBTRACT(int val) {
+		this.val = val;
+	}
+}
+


### PR DESCRIPTION
# **Motivation and Algorithm**

This is a first version of the adapted snapshot algorithm to support iterations. It is correct and works in practice...well, when memory capacity is enough for its logging requirements but I am working on that, hopefully with a little feedback from you. Before we go into the implementation details let me describe briefly the new algorithm.
## Algorithm

Our existing checkpoint algorithm has a very fluid and straightforward protocol. It just makes sure that all checkpoint barriers are aligned in each operator so that all records before barriers (pre-shot) are processed before taking a snapshot. Since waiting indefinitely for all records in-transit within a cycle of an execution graph can violate termination (crucial liveness property) we have to...save any unprocessed records for later and get done with the snapshot. In this take of the algorithm on Flink we assign that role to the `Iteration Head`. The steps this version varies from the vanilla algorithm are simply the following:

(1) An `Iteration Head` receives a barrier from the system runtime (as before) and:
-  Goes into **Logging Mode**. That means that from that point on every record it receives from its `Iteration Sink` is buffered in its own operator state (log) and **not** forwarded further until it goes back to normal mode.
- **Forwards** the barrier to its downstream nodes (this guarantees liveness, otherwise we have a deadlock).

(2) Eventually, the `Iteration Head` receives a barrier back from its `Iteration Sink`. At that point:
- It **checkpoints** the log as its operator state.
- Flushes to its outputs all pending records from the log and resets it.
- Goes back to _normal_ forwarding mode.

(3) When the `Iteration Head` starts/restarts it looks at its initial operator state (the log) and flushes any records that are possibly pending.
## Example

This is just a very simple example topology. We have a single source **S** and a mapper **M** within an iteration with a head **H** and tail **T**. This is the bare minimum we need for now to check how this works.

![ftloops-topology](https://cloud.githubusercontent.com/assets/858078/13151679/7f150538-d66b-11e5-98c8-7bbe2243b810.png)

In the diagram below you can see the sequence of possible events, containing both barrier and record transmissions. For completeness I included the `Runtime` as a separate entity, this is in our case the Checkpoint Coordinator who periodically initialises checkpointing in all tasks without inputs. 

The point that this diagram tries to make is the following:
Record **R1** (or any record received in _normal mode_) gets forwarded to **M**, the only consumer of **H** before the checkpoint barrier. On the other hand, **R2** is not forwarded to **M** until **H** has finished snapshotting (or during the same atomic block anyway). In case of a failure **R2** is not lost, rather than saved for later. 

![diagram](https://cloud.githubusercontent.com/assets/858078/13151664/7361a638-d66b-11e5-94e9-64f70a8130d7.png)

A very brief description of a consistent/correct snapshot in our context could be summed up in the following sentence:

> Every record prior to a snapshot has been either processed by an operator (state **depends** on record) or **included** in the snapshot as event in transit (see Chandy Lamport algorithm). 

This algorithm guarantees this property and as explained earlier, it also terminates.
## Current Implementation Details

In the current prototype I tried to keep changes to a minimum until we agree on the pending issues (see below) so there is plenty of room for improvement, engineering-wise. The important changes are the following:
- Obviously there is no more checking for iterations during a fault tolerant `StreamGraph` construction.
- the `triggerCheckpoint` function of `StreamTask` was split (please do not freak out). That was necessary in order to extract the checkpointing logic from the barrier handling logic (which should be obviously decoupled in the updated algorithm). The actual state snapshotting now happens inside `checkpointStatesInternal`.
- The `StreamIterationTail` has to process and forward `Either<StreamRecord<IN>, CheckpointBarrier>` objects to `StreamIterationHead` which takes the necessary steps depending on the event according to the algorithm. An _internal_ task abstraction `ForwardingOneInputStreamTask` was introduced for forwarding barriers to the tail. 
- The `StreamIterationHead` uses a simple `UpstreamLogger` operator internally for its logging needs, nothing special about it.
- A `StreamIterationCheckpointingITCase` was added that checks exactly-once guarantees, loops included. More tests will follow upon demand.

I am sure we can improve this implementation but let's focus on the non-trivial problems first.
## Open/Pending Issues

During stress-testing I found the following issues that we need to discuss hoping that some of you are maybe eager to propose something.
- I realised that while flooding my cyclic topology with records I was still **losing** data, even at the **absence of task failures**. The problem seemed to be the way we transferring events from the `StreamIterationTail` to the `Head`. Apparently the tail **offers** records to the head with a specified  timeout on a blocking queue of size 1(!?). What is going on there? The Head makes sense to timeout on reading, but, why does the `StreamIterationTail` throw away events like there is no tomorrow? 
  Since at-most-once processing guarantees are not what we want I just commented out the _offer_ part until I understand why it is there. I think it is safe (deadlock-wise) to simply **put** records to the queue, right?...I can also fire a new JIRA issue reporting this if needed.
- I feel that we really need to spill log state to disk (`BufferSpiller`?), or/and restrict iterative jobs to out-of-core backend and forbid in-memory. The upstream log size can very easily pass the boundaries of the allowed in-memory state (e.g. when millions records in transit are snapshotted). Any ideas on that are welcome!

Thanks a lot for looking into this. Really looking forward to your suggestions.
