### PR TITLE
[FLINK-3446] [runtime-web] Don't trigger back pressure sample for archived job

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Maps;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
@@ -25,9 +25,11 @@ import com.google.common.collect.Maps;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
+import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -150,26 +152,37 @@ public class BackPressureStatsTracker {
 	 * is ignored.
 	 *
 	 * @param vertex Operator to get the stats for.
+	 * @return Flag indicating whether a sample with triggered.
 	 */
 	@SuppressWarnings("unchecked")
-	public void triggerStackTraceSample(ExecutionJobVertex vertex) {
+	public boolean triggerStackTraceSample(ExecutionJobVertex vertex) {
 		synchronized (lock) {
 			if (shutDown) {
-				return;
+				return false;
 			}
 
-			if (!pendingStats.contains(vertex)) {
-				pendingStats.add(vertex);
+			if (!pendingStats.contains(vertex) &&
+					!vertex.getGraph().getState().isTerminalState()) {
 
-				Future<StackTraceSample> sample = coordinator.triggerStackTraceSample(
-						vertex.getTaskVertices(),
-						numSamples,
-						delayBetweenSamples,
-						MAX_STACK_TRACE_DEPTH);
+				ExecutionContext executionContext = vertex.getGraph().getExecutionContext();
 
-				sample.onComplete(new StackTraceSampleCompletionCallback(
-						vertex), vertex.getGraph().getExecutionContext());
+				// Only trigger if still active job
+				if (executionContext != null) {
+					pendingStats.add(vertex);
+
+					Future<StackTraceSample> sample = coordinator.triggerStackTraceSample(
+							vertex.getTaskVertices(),
+							numSamples,
+							delayBetweenSamples,
+							MAX_STACK_TRACE_DEPTH);
+
+					sample.onComplete(new StackTraceSampleCompletionCallback(vertex), executionContext);
+
+					return true;
+				}
 			}
+
+			return false;
 		}
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
@@ -55,6 +55,8 @@ import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.Ex
 import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.RequestExecutionGraph;
 import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -238,6 +240,13 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 
 							// Response to removal notification
 							expectMsgEquals(true);
+
+							//
+							// 3) Trigger stats for archived job
+							//
+							statsTracker.invalidateOperatorStatsCache();
+							assertFalse("Unexpected trigger", statsTracker.triggerStackTraceSample(vertex));
+
 						} catch (Exception e) {
 							e.printStackTrace();
 							fail(e.getMessage());
@@ -265,7 +274,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 			ExecutionJobVertex vertex) throws InterruptedException {
 
 		statsTracker.invalidateOperatorStatsCache();
-		statsTracker.triggerStackTraceSample(vertex);
+		assertTrue("Failed to trigger", statsTracker.triggerStackTraceSample(vertex));
 
 		// Sleep minimum duration
 		Thread.sleep(20 * 10);


### PR DESCRIPTION
Sampling a back pressure sample when the job has been archived, lead to a NPE being thrown as reported by @rmetzger. Fix is pretty straight forward, waiting for Travis...