### PR TITLE
[FLINK-3453] [runtime, runtime-web] Report partial stack trace sample for cleared tasks

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
@@ -225,11 +226,15 @@ public class BackPressureStatsTracker {
 						return;
 					}
 
-					if (success != null) {
+					// Job finished, ignore.
+					JobStatus jobState = vertex.getGraph().getState();
+					if (jobState.isTerminalState()) {
+						LOG.debug("Ignoring sample, because job is in state " + jobState + ".");
+					} else if (success != null) {
 						OperatorBackPressureStats stats = createStatsFromSample(success);
 						operatorStatsCache.put(vertex, stats);
 					} else {
-						LOG.error("Failed to gather stack trace sample.", failure);
+						LOG.warn("Failed to gather stack trace sample.", failure);
 					}
 				} catch (Throwable t) {
 					LOG.error("Error during stats completion.", t);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/StackTraceSample.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/StackTraceSample.java
@@ -108,4 +108,12 @@ public class StackTraceSample {
 		return stackTracesByTask;
 	}
 
+	@Override
+	public String toString() {
+		return "StackTraceSample{" +
+				"sampleId=" + sampleId +
+				", startTime=" + startTime +
+				", endTime=" + endTime +
+				'}';
+	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.junit.Test;
 import scala.concurrent.ExecutionContext;
@@ -62,6 +63,7 @@ public class BackPressureStatsTrackerTest {
 				anyInt())).thenReturn(samplePromise.future());
 
 		ExecutionGraph graph = mock(ExecutionGraph.class);
+		when(graph.getState()).thenReturn(JobStatus.RUNNING);
 
 		// Same Thread execution context
 		when(graph.getExecutionContext()).thenReturn(new ExecutionContext() {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor;
+
+import akka.actor.ActorSystem;
+import akka.testkit.JavaTestKit;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.AkkaActorGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.Tasks;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.AllVerticesRunning;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.ExecutionGraphFound;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.RequestExecutionGraph;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
+import static org.junit.Assert.fail;
+
+/**
+ * Simple stack trace sampling test.
+ */
+public class StackTraceSampleCoordinatorITCase extends TestLogger {
+
+	private static ActorSystem testActorSystem;
+
+	@BeforeClass
+	public static void setup() {
+		testActorSystem = AkkaUtils.createLocalActorSystem(new Configuration());
+	}
+
+	@AfterClass
+	public static void teardown() {
+		JavaTestKit.shutdownActorSystem(testActorSystem);
+	}
+
+	/**
+	 * Tests that a cleared task is answered with a partial success response.
+	 */
+	@Test
+	public void testTaskClearedWhileSampling() throws Exception {
+		new JavaTestKit(testActorSystem) {{
+			final FiniteDuration deadline = new FiniteDuration(60, TimeUnit.SECONDS);
+
+			// The JobGraph
+			final JobGraph jobGraph = new JobGraph();
+			final int parallelism = 1;
+
+			final JobVertex task = new JobVertex("Task");
+			task.setInvokableClass(Tasks.BlockingNoOpInvokable.class);
+			task.setParallelism(parallelism);
+
+			jobGraph.addVertex(task);
+
+			ActorGateway jobManger = null;
+			ActorGateway taskManager = null;
+
+			try {
+				jobManger = TestingUtils.createJobManager(testActorSystem, new Configuration());
+
+				Configuration config = new Configuration();
+				config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, parallelism);
+
+				taskManager = TestingUtils.createTaskManager(
+						testActorSystem, jobManger, config, true, true);
+
+				final ActorGateway jm = jobManger;
+
+				new Within(deadline) {
+					@Override
+					protected void run() {
+						try {
+							ActorGateway testActor = new AkkaActorGateway(getTestActor(), null);
+
+							int maxAttempts = 10;
+							int sleepTime = 100;
+
+							for (int i = 0; i < maxAttempts; i++, sleepTime *= 2) {
+								// Submit the job and wait until it is running
+								JobClient.submitJobDetached(
+										jm,
+										jobGraph,
+										deadline,
+										ClassLoader.getSystemClassLoader());
+
+								jm.tell(new WaitForAllVerticesToBeRunning(jobGraph.getJobID()), testActor);
+
+								expectMsgEquals(new AllVerticesRunning(jobGraph.getJobID()));
+
+								// Get the ExecutionGraph
+								jm.tell(new RequestExecutionGraph(jobGraph.getJobID()), testActor);
+								ExecutionGraphFound executionGraphResponse =
+										expectMsgClass(ExecutionGraphFound.class);
+								ExecutionGraph executionGraph = executionGraphResponse.executionGraph();
+								ExecutionJobVertex vertex = executionGraph.getJobVertex(task.getID());
+
+								StackTraceSampleCoordinator coordinator = new StackTraceSampleCoordinator(
+										testActorSystem, 60000);
+
+								Future<?> sampleFuture = coordinator.triggerStackTraceSample(
+										vertex.getTaskVertices(),
+										// Do this often so we have a good
+										// chance of removing the job during
+										// sampling.
+										Integer.MAX_VALUE,
+										new FiniteDuration(10, TimeUnit.MILLISECONDS),
+										0);
+
+								// Wait before cancelling so that some samples
+								// are actually taken.
+								Thread.sleep(sleepTime);
+
+								// Cancel job
+								Future<?> removeFuture = jm.ask(
+										new TestingJobManagerMessages.NotifyWhenJobRemoved(jobGraph.getJobID()),
+										remaining());
+
+								jm.tell(new JobManagerMessages.CancelJob(jobGraph.getJobID()));
+
+								try {
+									// Throws Exception on failure
+									Await.result(sampleFuture, remaining());
+
+									// OK, we are done. Got the expected
+									// partial result.
+									break;
+								} catch (Throwable t) {
+									// We were too fast in cancelling the job.
+									// Fall through and retry.
+								} finally {
+									Await.ready(removeFuture, remaining());
+								}
+							}
+						} catch (Exception e) {
+							e.printStackTrace();
+							fail(e.getMessage());
+						}
+					}
+				};
+			} finally {
+				TestingUtils.stopActor(jobManger);
+				TestingUtils.stopActor(taskManager);
+			}
+		}};
+	}
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -729,19 +729,16 @@ class TaskManager(
                   // ---- Done ----
                   log.debug(s"Done with stack trace sample $sampleId.")
 
-                  sender ! ResponseStackTraceSampleSuccess(
-                    sampleId,
-                    executionId,
-                    currentTraces)
+                  sender ! ResponseStackTraceSampleSuccess(sampleId, executionId, currentTraces)
                 }
 
               case None =>
-                if (currentTraces.size() == 0) {
+                if (currentTraces.isEmpty()) {
                   throw new IllegalStateException(s"Cannot sample task $executionId. " +
                     s"Either the task is not known to the task manager or it is not running.")
                 } else {
-                  throw new IllegalStateException(s"Cannot sample task $executionId. " +
-                    s"Task was removed after ${currentTraces.size()} sample(s).")
+                  // Task removed during sampling. Reply with partial result.
+                  sender ! ResponseStackTraceSampleSuccess(sampleId, executionId, currentTraces)
                 }
             }
           } else {


### PR DESCRIPTION
Ongoing stack trace samples were considered failed if the tasks were cleared concurrently. Instead, they now report a partial sample success (i.e. less samples taken than actually planned). This result will be ignored at the job manager (as soon as the job state is terminal) or displayed as a partial result for a brief period of time.