### PR TITLE
[FLINK-3458] [build] Disable shade-flink execution in flink-shaded-hadoop

### DIFF
--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -63,6 +63,12 @@ under the License.
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
+						<!--Disable shade-flink execution to avoid duplicate relocation of
+						dependencies-->
+						<id>shade-flink</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
 						<id>shade-hadoop</id>
 						<phase>package</phase>
 						<goals>


### PR DESCRIPTION
The `shade-flink` execution of the parent pom caused the problem that the guava
dependencies were relocated twice in the flink-shaded-hadoop jar. In order to
avoid this, this patch disables the `shade-flink` execution.