### PR TITLE
[FLINK-3450] Duplicate TypeSerializer in StateDescriptor.writeObject

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -260,7 +260,9 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 			try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); 
 					DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
 			{
-				serializer.serialize(defaultValue, outView);
+				TypeSerializer<T> duplicateSerializer = serializer.duplicate();
+				duplicateSerializer.serialize(defaultValue, outView);
+
 				outView.flush();
 				serializedDefaultValue = baos.toByteArray();
 			}


### PR DESCRIPTION
The StateDescriptor can be serializer asynchronously in case of
asynchronous checkpoints. In that case two threads would try to
concurrently use the TypeSerializer: The normal state updating and the
checkpoint serialization. If the TypeSerializer is a KryoSerializer this
can lead to problems. Therefore the need to duplicate it before using in
"writeObject".