### PR TITLE
added support for Main-Class separated by / instead of .

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -566,7 +566,8 @@ public class PackagedProgram {
 			// check for a main class
 			className = attributes.getValue(PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS);
 			if (className != null) {
-				return className;
+			    // Main-Class may use "/" as separator, not just "."
+				return className.replaceAll("/", "\\.");
 			} else {
 				throw new ProgramInvocationException("Neither a '" + MANIFEST_ATTRIBUTE_MAIN_CLASS + "', nor a '" +
 						MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS + "' entry was found in the jar file.");

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -85,7 +85,8 @@ public class JarListHandler implements RequestHandler {
 					if (manifest != null) {
 						assemblerClass = manifest.getMainAttributes().getValue(PackagedProgram.MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS);
 						if (assemblerClass == null) {
-							assemblerClass = manifest.getMainAttributes().getValue(PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS);
+						    // Main-Class may use "/" as separator, not just "."
+							assemblerClass = manifest.getMainAttributes().getValue(PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS).replaceAll("/", "\\.");
 						}
 					}
 					if (assemblerClass != null) {


### PR DESCRIPTION
I ran into this while trying something out with cascading-flink:

The Main-Class in a jar manifest may be written as "package/subpackage/SomeClass", which confuses the flink runner, since it assumes that classes are always written with "." as the separator.
