### PR TITLE
[FLINK-3434] Prevent NPE in ClientFrontend#getClient()

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnClientBase.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/FlinkYarnClientBase.java
@@ -367,9 +367,8 @@ public abstract class FlinkYarnClientBase extends AbstractFlinkYarnClient {
 		try {
 			org.apache.flink.core.fs.FileSystem.setDefaultScheme(flinkConfiguration);
 		} catch (IOException e) {
-			LOG.error("Error while setting the default " +
+			throw new IOException("Error while setting the default " +
 				"filesystem scheme from configuration.", e);
-			return null;
 		}
 		// ------------------ Check if the specified queue exists --------------
 


### PR DESCRIPTION
CliFrontend#getClient() can enocunter a NullPointerException when executing 
```
yarnCluster = flinkYarnClient.deploy();
yarnCluster.connectToCluster();
```
since the deploy call can return null if ```org.apache.flink.core.fs.FileSystem.setDefaultScheme(flinkConfiguration)``` 
throws an IOException . 

This NPE would be catched and wrapped in a new IOException. By rethrowing the original IOException directly instead of returning null the whole affair is a bit more straight forward, and removes an unnecessary exception form the stack trace.