### PR TITLE
[FLINK-3478] [runtime-web] Don't serve files outside of web folder

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -146,14 +146,14 @@ public class WebRuntimeMonitor implements WebMonitor {
 		
 		// create an empty directory in temp for the web server
 		String rootDirFileName = "flink-web-" + UUID.randomUUID();
-		webRootDir = new File(System.getProperty("java.io.tmpdir"), rootDirFileName);
+		webRootDir = new File(getBaseDir(), rootDirFileName);
 		LOG.info("Using directory {} for the web interface files", webRootDir);
 
 		final boolean webSubmitAllow = cfg.isProgramSubmitEnabled();
 		if (webSubmitAllow) {
 			// create storage for uploads
 			String uploadDirName = "flink-web-upload-" + UUID.randomUUID();
-			this.uploadDir = new File(System.getProperty("java.io.tmpdir"), uploadDirName);
+			this.uploadDir = new File(getBaseDir(), uploadDirName);
 			if (!uploadDir.mkdir() || !uploadDir.canWrite()) {
 				throw new IOException("Unable to create temporary directory to support jar uploads.");
 			}
@@ -423,5 +423,9 @@ public class WebRuntimeMonitor implements WebMonitor {
 
 	private RuntimeMonitorHandler handler(RequestHandler handler) {
 		return new RuntimeMonitorHandler(handler, retriever, jobManagerAddressPromise.future(), timeout);
+	}
+
+	File getBaseDir() {
+		return new File(System.getProperty("java.io.tmpdir"));
 	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
@@ -50,9 +50,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -324,6 +326,149 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 
 			if (webRuntimeMonitor != null) {
 				webRuntimeMonitor.stop();
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Tests that access outside of the web root is not allowed
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Files are copied from the flink-dist jar to a temporary directory and
+	 * then served from there. Only allow to access files in this temporary
+	 * directory.
+	 */
+	@Test
+	public void testNoEscape() throws Exception {
+		final Deadline deadline = TestTimeout.fromNow();
+
+		TestingCluster flink = null;
+		WebRuntimeMonitor webMonitor = null;
+
+		try {
+			flink = new TestingCluster(new Configuration());
+			flink.start(true);
+
+			ActorSystem jmActorSystem = flink.jobManagerActorSystems().get().head();
+			ActorRef jmActor = flink.jobManagerActors().get().head();
+
+			// Needs to match the leader address from the leader retrieval service
+			String jobManagerAddress = AkkaUtils.getAkkaURL(jmActorSystem, jmActor);
+
+			// Web frontend on random port
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.JOB_MANAGER_WEB_PORT_KEY, 0);
+
+			webMonitor = new WebRuntimeMonitor(
+					config,
+					flink.createLeaderRetrievalService(),
+					jmActorSystem);
+
+			webMonitor.start(jobManagerAddress);
+
+			try (HttpTestClient client = new HttpTestClient("localhost", webMonitor.getServerPort())) {
+				String expectedIndex = new Scanner(new File(MAIN_RESOURCES_PATH + "/index.html"))
+						.useDelimiter("\\A").next();
+
+				// 1) Request index.html from web server
+				client.sendGetRequest("index.html", deadline.timeLeft());
+
+				HttpTestClient.SimpleHttpResponse response = client.getNextResponse(deadline.timeLeft());
+				assertEquals(HttpResponseStatus.OK, response.getStatus());
+				assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("html"));
+				assertEquals(expectedIndex, response.getContent());
+
+				// 2) Request file outside of web root
+
+				// Create a test file in the web base dir (parent of web root)
+				File illegalFile = new File(webMonitor.getBaseDir(), "test-file-" + UUID.randomUUID());
+				illegalFile.deleteOnExit();
+
+				assertTrue("Failed to create test file", illegalFile.createNewFile());
+
+				// Request the created file from the web server
+				client.sendGetRequest("../" + illegalFile.getName(), deadline.timeLeft());
+				response = client.getNextResponse(deadline.timeLeft());
+				assertEquals(
+						"Returned status code " + response.getStatus() + " for file outside of web root.",
+						HttpResponseStatus.NOT_FOUND,
+						response.getStatus());
+			}
+		} finally {
+			if (flink != null) {
+				flink.shutdown();
+			}
+
+			if (webMonitor != null) {
+				webMonitor.stop();
+			}
+		}
+	}
+
+	/**
+	 * Files are copied from the flink-dist jar to a temporary directory and
+	 * then served from there. Only allow to copy files from <code>flink-dist.jar:/web</code>
+	 */
+	@Test
+	public void testNoCopyFromJar() throws Exception {
+		final Deadline deadline = TestTimeout.fromNow();
+
+		TestingCluster flink = null;
+		WebRuntimeMonitor webMonitor = null;
+
+		try {
+			flink = new TestingCluster(new Configuration());
+			flink.start(true);
+
+			ActorSystem jmActorSystem = flink.jobManagerActorSystems().get().head();
+			ActorRef jmActor = flink.jobManagerActors().get().head();
+
+			// Needs to match the leader address from the leader retrieval service
+			String jobManagerAddress = AkkaUtils.getAkkaURL(jmActorSystem, jmActor);
+
+			// Web frontend on random port
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.JOB_MANAGER_WEB_PORT_KEY, 0);
+
+			webMonitor = new WebRuntimeMonitor(
+					config,
+					flink.createLeaderRetrievalService(),
+					jmActorSystem);
+
+			webMonitor.start(jobManagerAddress);
+
+			try (HttpTestClient client = new HttpTestClient("localhost", webMonitor.getServerPort())) {
+				String expectedIndex = new Scanner(new File(MAIN_RESOURCES_PATH + "/index.html"))
+						.useDelimiter("\\A").next();
+
+				// 1) Request index.html from web server
+				client.sendGetRequest("index.html", deadline.timeLeft());
+
+				HttpTestClient.SimpleHttpResponse response = client.getNextResponse(deadline.timeLeft());
+				assertEquals(HttpResponseStatus.OK, response.getStatus());
+				assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("html"));
+				assertEquals(expectedIndex, response.getContent());
+
+				// 2) Request file from class loader
+				client.sendGetRequest("../log4j-test.properties", deadline.timeLeft());
+
+				response = client.getNextResponse(deadline.timeLeft());
+				assertEquals(
+						"Returned status code " + response.getStatus() + " for file outside of web root.",
+						HttpResponseStatus.NOT_FOUND,
+						response.getStatus());
+
+				assertFalse("Did not respond with the file, but still copied it from the JAR.",
+						new File(webMonitor.getBaseDir(), "log4j-test.properties").exists());
+			}
+		} finally {
+			if (flink != null) {
+				flink.shutdown();
+			}
+
+			if (webMonitor != null) {
+				webMonitor.stop();
 			}
 		}
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
@@ -380,7 +380,6 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 				assertEquals(expectedIndex, response.getContent());
 
 				// 2) Request file outside of web root
-
 				// Create a test file in the web base dir (parent of web root)
 				File illegalFile = new File(webMonitor.getBaseDir(), "test-file-" + UUID.randomUUID());
 				illegalFile.deleteOnExit();
@@ -391,7 +390,15 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 				client.sendGetRequest("../" + illegalFile.getName(), deadline.timeLeft());
 				response = client.getNextResponse(deadline.timeLeft());
 				assertEquals(
-						"Returned status code " + response.getStatus() + " for file outside of web root.",
+						"Unexpected status code " + response.getStatus() + " for file outside of web root.",
+						HttpResponseStatus.NOT_FOUND,
+						response.getStatus());
+
+				// 3) Request non-existing file
+				client.sendGetRequest("not-existing-resource", deadline.timeLeft());
+				response = client.getNextResponse(deadline.timeLeft());
+				assertEquals(
+						"Unexpected status code " + response.getStatus() + " for file outside of web root.",
 						HttpResponseStatus.NOT_FOUND,
 						response.getStatus());
 			}
@@ -461,6 +468,14 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 
 				assertFalse("Did not respond with the file, but still copied it from the JAR.",
 						new File(webMonitor.getBaseDir(), "log4j-test.properties").exists());
+
+				// 3) Request non-existing file
+				client.sendGetRequest("not-existing-resource", deadline.timeLeft());
+				response = client.getNextResponse(deadline.timeLeft());
+				assertEquals(
+						"Unexpected status code " + response.getStatus() + " for file outside of web root.",
+						HttpResponseStatus.NOT_FOUND,
+						response.getStatus());
 			}
 		} finally {
 			if (flink != null) {


### PR DESCRIPTION
Previously it was possible to request arbitrary files via the web interface by specifying a relative file path (this usually does not work with curl, browsers etc., which resolve the relative paths before sending the GET request) or copying any loadable resources (like Flink config) to the tmp directory.

This fix tries to ensure that it does not happen any more.