### PR TITLE
redundant check in getting leadership status

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
@@ -148,11 +148,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 
 	@Override
 	public boolean hasLeadership() {
-		if(leaderLatch.getState().equals(LeaderLatch.State.STARTED)) {
-			return leaderLatch.hasLeadership();
-		} else {
-			return false;
-		}
+        return leaderLatch.hasLeadership();
 	}
 
 	@Override


### PR DESCRIPTION
Don't need to check again in ZooKeeperLeaderElectionService as LeaderLatch already checks for it.