### PR TITLE
[FLINK-3491] Prevent failure of HDFSCopyUtilitiesTest on Windows

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
@@ -18,6 +18,8 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.core.fs.Path;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -34,6 +36,11 @@ public class HDFSCopyUtilitiesTest {
 
 	@Rule
 	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Before
+	public void checkOperatingSystem() {
+		Assume.assumeTrue("This test can't run successfully on Windows.", !System.getProperty("os.name").startsWith("Windows"));
+	}
 
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.core.fs.Path;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -26,7 +27,6 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.net.URI;
 
 import static org.junit.Assert.assertTrue;
 
@@ -54,7 +54,7 @@ public class HDFSCopyUtilitiesTest {
 
 		HDFSCopyFromLocal.copyFromLocal(
 				originalFile,
-				new URI(copyFile.getAbsolutePath()));
+				new Path(copyFile.getAbsolutePath()).toUri());
 
 		try (DataInputStream in = new DataInputStream(new FileInputStream(copyFile))) {
 			assertTrue(in.readUTF().equals("Hello there, 42!"));
@@ -79,7 +79,7 @@ public class HDFSCopyUtilitiesTest {
 		}
 
 		HDFSCopyToLocal.copyToLocal(
-				new URI(originalFile.getAbsolutePath()),
+				new Path(originalFile.getAbsolutePath()).toUri(),
 				copyFile);
 
 		try (DataInputStream in = new DataInputStream(new FileInputStream(copyFile))) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.OperatingSystem;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,7 +40,7 @@ public class HDFSCopyUtilitiesTest {
 
 	@Before
 	public void checkOperatingSystem() {
-		Assume.assumeTrue("This test can't run successfully on Windows.", !System.getProperty("os.name").startsWith("Windows"));
+		Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows());
 	}
 
 


### PR DESCRIPTION
This PR contains two commits to that prevent this test from failing on Windows.

The first commit resolves the problem raised in the JIRA: it changes how the URI is generated, using new Path(file).toUri() instead of file.toUri(), since the latter fails for Windows paths.

After this change, i got a new exception when running the test:
```
testCopyFromLocal(org.apache.flink.streaming.util.HDFSCopyUtilitiesTest)  Time elapsed: 1.892 sec  <<< ERROR!
java.lang.NullPointerException: null
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1012)
        at org.apache.hadoop.util.Shell.runCommand(Shell.java:445)
        at org.apache.hadoop.util.Shell.run(Shell.java:418)
        at org.apache.hadoop.util.Shell$ShellCommandExecutor.execute(Shell.java:650)
        at org.apache.hadoop.util.Shell.execCommand(Shell.java:739)
        at org.apache.hadoop.util.Shell.execCommand(Shell.java:722)
        at org.apache.hadoop.fs.RawLocalFileSystem.setPermission(RawLocalFileSystem.java:631)
        at org.apache.hadoop.fs.FilterFileSystem.setPermission(FilterFileSystem.java:468)
        at org.apache.hadoop.fs.ChecksumFileSystem.create(ChecksumFileSystem.java:456)
        at org.apache.hadoop.fs.ChecksumFileSystem.create(ChecksumFileSystem.java:424)
        at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:907)
        at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:888)
        at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:785)
        at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:365)
        at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:338)
        at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:289)
        at org.apache.hadoop.fs.LocalFileSystem.copyFromLocalFile(LocalFileSystem.java:82)
        at org.apache.hadoop.fs.FileSystem.copyFromLocalFile(FileSystem.java:1837)
        at org.apache.flink.streaming.util.HDFSCopyFromLocal$1.run(HDFSCopyFromLocal.java:49)

```

After googling a bit it appears that several hadoop versions can't deal with windows paths unless it has access to fancy libraries/dll's. (see https://issues.apache.org/jira/browse/SPARK-6961) As such I added a  second commit that disables the test when run on windows. 