### PR TITLE
[FLINK-3495] Disable RocksDB tests on Windows

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncKVSnapshotTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncKVSnapshotTest.java
@@ -42,9 +42,12 @@ import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskState;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskStateList;
+import org.apache.flink.util.OperatingSystem;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -66,6 +69,11 @@ import static org.junit.Assert.assertTrue;
 @PrepareForTest({ResultPartitionWriter.class, FileSystem.class})
 @SuppressWarnings("serial")
 public class RocksDBAsyncKVSnapshotTest {
+
+	@Before
+	public void checkOperatingSystem() {
+		Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows());
+	}
 
 	/**
 	 * This ensures that asynchronous state handles are actually materialized asynchonously.

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -26,6 +26,9 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 
+import org.apache.flink.util.OperatingSystem;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.rocksdb.CompactionStyle;
@@ -44,6 +47,11 @@ import static org.mockito.Mockito.*;
 public class RocksDBStateBackendConfigTest {
 	
 	private static final String TEMP_URI = new File(System.getProperty("java.io.tmpdir")).toURI().toString();
+
+	@Before
+	public void checkOperatingSystem() {
+		Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows());
+	}
 
 	// ------------------------------------------------------------------------
 	//  RocksDB local file directory

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -22,6 +22,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.state.StateBackendTestBase;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.util.OperatingSystem;
+import org.junit.Assume;
+import org.junit.Before;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +37,11 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 
 	private File dbDir;
 	private File chkDir;
+
+	@Before
+	public void checkOperatingSystem() {
+		Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows());
+	}
 
 	@Override
 	protected RocksDBStateBackend getStateBackend() throws IOException {


### PR DESCRIPTION
This PR disables all RocksDbStateBackend tests when run on Windows, as they straight up won't run until a RocksDB version is released that contains Windows support.