### PR TITLE
[FLINK-3513] [FLINK-3512] Fix savepoint issues

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -736,8 +736,6 @@ public class StreamingJobGraphGenerator {
 
 		hasher.putInt(node.getParallelism());
 
-		hasher.putString(node.getOperatorName(), Charset.forName("UTF-8"));
-
 		if (node.getOperator() instanceof AbstractUdfStreamOperator) {
 			String udfClassName = ((AbstractUdfStreamOperator<?, ?>) node.getOperator())
 					.getUserFunction().getClass().getName();


### PR DESCRIPTION
@aljoscha spotted the following two issues (so far) while working with savepoints and the rocks DB state backend.

- FLINK-3513: The operator name is used in the deterministic hash assignment, which is actually not necessary and leads to problems with the WindowOperator (changing name).
- FLINK-3512: The savepoint backend was trying to be too clever and fell back to jobmanager when it found "wrong" config combinations.