### PR TITLE
[hotfix] fix PageRank example to run with no args; some doc fixes

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -87,7 +87,7 @@ Run the __Word Count example__ to see Flink at work.
 * __Start the example program__:
 
   ~~~bash
-  $ bin/flink run ./examples/WordCount.jar file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
+  $ bin/flink run ./examples/batch/WordCount.jar --input file://`pwd`/hamlet.txt --output file://`pwd`/wordcount-result.txt
   ~~~
 
 * You will find a file called __wordcount-result.txt__ in your current directory.

--- a/docs/setup/jobmanager_high_availability.md
+++ b/docs/setup/jobmanager_high_availability.md
@@ -23,11 +23,11 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The JobManager is coordinates every Flink deployment. It is responsible for both *scheduling* and *resource management*.
+The JobManager coordinates every Flink deployment. It is responsible for both *scheduling* and *resource management*.
 
 By default, there is a single JobManager instance per Flink cluster. This creates a *single point of failure* (SPOF): if the JobManager crashes, no new programs can be submitted and running programs fail.
 
-With JobManager High Availability, you can run recover from JobManager failures and thereby eliminate the *SPOF*. You can configure high availability for both **standalone** and **YARN clusters**.
+With JobManager High Availability, you can recover from JobManager failures and thereby eliminate the *SPOF*. You can configure high availability for both **standalone** and **YARN clusters**.
 
 * Toc
 {:toc}

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/graph/PageRank.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/graph/PageRank.java
@@ -85,7 +85,7 @@ public class PageRank {
 		ParameterTool params = ParameterTool.fromArgs(args);
 		System.out.println("Usage: PageRankBasic --pages <path> --links <path> --output <path> --numPages <n> --iterations <n>");
 
-		final int numPages = params.getInt("numPages");
+		final int numPages = params.getInt("numPages", PageRankData.getNumberOfPages());
 		final int maxIterations = params.getInt("iterations", 10);
 		
 		// set up execution environment

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/graph/util/PageRankData.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/graph/util/PageRankData.java
@@ -64,7 +64,7 @@ public class PageRankData {
 		{15L, 1L},
 	};
 	
-	private static long numPages = 15;
+	private static int numPages = 15;
 	
 	public static DataSet<Tuple2<Long, Long>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 		
@@ -79,7 +79,7 @@ public class PageRankData {
 		return env.generateSequence(1, 15);
 	}
 	
-	public static long getNumberOfPages() {
+	public static int getNumberOfPages() {
 		return numPages;
 	}
 	


### PR DESCRIPTION
This PR includes a fix for the java PageRank example to retrieve the required parameter `numPages ` when run with no arguments and some documentation fixes.