### PR TITLE
[FLINK-3517] [dist] Only count active PIDs in start script

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -85,8 +85,16 @@ case $STARTSTOP in
 
         # Print a warning if daemons are already running on host
         if [ -f $pid ]; then
-            count=$(wc -l $pid | awk '{print $1}')
-            echo "[WARNING] $count instance(s) of $DAEMON are already running on $HOSTNAME."
+          active=()
+          while IFS='' read -r p || [[ -n "$p" ]]; do
+            kill -0 $p >/dev/null 2>&1
+            if [ $? -eq 0 ]; then
+              active+=($p)
+            fi
+          done < "${pid}"
+
+          count="${#active[@]}"
+          echo "[INFO] $count instance(s) of $DAEMON are already running on $HOSTNAME."
         fi
 
         echo "Starting $DAEMON daemon on host $HOSTNAME."


### PR DESCRIPTION
```bash
$ bin/start-cluster.sh
Starting cluster.
Starting jobmanager daemon on host pablo.
Starting taskmanager daemon on host pablo.
$ bin/taskmanager.sh start
[INFO] 1 instance(s) of taskmanager are already running on pablo.
Starting taskmanager daemon on host pablo.
$ bin/taskmanager.sh start
[INFO] 2 instance(s) of taskmanager are already running on pablo.
Starting taskmanager daemon on host pablo.
$ bin/taskmanager.sh start
[INFO] 3 instance(s) of taskmanager are already running on pablo.
Starting taskmanager daemon on host pablo.
$ jps
27328 TaskManager
27140 TaskManager
26949 TaskManager
26523 JobManager
26716 TaskManager
$ kill -9 27140
$ bin/taskmanager.sh start
>>> [INFO] 3 instance(s) of taskmanager are already running on pablo <<< Correct now
Starting taskmanager daemon on host pablo.
$ bin/stop-cluster.sh
Stopping taskmanager daemon (pid: 27545) on host pablo.
Stopping jobmanager daemon (pid: 26523) on host pablo.
$ bin/taskmanager.sh stop
Stopping taskmanager daemon (pid: 27328) on host pablo.
$ bin/taskmanager.sh stop
No taskmanager daemon (pid: 27140) is running anymore on pablo.
$ bin/taskmanager.sh stop
Stopping taskmanager daemon (pid: 26949) on host pablo.
$ bin/taskmanager.sh stop
Stopping taskmanager daemon (pid: 26716) on host pablo.
$ bin/taskmanager.sh stop
No taskmanager daemon to stop on host pablo.
```

We can further improve the stop part by repeatedly the PIDs in the pid file if a value is not matching an active PID.