### PR TITLE
[FLINK-3519] [core] Add warning about subclasses to Tuple javadocs.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 1 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple1, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple1", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple1&gt; / DataSet&lt;Tuple1&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 10 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple10, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple10", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple10&gt; / DataSet&lt;Tuple10&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 11 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple11, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple11", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple11&gt; / DataSet&lt;Tuple11&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 12 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple12, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple12", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple12&gt; / DataSet&lt;Tuple12&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 13 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple13, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple13", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple13&gt; / DataSet&lt;Tuple13&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 14 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple14, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple14", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple14&gt; / DataSet&lt;Tuple14&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 15 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple15, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple15", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple15&gt; / DataSet&lt;Tuple15&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 16 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple16, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple16", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple16&gt; / DataSet&lt;Tuple16&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 17 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple17, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple17", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple17&gt; / DataSet&lt;Tuple17&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 18 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple18, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple18", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple18&gt; / DataSet&lt;Tuple18&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 19 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple19, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple19", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple19&gt; / DataSet&lt;Tuple19&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 2 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple2, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple2", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple2&gt; / DataSet&lt;Tuple2&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 20 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple20, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple20", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple20&gt; / DataSet&lt;Tuple20&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 21 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple21, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple21", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple21&gt; / DataSet&lt;Tuple21&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 22 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple22, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple22", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple22&gt; / DataSet&lt;Tuple22&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 23 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple23, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple23", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple23&gt; / DataSet&lt;Tuple23&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 24 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple24, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple24", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple24&gt; / DataSet&lt;Tuple24&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 25 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple25, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple25", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple25&gt; / DataSet&lt;Tuple25&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 3 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple3, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple3", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple3&gt; / DataSet&lt;Tuple3&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 4 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple4, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple4", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple4&gt; / DataSet&lt;Tuple4&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 5 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple5, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple5", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple5&gt; / DataSet&lt;Tuple5&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 6 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple6, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple6", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple6&gt; / DataSet&lt;Tuple6&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 7 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple7, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple7", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple7&gt; / DataSet&lt;Tuple7&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 8 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple8, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple8", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple8&gt; / DataSet&lt;Tuple8&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
@@ -32,10 +32,17 @@ import org.apache.flink.util.StringUtils;
  * A tuple with 9 fields. Tuples are strongly typed; each field may be of a separate type.
  * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
  * through the {@link #getField(int)} method. The tuple field positions start at zero.
- * <p>
- * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
- * with Tuples to reuse objects in order to reduce pressure on the garbage collector.
  *
+ * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work
+ * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>
+ *
+ * <p>Warning: If you subclass Tuple9, then be sure to either <ul>
+ *  <li> not add any new fields, or </li>
+ *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant
+ *       type. (That is, if you have a "class Foo extends Tuple9", then don't use instances of
+ *       Foo in a DataStream&lt;Tuple9&gt; / DataSet&lt;Tuple9&gt;, but declare it as
+ *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>
+ * </ul></p>
  * @see Tuple
  *
  * @param <T0> The type of field 0

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -167,7 +167,7 @@ class TupleGenerator {
 		// package and imports
 		w.println("package " + PACKAGE + ';');
 		w.println();
-		w.println("import PublicInterface;");
+		w.println("import org.apache.flink.annotation.Public;");
 		w.println("import org.apache.flink.util.StringUtils;");
 		w.println();
 
@@ -186,7 +186,7 @@ class TupleGenerator {
 			w.println(" * @param <" + GEN_TYPE_PREFIX + i + "> The type of field " + i);
 		}
 		w.println(" */");
-		w.println("@PublicInterface");
+		w.println("@Public");
 		w.print("public class " + className + "<");
 		for (int i = 0; i < numFields; i++) {
 			if (i > 0) {
@@ -445,12 +445,12 @@ class TupleGenerator {
 		w.println("import java.util.ArrayList;");
 		w.println("import java.util.List;");
 		w.println();
-		w.println("import PublicInterface;");
+		w.println("import org.apache.flink.annotation.Public;");
 		w.println("import " + PACKAGE + ".Tuple" + numFields + ";");
 		w.println();
 
 		// class declaration
-		w.println("@PublicInterface");
+		w.println("@Public");
 		w.print("public class " + className);
 		printGenericsString(w, numFields);
 		w.println(" {");

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -176,10 +176,17 @@ class TupleGenerator {
 		w.println(" * A tuple with " + numFields + " fields. Tuples are strongly typed; each field may be of a separate type.");
 		w.println(" * The fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position");
 		w.println(" * through the {@link #getField(int)} method. The tuple field positions start at zero.");
-		w.println(" * <p>");
-		w.println(" * Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work");
-		w.println(" * with Tuples to reuse objects in order to reduce pressure on the garbage collector.");
 		w.println(" *");
+		w.println(" * <p>Tuples are mutable types, meaning that their fields can be re-assigned. This allows functions that work");
+		w.println(" * with Tuples to reuse objects in order to reduce pressure on the garbage collector.</p>");
+		w.println(" *");
+		w.println(" * <p>Warning: If you subclass " + className + ", then be sure to either <ul>");
+		w.println(" *  <li> not add any new fields, or </li>");
+		w.println(" *  <li> make it a POJO, and always declare the element type of your DataStreams/DataSets to your descendant");
+		w.println(" *       type. (That is, if you have a \"class Foo extends " + className + "\", then don't use instances of");
+		w.println(" *       Foo in a DataStream&lt;" + className + "&gt; / DataSet&lt;" + className + "&gt;, but declare it as");
+		w.println(" *       DataStream&lt;Foo&gt; / DataSet&lt;Foo&gt;.) </li>");
+		w.println(" * </ul></p>");
 		w.println(" * @see Tuple");
 		w.println(" *");
 		for (int i = 0; i < numFields; i++) {


### PR DESCRIPTION
I went with option (2), that is, adding a warning to the javadocs.

The generated classes were out of sync with the TupleGenerator, so the first commit just brings the TupleGenerator up-to-date.