### PR TITLE
[FLINK-3443] [runtime] Prevent cancelled jobs from restarting

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -809,7 +809,8 @@ public class ExecutionGraph implements Serializable {
 	public void fail(Throwable t) {
 		while (true) {
 			JobStatus current = state;
-			if (current == JobStatus.FAILED || current == JobStatus.FAILING) {
+			if (current == JobStatus.FAILED || current == JobStatus.FAILING
+					|| current == JobStatus.CANCELED || current == JobStatus.CANCELLING) {
 				return;
 			}
 			else if (transitionState(current, JobStatus.FAILING, t)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -488,6 +489,54 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		assertEquals(ExecutionState.FINISHED, finishedExecution.getState());
 
 		assertEquals(JobStatus.FINISHED, eg.getState());
+	}
+
+	/**
+	 * Tests that a graph is not restarted after cancellation via a call to
+	 * {@link ExecutionGraph#fail(Throwable)}. This can happen when a slot is
+	 * released concurrently with cancellation.
+	 */
+	@Test
+	public void testNoRestartAfterCancel() throws Exception {
+		Instance instance = ExecutionGraphTestUtils.getInstance(
+				new SimpleActorGateway(TestingUtils.directExecutionContext()),
+				2);
+
+		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
+		scheduler.newInstanceAvailable(instance);
+
+		JobVertex vertex = new JobVertex("Test Vertex");
+		vertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		vertex.setParallelism(1);
+
+		JobGraph jobGraph = new JobGraph("Test Job", vertex);
+		jobGraph.setRestartStrategyConfiguration(RestartStrategies.fixedDelayRestart(
+				Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				new JobID(),
+				"test job",
+				new Configuration(),
+				AkkaUtils.getDefaultTimeout(),
+				new FixedDelayRestartStrategy(1, 1000));
+
+		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
+
+		assertEquals(JobStatus.CREATED, eg.getState());
+
+		eg.scheduleForExecution(scheduler);
+		assertEquals(JobStatus.RUNNING, eg.getState());
+
+		// Fail right after cancel (for example with concurrent slot release)
+		eg.cancel();
+		eg.fail(new Exception("Test Exception"));
+		assertEquals(JobStatus.CANCELLING, eg.getState());
+
+		Execution execution = eg.getAllExecutionVertices().iterator().next().getCurrentExecutionAttempt();
+
+		execution.cancelingComplete();
+		assertEquals(JobStatus.CANCELED, eg.getState());
 	}
 
 	private static void restartAfterFailure(ExecutionGraph eg, FiniteDuration timeout, boolean haltAfterRestart) throws InterruptedException {


### PR DESCRIPTION
This is one part of #1669 for which we have consensus I think. It would be good to have it in the next RC. @rmetzger ran into this issue. It showed up as a job not cancelling, because a failure was overwriting the cancellation.
