### PR TITLE
[FLINK-3526] [streaming] Fix Processing Time Window Assigner and Trigger

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -52,7 +52,8 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 
 	@Override
 	public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
-		long start = timestamp - (timestamp % size);
+		final long now = System.currentTimeMillis();
+		long start = now - (now % size);
 		return Collections.singletonList(new TimeWindow(start, start + size));
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
@@ -33,7 +33,7 @@ public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
 
 	@Override
 	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) {
-		ctx.registerProcessingTimeTimer(window.maxTimestamp());
+		ctx.registerProcessingTimeTimer(window.getEnd());
 		return TriggerResult.CONTINUE;
 	}
 


### PR DESCRIPTION
Fixed the processing time window assigner to use actual processing time

Fixed the processing time trigger to fire after the window, not on the latest element of the window.

This is a 1.0 blocker in my opinion.