### PR TITLE
[FLINK-3532] [gelly] Fix artifact ID of flink-gelly-examples module

### DIFF
--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -27,7 +27,7 @@
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-gelly_examples_2.10</artifactId>
+	<artifactId>flink-gelly-examples_2.10</artifactId>
 	<name>flink-gelly-examples</name>
 	<packaging>jar</packaging>
 


### PR DESCRIPTION
The current flink-gelly-examples artifact id wrongly used an underscore to separate
examples from flink-gelly. This commit replaces the underscore with an hyphen.