### PR TITLE
[FLINK-3504] Fix join translation. Equality predicates may only reference fields

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/JoinITCase.scala
@@ -180,4 +180,24 @@ class JoinITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode)
     val results = joinT.toDataSet[Row]collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
+
+  @Test
+  def testJoinWithExpressionPreds(): Unit = {
+
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).as('d, 'e, 'f, 'g, 'h)
+
+    val joinT = ds1.join(ds2).filter('b === 'h + 1 && 'a - 1 === 'd + 2).select('c, 'g)
+
+    val expected =
+        "I am fine.,Hallo Welt\n" +
+        "Luke Skywalker,Hallo Welt wie gehts?\n" +
+        "Luke Skywalker,ABC\n" +
+        "Comment#2,HIJ\n" +
+        "Comment#2,IJK"
+    val results = joinT.toDataSet[Row]collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
 }


### PR DESCRIPTION
Adapts the join translation rule such that only joins with proper equality join predicates are translated.
A proper equality join predicate does only references fields, i.e., it does not reference expressions.

Joins without at least one proper equality join predicates or with an equality join predicate which references an expression are not translated.