### PR TITLE
[FLINK-3534] [runtime] Prevent canceling Execution from failing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -797,6 +797,11 @@ public class Execution implements Serializable {
 				return false;
 			}
 
+			if (current == CANCELING) {
+				cancelingComplete();
+				return false;
+			}
+
 			if (transitionState(current, FAILED, t)) {
 				// success (in a manner of speaking)
 				this.failureCause = t;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -809,7 +809,7 @@ public class ExecutionGraph implements Serializable {
 	public void fail(Throwable t) {
 		while (true) {
 			JobStatus current = state;
-			if (current == JobStatus.FAILED || current == JobStatus.FAILING) {
+			if (current == JobStatus.FAILING || current.isTerminalState()) {
 				return;
 			}
 			else if (transitionState(current, JobStatus.FAILING, t)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -488,6 +489,107 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		assertEquals(ExecutionState.FINISHED, finishedExecution.getState());
 
 		assertEquals(JobStatus.FINISHED, eg.getState());
+	}
+
+	/**
+	 * Tests that a graph is not restarted after cancellation via a call to
+	 * {@link ExecutionGraph#fail(Throwable)}. This can happen when a slot is
+	 * released concurrently with cancellation.
+	 */
+	@Test
+	public void testFailExecutionAfterCancel() throws Exception {
+		Instance instance = ExecutionGraphTestUtils.getInstance(
+				new SimpleActorGateway(TestingUtils.directExecutionContext()),
+				2);
+
+		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
+		scheduler.newInstanceAvailable(instance);
+
+		JobVertex vertex = new JobVertex("Test Vertex");
+		vertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		vertex.setParallelism(1);
+
+		JobGraph jobGraph = new JobGraph("Test Job", vertex);
+		jobGraph.setRestartStrategyConfiguration(RestartStrategies.fixedDelayRestart(
+				Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				new JobID(),
+				"test job",
+				new Configuration(),
+				AkkaUtils.getDefaultTimeout(),
+				new FixedDelayRestartStrategy(1, 1000000));
+
+		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
+
+		assertEquals(JobStatus.CREATED, eg.getState());
+
+		eg.scheduleForExecution(scheduler);
+		assertEquals(JobStatus.RUNNING, eg.getState());
+
+		// Fail right after cancel (for example with concurrent slot release)
+		eg.cancel();
+
+		for (ExecutionVertex v : eg.getAllExecutionVertices()) {
+			v.getCurrentExecutionAttempt().fail(new Exception("Test Exception"));
+		}
+
+		assertEquals(JobStatus.CANCELED, eg.getState());
+
+		Execution execution = eg.getAllExecutionVertices().iterator().next().getCurrentExecutionAttempt();
+
+		execution.cancelingComplete();
+		assertEquals(JobStatus.CANCELED, eg.getState());
+	}
+
+	/**
+	 * Tests that it is possible to fail a graph via a call to
+	 * {@link ExecutionGraph#fail(Throwable)} after cancellation.
+	 */
+	@Test
+	public void testFailExecutionGraphAfterCancel() throws Exception {
+		Instance instance = ExecutionGraphTestUtils.getInstance(
+				new SimpleActorGateway(TestingUtils.directExecutionContext()),
+				2);
+
+		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
+		scheduler.newInstanceAvailable(instance);
+
+		JobVertex vertex = new JobVertex("Test Vertex");
+		vertex.setInvokableClass(Tasks.NoOpInvokable.class);
+		vertex.setParallelism(1);
+
+		JobGraph jobGraph = new JobGraph("Test Job", vertex);
+		jobGraph.setRestartStrategyConfiguration(RestartStrategies.fixedDelayRestart(
+				Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		ExecutionGraph eg = new ExecutionGraph(
+				TestingUtils.defaultExecutionContext(),
+				new JobID(),
+				"test job",
+				new Configuration(),
+				AkkaUtils.getDefaultTimeout(),
+				new FixedDelayRestartStrategy(1, 1000000));
+
+		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
+
+		assertEquals(JobStatus.CREATED, eg.getState());
+
+		eg.scheduleForExecution(scheduler);
+		assertEquals(JobStatus.RUNNING, eg.getState());
+
+		// Fail right after cancel (for example with concurrent slot release)
+		eg.cancel();
+		assertEquals(JobStatus.CANCELLING, eg.getState());
+
+		eg.fail(new Exception("Test Exception"));
+		assertEquals(JobStatus.FAILING, eg.getState());
+
+		Execution execution = eg.getAllExecutionVertices().iterator().next().getCurrentExecutionAttempt();
+
+		execution.cancelingComplete();
+		assertEquals(JobStatus.RESTARTING, eg.getState());
 	}
 
 	private static void restartAfterFailure(ExecutionGraph eg, FiniteDuration timeout, boolean haltAfterRestart) throws InterruptedException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -311,7 +311,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		while (deadline.hasTimeLeft() && !success) {
 			success = true;
 			for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
-				if (vertex.getExecutionState() != ExecutionState.FAILED) {
+				ExecutionState state = vertex.getExecutionState();
+				if (state != ExecutionState.FAILED && state != ExecutionState.CANCELED) {
 					success = false;
 					Thread.sleep(100);
 					break;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -399,15 +399,13 @@ public class ExecutionVertexCancelTest {
 
 			vertex.cancel();
 
-			assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
+			// Callback fails, leading to CANCELED
+			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
 			assertTrue(slot.isReleased());
 
-			assertNotNull(vertex.getFailureCause());
-
 			assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
 			assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
-			assertTrue(vertex.getStateTimestamp(ExecutionState.FAILED) > 0);
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
@@ -551,8 +549,7 @@ public class ExecutionVertexCancelTest {
 				Exception failureCause = new Exception("test exception");
 
 				vertex.fail(failureCause);
-				assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
-				assertEquals(failureCause, vertex.getFailureCause());
+				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
 				assertTrue(slot.isReleased());
 			}


### PR DESCRIPTION
@StephanEwen, can you have a look at this?

This should handle cases where a cancelled execution is failed (as reported by @rmetzger), but still allow the `ExecutionGraph` to be failed (and not suffer from the point you raised in #1726).

Robert would like this in the next RC, but in general I think that it's better to have more exposure for a change to the `ExecutionGraph`... I'm undecided right now. What do you think?