### PR TITLE
[FLINK-3556] [runtime] Remove false check in HA blob store configuration

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -100,17 +100,11 @@ public class BlobServer extends Thread implements BlobService {
 		if (recoveryMode == RecoveryMode.STANDALONE) {
 			this.blobStore = new VoidBlobStore();
 		}
-		// Recovery. Check that everything has been setup correctly. This is not clean, but it's
-		// better to resolve this with some upcoming changes to the state backend setup.
+		// Recovery.
 		else if (recoveryMode == RecoveryMode.ZOOKEEPER) {
-			if (config.containsKey(ConfigConstants.ZOOKEEPER_RECOVERY_PATH)) {
-				this.blobStore = new FileSystemBlobStore(config);
-			} else {
-				throw new IllegalConfigurationException("Missing '" + ConfigConstants.ZOOKEEPER_RECOVERY_PATH
-						+ "' configuration key. Please configure a path for recovery files.");
-			}
+			this.blobStore = new FileSystemBlobStore(config);
 		} else {
-			throw new IllegalConfigurationException("Unexpected recovery mode '" + recoveryMode + "'.");
+			throw new IllegalConfigurationException("Unexpected recovery mode '" + recoveryMode + ".");
 		}
 
 		// configure the maximum number of concurrent connections

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.util.NetUtils;
 import org.slf4j.Logger;
@@ -101,14 +102,15 @@ public class BlobServer extends Thread implements BlobService {
 		}
 		// Recovery. Check that everything has been setup correctly. This is not clean, but it's
 		// better to resolve this with some upcoming changes to the state backend setup.
-		else if (config.containsKey(ConfigConstants.STATE_BACKEND) &&
-				config.containsKey(ConfigConstants.ZOOKEEPER_RECOVERY_PATH)) {
-
-			this.blobStore = new FileSystemBlobStore(config);
-		}
-		// Fallback.
-		else {
-			this.blobStore = new VoidBlobStore();
+		else if (recoveryMode == RecoveryMode.ZOOKEEPER) {
+			if (config.containsKey(ConfigConstants.ZOOKEEPER_RECOVERY_PATH)) {
+				this.blobStore = new FileSystemBlobStore(config);
+			} else {
+				throw new IllegalConfigurationException("Missing '" + ConfigConstants.ZOOKEEPER_RECOVERY_PATH
+						+ "' configuration key. Please configure a path for recovery files.");
+			}
+		} else {
+			throw new IllegalConfigurationException("Unexpected recovery mode '" + recoveryMode + "'.");
 		}
 
 		// configure the maximum number of concurrent connections

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -40,6 +40,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Blob store backed by {@link FileSystem}.
+ *
+ * <p>This is used in addition to the local blob storage.
  */
 class FileSystemBlobStore implements BlobStore {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -41,7 +41,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Blob store backed by {@link FileSystem}.
  *
- * <p>This is used in addition to the local blob storage.
+ * <p>This is used in addition to the local blob storage
  */
 class FileSystemBlobStore implements BlobStore {
 
@@ -51,18 +51,15 @@ class FileSystemBlobStore implements BlobStore {
 	private final String basePath;
 
 	FileSystemBlobStore(Configuration config) throws IOException {
-		String stateBackendBasePath = config.getString(
-				ConfigConstants.ZOOKEEPER_RECOVERY_PATH, "");
+		String recoveryPath = config.getString(ConfigConstants.ZOOKEEPER_RECOVERY_PATH, null);
 
-		if (stateBackendBasePath.equals("")) {
+		if (recoveryPath == null) {
 			throw new IllegalConfigurationException(String.format("Missing configuration for " +
-				"file system state backend recovery path. Please specify via " +
-				"'%s' key.", ConfigConstants.ZOOKEEPER_RECOVERY_PATH));
+					"file system state backend recovery path. Please specify via " +
+					"'%s' key.", ConfigConstants.ZOOKEEPER_RECOVERY_PATH));
 		}
 
-		stateBackendBasePath += "/blob";
-
-		this.basePath = stateBackendBasePath;
+		this.basePath = recoveryPath + "/blob";
 
 		FileSystem.get(new Path(basePath).toUri()).mkdirs(new Path(basePath));
 		LOG.info("Created blob directory {}.", basePath);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -225,7 +225,6 @@ public class ZooKeeperUtils {
 			ConfigConstants.ZOOKEEPER_CHECKPOINTS_PATH,
 			ConfigConstants.DEFAULT_ZOOKEEPER_CHECKPOINTS_PATH);
 
-
 		StateStorageHelper<CompletedCheckpoint> stateStorage = createFileSystemStateStorage(
 			configuration,
 			"completedCheckpoint");


### PR DESCRIPTION
If you use the `RocksDBStateBackend` and configure HA w/o setting the state backend to `filesystem`, restoring your job will fail, because the BLOBs are not persisted. The really ugly part is that this does not log a warning  or anything. I'm leaning towards making this a release blocker, but it can also be postponed to `1.0.1`, if that follows very soon.