### PR TITLE
[FLINK-3554] [streaming] Emit a MAX Watermark after finite sources finished

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/ml/util/IncrementalLearningSkeletonData.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/ml/util/IncrementalLearningSkeletonData.java
@@ -20,12 +20,12 @@ package org.apache.flink.streaming.examples.ml.util;
 public class IncrementalLearningSkeletonData {
 
 	public static final String RESULTS = "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" +
-			"1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "0\n" + "0\n" +
+			"1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "0\n" +
 			"0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" +
 			"0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" +
 			"0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" +
 			"0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" + "0\n" +
-			"0\n" + "0\n" + "0\n" + "0\n";
+			"0\n" + "0\n" + "0\n" + "0\n" + "0\n";
 
 	private IncrementalLearningSkeletonData() {
 	}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -296,9 +296,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			Tuple2.of(new Event(2, "end", 2.0), 8L),
 			Tuple2.of(new Event(1, "middle", 5.0), 7L),
 			Tuple2.of(new Event(3, "middle", 6.0), 9L),
-			Tuple2.of(new Event(3, "end", 7.0), 7L),
-			// last element for high final watermark
-			Tuple2.of(new Event(3, "end", 7.0), 100L)
+			Tuple2.of(new Event(3, "end", 7.0), 7L)
 		).assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Tuple2<Event,Long>>() {
 
 			@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.operators.testutils;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -105,7 +106,7 @@ public class DummyEnvironment implements Environment {
 
 	@Override
 	public Map<String, Future<Path>> getDistributedCacheEntries() {
-		return null;
+		return Collections.emptyMap();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StoppableStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StoppableStreamSource.java
@@ -41,7 +41,14 @@ public class StoppableStreamSource<OUT, SRC extends SourceFunction<OUT> & Stoppa
 		super(sourceFunction);
 	}
 
+	/**
+	 * Marks the source a stopped and calls {@link StoppableFunction#stop()} on the user function.
+	 */
 	public void stop() {
+		// important: marking the source as stopped has to happen before the function is stopped.
+		// the flag that tracks this status is volatile, so the memory model also guarantees
+		// the happens-before relationship
+		markCanceledOrStopped();
 		userFunction.stop();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/watermark/Watermark.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/watermark/Watermark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.streaming.api.watermark;
 
 import org.apache.flink.annotation.PublicEvolving;
@@ -38,11 +39,15 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
  * <p>
  * When a source closes it will emit a final watermark with timestamp {@code Long.MAX_VALUE}. When
  * an operator receives this it will know that no more input will be arriving in the future.
- *
  */
 @PublicEvolving
-public class Watermark extends StreamElement {
+public final class Watermark extends StreamElement {
 
+	/** The watermark that signifies end-of-event-time */
+	public static final Watermark MAX_WATERMARK = new Watermark(Long.MAX_VALUE);
+	
+	// ------------------------------------------------------------------------
+	
 	/** The timestamp of the watermark */
 	private final long timestamp;
 
@@ -60,6 +65,8 @@ public class Watermark extends StreamElement {
 		return timestamp;
 	}
 
+	// ------------------------------------------------------------------------
+	
 	@Override
 	public boolean equals(Object o) {
 		return this == o ||

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
@@ -60,25 +60,4 @@ public class SourceFunctionTest {
 				7));
 		assertEquals(expectedList, actualList);
 	}
-
-// TODO: does not work because we cannot set the internal socket anymore
-//	@Test
-//	public void socketTextStreamTest() throws Exception {
-//		List<String> expectedList = Arrays.asList("a", "b", "c");
-//		List<String> actualList = new ArrayList<String>();
-//
-//		byte[] data = { 'a', '\n', 'b', '\n', 'c', '\n' };
-//
-//		Socket socket = mock(Socket.class);
-//		when(socket.getInputStream()).thenReturn(new ByteArrayInputStream(data));
-//		when(socket.isClosed()).thenReturn(false);
-//		when(socket.isConnected()).thenReturn(true);
-//
-//		SocketTextStreamFunction source = new SocketTextStreamFunction("", 0, '\n', 0);
-//		source.open(new Configuration());
-//		while (!source.reachedEnd()) {
-//			actualList.add(source.next());
-//		}
-//		assertEquals(expectedList, actualList);
-//	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
@@ -61,9 +61,9 @@ public class SourceFunctionTest {
 		assertEquals(expectedList, actualList);
 	}
 
-	@Test
-	public void socketTextStreamTest() throws Exception {
-		// TODO: does not work because we cannot set the internal socket anymore
+// TODO: does not work because we cannot set the internal socket anymore
+//	@Test
+//	public void socketTextStreamTest() throws Exception {
 //		List<String> expectedList = Arrays.asList("a", "b", "c");
 //		List<String> actualList = new ArrayList<String>();
 //
@@ -80,5 +80,5 @@ public class SourceFunctionTest {
 //			actualList.add(source.next());
 //		}
 //		assertEquals(expectedList, actualList);
-	}
+//	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.functions.StoppableFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StoppableStreamSource;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("serial")
+public class StreamSourceOperatorTest {
+	
+	@Test
+	public void testEmitMaxWatermarkForFiniteSource() throws Exception {
+
+		// regular stream source operator
+		StreamSource<String, FiniteSource<String>> operator = 
+				new StreamSource<>(new FiniteSource<String>());
+		
+		final List<StreamElement> output = new ArrayList<>();
+		
+		setupSourceOperator(operator);
+		operator.run(new Object(), new CollectorOutput<String>(output));
+		
+		assertEquals(1, output.size());
+		assertEquals(Watermark.MAX_WATERMARK, output.get(0));
+	}
+
+	@Test
+	public void testNoMaxWatermarkOnImmediateCancel() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		// regular stream source operator
+		final StreamSource<String, InfiniteSource<String>> operator =
+				new StreamSource<>(new InfiniteSource<String>());
+
+
+		setupSourceOperator(operator);
+		operator.cancel();
+
+		// run and exit
+		operator.run(new Object(), new CollectorOutput<String>(output));
+		
+		assertTrue(output.isEmpty());
+	}
+	
+	@Test
+	public void testNoMaxWatermarkOnAsyncCancel() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+		final Thread runner = Thread.currentThread();
+		
+		// regular stream source operator
+		final StreamSource<String, InfiniteSource<String>> operator =
+				new StreamSource<>(new InfiniteSource<String>());
+
+		
+		setupSourceOperator(operator);
+		
+		// trigger an async cancel in a bit
+		new Thread("canceler") {
+			@Override
+			public void run() {
+				try {
+					Thread.sleep(200);
+				} catch (InterruptedException ignored) {}
+				operator.cancel();
+				runner.interrupt();
+			}
+		}.start();
+		
+		// run and wait to be canceled
+		try {
+			operator.run(new Object(), new CollectorOutput<String>(output));
+		}
+		catch (InterruptedException ignored) {}
+
+		assertTrue(output.isEmpty());
+	}
+
+	@Test
+	public void testNoMaxWatermarkOnImmediateStop() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		// regular stream source operator
+		final StoppableStreamSource<String, InfiniteSource<String>> operator =
+				new StoppableStreamSource<>(new InfiniteSource<String>());
+
+
+		setupSourceOperator(operator);
+		operator.stop();
+
+		// run and stop
+		operator.run(new Object(), new CollectorOutput<String>(output));
+
+		assertTrue(output.isEmpty());
+	}
+
+	@Test
+	public void testNoMaxWatermarkOnAsyncStop() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		// regular stream source operator
+		final StoppableStreamSource<String, InfiniteSource<String>> operator =
+				new StoppableStreamSource<>(new InfiniteSource<String>());
+
+
+		setupSourceOperator(operator);
+
+		// trigger an async cancel in a bit
+		new Thread("canceler") {
+			@Override
+			public void run() {
+				try {
+					Thread.sleep(200);
+				} catch (InterruptedException ignored) {}
+				operator.stop();
+			}
+		}.start();
+
+		// run and wait to be stopped
+		operator.run(new Object(), new CollectorOutput<String>(output));
+
+		assertTrue(output.isEmpty());
+	}
+	
+	
+	// ------------------------------------------------------------------------
+	
+	@SuppressWarnings("unchecked")
+	private static <T> void setupSourceOperator(StreamSource<T, ?> operator) {
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		StreamConfig cfg = new StreamConfig(new Configuration());
+		
+		cfg.setTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		Environment env = new DummyEnvironment("MockTwoInputTask", 1, 0);
+		
+		StreamTask<?, ?> mockTask = mock(StreamTask.class);
+		when(mockTask.getName()).thenReturn("Mock Task");
+		when(mockTask.getCheckpointLock()).thenReturn(new Object());
+		when(mockTask.getConfiguration()).thenReturn(cfg);
+		when(mockTask.getEnvironment()).thenReturn(env);
+		when(mockTask.getExecutionConfig()).thenReturn(executionConfig);
+		when(mockTask.getAccumulatorMap()).thenReturn(Collections.<String, Accumulator<?, ?>>emptyMap());
+
+		operator.setup(mockTask, cfg, (Output< StreamRecord<T>>) mock(Output.class));
+	}
+	
+	// ------------------------------------------------------------------------
+	
+	private static final class FiniteSource<T> implements SourceFunction<T>, StoppableFunction {
+
+		@Override
+		public void run(SourceContext<T> ctx) {}
+
+		@Override
+		public void cancel() {}
+
+		@Override
+		public void stop() {}
+	}
+
+	private static final class InfiniteSource<T> implements SourceFunction<T>, StoppableFunction {
+
+		private volatile boolean running = true;
+		
+		@Override
+		public void run(SourceContext<T> ctx) throws Exception {
+			while (running) {
+				Thread.sleep(20);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		@Override
+		public void stop() {
+			running = false;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	
+	private static class CollectorOutput<T> implements Output<StreamRecord<T>> {
+
+		private final List<StreamElement> list;
+
+		private CollectorOutput(List<StreamElement> list) {
+			this.list = list;
+		}
+
+		@Override
+		public void emitWatermark(Watermark mark) {
+			list.add(mark);
+		}
+
+		@Override
+		public void collect(StreamRecord<T> record) {
+			list.add(record);
+		}
+
+		@Override
+		public void close() {}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/CoGroupJoinITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/CoGroupJoinITCase.java
@@ -74,8 +74,7 @@ public class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
 				ctx.collect(Tuple2.of("a", 7));
 				ctx.collect(Tuple2.of("a", 8));
 
-				// so we get a final big watermark
-				ctx.collect(Tuple2.of("a", 20));
+				// source is finite, so it will have an implicit MAX watermark when it finishes
 			}
 
 			@Override
@@ -96,8 +95,7 @@ public class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
 				ctx.collect(Tuple2.of("c", 7));
 				ctx.collect(Tuple2.of("c", 8));
 
-				// so we get a final big watermark
-				ctx.collect(Tuple2.of("a", 20));
+				// source is finite, so it will have an implicit MAX watermark when it finishes
 			}
 
 			@Override
@@ -172,8 +170,7 @@ public class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
 				ctx.collect(Tuple3.of("a", "j", 7));
 				ctx.collect(Tuple3.of("a", "k", 8));
 
-				// so we get a final big watermark
-				ctx.collect(Tuple3.of("a", "k", 20));
+				// source is finite, so it will have an implicit MAX watermark when it finishes
 			}
 
 			@Override
@@ -194,8 +191,7 @@ public class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
 				ctx.collect(Tuple3.of("a", "x", 6));
 				ctx.collect(Tuple3.of("a", "z", 8));
 
-				// so we get a final high watermark
-				ctx.collect(Tuple3.of("a", "z", 20));
+				// source is finite, so it will have an implicit MAX watermark when it finishes
 			}
 
 			@Override
@@ -272,8 +268,7 @@ public class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
 				ctx.collect(Tuple3.of("a", "j", 7));
 				ctx.collect(Tuple3.of("a", "k", 8));
 
-				// so we get a final high watermark
-				ctx.collect(Tuple3.of("a", "k", 20));
+				// source is finite, so it will have an implicit MAX watermark when it finishes
 			}
 
 			@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowFoldITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowFoldITCase.java
@@ -74,13 +74,12 @@ public class WindowFoldITCase extends StreamingMultipleProgramsTestBase {
 				ctx.collect(Tuple2.of("a", 7));
 				ctx.collect(Tuple2.of("a", 8));
 
-				// so that we get a high final watermark to process the previously sent elements
-				ctx.collect(Tuple2.of("a", 20));
+				// source is finite, so it will have an implicit MAX watermark when it finishes
 			}
 
 			@Override
-			public void cancel() {
-			}
+			public void cancel() {}
+			
 		}).assignTimestampsAndWatermarks(new Tuple2TimestampExtractor());
 
 		source1
@@ -139,8 +138,7 @@ public class WindowFoldITCase extends StreamingMultipleProgramsTestBase {
 				ctx.collect(Tuple2.of("b", 5));
 				ctx.collect(Tuple2.of("a", 5));
 
-				// so that we get a high final watermark to process the previously sent elements
-				ctx.collect(Tuple2.of("a", 20));
+				// source is finite, so it will have an implicit MAX watermark when it finishes
 			}
 
 			@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -102,7 +102,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT> {
 				}
 			}).when(mockTask).createStateBackend(any(String.class), any(TypeSerializer.class));
 		} catch (Exception e) {
-			e.printStackTrace();
+			throw new RuntimeException(e.getMessage(), e);
 		}
 		
 		doAnswer(new Answer<Void>() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
@@ -28,12 +28,9 @@ import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.runtime.state.AbstractStateBackend;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
-import org.mockito.stubbing.OngoingStubbing;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CoGroupJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CoGroupJoinITCase.scala
@@ -56,8 +56,7 @@ class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
         ctx.collect(("a", 7))
         ctx.collect(("a", 8))
 
-        // so that we get a high final watermark to process the previously sent elements
-        ctx.collect(("a", 20))
+        // source is finite, so it will have an implicit MAX watermark when it finishes
       }
 
       def cancel() {}
@@ -73,8 +72,7 @@ class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
         ctx.collect(("c", 7))
         ctx.collect(("c", 8))
 
-        // so that we get a high final watermark to process the previously sent elements
-        ctx.collect(("c", 20))
+        // source is finite, so it will have an implicit MAX watermark when it finishes
       }
 
       def cancel() {
@@ -126,8 +124,7 @@ class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
         ctx.collect(("a", "j", 7))
         ctx.collect(("a", "k", 8))
 
-        // so that we get a high final watermark to process the previously sent elements
-        ctx.collect(("a", "k", 20))
+        // source is finite, so it will have an implicit MAX watermark when it finishes
       }
 
       def cancel() {}
@@ -145,8 +142,7 @@ class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
         ctx.collect(("a", "x", 6))
         ctx.collect(("a", "z", 8))
 
-        // so that we get a high final watermark to process the previously sent elements
-        ctx.collect(("a", "z", 20))
+        // source is finite, so it will have an implicit MAX watermark when it finishes
       }
 
       def cancel() {}
@@ -208,8 +204,7 @@ class CoGroupJoinITCase extends StreamingMultipleProgramsTestBase {
         ctx.collect(("a", "j", 7))
         ctx.collect(("a", "k", 8))
 
-        // so that we get a high final watermark to process the previously sent elements
-        ctx.collect(("a", "k", 20))
+        // source is finite, so it will have an implicit MAX watermark when it finishes
       }
 
       def cancel() {}

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowFoldITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowFoldITCase.scala
@@ -59,8 +59,7 @@ class WindowFoldITCase extends StreamingMultipleProgramsTestBase {
         ctx.collect(("a", 7))
         ctx.collect(("a", 8))
 
-        // so we get a big watermark to trigger processing of the previous elements
-        ctx.collect(("a", 20))
+        // source is finite, so it will have an implicit MAX watermark when it finishes
       }
 
       def cancel() {
@@ -107,8 +106,7 @@ class WindowFoldITCase extends StreamingMultipleProgramsTestBase {
         ctx.collect(("b", 5))
         ctx.collect(("a", 5))
 
-        // so we get a big watermark to trigger processing of the previous elements
-        ctx.collect(("a", 20))
+        // source is finite, so it will have an implicit MAX watermark when it finishes
       }
 
       def cancel() {


### PR DESCRIPTION
Finite sources now emit a MAX_LONG watermark once they cleanly finished.

This prevents loss of pending windows over finite sources when they finish.

Canceling and stopping sources will NOT emit a MAX Watermark.