### PR TITLE
[FLINK-3559] [dist] Don't print INFO if no active process

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -94,7 +94,10 @@ case $STARTSTOP in
           done < "${pid}"
 
           count="${#active[@]}"
-          echo "[INFO] $count instance(s) of $DAEMON are already running on $HOSTNAME."
+
+          if [ ${count} -gt 0 ]; then
+            echo "[INFO] $count instance(s) of $DAEMON are already running on $HOSTNAME."
+          fi
         fi
 
         echo "Starting $DAEMON daemon on host $HOSTNAME."


### PR DESCRIPTION
Fix info messages like:
```
[INFO] 0 instance(s) of jobmanager are already running on pablo.
```