### PR TITLE
[FLINK-3565] add module to force execution of Shade plugin

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -34,6 +34,15 @@ under the License.
 	<packaging>jar</packaging>
 
 	<dependencies>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>force-shading</artifactId>
+			<version>1.0.0</version>
+			<!-- This is necessary to prevent shading of this module -->
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- BINARIES -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@ under the License.
 	</scm>
 
 	<modules>
+		<!--- Dummy module to force execution of the Maven Shade plugin (see Shade plugin below) -->
+		<module>tools/force-shading</module>
 		<module>flink-annotations</module>
 		<module>flink-shaded-hadoop</module>
 		<module>flink-shaded-curator</module>
@@ -104,6 +106,13 @@ under the License.
 	</properties>
 
 	<dependencies>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>force-shading</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
@@ -987,6 +996,13 @@ under the License.
 							</filters>
 							<artifactSet>
 								<includes>
+									<!-- Unfortunately, the next line is necessary for now to force the execution
+									of the Shade plugin upon all sub modules. This will generate effective poms,
+									i.e. poms which do not contain properties which are derived from this root pom.
+									In particular, the Scala version properties are defined in the root pom and without
+									shading, the root pom would have to be Scala suffixed and thereby all other modules.
+									-->
+									<include>org.apache.flink:force-shading</include>
 									<include>com.google.guava:*</include>
 									<include>org.ow2.asm:*</include>
 								</includes>

--- a/tools/force-shading/pom.xml
+++ b/tools/force-shading/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<!---
+	This module is used a dependency in the root pom. It activates shading for all sub modules
+	through an include rule in the shading configuration. This assures that Maven always generates
+	an effective pom for all modules, i.e. get rid of Maven properties. In particular, this is needed
+	to define the Scala version property in the root pom but not let the root pom depend on Scala
+	and thus be suffixed along with all other modules.
+	-->
+
+	<groupId>org.apache.flink</groupId>
+	<artifactId>force-shading</artifactId>
+	<version>1.0.0</version>
+
+	<packaging>jar</packaging>
+
+</project>


### PR DESCRIPTION
This ensures that all properties of the root pom are properly
resolved by running the Shade plugin. Thus, our root pom does not have
to depend on a Scala version just because it holds the Scala version
properties.