### PR TITLE
[docs] fix javascript exception caused by disqus

### DIFF
--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -87,6 +87,7 @@ under the License.
     </script>
 
     <!-- Disqus -->
+    {% comment %}
     <script type="text/javascript">
     var disqus_shortname = 'stratosphere-eu';
     (function() {
@@ -94,6 +95,7 @@ under the License.
         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
-</script>
+    </script>
+    {% endcomment %}
   </body>
 </html>

--- a/docs/apis/cluster_execution.md
+++ b/docs/apis/cluster_execution.md
@@ -86,7 +86,7 @@ takes the path(s) to the JAR file(s).
 ## Linking with modules not contained in the binary distribution
 
 The binary distribution contains jar packages in the `lib` folder that are automatically
-provided to the classpath of your distrbuted programs. Almost all of Flink classes are
+provided to the classpath of your distributed programs. Almost all of Flink classes are
 located there with a few exceptions, for example the streaming connectors and some freshly
 added modules. To run code depending on these modules you need to make them accessible
 during runtime, for which we suggest two options:


### PR DESCRIPTION
As we comment `<div id="disqus_thread"></div>` but not the disqus javascript. It will cause an exception like this:

![image](https://cloud.githubusercontent.com/assets/5378924/13482083/40bd92ea-e125-11e5-90f4-2682b763a288.png)

And fix a minor typo in `cluster_execution.md`