### PR TITLE
[FLINK-3570] [runtime] Use InetAddress.getLocalHost() as heuristic to find local address

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.net;
 
 import java.io.IOException;
-import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
@@ -278,17 +277,10 @@ public class ConnectionUtils {
 
 					case HEURISTIC:
 						if (LOG.isDebugEnabled()) {
-							LOG.debug("Checking address {} using heuristics: linkLocal: {} loopback: {}",
-									interfaceAddress, interfaceAddress.isLinkLocalAddress(),
-									interfaceAddress.isLoopbackAddress());
+							LOG.debug("Choosing InetAddress.getLocalHost() address as a heuristic.");
 						}
-						// pick a non-loopback non-link-local address
-						if (interfaceAddress instanceof Inet4Address && !interfaceAddress.isLinkLocalAddress() &&
-								!interfaceAddress.isLoopbackAddress())
-						{
-							return tryLocalHostBeforeReturning(interfaceAddress, targetAddress, logging);
-						}
-						break;
+
+						return InetAddress.getLocalHost();
 
 					default:
 						throw new RuntimeException("Unsupported strategy: " + strategy);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
@@ -31,7 +31,7 @@ import java.net.InetSocketAddress;
 public class ConnectionUtilsTest {
 
 	@Test
-	public void testFindConnectableAddress() {
+	public void testReturnLocalHostAddressUsingHeuristics() {
 		int unusedPort;
 		try {
 			unusedPort = org.apache.flink.util.NetUtils.getAvailablePort();
@@ -55,12 +55,8 @@ public class ConnectionUtilsTest {
 			// we should have found a heuristic address
 			assertNotNull(add);
 
-			// these checks are desirable, but will not work on every machine
-			// such as machines with no connected network media, which may
-			// default to a link local address
-			// assertFalse(add.isLinkLocalAddress());
-			// assertFalse(add.isLoopbackAddress());
-			// assertFalse(add.isAnyLocalAddress());
+			// make sure that we returned the InetAddress.getLocalHost as a heuristic
+			assertEquals(InetAddress.getLocalHost(), add);
 		}
 		catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
The ConnectionUtils.findAddressUsingStrategy method tries to find out the local address which is
accessible by other machines of the cluster. It tries to connect to a specified address to do so.
In case that the no connection could be established, it uses an heuristic. Before it randomly
picked a NetworkInterface which is bound to an Inet4Address, not a loop back address and not a
link local address. In most cases it makes more sense to default to the
InetAddress.getLocalHost() address instead. This PR replaces the old heuristic with simply
returning the InetAddress.getLocalHost(). This of course requires that the system on which Flink
is running, is properly configured.