### PR TITLE
[FLINK-3566] [FLINK-3563] Input type validation improvements

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -890,8 +890,8 @@ public class TypeExtractor {
 		}
 		
 		if (!(type instanceof TypeVariable<?>)) {
-			// check for basic type
-			if (typeInfo.isBasicType()) {
+			// check for Java Basic Types
+			if (typeInfo instanceof BasicTypeInfo) {
 				
 				TypeInformation<?> actual;
 				// check if basic type at all
@@ -904,8 +904,8 @@ public class TypeExtractor {
 				}
 				
 			}
-			// check for tuple
-			else if (typeInfo.isTupleType()) {
+			// check for Java Tuples
+			else if (typeInfo instanceof TupleTypeInfo) {
 				// check if tuple at all
 				if (!(isClassType(type) && Tuple.class.isAssignableFrom(typeToClass(type)))) {
 					throw new InvalidTypesException("Tuple type expected.");
@@ -1079,9 +1079,9 @@ public class TypeExtractor {
 			// check for generic object
 			else if (typeInfo instanceof GenericTypeInfo<?>) {
 				Class<?> clazz = null;
-				if (!(isClassType(type) && ((GenericTypeInfo<?>) typeInfo).getTypeClass() == (clazz = typeToClass(type)))) {
-					throw new InvalidTypesException("Generic object type '"
-							+ ((GenericTypeInfo<?>) typeInfo).getTypeClass().getCanonicalName() + "' expected but was '"
+				if (!(isClassType(type) && (clazz = typeToClass(type)).isAssignableFrom(((GenericTypeInfo<?>) typeInfo).getTypeClass()))) {
+					throw new InvalidTypesException("Generic type '"
+							+ ((GenericTypeInfo<?>) typeInfo).getTypeClass().getCanonicalName() + "' or a subclass of it expected but was '"
 							+ clazz.getCanonicalName() + "'.");
 				}
 			}


### PR DESCRIPTION
This PR fixes issues with the input type validation. 

[FLINK-3566] Custom type information have been interpreted as basic or tuple types, because their `isTupleType()`/`isBasicType()` methods returned `true`. Subclasses of GenericTypes caused problems.

[FLINK-3563] Subclasses of GenericTypes caused problems.

@gyfora Can you check if you still have problems?