### PR TITLE
[FLINK-3577] [docs] Display anchor links when hovering over headers.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -233,6 +233,7 @@ The Apache Flink project bundles the following files under the MIT License:
  - moment.js v2.10.6 (http://momentjs.com/docs/) - Copyright (c) 2011-2014 Tim Wood, Iskren Chernev, Moment.js contributors
  - moment-duration-format v1.3.0 (https://github.com/jsmreese/moment-duration-format) - Copyright (c) 2013 John Madhavan-Reese
  - qtip2 v2.2.1 (http://qtip2.com) - Copyright (c) 2012 Craig Michael Thompson
+ - AnchorJS (https://github.com/bryanbraun/anchorjs) - Copyright (c) 2013 Craig Michael Thompson
 
 All rights reserved.
 

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -73,7 +73,8 @@ under the License.
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-    <script src="{{ site.baseurl }}/page/js/codetabs.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.1.0/anchor.min.js"></script>
+    <script src="{{ site.baseurl }}/page/js/flink.js"></script>
 
     <!-- Google Analytics -->
     <script>

--- a/docs/page/css/flink.css
+++ b/docs/page/css/flink.css
@@ -225,3 +225,14 @@ th {
 td {
 	padding: 5px;
 }
+
+/*=============================================================================
+            AnchorJS (anchor links when hovering over headers)
+=============================================================================*/
+
+.anchorjs-link:hover {
+    text-decoration: none;
+}
+*:hover > .anchorjs-link {
+    transition: color .25s linear;
+}

--- a/docs/page/js/flink.js
+++ b/docs/page/js/flink.js
@@ -111,6 +111,13 @@ $(function() {
   codeTabs();
   viewSolution();
 
+  // Display anchor links when hovering over headers. For documentation of the
+  // configuration options, see the AnchorJS documentation.
+  anchors.options = {
+      placement: 'right'
+  };
+  anchors.add();
+
   $(window).bind('hashchange', function() {
     maybeScrollToHash();
   });


### PR DESCRIPTION
This is useful to share the document url if display anchor links when hovering over headers.  Currently we must scroll up to the TOC, find the section,click it, then copy  the url.

Also add AnchorJs to LISENCE

![2016-03-04 7 03 42](https://cloud.githubusercontent.com/assets/5378924/13525491/37c994be-e23c-11e5-9ed2-319a3fbb9cfb.png)



