### PR TITLE
[docs] fix the active tab caption is not displaying blue

### DIFF
--- a/docs/apis/streaming/index.md
+++ b/docs/apis/streaming/index.md
@@ -1493,7 +1493,7 @@ DataStream<Integer> iterationBody = iteration.map(/* this is executed many times
 
 To close an iteration and define the iteration tail, call the `closeWith(feedbackStream)` method of the `IterativeStream`.
 The DataStream given to the `closeWith` function will be fed back to the iteration head.
-A common pattern is to use a filter to separate the part of the strem that is fed back,
+A common pattern is to use a filter to separate the part of the stream that is fed back,
 and the part of the stream which is propagated forward. These filters can, e.g., define
 the "termination" logic, where an element is allowed to propagate downstream rather
 than being fed back.

--- a/docs/page/css/codetabs.css
+++ b/docs/page/css/codetabs.css
@@ -53,10 +53,14 @@ ul.nav li.dropdown ul.dropdown-menu li.dropdown-submenu ul.dropdown-menu {
  * That looks weird. Changed the colors to active - blue, inactive - black, and
  * no color change on hover.
  */
-.nav-tabs > .active > a, .nav-tabs > .active > a:hover {
-  color: #08c;
+.nav-tabs > li.active > a, .nav-tabs > li.active > a:hover {
+  color: #08c !important;
 }
 
 .nav-tabs > li > a, .nav-tabs > li > a:hover {
   color: #333;
+}
+
+.nav.nav-tabs {
+    margin-bottom: 20px;
 }


### PR DESCRIPTION
and a very very minor typo fix

![image](https://cloud.githubusercontent.com/assets/5378924/13525465/0c4c8544-e23c-11e5-9ea3-b3357b114adc.png)
