### PR TITLE
[FLINK-3573] [table] Implement more String functions for Table API

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
@@ -124,6 +124,55 @@ trait ImplicitExpressionOperations {
       expr
     }
   }
+
+  /**
+    * Returns the length of a String.
+    */
+  def charLength() = {
+    Call(BuiltInFunctionNames.CHAR_LENGTH, expr)
+  }
+
+  /**
+    * Returns all of the characters in a String in upper case using the rules of
+    * the default locale.
+    */
+  def upperCase() = {
+    Call(BuiltInFunctionNames.UPPER_CASE, expr)
+  }
+
+  /**
+    * Returns all of the characters in a String in lower case using the rules of
+    * the default locale.
+    */
+  def lowerCase() = {
+    Call(BuiltInFunctionNames.LOWER_CASE, expr)
+  }
+
+  /**
+    * Converts the initial letter of each word in a String to uppercase.
+    * Assumes a String containing only [A-Za-z0-9], everything else is treated as whitespace.
+    */
+  def initCap() = {
+    Call(BuiltInFunctionNames.INIT_CAP, expr)
+  }
+
+  /**
+    * Returns true, if a String matches the specified LIKE pattern.
+    *
+    * e.g. "Jo_n%" matches all Strings that start with "Jo(arbitrary letter)n"
+    */
+  def like(pattern: Expression) = {
+    Call(BuiltInFunctionNames.LIKE, expr, pattern)
+  }
+
+  /**
+    * Returns true, if a String matches the specified SQL regex pattern.
+    *
+    * e.g. "A+" matches all Strings that consist of at least one A
+    */
+  def similar(pattern: Expression) = {
+    Call(BuiltInFunctionNames.SIMILAR, expr, pattern)
+  }
 }
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
@@ -712,6 +712,13 @@ class CodeGenerator(
         val operand = operands.head
         generateCast(nullCheck, operand, resultType)
 
+      // string arithmetic
+      case CONCAT =>
+        val left = operands.head
+        val right = operands(1)
+        requireString(left)
+        generateArithmeticOperator("+", nullCheck, resultType, left, right)
+
       // advanced scalar functions
       case call: SqlOperator =>
         val callGen = ScalarFunctions.getCallGenerator(call, operands.map(_.resultType))

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/calls/NotCallGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/calls/NotCallGenerator.scala
@@ -1,0 +1,19 @@
+package org.apache.flink.api.table.codegen.calls
+
+import org.apache.flink.api.table.codegen.calls.ScalarOperators.generateNot
+import org.apache.flink.api.table.codegen.{GeneratedExpression, CodeGenerator}
+
+/**
+  * Inverts the boolean value of a CallGenerator result.
+  */
+class NotCallGenerator(callGenerator: CallGenerator) extends CallGenerator {
+
+  override def generate(
+      codeGenerator: CodeGenerator,
+      operands: Seq[GeneratedExpression])
+    : GeneratedExpression = {
+    val expr = callGenerator.generate(codeGenerator, operands)
+    generateNot(codeGenerator.nullCheck, expr)
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/calls/NotCallGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/calls/NotCallGenerator.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.api.table.codegen.calls
 
 import org.apache.flink.api.table.codegen.calls.ScalarOperators.generateNot

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/calls/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/calls/ScalarFunctions.scala
@@ -37,6 +37,9 @@ object ScalarFunctions {
     mutable.Map()
 
   // ----------------------------------------------------------------------------------------------
+  // String functions
+  // ----------------------------------------------------------------------------------------------
+
   addSqlFunctionMethod(
     SUBSTRING,
     Seq(STRING_TYPE_INFO, INT_TYPE_INFO, INT_TYPE_INFO),
@@ -53,6 +56,58 @@ object ScalarFunctions {
     TRIM,
     Seq(INT_TYPE_INFO, STRING_TYPE_INFO, STRING_TYPE_INFO),
     STRING_TYPE_INFO)
+
+  addSqlFunctionMethod(
+    CHAR_LENGTH,
+    Seq(STRING_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethod.CHAR_LENGTH.method)
+
+  addSqlFunctionMethod(
+    CHARACTER_LENGTH,
+    Seq(STRING_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethod.CHAR_LENGTH.method)
+
+  addSqlFunctionMethod(
+    UPPER,
+    Seq(STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethod.UPPER.method)
+
+  addSqlFunctionMethod(
+    LOWER,
+    Seq(STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethod.LOWER.method)
+
+  addSqlFunctionMethod(
+    INITCAP,
+    Seq(STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethod.INITCAP.method)
+
+  addSqlFunctionMethod(
+    LIKE,
+    Seq(STRING_TYPE_INFO, STRING_TYPE_INFO),
+    BOOLEAN_TYPE_INFO,
+    BuiltInMethod.LIKE.method)
+
+  addSqlFunctionNotMethod(
+    NOT_LIKE,
+    Seq(STRING_TYPE_INFO, STRING_TYPE_INFO),
+    BuiltInMethod.LIKE.method)
+
+  addSqlFunctionMethod(
+    SIMILAR_TO,
+    Seq(STRING_TYPE_INFO, STRING_TYPE_INFO),
+    BOOLEAN_TYPE_INFO,
+    BuiltInMethod.SIMILAR.method)
+
+  addSqlFunctionNotMethod(
+    NOT_SIMILAR_TO,
+    Seq(STRING_TYPE_INFO, STRING_TYPE_INFO),
+    BuiltInMethod.SIMILAR.method)
 
   // ----------------------------------------------------------------------------------------------
 
@@ -72,6 +127,15 @@ object ScalarFunctions {
       method: Method)
     : Unit = {
     sqlFunctions((sqlOperator, operandTypes)) = new MethodCallGenerator(returnType, method)
+  }
+
+  private def addSqlFunctionNotMethod(
+      sqlOperator: SqlOperator,
+      operandTypes: Seq[TypeInformation[_]],
+      method: Method)
+    : Unit = {
+    sqlFunctions((sqlOperator, operandTypes)) =
+      new NotCallGenerator(new MethodCallGenerator(BOOLEAN_TYPE_INFO, method))
   }
 
   private def addSqlFunctionTrim(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/call.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/call.scala
@@ -44,6 +44,12 @@ case class Call(functionName: String, args: Expression*) extends Expression {
 object BuiltInFunctionNames {
   val SUBSTRING = "SUBSTRING"
   val TRIM = "TRIM"
+  val CHAR_LENGTH = "CHARLENGTH"
+  val UPPER_CASE = "UPPERCASE"
+  val LOWER_CASE = "LOWERCASE"
+  val INIT_CAP = "INITCAP"
+  val LIKE = "LIKE"
+  val SIMILAR = "SIMILAR"
 }
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
@@ -189,6 +189,12 @@ object RexNodeTranslator {
     name match {
       case BuiltInFunctionNames.SUBSTRING => SqlStdOperatorTable.SUBSTRING
       case BuiltInFunctionNames.TRIM => SqlStdOperatorTable.TRIM
+      case BuiltInFunctionNames.CHAR_LENGTH => SqlStdOperatorTable.CHAR_LENGTH
+      case BuiltInFunctionNames.UPPER_CASE => SqlStdOperatorTable.UPPER
+      case BuiltInFunctionNames.LOWER_CASE => SqlStdOperatorTable.LOWER
+      case BuiltInFunctionNames.INIT_CAP => SqlStdOperatorTable.INITCAP
+      case BuiltInFunctionNames.LIKE => SqlStdOperatorTable.LIKE
+      case BuiltInFunctionNames.SIMILAR => SqlStdOperatorTable.SIMILAR_TO
       case _ => ???
     }
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/test/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/test/ScalarFunctionsTest.scala
@@ -31,6 +31,10 @@ import org.junit.Test
 
 class ScalarFunctionsTest {
 
+  // ----------------------------------------------------------------------------------------------
+  // String functions
+  // ----------------------------------------------------------------------------------------------
+
   @Test
   def testSubstring(): Unit = {
     testFunction(
@@ -77,6 +81,117 @@ class ScalarFunctionsTest {
       "trim(BOTH, '.', f0)",
       "TRIM(BOTH '.' FROM f0)",
       "This is a test String")
+  }
+
+  @Test
+  def testCharLength(): Unit = {
+    testFunction(
+      'f0.charLength(),
+      "f0.charLength()",
+      "CHAR_LENGTH(f0)",
+      "22")
+
+    testFunction(
+      'f0.charLength(),
+      "charLength(f0)",
+      "CHARACTER_LENGTH(f0)",
+      "22")
+  }
+
+  @Test
+  def testUpperCase(): Unit = {
+    testFunction(
+      'f0.upperCase(),
+      "f0.upperCase()",
+      "UPPER(f0)",
+      "THIS IS A TEST STRING.")
+  }
+
+  @Test
+  def testLowerCase(): Unit = {
+    testFunction(
+      'f0.lowerCase(),
+      "f0.lowerCase()",
+      "LOWER(f0)",
+      "this is a test string.")
+  }
+
+  @Test
+  def testInitCap(): Unit = {
+    testFunction(
+      'f0.initCap(),
+      "f0.initCap()",
+      "INITCAP(f0)",
+      "This Is A Test String.")
+  }
+
+  @Test
+  def testConcat(): Unit = {
+    testFunction(
+      'f0 + 'f0,
+      "f0 + f0",
+      "f0||f0",
+      "This is a test String.This is a test String.")
+  }
+
+  @Test
+  def testLike(): Unit = {
+    testFunction(
+      'f0.like("Th_s%"),
+      "f0.like('Th_s%')",
+      "f0 LIKE 'Th_s%'",
+      "true")
+
+    testFunction(
+      'f0.like("%is a%"),
+      "f0.like('%is a%')",
+      "f0 LIKE '%is a%'",
+      "true")
+  }
+
+  @Test
+  def testNotLike(): Unit = {
+    testFunction(
+      !'f0.like("Th_s%"),
+      "!f0.like('Th_s%')",
+      "f0 NOT LIKE 'Th_s%'",
+      "false")
+
+    testFunction(
+      !'f0.like("%is a%"),
+      "!f0.like('%is a%')",
+      "f0 NOT LIKE '%is a%'",
+      "false")
+  }
+
+  @Test
+  def testSimilar(): Unit = {
+    testFunction(
+      'f0.similar("_*"),
+      "f0.similar('_*')",
+      "f0 SIMILAR TO '_*'",
+      "true")
+
+    testFunction(
+      'f0.similar("This (is)? a (test)+ Strin_*"),
+      "f0.similar('This (is)? a (test)+ Strin_*')",
+      "f0 SIMILAR TO 'This (is)? a (test)+ Strin_*'",
+      "true")
+  }
+
+  @Test
+  def testNotSimilar(): Unit = {
+    testFunction(
+      !'f0.similar("_*"),
+      "!f0.similar('_*')",
+      "f0 NOT SIMILAR TO '_*'",
+      "false")
+
+    testFunction(
+      !'f0.similar("This (is)? a (test)+ Strin_*"),
+      "!f0.similar('This (is)? a (test)+ Strin_*')",
+      "f0 NOT SIMILAR TO 'This (is)? a (test)+ Strin_*'",
+      "false")
   }
 
   // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR implements the remaining string functions:

CHARACTER_LENGTH
CONCAT
UPPER
LOWER
INITCAP
LIKE
SIMILAR

And simplifies the CallGenerators a bit.