### PR TITLE
[FLINK-3569] fix test cases that expect a different working directory

### DIFF
--- a/flink-batch-connectors/flink-avro/src/test/java/org/apache/flink/api/avro/AvroExternalJarProgramITCase.java
+++ b/flink-batch-connectors/flink-avro/src/test/java/org/apache/flink/api/avro/AvroExternalJarProgramITCase.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 
 public class AvroExternalJarProgramITCase {
 
-	private static final String JAR_FILE = "target/maven-test-jar.jar";
+	private static final String JAR_FILE = "maven-test-jar.jar";
 
 	private static final String TEST_DATA_FILE = "/testdata.avro";
 

--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountRemoteByClient.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/wordcount/WordCountRemoteByClient.java
@@ -50,7 +50,7 @@ import org.apache.flink.storm.api.FlinkTopology;
  */
 public class WordCountRemoteByClient {
 	public final static String topologyId = "Storm WordCount";
-	private final static String uploadedJarLocation = "target/WordCount-StormTopology.jar";
+	private final static String uploadedJarLocation = "WordCount-StormTopology.jar";
 
 	// *************************************************************************
 	// PROGRAM

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -35,14 +35,6 @@ under the License.
 
 	<dependencies>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>force-shading</artifactId>
-			<version>1.0.0</version>
-			<!-- This is necessary to prevent shading of this module -->
-			<scope>provided</scope>
-		</dependency>
-
 		<!-- BINARIES -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -185,6 +177,15 @@ under the License.
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
 							</transformers>
 						</configuration>
+					</execution>
+					<execution>
+						<!--
+						Disable inherited shade-flink to prevent the Shade plugin from changing the project.basedir. The basedir
+						is changed by the Shade plugin when dependencyReducedPomLocation is set to a different location than the
+						original basedir. We do that in the root pom.xml.
+						-->
+						<id>shade-flink</id>
+						<phase>none</phase>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
+++ b/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
@@ -155,7 +155,7 @@ class ScalaShellITCase extends TestLogger {
 
     // find jar file that contains the ml code
     var externalJar = ""
-    val folder = new File("../flink-libraries/flink-ml/target/")
+    val folder = new File("../../flink-libraries/flink-ml/target/")
     val listOfFiles = folder.listFiles()
 
     for (i <- listOfFiles.indices) {

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -35,15 +35,15 @@ import static org.junit.Assert.fail;
 
 public class ClassLoaderITCase {
 
-	private static final String INPUT_SPLITS_PROG_JAR_FILE = "target/customsplit-test-jar.jar";
+	private static final String INPUT_SPLITS_PROG_JAR_FILE = "customsplit-test-jar.jar";
 
-	private static final String STREAMING_INPUT_SPLITS_PROG_JAR_FILE = "target/streaming-customsplit-test-jar.jar";
+	private static final String STREAMING_INPUT_SPLITS_PROG_JAR_FILE = "streaming-customsplit-test-jar.jar";
 
-	private static final String STREAMING_PROG_JAR_FILE = "target/streamingclassloader-test-jar.jar";
+	private static final String STREAMING_PROG_JAR_FILE = "streamingclassloader-test-jar.jar";
 
-	private static final String STREAMING_CHECKPOINTED_PROG_JAR_FILE = "target/streaming-checkpointed-classloader-test-jar.jar";
+	private static final String STREAMING_CHECKPOINTED_PROG_JAR_FILE = "streaming-checkpointed-classloader-test-jar.jar";
 
-	private static final String KMEANS_JAR_PATH = "target/kmeans-test-jar.jar";
+	private static final String KMEANS_JAR_PATH = "kmeans-test-jar.jar";
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
@@ -252,7 +252,7 @@ public abstract class YarnTestBase extends TestLogger {
 	 *
 	 */
 	public static void ensureNoProhibitedStringInLogFiles(final String[] prohibited, final String[] whitelisted) {
-		File cwd = new File("target/"+yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
+		File cwd = new File(yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
 		Assert.assertTrue("Expecting directory " + cwd.getAbsolutePath() + " to exist", cwd.exists());
 		Assert.assertTrue("Expecting directory " + cwd.getAbsolutePath() + " to be a directory", cwd.isDirectory());
 		
@@ -598,7 +598,7 @@ public abstract class YarnTestBase extends TestLogger {
 		// The files from there are picked up by the ./tools/travis_watchdog.sh script
 		// to upload them to Amazon S3.
 		if(isOnTravis()) {
-			File target = new File("../target/"+yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
+			File target = new File(yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
 			if(!target.mkdirs()) {
 				LOG.warn("Error creating dirs to {}", target);
 			}

--- a/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/main/java/org/apache/flink/yarn/YarnTestBase.java
@@ -252,7 +252,7 @@ public abstract class YarnTestBase extends TestLogger {
 	 *
 	 */
 	public static void ensureNoProhibitedStringInLogFiles(final String[] prohibited, final String[] whitelisted) {
-		File cwd = new File(yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
+		File cwd = new File("target/" + yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
 		Assert.assertTrue("Expecting directory " + cwd.getAbsolutePath() + " to exist", cwd.exists());
 		Assert.assertTrue("Expecting directory " + cwd.getAbsolutePath() + " to be a directory", cwd.isDirectory());
 		
@@ -598,7 +598,7 @@ public abstract class YarnTestBase extends TestLogger {
 		// The files from there are picked up by the ./tools/travis_watchdog.sh script
 		// to upload them to Amazon S3.
 		if(isOnTravis()) {
-			File target = new File(yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
+			File target = new File("../target" + yarnConfiguration.get(TEST_CLUSTER_NAME_KEY));
 			if(!target.mkdirs()) {
 				LOG.warn("Error creating dirs to {}", target);
 			}


### PR DESCRIPTION
All the IT cases executed after shading now have the target directory as working directory.