### PR TITLE
[FLINK-3590] Hide derby log in JDBC tests

### DIFF
--- a/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/DerbyUtil.java
+++ b/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/DerbyUtil.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.java.io.jdbc;
+
+import java.io.OutputStream;
+
+@SuppressWarnings("unused")
+/**
+ * Utility class to disable derby logging
+ */
+public class DerbyUtil {
+	public static final OutputStream DEV_NULL = new OutputStream() {
+		public void write(int b) {
+		}
+	};
+}

--- a/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -57,7 +57,7 @@ public class JDBCInputFormatTest {
 	}
 
 	private static void prepareDerbyDatabase() throws ClassNotFoundException, SQLException {
-		System.setProperty("derby.stream.error.field", "org.apache.flink.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
+		System.setProperty("derby.stream.error.field", "org.apache.flink.api.java.io.jdbc.DerbyUtil.DEV_NULL");
 		String dbURL = "jdbc:derby:memory:ebookshop;create=true";
 		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
 		conn = DriverManager.getConnection(dbURL);

--- a/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
+++ b/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
@@ -49,7 +49,7 @@ public class JDBCOutputFormatTest {
 	@BeforeClass
 	public static void setUpClass() throws SQLException {
 		try {
-			System.setProperty("derby.stream.error.field", "org.apache.flink.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
+			System.setProperty("derby.stream.error.field", "org.apache.flink.api.java.io.jdbc.DerbyUtil.DEV_NULL");
 			prepareDerbyDatabase();
 		} catch (ClassNotFoundException e) {
 			e.printStackTrace();

--- a/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/example/JDBCExample.java
+++ b/flink-batch-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/example/JDBCExample.java
@@ -57,6 +57,7 @@ public class JDBCExample {
 	}
 
 	private static void prepareTestDb() throws Exception {
+		System.setProperty("derby.stream.error.field", "org.apache.flink.api.java.io.jdbc.DerbyUtil.DEV_NULL");
 		String dbURL = "jdbc:derby:memory:ebookshop;create=true";
 		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
 		Connection conn = DriverManager.getConnection(dbURL);


### PR DESCRIPTION
Hides derby logs by redirecting the log stream to a dummy stream