### PR TITLE
Netcat  arguments for Mac OS X

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -61,7 +61,10 @@ Now, we are going to run the [SocketTextStreamWordCount example](https://github.
 * First of all, we use **netcat** to start local server via
 
   ~~~bash
+  If you are using linux
   $ nc -l -p 9000
+  On Mac OS X
+  $ nc -l 9000
   ~~~ 
 
 * Submit the Flink program:


### PR DESCRIPTION
The default netcat implementation for mac OS X uses nc -l 9000 to listen on port 9000.