### PR TITLE
[FLINK-3610][api-breaking][streaming] Introduced Scala DataStreamSink

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -36,7 +36,8 @@ public class DataStreamSink<T> {
 
 	@SuppressWarnings("unchecked")
 	protected DataStreamSink(DataStream<T> inputStream, StreamSink<T> operator) {
-		this.transformation = new SinkTransformation<T>(inputStream.getTransformation(), "Unnamed", operator, inputStream.getExecutionEnvironment().getParallelism());
+		this.transformation = new SinkTransformation<>(inputStream.getTransformation(), "Unnamed Sink",
+			operator, inputStream.getExecutionEnvironment().getParallelism());
 	}
 
 	/**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
-import org.apache.flink.annotation.{Internal, PublicEvolving, Public}
+import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.functions.{FilterFunction, FlatMapFunction, MapFunction, Partitioner}
 import org.apache.flink.api.common.io.OutputFormat
@@ -29,9 +29,9 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.api.scala.operators.ScalaCsvOutputFormat
 import org.apache.flink.core.fs.{FileSystem, Path}
 import org.apache.flink.streaming.api.collector.selector.OutputSelector
-import org.apache.flink.streaming.api.datastream.{AllWindowedStream => JavaAllWindowedStream, DataStream => JavaStream, KeyedStream => JavaKeyedStream, _}
+import org.apache.flink.streaming.api.datastream.{AllWindowedStream => JavaAllWindowedStream, DataStream => JavaStream, KeyedStream => JavaKeyedStream, SingleOutputStreamOperator}
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
-import org.apache.flink.streaming.api.functions.{AssignerWithPunctuatedWatermarks, AssignerWithPeriodicWatermarks, AscendingTimestampExtractor, TimestampExtractor}
+import org.apache.flink.streaming.api.functions.{AscendingTimestampExtractor, AssignerWithPeriodicWatermarks, AssignerWithPunctuatedWatermarks, TimestampExtractor}
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.time.Time
@@ -797,7 +797,7 @@ class DataStream[T](stream: JavaStream[T]) {
    *
    */
   @PublicEvolving
-  def print(): DataStreamSink[T] = stream.print()
+  def print(): DataStreamSink[T] = asScalaStream(stream.print())
 
   /**
    * Writes a DataStream to the standard output stream (stderr).
@@ -819,7 +819,7 @@ class DataStream[T](stream: JavaStream[T]) {
     */
   @PublicEvolving
   def writeAsText(path: String): DataStreamSink[T] =
-    stream.writeAsText(path)
+    asScalaStream(stream.writeAsText(path))
 
 
 
@@ -835,9 +835,9 @@ class DataStream[T](stream: JavaStream[T]) {
   @PublicEvolving
   def writeAsText(path: String, writeMode: FileSystem.WriteMode): DataStreamSink[T] = {
     if (writeMode != null) {
-      stream.writeAsText(path, writeMode)
+      asScalaStream(stream.writeAsText(path, writeMode))
     } else {
-      stream.writeAsText(path)
+      asScalaStream(stream.writeAsText(path))
     }
   }
 
@@ -896,7 +896,7 @@ class DataStream[T](stream: JavaStream[T]) {
     if (writeMode != null) {
       of.setWriteMode(writeMode)
     }
-    stream.writeUsingOutputFormat(of.asInstanceOf[OutputFormat[T]])
+    asScalaStream(stream.writeUsingOutputFormat(of.asInstanceOf[OutputFormat[T]]))
   }
 
   /**
@@ -904,7 +904,7 @@ class DataStream[T](stream: JavaStream[T]) {
    */
   @PublicEvolving
   def writeUsingOutputFormat(format: OutputFormat[T]): DataStreamSink[T] = {
-    stream.writeUsingOutputFormat(format)
+    asScalaStream(stream.writeUsingOutputFormat(format))
   }
 
   /**
@@ -916,7 +916,7 @@ class DataStream[T](stream: JavaStream[T]) {
       hostname: String,
       port: Integer,
       schema: SerializationSchema[T]): DataStreamSink[T] = {
-    stream.writeToSocket(hostname, port, schema)
+    asScalaStream(stream.writeToSocket(hostname, port, schema))
   }
 
   /**
@@ -926,7 +926,7 @@ class DataStream[T](stream: JavaStream[T]) {
    *
    */
   def addSink(sinkFunction: SinkFunction[T]): DataStreamSink[T] =
-    stream.addSink(sinkFunction)
+    asScalaStream(stream.addSink(sinkFunction))
 
   /**
    * Adds the given sink to this DataStream. Only streams with sinks added

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStreamSink.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStreamSink.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.annotation.PublicEvolving
+import org.apache.flink.streaming.api.datastream.{DataStreamSink => JavaStreamSink}
+
+class DataStreamSink[T](stream : JavaStreamSink[T]) {
+
+  /**
+    * Gets the underlying java DataStream object.
+    */
+  def javaStream: JavaStreamSink[T] = stream
+
+  /**
+    * Sets the name of the current data stream. This name is
+    * used by the visualization and logging during runtime.
+    *
+    * @return The named operator
+    */
+  def name(name: String) : DataStreamSink[T] = {
+    stream.name(name)
+    this
+  }
+
+  /**
+    * Sets an ID for this operator.
+    *
+    * The specified ID is used to assign the same operator ID across job
+    * submissions (for example when starting a job from a savepoint).
+    *
+    * <strong>Important</strong>: this ID needs to be unique per
+    * transformation and job. Otherwise, job submission will fail.
+    *
+    * @param uid The unique user-specified ID of this transformation.
+    * @return The operator with the specified ID.
+    */
+  @PublicEvolving
+  def uid(uid: String) : DataStreamSink[T] =  {
+    stream.uid(uid)
+    this
+  }
+
+  /**
+    * Sets the parallelism of this operation. This must be at least 1.
+    */
+  def setParallelism(parallelism: Int): DataStreamSink[T] = {
+    stream.setParallelism(parallelism)
+    this
+  }
+
+  /**
+    * Turns off chaining for this operator so thread co-location will not be
+    * used as an optimization. </p> Chaining can be turned off for the whole
+    * job by [[StreamExecutionEnvironment.disableOperatorChaining()]]
+    * however it is not advised for performance considerations.
+    *
+    */
+  @PublicEvolving
+  def disableChaining(): DataStreamSink[T] = {
+    stream.disableChaining()
+    this
+  }
+
+  /**
+    * Sets the slot sharing group of this operation. Parallel instances of
+    * operations that are in the same slot sharing group will be co-located in the same
+    * TaskManager slot, if possible.
+    *
+    * Operations inherit the slot sharing group of input operations if all input operations
+    * are in the same slot sharing group and no slot sharing group was explicitly specified.
+    *
+    * Initially an operation is in the default slot sharing group. An operation can be put into
+    * the default group explicitly by setting the slot sharing group to `"default"`.
+    *
+    * @param slotSharingGroup The slot sharing group name.
+    */
+  @PublicEvolving
+  def slotSharingGroup(slotSharingGroup: String): DataStreamSink[T] = {
+    stream.slotSharingGroup(slotSharingGroup)
+    this
+  }
+
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/package.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/package.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.{createTuple2TypeInformation => apiTupleCreator}
 import org.apache.flink.api.scala.typeutils.{CaseClassTypeInfo, TypeUtils}
 import org.apache.flink.streaming.api.datastream.{ DataStream => JavaStream }
+import org.apache.flink.streaming.api.datastream.{ DataStreamSink => JavaStreamSink }
 import org.apache.flink.streaming.api.datastream.{ SplitStream => SplitJavaStream }
 import org.apache.flink.streaming.api.datastream.{ ConnectedStreams => ConnectedJavaStreams }
 import org.apache.flink.streaming.api.datastream.{ KeyedStream => KeyedJavaStream }
@@ -62,7 +63,14 @@ package object scala {
   private[flink] def asScalaStream[IN1, IN2](stream: ConnectedJavaStreams[IN1, IN2])
                                              = new ConnectedStreams[IN1, IN2](stream)
 
-  
+
+  /**
+    * Converts an [[org.apache.flink.streaming.api.datastream.DataStreamSink]] to a
+    * [[org.apache.flink.streaming.api.scala.DataStreamSink]].
+    */
+  private[flink] def asScalaStream[R](stream: JavaStreamSink[R])
+                                      = new DataStreamSink[R](stream)
+
   private[flink] def fieldNames2Indices(
       typeInfo: TypeInformation[_],
       fields: Array[String]): Array[Int] = {

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -255,7 +255,8 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
     assert(1 == env.getStreamGraph.getStreamNode(src.getId).getParallelism)
     assert(10 == env.getStreamGraph.getStreamNode(map.getId).getParallelism)
     assert(1 == env.getStreamGraph.getStreamNode(windowed.getId).getParallelism)
-    assert(10 == env.getStreamGraph.getStreamNode(sink.getTransformation.getId).getParallelism)
+    assert(10 ==
+      env.getStreamGraph.getStreamNode(sink.javaStream.getTransformation.getId).getParallelism)
 
     try {
       src.setParallelism(3)
@@ -272,7 +273,8 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
     assert(1 == env.getStreamGraph.getStreamNode(src.getId).getParallelism)
     assert(10 == env.getStreamGraph.getStreamNode(map.getId).getParallelism)
     assert(1 == env.getStreamGraph.getStreamNode(windowed.getId).getParallelism)
-    assert(10 == env.getStreamGraph.getStreamNode(sink.getTransformation.getId).getParallelism)
+    assert(10 ==
+      env.getStreamGraph.getStreamNode(sink.javaStream.getTransformation.getId).getParallelism)
 
     val parallelSource = env.generateSequence(0, 0)
     parallelSource.print()
@@ -286,7 +288,8 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
     assert(2 == env.getStreamGraph.getStreamNode(map.getId).getParallelism)
 
     sink.setParallelism(4)
-    assert(4 == env.getStreamGraph.getStreamNode(sink.getTransformation.getId).getParallelism)
+    assert(4 ==
+      env.getStreamGraph.getStreamNode(sink.javaStream.getTransformation.getId).getParallelism)
   }
 
   @Test
@@ -394,7 +397,7 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
     val select = split.select("a")
     val sink = select.print()
     val splitEdge =
-      env.getStreamGraph.getStreamEdges(unionFilter.getId, sink.getTransformation.getId)
+      env.getStreamGraph.getStreamEdges(unionFilter.getId, sink.javaStream.getTransformation.getId)
     assert("a" == splitEdge.get(0).getSelectedNames.get(0))
 
     val foldFunction = new FoldFunction[Int, String] {
@@ -445,31 +448,36 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
     val broadcast = src.broadcast
     val broadcastSink = broadcast.print()
     val broadcastPartitioner = env.getStreamGraph
-      .getStreamEdges(src.getId, broadcastSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdges(src.getId, broadcastSink.javaStream.getTransformation.getId)
+      .get(0).getPartitioner
     assert(broadcastPartitioner.isInstanceOf[BroadcastPartitioner[_]])
 
     val shuffle: DataStream[Long] = src.shuffle
     val shuffleSink = shuffle.print()
     val shufflePartitioner = env.getStreamGraph
-      .getStreamEdges(src.getId, shuffleSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdges(src.getId, shuffleSink.javaStream.getTransformation.getId)
+      .get(0).getPartitioner
     assert(shufflePartitioner.isInstanceOf[ShufflePartitioner[_]])
 
     val forward: DataStream[Long] = src.forward
     val forwardSink = forward.print()
     val forwardPartitioner = env.getStreamGraph
-      .getStreamEdges(src.getId, forwardSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdges(src.getId, forwardSink.javaStream.getTransformation.getId)
+      .get(0).getPartitioner
     assert(forwardPartitioner.isInstanceOf[ForwardPartitioner[_]])
 
     val rebalance: DataStream[Long] = src.rebalance
     val rebalanceSink = rebalance.print()
     val rebalancePartitioner = env.getStreamGraph
-      .getStreamEdges(src.getId, rebalanceSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdges(src.getId, rebalanceSink.javaStream.getTransformation.getId)
+      .get(0).getPartitioner
     assert(rebalancePartitioner.isInstanceOf[RebalancePartitioner[_]])
 
     val global: DataStream[Long] = src.global
     val globalSink = global.print()
     val globalPartitioner = env.getStreamGraph
-      .getStreamEdges(src.getId, globalSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdges(src.getId, globalSink.javaStream.getTransformation.getId)
+      .get(0).getPartitioner
     assert(globalPartitioner.isInstanceOf[GlobalPartitioner[_]])
   }
 
@@ -521,7 +529,7 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
   }
 
   private def createDownStreamId(dataStream: DataStream[_]): Integer = {
-    dataStream.print().getTransformation.getId
+    dataStream.print().javaStream.getTransformation.getId
   }
 
   private def createDownStreamId(dataStream: ConnectedStreams[_, _]): Integer = {


### PR DESCRIPTION
The change is effectively already tested in `DataStreamTest`.

It might make sense to introduce further testing that ensures that all the scala api method calls returning data stream variants reamin in the scala api.