### PR TITLE
[FLINK-3503] [tableAPI] Add cost model for DataSet RelNodes to improve plan selection

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/TranslationContext.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/TranslationContext.scala
@@ -26,6 +26,7 @@ import org.apache.calcite.schema.impl.AbstractTable
 import org.apache.calcite.schema.SchemaPlus
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools.{FrameworkConfig, Frameworks, RelBuilder}
+import org.apache.flink.api.table.plan.cost.DataSetCostFactory
 import org.apache.flink.api.table.plan.schema.DataSetTable
 
 object TranslationContext {
@@ -54,6 +55,7 @@ object TranslationContext {
       .newConfigBuilder
       .defaultSchema(tables)
       .parserConfig(parserConfig)
+      .costFactory(new DataSetCostFactory)
       .traitDefs(ConventionTraitDef.INSTANCE)
       .build
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/cost/DataSetCost.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/cost/DataSetCost.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.plan.cost
+
+import org.apache.calcite.plan.{RelOptUtil, RelOptCostFactory, RelOptCost}
+import org.apache.calcite.util.Util
+
+/**
+  * This class is based on Apache Calcite's `org.apache.calcite.plan.volcano.VolcanoCost` and has
+  * an adapted cost comparison method `isLe(other: RelOptCost)` that takes io and cpu into account.
+  */
+class DataSetCost(val rowCount: Double, val cpu: Double, val io: Double) extends RelOptCost {
+
+  def getCpu: Double = cpu
+
+  def isInfinite: Boolean = {
+    (this eq DataSetCost.Infinity) ||
+      (this.rowCount == Double.PositiveInfinity) ||
+      (this.cpu == Double.PositiveInfinity) ||
+      (this.io == Double.PositiveInfinity)
+  }
+
+  def getIo: Double = io
+
+  def isLe(other: RelOptCost): Boolean = {
+    val that: DataSetCost = other.asInstanceOf[DataSetCost]
+    (this eq that) ||
+      (this.io < that.io) ||
+      (this.io == that.io && this.cpu < that.cpu) ||
+      (this.io == that.io && this.cpu == that.cpu && this.rowCount < that.rowCount)
+  }
+
+  def isLt(other: RelOptCost): Boolean = {
+    isLe(other) && !(this == other)
+  }
+
+  def getRows: Double = rowCount
+
+  override def hashCode: Int = Util.hashCode(rowCount) + Util.hashCode(cpu) + Util.hashCode(io)
+
+  def equals(other: RelOptCost): Boolean = {
+    (this eq other) ||
+      other.isInstanceOf[DataSetCost] &&
+        (this.rowCount == other.asInstanceOf[DataSetCost].rowCount) &&
+        (this.cpu == other.asInstanceOf[DataSetCost].cpu) &&
+        (this.io == other.asInstanceOf[DataSetCost].io)
+  }
+
+  def isEqWithEpsilon(other: RelOptCost): Boolean = {
+    if (!other.isInstanceOf[DataSetCost]) {
+      return false
+    }
+    val that: DataSetCost = other.asInstanceOf[DataSetCost]
+    (this eq that) ||
+      ((Math.abs(this.rowCount - that.rowCount) < RelOptUtil.EPSILON) &&
+        (Math.abs(this.cpu - that.cpu) < RelOptUtil.EPSILON) &&
+        (Math.abs(this.io - that.io) < RelOptUtil.EPSILON))
+  }
+
+  def minus(other: RelOptCost): RelOptCost = {
+    if (this eq DataSetCost.Infinity) {
+      return this
+    }
+    val that: DataSetCost = other.asInstanceOf[DataSetCost]
+    new DataSetCost(this.rowCount - that.rowCount, this.cpu - that.cpu, this.io - that.io)
+  }
+
+  def multiplyBy(factor: Double): RelOptCost = {
+    if (this eq DataSetCost.Infinity) {
+      return this
+    }
+    new DataSetCost(rowCount * factor, cpu * factor, io * factor)
+  }
+
+  def divideBy(cost: RelOptCost): Double = {
+    val that: DataSetCost = cost.asInstanceOf[DataSetCost]
+    var d: Double = 1
+    var n: Double = 0
+    if ((this.rowCount != 0) && !this.rowCount.isInfinite &&
+      (that.rowCount != 0) && !that.rowCount.isInfinite)
+    {
+      d *= this.rowCount / that.rowCount
+      n += 1
+    }
+    if ((this.cpu != 0) && !this.cpu.isInfinite && (that.cpu != 0) && !that.cpu.isInfinite) {
+      d *= this.cpu / that.cpu
+      n += 1
+    }
+    if ((this.io != 0) && !this.io.isInfinite && (that.io != 0) && !that.io.isInfinite) {
+      d *= this.io / that.io
+      n += 1
+    }
+    if (n == 0) {
+      return 1.0
+    }
+    Math.pow(d, 1 / n)
+  }
+
+  def plus(other: RelOptCost): RelOptCost = {
+    val that: DataSetCost = other.asInstanceOf[DataSetCost]
+    if ((this eq DataSetCost.Infinity) || (that eq DataSetCost.Infinity)) {
+      return DataSetCost.Infinity
+    }
+    new DataSetCost(this.rowCount + that.rowCount, this.cpu + that.cpu, this.io + that.io)
+  }
+
+  override def toString: String = s"{$rowCount rows, $cpu cpu, $io io}"
+
+}
+
+object DataSetCost {
+
+  private[flink] val Infinity = new DataSetCost(
+    Double.PositiveInfinity,
+    Double.PositiveInfinity,
+    Double.PositiveInfinity)
+  {
+    override def toString: String = "{inf}"
+  }
+
+  private[flink] val Huge = new DataSetCost(Double.MaxValue, Double.MaxValue, Double.MaxValue) {
+    override def toString: String = "{huge}"
+  }
+
+  private[flink] val Zero = new DataSetCost(0.0, 0.0, 0.0) {
+    override def toString: String = "{0}"
+  }
+
+  private[flink] val Tiny = new DataSetCost(1.0, 1.0, 0.0) {
+    override def toString = "{tiny}"
+  }
+
+  val FACTORY: RelOptCostFactory = new DataSetCostFactory
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/cost/DataSetCostFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/cost/DataSetCostFactory.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.plan.cost
+
+import org.apache.calcite.plan.{RelOptCost, RelOptCostFactory}
+
+/**
+  * This class is based on Apache Calcite's `org.apache.calcite.plan.volcano.VolcanoCost#Factory`.
+  */
+class DataSetCostFactory extends RelOptCostFactory {
+
+  override def makeCost(dRows: Double, dCpu: Double, dIo: Double): RelOptCost = {
+    new DataSetCost(dRows, dCpu, dIo)
+  }
+
+  override def makeHugeCost: RelOptCost = {
+    DataSetCost.Huge
+  }
+
+  override def makeInfiniteCost: RelOptCost = {
+    DataSetCost.Infinity
+  }
+
+  override def makeTinyCost: RelOptCost = {
+    DataSetCost.Tiny
+  }
+
+  override def makeZeroCost: RelOptCost = {
+    DataSetCost.Zero
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetAggregate.scala
@@ -18,9 +18,10 @@
 
 package org.apache.flink.api.table.plan.nodes.dataset
 
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.plan.{RelOptCost, RelOptPlanner, RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
@@ -63,6 +64,15 @@ class DataSetAggregate(
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     super.explainTerms(pw).item("name", opName)
+  }
+
+  override def computeSelfCost (planner: RelOptPlanner): RelOptCost = {
+
+    val child = this.getInput
+    val rowCnt = RelMetadataQuery.getRowCount(child)
+    val rowSize = this.estimateRowSize(child.getRowType)
+    val aggCnt = this.namedAggregates.size
+    planner.getCostFactory.makeCost(rowCnt, rowCnt * aggCnt, rowCnt * rowSize)
   }
 
   override def translateToPlan(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetCalc.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetCalc.scala
@@ -18,8 +18,9 @@
 
 package org.apache.flink.api.table.plan.nodes.dataset
 
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.plan.{RelOptPlanner, RelOptCost, RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
 import org.apache.flink.api.common.functions.FlatMapFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -66,7 +67,27 @@ class DataSetCalc(
     super.explainTerms(pw).item("name", opName)
   }
 
+  override def computeSelfCost (planner: RelOptPlanner): RelOptCost = {
+
+    val child = this.getInput
+    val rowCnt = RelMetadataQuery.getRowCount(child)
+    val exprCnt = calcProgram.getExprCount
+    planner.getCostFactory.makeCost(rowCnt, rowCnt * exprCnt, 0)
+  }
+
   override def toString = opName
+
+  override def getRows: Double = {
+    val child = this.getInput
+    val rowCnt = RelMetadataQuery.getRowCount(child)
+
+    if (calcProgram.getCondition != null) {
+      // we reduce the result card to push filters down
+      (rowCnt * 0.75).min(1.0)
+    } else {
+      rowCnt
+    }
+  }
 
   override def translateToPlan(config: TableConfig,
       expectedType: Option[TypeInformation[Any]]): DataSet[Any] = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetJoin.scala
@@ -18,9 +18,10 @@
 
 package org.apache.flink.api.table.plan.nodes.dataset
 
-import org.apache.calcite.plan.{RelTraitSet, RelOptCluster}
+import org.apache.calcite.plan.{RelOptCost, RelOptPlanner, RelTraitSet, RelOptCluster}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinInfo
+import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelWriter, BiRel, RelNode}
 import org.apache.calcite.util.mapping.IntPair
 import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint
@@ -80,6 +81,17 @@ class DataSetJoin(
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     super.explainTerms(pw).item("name", opName)
+  }
+
+  override def computeSelfCost (planner: RelOptPlanner): RelOptCost = {
+
+    val children = this.getInputs
+
+    children.foldLeft(planner.getCostFactory.makeCost(0, 0, 0)) { (cost, child) =>
+      val rowCnt = RelMetadataQuery.getRowCount(child)
+      val rowSize = this.estimateRowSize(child.getRowType)
+      cost.plus(planner.getCostFactory.makeCost(rowCnt, rowCnt, rowCnt * rowSize))
+    }
   }
 
   override def translateToPlan(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetRel.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetRel.scala
@@ -19,7 +19,9 @@
 package org.apache.flink.api.table.plan.nodes.dataset
 
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
+import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.table.TableConfig
@@ -64,6 +66,25 @@ trait DataSetRel extends RelNode {
       }
       case _ => throw new IllegalArgumentException("Unknown expression type: " + expr)
     }
+  }
+
+  private[flink] def estimateRowSize(rowType: RelDataType): Double = {
+
+    rowType.getFieldList.map(_.getType.getSqlTypeName).foldLeft(0) { (s, t) =>
+      t match {
+        case SqlTypeName.TINYINT => s + 1
+        case SqlTypeName.SMALLINT => s + 2
+        case SqlTypeName.INTEGER => s + 4
+        case SqlTypeName.BIGINT => s + 8
+        case SqlTypeName.BOOLEAN => s + 1
+        case SqlTypeName.FLOAT => s + 4
+        case SqlTypeName.DOUBLE => s + 8
+        case SqlTypeName.VARCHAR => s + 12
+        case SqlTypeName.CHAR => s + 1
+        case _ => throw new IllegalArgumentException("Unsupported data type encountered")
+      }
+    }
+
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetSource.scala
@@ -22,6 +22,7 @@ import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
+import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
@@ -60,6 +61,12 @@ class DataSetSource(
       table,
       rowType
     )
+  }
+
+  override def computeSelfCost (planner: RelOptPlanner): RelOptCost = {
+
+    val rowCnt = RelMetadataQuery.getRowCount(this)
+    planner.getCostFactory.makeCost(rowCnt, rowCnt, 0)
   }
 
   override def translateToPlan(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/DataSetTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/DataSetTable.scala
@@ -76,9 +76,9 @@ class DataSetTable[T](
     builder.build
   }
 
-//  override def getStatistic: Statistic = {
-//    new DefaultDataSetStatistic
-//  }
+  override def getStatistic: Statistic = {
+    new DefaultDataSetStatistic
+  }
 
 }
 


### PR DESCRIPTION
Calcite's default cost model does not take IO and CPU into account. As a consequence, projections are not pushed down (as described in FLINK-3503).

This PR adds a basic cost model to push filters and projections towards the sources.