### PR TITLE
[hotFix] [tableAPI] Improve naming of DataSetRelNodes

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetAggregate.scala
@@ -42,7 +42,6 @@ class DataSetAggregate(
     namedAggregates: Seq[CalcitePair[AggregateCall, String]],
     rowType: RelDataType,
     inputType: RelDataType,
-    opName: String,
     grouping: Array[Int])
   extends SingleRel(cluster, traitSet, input)
   with DataSetRel {
@@ -57,12 +56,13 @@ class DataSetAggregate(
       namedAggregates,
       rowType,
       inputType,
-      opName,
       grouping)
   }
 
   override def explainTerms(pw: RelWriter): RelWriter = {
-    super.explainTerms(pw).item("name", opName)
+    super.explainTerms(pw)
+      .itemIf("groupBy",groupingToString, !grouping.isEmpty)
+      .item("select", aggregationToString)
   }
 
   override def translateToPlan(
@@ -91,50 +91,65 @@ class DataSetAggregate(
     .map(n => TypeConverter.sqlTypeToTypeInfo(n))
     .toArray
 
-    val rowTypeInfo = new RowTypeInfo(fieldTypes, rowType.getFieldNames.asScala)
     val aggString = aggregationToString
-    val mappedInput = inputDS.map(aggregateResult._1).name(s"prepare $aggString")
+    val prepareOpName = s"prepare select: ($aggString)"
+    val mappedInput = inputDS
+      .map(aggregateResult._1)
+      .name(prepareOpName)
+
     val groupReduceFunction = aggregateResult._2
+    val rowTypeInfo = new RowTypeInfo(fieldTypes, rowType.getFieldNames.asScala)
 
     if (groupingKeys.length > 0) {
-
-      val inFields = inputType.getFieldNames.asScala.toList
-      val groupByString = s"groupBy: (${grouping.map( inFields(_) ).mkString(", ")})"
-
+      // grouped aggregation
+      val aggOpName = s"groupBy: ($groupingToString), select:($aggString)"
       mappedInput.asInstanceOf[DataSet[Row]]
         .groupBy(groupingKeys: _*)
         .reduceGroup(groupReduceFunction)
         .returns(rowTypeInfo)
-          .name(groupByString + ", " + aggString)
+          .name(aggOpName)
         .asInstanceOf[DataSet[Any]]
     }
     else {
       // global aggregation
+      val aggOpName = s"select:($aggString)"
       mappedInput.asInstanceOf[DataSet[Row]]
         .reduceGroup(groupReduceFunction)
         .returns(rowTypeInfo)
+          .name(aggOpName)
         .asInstanceOf[DataSet[Any]]
     }
   }
 
+  private def groupingToString: String = {
+
+    val inFields = inputType.getFieldNames.asScala
+    grouping.map( inFields(_) ).mkString(", ")
+  }
+
   private def aggregationToString: String = {
 
-    val inFields = inputType.getFieldNames.asScala.toList
-    val outFields = rowType.getFieldNames.asScala.toList
+    val inFields = inputType.getFieldNames.asScala
+    val outFields = rowType.getFieldNames.asScala
+
+    val groupStrings = grouping.map( inFields(_) )
+
     val aggs = namedAggregates.map(_.getKey)
+    val aggStrings = aggs.map( a => s"${a.getAggregation}(${
+      if (a.getArgList.size() > 0) {
+        inFields(a.getArgList.get(0))
+      } else {
+        "*"
+      }
+    })")
 
-    val groupFieldsString = grouping.map( inFields(_) )
-    val aggsString = aggs.map( a => s"${a.getAggregation}(${inFields(a.getArgList.get(0))})")
-
-    val outFieldsString = (groupFieldsString ++ aggsString).zip(outFields).map {
+    (groupStrings ++ aggStrings).zip(outFields).map {
       case (f, o) => if (f == o) {
         f
       } else {
         s"$f AS $o"
       }
-    }
-
-    s"select: (${outFieldsString.mkString(", ")})"
+    }.mkString(", ")
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetUnion.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetUnion.scala
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.table.TableConfig
 
+import scala.collection.JavaConverters._
+
 /**
 * Flink RelNode which matches along with UnionOperator.
 *
@@ -34,8 +36,7 @@ class DataSetUnion(
     traitSet: RelTraitSet,
     left: RelNode,
     right: RelNode,
-    rowType: RelDataType,
-    opName: String)
+    rowType: RelDataType)
   extends BiRel(cluster, traitSet, left, right)
   with DataSetRel {
 
@@ -47,13 +48,12 @@ class DataSetUnion(
       traitSet,
       inputs.get(0),
       inputs.get(1),
-      rowType,
-      opName
+      rowType
     )
   }
 
   override def explainTerms(pw: RelWriter): RelWriter = {
-    super.explainTerms(pw).item("name", opName)
+    super.explainTerms(pw).item("union", unionSelectionToString)
   }
 
   override def translateToPlan(
@@ -63,6 +63,10 @@ class DataSetUnion(
     val leftDataSet = left.asInstanceOf[DataSetRel].translateToPlan(config)
     val rightDataSet = right.asInstanceOf[DataSetRel].translateToPlan(config)
     leftDataSet.union(rightDataSet).asInstanceOf[DataSet[Any]]
+  }
+
+  private def unionSelectionToString: String = {
+    rowType.getFieldNames.asScala.toList.mkString(", ")
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateRule.scala
@@ -45,7 +45,6 @@ class DataSetAggregateRule
         agg.getNamedAggCalls,
         rel.getRowType,
         agg.getInput.getRowType,
-        agg.toString,
         agg.getGroupSet.toArray)
       }
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetCalcRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetCalcRule.scala
@@ -43,7 +43,6 @@ class DataSetCalcRule
         convInput,
         rel.getRowType,
         calc.getProgram,
-        calc.toString,
         description)
     }
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetJoinRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetJoinRule.scala
@@ -99,7 +99,6 @@ class DataSetJoinRule
           convLeft,
           convRight,
           rel.getRowType,
-          join.toString,
           join.getCondition,
           join.getRowType,
           joinInfo,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetUnionRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetUnionRule.scala
@@ -44,8 +44,7 @@ class DataSetUnionRule
         traitSet,
         convLeft,
         convRight,
-        rel.getRowType,
-        union.toString)
+        rel.getRowType)
     }
   }
 


### PR DESCRIPTION
Some clean up for DataSet ReNodes.
- remove the name parameter for all DataSet RelNodes.
- generate descriptive operator names and explain terms.