### PR TITLE
[hotfix][examples] Add zookeeper.connect to usage line

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/WriteIntoKafka.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/WriteIntoKafka.java
@@ -37,7 +37,7 @@ public class WriteIntoKafka {
 
 	public static void main(String[] args) throws Exception {
 		ParameterTool parameterTool = ParameterTool.fromArgs(args);
-		if(parameterTool.getNumberOfParameters() < 2) {
+		if(parameterTool.getNumberOfParameters() < 3) {
 			System.out.println("Missing parameters!");
 			System.out.println("Usage: Kafka --topic <topic> --bootstrap.servers <kafka brokers> --zookeeper.connect <zk quorum>");
 			System.exit(1);

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/WriteIntoKafka.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/WriteIntoKafka.java
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
  * Generate a String every 500 ms and write it into a Kafka topic
  *
  * Please pass the following arguments to run the example:
- * 	--topic test --bootstrap.servers localhost:9092
+ * 	--topic test --bootstrap.servers localhost:9092 --zookeeper.connect localhost:2181
  *
  */
 public class WriteIntoKafka {
@@ -38,7 +38,8 @@ public class WriteIntoKafka {
 	public static void main(String[] args) throws Exception {
 		ParameterTool parameterTool = ParameterTool.fromArgs(args);
 		if(parameterTool.getNumberOfParameters() < 2) {
-			System.out.println("Missing parameters!\nUsage: Kafka --topic <topic> --bootstrap.servers <kafka brokers>");
+			System.out.println("Missing parameters!");
+			System.out.println("Usage: Kafka --topic <topic> --bootstrap.servers <kafka brokers> --zookeeper.connect <zk quorum>");
 			System.exit(1);
 		}
 


### PR DESCRIPTION
Follow-up to [this thread](http://apache-flink-user-mailing-list-archive.2336050.n4.nabble.com/Unable-to-Read-from-Kafka-zookeeper-connect-error-td5577.html) on the Flink user mailing list.