### PR TITLE
[FLINK-3629] Fix quick start description for the ".timeWindow()" function call

### DIFF
--- a/docs/quickstart/run_example_quickstart.md
+++ b/docs/quickstart/run_example_quickstart.md
@@ -183,7 +183,7 @@ DataStream<Tuple2<String, Long>> result = keyedEdits
     });
 {% endhighlight %}
 
-The first call, `.window()`, specifies that we want to have tumbling (non-overlapping) windows
+The first call, `.timeWindow()`, specifies that we want to have tumbling (non-overlapping) windows
 of five seconds. The second call specifies a *Fold transformation* on each window slice for
 each unique key. In our case we start from an initial value of `("", 0L)` and add to it the byte
 difference of every edit in that time window for a user. The resulting Stream now contains


### PR DESCRIPTION
Jira Issue:
https://issues.apache.org/jira/browse/FLINK-3629

On Quick Start page (https://ci.apache.org/projects/flink/flink-docs-release-1.0/quickstart/run_example_quickstart.html).

> The first call, .window(), specifies that we want to have tumbling (non-overlapping) windows of five seconds.

This is not consistent with the sample code. In the sample code,
` KeyedStream.timeWindow() `
function is used.

So, change the document to say "The first call, .timeWindow() ...".
