### PR TITLE
[FLINK-3645] [tests] HDFSCopyUtilitiesTest fails in a Hadoop cluster

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/HDFSCopyUtilitiesTest.java
@@ -62,7 +62,7 @@ public class HDFSCopyUtilitiesTest {
 
 		HDFSCopyFromLocal.copyFromLocal(
 				originalFile,
-				new Path(copyFile.getAbsolutePath()).toUri());
+				new Path("file://" + copyFile.getAbsolutePath()).toUri());
 
 		try (DataInputStream in = new DataInputStream(new FileInputStream(copyFile))) {
 			assertTrue(in.readUTF().equals("Hello there, 42!"));
@@ -87,7 +87,7 @@ public class HDFSCopyUtilitiesTest {
 		}
 
 		HDFSCopyToLocal.copyToLocal(
-				new Path(originalFile.getAbsolutePath()).toUri(),
+				new Path("file://" + originalFile.getAbsolutePath()).toUri(),
 				copyFile);
 
 		try (DataInputStream in = new DataInputStream(new FileInputStream(copyFile))) {


### PR DESCRIPTION
Please check [JIRA](https://issues.apache.org/jira/browse/FLINK-3645). `HDFSCopyUtilitiesTest` should use local file system only. This PR forces the test to use local file system.