### PR TITLE
[FLINK-3637] Refactor rolling sink writer

### DIFF
--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
@@ -253,11 +253,6 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 	private transient Path currentBucketDirectory;
 
 	/**
-	 * The {@code FSDataOutputStream} for the current part file.
-	 */
-	private transient FSDataOutputStream outStream;
-
-	/**
 	 * Our subtask index, retrieved from the {@code RuntimeContext} in {@link #open}.
 	 */
 	private transient int subtaskIndex;
@@ -269,10 +264,9 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 	private transient int partCounter;
 
 	/**
-	 * We use reflection to get the hflush method or use sync as a fallback.
-	 * The idea for this and the code comes from the Flume HDFS Sink.
+	 * Tracks if the writer is currently opened or closed.
 	 */
-	private transient Method refHflushOrSync;
+	private transient boolean isWriterOpen = false;
 
 	/**
 	 * We use reflection to get the .truncate() method, this is only available starting with
@@ -385,7 +379,7 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 	 */
 	private boolean shouldRoll() throws IOException {
 		boolean shouldRoll = false;
-		if (outStream == null) {
+		if (!isWriterOpen) {
 			shouldRoll = true;
 			LOG.debug("RollingSink {} starting new initial bucket. ", subtaskIndex);
 		}
@@ -395,9 +389,9 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 			// we will retrieve a new bucket base path in openNewPartFile so reset the part counter
 			partCounter = 0;
 		}
-		if (outStream != null) {
-			long writePosition = outStream.getPos();
-			if (outStream != null && writePosition > batchSize) {
+		if (isWriterOpen) {
+			long writePosition = writer.getPos();
+			if (isWriterOpen && writePosition > batchSize) {
 				shouldRoll = true;
 				LOG.debug(
 						"RollingSink {} starting new bucket because file position {} is above batch size {}.",
@@ -452,16 +446,8 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 
 		Path inProgressPath = new Path(currentPartPath.getParent(), inProgressPrefix + currentPartPath.getName()).suffix(inProgressSuffix);
 
-
-
-		outStream = fs.create(inProgressPath, false);
-
-		// We do the reflection here since this is the first time that we have a FSDataOutputStream
-		if (refHflushOrSync == null) {
-			refHflushOrSync = reflectHflushOrSync(outStream);
-		}
-
-		writer.open(outStream);
+		writer.open(fs, inProgressPath);
+		isWriterOpen = true;
 	}
 
 	/**
@@ -472,15 +458,11 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 	 * of pending files in our bucket state.
 	 */
 	private void closeCurrentPartFile() throws Exception {
-		if (writer != null) {
+		if (isWriterOpen) {
 			writer.close();
+			isWriterOpen = false;
 		}
 
-		if (outStream != null) {
-			hflushOrSync(outStream);
-			outStream.close();
-			outStream = null;
-		}
 		if (currentPartPath != null) {
 			Path inProgressPath = new Path(currentPartPath.getParent(), inProgressPrefix + currentPartPath.getName()).suffix(inProgressSuffix);
 			Path pendingPath = new Path(currentPartPath.getParent(), pendingPrefix + currentPartPath.getName()).suffix(pendingSuffix);
@@ -491,62 +473,6 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 					pendingPath);
 			this.bucketState.pendingFiles.add(currentPartPath.toString());
 		}
-	}
-
-	/**
-	 * If hflush is available in this version of HDFS, then this method calls
-	 * hflush, else it calls sync.
-	 * @param os - The stream to flush/sync
-	 * @throws java.io.IOException
-	 *
-	 * <p>
-	 * Note: This code comes from Flume
-	 */
-	protected void hflushOrSync(FSDataOutputStream os) throws IOException {
-		try {
-			// At this point the refHflushOrSync cannot be null,
-			// since register method would have thrown if it was.
-			this.refHflushOrSync.invoke(os);
-		} catch (InvocationTargetException e) {
-			String msg = "Error while trying to hflushOrSync!";
-			LOG.error(msg + " " + e.getCause());
-			Throwable cause = e.getCause();
-			if(cause != null && cause instanceof IOException) {
-				throw (IOException)cause;
-			}
-			throw new RuntimeException(msg, e);
-		} catch (Exception e) {
-			String msg = "Error while trying to hflushOrSync!";
-			LOG.error(msg + " " + e);
-			throw new RuntimeException(msg, e);
-		}
-	}
-
-	/**
-	 * Gets the hflush call using reflection. Fallback to sync if hflush is not available.
-	 *
-	 * <p>
-	 * Note: This code comes from Flume
-	 */
-	private Method reflectHflushOrSync(FSDataOutputStream os) {
-		Method m = null;
-		if(os != null) {
-			Class<?> fsDataOutputStreamClass = os.getClass();
-			try {
-				m = fsDataOutputStreamClass.getMethod("hflush");
-			} catch (NoSuchMethodException ex) {
-				LOG.debug("HFlush not found. Will use sync() instead");
-				try {
-					m = fsDataOutputStreamClass.getMethod("sync");
-				} catch (Exception ex1) {
-					String msg = "Neither hflush not sync were found. That seems to be " +
-							"a problem!";
-					LOG.error(msg);
-					throw new RuntimeException(msg, ex1);
-				}
-			}
-		}
-		return m;
 	}
 
 	/**
@@ -633,14 +559,10 @@ public class RollingSink<T> extends RichSinkFunction<T> implements InputTypeConf
 
 	@Override
 	public BucketState snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
-		if (writer != null) {
-			writer.flush();
-		}
-		if (outStream != null) {
-			outStream.flush();
-			hflushOrSync(outStream);
+		if (isWriterOpen) {
+			long pos = writer.flush();
 			bucketState.currentFile = currentPartPath.toString();
-			bucketState.currentFileValidLength = outStream.getPos();
+			bucketState.currentFileValidLength = pos;
 		}
 		synchronized (bucketState.pendingFilesPerCheckpoint) {
 			bucketState.pendingFilesPerCheckpoint.put(checkpointId, bucketState.pendingFiles);

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StreamWriterBase.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StreamWriterBase.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.fs;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public abstract class StreamWriterBase<T> implements Writer<T> {
+
+	private static Logger LOG = LoggerFactory.getLogger(RollingSink.class);
+
+	/**
+	 * The {@code FSDataOutputStream} for the current part file.
+	 */
+	private transient FSDataOutputStream outStream;
+
+	/**
+	 * We use reflection to get the hflush method or use sync as a fallback.
+	 * The idea for this and the code comes from the Flume HDFS Sink.
+	 */
+	private transient Method refHflushOrSync;
+
+	/**
+	 * Returns the current output stream, if the stream is open.
+	 */
+	protected FSDataOutputStream getStream() {
+		if (outStream == null) {
+			throw new IllegalStateException("Output stream has not been opened");
+		}
+		return outStream;
+	}
+
+	/**
+	 * If hflush is available in this version of HDFS, then this method calls
+	 * hflush, else it calls sync.
+	 * @param os - The stream to flush/sync
+	 * @throws java.io.IOException
+	 *
+	 * <p>
+	 * Note: This code comes from Flume
+	 */
+	protected void hflushOrSync(FSDataOutputStream os) throws IOException {
+		try {
+			// At this point the refHflushOrSync cannot be null,
+			// since register method would have thrown if it was.
+			this.refHflushOrSync.invoke(os);
+		} catch (InvocationTargetException e) {
+			String msg = "Error while trying to hflushOrSync!";
+			LOG.error(msg + " " + e.getCause());
+			Throwable cause = e.getCause();
+			if(cause != null && cause instanceof IOException) {
+				throw (IOException)cause;
+			}
+			throw new RuntimeException(msg, e);
+		} catch (Exception e) {
+			String msg = "Error while trying to hflushOrSync!";
+			LOG.error(msg + " " + e);
+			throw new RuntimeException(msg, e);
+		}
+	}
+
+	/**
+	 * Gets the hflush call using reflection. Fallback to sync if hflush is not available.
+	 *
+	 * <p>
+	 * Note: This code comes from Flume
+	 */
+	private Method reflectHflushOrSync(FSDataOutputStream os) {
+		Method m = null;
+		if(os != null) {
+			Class<?> fsDataOutputStreamClass = os.getClass();
+			try {
+				m = fsDataOutputStreamClass.getMethod("hflush");
+			} catch (NoSuchMethodException ex) {
+				LOG.debug("HFlush not found. Will use sync() instead");
+				try {
+					m = fsDataOutputStreamClass.getMethod("sync");
+				} catch (Exception ex1) {
+					String msg = "Neither hflush not sync were found. That seems to be " +
+							"a problem!";
+					LOG.error(msg);
+					throw new RuntimeException(msg, ex1);
+				}
+			}
+		}
+		return m;
+	}
+
+	@Override
+	public void open(FileSystem fs, Path path) throws IOException {
+		if (outStream != null) {
+			throw new IllegalStateException("Writer has already been opened");
+		}
+		outStream = fs.create(path, false);
+		if (refHflushOrSync == null) {
+			refHflushOrSync = reflectHflushOrSync(outStream);
+		}
+	}
+
+	@Override
+	public long flush() throws IOException {
+		if (outStream == null) {
+			throw new IllegalStateException("Writer is not open");
+		}
+		hflushOrSync(outStream);
+		return outStream.getPos();
+	}
+
+	@Override
+	public long getPos() throws IOException {
+		if (outStream == null) {
+			throw new IllegalStateException("Writer is not open");
+		}
+		return outStream.getPos();
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (outStream != null) {
+			flush();
+			outStream.close();
+			outStream = null;
+		}
+	}
+
+}

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
@@ -17,8 +17,9 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
-
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -31,10 +32,8 @@ import java.nio.charset.UnsupportedCharsetException;
  *
  * @param <T> The type of the elements that are being written by the sink.
  */
-public class StringWriter<T> implements Writer<T> {
+public class StringWriter<T> extends StreamWriterBase<T> {
 	private static final long serialVersionUID = 1L;
-
-	private transient FSDataOutputStream outputStream;
 
 	private String charsetName;
 
@@ -59,11 +58,8 @@ public class StringWriter<T> implements Writer<T> {
 	}
 
 	@Override
-	public void open(FSDataOutputStream outStream) throws IOException {
-		if (outputStream != null) {
-			throw new IllegalStateException("StringWriter has already been opened.");
-		}
-		this.outputStream = outStream;
+	public void open(FileSystem fs, Path path) throws IOException {
+		super.open(fs, path);
 
 		try {
 			this.charset = Charset.forName(charsetName);
@@ -77,23 +73,10 @@ public class StringWriter<T> implements Writer<T> {
 	}
 
 	@Override
-	public void flush() throws IOException {
-
-	}
-
-	@Override
-	public void close() throws IOException {
-		outputStream = null;
-	}
-
-	@Override
 	public void write(T element) throws IOException {
-		if (outputStream == null) {
-			throw new IllegalStateException("StringWriter has not been opened.");
-		}
+		FSDataOutputStream outputStream = getStream();
 		outputStream.write(element.toString().getBytes(charset));
 		outputStream.write('\n');
-
 	}
 
 	@Override

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Writer.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/Writer.java
@@ -17,7 +17,8 @@
  */
 package org.apache.flink.streaming.connectors.fs;
 
-import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -35,19 +36,26 @@ public interface Writer<T> extends Serializable {
 	 * Initializes the {@code Writer} for a newly opened bucket file.
 	 * Any internal per-bucket initialization should be performed here.
 	 *
-	 * @param outStream The {@link org.apache.hadoop.fs.FSDataOutputStream} for the newly opened file.
+	 * @param fs The {@link org.apache.hadoop.fs.FileSystem} containing the newly opened file.
+	 * @param path The {@link org.apache.hadoop.fs.Path} of the newly opened file.
 	 */
-	void open(FSDataOutputStream outStream) throws IOException;
+	void open(FileSystem fs, Path path) throws IOException;
 
 	/**
-	 * Flushes out any internally held data.
+	 * Flushes out any internally held data, and returns the offset that the file
+	 * must be truncated to at recovery.
 	 */
-	void flush()throws IOException ;
+	long flush() throws IOException;
 
 	/**
-	 * Closes the {@code Writer}. This must not close the {@code FSDataOutputStream} that
-	 * was handed in in the {@link #open} method. Only internally held state should be
-	 * closed.
+	 * Retrieves the current position, and thus size, of the output file.
+	 */
+	long getPos() throws IOException;
+
+	/**
+	 * Closes the {@code Writer}. If the writer is already closed, no action will be
+	 * taken. The call should close all state related to the current output file,
+	 * including the output stream opened in {@code open}.
 	 */
 	void close() throws IOException ;
 


### PR DESCRIPTION
Implements FLINK-3637 by changing the Writer interface such that the Writer must handle the output stream, instead of having the RollingSink handling it. This makes it possible to write outputs for ORC and Parquet.