### PR TITLE
[FLINK-3639] add methods for registering datasets and tables in the TableEnvironment

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/java/table/JavaBatchTranslator.scala
@@ -51,7 +51,7 @@ class JavaBatchTranslator(config: TableConfig) extends PlanTranslator {
       fieldNames
     )
 
-    val tabName = TranslationContext.addDataSet(dataSetTable)
+    val tabName = TranslationContext.registerDataSetTable(dataSetTable)
     val relBuilder = TranslationContext.getRelBuilder
 
     // create table scan operator

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
@@ -21,9 +21,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.table.expressions.ExpressionParser
-import org.apache.flink.api.table.plan.TranslationContext
-import org.apache.flink.api.table.plan.schema.{TableTable, DataSetTable}
-import org.apache.flink.api.table.{TableException, TableConfig, Table}
+import org.apache.flink.api.table.{AbstractTableEnvironment, Table}
 
 /**
  * Environment for working with the Table API.
@@ -31,14 +29,7 @@ import org.apache.flink.api.table.{TableException, TableConfig, Table}
  * This can be used to convert a [[DataSet]] to a [[Table]] and back again. You
  * can also use the provided methods to create a [[Table]] directly from a data source.
  */
-class TableEnvironment {
-
-  private val config = new TableConfig()
-
-  /**
-   * Returns the table config to define the runtime behavior of the Table API.
-   */
-  def getConfig = config
+class TableEnvironment extends AbstractTableEnvironment {
 
   /**
    * Transforms the given DataSet to a [[org.apache.flink.api.table.Table]].
@@ -97,14 +88,7 @@ class TableEnvironment {
    * @param dataset the DataSet to register
    */
   def registerDataSet[T](name: String, dataset: DataSet[T]): Unit = {
-
-    val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](dataset.getType)
-    val dataSetTable = new DataSetTable[T](
-      dataset,
-      fieldIndexes,
-      fieldNames
-    )
-    TranslationContext.addAndRegisterDataSet(dataSetTable, name)
+    registerUniqueNameDataSet(name, dataset)
   }
 
   /**
@@ -116,46 +100,10 @@ class TableEnvironment {
    * @param fields the Table field names
    */
   def registerDataSet[T](name: String, dataset: DataSet[T], fields: String): Unit = {
-
     val exprs = ExpressionParser
       .parseExpressionList(fields)
       .toArray
-
-    val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](dataset.getType, exprs)
-
-    val dataSetTable = new DataSetTable[T](
-      dataset,
-      fieldIndexes.toArray,
-      fieldNames.toArray
-    )
-    TranslationContext.addAndRegisterDataSet(dataSetTable, name)
+    registerDataSetWithFields(name, dataset, exprs)
   }
 
-  /**
-   * Registers a Table under a unique name, so that it can be used in SQL queries.
-   * @param name the Table name
-   * @param table the Table to register
-   */
-  def registerTable[T](name: String, table: Table): Unit = {
-    val tableTable = new TableTable(table.getRelNode())
-    TranslationContext.registerTable(tableTable, name)
-  }
-
-  /**
-   * Retrieve a registered Table.
-   * @param tableName the name under which the Table has been registered
-   * @return the Table object
-   */
-  @throws[TableException]
-  def scan(tableName: String): Table = {
-    if (TranslationContext.isRegistered(tableName)) {
-      val relBuilder = TranslationContext.getRelBuilder
-      relBuilder.scan(tableName)
-      new Table(relBuilder.build(), relBuilder)
-    }
-    else {
-      throw new TableException("Table \"" + tableName + "\" was not found in the registry.")
-    }
-
-  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/java/table/TableEnvironment.scala
@@ -88,7 +88,7 @@ class TableEnvironment extends AbstractTableEnvironment {
    * @param dataset the DataSet to register
    */
   def registerDataSet[T](name: String, dataset: DataSet[T]): Unit = {
-    registerUniqueNameDataSet(name, dataset)
+    registerDataSetInternal(name, dataset)
   }
 
   /**
@@ -103,7 +103,7 @@ class TableEnvironment extends AbstractTableEnvironment {
     val exprs = ExpressionParser
       .parseExpressionList(fields)
       .toArray
-    registerDataSetWithFields(name, dataset, exprs)
+    registerDataSetInternal(name, dataset, exprs)
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
@@ -72,7 +72,7 @@ class TableEnvironment extends AbstractTableEnvironment {
    * @param dataset the DataSet to register
    */
   def registerDataSet[T](name: String, dataset: DataSet[T]): Unit = {
-    registerUniqueNameDataSet(name, dataset.javaSet)
+    registerDataSetInternal(name, dataset.javaSet)
   }
 
   /**
@@ -84,7 +84,7 @@ class TableEnvironment extends AbstractTableEnvironment {
    * @param fields the field names expression
    */
   def registerDataSet[T](name: String, dataset: DataSet[T], fields: Expression*): Unit = {
-    registerDataSetWithFields(name, dataset.javaSet, fields.toArray)
+    registerDataSetInternal(name, dataset.javaSet, fields.toArray)
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableEnvironment.scala
@@ -20,7 +20,9 @@ package org.apache.flink.api.scala.table
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.DataSet
 import org.apache.flink.api.table.expressions.Expression
-import org.apache.flink.api.table.{TableConfig, Table}
+import org.apache.flink.api.table.plan.TranslationContext
+import org.apache.flink.api.table.plan.schema.{TableTable, DataSetTable}
+import org.apache.flink.api.table.{TableException, TableConfig, Table}
 
 /**
  * Environment for working with the Table API.
@@ -72,5 +74,68 @@ class TableEnvironment {
      new ScalaBatchTranslator(config).translate[T](table.relNode)
   }
 
-}
+  /**
+   * Registers a DataSet under a unique name, so that it can be used in SQL queries.
+   * The fields of the DataSet type are used to name the Table fields.
+   * @param name the Table name
+   * @param dataset the DataSet to register
+   */
+  def registerDataSet[T](name: String, dataset: DataSet[T]): Unit = {
 
+    val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](dataset.getType)
+    val dataSetTable = new DataSetTable[T](
+      dataset.javaSet,
+      fieldIndexes,
+      fieldNames
+    )
+    TranslationContext.addAndRegisterDataSet(dataSetTable, name)
+  }
+
+  /**
+   * Registers a DataSet under a unique name, so that it can be used in SQL queries.
+   * The fields of the DataSet type are renamed to the given set of fields.
+   *
+   * @param name the Table name
+   * @param dataset the DataSet to register
+   * @param fields the field names expression
+   */
+  def registerDataSet[T](name: String, dataset: DataSet[T], fields: Expression*): Unit = {
+
+    val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](
+      dataset.getType, fields.toArray)
+
+    val dataSetTable = new DataSetTable[T](
+      dataset.javaSet,
+      fieldIndexes.toArray,
+      fieldNames.toArray
+    )
+    TranslationContext.addAndRegisterDataSet(dataSetTable, name)
+  }
+
+  /**
+   * Registers a Table under a unique name, so that it can be used in SQL queries.
+   * @param name the Table name
+   * @param table the Table to register
+   */
+  def registerTable[T](name: String, table: Table): Unit = {
+    val tableTable = new TableTable(table.getRelNode())
+    TranslationContext.registerTable(tableTable, name)
+  }
+
+  /**
+   * Retrieve a registered Table.
+   * @param tableName the name under which the Table has been registered
+   * @return the Table object
+   */
+  @throws[TableException]
+  def scan(tableName: String): Table = {
+    if (TranslationContext.isRegistered(tableName)) {
+      val relBuilder = TranslationContext.getRelBuilder
+      relBuilder.scan(tableName)
+      new Table(relBuilder.build(), relBuilder)
+    }
+    else {
+      throw new TableException("Table \"" + tableName + "\" was not found in the registry.")
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/AbstractTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/AbstractTableEnvironment.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table
+
+import org.apache.flink.api.java.DataSet
+import org.apache.flink.api.table.expressions.Expression
+import org.apache.flink.api.table.plan.TranslationContext
+import org.apache.flink.api.table.plan.schema.{DataSetTable, TableTable}
+
+class AbstractTableEnvironment {
+
+  private[flink] val config = new TableConfig()
+
+  /**
+   * Returns the table config to define the runtime behavior of the Table API.
+   */
+  def getConfig = config
+
+  /**
+   * Registers a Table under a unique name, so that it can be used in SQL queries.
+   * @param name the Table name
+   * @param table the Table to register
+   */
+  def registerTable[T](name: String, table: Table): Unit = {
+    val tableTable = new TableTable(table.getRelNode())
+    TranslationContext.registerTable(tableTable, name)
+  }
+
+  /**
+   * Retrieve a registered Table.
+   * @param tableName the name under which the Table has been registered
+   * @return the Table object
+   */
+  @throws[TableException]
+  def scan(tableName: String): Table = {
+    if (TranslationContext.isRegistered(tableName)) {
+      val relBuilder = TranslationContext.getRelBuilder
+      relBuilder.scan(tableName)
+      new Table(relBuilder.build(), relBuilder)
+    }
+    else {
+      throw new TableException(s"Table \'$tableName\' was not found in the registry.")
+    }
+  }
+
+  def registerUniqueNameDataSet[T](name: String, dataset: DataSet[T]): Unit = {
+
+    val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](dataset.getType)
+    val dataSetTable = new DataSetTable[T](
+      dataset,
+      fieldIndexes,
+      fieldNames
+    )
+    TranslationContext.registerTable(dataSetTable, name)
+  }
+
+  def registerDataSetWithFields[T](
+      name: String, dataset: DataSet[T], fields: Array[Expression]): Unit = {
+
+    val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](
+      dataset.getType, fields.toArray)
+
+    val dataSetTable = new DataSetTable[T](
+      dataset,
+      fieldIndexes.toArray,
+      fieldNames.toArray
+    )
+    TranslationContext.registerTable(dataSetTable, name)
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/AbstractTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/AbstractTableEnvironment.scala
@@ -59,7 +59,7 @@ class AbstractTableEnvironment {
     }
   }
 
-  def registerUniqueNameDataSet[T](name: String, dataset: DataSet[T]): Unit = {
+  private[flink] def registerDataSetInternal[T](name: String, dataset: DataSet[T]): Unit = {
 
     val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](dataset.getType)
     val dataSetTable = new DataSetTable[T](
@@ -70,7 +70,7 @@ class AbstractTableEnvironment {
     TranslationContext.registerTable(dataSetTable, name)
   }
 
-  def registerDataSetWithFields[T](
+  private[flink] def registerDataSetInternal[T](
       name: String, dataset: DataSet[T], fields: Array[Expression]): Unit = {
 
     val (fieldNames, fieldIndexes) = TranslationContext.getFieldInfo[T](

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/TranslationContext.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/TranslationContext.scala
@@ -26,15 +26,20 @@ import org.apache.calcite.schema.impl.AbstractTable
 import org.apache.calcite.schema.SchemaPlus
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools.{FrameworkConfig, Frameworks, RelBuilder}
+import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
+import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfo}
+import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
+import org.apache.flink.api.table.TableException
+import org.apache.flink.api.table.expressions.{Naming, UnresolvedFieldReference, Expression}
 import org.apache.flink.api.table.plan.cost.DataSetCostFactory
-import org.apache.flink.api.table.plan.schema.DataSetTable
+import org.apache.flink.api.table.plan.schema.{TableTable, DataSetTable}
 
 object TranslationContext {
 
   private var frameworkConfig: FrameworkConfig = null
   private var relBuilder: RelBuilder = null
   private var tables: SchemaPlus = null
-  private var tabNames: Map[AbstractTable, String] = null
+  private var tablesRegistry: Map[String, AbstractTable] = null
   private val nameCntr: AtomicInteger = new AtomicInteger(0)
 
   reset()
@@ -59,29 +64,55 @@ object TranslationContext {
       .traitDefs(ConventionTraitDef.INSTANCE)
       .build
 
-    tabNames = Map[AbstractTable, String]()
-
+    tablesRegistry = Map[String, AbstractTable]()
     relBuilder = RelBuilder.create(frameworkConfig)
-
     nameCntr.set(0)
 
   }
 
   def addDataSet(newTable: DataSetTable[_]): String = {
+    val tabName = "DataSetTable_" + nameCntr.getAndIncrement()
+    tables.add(tabName, newTable)
+    tabName
+  }
 
-    // look up name
-    val tabName = tabNames.get(newTable)
+  @throws[TableException]
+  def addAndRegisterDataSet(table: DataSetTable[_], name: String): Unit = {
 
-    tabName match {
-      case Some(name) =>
-        name
+    val existingTable = tablesRegistry.get(name)
+
+    existingTable match {
+      case Some(_) =>
+        throw new TableException("Table \"" + name + "\" already exists. "
+        + "Please, choose a different name.")
       case None =>
-        val tabName = "DataSetTable_" + nameCntr.getAndIncrement()
-        tabNames += (newTable -> tabName)
-        tables.add(tabName, newTable)
-        tabName
+        tablesRegistry += (name -> table)
+        tables.add(name, table)
     }
+  }
 
+  @throws[TableException]
+  def registerTable(table: TableTable, name: String): Unit = {
+    val existingTable = tablesRegistry.get(name)
+
+    existingTable match {
+      case Some(_) =>
+        throw new TableException("Table \"" + name + "\" already exists. "
+          + "Please, choose a different name.")
+      case None =>
+        tablesRegistry += (name -> table)
+        tables.add(name, table)
+    }
+  }
+
+  def isRegistered(name: String): Boolean = {
+    val table = tablesRegistry.get(name)
+    table match {
+      case Some(_) =>
+        true
+      case None =>
+        false
+    }
   }
 
   def getUniqueName: String = {
@@ -96,6 +127,75 @@ object TranslationContext {
     frameworkConfig
   }
 
+  def getFieldInfo[A](inputType: TypeInformation[A]): (Array[String], Array[Int]) = {
+    val fieldNames: Array[String] = inputType match {
+      case t: TupleTypeInfo[A] => t.getFieldNames
+      case c: CaseClassTypeInfo[A] => c.getFieldNames
+      case p: PojoTypeInfo[A] => p.getFieldNames
+      case tpe =>
+        throw new IllegalArgumentException(
+          s"Type $tpe requires explicit field naming with AS.")
+    }
+    val fieldIndexes = fieldNames.indices.toArray
+    (fieldNames, fieldIndexes)
+  }
+
+  def getFieldInfo[A](
+    inputType: TypeInformation[A],
+    exprs: Array[Expression]): (Array[String], Array[Int]) = {
+
+    val indexedNames: Array[(Int, String)] = inputType match {
+      case a: AtomicType[A] =>
+        if (exprs.length != 1) {
+          throw new IllegalArgumentException("Atomic type may can only have a single field.")
+        }
+        exprs.map {
+          case UnresolvedFieldReference(name) => (0, name)
+          case _ => throw new IllegalArgumentException(
+            "Field reference expression expected.")
+        }
+      case t: TupleTypeInfo[A] =>
+        exprs.zipWithIndex.map {
+          case (UnresolvedFieldReference(name), idx) => (idx, name)
+          case (Naming(UnresolvedFieldReference(origName), name), _) =>
+            val idx = t.getFieldIndex(origName)
+            if (idx < 0) {
+              throw new IllegalArgumentException(s"$origName is not a field of type $t")
+            }
+            (idx, name)
+          case _ => throw new IllegalArgumentException(
+            "Field reference expression or naming expression expected.")
+        }
+      case c: CaseClassTypeInfo[A] =>
+        exprs.zipWithIndex.map {
+          case (UnresolvedFieldReference(name), idx) => (idx, name)
+          case (Naming(UnresolvedFieldReference(origName), name), _) =>
+            val idx = c.getFieldIndex(origName)
+            if (idx < 0) {
+              throw new IllegalArgumentException(s"$origName is not a field of type $c")
+            }
+            (idx, name)
+          case _ => throw new IllegalArgumentException(
+            "Field reference expression or naming expression expected.")
+        }
+      case p: PojoTypeInfo[A] =>
+        exprs.map {
+          case Naming(UnresolvedFieldReference(origName), name) =>
+            val idx = p.getFieldIndex(origName)
+            if (idx < 0) {
+              throw new IllegalArgumentException(s"$origName is not a field of type $p")
+            }
+            (idx, name)
+          case _ => throw new IllegalArgumentException(
+            "Field naming expression expected.")
+        }
+      case tpe => throw new IllegalArgumentException(
+        s"Type $tpe cannot be converted into Table.")
+    }
+
+    val (fieldIndexes, fieldNames) = indexedNames.unzip
+    (fieldNames.toArray, fieldIndexes.toArray)
+  }
 }
 
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/TranslationContext.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/TranslationContext.scala
@@ -70,35 +70,28 @@ object TranslationContext {
 
   }
 
+  /**
+   * Adds a table to the Calcite schema so it can be used by the Table API
+   */
   def addDataSet(newTable: DataSetTable[_]): String = {
     val tabName = "DataSetTable_" + nameCntr.getAndIncrement()
     tables.add(tabName, newTable)
     tabName
   }
 
+  /**
+   * Adds a table to the Calcite schema and the tables registry,
+   * so it can be used by both Table API and SQL statements.
+   */
   @throws[TableException]
-  def addAndRegisterDataSet(table: DataSetTable[_], name: String): Unit = {
+  def registerTable(table: AbstractTable, name: String): Unit = {
 
     val existingTable = tablesRegistry.get(name)
 
     existingTable match {
       case Some(_) =>
-        throw new TableException("Table \"" + name + "\" already exists. "
-        + "Please, choose a different name.")
-      case None =>
-        tablesRegistry += (name -> table)
-        tables.add(name, table)
-    }
-  }
-
-  @throws[TableException]
-  def registerTable(table: TableTable, name: String): Unit = {
-    val existingTable = tablesRegistry.get(name)
-
-    existingTable match {
-      case Some(_) =>
-        throw new TableException("Table \"" + name + "\" already exists. "
-          + "Please, choose a different name.")
+        throw new TableException(s"Table \'$name\' already exists. " +
+        "Please, choose a different name.")
       case None =>
         tablesRegistry += (name -> table)
         tables.add(name, table)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/FlinkRuleSets.scala
@@ -93,7 +93,10 @@ object FlinkRuleSets {
     DataSetCalcRule.INSTANCE,
     DataSetJoinRule.INSTANCE,
     DataSetScanRule.INSTANCE,
-    DataSetUnionRule.INSTANCE
+    DataSetUnionRule.INSTANCE,
+
+    // convert a logical table scan to a relational expression
+    TableScanRule.INSTANCE
   )
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/FlinkRuleSets.scala
@@ -29,6 +29,9 @@ object FlinkRuleSets {
     */
   val DATASET_OPT_RULES: RuleSet = RuleSets.ofList(
 
+    // convert a logical table scan to a relational expression
+    TableScanRule.INSTANCE,
+
     // push a filter into a join
     FilterJoinRule.FILTER_ON_JOIN,
     // push filter into the children of a join
@@ -93,10 +96,7 @@ object FlinkRuleSets {
     DataSetCalcRule.INSTANCE,
     DataSetJoinRule.INSTANCE,
     DataSetScanRule.INSTANCE,
-    DataSetUnionRule.INSTANCE,
-
-    // convert a logical table scan to a relational expression
-    TableScanRule.INSTANCE
+    DataSetUnionRule.INSTANCE
   )
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/TableTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/TableTable.scala
@@ -18,22 +18,23 @@
 
 package org.apache.flink.api.table.plan.schema
 
-import java.lang.Double
-import java.util
-import java.util.Collections
-
 import org.apache.calcite.plan.RelOptTable
 import org.apache.calcite.plan.RelOptTable.ToRelContext
-import org.apache.calcite.rel.{RelDistribution, RelCollation, RelNode}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.calcite.schema.Schema.TableType
 import org.apache.calcite.schema.impl.AbstractTable
-import org.apache.calcite.schema.{TranslatableTable, Statistic}
-import org.apache.calcite.util.ImmutableBitSet
+import org.apache.calcite.schema.TranslatableTable
 
+/**
+ * A [[org.apache.calcite.schema.Table]] implementation for registering
+ * Table API Tables in the Calcite schema to be used by Flink SQL.
+ * It implements [[TranslatableTable]] so that its logical scan
+ * can be converted to a relational expression.
+ *
+ * @see [[DataSetTable]]
+ */
 class TableTable(relNode: RelNode) extends AbstractTable with TranslatableTable {
-
-  override def getStatistic: Statistic = new DefaultTableStatistic
 
   override def getJdbcTableType: TableType = ???
 
@@ -42,14 +43,4 @@ class TableTable(relNode: RelNode) extends AbstractTable with TranslatableTable 
   override def toRel(context: ToRelContext, relOptTable: RelOptTable): RelNode = {
     relNode
   }
-}
-
-class DefaultTableStatistic extends Statistic {
-  override def getRowCount: Double = 1000d
-
-  override def getCollations: util.List[RelCollation] = Collections.emptyList()
-
-  override def isKey(columns: ImmutableBitSet): Boolean = false
-
-  override def getDistribution: RelDistribution = null
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/TableTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/TableTable.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.plan.schema
+
+import java.lang.Double
+import java.util
+import java.util.Collections
+
+import org.apache.calcite.plan.RelOptTable
+import org.apache.calcite.plan.RelOptTable.ToRelContext
+import org.apache.calcite.rel.{RelDistribution, RelCollation, RelNode}
+import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
+import org.apache.calcite.schema.Schema.TableType
+import org.apache.calcite.schema.impl.AbstractTable
+import org.apache.calcite.schema.{TranslatableTable, Statistic}
+import org.apache.calcite.util.ImmutableBitSet
+
+class TableTable(relNode: RelNode) extends AbstractTable with TranslatableTable {
+
+  override def getStatistic: Statistic = new DefaultTableStatistic
+
+  override def getJdbcTableType: TableType = ???
+
+  override def getRowType(typeFactory: RelDataTypeFactory): RelDataType = relNode.getRowType
+
+  override def toRel(context: ToRelContext, relOptTable: RelOptTable): RelNode = {
+    relNode
+  }
+}
+
+class DefaultTableStatistic extends Statistic {
+  override def getRowCount: Double = 1000d
+
+  override def getCollations: util.List[RelCollation] = Collections.emptyList()
+
+  override def isKey(columns: ImmutableBitSet): Boolean = false
+
+  override def getDistribution: RelDistribution = null
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/table.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/table.scala
@@ -73,6 +73,8 @@ class Table(
   extends BaseTable(relNode, relBuilder)
 {
 
+  def getRelNode(): RelNode = relNode
+
   /**
     * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
     * can contain complex expressions and aggregations.

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/RegisterDataSetITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/RegisterDataSetITCase.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.table.test;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.table.TableEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.Table;
+import org.apache.flink.api.table.TableException;
+import org.apache.flink.api.table.plan.TranslationContext;
+import org.apache.flink.api.table.test.utils.TableProgramsTestBase;
+import org.apache.flink.test.javaApiOperators.util.CollectionDataSets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class RegisterDataSetITCase extends TableProgramsTestBase {
+
+	public RegisterDataSetITCase(TestExecutionMode mode, TableConfigMode configMode) {
+		super(mode, configMode);
+	}
+
+	@Test
+	public void testSimpleRegister() throws Exception {
+		final String tableName = "MyTable";
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+		TranslationContext.reset();
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		tableEnv.registerDataSet(tableName, ds);
+		Table t = tableEnv.scan(tableName);
+
+		Table result = t.select("f0, f1");
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "1,1\n" + "2,2\n" + "3,2\n" + "4,3\n" + "5,3\n" + "6,3\n" + "7,4\n" +
+				"8,4\n" + "9,4\n" + "10,4\n" + "11,5\n" + "12,5\n" + "13,5\n" + "14,5\n" + "15,5\n" +
+				"16,6\n" + "17,6\n" + "18,6\n" + "19,6\n" + "20,6\n" + "21,6\n";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testRegisterWithFields() throws Exception {
+		final String tableName = "MyTable";
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+		TranslationContext.reset();
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		tableEnv.registerDataSet(tableName, ds, "a, b, c");
+		Table t = tableEnv.scan(tableName);
+
+		Table result = t.select("a, b, c");
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "1,1,Hi\n" + "2,2,Hello\n" + "3,2,Hello world\n" +
+				"4,3,Hello world, how are you?\n" + "5,3,I am fine.\n" + "6,3,Luke Skywalker\n" +
+				"7,4,Comment#1\n" + "8,4,Comment#2\n" + "9,4,Comment#3\n" + "10,4,Comment#4\n" +
+				"11,5,Comment#5\n" + "12,5,Comment#6\n" + "13,5,Comment#7\n" +
+				"14,5,Comment#8\n" + "15,5,Comment#9\n" + "16,6,Comment#10\n" +
+				"17,6,Comment#11\n" + "18,6,Comment#12\n" + "19,6,Comment#13\n" +
+				"20,6,Comment#14\n" + "21,6,Comment#15\n";
+		compareResultAsText(results, expected);
+	}
+
+	@Test(expected = TableException.class)
+	public void testRegisterExistingDatasetTable() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+		TranslationContext.reset();
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		tableEnv.registerDataSet("MyTable", ds);
+		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 =
+				CollectionDataSets.getSmall5TupleDataSet(env);
+		tableEnv.registerDataSet("MyTable", ds2);
+	}
+
+	@Test(expected = TableException.class)
+	public void testScanUnregisteredTable() throws Exception {
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+		TranslationContext.reset();
+
+		tableEnv.scan("nonRegisteredTable");
+	}
+
+	@Test
+	public void testTableRegister() throws Exception {
+		final String tableName = "MyTable";
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+		TranslationContext.reset();
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		Table t = tableEnv.fromDataSet(ds);
+		tableEnv.registerTable(tableName, t);
+		Table result = tableEnv.scan(tableName).select("f0, f1").filter("f0 > 7");
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "8,4\n" + "9,4\n" + "10,4\n" + "11,5\n" + "12,5\n" +
+				"13,5\n" + "14,5\n" + "15,5\n" +
+				"16,6\n" + "17,6\n" + "18,6\n" + "19,6\n" + "20,6\n" + "21,6\n";
+		compareResultAsText(results, expected);
+	}
+
+	@Test(expected = TableException.class)
+	public void testRegisterExistingTable() throws Exception {
+		final String tableName = "MyTable";
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+		TranslationContext.reset();
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		Table t = tableEnv.fromDataSet(ds);
+		tableEnv.registerTable(tableName, t);
+		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 =
+				CollectionDataSets.getSmall5TupleDataSet(env);
+		Table t2 = tableEnv.fromDataSet(ds2);
+		tableEnv.registerTable(tableName, t2);
+	}
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/RegisterDataSetITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/RegisterDataSetITCase.java
@@ -130,18 +130,13 @@ public class RegisterDataSetITCase extends TableProgramsTestBase {
 	}
 
 	@Test(expected = TableException.class)
-	public void testRegisterExistingTable() throws Exception {
-		final String tableName = "MyTable";
+	public void testIllegalName() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		TableEnvironment tableEnv = getJavaTableEnvironment();
 		TranslationContext.reset();
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table t = tableEnv.fromDataSet(ds);
-		tableEnv.registerTable(tableName, t);
-		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 =
-				CollectionDataSets.getSmall5TupleDataSet(env);
-		Table t2 = tableEnv.fromDataSet(ds2);
-		tableEnv.registerTable(tableName, t2);
+		tableEnv.registerTable("_DataSetTable_42", t);
 	}
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/RegisterDataSetITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/RegisterDataSetITCase.scala
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.table.test
+
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.table._
+import org.apache.flink.api.scala.util.CollectionDataSets
+import org.apache.flink.api.table.{TableException, Row}
+import org.apache.flink.api.table.plan.TranslationContext
+import org.apache.flink.api.table.test.utils.TableProgramsTestBase
+import org.apache.flink.api.table.test.utils.TableProgramsTestBase.TableConfigMode
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
+import org.apache.flink.test.util.TestBaseUtils
+import org.junit._
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[Parameterized])
+class RegisterDataSetITCase(
+    mode: TestExecutionMode,
+    configMode: TableConfigMode)
+  extends TableProgramsTestBase(mode, configMode) {
+
+  @Test
+  def testSimpleRegister(): Unit = {
+
+    val tableName = "MyTable"
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    val ds = CollectionDataSets.get3TupleDataSet(env)
+    tEnv.registerDataSet(tableName, ds)
+    val t = tEnv.scan(tableName).select('_1, '_2, '_3)
+
+    val expected = "1,1,Hi\n" + "2,2,Hello\n" + "3,2,Hello world\n" +
+      "4,3,Hello world, how are you?\n" + "5,3,I am fine.\n" + "6,3,Luke Skywalker\n" +
+      "7,4,Comment#1\n" + "8,4,Comment#2\n" + "9,4,Comment#3\n" + "10,4,Comment#4\n" +
+      "11,5,Comment#5\n" + "12,5,Comment#6\n" + "13,5,Comment#7\n" + "14,5,Comment#8\n" +
+      "15,5,Comment#9\n" + "16,6,Comment#10\n" + "17,6,Comment#11\n" + "18,6,Comment#12\n" +
+      "19,6,Comment#13\n" + "20,6,Comment#14\n" + "21,6,Comment#15\n"
+    val results = t.toDataSet[Row](getConfig).collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testRegisterWithFields(): Unit = {
+
+    val tableName = "MyTable"
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    val ds = CollectionDataSets.get3TupleDataSet(env)
+    tEnv.registerDataSet(tableName, ds, 'a, 'b, 'c)
+    val t = tEnv.scan(tableName).select('a, 'b)
+
+    val expected = "1,1\n" + "2,2\n" + "3,2\n" + "4,3\n" + "5,3\n" + "6,3\n" +
+      "7,4\n" + "8,4\n" + "9,4\n" + "10,4\n" + "11,5\n" + "12,5\n" + "13,5\n" + "14,5\n" +
+      "15,5\n" + "16,6\n" + "17,6\n" + "18,6\n" + "19,6\n" + "20,6\n" + "21,6\n"
+    val results = t.toDataSet[Row](getConfig).collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testRegisterExistingDataSet(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env)
+    tEnv.registerDataSet("MyTable", ds1)
+    val ds2 = CollectionDataSets.get5TupleDataSet(env)
+    tEnv.registerDataSet("MyTable", ds2)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testScanUnregisteredTable(): Unit = {
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    tEnv.scan("someTable")
+  }
+
+  @Test
+  def testTableRegister(): Unit = {
+
+    val tableName = "MyTable"
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    val t = CollectionDataSets.get3TupleDataSet(env).as('a, 'b, 'c)
+    tEnv.registerTable(tableName, t)
+
+    val regT = tEnv.scan(tableName).select('a, 'b).filter('a > 8)
+
+    val expected = "9,4\n" + "10,4\n" +
+      "11,5\n" + "12,5\n" + "13,5\n" + "14,5\n" +
+      "15,5\n" + "16,6\n" + "17,6\n" + "18,6\n" +
+      "19,6\n" + "20,6\n" + "21,6\n"
+
+    val results = regT.toDataSet[Row](getConfig).collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testRegisterExistingTable(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    val t1 = CollectionDataSets.get3TupleDataSet(env).toTable
+    tEnv.registerTable("MyTable", t1)
+    val t2 = CollectionDataSets.get5TupleDataSet(env).toTable
+    tEnv.registerDataSet("MyTable", t2)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/test/utils/ExpressionEvaluator.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/test/utils/ExpressionEvaluator.scala
@@ -49,7 +49,7 @@ object ExpressionEvaluator {
     // create DataSetTable
     val dataSetMock = mock(classOf[DataSet[Any]])
     when(dataSetMock.getType).thenReturn(typeInfo)
-    val tableName = TranslationContext.addDataSet(new DataSetTable[Any](
+    val tableName = TranslationContext.registerDataSetTable(new DataSetTable[Any](
       dataSetMock,
       (0 until typeInfo.getArity).toArray,
       (0 until typeInfo.getArity).map("f" + _).toArray))

--- a/flink-libraries/flink-table/src/test/scala/resources/testFilter0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testFilter0.out
@@ -1,6 +1,6 @@
 == Abstract Syntax Tree ==
 LogicalFilter(condition=[=(MOD($0, 2), 0)])
-  LogicalTableScan(table=[[DataSetTable_0]])
+  LogicalTableScan(table=[[_DataSetTable_0]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testFilter1.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testFilter1.out
@@ -1,6 +1,6 @@
 == Abstract Syntax Tree ==
 LogicalFilter(condition=[=(MOD($0, 2), 0)])
-  LogicalTableScan(table=[[DataSetTable_0]])
+  LogicalTableScan(table=[[_DataSetTable_0]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testJoin0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testJoin0.out
@@ -2,8 +2,8 @@
 LogicalProject(a=[$0], c=[$2])
   LogicalFilter(condition=[=($1, $3)])
     LogicalJoin(condition=[true], joinType=[inner])
-      LogicalTableScan(table=[[DataSetTable_0]])
-      LogicalTableScan(table=[[DataSetTable_1]])
+      LogicalTableScan(table=[[_DataSetTable_0]])
+      LogicalTableScan(table=[[_DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 4 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testJoin1.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testJoin1.out
@@ -2,8 +2,8 @@
 LogicalProject(a=[$0], c=[$2])
   LogicalFilter(condition=[=($1, $3)])
     LogicalJoin(condition=[true], joinType=[inner])
-      LogicalTableScan(table=[[DataSetTable_0]])
-      LogicalTableScan(table=[[DataSetTable_1]])
+      LogicalTableScan(table=[[_DataSetTable_0]])
+      LogicalTableScan(table=[[_DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 4 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnion0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnion0.out
@@ -1,7 +1,7 @@
 == Abstract Syntax Tree ==
 LogicalUnion(all=[true])
-  LogicalTableScan(table=[[DataSetTable_0]])
-  LogicalTableScan(table=[[DataSetTable_1]])
+  LogicalTableScan(table=[[_DataSetTable_0]])
+  LogicalTableScan(table=[[_DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnion1.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnion1.out
@@ -1,7 +1,7 @@
 == Abstract Syntax Tree ==
 LogicalUnion(all=[true])
-  LogicalTableScan(table=[[DataSetTable_0]])
-  LogicalTableScan(table=[[DataSetTable_1]])
+  LogicalTableScan(table=[[_DataSetTable_0]])
+  LogicalTableScan(table=[[_DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source


### PR DESCRIPTION
This PR add methods for registering DataSets and Tables in the TableEnvironment to allow executing SQL queries in them in the (near) future. Registration will fail if there already exists a table or dataset with the same name. However, we do allow registering the same dataset and/or table under different names.
It also adds a `scan` method to retrieve a registered Table from the registry.