### PR TITLE
[FLINK-3651] Fix faulty RollingSink Restore

### DIFF
--- a/flink-streaming-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultTolerance2ITCase.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultTolerance2ITCase.java
@@ -104,7 +104,7 @@ public class RollingSinkFaultTolerance2ITCase extends StreamFaultToleranceTestBa
 	public void testProgram(StreamExecutionEnvironment env) {
 		assertTrue("Broken test setup", NUM_STRINGS % 40 == 0);
 
-		int PARALLELISM = 6;
+		int PARALLELISM = 12;
 
 		env.enableCheckpointing(Long.MAX_VALUE);
 		env.setParallelism(PARALLELISM);

--- a/flink-streaming-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
@@ -99,7 +99,7 @@ public class RollingSinkFaultToleranceITCase extends StreamFaultToleranceTestBas
 	public void testProgram(StreamExecutionEnvironment env) {
 		assertTrue("Broken test setup", NUM_STRINGS % 40 == 0);
 
-		int PARALLELISM = 6;
+		int PARALLELISM = 12;
 
 		env.enableCheckpointing(200);
 		env.setParallelism(PARALLELISM);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
@@ -37,8 +37,8 @@ import static org.junit.Assert.fail;
  */
 public abstract class StreamFaultToleranceTestBase extends TestLogger {
 
-	protected static final int NUM_TASK_MANAGERS = 2;
-	protected static final int NUM_TASK_SLOTS = 3;
+	protected static final int NUM_TASK_MANAGERS = 3;
+	protected static final int NUM_TASK_SLOTS = 4;
 	protected static final int PARALLELISM = NUM_TASK_MANAGERS * NUM_TASK_SLOTS;
 
 	private static ForkableFlinkMiniCluster cluster;


### PR DESCRIPTION
On restore the sink for subtask index i has to cleanup leftover files
for subtask i. The pattern used for checking this was not properly
terminated so the sink for subtask 1 would, for example, delete some
files for sink i=11. This would lead to data loss.