### PR TITLE
[FLINK-3658][Kafka] Allow producing into multiple topics

### DIFF
--- a/docs/apis/streaming/connectors/kafka.md
+++ b/docs/apis/streaming/connectors/kafka.md
@@ -142,6 +142,7 @@ stream = env
 The `FlinkKafkaConsumer08` needs to know how to turn the data in Kafka into Java objects. The 
 `DeserializationSchema` allows users to specify such a schema. The `T deserialize(byte[] message)`
 method gets called for each Kafka message, passing the value from Kafka.
+
 For accessing both the key and value of the Kafka message, the `KeyedDeserializationSchema` has
 the following deserialize method ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset)`.
 
@@ -203,6 +204,13 @@ stream.addSink(new FlinkKafkaProducer08[String]("localhost:9092", "my-topic", ne
 You can also define a custom Kafka producer configuration for the KafkaSink with the constructor. Please refer to
 the [Apache Kafka documentation](https://kafka.apache.org/documentation.html) for details on how to configure
 Kafka Producers.
+
+Similar to the consumer, the producer also allows using an advanced serialization schema which allows
+serializing the key and value separately. It also allows to override the target topic id, so that
+one producer instance can send data to multiple topics.
+
+The interface of the serialization schema is called `KeyedSerializationSchema`.
+
 
 **Note**: By default, the number of retries is set to "0". This means that the producer fails immediately on errors,
 including leader changes. The value is set to "0" by default to avoid duplicate messages in the target topic.

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.runtime.client.JobCancellationException;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.internals.ZookeeperOffsetHandler;
 import org.apache.flink.streaming.connectors.kafka.testutils.DiscardingSink;
@@ -142,7 +141,7 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 
 	@Test(timeout = 60000)
 	public void testMultipleTopics() throws Exception {
-		runConsumeMultipleTopics();
+		runProduceConsumeMultipleTopics();
 	}
 
 	@Test(timeout = 60000)

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -98,7 +98,7 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 
 	@Test(timeout = 60000)
 	public void testMultipleTopics() throws Exception {
-		runConsumeMultipleTopics();
+		runProduceConsumeMultipleTopics();
 	}
 
 	@Test(timeout = 60000)

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedSerializationSchema.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedSerializationSchema.java
@@ -45,4 +45,11 @@ public interface KeyedSerializationSchema<T> extends Serializable {
 	 */
 	byte[] serializeValue(T element);
 
+	/**
+	 * Optional method to determine the target topic for the element
+	 *
+	 * @param element Incoming element to determine the target topic from
+	 * @return null or the target topic
+	 */
+	String getTargetTopic(T element);
 }

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedSerializationSchemaWrapper.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedSerializationSchemaWrapper.java
@@ -40,4 +40,9 @@ public class KeyedSerializationSchemaWrapper<T> implements KeyedSerializationSch
 	public byte[] serializeValue(T element) {
 		return serializationSchema.serialize(element);
 	}
+
+	@Override
+	public String getTargetTopic(T element) {
+		return null; // we are never overriding the topic
+	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/TypeInformationKeyValueSerializationSchema.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/TypeInformationKeyValueSerializationSchema.java
@@ -177,6 +177,11 @@ public class TypeInformationKeyValueSerializationSchema<K, V> implements KeyedDe
 		return res;
 	}
 
+	@Override
+	public String getTargetTopic(Tuple2<K, V> element) {
+		return null; // we are never overriding the topic
+	}
+
 
 	@Override
 	public TypeInformation<Tuple2<K,V>> getProducedType() {


### PR DESCRIPTION
Kafka's Producer API allows to send messages to any available topic. This was not exposed in the Flink APIs.
With this change, the topic specified when creating the producer is the default target topic.
With the `KeyedSerializationSchema`, users can now, based on each record's data, also override the target topic.