### PR TITLE
[FLINK-2609] [streaming] auto-register types

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -95,7 +95,9 @@ public class CoGroupedStreams<T1, T2> {
 	 */
 	public <KEY> Where<KEY> where(KeySelector<T1, KEY> keySelector)  {
 		TypeInformation<KEY> keyType = TypeExtractor.getKeySelectorTypes(keySelector, input1.getType());
-		Serializers.recursivelyRegisterType(keyType, input1.getExecutionEnvironment().getConfig(), DataStream.deduplicator);
+		if (!input1.getExecutionEnvironment().getConfig().isAutoTypeRegistrationDisabled()) {
+			Serializers.recursivelyRegisterType(keyType, input1.getExecutionEnvironment().getConfig(), DataStream.deduplicator);
+		}
 		return new Where<>(input1.clean(keySelector), keyType);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.datastream;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.flink.annotation.PublicEvolving;
@@ -43,6 +44,7 @@ import org.apache.flink.api.common.operators.Keys;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -110,6 +112,8 @@ public class DataStream<T> {
 	protected final StreamExecutionEnvironment environment;
 
 	protected final StreamTransformation<T> transformation;
+
+	protected static final HashSet<Class<?>> deduplicator = new HashSet<>();
 
 	/**
 	 * Create a new {@link DataStream} in the given execution environment with
@@ -1021,6 +1025,10 @@ public class DataStream<T> {
 
 		// read the output type of the input Transform to coax out errors about MissingTypeInfo
 		transformation.getOutputType();
+
+		if (!environment.getConfig().isAutoTypeRegistrationDisabled()) {
+			Serializers.recursivelyRegisterType(transformation.getOutputType(), environment.getConfig(), deduplicator);
+		}
 
 		OneInputTransformation<T, R> resultTransform = new OneInputTransformation<>(
 				this.transformation,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1027,7 +1027,7 @@ public class DataStream<T> {
 		transformation.getOutputType();
 
 		if (!environment.getConfig().isAutoTypeRegistrationDisabled()) {
-			Serializers.recursivelyRegisterType(transformation.getOutputType(), environment.getConfig(), deduplicator);
+			Serializers.recursivelyRegisterType(outTypeInfo, environment.getConfig(), deduplicator);
 		}
 
 		OneInputTransformation<T, R> resultTransform = new OneInputTransformation<>(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.api.datastream;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
@@ -37,6 +38,10 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 			TypeInformation<T> outTypeInfo, StreamSource<T, ?> operator,
 			boolean isParallel, String sourceName) {
 		super(environment, new SourceTransformation<>(sourceName, operator, outTypeInfo, environment.getParallelism()));
+
+		if (!environment.getConfig().isAutoTypeRegistrationDisabled()) {
+			Serializers.recursivelyRegisterType(outTypeInfo, environment.getConfig(), deduplicator);
+		}
 
 		this.isParallel = isParallel;
 		if (!isParallel) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
 import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
@@ -101,6 +102,10 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 				dataStream.getTransformation(), new HashPartitioner<>(keySelector)));
 		this.keySelector = keySelector;
 		this.keyType = keyType;
+
+		if (!environment.getConfig().isAutoTypeRegistrationDisabled()) {
+			Serializers.recursivelyRegisterType(keyType, environment.getConfig(), deduplicator);
+		}
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
+import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
@@ -228,6 +229,10 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 		requireNonNull(typeInfo, "TypeInformation must not be null");
 		
 		transformation.setOutputType(typeInfo);
+		if (!environment.getConfig().isAutoTypeRegistrationDisabled()) {
+			Serializers.recursivelyRegisterType(typeInfo, environment.getConfig(), deduplicator);
+		}
+		
 		return this;
 	}
 	


### PR DESCRIPTION
This PR attempts to register all streaming operator output types at kryo.

In contrast to the Batch API
- the registration is done when an operation is defined, opposed to after all operations are defined
  - autoRegistration must be disabled before an operation is created to have an effect
- the deduplicator HashSet is a protected field of the DataStream class opposed to a local variable
  - still not visible to users
  - accessible by all DataStream's
  - accessible by Non-DataStream streams (KeyedStream etc) as long as they are in the same package
    - a separate superclass for all Streams is a good idea in the long run

Most operations use DataStream#transform(), as such most registrations will take place here. One exception are key-selectors, which aremysteriously hidden in the Keyed-/Joined-/CoGroupedStreams where()/equalTo() methods, where their registration takes place.
