### PR TITLE
Adds watermark emission to the Kafka source by allowing the user to specify her TimestampExtractor.

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/ZookeeperOffsetHandler.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/ZookeeperOffsetHandler.java
@@ -24,7 +24,7 @@ import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer08;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumerBase;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import org.slf4j.Logger;
@@ -43,7 +43,7 @@ public class ZookeeperOffsetHandler implements OffsetHandler {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ZookeeperOffsetHandler.class);
 	
-	private static final long OFFSET_NOT_SET = FlinkKafkaConsumer08.OFFSET_NOT_SET;
+	private static final long OFFSET_NOT_SET = FlinkKafkaConsumerBase.OFFSET_NOT_SET;
 
 	private final String groupId;
 

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
@@ -61,6 +61,16 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 	}
 
 	@Test(timeout = 60000)
+	public void testPunctuatedExplicitWMConsumer() throws Exception {
+		runExplicitPunctuatedWMgeneratingConsumerTest(false);
+	}
+
+	@Test(timeout = 60000)
+	public void testPunctuatedExplicitWMConsumerWithEmptyTopic() throws Exception {
+		runExplicitPunctuatedWMgeneratingConsumerTest(true);
+	}
+
+	@Test(timeout = 60000)
 	public void testKeyValueSupport() throws Exception {
 		runKeyValueTest();
 	}
@@ -198,9 +208,9 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 
 		LOG.info("Got final offsets from zookeeper o1={}, o2={}, o3={}", o1, o2, o3);
 
-		assertTrue(o1 == FlinkKafkaConsumer08.OFFSET_NOT_SET || (o1 >= 0 && o1 <= 100));
-		assertTrue(o2 == FlinkKafkaConsumer08.OFFSET_NOT_SET || (o2 >= 0 && o2 <= 100));
-		assertTrue(o3 == FlinkKafkaConsumer08.OFFSET_NOT_SET || (o3 >= 0 && o3 <= 100));
+		assertTrue(o1 == FlinkKafkaConsumerBase.OFFSET_NOT_SET || (o1 >= 0 && o1 <= 100));
+		assertTrue(o2 == FlinkKafkaConsumerBase.OFFSET_NOT_SET || (o2 >= 0 && o2 <= 100));
+		assertTrue(o3 == FlinkKafkaConsumerBase.OFFSET_NOT_SET || (o3 >= 0 && o3 <= 100));
 
 		LOG.info("Manipulating offsets");
 

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -36,10 +36,19 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 		runFailOnNoBrokerTest();
 	}
 
-
 	@Test(timeout = 60000)
 	public void testConcurrentProducerConsumerTopology() throws Exception {
 		runSimpleConcurrentProducerConsumerTopology();
+	}
+
+	@Test(timeout = 60000)
+	public void testPunctuatedExplicitWMConsumer() throws Exception {
+		runExplicitPunctuatedWMgeneratingConsumerTest(false);
+	}
+
+	@Test(timeout = 60000)
+	public void testPunctuatedExplicitWMConsumerWithEmptyTopic() throws Exception {
+		runExplicitPunctuatedWMgeneratingConsumerTest(true);
 	}
 
 	@Test(timeout = 60000)

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -18,12 +18,22 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.commons.collections.map.LinkedMap;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedAsynchronously;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.streaming.api.functions.TimestampAssigner;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaPartitionState;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
+import org.apache.flink.streaming.runtime.operators.Triggerable;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,13 +48,17 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.flink.streaming.connectors.kafka.util.KafkaUtils.checkArgument;
 
 public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFunction<T>
-		implements CheckpointListener, CheckpointedAsynchronously<HashMap<KafkaTopicPartition, Long>>, ResultTypeQueryable<T> {
+		implements CheckpointListener, CheckpointedAsynchronously<HashMap<KafkaTopicPartition, Long>>, ResultTypeQueryable<T>, Triggerable {
 
 	// ------------------------------------------------------------------------
 
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkKafkaConsumerBase.class);
 
 	private static final long serialVersionUID = -6272159445203409112L;
+
+	/** Magic number to define an unset offset. Negative offsets are not used by Kafka (invalid),
+	 * and we pick a number that is probably (hopefully) not used by Kafka as a magic number for anything else. */
+	public static final long OFFSET_NOT_SET = -915623761776L;
 
 	/** The maximum number of pending non-committed checkpoints to track, to avoid memory leaks */
 	public static final int MAX_NUM_PENDING_CHECKPOINTS = 100;
@@ -58,8 +72,13 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	/** Data for pending but uncommitted checkpoints */
 	protected final LinkedMap pendingCheckpoints = new LinkedMap();
 
-	/** The offsets of the last returned elements */
-	protected transient HashMap<KafkaTopicPartition, Long> offsetsState;
+	/**
+	 * Information about the partitions being read by the local consumer. This contains:
+	 * offsets of the last returned elements, and if a timestamp assigner is used, it
+	 * also contains the maximum seen timestamp in the partition and if the partition
+	 * still receives elements or it is inactive.
+	 */
+	protected transient HashMap<KafkaTopicPartition, KafkaPartitionState> partitionState;
 
 	/** The offsets to restore to, if the consumer restores state from a checkpoint */
 	protected transient HashMap<KafkaTopicPartition, Long> restoreToOffset;
@@ -68,13 +87,41 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	protected volatile boolean running = true;
 
 	// ------------------------------------------------------------------------
+	//							WATERMARK EMISSION
+	// ------------------------------------------------------------------------
 
+	/**
+	 * The user-specified methods to extract the timestamps from the records in Kafka, and
+	 * to decide when to emit watermarks.
+	 */
+	private AssignerWithPunctuatedWatermarks<T> punctuatedWatermarkAssigner;
+
+	/**
+	 * The user-specified methods to extract the timestamps from the records in Kafka, and
+	 * to decide when to emit watermarks.
+	 */
+	private AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner;
+
+	private StreamingRuntimeContext runtime = null;
+
+	private SourceContext<T> srcContext = null;
+
+	/**
+	 * The interval between consecutive periodic watermark emissions,
+	 * as configured via the {@link ExecutionConfig#getAutoWatermarkInterval()}.
+	 */
+	private long watermarkInterval = -1;
+
+	/** The last emitted watermark. */
+	private long lastEmittedWatermark = Long.MIN_VALUE;
+
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Creates a new Flink Kafka Consumer, using the given type of fetcher and offset handler.
 	 *
 	 * <p>To determine which kink of fetcher and offset handler to use, please refer to the docs
-	 * at the beginnign of this class.</p>
+	 * at the beginning of this class.</p>
 	 *
 	 * @param deserializer
 	 *           The deserializer to turn raw byte messages into Java/Scala objects.
@@ -85,13 +132,300 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 		this.deserializer = requireNonNull(deserializer, "valueDeserializer");
 	}
 
+	/**
+	 * Specifies an {@link AssignerWithPunctuatedWatermarks} to emit watermarks in a punctuated manner. Bare in mind
+	 * that the source can either have an {@link AssignerWithPunctuatedWatermarks} or an
+	 * {@link AssignerWithPeriodicWatermarks}, not both.
+	 */
+	public FlinkKafkaConsumerBase<T> setPunctuatedWatermarkEmitter(AssignerWithPunctuatedWatermarks<T> assigner) {
+		checkEmitterDuringInit();
+		this.punctuatedWatermarkAssigner = assigner;
+		return this;
+	}
+
+	/**
+	 * Specifies an {@link AssignerWithPeriodicWatermarks} to emit watermarks periodically. Bare in mind that the
+	 * source can either have an {@link AssignerWithPunctuatedWatermarks} or an
+	 * {@link AssignerWithPeriodicWatermarks}, not both.
+	 */
+	public FlinkKafkaConsumerBase<T> setPeriodicWatermarkEmitter(AssignerWithPeriodicWatermarks<T> assigner) {
+		checkEmitterDuringInit();
+		this.periodicWatermarkAssigner = assigner;
+		return this;
+	}
+
+	/**
+	 * Processes the element after having been read from Kafka and deserialized, and updates the
+	 * last read offset for the specifies partition. These two actions should be performed in
+	 * an atomic way in order to guarantee exactly once semantics.
+	 * @param sourceContext
+	 *           The context the task operates in.
+	 * @param partDescriptor
+	 *            A descriptor containing the topic and the id of the partition.
+	 * @param value
+	 *           The element to process.
+	 * @param offset
+	 *           The offset of the element in the partition.
+	 * */
+	public void processElement(SourceContext<T> sourceContext, KafkaTopicPartition partDescriptor, T value, long offset) {
+		if (punctuatedWatermarkAssigner == null && periodicWatermarkAssigner == null) {
+			// the case where no watermark emitter is specified.
+			sourceContext.collect(value);
+		} else {
+
+			if (srcContext == null) {
+				srcContext = sourceContext;
+			}
+
+			long extractedTimestamp = extractTimestampAndEmitElement(partDescriptor, value);
+
+			// depending on the specified watermark emitter, either send a punctuated watermark,
+			// or set the timer for the first periodic watermark. In the periodic case, we set the timer
+			// only for the first watermark, as it is the trigger() that will set the subsequent ones.
+
+			if (punctuatedWatermarkAssigner != null) {
+				final Watermark nextWatermark = punctuatedWatermarkAssigner
+					.checkAndGetNextWatermark(value, extractedTimestamp);
+				if (nextWatermark != null) {
+					emitWatermarkIfMarkingProgress(sourceContext);
+				}
+			} else if(periodicWatermarkAssigner != null && runtime == null) {
+				runtime = (StreamingRuntimeContext) getRuntimeContext();
+				watermarkInterval = runtime.getExecutionConfig().getAutoWatermarkInterval();
+				if (watermarkInterval > 0) {
+					runtime.registerTimer(System.currentTimeMillis() + watermarkInterval, this);
+				}
+			}
+		}
+		updateOffsetForPartition(partDescriptor, offset);
+	}
+
+	/**
+	 * Extract the timestamp from the element based on the user-specified extractor,
+	 * emit the element with the new timestamp, and update the partition monitoring info (if necessary).
+	 * In more detail, upon reception of an element with a timestamp greater than the greatest timestamp
+	 * seen so far in that partition, this method updates the maximum timestamp seen for that partition,
+	 * and marks the partition as {@code active}, i.e. it still receives fresh data.
+	 * @param partDescriptor the partition the new element belongs to.
+	 * @param value the element to be forwarded.
+	 * @return the timestamp of the new element.
+	 */
+	private long extractTimestampAndEmitElement(KafkaTopicPartition partDescriptor, T value) {
+		long extractedTimestamp = getTimestampAssigner().extractTimestamp(value, Long.MIN_VALUE);
+		srcContext.collectWithTimestamp(value, extractedTimestamp);
+		updateMaximumTimestampForPartition(partDescriptor, extractedTimestamp);
+		return extractedTimestamp;
+	}
+
+	/**
+	 * Upon reception of an element with a timestamp greater than the greatest timestamp seen so far in the partition,
+	 * this method updates the maximum timestamp seen for that partition to {@code timestamp}, and marks the partition
+	 * as {@code active}, i.e. it still receives fresh data. If the partition is not known to the system, then a new
+	 * {@link KafkaPartitionState} is created and is associated to the new partition for future monitoring.
+	 * @param partDescriptor
+	 *            A descriptor containing the topic and the id of the partition.
+	 * @param timestamp
+	 *           The timestamp to set the minimum to, if smaller than the already existing one.
+	 * @return {@code true} if the minimum was updated successfully to {@code timestamp}, {@code false}
+	 *           if the previous value is smaller than the provided timestamp
+	 * */
+	private boolean updateMaximumTimestampForPartition(KafkaTopicPartition partDescriptor, long timestamp) {
+		KafkaPartitionState info = getOrInitializeInfo(partDescriptor);
+
+		if(timestamp > info.getMaxTimestamp()) {
+
+			// the flag is set to false as soon as the current partition's max timestamp is sent as a watermark.
+			// if then, and for that partition, only late elements arrive, then the max timestamp will stay the
+			// same, and it will keep the overall system from progressing.
+			// To avoid this, we only mark a partition as active on non-late elements.
+
+			info.setActive(true);
+			info.setMaxTimestamp(timestamp);
+			return  true;
+		}
+		return false;
+	}
+
+	/**
+	 * Updates the last read offset for the partition specified by the {@code partDescriptor} to {@code offset}.
+	 * If it is the first time we see the partition, then a new {@link KafkaPartitionState} is created to monitor
+	 * this specific partition.
+	 * @param partDescriptor the partition whose info to update.
+	 * @param offset the last read offset of the partition.
+	 */
+	public void updateOffsetForPartition(KafkaTopicPartition partDescriptor, long offset) {
+		KafkaPartitionState info = getOrInitializeInfo(partDescriptor);
+		info.setOffset(offset);
+	}
+
+	@Override
+	public void trigger(long timestamp) throws Exception {
+		if(this.srcContext == null) {
+			// if the trigger is called before any elements, then we
+			// just set the next timer to fire when it should and we
+			// ignore the triggering as this would produce no results.
+			setNextWatermarkTimer();
+			return;
+		}
+
+		// this is valid because this method is only called when watermarks
+		// are set to be emitted periodically.
+		final Watermark nextWatermark = periodicWatermarkAssigner.getCurrentWatermark();
+		if(nextWatermark != null) {
+			emitWatermarkIfMarkingProgress(srcContext);
+		}
+		setNextWatermarkTimer();
+	}
+
+	/**
+	 * Emits a new watermark, with timestamp equal to the minimum across all the maximum timestamps
+	 * seen per local partition (across all topics). The new watermark is emitted if and only if
+	 * it signals progress in event-time, i.e. if its timestamp is greater than the timestamp of
+	 * the last emitted watermark. In addition, this method marks as inactive the partition whose
+	 * timestamp was emitted as watermark, i.e. the one with the minimum across the maximum timestamps
+	 * of the local partitions. This is done to avoid not making progress because
+	 * a partition stopped receiving data. The partition is going to be marked as {@code active}
+	 * as soon as the <i>next non-late</i> element arrives.
+	 *
+	 * @return {@code true} if the Watermark was successfully emitted, {@code false} otherwise.
+	 */
+	private boolean emitWatermarkIfMarkingProgress(SourceFunction.SourceContext<T> sourceContext) {
+		Tuple2<KafkaTopicPartition, Long> globalMinTs = getMinTimestampAcrossAllTopics();
+		if(globalMinTs.f0 != null ) {
+			synchronized (sourceContext.getCheckpointLock()) {
+				long minTs = globalMinTs.f1;
+				if(minTs > lastEmittedWatermark) {
+					lastEmittedWatermark = minTs;
+					Watermark toEmit = new Watermark(minTs);
+					sourceContext.emitWatermark(toEmit);
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Kafka sources with timestamp extractors are expected to keep the maximum timestamp seen per
+	 * partition they are reading from. This is to mark the per-partition event-time progress.
+	 *
+	 * This method iterates this list, and returns the minimum timestamp across these per-partition
+	 * max timestamps, and across all topics. In addition to this information, it also returns the topic and
+	 * the partition within the topic the timestamp belongs to.
+	 */
+	private Tuple2<KafkaTopicPartition, Long> getMinTimestampAcrossAllTopics() {
+		Tuple2<KafkaTopicPartition, Long> minTimestamp = new Tuple2<>(null, Long.MAX_VALUE);
+		for(Map.Entry<KafkaTopicPartition, KafkaPartitionState> entries: partitionState.entrySet()) {
+			KafkaTopicPartition part = entries.getKey();
+			KafkaPartitionState info = entries.getValue();
+
+			if(partitionIsActive(part) && info.getMaxTimestamp() < minTimestamp.f1) {
+				minTimestamp.f0 = part;
+				minTimestamp.f1 = info.getMaxTimestamp();
+			}
+		}
+
+		if(minTimestamp.f0 != null) {
+			// it means that we have a winner and we have to set its flag to
+			// inactive, until its next non-late element.
+			KafkaTopicPartition partitionDescriptor = minTimestamp.f0;
+			setActiveFlagForPartition(partitionDescriptor, false);
+		}
+
+		return minTimestamp;
+	}
+
+	/**
+	 * Sets the {@code active} flag for a given partition of a topic to {@code isActive}.
+	 * This flag signals if the partition is still receiving data and it is used to avoid the case
+	 * where a partition stops receiving data, so its max seen timestamp does not advance, and it
+	 * holds back the progress of the watermark for all partitions. Note that if the partition is
+	 * not known to the system, then a new {@link KafkaPartitionState} is created and is associated
+	 * to the new partition for future monitoring.
+	 *
+	 * @param partDescriptor
+	 * 				A descriptor containing the topic and the id of the partition.
+	 * @param isActive
+	 * 				The value {@code true} or {@code false} to set the flag to.
+	 */
+	private void setActiveFlagForPartition(KafkaTopicPartition partDescriptor, boolean isActive) {
+		KafkaPartitionState info = getOrInitializeInfo(partDescriptor);
+		info.setActive(isActive);
+	}
+
+	/**
+	 * Gets the statistics for a given partition specified by the {@code partition} argument.
+	 * If it is the first time we see this partition, a new {@link KafkaPartitionState} data structure
+	 * is initialized to monitor it from now on. This method never throws a {@link NullPointerException}.
+	 * @param partition the partition to be fetched.
+	 * @return the gathered statistics for that partition.
+	 * */
+	private KafkaPartitionState getOrInitializeInfo(KafkaTopicPartition partition) {
+		KafkaPartitionState info = partitionState.get(partition);
+		if(info == null) {
+			info = new KafkaPartitionState(partition.getPartition(), FlinkKafkaConsumerBase.OFFSET_NOT_SET);
+			partitionState.put(partition, info);
+		}
+		return info;
+	}
+
+	/**
+	 * Checks if a partition of a topic is still active, i.e. if it still receives data.
+	 * @param partDescriptor
+	 *          A descriptor containing the topic and the id of the partition.
+	 * */
+	private boolean partitionIsActive(KafkaTopicPartition partDescriptor) {
+		KafkaPartitionState info = partitionState.get(partDescriptor);
+		if(info == null) {
+			throw new RuntimeException("Unknown Partition: Topic=" + partDescriptor.getTopic() +
+				" Partition=" + partDescriptor.getPartition());
+		}
+		return info.isActive();
+	}
+
+	private TimestampAssigner<T> getTimestampAssigner() {
+		checkEmitterStateAfterInit();
+		return periodicWatermarkAssigner != null ? periodicWatermarkAssigner : punctuatedWatermarkAssigner;
+	}
+
+	private void setNextWatermarkTimer() {
+		long timeToNextWatermark = System.currentTimeMillis() + watermarkInterval;
+		runtime.registerTimer(timeToNextWatermark, this);
+	}
+
+	private void checkEmitterDuringInit() {
+		if(periodicWatermarkAssigner != null) {
+			throw new RuntimeException("A periodic watermark emitter has already been provided.");
+		} else if(punctuatedWatermarkAssigner != null) {
+			throw new RuntimeException("A punctuated watermark emitter has already been provided.");
+		}
+	}
+
+	private void checkEmitterStateAfterInit() {
+		if(periodicWatermarkAssigner == null && punctuatedWatermarkAssigner == null) {
+			throw new RuntimeException("The timestamp assigner has not been initialized.");
+		} else if(periodicWatermarkAssigner != null && punctuatedWatermarkAssigner != null) {
+			throw new RuntimeException("The source can either have an assigner with punctuated " +
+				"watermarks or one with periodic watermarks, not both.");
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Checkpoint and restore
 	// ------------------------------------------------------------------------
 
+	HashMap<KafkaTopicPartition, KafkaPartitionState> restoreInfoFromCheckpoint() {
+		HashMap<KafkaTopicPartition, KafkaPartitionState> partInfo = new HashMap<>(restoreToOffset.size());
+		for(Map.Entry<KafkaTopicPartition, Long> offsets: restoreToOffset.entrySet()) {
+			KafkaTopicPartition key = offsets.getKey();
+			partInfo.put(key, new KafkaPartitionState(key.getPartition(), offsets.getValue()));
+		}
+		return partInfo;
+	}
+
 	@Override
 	public HashMap<KafkaTopicPartition, Long> snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
-		if (offsetsState == null) {
+		if (partitionState == null) {
 			LOG.debug("snapshotState() requested on not yet opened source; returning null.");
 			return null;
 		}
@@ -100,14 +434,15 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 			return null;
 		}
 
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("Snapshotting state. Offsets: {}, checkpoint id: {}, timestamp: {}",
-					KafkaTopicPartition.toString(offsetsState), checkpointId, checkpointTimestamp);
+		HashMap<KafkaTopicPartition, Long> currentOffsets = new HashMap<>();
+		for (Map.Entry<KafkaTopicPartition, KafkaPartitionState> entry: partitionState.entrySet()) {
+			currentOffsets.put(entry.getKey(), entry.getValue().getOffset());
 		}
 
-		// the use of clone() is okay here is okay, we just need a new map, the keys are not changed
-		//noinspection unchecked
-		HashMap<KafkaTopicPartition, Long> currentOffsets = (HashMap<KafkaTopicPartition, Long>) offsetsState.clone();
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Snapshotting state. Offsets: {}, checkpoint id: {}, timestamp: {}",
+					KafkaTopicPartition.toString(currentOffsets), checkpointId, checkpointTimestamp);
+		}
 
 		// the map cannot be asynchronously updated, because only one checkpoint call can happen
 		// on this function at a time: either snapshotState() or notifyCheckpointComplete()
@@ -128,7 +463,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 
 	@Override
 	public void notifyCheckpointComplete(long checkpointId) throws Exception {
-		if (offsetsState == null) {
+		if (partitionState == null) {
 			LOG.debug("notifyCheckpointComplete() called on uninitialized source");
 			return;
 		}

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaPartitionState.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaPartitionState.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internals;
+
+import java.io.Serializable;
+
+public class KafkaPartitionState implements Serializable {
+
+	private static final long serialVersionUID = 722083576322742328L;
+
+	private final int partitionID;
+	private long offset;
+
+	private long maxTimestamp = Long.MIN_VALUE;
+	private boolean isActive = false;
+
+	public KafkaPartitionState(int id, long offset) {
+		this.partitionID = id;
+		this.offset = offset;
+	}
+
+	public void setOffset(long offset) {
+		this.offset = offset;
+	}
+
+	public void setActive(boolean isActive) {
+		this.isActive = isActive;
+	}
+
+	public void setMaxTimestamp(long timestamp) {
+		maxTimestamp = timestamp;
+	}
+
+	public int getPartition() {
+		return partitionID;
+	}
+
+	public boolean isActive() {
+		return isActive;
+	}
+
+	public long getMaxTimestamp() {
+		return maxTimestamp;
+	}
+
+	public long getOffset() {
+		return offset;
+	}
+
+}

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
@@ -50,15 +51,21 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.testutils.DataGenerators;
 import org.apache.flink.streaming.connectors.kafka.testutils.DiscardingSink;
@@ -69,6 +76,7 @@ import org.apache.flink.streaming.connectors.kafka.testutils.PartitionValidating
 import org.apache.flink.streaming.connectors.kafka.testutils.ThrottledMapper;
 import org.apache.flink.streaming.connectors.kafka.testutils.Tuple2Partitioner;
 import org.apache.flink.streaming.connectors.kafka.testutils.ValidatingExactlyOnceSink;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchemaWrapper;
 import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
@@ -373,7 +381,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 		deleteTestTopic(topic);
 	}
-
 
 	/**
 	 * Tests the proper consumption when having a 1:1 correspondence between kafka partitions and
@@ -1441,6 +1448,231 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		@Override
 		public void restoreState(Integer state) {
 			this.numElementsTotal = state;
+		}
+	}
+
+	/////////////			Testing the Kafka consumer with embeded watermark generation functionality			///////////////
+
+	@RetryOnException(times=0, exception=kafka.common.NotLeaderForPartitionException.class)
+	public void runExplicitPunctuatedWMgeneratingConsumerTest(boolean emptyPartition) throws Exception {
+
+		final String topic1 = "wmExtractorTopic1_" + UUID.randomUUID().toString();
+		final String topic2 = "wmExtractorTopic2_" + UUID.randomUUID().toString();
+
+		final Map<String, Boolean> topics = new HashMap<>();
+		topics.put(topic1, false);
+		topics.put(topic2, emptyPartition);
+
+		final int noOfTopcis = topics.size();
+		final int partitionsPerTopic = 1;
+		final int elementsPerPartition = 100 + 1;
+
+		final int totalElements = emptyPartition ?
+			partitionsPerTopic * elementsPerPartition :
+			noOfTopcis * partitionsPerTopic * elementsPerPartition;
+
+		createTestTopic(topic1, partitionsPerTopic, 1);
+		createTestTopic(topic2, partitionsPerTopic, 1);
+
+		final StreamExecutionEnvironment env =
+			StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(partitionsPerTopic);
+		env.setRestartStrategy(RestartStrategies.noRestart()); // fail immediately
+		env.getConfig().disableSysoutLogging();
+
+		TypeInformation<Tuple2<Long, Integer>> longIntType = TypeInfoParser.parse("Tuple2<Long, Integer>");
+
+		Properties producerProperties = FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings);
+		producerProperties.setProperty("retries", "0");
+
+		putDataInTopics(env, producerProperties, elementsPerPartition, topics, longIntType);
+
+		List<String> topicTitles = new ArrayList<>(topics.keySet());
+		runPunctuatedComsumer(env, topicTitles, totalElements, longIntType);
+
+		executeAndCatchException(env, "runComsumerWithPunctuatedExplicitWMTest");
+
+		for(String topic: topicTitles) {
+			deleteTestTopic(topic);
+		}
+	}
+
+	private void executeAndCatchException(StreamExecutionEnvironment env, String execName) throws Exception {
+		try {
+			tryExecutePropagateExceptions(env, execName);
+		}
+		catch (ProgramInvocationException | JobExecutionException e) {
+			// look for NotLeaderForPartitionException
+			Throwable cause = e.getCause();
+
+			// search for nested SuccessExceptions
+			int depth = 0;
+			while (cause != null && depth++ < 20) {
+				if (cause instanceof kafka.common.NotLeaderForPartitionException) {
+					throw (Exception) cause;
+				}
+				cause = cause.getCause();
+			}
+			throw e;
+		}
+	}
+
+	private void putDataInTopics(StreamExecutionEnvironment env,
+								Properties producerProperties,
+								final int elementsPerPartition,
+								Map<String, Boolean> topics,
+								TypeInformation<Tuple2<Long, Integer>> outputTypeInfo) {
+		if(topics.size() != 2) {
+			throw new RuntimeException("This method accepts two topics as arguments.");
+		}
+
+		TypeInformationSerializationSchema<Tuple2<Long, Integer>> sinkSchema =
+			new TypeInformationSerializationSchema<>(outputTypeInfo, env.getConfig());
+
+		DataStream<Tuple2<Long, Integer>> stream = env
+			.addSource(new RichParallelSourceFunction<Tuple2<Long, Integer>>() {
+				private boolean running = true;
+
+				@Override
+				public void run(SourceContext<Tuple2<Long, Integer>> ctx) throws InterruptedException {
+					int topic = 0;
+					int currentTs = 1;
+
+					while (running && currentTs < elementsPerPartition) {
+						long timestamp = (currentTs % 10 == 0) ? -1L : currentTs;
+						ctx.collect(new Tuple2<Long, Integer>(timestamp, topic));
+						currentTs++;
+					}
+
+					Tuple2<Long, Integer> toWrite2 = new Tuple2<Long, Integer>(-1L, topic);
+					ctx.collect(toWrite2);
+				}
+
+				@Override
+				public void cancel() {
+				running = false;
+			}
+			}).setParallelism(1);
+
+		List<Map.Entry<String, Boolean>> topicsL = new ArrayList<>(topics.entrySet());
+		stream.map(new MapFunction<Tuple2<Long,Integer>, Tuple2<Long,Integer>>() {
+
+			@Override
+			public Tuple2<Long, Integer> map(Tuple2<Long, Integer> value) throws Exception {
+				return value;
+			}
+		}).setParallelism(1).addSink(kafkaServer.getProducer(topicsL.get(0).getKey(),
+			new KeyedSerializationSchemaWrapper<>(sinkSchema), producerProperties, null)).setParallelism(1);
+
+		if(!topicsL.get(1).getValue()) {
+			stream.map(new MapFunction<Tuple2<Long,Integer>, Tuple2<Long,Integer>>() {
+
+				@Override
+				public Tuple2<Long, Integer> map(Tuple2<Long, Integer> value) throws Exception {
+					long timestamp = (value.f0 == -1) ? -1L : 1000 + value.f0;
+					return new Tuple2<Long, Integer>(timestamp, 1);
+				}
+			}).setParallelism(1).addSink(kafkaServer.getProducer(topicsL.get(1).getKey(),
+				new KeyedSerializationSchemaWrapper<>(sinkSchema), producerProperties, null)).setParallelism(1);
+		}
+	}
+
+	private DataStreamSink<Tuple2<Long, Integer>> runPunctuatedComsumer(StreamExecutionEnvironment env,
+																		List<String> topics,
+																		final int totalElementsToExpect,
+																		TypeInformation<Tuple2<Long, Integer>> inputTypeInfo) {
+
+		TypeInformationSerializationSchema<Tuple2<Long, Integer>> sourceSchema =
+			new TypeInformationSerializationSchema<>(inputTypeInfo, env.getConfig());
+
+		FlinkKafkaConsumerBase<Tuple2<Long, Integer>> source = kafkaServer
+			.getConsumer(topics, sourceSchema, standardProps)
+			.setPunctuatedWatermarkEmitter(new TestPunctuatedTSExtractor());
+
+		DataStreamSource<Tuple2<Long, Integer>> consuming = env.setParallelism(1).addSource(source);
+
+		return consuming
+			.transform("testingWatermarkOperator", inputTypeInfo, new WMTestingOperator())
+			.addSink(new RichSinkFunction<Tuple2<Long, Integer>>() {
+
+				private int elementCount = 0;
+
+				@Override
+				public void invoke(Tuple2<Long, Integer> value) throws Exception {
+					elementCount++;
+					if (elementCount == totalElementsToExpect) {
+						throw new SuccessException();
+					}
+				}
+
+				@Override
+				public void close() throws Exception {
+					super.close();
+				}
+			});
+	}
+
+	/** An extractor that emits a Watermark whenever the timestamp <b>in the record</b> is equal to {@code -1}. */
+	private static class TestPunctuatedTSExtractor implements AssignerWithPunctuatedWatermarks<Tuple2<Long, Integer>> {
+
+		@Override
+		public Watermark checkAndGetNextWatermark(Tuple2<Long, Integer> lastElement, long extractedTimestamp) {
+			return (lastElement.f0 == -1) ? new Watermark(extractedTimestamp) : null;
+		}
+
+		@Override
+		public long extractTimestamp(Tuple2<Long, Integer> element, long previousElementTimestamp) {
+			return element.f0;
+		}
+	}
+
+	private static class WMTestingOperator extends AbstractStreamOperator<Tuple2<Long, Integer>> implements OneInputStreamOperator<Tuple2<Long, Integer>, Tuple2<Long, Integer>> {
+
+		private long lastReceivedWatermark = Long.MIN_VALUE;
+
+		private Map<Integer, Boolean> isEligible = new HashMap<>();
+		private Map<Integer, Long> perPartitionMaxTs = new HashMap<>();
+
+		WMTestingOperator() {
+			isEligible = new HashMap<>();
+			perPartitionMaxTs = new HashMap<>();
+		}
+
+		@Override
+		public void processElement(StreamRecord<Tuple2<Long, Integer>> element) throws Exception {
+			int partition = element.getValue().f1;
+			Long maxTs = perPartitionMaxTs.get(partition);
+			if(maxTs == null || maxTs < element.getValue().f0) {
+				perPartitionMaxTs.put(partition, element.getValue().f0);
+				isEligible.put(partition, element.getValue().f0 > lastReceivedWatermark);
+			}
+			output.collect(element);
+		}
+
+		@Override
+		public void processWatermark(Watermark mark) throws Exception {
+			int partition = -1;
+			long minTS = Long.MAX_VALUE;
+			for (Integer part : perPartitionMaxTs.keySet()) {
+				Long ts = perPartitionMaxTs.get(part);
+				if (ts < minTS && isEligible.get(part)) {
+					partition = part;
+					minTS = ts;
+					lastReceivedWatermark = ts;
+				}
+			}
+			isEligible.put(partition, false);
+
+			assertEquals(minTS, mark.getTimestamp());
+			output.emitWatermark(mark);
+		}
+
+		@Override
+		public void close() throws Exception {
+			super.close();
+			perPartitionMaxTs.clear();
+			isEligible.clear();
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AssignerWithPeriodicWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AssignerWithPeriodicWatermarks.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
  * 
  * <p>This class is used to generate watermarks in a periodical interval.
  * At most every {@code i} milliseconds (configured via
- * {@link ExecutionConfig#getAutoWatermarkInterval()}, the system will call the
+ * {@link ExecutionConfig#getAutoWatermarkInterval()}), the system will call the
  * {@link #getCurrentWatermark()} method to probe for the next watermark value.
  * The system will generate a new watermark, if the probed value is larger than
  * zero and larger than the previous watermark.


### PR DESCRIPTION
This PR solves issue FLINK-3375 and allows the user to embed her desired timestampExtractor (or Watermark emitter) in the Kafka source itself, and it makes the source responsible for synchronizing between the different partitions/topics  with lagging timestamps. 

In more detail, if a task handles two partitions, the first with timestamps of 0 to 100 and the other from 1000 to 2000, if it were to emit a watermark with timestamp equal to the maximum timestamp seen, then as soon as an element from the partition with the 1000 to 2000 timestamps arrives, it would render all elements in the other partition late. To avoid this, this source will monitor the per partition/topic max timestamps, and emit a watermark with a timestamp equal to the minimum across the max per partition per topic timestamps. The emission will be done in a periodic or a punctuates way, depending on the type of the timestamp extractor the user specified. 