### PR TITLE
[FLINK-3682] [cep] Assign processing timestamp in CEP operators

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -155,6 +155,13 @@ public class NFA<T> implements Serializable {
 			if(windowTime > 0) {
 				long pruningTimestamp = timestamp - windowTime;
 
+				// sanity check to guard against underflows
+				if (pruningTimestamp >= timestamp) {
+					throw new IllegalStateException("Detected an underflow in the pruning timestamp. This indicates that" +
+						" either the window length is too long (" + windowTime + ") or that the timestamp has not been" +
+						" set correctly (e.g. Long.MIN_VALUE).");
+				}
+
 				// remove all elements which are expired with respect to the window length
 				sharedBuffer.prune(pruningTimestamp);
 			}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractCEPPatternOperator.java
@@ -66,7 +66,7 @@ public abstract class AbstractCEPPatternOperator<IN>
 		if (isProcessingTime) {
 			// there can be no out of order elements in processing time
 			NFA<IN> nfa = getNFA();
-			processEvent(nfa, element.getValue(), element.getTimestamp());
+			processEvent(nfa, element.getValue(), System.currentTimeMillis());
 		} else {
 			PriorityQueue<StreamRecord<IN>> priorityQueue = getPriorityQueue();
 


### PR DESCRIPTION
This PR fixes the problem that the CEP operators did not assign the wall clock time
as the timestamp to incoming in StreamRecords if the TimeCharacteristic was set to
ProcessingTime. Processing element with a Long.MIN_VALUE timestamp can lead to underflows
in the NFA if a positive window length is subtracted from the timestamp. For this
underflow a sanity check has been added to notify the user with an exception about it.