### PR TITLE
[FLINK-3689] do not shutdown test ActorSystem

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -315,13 +315,7 @@ class TaskManager(
     case msg: StopCluster =>
       log.info(s"Stopping TaskManager with final application status ${msg.finalStatus()} " +
         s"and diagnostics: ${msg.message()}")
-      context.system.shutdown()
-
-      // Await actor system termination and shut down JVM
-      new ProcessShutDownThread(
-        log.logger,
-        context.system,
-        FiniteDuration(10, SECONDS)).start()
+      shutdown()
 
     case FatalError(message, cause) =>
       killTaskManagerFatal(message, cause)
@@ -1298,6 +1292,16 @@ class TaskManager(
     log.error("Error in leader retrieval service", exception)
 
     self ! decorateMessage(PoisonPill)
+  }
+
+  protected def shutdown(): Unit = {
+    context.system.shutdown()
+
+    // Await actor system termination and shut down JVM
+    new ProcessShutDownThread(
+      log.logger,
+      context.system,
+      FiniteDuration(10, SECONDS)).start()
   }
 }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ClusterShutdownITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ClusterShutdownITCase.java
@@ -18,46 +18,28 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.SavepointStore;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.StopCluster;
 import org.apache.flink.runtime.clusterframework.messages.StopClusterSuccessful;
-import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
-import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.instance.InstanceManager;
-import org.apache.flink.runtime.jobmanager.JobManager;
-import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
-import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
-import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.messages.Messages;
+import org.apache.flink.runtime.testingUtils.TestingMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.TestingResourceManager;
 import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 import scala.Option;
-import scala.concurrent.duration.FiniteDuration;
-
-import java.util.concurrent.ExecutorService;
-
-import static org.junit.Assert.assertTrue;
 
 
 /**
- * Starts a dedicated Actor system and runs a shutdown test to shut it down.
+ * Runs tests to ensure that a cluster is shutdown properly.
  */
-// The last test shuts down the actor system
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ClusterShutdownITCase extends TestLogger {
 
 	private static ActorSystem system;
@@ -75,10 +57,10 @@ public class ClusterShutdownITCase extends TestLogger {
 	}
 
 	/**
-	 * Tests a faked cluster shutdown procedure with and without the ResourceManager.
+	 * Tests a faked cluster shutdown procedure without the ResourceManager.
 	 */
 	@Test
-	public void testClusterShutdownScenarios() {
+	public void testClusterShutdownWithoutResourceManager() {
 
 		new JavaTestKit(system){{
 		new Within(duration("30 seconds")) {
@@ -90,37 +72,37 @@ public class ClusterShutdownITCase extends TestLogger {
 
 			// start job manager which doesn't shutdown the actor system
 			ActorGateway jobManager =
-				TestingUtils.createJobManager(system, config, TestJobManager.class, "fakeShutdown");
+				TestingUtils.createJobManager(system, config, "jobmanager1");
+
+			// Tell the JobManager to inform us of shutdown actions
+			jobManager.tell(TestingMessages.getNotifyOfComponentShutdown(), me);
+
+			// Register a TaskManager
+			ActorGateway taskManager =
+				TestingUtils.createTaskManager(system, jobManager, config, true, true);
+
+			// Tell the TaskManager to inform us of TaskManager shutdowns
+			taskManager.tell(TestingMessages.getNotifyOfComponentShutdown(), me);
+
 
 			// No resource manager connected
 			jobManager.tell(new StopCluster(ApplicationStatus.SUCCEEDED, "Shutting down."), me);
 
-			expectMsgClass(StopClusterSuccessful.class);
-
-			// Start resource manager and let it register
-			ActorGateway resourceManager =
-				TestingUtils.createResourceManager(system, jobManager.actor(), config);
-
-			// notify about a resource manager registration at the job manager
-			resourceManager.tell(new TestingResourceManager.NotifyWhenResourceManagerConnected(), me);
-
-			// Wait for resource manager
-			expectMsgEquals(Messages.getAcknowledge());
-
-			// Resource Manager connected
-			jobManager.tell(new StopCluster(ApplicationStatus.SUCCEEDED, "Shutting down."), me);
-
-			expectMsgClass(StopClusterSuccessful.class);
+			expectMsgAllOf(
+				new TestingMessages.ComponentShutdown(taskManager.actor()),
+				new TestingMessages.ComponentShutdown(jobManager.actor()),
+				StopClusterSuccessful.getInstance()
+			);
 
 		}};
 		}};
 	}
 
 	/**
-	 * Tests proper cluster shutdown procedure of RM.
+	 * Tests a faked cluster shutdown procedure with the ResourceManager.
 	 */
 	@Test
-	public void testProperClusterShutdown() {
+	public void testClusterShutdownWithResourceManager() {
 
 		new JavaTestKit(system){{
 		new Within(duration("30 seconds")) {
@@ -130,10 +112,26 @@ public class ClusterShutdownITCase extends TestLogger {
 			ActorGateway me =
 				TestingUtils.createForwardingActor(system, getTestActor(), Option.<String>empty());
 
-			ActorGateway jobManager = TestingUtils.createJobManager(system, config);
+			// start job manager which doesn't shutdown the actor system
+			ActorGateway jobManager =
+				TestingUtils.createJobManager(system, config, "jobmanager2");
 
+			// Tell the JobManager to inform us of shutdown actions
+			jobManager.tell(TestingMessages.getNotifyOfComponentShutdown(), me);
+
+			// Register a TaskManager
+			ActorGateway taskManager =
+				TestingUtils.createTaskManager(system, jobManager, config, true, true);
+
+			// Tell the TaskManager to inform us of TaskManager shutdowns
+			taskManager.tell(TestingMessages.getNotifyOfComponentShutdown(), me);
+
+			// Start resource manager and let it register
 			ActorGateway resourceManager =
 				TestingUtils.createResourceManager(system, jobManager.actor(), config);
+
+			// Tell the ResourceManager to inform us of ResourceManager shutdowns
+			resourceManager.tell(TestingMessages.getNotifyOfComponentShutdown(), me);
 
 			// notify about a resource manager registration at the job manager
 			resourceManager.tell(new TestingResourceManager.NotifyWhenResourceManagerConnected(), me);
@@ -141,63 +139,18 @@ public class ClusterShutdownITCase extends TestLogger {
 			// Wait for resource manager
 			expectMsgEquals(Messages.getAcknowledge());
 
+
+			// Shutdown cluster with resource manager connected
 			jobManager.tell(new StopCluster(ApplicationStatus.SUCCEEDED, "Shutting down."), me);
 
-			expectMsgClass(StopClusterSuccessful.class);
-
-			boolean isTerminated = false;
-			for (int i=0; i < 10 && !isTerminated; i++) {
-				isTerminated = system.isTerminated();
-				try {
-					Thread.sleep(1000);
-				} catch (InterruptedException e) {
-					// try again
-				}
-			}
-
-			assertTrue(isTerminated);
+			expectMsgAllOf(
+				new TestingMessages.ComponentShutdown(taskManager.actor()),
+				new TestingMessages.ComponentShutdown(jobManager.actor()),
+				new TestingMessages.ComponentShutdown(resourceManager.actor()),
+				StopClusterSuccessful.getInstance()
+			);
 
 		}};
 		}};
 	}
-
-	/**
-	 * A job manager which doesn't execute the final shutdown code
-	 */
-	private static class TestJobManager extends JobManager {
-
-		public TestJobManager(Configuration flinkConfiguration,
-			 ExecutorService executorService,
-			 InstanceManager instanceManager,
-			 Scheduler scheduler,
-			 BlobLibraryCacheManager libraryCacheManager,
-			 ActorRef archive,
-			 RestartStrategy defaultRestartStrategy,
-			 FiniteDuration timeout,
-			 LeaderElectionService leaderElectionService,
-			 SubmittedJobGraphStore submittedJobGraphs,
-			 CheckpointRecoveryFactory checkpointRecoveryFactory,
-			 SavepointStore savepointStore,
-			 FiniteDuration jobRecoveryTimeout) {
-			super(flinkConfiguration,
-			 executorService,
-			 instanceManager,
-			 scheduler,
-			 libraryCacheManager,
-			 archive,
-			 defaultRestartStrategy,
-			 timeout,
-			 leaderElectionService,
-			 submittedJobGraphs,
-			 checkpointRecoveryFactory,
-			 savepointStore,
-			 jobRecoveryTimeout);
-		}
-
-		@Override
-		public void shutdown() {
-			// do not shutdown
-		}
-	}
-
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingMessages.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.testingUtils
 
+import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 
 object TestingMessages {
@@ -31,4 +32,9 @@ object TestingMessages {
   def getAlive: AnyRef = Alive
 
   def getDisableDisconnect: AnyRef = DisableDisconnect
+
+  case object NotifyOfComponentShutdown
+  case class ComponentShutdown(ref: ActorRef)
+
+  def getNotifyOfComponentShutdown(): AnyRef = NotifyOfComponentShutdown
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerLike.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerLike.scala
@@ -18,24 +18,21 @@
 
 package org.apache.flink.runtime.testingUtils
 
-import akka.actor.{Terminated, ActorRef}
+import akka.actor.{ActorRef, Terminated}
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.FlinkActor
 import org.apache.flink.runtime.execution.ExecutionState
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
-import org.apache.flink.runtime.messages.JobManagerMessages.{ResponseLeaderSessionID,
-RequestLeaderSessionID}
+import org.apache.flink.runtime.messages.JobManagerMessages.{RequestLeaderSessionID, ResponseLeaderSessionID}
 import org.apache.flink.runtime.messages.Messages.{Acknowledge, Disconnect}
-import org.apache.flink.runtime.messages.RegistrationMessages.{AlreadyRegistered,
-AcknowledgeRegistration}
-import org.apache.flink.runtime.messages.TaskMessages.{SubmitTask, UpdateTaskExecutionState, TaskInFinalState}
+import org.apache.flink.runtime.messages.RegistrationMessages.{AcknowledgeRegistration, AlreadyRegistered}
+import org.apache.flink.runtime.messages.TaskMessages.{SubmitTask, TaskInFinalState, UpdateTaskExecutionState}
 import org.apache.flink.runtime.taskmanager.TaskManager
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobRemoved
-import org.apache.flink.runtime.testingUtils.TestingMessages.{DisableDisconnect, CheckIfJobRemoved, Alive}
+import org.apache.flink.runtime.testingUtils.TestingMessages._
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages._
 
 import scala.concurrent.duration._
-
 import language.postfixOps
 
 /** This mixin can be used to decorate a TaskManager with messages for testing purposes. */
@@ -53,6 +50,8 @@ trait TestingTaskManagerLike extends FlinkActor {
 
   /** Map of registered task submit listeners */
   val registeredSubmitTaskListeners = scala.collection.mutable.HashMap[JobID, ActorRef]()
+
+  val waitForShutdown = scala.collection.mutable.HashSet[ActorRef]()
 
   var disconnectDisabled = false
 
@@ -199,6 +198,9 @@ trait TestingTaskManagerLike extends FlinkActor {
     case DisableDisconnect =>
       disconnectDisabled = true
 
+    case NotifyOfComponentShutdown =>
+      waitForShutdown += sender()
+
     case msg @ UpdateTaskExecutionState(taskExecutionState) =>
       super.handleMessage(msg)
 
@@ -233,5 +235,14 @@ trait TestingTaskManagerLike extends FlinkActor {
             listener ! true
         }
       }
+  }
+
+  /**
+    * No killing of the VM for testing.
+    */
+  override protected def shutdown(): Unit = {
+    log.info("Shutting down TestingJobManager.")
+    waitForShutdown.foreach(_ ! ComponentShutdown(self))
+    waitForShutdown.clear()
   }
 }


### PR DESCRIPTION
Instead of shutting down the ActorSystem created in the test, we simply send a
message upon executing the shutdown method of the JobManager, TaskManager, and
ResourceManager. This ensures we can check for shutdown code execution without
interfering with the test.