### PR TITLE
[FLINK-3700] [core] Remove Guava as a dependency from "flink-core"

### DIFF
--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
@@ -21,7 +21,7 @@ import backtype.storm.Config;
 import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.tuple.Fields;
 
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.storm.api.FlinkLocalCluster;
 import org.apache.flink.storm.api.FlinkTopology;
 import org.apache.flink.storm.tests.operators.FiniteRandomSpout;

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -70,12 +70,6 @@ under the License.
 			<artifactId>${shading-artifact.name}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
 
 		<!-- test depedencies -->
 		

--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.api.common;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -43,6 +40,8 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Visitable;
 import org.apache.flink.util.Visitor;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
 /**
  * This class represents Flink programs, in the form of dataflow plans.
  *

--- a/flink-core/src/main/java/org/apache/flink/api/common/TaskInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/TaskInfo.java
@@ -20,8 +20,8 @@ package org.apache.flink.api.common;
 
 import org.apache.flink.annotation.Internal;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Encapsulates task-specific information: name, index of subtask, parallelism and attempt number.

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Future;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.TaskInfo;
@@ -44,6 +43,8 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.core.fs.Path;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A standalone implementation of the {@link RuntimeContext}, created by runtime UDF operators.
@@ -66,11 +67,11 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 										ExecutionConfig executionConfig,
 										Map<String, Accumulator<?,?>> accumulators,
 										Map<String, Future<Path>> cpTasks) {
-		this.taskInfo = Preconditions.checkNotNull(taskInfo);
+		this.taskInfo = checkNotNull(taskInfo);
 		this.userCodeClassLoader = userCodeClassLoader;
 		this.executionConfig = executionConfig;
-		this.distributedCache = new DistributedCache(Preconditions.checkNotNull(cpTasks));
-		this.accumulators = Preconditions.checkNotNull(accumulators);
+		this.distributedCache = new DistributedCache(checkNotNull(cpTasks));
+		this.accumulators = checkNotNull(accumulators);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -18,12 +18,7 @@
 
 package org.apache.flink.api.common.io;
 
-import java.io.IOException;
-import java.util.ArrayList;
-
 import org.apache.flink.annotation.Public;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -33,7 +28,12 @@ import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 
-import com.google.common.base.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 
 /**
  * Base implementation for input formats that split the input at a delimiter into records.
@@ -53,6 +53,9 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 	 * The log.
 	 */
 	private static final Logger LOG = LoggerFactory.getLogger(DelimitedInputFormat.class);
+
+	/** The default charset  to convert strings to bytes */
+	private static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
 	
 	/**
 	 * The default read buffer size = 1MB.
@@ -185,7 +188,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 	}
 	
 	public void setDelimiter(String delimiter) {
-		this.delimiter = delimiter.getBytes(Charsets.UTF_8);
+		this.delimiter = delimiter.getBytes(UTF_8_CHARSET);
 	}
 	
 	public int getLineLengthLimit() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -18,22 +18,10 @@
 
 package org.apache.flink.api.common.io;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.io.compression.DeflateInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.GzipInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -44,6 +32,20 @@ import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The base class for {@link RichInputFormat}s that read from files. For specific input types the
@@ -143,7 +145,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 * @return the extension of the file name or {@code null} if there is no extension.
 	 */
 	protected static String extractFileExtension(String fileName) {
-		Preconditions.checkNotNull(fileName);
+		checkNotNull(fileName);
 		int lastPeriodIndex = fileName.lastIndexOf('.');
 		if (lastPeriodIndex < 0){
 			return null;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -16,12 +16,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.api.common.io;
-
-import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FileInputSplit;
@@ -30,6 +25,7 @@ import org.apache.flink.types.parser.FieldParser;
 import org.apache.flink.types.parser.StringParser;
 import org.apache.flink.types.parser.StringValueParser;
 import org.apache.flink.util.InstantiationUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,12 +37,19 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 @Internal
 public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT> {
 
-	private static final Logger LOG = LoggerFactory.getLogger(GenericCsvInputFormat.class);
-	
 	private static final long serialVersionUID = 1L;
+	
+	
+	private static final Logger LOG = LoggerFactory.getLogger(GenericCsvInputFormat.class);
+
+	/** The default charset  to convert strings to bytes */
+	private static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
 	
 	private static final Class<?>[] EMPTY_TYPES = new Class<?>[0];
 	
@@ -127,7 +130,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	}
 
 	public void setCommentPrefix(String commentPrefix) {
-		setCommentPrefix(commentPrefix, Charsets.UTF_8);
+		setCommentPrefix(commentPrefix, UTF_8_CHARSET);
 	}
 
 	public void setCommentPrefix(String commentPrefix, String charsetName) throws IllegalCharsetNameException, UnsupportedCharsetException {
@@ -171,7 +174,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	}
 
 	public void setFieldDelimiter(String delimiter) {
-		this.fieldDelim = delimiter.getBytes(Charsets.UTF_8);
+		this.fieldDelim = delimiter.getBytes(UTF_8_CHARSET);
 	}
 
 	public boolean isLenient() {
@@ -247,9 +250,9 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	}
 	
 	protected void setFieldsGeneric(int[] sourceFieldIndices, Class<?>[] fieldTypes) {
-		Preconditions.checkNotNull(sourceFieldIndices);
-		Preconditions.checkNotNull(fieldTypes);
-		Preconditions.checkArgument(sourceFieldIndices.length == fieldTypes.length,
+		checkNotNull(sourceFieldIndices);
+		checkNotNull(fieldTypes);
+		checkArgument(sourceFieldIndices.length == fieldTypes.length,
 			"Number of field indices and field types must match.");
 
 		for (int i : sourceFieldIndices) {
@@ -258,7 +261,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 			}
 		}
 
-		int largestFieldIndex = Ints.max(sourceFieldIndices);
+		int largestFieldIndex = max(sourceFieldIndices);
 		this.fieldIncluded = new boolean[largestFieldIndex + 1];
 		ArrayList<Class<?>> types = new ArrayList<Class<?>>();
 
@@ -280,8 +283,8 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	}
 	
 	protected void setFieldsGeneric(boolean[] includedMask, Class<?>[] fieldTypes) {
-		Preconditions.checkNotNull(includedMask);
-		Preconditions.checkNotNull(fieldTypes);
+		checkNotNull(includedMask);
+		checkNotNull(fieldTypes);
 
 		ArrayList<Class<?>> types = new ArrayList<Class<?>>();
 
@@ -529,5 +532,15 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 
 			lastPos = positions[i];
 		}
+	}
+	
+	private static int max(int[] ints) {
+		checkArgument(ints.length > 0);
+		
+		int max = ints[0];
+		for (int i = 1 ; i < ints.length; i++) {
+			max = Math.max(max, ints[i]);
+		}
+		return max;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/GenericDataSinkBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/GenericDataSinkBase.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.api.common.operators;
 
 import java.util.List;
@@ -39,7 +38,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.types.Nothing;
 import org.apache.flink.util.Visitor;
 
-import com.google.common.base.Preconditions;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Operator for nodes that act as data sinks, storing the data they receive.
@@ -66,7 +65,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 	public GenericDataSinkBase(OutputFormat<IN> f, UnaryOperatorInformation<IN, Nothing> operatorInfo, String name) {
 		super(operatorInfo, name);
 
-		Preconditions.checkNotNull(f, "The OutputFormat may not be null.");
+		checkNotNull(f, "The OutputFormat may not be null.");
 		this.formatWrapper = new UserCodeObjectWrapper<OutputFormat<IN>>(f);
 	}
 
@@ -79,8 +78,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 	 */
 	public GenericDataSinkBase(UserCodeWrapper<? extends OutputFormat<IN>> f, UnaryOperatorInformation<IN, Nothing> operatorInfo, String name) {
 		super(operatorInfo, name);
-		Preconditions.checkNotNull(f, "The OutputFormat class may not be null.");
-		this.formatWrapper = f;
+		this.formatWrapper = checkNotNull(f, "The OutputFormat class may not be null.");
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -100,8 +98,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 	 * @param input The operator to use as the input.
 	 */
 	public void setInput(Operator<IN> input) {
-		Preconditions.checkNotNull(input, "The input may not be null.");
-		this.input = input;
+		this.input = checkNotNull(input, "The input may not be null.");
 	}
 
 	/**
@@ -112,7 +109,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 	 */
 	@Deprecated
 	public void setInputs(Operator<IN>... inputs) {
-		Preconditions.checkNotNull(inputs, "The inputs may not be null.");
+		checkNotNull(inputs, "The inputs may not be null.");
 		this.input = Operator.createUnionCascade(inputs);
 	}
 
@@ -124,7 +121,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 	 */
 	@Deprecated
 	public void setInputs(List<Operator<IN>> inputs) {
-		Preconditions.checkNotNull(inputs, "The inputs may not be null.");
+		checkNotNull(inputs, "The inputs may not be null.");
 		this.input = Operator.createUnionCascade(inputs);
 	}
 
@@ -136,7 +133,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 	 */
 	@Deprecated
 	public void addInput(Operator<IN>... inputs) {
-		Preconditions.checkNotNull(inputs, "The input may not be null.");
+		checkNotNull(inputs, "The input may not be null.");
 		this.input = Operator.createUnionCascade(this.input, inputs);
 	}
 
@@ -149,7 +146,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 	@SuppressWarnings("unchecked")
 	@Deprecated
 	public void addInputs(List<? extends Operator<IN>> inputs) {
-		Preconditions.checkNotNull(inputs, "The inputs may not be null.");
+		checkNotNull(inputs, "The inputs may not be null.");
 		this.input = createUnionCascade(this.input, (Operator<IN>[]) inputs.toArray(new Operator[inputs.size()]));
 	}
 
@@ -259,7 +256,7 @@ public class GenericDataSinkBase<IN> extends Operator<Nothing> {
 		format.configure(this.parameters);
 
 		if(format instanceof RichOutputFormat){
-			((RichOutputFormat) format).setRuntimeContext(ctx);
+			((RichOutputFormat<?>) format).setRuntimeContext(ctx);
 		}
 		format.open(0, 1);
 		for (IN element : inputData) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/Keys.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/Keys.java
@@ -18,10 +18,7 @@
 
 package org.apache.flink.api.common.operators;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.google.common.base.Joiner;
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.InvalidProgramException;
@@ -33,7 +30,11 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 
-import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 @Internal
 public abstract class Keys<T> {
@@ -232,7 +233,8 @@ public abstract class Keys<T> {
 			} else {
 				rangeCheckFields(keyPositions, type.getArity() - 1);
 			}
-			Preconditions.checkArgument(keyPositions.length > 0, "Grouping fields can not be empty at this point");
+			
+			checkArgument(keyPositions.length > 0, "Grouping fields can not be empty at this point");
 
 			// extract key field types
 			CompositeType<T> cType = (CompositeType<T>)type;
@@ -266,7 +268,7 @@ public abstract class Keys<T> {
 		 * Create String-based (nested) field expression keys on a composite type.
 		 */
 		public ExpressionKeys(String[] keyExpressions, TypeInformation<T> type) {
-			Preconditions.checkNotNull(keyExpressions, "Field expression cannot be null.");
+			checkNotNull(keyExpressions, "Field expression cannot be null.");
 
 			this.keyFields = new ArrayList<>(keyExpressions.length);
 
@@ -375,8 +377,7 @@ public abstract class Keys<T> {
 
 		@Override
 		public String toString() {
-			Joiner join = Joiner.on('.');
-			return "ExpressionKeys: " + join.join(keyFields);
+			return "ExpressionKeys: " + StringUtils.join(keyFields, '.');
 		}
 
 		public static boolean isSortKey(int fieldPos, TypeInformation<?> type) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/base/GroupCombineOperatorBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/base/GroupCombineOperatorBase.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.api.common.operators.base;
 
-import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.ArrayUtils;
+
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
@@ -42,6 +42,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Base operator for the combineGroup transformation. It receives the UDF GroupCombineFunction as an input.
@@ -109,7 +111,7 @@ public class GroupCombineOperatorBase<IN, OUT, FT extends GroupCombineFunction<I
 		}
 
 		if(sortColumns.length == 0) { // => all reduce. No comparator
-			Preconditions.checkArgument(sortOrderings.length == 0);
+			checkArgument(sortOrderings.length == 0);
 		} else {
 			final TypeComparator<IN> sortComparator = getTypeComparator(inputType, sortColumns, sortOrderings, executionConfig);
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/base/GroupReduceOperatorBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/base/GroupReduceOperatorBase.java
@@ -41,12 +41,12 @@ import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-import com.google.common.base.Preconditions;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * @see org.apache.flink.api.common.functions.GroupReduceFunction
@@ -181,7 +181,7 @@ public class GroupReduceOperatorBase<IN, OUT, FT extends GroupReduceFunction<IN,
 		}
 
 		if(sortColumns.length == 0) { // => all reduce. No comparator
-			Preconditions.checkArgument(sortOrderings.length == 0);
+			checkArgument(sortOrderings.length == 0);
 		} else {
 			final TypeComparator<IN> sortComparator = getTypeComparator(inputType, sortColumns, sortOrderings, executionConfig);
 			Collections.sort(inputData, new Comparator<IN>() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/FieldList.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/FieldList.java
@@ -16,15 +16,15 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.api.common.operators.util;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.Internal;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Immutable ordered list of fields IDs.
@@ -44,7 +44,7 @@ public class FieldList extends FieldSet {
 	}
 	
 	public FieldList(Integer fieldId) {
-		super(Collections.singletonList(Preconditions.checkNotNull(fieldId, "The fields ID must not be null.")));
+		super(Collections.singletonList(checkNotNull(fieldId, "The fields ID must not be null.")));
 	}
 	
 	public FieldList(int... columnIndexes) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/UserCodeObjectWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/UserCodeObjectWrapper.java
@@ -27,7 +27,8 @@ import java.lang.reflect.Modifier;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.NonSerializableUserCodeException;
 
-import com.google.common.base.Preconditions;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * This holds an actual object containing user defined code.
@@ -39,8 +40,8 @@ public class UserCodeObjectWrapper<T> implements UserCodeWrapper<T> {
 	private final T userCodeObject;
 	
 	public UserCodeObjectWrapper(T userCodeObject) {
-		Preconditions.checkNotNull(userCodeObject, "The user code object may not be null.");
-		Preconditions.checkArgument(userCodeObject instanceof Serializable, "User code object is not serializable: " + userCodeObject.getClass().getName());
+		checkNotNull(userCodeObject, "The user code object may not be null.");
+		checkArgument(userCodeObject instanceof Serializable, "User code object is not serializable: " + userCodeObject.getClass().getName());
 		
 		this.userCodeObject = userCodeObject;
 		

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfo.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -30,6 +29,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.StringArraySerializer;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 @Public
 public final class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
@@ -51,11 +52,10 @@ public final class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
 
 	private final Class<T> arrayClass;
 	private final TypeInformation<C> componentInfo;
-
-	@SuppressWarnings("unchecked")
+	
 	private BasicArrayTypeInfo(Class<T> arrayClass, BasicTypeInfo<C> componentInfo) {
-		this.arrayClass = Preconditions.checkNotNull(arrayClass);
-		this.componentInfo = Preconditions.checkNotNull(componentInfo);
+		this.arrayClass = checkNotNull(arrayClass);
+		this.componentInfo = checkNotNull(componentInfo);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicTypeInfo.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -54,6 +53,7 @@ import org.apache.flink.api.common.typeutils.base.StringComparator;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Type information for primitive types (int, long, double, byte, ...), String, Date, and Void.
@@ -87,9 +87,9 @@ public class BasicTypeInfo<T> extends TypeInformation<T> implements AtomicType<T
 	
 	
 	protected BasicTypeInfo(Class<T> clazz, Class<?>[] possibleCastTargetTypes, TypeSerializer<T> serializer, Class<? extends TypeComparator<T>> comparatorClass) {
-		this.clazz = Preconditions.checkNotNull(clazz);
-		this.possibleCastTargetTypes = Preconditions.checkNotNull(possibleCastTargetTypes);
-		this.serializer = Preconditions.checkNotNull(serializer);
+		this.clazz = checkNotNull(clazz);
+		this.possibleCastTargetTypes = checkNotNull(possibleCastTargetTypes);
+		this.serializer = checkNotNull(serializer);
 		// comparator can be null as in VOID_TYPE_INFO
 		this.comparatorClass = comparatorClass;
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/FractionalTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/FractionalTypeInfo.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.api.common.typeinfo;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-import java.util.Set;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Type information for numeric fractional primitive types (double, float).
@@ -34,15 +35,15 @@ public class FractionalTypeInfo<T> extends NumericTypeInfo<T> {
 
 	private static final long serialVersionUID = 554334260950199994L;
 
-	private static final Set<Class<?>> fractionalTypes = Sets.<Class<?>>newHashSet(
-			Double.class,
-			Float.class
-	);
+	private static final HashSet<Class<?>> fractionalTypes = new HashSet<Class<?>>(
+			Arrays.asList(
+				Double.class,
+				Float.class));
 
 	protected FractionalTypeInfo(Class<T> clazz, Class<?>[] possibleCastTargetTypes, TypeSerializer<T> serializer, Class<? extends TypeComparator<T>> comparatorClass) {
 		super(clazz, possibleCastTargetTypes, serializer, comparatorClass);
 
-		Preconditions.checkArgument(fractionalTypes.contains(clazz), "The given class " +
-			clazz.getSimpleName() + " is not a fractional type.");
+		checkArgument(fractionalTypes.contains(clazz), 
+				"The given class %s is not a fractional type.", clazz.getSimpleName());
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/IntegerTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/IntegerTypeInfo.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.api.common.typeinfo;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-import java.util.Set;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Type information for numeric integer primitive types: int, long, byte, short, character.
@@ -34,18 +35,18 @@ public class IntegerTypeInfo<T> extends NumericTypeInfo<T> {
 
 	private static final long serialVersionUID = -8068827354966766955L;
 
-	private static final Set<Class<?>> integerTypes = Sets.<Class<?>>newHashSet(
-			Integer.class,
-			Long.class,
-			Byte.class,
-			Short.class,
-			Character.class
-	);
+	private static final HashSet<Class<?>> integerTypes = new HashSet<Class<?>>(
+			Arrays.asList(
+				Integer.class,
+				Long.class,
+				Byte.class,
+				Short.class,
+				Character.class));
 
 	protected IntegerTypeInfo(Class<T> clazz, Class<?>[] possibleCastTargetTypes, TypeSerializer<T> serializer, Class<? extends TypeComparator<T>> comparatorClass) {
 		super(clazz, possibleCastTargetTypes, serializer, comparatorClass);
 
-		Preconditions.checkArgument(integerTypes.contains(clazz), "The given class " +
-		clazz.getSimpleName() + " is not a integer type.");
+		checkArgument(integerTypes.contains(clazz),
+				"The given class %s is not a integer type.", clazz.getSimpleName());
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NumericTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NumericTypeInfo.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.api.common.typeinfo;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-import java.util.Set;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Type information for numeric primitive types: int, long, double, byte, short, float, char.
@@ -34,21 +35,21 @@ public abstract class NumericTypeInfo<T> extends BasicTypeInfo<T> {
 
 	private static final long serialVersionUID = -5937777910658986986L;
 
-	private static final Set<Class<?>> numericalTypes = Sets.<Class<?>>newHashSet(
-			Integer.class,
-			Long.class,
-			Double.class,
-			Byte.class,
-			Short.class,
-			Float.class,
-			Character.class
-	);
+	private static final HashSet<Class<?>> numericalTypes = new HashSet<Class<?>>(
+			Arrays.asList(
+				Integer.class,
+				Long.class,
+				Double.class,
+				Byte.class,
+				Short.class,
+				Float.class,
+				Character.class));
 
 	protected NumericTypeInfo(Class<T> clazz, Class<?>[] possibleCastTargetTypes, TypeSerializer<T> serializer, Class<? extends
 			TypeComparator<T>> comparatorClass) {
 		super(clazz, possibleCastTargetTypes, serializer, comparatorClass);
 
-		Preconditions.checkArgument(numericalTypes.contains(clazz), "The given class " +
-				clazz.getSimpleName() + " is not a numerical type.");
+		checkArgument(numericalTypes.contains(clazz), 
+				"The given class %s is not a numerical type", clazz.getSimpleName());
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/PrimitiveArrayTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/PrimitiveArrayTypeInfo.java
@@ -18,13 +18,8 @@
 
 package org.apache.flink.api.common.typeinfo;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
-import com.google.common.base.Preconditions;
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -45,6 +40,13 @@ import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerial
 import org.apache.flink.api.common.typeutils.base.array.PrimitiveArrayComparator;
 import org.apache.flink.api.common.typeutils.base.array.ShortPrimitiveArrayComparator;
 import org.apache.flink.api.common.typeutils.base.array.ShortPrimitiveArraySerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A {@link TypeInformation} for arrays of primitive types (int, long, double, ...).
@@ -83,11 +85,11 @@ public class PrimitiveArrayTypeInfo<T> extends TypeInformation<T> implements Ato
 	 * @param comparatorClass The class of the array comparator
 	 */
 	private PrimitiveArrayTypeInfo(Class<T> arrayClass, TypeSerializer<T> serializer, Class<? extends PrimitiveArrayComparator<T, ?>> comparatorClass) {
-		this.arrayClass = Preconditions.checkNotNull(arrayClass);
-		this.serializer = Preconditions.checkNotNull(serializer);
-		this.comparatorClass = Preconditions.checkNotNull(comparatorClass);
+		this.arrayClass = checkNotNull(arrayClass);
+		this.serializer = checkNotNull(serializer);
+		this.comparatorClass = checkNotNull(comparatorClass);
 
-		Preconditions.checkArgument(
+		checkArgument(
 			arrayClass.isArray() && arrayClass.getComponentType().isPrimitive(),
 			"Class must represent an array of primitives");
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeType.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeType.java
@@ -22,13 +22,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.AtomicType;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Base type information class for Tuple and Pojo types
@@ -44,7 +44,7 @@ public abstract class CompositeType<T> extends TypeInformation<T> {
 
 	@PublicEvolving
 	public CompositeType(Class<T> typeClass) {
-		this.typeClass = Preconditions.checkNotNull(typeClass);
+		this.typeClass = checkNotNull(typeClass);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
@@ -22,11 +22,12 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.reflect.Method;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 @Internal
 public final class EnumSerializer<T extends Enum<T>> extends TypeSerializer<T> {
@@ -38,7 +39,7 @@ public final class EnumSerializer<T extends Enum<T>> extends TypeSerializer<T> {
 	private final Class<T> enumClass;
 
 	public EnumSerializer(Class<T> enumClass) {
-		this.enumClass = Preconditions.checkNotNull(enumClass);
+		this.enumClass = checkNotNull(enumClass);
 		this.values = createValues(enumClass);
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
@@ -21,11 +21,12 @@ package org.apache.flink.api.common.typeutils.base;
 import java.io.IOException;
 import java.lang.reflect.Array;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A serializer for arrays of objects.
@@ -45,8 +46,8 @@ public final class GenericArraySerializer<C> extends TypeSerializer<C[]> {
 	
 	
 	public GenericArraySerializer(Class<C> componentClass, TypeSerializer<C> componentSerializer) {
-		this.componentClass = Preconditions.checkNotNull(componentClass);
-		this.componentSerializer = Preconditions.checkNotNull(componentSerializer);
+		this.componentClass = checkNotNull(componentClass);
+		this.componentSerializer = checkNotNull(componentSerializer);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.AtomicType;
@@ -27,7 +27,8 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.EnumComparator;
 import org.apache.flink.api.common.typeutils.base.EnumSerializer;
-import org.apache.flink.annotation.Public;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A {@link TypeInformation} for java enumeration types. 
@@ -43,7 +44,7 @@ public class EnumTypeInfo<T extends Enum<T>> extends TypeInformation<T> implemen
 
 	@PublicEvolving
 	public EnumTypeInfo(Class<T> typeClass) {
-		Preconditions.checkNotNull(typeClass, "Enum type class must not be null.");
+		checkNotNull(typeClass, "Enum type class must not be null.");
 
 		if (!Enum.class.isAssignableFrom(typeClass) ) {
 			throw new IllegalArgumentException("EnumTypeInfo can only be used for subclasses of " + Enum.class.getName());

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -29,6 +28,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.GenericTypeComparator;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 @Public
 public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType<T> {
@@ -39,7 +39,7 @@ public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType
 
 	@PublicEvolving
 	public GenericTypeInfo(Class<T> typeClass) {
-		this.typeClass = Preconditions.checkNotNull(typeClass);
+		this.typeClass = checkNotNull(typeClass);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfo.java
@@ -27,7 +27,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
 
-import com.google.common.base.Preconditions;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 @Public
 public class ObjectArrayTypeInfo<T, C> extends TypeInformation<T> {
@@ -38,8 +39,8 @@ public class ObjectArrayTypeInfo<T, C> extends TypeInformation<T> {
 	private final TypeInformation<C> componentInfo;
 
 	private ObjectArrayTypeInfo(Class<T> arrayType, TypeInformation<C> componentInfo) {
-		this.arrayType = Preconditions.checkNotNull(arrayType);
-		this.componentInfo = Preconditions.checkNotNull(componentInfo);
+		this.arrayType = checkNotNull(arrayType);
+		this.componentInfo = checkNotNull(componentInfo);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -128,9 +129,9 @@ public class ObjectArrayTypeInfo<T, C> extends TypeInformation<T> {
 
 	@PublicEvolving
 	public static <T, C> ObjectArrayTypeInfo<T, C> getInfoFor(Class<T> arrayClass, TypeInformation<C> componentInfo) {
-		Preconditions.checkNotNull(arrayClass);
-		Preconditions.checkNotNull(componentInfo);
-		Preconditions.checkArgument(arrayClass.isArray(), "Class " + arrayClass + " must be an array.");
+		checkNotNull(arrayClass);
+		checkNotNull(componentInfo);
+		checkArgument(arrayClass.isArray(), "Class " + arrayClass + " must be an array.");
 
 		return new ObjectArrayTypeInfo<T, C>(arrayClass, componentInfo);
 	}
@@ -146,7 +147,7 @@ public class ObjectArrayTypeInfo<T, C> extends TypeInformation<T> {
 	@SuppressWarnings("unchecked")
 	@PublicEvolving
 	public static <T, C> ObjectArrayTypeInfo<T, C> getInfoFor(TypeInformation<C> componentInfo) {
-		Preconditions.checkNotNull(componentInfo);
+		checkNotNull(componentInfo);
 
 		return new ObjectArrayTypeInfo<T, C>(
 			(Class<T>)Array.newInstance(componentInfo.getTypeClass(), 0).getClass(),

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoField.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoField.java
@@ -25,9 +25,10 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Represent a field definition for {@link PojoTypeInfo} type of objects.
@@ -41,8 +42,8 @@ public class PojoField implements Serializable {
 	private final TypeInformation<?> type;
 
 	public PojoField(Field field, TypeInformation<?> type) {
-		this.field = Preconditions.checkNotNull(field);
-		this.type = Preconditions.checkNotNull(type);
+		this.field = checkNotNull(field);
+		this.type = checkNotNull(type);
 	}
 
 	public Field getField() {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
@@ -18,19 +18,9 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.google.common.base.Preconditions;
-
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.Keys.ExpressionKeys;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -40,9 +30,19 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.AvroSerializer;
 import org.apache.flink.api.java.typeutils.runtime.PojoComparator;
 import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
-
-import com.google.common.base.Joiner;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * TypeInformation for "Java Beans"-style types. Flink refers to them as POJOs,
@@ -78,8 +78,8 @@ public class PojoTypeInfo<T> extends CompositeType<T> {
 	public PojoTypeInfo(Class<T> typeClass, List<PojoField> fields) {
 		super(typeClass);
 
-		Preconditions.checkArgument(Modifier.isPublic(typeClass.getModifiers()),
-				"POJO " + typeClass + " is not public");
+		checkArgument(Modifier.isPublic(typeClass.getModifiers()),
+				"POJO %s is not public", typeClass);
 
 		this.fields = fields.toArray(new PojoField[fields.size()]);
 
@@ -350,7 +350,7 @@ public class PojoTypeInfo<T> extends CompositeType<T> {
 			fieldStrings.add(field.getField().getName() + ": " + field.getTypeInformation().toString());
 		}
 		return "PojoType<" + getTypeClass().getName()
-				+ ", fields = [" + Joiner.on(", ").join(fieldStrings) + "]"
+				+ ", fields = [" + StringUtils.join(fieldStrings, ", ") + "]"
 				+ ">";
 	}
 
@@ -381,15 +381,15 @@ public class PojoTypeInfo<T> extends CompositeType<T> {
 
 		@Override
 		public TypeComparator<T> createTypeComparator(ExecutionConfig config) {
-			Preconditions.checkState(
+			checkState(
 				keyFields.size() > 0,
 				"No keys were defined for the PojoTypeComparatorBuilder.");
 
-			Preconditions.checkState(
+			checkState(
 				fieldComparators.size() > 0,
 				"No type comparators were defined for the PojoTypeComparatorBuilder.");
 
-			Preconditions.checkState(
+			checkState(
 				keyFields.size() == fieldComparators.size(),
 				"Number of key fields and field comparators is not equal.");
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -22,23 +22,25 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-//CHECKSTYLE.OFF: AvoidStarImport - Needed for TupleGenerator
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.*;
 import org.apache.flink.api.java.typeutils.runtime.Tuple0Serializer;
-//CHECKSTYLE.ON: AvoidStarImport
 import org.apache.flink.api.java.typeutils.runtime.TupleComparator;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.types.Value;
+
+//CHECKSTYLE.OFF: AvoidStarImport - Needed for TupleGenerator
+import org.apache.flink.api.java.tuple.*;
+//CHECKSTYLE.ON: AvoidStarImport
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link TypeInformation} for the tuple types of the Java API.
@@ -62,7 +64,7 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 	public TupleTypeInfo(Class<T> tupleType, TypeInformation<?>... types) {
 		super(tupleType, types);
 
-		Preconditions.checkArgument(
+		checkArgument(
 			types.length <= Tuple.MAX_ARITY,
 			"The tuple type exceeds the maximum supported arity.");
 
@@ -131,24 +133,24 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 
 		@Override
 		public TypeComparator<T> createTypeComparator(ExecutionConfig config) {
-			Preconditions.checkState(
+			checkState(
 				fieldComparators.size() > 0,
 				"No field comparators were defined for the TupleTypeComparatorBuilder."
 			);
 
-			Preconditions.checkState(
+			checkState(
 				logicalKeyFields.size() > 0,
 				"No key fields were defined for the TupleTypeComparatorBuilder."
 			);
 
-			Preconditions.checkState(
+			checkState(
 				fieldComparators.size() == logicalKeyFields.size(),
 				"The number of field comparators and key fields is not equal."
 			);
 
 			final int maxKey = Collections.max(logicalKeyFields);
 
-			Preconditions.checkState(
+			checkState(
 				maxKey >= 0,
 				"The maximum key field must be greater or equal than 0."
 			);
@@ -160,7 +162,7 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 			}
 
 			return new TupleComparator<T>(
-				Ints.toArray(logicalKeyFields),
+				listToPrimitives(logicalKeyFields),
 				fieldComparators.toArray(new TypeComparator[fieldComparators.size()]),
 				fieldSerializers
 			);
@@ -254,5 +256,13 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 
 
 		return (TupleTypeInfo<X>) new TupleTypeInfo<>(infos);
+	}
+	
+	private static int[] listToPrimitives(ArrayList<Integer> ints) {
+		int[] result = new int[ints.size()];
+		for (int i = 0; i < result.length; i++) {
+			result[i] = ints.get(i);
+		}
+		return result;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -23,11 +23,11 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Preconditions;
-
 import org.apache.flink.api.common.operators.Keys.ExpressionKeys;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 
@@ -52,7 +52,7 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	public TupleTypeInfoBase(Class<T> tupleType, TypeInformation<?>... types) {
 		super(tupleType);
 
-		this.types = Preconditions.checkNotNull(types);
+		this.types = checkNotNull(types);
 
 		int fieldCounter = 0;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -66,7 +66,7 @@ import org.apache.hadoop.io.Writable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A utility for reflection analysis on classes, to determine the return type of implementations of transformation
@@ -902,7 +902,7 @@ public class TypeExtractor {
 		if (isClassType(originalType)) {
 			originalTypeAsClass = typeToClass(originalType);
 		}
-		Preconditions.checkNotNull(originalTypeAsClass, "originalType has an unexpected type");
+		checkNotNull(originalTypeAsClass, "originalType has an unexpected type");
 		// check if the class we assumed to conform to the defining type so far is actually a pojo because the
 		// original type contains additional fields.
 		// check for additional fields.
@@ -1466,7 +1466,7 @@ public class TypeExtractor {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private <OUT,IN1,IN2> TypeInformation<OUT> privateGetForClass(Class<OUT> clazz, ArrayList<Type> typeHierarchy,
 			ParameterizedType parameterizedType, TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
-		Preconditions.checkNotNull(clazz);
+		checkNotNull(clazz);
 
 		// Object is handled as generic type info
 		if (clazz.equals(Object.class)) {
@@ -1822,7 +1822,7 @@ public class TypeExtractor {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private <X> TypeInformation<X> privateGetForObject(X value) {
-		Preconditions.checkNotNull(value);
+		checkNotNull(value);
 
 		// check if we can extract the types from tuples, otherwise work with the class
 		if (value instanceof Tuple) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
@@ -18,9 +18,8 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import com.google.common.base.Preconditions;
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.AtomicType;
@@ -43,6 +42,9 @@ import org.apache.flink.types.NullValue;
 import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Type information for data types that extend the {@link Value} interface. The value
@@ -70,11 +72,11 @@ public class ValueTypeInfo<T extends Value> extends TypeInformation<T> implement
 
 	@PublicEvolving
 	public ValueTypeInfo(Class<T> type) {
-		this.type = Preconditions.checkNotNull(type);
+		this.type = checkNotNull(type);
 
-		Preconditions.checkArgument(
+		checkArgument(
 			Value.class.isAssignableFrom(type) || type.equals(Value.class),
-			"ValueTypeInfo can only be used for subclasses of " + Value.class.getName());
+			"ValueTypeInfo can only be used for subclasses of %s", Value.class.getName());
 	}
 	
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/WritableTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/WritableTypeInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -29,7 +28,11 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.WritableComparator;
 import org.apache.flink.api.java.typeutils.runtime.WritableSerializer;
+
 import org.apache.hadoop.io.Writable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Type information for data types that extend Hadoop's {@link Writable} interface. The Writable
@@ -46,11 +49,11 @@ public class WritableTypeInfo<T extends Writable> extends TypeInformation<T> imp
 
 	@PublicEvolving
 	public WritableTypeInfo(Class<T> typeClass) {
-		this.typeClass = Preconditions.checkNotNull(typeClass);
+		this.typeClass = checkNotNull(typeClass);
 
-		Preconditions.checkArgument(
+		checkArgument(
 			Writable.class.isAssignableFrom(typeClass) && !typeClass.equals(Writable.class),
-			"WritableTypeInfo can only be used for subclasses of " + Writable.class.getName());
+			"WritableTypeInfo can only be used for subclasses of %s", Writable.class.getName());
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
@@ -20,11 +20,11 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
-import com.google.common.base.Preconditions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.reflect.ReflectDatumWriter;
 import org.apache.avro.util.Utf8;
+
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
 import org.apache.flink.core.memory.DataInputView;
@@ -34,6 +34,7 @@ import org.apache.flink.util.InstantiationUtil;
 import com.esotericsoftware.kryo.Kryo;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * General purpose serialization. Currently using Apache Avro's Reflect-serializers for serialization and
@@ -66,8 +67,8 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 	}
 	
 	public AvroSerializer(Class<T> type, Class<? extends T> typeToInstantiate) {
-		this.type = Preconditions.checkNotNull(type);
-		this.typeToInstantiate = Preconditions.checkNotNull(typeToInstantiate);
+		this.type = checkNotNull(type);
+		this.typeToInstantiate = checkNotNull(typeToInstantiate);
 		
 		InstantiationUtil.checkForInstantiation(typeToInstantiate);
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
@@ -20,13 +20,13 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.CopyableValue;
 import org.apache.flink.util.InstantiationUtil;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 public class CopyableValueSerializer<T extends CopyableValue<T>> extends TypeSerializer<T> {
 
@@ -39,7 +39,7 @@ public class CopyableValueSerializer<T extends CopyableValue<T>> extends TypeSer
 	
 	
 	public CopyableValueSerializer(Class<T> valueClass) {
-		this.valueClass = Preconditions.checkNotNull(valueClass);
+		this.valueClass = checkNotNull(valueClass);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -40,6 +39,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 public final class PojoSerializer<T> extends TypeSerializer<T> {
 
@@ -75,11 +75,11 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			Field[] fields,
 			ExecutionConfig executionConfig) {
 
-		this.clazz = Preconditions.checkNotNull(clazz);
-		this.fieldSerializers = (TypeSerializer<Object>[]) Preconditions.checkNotNull(fieldSerializers);
-		this.fields = Preconditions.checkNotNull(fields);
+		this.clazz = checkNotNull(clazz);
+		this.fieldSerializers = (TypeSerializer<Object>[]) checkNotNull(fieldSerializers);
+		this.fields = checkNotNull(fields);
 		this.numFields = fieldSerializers.length;
-		this.executionConfig = Preconditions.checkNotNull(executionConfig);
+		this.executionConfig = checkNotNull(executionConfig);
 
 		LinkedHashSet<Class<?>> registeredPojoTypes = executionConfig.getRegisteredPojoTypes();
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -27,6 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 
@@ -42,8 +42,8 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 
 	@SuppressWarnings("unchecked")
 	public TupleSerializerBase(Class<T> tupleClass, TypeSerializer<?>[] fieldSerializers) {
-		this.tupleClass = Preconditions.checkNotNull(tupleClass);
-		this.fieldSerializers = (TypeSerializer<Object>[]) Preconditions.checkNotNull(fieldSerializers);
+		this.tupleClass = checkNotNull(tupleClass);
+		this.fieldSerializers = (TypeSerializer<Object>[]) checkNotNull(fieldSerializers);
 		this.arity = fieldSerializers.length;
 	}
 	

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import java.io.IOException;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -29,6 +28,8 @@ import org.apache.flink.util.InstantiationUtil;
 
 import com.esotericsoftware.kryo.Kryo;
 import org.objenesis.strategy.StdInstantiatorStrategy;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Serializer for {@link Value} types. Uses the value's serialization methods, and uses
@@ -49,7 +50,7 @@ public class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 	// --------------------------------------------------------------------------------------------
 	
 	public ValueSerializer(Class<T> type) {
-		this.type = Preconditions.checkNotNull(type);
+		this.type = checkNotNull(type);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -25,9 +25,9 @@ import com.esotericsoftware.kryo.factories.ReflectionSerializerFactory;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.JavaSerializer;
-import com.google.common.base.Preconditions;
 
 import org.apache.avro.generic.GenericData;
+
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.DataInputViewStream;
@@ -36,7 +36,9 @@ import org.apache.flink.api.java.typeutils.runtime.NoFetchingInput;
 import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers.SpecificInstanceCollectionSerializerForArrayList;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+
 import org.objenesis.strategy.StdInstantiatorStrategy;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +53,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A type serializer that serializes its type using the Kryo serialization
@@ -92,7 +96,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 	// ------------------------------------------------------------------------
 
 	public KryoSerializer(Class<T> type, ExecutionConfig executionConfig){
-		this.type = Preconditions.checkNotNull(type);
+		this.type = checkNotNull(type);
 
 		this.defaultSerializers = executionConfig.getDefaultKryoSerializers();
 		this.defaultSerializerClasses = executionConfig.getDefaultKryoSerializerClasses();

--- a/flink-core/src/main/java/org/apache/flink/types/StringValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/StringValue.java
@@ -28,7 +28,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 
-import com.google.common.base.Preconditions;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Mutable string data type that implements the Key interface.
@@ -147,7 +147,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 * @param value The new string value.
 	 */
 	public void setValue(CharSequence value) {
-		Preconditions.checkNotNull(value);
+		checkNotNull(value);
 		setValue(value, 0, value.length());
 	}
 	
@@ -158,7 +158,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 */
 	@Override
 	public void setValue(StringValue value) {
-		Preconditions.checkNotNull(value);
+		checkNotNull(value);
 		setValue(value.value, 0, value.len);
 	}
 
@@ -170,7 +170,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 * @param len The length of the substring.
 	 */
 	public void setValue(StringValue value, int offset, int len) {
-		Preconditions.checkNotNull(value);
+		checkNotNull(value);
 		setValue(value.value, offset, len);
 	}
 	
@@ -182,7 +182,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 * @param len The length of the substring.
 	 */
 	public void setValue(CharSequence value, int offset, int len) {
-		Preconditions.checkNotNull(value);
+		checkNotNull(value);
 		if (offset < 0 || len < 0 || offset > value.length() - len) {
 			throw new IndexOutOfBoundsException("offset: " + offset + " len: " + len + " value.len: " + len);
 		}
@@ -204,7 +204,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 * @param buffer The character buffer to read the characters from.
 	 */
 	public void setValue(CharBuffer buffer) {
-		Preconditions.checkNotNull(buffer);
+		checkNotNull(buffer);
 		final int len = buffer.length();
 		ensureSize(len);
 		buffer.get(this.value, 0, len);
@@ -220,7 +220,7 @@ public class StringValue implements NormalizableKey<StringValue>, CharSequence, 
 	 * @param len The length of the substring.
 	 */
 	public void setValue(char[] chars, int offset, int len) {
-		Preconditions.checkNotNull(chars);
+		checkNotNull(chars);
 		if (offset < 0 || len < 0 || offset > chars.length - len) {
 			throw new IndexOutOfBoundsException();
 		}

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -16,7 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 
 /**
  * This is a utility class to deal with temporary files.
@@ -34,11 +39,7 @@ public final class FileUtils {
 	 */
 	private static final int LENGTH = 12;
 
-	/**
-	 * Empty private constructor to avoid instantiation.
-	 */
-	private FileUtils() {
-	}
+	
 
 	/**
 	 * Constructs a random filename with the given prefix and
@@ -58,4 +59,33 @@ public final class FileUtils {
 
 		return stringBuilder.toString();
 	}
+	
+	// ------------------------------------------------------------------------
+	//  Simple reading and writing of files
+	// ------------------------------------------------------------------------
+	
+	public static String readFile(File file, String charsetName) throws IOException {
+		byte[] bytes = Files.readAllBytes(file.toPath());
+		return new String(bytes, charsetName);
+	}
+
+	public static String readFileUtf8(File file) throws IOException {
+		return readFile(file, "UTF-8");
+	}
+
+	public static void writeFile(File file, String contents, String encoding) throws IOException {
+		byte[] bytes = contents.getBytes(encoding);
+		Files.write(file.toPath(), bytes, StandardOpenOption.WRITE);
+	}
+	
+	public static void writeFileUtf8(File file, String contents) throws IOException {
+		writeFile(file, contents, "UTF-8");
+	}
+	
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Private default constructor to avoid instantiation.
+	 */
+	private FileUtils() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
@@ -16,8 +16,7 @@
  * limitations under the License.
  */
 
-
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,16 +32,12 @@ import org.slf4j.Logger;
  */
 public final class IOUtils {
 
-	/**
-	 * The block size for byte operations in byte.
-	 */
+	/** The block size for byte operations in byte. */
 	private static final int BLOCKSIZE = 4096;
-
-	/**
-	 * Private constructor to overwrite the public one.
-	 */
-	private IOUtils() {
-	}
+	
+	// ------------------------------------------------------------------------
+	//  Byte copy operations
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Copies from one stream to another.
@@ -114,6 +109,10 @@ public final class IOUtils {
 		copyBytes(in, out, BLOCKSIZE, close);
 	}
 
+	// ------------------------------------------------------------------------
+	//  Stream input skipping
+	// ------------------------------------------------------------------------
+	
 	/**
 	 * Reads len bytes in a loop.
 	 * 
@@ -161,6 +160,10 @@ public final class IOUtils {
 		}
 	}
 
+	// ------------------------------------------------------------------------
+	//  Silent I/O cleanup / closing
+	// ------------------------------------------------------------------------
+	
 	/**
 	 * Close the Closeable objects and <b>ignore</b> any {@link IOException} or
 	 * null pointers. Must only be used for cleanup in exception handlers.
@@ -210,4 +213,11 @@ public final class IOUtils {
 			}
 		}
 	}
+	
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Private constructor to prevent instantiation.
+	 */
+	private IOUtils() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
@@ -16,8 +16,7 @@
  * limitations under the License.
  */
 
-
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
 
 /**
  * Collection of simple mathematical routines.

--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -18,9 +18,8 @@
 
 package org.apache.flink.util;
 
-import com.google.common.collect.Iterators;
-import com.google.common.net.InetAddresses;
 import org.apache.flink.annotation.Internal;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,9 +32,9 @@ import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 
 @Internal
 public class NetUtils {
@@ -116,8 +115,6 @@ public class NetUtils {
 	/**
 	 * Encodes an IP address properly as a URL string. This method makes sure that IPv6 addresses
 	 * have the proper formatting to be included in URLs.
-	 * <p>
-	 * This method internally uses Guava's functionality to properly encode IPv6 addresses.
 	 * 
 	 * @param address The IP address to encode.
 	 * @return The proper URL string encoded IP address.
@@ -130,7 +127,7 @@ public class NetUtils {
 			return address.getHostAddress();
 		}
 		else if (address instanceof Inet6Address) {
-			return '[' + InetAddresses.toAddrString(address) + ']';
+			return getIPv6UrlRepresentation((Inet6Address) address);
 		}
 		else {
 			throw new IllegalArgumentException("Unrecognized type of InetAddress: " + address);
@@ -178,6 +175,70 @@ public class NetUtils {
 	}
 
 	/**
+	 * Creates a compressed URL style representation of an Inet6Address.
+	 * 
+	 * <p>This method copies and adopts code from Google's Guava library.
+	 * We re-implement this here in order to reduce dependency on Guava.
+	 * The Guava library has frequently caused dependency conflicts in the past.
+	 */
+	private static String getIPv6UrlRepresentation(Inet6Address address) {
+		// first, convert bytes to 16 bit chunks
+		byte[] addressBytes = address.getAddress();
+		int[] hextets = new int[8];
+		for (int i = 0; i < hextets.length; i++) {
+			hextets[i] = (addressBytes[2 * i] & 0xFF) << 8 | (addressBytes[2 * i + 1] & 0xFF);
+		}
+
+		// now, find the sequence of zeros that should be compressed
+		int bestRunStart = -1;
+		int bestRunLength = -1;
+		int runStart = -1;
+		for (int i = 0; i < hextets.length + 1; i++) {
+			if (i < hextets.length && hextets[i] == 0) {
+				if (runStart < 0) {
+					runStart = i;
+				}
+			} else if (runStart >= 0) {
+				int runLength = i - runStart;
+				if (runLength > bestRunLength) {
+					bestRunStart = runStart;
+					bestRunLength = runLength;
+				}
+				runStart = -1;
+			}
+		}
+		if (bestRunLength >= 2) {
+			Arrays.fill(hextets, bestRunStart, bestRunStart + bestRunLength, -1);
+		}
+
+		// convert into text form
+		StringBuilder buf = new StringBuilder(40);
+		buf.append('[');
+		
+		boolean lastWasNumber = false;
+		for (int i = 0; i < hextets.length; i++) {
+			boolean thisIsNumber = hextets[i] >= 0;
+			if (thisIsNumber) {
+				if (lastWasNumber) {
+					buf.append(':');
+				}
+				buf.append(Integer.toHexString(hextets[i]));
+			} else {
+				if (i == 0 || lastWasNumber) {
+					buf.append("::");
+				}
+			}
+			lastWasNumber = thisIsNumber;
+		}
+		buf.append(']');
+		return buf.toString();
+	}
+	
+	// ------------------------------------------------------------------------
+	//  Port range parsing
+	// ------------------------------------------------------------------------
+	
+	/**
 	 * Returns an iterator over available ports defined by the range definition.
 	 *
 	 * @param rangeDefinition String describing a single port, a range of ports or multiple ranges.
@@ -186,14 +247,16 @@ public class NetUtils {
 	 */
 	public static Iterator<Integer> getPortRangeFromString(String rangeDefinition) throws NumberFormatException {
 		final String[] ranges = rangeDefinition.trim().split(",");
-		List<Iterator<Integer>> iterators = new ArrayList<>(ranges.length);
-		for(String rawRange: ranges) {
+		
+		UnionIterator<Integer> iterators = new UnionIterator<>();
+		
+		for (String rawRange: ranges) {
 			Iterator<Integer> rangeIterator;
 			String range = rawRange.trim();
 			int dashIdx = range.indexOf('-');
 			if (dashIdx == -1) {
 				// only one port in range:
-				rangeIterator = Iterators.singletonIterator(Integer.valueOf(range));
+				rangeIterator = Collections.singleton(Integer.valueOf(range)).iterator();
 			} else {
 				// evaluate range
 				final int start = Integer.valueOf(range.substring(0, dashIdx));
@@ -218,7 +281,8 @@ public class NetUtils {
 			}
 			iterators.add(rangeIterator);
 		}
-		return Iterators.concat(iterators.iterator());
+		
+		return iterators;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/util/Preconditions.java
+++ b/flink-core/src/main/java/org/apache/flink/util/Preconditions.java
@@ -107,7 +107,7 @@ public final class Preconditions {
 	}
 
 	// ------------------------------------------------------------------------
-	//  Boolean Condition Checking
+	//  Boolean Condition Checking (Argument)
 	// ------------------------------------------------------------------------
 	
 	/**
@@ -162,6 +162,61 @@ public final class Preconditions {
 		}
 	}
 
+	// ------------------------------------------------------------------------
+	//  Boolean Condition Checking (State)
+	// ------------------------------------------------------------------------
+	
+	/**
+	 * Checks the given boolean condition, and throws an {@code IllegalStateException} if
+	 * the condition is not met (evaluates to {@code false}).
+	 *
+	 * @param condition The condition to check
+	 *
+	 * @throws IllegalStateException Thrown, if the condition is violated.
+	 */
+	public static void checkState(boolean condition) {
+		if (!condition) {
+			throw new IllegalStateException();
+		}
+	}
+
+	/**
+	 * Checks the given boolean condition, and throws an {@code IllegalStateException} if
+	 * the condition is not met (evaluates to {@code false}). The exception will have the
+	 * given error message.
+	 *
+	 * @param condition The condition to check
+	 * @param errorMessage The message for the {@code IllegalStateException} that is thrown if the check fails.
+	 *
+	 * @throws IllegalStateException Thrown, if the condition is violated.
+	 */
+	public static void checkState(boolean condition, @Nullable Object errorMessage) {
+		if (!condition) {
+			throw new IllegalStateException(String.valueOf(errorMessage));
+		}
+	}
+
+	/**
+	 * Checks the given boolean condition, and throws an {@code IllegalStateException} if
+	 * the condition is not met (evaluates to {@code false}).
+	 *
+	 * @param condition The condition to check
+	 * @param errorMessageTemplate The message template for the {@code IllegalStateException}
+	 *                             that is thrown if the check fails. The template substitutes its
+	 *                             {@code %s} placeholders with the error message arguments.
+	 * @param errorMessageArgs The arguments for the error message, to be inserted into the
+	 *                         message template for the {@code %s} placeholders.
+	 *
+	 * @throws IllegalStateException Thrown, if the condition is violated.
+	 */
+	public static void checkState(boolean condition,
+			@Nullable String errorMessageTemplate,
+			@Nullable Object... errorMessageArgs) {
+
+		if (!condition) {
+			throw new IllegalStateException(format(errorMessageTemplate, errorMessageArgs));
+		}
+	}
 
 	// ------------------------------------------------------------------------
 	//  Utilities

--- a/flink-core/src/main/java/org/apache/flink/util/Preconditions.java
+++ b/flink-core/src/main/java/org/apache/flink/util/Preconditions.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+//  This class is largely adapted from "com.google.common.base.Preconditions",
+//  which is part of the "Guava" library.
+//
+//  Because of frequent issues with dependency conflicts, this class was
+//  added to the Flink code base to reduce dependency on Guava.
+// ----------------------------------------------------------------------------
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.Nullable;
+
+/**
+ * A collection of static utility methods to validate input.
+ * 
+ * <p>This class is modelled after Google Guava's Preconditions class, and partly takes code
+ * from that class. We add this code to the Flink code base in order to reduce external
+ * dependencies.
+ */
+@Internal
+public final class Preconditions {
+
+	// ------------------------------------------------------------------------
+	//  Null checks
+	// ------------------------------------------------------------------------
+	
+	/**
+	 * Ensures that the given object reference is not null.
+	 * Upon violation, a {@code NullPointerException} with no message is thrown.
+	 * 
+	 * @param reference The object reference
+	 * @return The object reference itself (generically typed).
+	 * 
+	 * @throws NullPointerException Thrown, if the passed reference was null.
+	 */
+	public static <T> T checkNotNull(T reference) {
+		if (reference == null) {
+			throw new NullPointerException();
+		}
+		return reference;
+	}
+	
+	/**
+	 * Ensures that the given object reference is not null.
+	 * Upon violation, a {@code NullPointerException} with the given message is thrown.
+	 * 
+	 * @param reference The object reference
+	 * @param errorMessage The message for the {@code NullPointerException} that is thrown if the check fails.
+	 * @return The object reference itself (generically typed).
+	 *
+	 * @throws NullPointerException Thrown, if the passed reference was null.
+	 */
+	public static <T> T checkNotNull(T reference, @Nullable String errorMessage) {
+		if (reference == null) {
+			throw new NullPointerException(String.valueOf(errorMessage));
+		}
+		return reference;
+	}
+
+	/**
+	 * Ensures that the given object reference is not null.
+	 * Upon violation, a {@code NullPointerException} with the given message is thrown.
+	 * 
+	 * <p>The error message is constructed from a template and an arguments array, after
+	 * a similar fashion as {@link String#format(String, Object...)}, but supporting only
+	 * {@code %s} as a placeholder.
+	 *
+	 * @param reference The object reference
+	 * @param errorMessageTemplate The message template for the {@code NullPointerException}
+	 *                             that is thrown if the check fails. The template substitutes its
+	 *                             {@code %s} placeholders with the error message arguments.
+	 * @param errorMessageArgs The arguments for the error message, to be inserted into the
+	 *                         message template for the {@code %s} placeholders.
+	 *                         
+	 * @return The object reference itself (generically typed).
+	 *
+	 * @throws NullPointerException Thrown, if the passed reference was null.
+	 */
+	public static <T> T checkNotNull(T reference,
+				@Nullable String errorMessageTemplate,
+				@Nullable Object... errorMessageArgs) {
+		
+		if (reference == null) {
+			throw new NullPointerException(format(errorMessageTemplate, errorMessageArgs));
+		}
+		return reference;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Boolean Condition Checking
+	// ------------------------------------------------------------------------
+	
+	/**
+	 * Checks the given boolean condition, and throws an {@code IllegalArgumentException} if
+	 * the condition is not met (evaluates to {@code false}).
+	 *
+	 * @param condition The condition to check
+	 *                     
+	 * @throws IllegalArgumentException Thrown, if the condition is violated.
+	 */
+	public static void checkArgument(boolean condition) {
+		if (!condition) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	/**
+	 * Checks the given boolean condition, and throws an {@code IllegalArgumentException} if
+	 * the condition is not met (evaluates to {@code false}). The exception will have the
+	 * given error message.
+	 *
+	 * @param condition The condition to check
+	 * @param errorMessage The message for the {@code IllegalArgumentException} that is thrown if the check fails.
+	 * 
+	 * @throws IllegalArgumentException Thrown, if the condition is violated.
+	 */
+	public static void checkArgument(boolean condition, @Nullable Object errorMessage) {
+		if (!condition) {
+			throw new IllegalArgumentException(String.valueOf(errorMessage));
+		}
+	}
+
+	/**
+	 * Checks the given boolean condition, and throws an {@code IllegalArgumentException} if
+	 * the condition is not met (evaluates to {@code false}).
+	 *
+	 * @param condition The condition to check
+	 * @param errorMessageTemplate The message template for the {@code IllegalArgumentException}
+	 *                             that is thrown if the check fails. The template substitutes its
+	 *                             {@code %s} placeholders with the error message arguments.
+	 * @param errorMessageArgs The arguments for the error message, to be inserted into the
+	 *                         message template for the {@code %s} placeholders.
+	 * 
+	 * @throws IllegalArgumentException Thrown, if the condition is violated.
+	 */
+	public static void checkArgument(boolean condition,
+			@Nullable String errorMessageTemplate,
+			@Nullable Object... errorMessageArgs) {
+		
+		if (!condition) {
+			throw new IllegalArgumentException(format(errorMessageTemplate, errorMessageArgs));
+		}
+	}
+
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A simplified formatting method. Similar to {@link String#format(String, Object...)}, but
+	 * with lower overhead (only String parameters, no locale, no format validation).
+	 * 
+	 * <p>This method is taken quasi verbatim from the Guava Preconditions class.
+	 */
+	private static String format(@Nullable String template, @Nullable Object... args) {
+		final int numArgs = args == null ? 0 : args.length;
+		template = String.valueOf(template); // null -> "null"
+		
+		// start substituting the arguments into the '%s' placeholders
+		StringBuilder builder = new StringBuilder(template.length() + 16 * numArgs);
+		int templateStart = 0;
+		int i = 0;
+		while (i < numArgs) {
+			int placeholderStart = template.indexOf("%s", templateStart);
+			if (placeholderStart == -1) {
+				break;
+			}
+			builder.append(template.substring(templateStart, placeholderStart));
+			builder.append(args[i++]);
+			templateStart = placeholderStart + 2;
+		}
+		builder.append(template.substring(templateStart));
+
+		// if we run out of placeholders, append the extra args in square braces
+		if (i < numArgs) {
+			builder.append(" [");
+			builder.append(args[i++]);
+			while (i < numArgs) {
+				builder.append(", ");
+				builder.append(args[i++]);
+			}
+			builder.append(']');
+		}
+
+		return builder.toString();
+	}
+	
+	// ------------------------------------------------------------------------
+
+	/** Private constructor to prevent instantiation */
+	private Preconditions() {}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/UnionIterator.java
+++ b/flink-core/src/main/java/org/apache/flink/util/UnionIterator.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
-
-import org.apache.flink.util.TraversableOnceException;
+package org.apache.flink.util;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,9 +27,9 @@ public class UnionIterator<T> implements Iterator<T>, Iterable<T> {
 	
 	private Iterator<T> currentIterator;
 	
-	private ArrayList<List<T>> furtherLists = new ArrayList<>();
+	private ArrayList<Iterator<T>> furtherIterators = new ArrayList<>();
 	
-	private int nextList;
+	private int nextIterator;
 	
 	private boolean iteratorAvailable = true;
 
@@ -39,17 +37,21 @@ public class UnionIterator<T> implements Iterator<T>, Iterable<T> {
 	
 	public void clear() {
 		currentIterator = null;
-		furtherLists.clear();
-		nextList = 0;
+		furtherIterators.clear();
+		nextIterator = 0;
 		iteratorAvailable = true;
 	}
 	
 	public void addList(List<T> list) {
+		add(list.iterator());
+	}
+
+	public void add(Iterator<T> iterator) {
 		if (currentIterator == null) {
-			currentIterator = list.iterator();
+			currentIterator = iterator;
 		}
 		else {
-			furtherLists.add(list);
+			furtherIterators.add(iterator);
 		}
 	}
 	
@@ -71,9 +73,9 @@ public class UnionIterator<T> implements Iterator<T>, Iterable<T> {
 			if (currentIterator.hasNext()) {
 				return true;
 			}
-			else if (nextList < furtherLists.size()) {
-				currentIterator = furtherLists.get(nextList).iterator();
-				nextList++;
+			else if (nextIterator < furtherIterators.size()) {
+				currentIterator = furtherIterators.get(nextIterator);
+				nextIterator++;
 			}
 			else {
 				currentIterator = null;

--- a/flink-core/src/main/java/org/apache/flink/util/XORShiftRandom.java
+++ b/flink-core/src/main/java/org/apache/flink/util/XORShiftRandom.java
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.util;
 
-import com.google.common.hash.Hashing;
 import org.apache.flink.annotation.Public;
 
 import java.util.Random;
@@ -42,7 +42,7 @@ public class XORShiftRandom extends Random {
 
 	public XORShiftRandom(long input) {
 		super(input);
-		this.seed = Hashing.murmur3_128().hashLong(input).asLong();
+		this.seed = MathUtils.murmurHash((int) input) ^ MathUtils.murmurHash((int) (input >>> 32));
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/base/OuterJoinOperatorBaseTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/base/OuterJoinOperatorBaseTest.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.api.common.operators.base;
 
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
-import com.google.common.base.Joiner;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.operators.BinaryOperatorInformation;
@@ -39,7 +37,7 @@ public class OuterJoinOperatorBaseTest implements Serializable {
 	private final FlatJoinFunction<String, String, String> joiner = new FlatJoinFunction<String, String, String>() {
 		@Override
 		public void join(String first, String second, Collector<String> out) throws Exception {
-			out.collect(Joiner.on(',').join(String.valueOf(first), String.valueOf(second)));
+			out.collect(String.valueOf(first) + ',' + String.valueOf(second));
 		}
 	};
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -18,8 +18,7 @@
 
 package org.apache.flink.api.java.tuple;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import org.apache.flink.util.FileUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -85,7 +84,7 @@ class TupleGenerator {
 	}
 
 	private static void insertCodeIntoFile(String code, File file) throws IOException {
-		String fileContent = Files.toString(file, Charsets.UTF_8);
+		String fileContent = FileUtils.readFileUtf8(file);
 		
 		try (Scanner s = new Scanner(fileContent)) {
 			StringBuilder sb = new StringBuilder();
@@ -126,7 +125,7 @@ class TupleGenerator {
 			while (s.hasNextLine() && (line = s.nextLine()) != null) {
 				sb.append(line).append("\n");
 			}
-			Files.write(sb.toString(), file, Charsets.UTF_8);
+			FileUtils.writeFileUtf8(file, sb.toString());
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.flink.api.common.functions.MapFunction;
@@ -36,8 +37,6 @@ import org.apache.flink.api.java.typeutils.TypeInfoParserTest.MyWritable;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.collect.HashMultiset;
 
 /**
  *  Pojo Type tests
@@ -87,7 +86,7 @@ public class PojoTypeExtractionTest {
 	// all public test
 	public static class AllPublic extends ComplexNestedClass {
 		public ArrayList<String> somethingFancy; // generic type
-		public HashMultiset<Integer> fancyIds; // generic type
+		public FancyCollectionSubtype<Integer> fancyIds; // generic type
 		public String[]	fancyArray;			 // generic type
 	}
 
@@ -436,7 +435,7 @@ public class PojoTypeExtractionTest {
 				}
 				multisetSeen = true;
 				Assert.assertTrue(field.getTypeInformation() instanceof GenericTypeInfo);
-				Assert.assertEquals(HashMultiset.class, field.getTypeInformation().getTypeClass());
+				Assert.assertEquals(FancyCollectionSubtype.class, field.getTypeInformation().getTypeClass());
 			} else if(name.equals("fancyArray")) {
 				if(strArraySeen) {
 					Assert.fail("already seen");
@@ -808,5 +807,11 @@ public class PojoTypeExtractionTest {
 		TupleTypeInfo<?> tti = ((TupleTypeInfo) ti);
 		Assert.assertTrue(tti.getTypeAt(0) instanceof PojoTypeInfo);
 		Assert.assertTrue(tti.getTypeAt(1) instanceof PojoTypeInfo);
+	}
+	
+	// ------------------------------------------------------------------------
+	
+	public static class FancyCollectionSubtype<T> extends HashSet<T> {
+		private static final long serialVersionUID = -3494469602638179921L;
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java.typeutils.runtime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 import org.apache.flink.api.common.ExecutionConfig;
@@ -36,10 +37,9 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.base.Objects;
 
 /**
  * A test for the {@link PojoSerializer}.
@@ -104,7 +104,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
 		@Override
 		public int hashCode() {
-			return Objects.hashCode(dumm1, dumm2, dumm3, dumm4, nestedClass);
+			return Objects.hash(dumm1, dumm2, dumm3, dumm4, nestedClass);
 		}
 
 		@Override
@@ -162,7 +162,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
 		@Override
 		public int hashCode() {
-			return Objects.hashCode(dumm1, dumm2, dumm3, dumm4);
+			return Objects.hash(dumm1, dumm2, dumm3, dumm4);
 		}
 
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
@@ -18,14 +18,15 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import com.google.common.base.Objects;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+
 import org.junit.Test;
 
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -88,7 +89,7 @@ public class PojoSubclassSerializerTest extends SerializerTestBase<PojoSubclassS
 
 		@Override
 		public int hashCode() {
-			return Objects.hashCode(dumm1, dumm2);
+			return Objects.hash(dumm1, dumm2);
 		}
 
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/SubclassFromInterfaceSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/SubclassFromInterfaceSerializerTest.java
@@ -18,15 +18,16 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import com.google.common.base.Objects;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+
 import org.junit.Test;
 
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -90,7 +91,7 @@ public class SubclassFromInterfaceSerializerTest extends SerializerTestBase<Subc
 
 		@Override
 		public int hashCode() {
-			return Objects.hashCode(dumm1, dumm2);
+			return Objects.hash(dumm1, dumm2);
 		}
 
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/testutils/junit/RetryRule.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/junit/RetryRule.java
@@ -22,11 +22,12 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A rule to retry failed tests for a fixed number of times.

--- a/flink-core/src/test/java/org/apache/flink/util/MathUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/MathUtilTest.java
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
+import org.apache.flink.util.MathUtils;
 import org.junit.Test;
 
 public class MathUtilTest {

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -18,17 +18,13 @@
 
 package org.apache.flink.util;
 
-import com.google.common.collect.DiscreteDomain;
-import com.google.common.collect.Iterators;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.core.IsCollectionContaining.hasItems;

--- a/flink-core/src/test/java/org/apache/flink/util/UnionIteratorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/UnionIteratorTest.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
 
 import org.apache.flink.util.TraversableOnceException;
+import org.apache.flink.util.UnionIterator;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -23,7 +23,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.util.IOUtils;
+import org.apache.flink.util.IOUtils;
 import org.slf4j.Logger;
 
 import java.io.EOFException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -25,7 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.util.IOUtils;
+import org.apache.flink.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FileSystemStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FileSystemStateStore.java
@@ -22,7 +22,7 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.filesystem.FileSerializableStateHandle;
-import org.apache.flink.runtime.util.FileUtils;
+import org.apache.flink.util.FileUtils;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -42,7 +42,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
-import org.apache.flink.runtime.util.IOUtils;
+import org.apache.flink.util.IOUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelInputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelInputView.java
@@ -29,7 +29,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.BlockChannelReader;
 import org.apache.flink.runtime.memory.AbstractPagedInputView;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 /**
  * A {@link org.apache.flink.core.memory.DataInputView} that is backed by a {@link BlockChannelReader},

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/RandomAccessInputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/RandomAccessInputView.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.SeekableDataInputView;
 import org.apache.flink.runtime.memory.AbstractPagedInputView;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 
 public class RandomAccessInputView extends AbstractPagedInputView implements SeekableDataInputView {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/RandomAccessOutputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/RandomAccessOutputView.java
@@ -24,7 +24,7 @@ import java.io.EOFException;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.SeekableDataOutputView;
 import org.apache.flink.runtime.memory.AbstractPagedOutputView;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SeekableFileChannelInputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SeekableFileChannelInputView.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.memory.AbstractPagedInputView;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 /**
  * A {@link org.apache.flink.core.memory.DataInputView} that is backed by a {@link BlockChannelReader},

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SimpleCollectingOutputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SimpleCollectingOutputView.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentSource;
 import org.apache.flink.runtime.memory.AbstractPagedOutputView;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 /**
  * The list with the full segments contains at any point all completely full segments, plus the segment that is

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -33,7 +33,7 @@ import org.apache.flink.core.memory.HeapMemorySegment;
 import org.apache.flink.core.memory.HybridMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 /**
  * The memory manager governs the memory that Flink uses for sorting, hashing, and caching. Memory

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
@@ -33,7 +33,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.memory.ListMemorySegmentSource;
 import org.apache.flink.runtime.util.IntArrayList;
 import org.apache.flink.runtime.util.LongArrayList;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.MutableObjectIterator;
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/HashPartition.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.memory.AbstractPagedInputView;
 import org.apache.flink.runtime.memory.AbstractPagedOutputView;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.MutableObjectIterator;
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/MutableHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/MutableHashTable.java
@@ -42,7 +42,7 @@ import org.apache.flink.runtime.io.disk.iomanager.ChannelReaderInputView;
 import org.apache.flink.runtime.io.disk.iomanager.HeaderlessChannelReaderInputView;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.operators.util.BloomFilter;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.MutableObjectIterator;
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputEmitter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputEmitter.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 /**
  * The output emitter decides to which of the possibly multiple output channels a record is sent.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.filesystem.FileSerializableStateHandle;
-import org.apache.flink.runtime.util.FileUtils;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.runtime.zookeeper.StateStorageHelper;
 
 import java.io.IOException;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -67,7 +67,7 @@ import org.apache.flink.runtime.security.SecurityUtils
 import org.apache.flink.runtime.security.SecurityUtils.FlinkSecuredRunner
 import org.apache.flink.runtime.util._
 import org.apache.flink.runtime.{FlinkActor, LeaderSessionMessageFilter, LogMessages}
-import org.apache.flink.util.NetUtils
+import org.apache.flink.util.{MathUtils, NetUtils}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.testutils;
 
-import org.apache.flink.runtime.util.FileUtils;
+import org.apache.flink.util.FileUtils;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.api.functions.source;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.runtime.util.IOUtils;
+import org.apache.flink.util.IOUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.runtime.state.StateHandle;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingKeyedTimePanes.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingKeyedTimePanes.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.runtime.util.UnionIterator;
+import org.apache.flink.util.UnionIterator;
 import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMap.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.ReduceFunction;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 
 import java.util.Arrays;
 import java.util.Comparator;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/HashPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/HashPartitioner.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.runtime.partitioner;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/IterateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/IterateTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.IterativeStream;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamingOperatorsITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamingOperatorsITCase.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.runtime.util.MathUtils;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SplitStream;

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
@@ -20,10 +20,10 @@ package org.apache.flink.streaming.api.scala
 
 import org.apache.flink.api.common.functions.{RichMapFunction, FoldFunction}
 import org.apache.flink.core.fs.FileSystem
-import org.apache.flink.runtime.util.MathUtils
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.test.util.TestBaseUtils
+import org.apache.flink.util.MathUtils
 import org.junit.rules.TemporaryFolder
 import org.junit.{After, Before, Rule, Test}
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@ under the License.
 			<version>1.1-SNAPSHOT</version>
 		</dependency>
 
+		<!-- Add the 'javax.annotation' annotations (JSR305), such as '@Nullable' -->
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
@@ -191,6 +197,13 @@ under the License.
 		-->
 		<dependencies>
 
+			<!-- This manages the 'javax.annotation' annotations (JSR305) -->
+			<dependency>
+				<groupId>com.google.code.findbugs</groupId>
+				<artifactId>jsr305</artifactId>
+				<version>1.3.9</version>
+			</dependency>
+			
 			<!-- Make sure we use a consistent avro version throughout the project -->
 			<dependency>
 				<groupId>org.apache.avro</groupId>


### PR DESCRIPTION
**Note: This builds on top of pull request  #1853**

Almost all Guava functionality used within `flink-core` has corresponding utils in Flink's codebase, or the JDK library.

This replaces the Guava code as follows
  - Preconditions calls by Flink's Preconditions class
  - Collection utils by simple Java Collection calls
  - Iterator's by Flink's Union Iterator
  - Murmur Hasher calls by Flink's `MathUtil.murmurHash()`
  - Files by simple util methods around `java.nio.Files`
  - InetAddresses IPv6 encoding code has been adapted into Flink's NetUtils (with attribution comments)
  - `Joiner` by `org.apache.commons.lang3.StringUtils`, which we reference anyways, and which is a well-behaved dependency (might even get rid of this in the future).

Some util classes where moved from `flink-runtime` to `flink-core`.
