### PR TITLE
FLINK-3650 Add maxBy/minBy to Scala DataSet API

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.aggregation.Aggregations
 import org.apache.flink.api.java.functions.{FirstReducer, KeySelector}
 import Keys.ExpressionKeys
 import org.apache.flink.api.java.operators._
+import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
 import org.apache.flink.api.scala.operators.ScalaAggregateOperator
 import org.apache.flink.util.Collector
 
@@ -353,6 +354,40 @@ class GroupedDataSet[T: ClassTag](
     wrap(
       new GroupReduceOperator[T, R](maybeCreateSortedGrouping(),
         implicitly[TypeInformation[R]], reducer, getCallLocationName()))
+  }
+
+  /**
+    * Applies a special case of a reduce transformation `maxBy` on a grouped [[DataSet]]
+    * The transformation consecutively calls a [[ReduceFunction]]
+    * until only a single element remains which is the result of the transformation.
+    * A ReduceFunction combines two elements into one new element of the same type.
+    *
+    * @param fields Keys taken into account for finding the minimum.
+    * @return A [[ReduceOperator]] representing the minimum.
+    */
+  def maxBy(fields: Int*) : DataSet[T]  = {
+    if (!set.getType().isTupleType) {
+      throw new InvalidProgramException("GroupedDataSet#maxBy(int...) only works on Tuple types.")
+    }
+    reduce(new SelectByMaxFunction[T](set.getType.asInstanceOf[TupleTypeInfoBase[T]],
+      fields.toArray))
+  }
+
+  /**
+    * Applies a special case of a reduce transformation `minBy` on a grouped [[DataSet]].
+    * The transformation consecutively calls a [[ReduceFunction]]
+    * until only a single element remains which is the result of the transformation.
+    * A ReduceFunction combines two elements into one new element of the same type.
+    *
+    * @param fields Keys taken into account for finding the minimum.
+    * @return A [[ReduceOperator]] representing the minimum.
+    */
+  def minBy(fields: Int*) : DataSet[T]  = {
+    if (!set.getType().isTupleType) {
+      throw new InvalidProgramException("GroupedDataSet#minBy(int...) only works on Tuple types.")
+    }
+    reduce(new SelectByMinFunction[T](set.getType.asInstanceOf[TupleTypeInfoBase[T]],
+      fields.toArray))
   }
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -361,9 +361,6 @@ class GroupedDataSet[T: ClassTag](
     * The transformation consecutively calls a [[ReduceFunction]]
     * until only a single element remains which is the result of the transformation.
     * A ReduceFunction combines two elements into one new element of the same type.
-    *
-    * @param fields Keys taken into account for finding the minimum.
-    * @return A [[ReduceOperator]] representing the minimum.
     */
   def maxBy(fields: Int*) : DataSet[T]  = {
     if (!set.getType().isTupleType) {
@@ -378,9 +375,6 @@ class GroupedDataSet[T: ClassTag](
     * The transformation consecutively calls a [[ReduceFunction]]
     * until only a single element remains which is the result of the transformation.
     * A ReduceFunction combines two elements into one new element of the same type.
-    *
-    * @param fields Keys taken into account for finding the minimum.
-    * @return A [[ReduceOperator]] representing the minimum.
     */
   def minBy(fields: Int*) : DataSet[T]  = {
     if (!set.getType().isTupleType) {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMaxFunction.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMaxFunction.scala
@@ -34,7 +34,7 @@ class SelectByMaxFunction[T](t : TupleTypeInfoBase[T], fields : Array[Int])
     }
 
     // Check whether type is comparable
-    if (!t.asInstanceOf[TupleTypeInfoBase[T]].getTypeAt(f).isKeyType()) {
+    if (!t.getTypeAt(f).isKeyType()) {
       throw new IllegalArgumentException(
         "SelectByMaxFunction supports only key(Comparable) types.")
     }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMaxFunction.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMaxFunction.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala
+
+import org.apache.flink.api.common.functions.ReduceFunction
+import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
+import org.apache.flink.annotation.Internal
+
+/**
+  * SelectByMaxFunction to work with Scala tuples
+  */
+@Internal
+class SelectByMaxFunction[T](t : TupleTypeInfoBase[T], fields : Array[Int])
+  extends ReduceFunction[T] {
+  for(f <- fields) {
+    if (f < 0 || f >= t.getArity()) {
+      throw new IndexOutOfBoundsException(
+        "SelectByMaxFunction field position " + f + " is out of range.")
+    }
+
+    // Check whether type is comparable
+    if (!t.asInstanceOf[TupleTypeInfoBase[T]].getTypeAt(f).isKeyType()) {
+      throw new IllegalArgumentException(
+        "SelectByMaxFunction supports only key(Comparable) types.")
+    }
+  }
+
+  override def reduce(value1: T, value2: T): T = {
+    for (f <- fields) {
+        val element1  = value1.asInstanceOf[Product].productElement(f).asInstanceOf[Comparable[Any]]
+        val element2 = value2.asInstanceOf[Product].productElement(f).asInstanceOf[Comparable[Any]]
+
+        val comp = element1.compareTo(element2)
+        // If comp is bigger than 0 comparable 1 is bigger.
+        // Return the smaller value.
+        if (comp > 0) {
+          return value1
+        } else if (comp < 0) {
+          return value2
+        }
+      }
+      value1
+  }
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMinFunction.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMinFunction.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.functions.ReduceFunction
+import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
+
+/**
+  * SelectByMinFunction to work with Scala tuples
+  */
+@Internal
+class SelectByMinFunction[T](t : TupleTypeInfoBase[T], fields : Array[Int])
+  extends ReduceFunction[T] {
+  for(f <- fields) {
+    if (f < 0 || f >= t.getArity()) {
+      throw new IndexOutOfBoundsException(
+        "SelectByMinFunction field position " + f + " is out of range.")
+    }
+
+    // Check whether type is comparable
+    if (!t.asInstanceOf[TupleTypeInfoBase[T]].getTypeAt(f).isKeyType()) {
+      throw new IllegalArgumentException(
+        "SelectByMinFunction supports only key(Comparable) types.")
+    }
+  }
+
+  override def reduce(value1: T, value2: T): T = {
+    for (f <- fields) {
+        val element1  = value1.asInstanceOf[Product].productElement(f).asInstanceOf[Comparable[Any]]
+        val element2 = value2.asInstanceOf[Product].productElement(f).asInstanceOf[Comparable[Any]]
+
+        val comp = element1.compareTo(element2)
+
+        // If comp is bigger than 0 comparable 1 is bigger.
+        // Return the smaller value.
+        if (comp < 0) {
+          return value1
+        } else if (comp > 0) {
+          return value2
+        }
+    }
+    value1
+  }
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMinFunction.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/SelectByMinFunction.scala
@@ -34,7 +34,7 @@ class SelectByMinFunction[T](t : TupleTypeInfoBase[T], fields : Array[Int])
     }
 
     // Check whether type is comparable
-    if (!t.asInstanceOf[TupleTypeInfoBase[T]].getTypeAt(f).isKeyType()) {
+    if (!t.getTypeAt(f).isKeyType()) {
       throw new IllegalArgumentException(
         "SelectByMinFunction supports only key(Comparable) types.")
     }

--- a/flink-scala/src/test/scala/org/apache/flink/api/operator/MaxByOperatorTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/operator/MaxByOperatorTest.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.operator
+
+import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.scala._
+import org.junit.Test
+import org.junit.Assert
+
+class MaxByOperatorTest {
+
+  private val emptyTupleData = List(Int, Long, String, Long, Int)
+  private val customTypeData = List[CustomType](new CustomType())
+
+  @Test
+  def testMaxByKeyFieldsDataset(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+    try {
+      collection.maxBy(0, 1, 2, 3, 4)
+    } catch {
+      case e : Exception => Assert.fail();
+    }
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsDataset1() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+
+    // should not work, key out of tuple bounds
+    collection.maxBy(5)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsDataset2() {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+
+    // should not work, key out of tuple bounds
+    collection.maxBy(-1)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsDataset3() {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+
+    // should not work, key out of tuple bounds
+    collection.maxBy(1, 2, 3, 4, -1)
+  }
+
+  /**
+    * This test validates that no exceptions is thrown when an empty grouping
+    * calls maxBy().
+    */
+  @Test
+  def testMaxByKeyFieldsGrouping() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+    // should work
+    try {
+      groupDs.maxBy(4, 0, 1, 2, 3)
+    } catch {
+      case e : Exception => Assert.fail();
+    }
+  }
+
+  /**
+    * This test validates that an InvalidProgrammException is thrown when maxBy
+    * is used on a custom data type.
+    */
+  @Test(expected = classOf[InvalidProgramException])
+  def testCustomKeyFieldsDataset() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val customDS = env.fromCollection(customTypeData)
+    // should not work: groups on custom type
+    customDS.maxBy(0)
+  }
+
+  /**
+    * This test validates that an InvalidProgrammException is thrown when maxBy
+    * is used on a custom data type.
+    */
+  @Test(expected = classOf[InvalidProgramException])
+  def testCustomKeyFieldsGrouping() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs: GroupedDataSet[CustomType] = env.fromCollection(customTypeData).groupBy(0)
+
+    groupDs.maxBy(0)
+  }
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsGrouping1() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+    groupDs.maxBy(5)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsGrouping2() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+    groupDs.maxBy(-1)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsGrouping3() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+    groupDs.maxBy(1, 2, 3, 4, -1)
+  }
+
+  class CustomType(var myInt: Int, var myLong: Long, var myString: String) {
+    def this() {
+      this(0, 0, "")
+    }
+
+    override def toString: String = {
+      myInt + "," + myLong + "," + myString
+    }
+  }
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/operator/MaxByOperatorTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/operator/MaxByOperatorTest.scala
@@ -24,8 +24,8 @@ import org.junit.Assert
 
 class MaxByOperatorTest {
 
-  private val emptyTupleData = List(Int, Long, String, Long, Int)
-  private val customTypeData = List[CustomType](new CustomType())
+  private val emptyTupleData = List[(Int, Long, String, Long, Int)]()
+  private val customTypeData = List[CustomType]()
 
   @Test
   def testMaxByKeyFieldsDataset(): Unit = {

--- a/flink-scala/src/test/scala/org/apache/flink/api/operator/MinByOperatorTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/operator/MinByOperatorTest.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.operator
+
+import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.api.scala._
+import org.junit.Test
+import org.junit.Assert
+
+class MinByOperatorTest {
+  private val emptyTupleData = List(Int, Long, String, Long, Int)
+  private val customTypeData = List[CustomType](new CustomType())
+
+  @Test
+  def testMinByKeyFieldsDataset(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+    try {
+      collection.minBy(4, 0, 1, 2, 3)
+    } catch {
+      case e : Exception => Assert.fail();
+    }
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsDataset1() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+
+    // should not work, key out of tuple bounds
+    collection.minBy(5)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsDataset2() {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+
+    // should not work, key out of tuple bounds
+    collection.minBy(-1)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsDataset3() {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val collection = env.fromCollection(emptyTupleData)
+
+    // should not work, key out of tuple bounds
+    collection.minBy(1, 2, 3, 4, -1)
+  }
+
+  /**
+    * This test validates that an InvalidProgrammException is thrown when minBy
+    * is used on a custom data type.
+    */
+  @Test(expected = classOf[InvalidProgramException])
+  def testCustomKeyFieldsDataset() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val customDS = env.fromCollection(customTypeData)
+    // should not work: groups on custom type
+    customDS.minBy(0)
+  }
+
+  /**
+    * This test validates that no exceptions is thrown when an empty grouping
+    * calls minBy().
+    */
+  @Test
+  def testMinByKeyFieldsGrouping() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+    // should work
+    try {
+      groupDs.minBy(4, 0, 1, 2, 3)
+    } catch {
+      case e : Exception => Assert.fail()
+    }
+  }
+
+  /**
+    * This test validates that an InvalidProgrammException is thrown when minBy
+    * is used on a custom data type.
+    */
+  @Test(expected = classOf[InvalidProgramException])
+  def testCustomKeyFieldsGrouping() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs: GroupedDataSet[CustomType] = env.fromCollection(customTypeData).groupBy(0)
+
+    groupDs.minBy(0)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsGrouping1() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+
+    groupDs.minBy(5)
+  }
+
+  /**
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsGrouping2() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+
+    groupDs.minBy(-1)
+  }
+
+  /**s
+    * This test validates that an index which is out of bounds throws an
+    * IndexOutOfBOundsExcpetion.
+    */
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testOutOfTupleBoundsGrouping3() {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val groupDs = env.fromCollection(emptyTupleData).groupBy(0)
+
+    groupDs.minBy(1, 2, 3, 4, -1)
+  }
+
+  class CustomType(var myInt: Int, var myLong: Long, var myString: String) {
+    def this() {
+      this(0, 0, "")
+    }
+
+    override def toString: String = {
+      myInt + "," + myLong + "," + myString
+    }
+  }
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/operator/MinByOperatorTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/operator/MinByOperatorTest.scala
@@ -24,8 +24,8 @@ import org.junit.Test
 import org.junit.Assert
 
 class MinByOperatorTest {
-  private val emptyTupleData = List(Int, Long, String, Long, Int)
-  private val customTypeData = List[CustomType](new CustomType())
+  private val emptyTupleData = List[(Int, Long, String, Long, Int)]()
+  private val customTypeData = List[CustomType]()
 
   @Test
   def testMinByKeyFieldsDataset(): Unit = {

--- a/flink-scala/src/test/scala/org/apache/flink/api/operator/SelectByFunctionTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/operator/SelectByFunctionTest.scala
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.operator
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.scala.{SelectByMaxFunction, SelectByMinFunction}
+import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
+import org.junit.{Assert, Test}
+
+/**
+  *
+  */
+class SelectByFunctionTest {
+
+  val tupleTypeInfo = new CaseClassTypeInfo(
+    classOf[(Int, Long, String, Long, Int)], Array(), Array(BasicTypeInfo.INT_TYPE_INFO,
+      BasicTypeInfo.LONG_TYPE_INFO,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO),
+    Array("_1", "_2","_3","_4","_5")) {
+
+    override def createSerializer(config: ExecutionConfig):
+      TypeSerializer[(Int, Long, String, Long, Int)] = ???
+  }
+
+  private val bigger  = (10, 100L, "HelloWorld", 200L, 20)
+  private val smaller = (10, 100L, "HelloWorld", 200L, 20)
+
+  //Special case where only the last value determines if bigger or smaller
+  private val specialCaseBigger  = (10, 100L, "HelloWorld", 200L, 20)
+  private val specialCaseSmaller = (10, 100L, "HelloWorld", 200L, 20)
+
+  /**
+    * This test validates whether the order of tuples has
+    *
+    * any impact on the outcome and if the bigger tuple is returned.
+    */
+  @Test
+  def testMaxByComparison(): Unit = {
+    val a1 = Array(0)
+    val maxByTuple = new SelectByMaxFunction(tupleTypeInfo, a1)
+      try {
+        Assert.assertSame("SelectByMax must return bigger tuple",
+          bigger, maxByTuple.reduce(smaller, bigger))
+        Assert.assertSame("SelectByMax must return bigger tuple",
+          bigger, maxByTuple.reduce(bigger, smaller))
+      } catch {
+        case e : Exception =>
+          Assert.fail("No exception should be thrown while comapring both tuples")
+      }
+  }
+
+  // ----------------------- MAXIMUM FUNCTION TEST BELOW --------------------------
+
+  /**
+    * This test cases checks when two tuples only differ in one value, but this value is not
+    * in the fields list. In that case it should be seen as equal
+    * and then the first given tuple (value1) should be returned by reduce().
+    */
+  @Test
+  def testMaxByComparisonSpecialCase1() : Unit = {
+    val a1 = Array(0, 3)
+    val maxByTuple = new SelectByMaxFunction(tupleTypeInfo, a1)
+
+    try {
+      Assert.assertSame("SelectByMax must return the first given tuple",
+        specialCaseBigger, maxByTuple.reduce(specialCaseBigger, bigger))
+      Assert.assertSame("SelectByMax must return the first given tuple",
+        bigger, maxByTuple.reduce(bigger, specialCaseBigger))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown " +
+        "while comapring both tuples")
+    }
+  }
+
+  /**
+    * This test cases checks when two tuples only differ in one value.
+    */
+  @Test
+  def testMaxByComparisonSpecialCase2() : Unit = {
+    val a1 = Array(0, 2, 1, 4, 3)
+    val maxByTuple = new SelectByMaxFunction(tupleTypeInfo, a1)
+    try {
+      Assert.assertSame("SelectByMax must return bigger tuple",
+        bigger, maxByTuple.reduce(specialCaseBigger, bigger))
+      Assert.assertSame("SelectByMax must return bigger tuple",
+        bigger, maxByTuple.reduce(bigger, specialCaseBigger))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown" +
+        " while comapring both tuples")
+    }
+  }
+
+  /**
+    * This test validates that equality is independent of the amount of used indices.
+    */
+  @Test
+  def testMaxByComparisonMultiple(): Unit = {
+    val a1 = Array(0, 1, 2, 3, 4)
+    val maxByTuple = new SelectByMaxFunction(tupleTypeInfo, a1)
+    try {
+      Assert.assertSame("SelectByMax must return bigger tuple",
+        bigger, maxByTuple.reduce(smaller, bigger))
+      Assert.assertSame("SelectByMax must return bigger tuple",
+        bigger, maxByTuple.reduce(bigger, smaller))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown " +
+        "while comapring both tuples")
+    }
+  }
+
+  /**
+    * Checks whether reduce does behave as expected if both values are the same object.
+    */
+  @Test
+  def testMaxByComparisonMustReturnATuple() : Unit = {
+    val a1 = Array(0)
+    val maxByTuple = new SelectByMaxFunction(tupleTypeInfo, a1)
+
+    try {
+      Assert.assertSame("SelectByMax must return bigger tuple",
+        bigger, maxByTuple.reduce(bigger, bigger))
+      Assert.assertSame("SelectByMax must return smaller tuple",
+        smaller, maxByTuple.reduce(smaller, smaller))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown" +
+        " while comapring both tuples")
+    }
+  }
+
+  // ----------------------- MINIMUM FUNCTION TEST BELOW --------------------------
+
+  /**
+    * This test validates whether the order of tuples has any impact
+    * on the outcome and if the smaller tuple is returned.
+    */
+  @Test
+  def testMinByComparison() : Unit = {
+    val a1 = Array(0)
+    val minByTuple = new SelectByMinFunction(tupleTypeInfo, a1)
+    try {
+      Assert.assertSame("SelectByMin must return smaller tuple",
+        smaller, minByTuple.reduce(smaller, bigger))
+      Assert.assertSame("SelectByMin must return smaller tuple",
+        smaller, minByTuple.reduce(bigger, smaller))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown " +
+        "while comapring both tuples")
+    }
+  }
+
+  /**
+    * This test cases checks when two tuples only differ in one value, but this value is not
+    * in the fields list. In that case it should be seen as equal and
+    * then the first given tuple (value1) should be returned by reduce().
+    */
+  @Test
+  def testMinByComparisonSpecialCase1() : Unit = {
+    val a1 = Array(0, 3)
+    val minByTuple = new SelectByMinFunction(tupleTypeInfo, a1)
+
+    try {
+      Assert.assertSame("SelectByMin must return the first given tuple",
+        specialCaseBigger, minByTuple.reduce(specialCaseBigger, bigger))
+      Assert.assertSame("SelectByMin must return the first given tuple",
+        bigger, minByTuple.reduce(bigger, specialCaseBigger))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown " +
+        "while comapring both tuples")
+    }
+  }
+
+  /**
+    * This test validates that when two tuples only differ in one value
+    * and that value's index is given at construction time. The smaller tuple must be returned
+    * then.
+    */
+  @Test
+  def  testMinByComparisonSpecialCase2() : Unit = {
+    val a1 = Array(0, 2, 1, 4, 3)
+    val minByTuple = new SelectByMinFunction(tupleTypeInfo, a1)
+
+    try {
+      Assert.assertSame("SelectByMin must return smaller tuple",
+        smaller, minByTuple.reduce(specialCaseSmaller, smaller))
+      Assert.assertSame("SelectByMin must return smaller tuple",
+        smaller, minByTuple.reduce(smaller, specialCaseSmaller))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown" +
+        " while comapring both tuples")
+    }
+  }
+
+  /**
+    * Checks whether reduce does behave as expected if both values are the same object.
+    */
+  @Test
+  def testMinByComparisonMultiple() : Unit =  {
+    val a1 = Array(0, 1, 2, 3, 4)
+    val minByTuple = new SelectByMinFunction(tupleTypeInfo, a1)
+
+    try {
+      Assert.assertSame("SelectByMin must return smaller tuple",
+        smaller, minByTuple.reduce(smaller, bigger))
+      Assert.assertSame("SelectByMin must return smaller tuple",
+        smaller, minByTuple.reduce(bigger, smaller))
+    } catch {
+      case e : Exception => Assert.fail("No exception should be thrown" +
+        " while comapring both tuples")
+    }
+  }
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/operator/SelectByFunctionTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/operator/SelectByFunctionTest.scala
@@ -40,12 +40,14 @@ class SelectByFunctionTest {
       TypeSerializer[(Int, Long, String, Long, Int)] = ???
   }
 
-  private val bigger  = (10, 100L, "HelloWorld", 200L, 20)
-  private val smaller = (10, 100L, "HelloWorld", 200L, 20)
+   private val bigger  = new Tuple5[Int, Long, String, Long, Int](10, 100L, "HelloWorld", 200L, 20)
+   private val smaller = new Tuple5[Int, Long, String, Long, Int](5, 50L, "Hello", 50L, 15)
 
-  //Special case where only the last value determines if bigger or smaller
-  private val specialCaseBigger  = (10, 100L, "HelloWorld", 200L, 20)
-  private val specialCaseSmaller = (10, 100L, "HelloWorld", 200L, 20)
+   //Special case where only the last value determines if bigger or smaller
+   private val specialCaseBigger =
+     new Tuple5[Int, Long, String, Long, Int](10, 100L, "HelloWorld", 200L, 17)
+   private val specialCaseSmaller  =
+     new Tuple5[Int, Long, String, Long, Int](5, 50L, "Hello", 50L, 17)
 
   /**
     * This test validates whether the order of tuples has
@@ -214,7 +216,9 @@ class SelectByFunctionTest {
   @Test
   def testMinByComparisonMultiple() : Unit =  {
     val a1 = Array(0, 1, 2, 3, 4)
-    val minByTuple = new SelectByMinFunction(tupleTypeInfo, a1)
+        val minByTuple : SelectByMinFunction[scala.Tuple5[Int, Long, String, Long, Int]] =
+            new SelectByMinFunction[scala.Tuple5[Int, Long,
+                String, Long, Int]](tupleTypeInfo, a1)
 
     try {
       Assert.assertSame("SelectByMin must return smaller tuple",


### PR DESCRIPTION
I have tried to expose the maxBy/minBy API to scala DataSet. But one thing to note is that in the existing scala DataSet API code groupBy() API returns a GroupedDataSet whereas in the case of java DataSet API it is UnsortedGrouping. The code in scala DataSet is

`  //  public UnsortedGrouping<T> groupBy(String... fields) {
  //    new UnsortedGrouping<T>(this, new Keys.ExpressionKeys<T>(fields, getType()));
  //  }
`
already commented out. The UnsortedGrouping internally has maxBy and minBy. So in this PR I have not tried to change those and hence the test case also does not cover groupBy() clause followed by maxBy and minBy ( they are now available only in java based MAxOperatorTest class).
Please review and provide valuable feedback.
Please note the change done to SelectByMaxFunction and SelectByMinFunction to support all Tuples but the API itself checks if the type is of type Tuple. 