### PR TITLE
[FLINK-3444] env.fromElements relies on the first input element for determining the DataSet/DataStream type

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -780,6 +780,33 @@ public abstract class ExecutionEnvironment {
 		return fromCollection(Arrays.asList(data), TypeExtractor.getForObject(data[0]), Utils.getCallLocationName());
 	}
 	
+	/**
+	 * Creates a new data set that contains the given elements. The elements must all be of the same type,
+	 * for example, all of the {@link String} or {@link Integer}. The sequence of elements must not be empty.
+	 * <p>
+	 * The framework will try and determine the exact type from the collection elements.
+	 * In case of generic elements, it may be necessary to manually supply the type information
+	 * via {@link #fromCollection(Collection, TypeInformation)}.
+	 * <p>
+	 * Note that this operation will result in a non-parallel data source, i.e. a data source with
+	 * a parallelism of one.
+	 *
+	 * @param type The base class type for every element in the collection.
+	 * @param data The elements to make up the data set.
+	 * @return A DataSet representing the given list of elements.
+	 */
+	@SafeVarargs
+	public final <X> DataSource<X> fromElements(Class<X> type, X... data) {
+		if (data == null) {
+			throw new IllegalArgumentException("The data must not be null.");
+		}
+		if (data.length == 0) {
+			throw new IllegalArgumentException("The number of elements must not be zero.");
+		}
+		
+		return fromCollection(Arrays.asList(data), TypeExtractor.getForClass(type), Utils.getCallLocationName());
+	}
+	
 	
 	/**
 	 * Creates a new data set that contains elements in the iterator. The iterator is splittable, allowing the

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -777,17 +777,23 @@ public abstract class ExecutionEnvironment {
 			throw new IllegalArgumentException("The number of elements must not be zero.");
 		}
 		
-		return fromCollection(Arrays.asList(data), TypeExtractor.getForObject(data[0]), Utils.getCallLocationName());
+		TypeInformation<X> typeInfo;
+		try {
+			typeInfo = TypeExtractor.getForObject(data[0]);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Could not create TypeInformation for type " + data[0].getClass().getName()
+					+ "; please specify the TypeInformation manually via "
+					+ "ExecutionEnvironment#fromElements(Collection, TypeInformation)");
+		}
+
+		return fromCollection(Arrays.asList(data), typeInfo, Utils.getCallLocationName());
 	}
 	
 	/**
-	 * Creates a new data set that contains the given elements. The elements must all be of the same type,
-	 * for example, all of the {@link String} or {@link Integer}. The sequence of elements must not be empty.
-	 * <p>
-	 * The framework will try and determine the exact type from the collection elements.
-	 * In case of generic elements, it may be necessary to manually supply the type information
-	 * via {@link #fromCollection(Collection, TypeInformation)}.
-	 * <p>
+	 * Creates a new data set that contains the given elements. The framework will determine the type according to the 
+	 * based type user supplied. The elements should be the same or be the subclass to the based type. 
+	 * The sequence of elements must not be empty.
 	 * Note that this operation will result in a non-parallel data source, i.e. a data source with
 	 * a parallelism of one.
 	 *
@@ -804,7 +810,17 @@ public abstract class ExecutionEnvironment {
 			throw new IllegalArgumentException("The number of elements must not be zero.");
 		}
 		
-		return fromCollection(Arrays.asList(data), TypeExtractor.getForClass(type), Utils.getCallLocationName());
+		TypeInformation<X> typeInfo;
+		try {
+			typeInfo = TypeExtractor.getForClass(type);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Could not create TypeInformation for type " + type.getName()
+					+ "; please specify the TypeInformation manually via "
+					+ "ExecutionEnvironment#fromElements(Collection, TypeInformation)");
+		}
+
+		return fromCollection(Arrays.asList(data), typeInfo, Utils.getCallLocationName());
 	}
 	
 	

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/FromElementsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/FromElementsTest.java
@@ -1,0 +1,34 @@
+package org.apache.flink.api.java.io;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.junit.Test;
+
+public class FromElementsTest {
+
+	@Test
+	public void fromElementsWithBaseTypeTest1() {
+		ExecutionEnvironment executionEnvironment = ExecutionEnvironment.getExecutionEnvironment();
+		executionEnvironment.fromElements(ParentType.class, new SubType(1, "Java"), new ParentType(1, "hello"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void fromElementsWithBaseTypeTest2() {
+		ExecutionEnvironment executionEnvironment = ExecutionEnvironment.getExecutionEnvironment();
+		executionEnvironment.fromElements(SubType.class, new SubType(1, "Java"), new ParentType(1, "hello"));
+	}
+
+	public static class ParentType {
+		int num;
+		String string;
+		public ParentType(int num, String string) {
+			this.num = num;
+			this.string = string;
+		}
+	}
+
+	public static class SubType extends ParentType{
+		public SubType(int num, String string) {
+			super(num, string);
+		}
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/FromElementsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/FromElementsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.api.java.io;
 
 import org.apache.flink.api.java.ExecutionEnvironment;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -673,6 +673,43 @@ public abstract class StreamExecutionEnvironment {
 	}
 
 	/**
+	 * Creates a new data stream that contains the given elements. The elements must all be of the same type, for
+	 * example, all of the {@link String} or {@link Integer}.
+	 * <p>
+	 * The framework will try and determine the exact type from the elements. In case of generic elements, it may be
+	 * necessary to manually supply the type information via {@link #fromCollection(java.util.Collection,
+	 * org.apache.flink.api.common.typeinfo.TypeInformation)}.
+	 * <p>
+	 * Note that this operation will result in a non-parallel data stream source, i.e. a data stream source with a
+	 * degree of parallelism one.
+	 *
+	 * @param clazz
+	 * 		The base class type in the collection.
+	 * @param data
+	 * 		The array of elements to create the data stream from.
+	 * @param <OUT>
+	 * 		The type of the returned data stream
+	 * @return The data stream representing the given array of elements
+	 */
+	@SafeVarargs
+	public final <OUT> DataStreamSource<OUT> fromElements(Class<OUT> clazz, OUT... data) {
+		if (data.length == 0) {
+			throw new IllegalArgumentException("fromElements needs at least one element as argument");
+		}
+
+		TypeInformation<OUT> typeInfo;
+		try {
+			typeInfo = TypeExtractor.getForClass(clazz);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Could not create TypeInformation for type " + data[0].getClass().getName()
+					+ "; please specify the TypeInformation manually via "
+					+ "StreamExecutionEnvironment#fromElements(Collection, TypeInformation)");
+		}
+		return fromCollection(Arrays.asList(data), typeInfo);
+	}
+
+	/**
 	 * Creates a data stream from the given non-empty collection. The type of the data stream is that of the
 	 * elements in the collection.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -673,18 +673,14 @@ public abstract class StreamExecutionEnvironment {
 	}
 
 	/**
-	 * Creates a new data stream that contains the given elements. The elements must all be of the same type, for
-	 * example, all of the {@link String} or {@link Integer}.
-	 * <p>
-	 * The framework will try and determine the exact type from the elements. In case of generic elements, it may be
-	 * necessary to manually supply the type information via {@link #fromCollection(java.util.Collection,
-	 * org.apache.flink.api.common.typeinfo.TypeInformation)}.
-	 * <p>
+	 * Creates a new data set that contains the given elements. The framework will determine the type according to the 
+	 * based type user supplied. The elements should be the same or be the subclass to the based type. 
+	 * The sequence of elements must not be empty.
 	 * Note that this operation will result in a non-parallel data stream source, i.e. a data stream source with a
 	 * degree of parallelism one.
 	 *
-	 * @param clazz
-	 * 		The base class type in the collection.
+	 * @param type
+	 * 		The based class type in the collection.
 	 * @param data
 	 * 		The array of elements to create the data stream from.
 	 * @param <OUT>
@@ -692,17 +688,17 @@ public abstract class StreamExecutionEnvironment {
 	 * @return The data stream representing the given array of elements
 	 */
 	@SafeVarargs
-	public final <OUT> DataStreamSource<OUT> fromElements(Class<OUT> clazz, OUT... data) {
+	public final <OUT> DataStreamSource<OUT> fromElements(Class<OUT> type, OUT... data) {
 		if (data.length == 0) {
 			throw new IllegalArgumentException("fromElements needs at least one element as argument");
 		}
 
 		TypeInformation<OUT> typeInfo;
 		try {
-			typeInfo = TypeExtractor.getForClass(clazz);
+			typeInfo = TypeExtractor.getForClass(type);
 		}
 		catch (Exception e) {
-			throw new RuntimeException("Could not create TypeInformation for type " + data[0].getClass().getName()
+			throw new RuntimeException("Could not create TypeInformation for type " + type.getName()
 					+ "; please specify the TypeInformation manually via "
 					+ "StreamExecutionEnvironment#fromElements(Collection, TypeInformation)");
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.testutils.CommonTestUtils;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.util.SourceFunctionUtil;
@@ -45,18 +44,6 @@ public class SourceFunctionTest {
 	}
 
 	@Test
-	public void fromElementsWithBaseTypeTest1() {
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.fromElements(ParentClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void fromElementsWithBaseTypeTest2() {
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.fromElements(SubClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
-	}
-
-	@Test
 	public void fromCollectionTest() throws Exception {
 		List<Integer> expectedList = Arrays.asList(1, 2, 3);
 		List<Integer> actualList = SourceFunctionUtil.runSourceFunction(
@@ -72,20 +59,5 @@ public class SourceFunctionTest {
 		List<Long> actualList = SourceFunctionUtil.runSourceFunction(new StatefulSequenceSource(1,
 				7));
 		assertEquals(expectedList, actualList);
-	}
-
-	public static class ParentClass {
-		int num;
-		String string;
-		public ParentClass(int num, String string) {
-			this.num = num;
-			this.string = string;
-		}
-	}
-
-	public static class SubClass extends ParentClass{
-		public SubClass(int num, String string) {
-			super(num, string);
-		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/SourceFunctionTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.util.SourceFunctionUtil;
@@ -44,6 +45,18 @@ public class SourceFunctionTest {
 	}
 
 	@Test
+	public void fromElementsWithBaseTypeTest1() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.fromElements(ParentClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void fromElementsWithBaseTypeTest2() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.fromElements(SubClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
+	}
+
+	@Test
 	public void fromCollectionTest() throws Exception {
 		List<Integer> expectedList = Arrays.asList(1, 2, 3);
 		List<Integer> actualList = SourceFunctionUtil.runSourceFunction(
@@ -59,5 +72,20 @@ public class SourceFunctionTest {
 		List<Long> actualList = SourceFunctionUtil.runSourceFunction(new StatefulSequenceSource(1,
 				7));
 		assertEquals(expectedList, actualList);
+	}
+
+	public static class ParentClass {
+		int num;
+		String string;
+		public ParentClass(int num, String string) {
+			this.num = num;
+			this.string = string;
+		}
+	}
+
+	public static class SubClass extends ParentClass{
+		public SubClass(int num, String string) {
+			super(num, string);
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
@@ -45,6 +45,18 @@ import org.junit.Test;
 public class StreamExecutionEnvironmentTest extends StreamingMultipleProgramsTestBase {
 
 	@Test
+	public void fromElementsWithBaseTypeTest1() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.fromElements(ParentClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void fromElementsWithBaseTypeTest2() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.fromElements(SubClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testFromCollectionParallelism() {
 		try {
@@ -157,6 +169,21 @@ public class StreamExecutionEnvironmentTest extends StreamingMultipleProgramsTes
 		@Override
 		public void remove() {
 			throw new UnsupportedOperationException();
+		}
+	}
+
+	public static class ParentClass {
+		int num;
+		String string;
+		public ParentClass(int num, String string) {
+			this.num = num;
+			this.string = string;
+		}
+	}
+
+	public static class SubClass extends ParentClass{
+		public SubClass(int num, String string) {
+			super(num, string);
 		}
 	}
 }


### PR DESCRIPTION
Add `fromElements` method with based class type to avoid the exception. The based class should equal to or be the superclass of classes of other elements.