### PR TITLE
[FLINK-3711][docs] Documentation of Scala fold()() uses correct syntax

### DIFF
--- a/docs/apis/streaming/index.md
+++ b/docs/apis/streaming/index.md
@@ -637,7 +637,7 @@ keyedStream.reduce { _ + _ }
           emits the sequence "start-1", "start-1-2", "start-1-2-3", ...</p>
           {% highlight scala %}
 val result: DataStream[String] =
-    keyedStream.fold("start", (str, i) => { str + "-" + i })
+    keyedStream.fold("start")((str, i) => { str + "-" + i })
           {% endhighlight %}
           </p>
           </td>


### PR DESCRIPTION
Scala's KeyedStream#fold which accepts scala.Function2 is defined as a partially appliable function. The documentation, however, is written as if it is a non-partial function.