### PR TITLE
[FLINK-3688] WindowOperator.trigger() does not emit Watermark anymore

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -341,6 +341,14 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 	@Override
 	public final void processWatermark(Watermark mark) throws Exception {
+		processTriggersFor(mark);
+
+		output.emitWatermark(mark);
+
+		this.currentWatermark = mark.getTimestamp();
+	}
+
+	private void processTriggersFor(Watermark mark) throws Exception {
 		boolean fire;
 
 		do {
@@ -360,10 +368,6 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 				fire = false;
 			}
 		} while (fire);
-
-		output.emitWatermark(mark);
-
-		this.currentWatermark = mark.getTimestamp();
 	}
 
 	@Override
@@ -391,7 +395,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		// Also check any watermark timers. We might have some in here since
 		// Context.registerEventTimeTimer sets a trigger if an event-time trigger is registered
 		// that is already behind the watermark.
-		processWatermark(new Watermark(currentWatermark));
+		processTriggersFor(new Watermark(currentWatermark));
 	}
 
 	/**


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - The pull request references the related JIRA issue
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Conflicts:
	flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java