### PR TITLE
[FLINK-3721] Min and max accumulators

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMaximum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMaximum.java
@@ -32,15 +32,11 @@ public class DoubleMaximum implements SimpleAccumulator<Double> {
 	 */
 	@Override
 	public void add(Double value) {
-		if (value > this.max) {
-			this.max = value;
-		}
+		this.max = Math.max(this.max, value);
 	}
 
 	public void add(double value) {
-		if (value > this.max) {
-			this.max = value;
-		}
+		this.max = Math.max(this.max, value);
 	}
 
 	@Override
@@ -55,11 +51,7 @@ public class DoubleMaximum implements SimpleAccumulator<Double> {
 
 	@Override
 	public void merge(Accumulator<Double, Double> other) {
-		double otherMax = other.getLocalValue();
-
-		if (otherMax > this.max) {
-			this.max = otherMax;
-		}
+		this.max = Math.max(this.max, other.getLocalValue());
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMaximum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMaximum.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+/**
+ * An accumulator that finds the maximum {@code double} value.
+ */
+public class DoubleMaximum implements SimpleAccumulator<Double> {
+
+	private static final long serialVersionUID = 1L;
+
+	private double max = Double.NEGATIVE_INFINITY;
+
+	/**
+	 * Consider using {@link #add(double)} instead for primitive double values
+	 */
+	@Override
+	public void add(Double value) {
+		if (value > this.max) {
+			this.max = value;
+		}
+	}
+
+	public void add(double value) {
+		if (value > this.max) {
+			this.max = value;
+		}
+	}
+
+	@Override
+	public Double getLocalValue() {
+		return this.max;
+	}
+
+	@Override
+	public void resetLocal() {
+		this.max = Double.NEGATIVE_INFINITY;
+	}
+
+	@Override
+	public void merge(Accumulator<Double, Double> other) {
+		double otherMax = other.getLocalValue();
+
+		if (otherMax > this.max) {
+			this.max = otherMax;
+		}
+	}
+
+	@Override
+	public DoubleMaximum clone() {
+		DoubleMaximum clone = new DoubleMaximum();
+		clone.max = this.max;
+		return clone;
+	}
+
+	@Override
+	public String toString() {
+		return "DoubleMaximum " + this.max;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMinimum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMinimum.java
@@ -32,15 +32,11 @@ public class DoubleMinimum implements SimpleAccumulator<Double> {
 	 */
 	@Override
 	public void add(Double value) {
-		if (value < this.min) {
-			this.min = value;
-		}
+		this.min = Math.min(this.min, value);
 	}
 
 	public void add(double value) {
-		if (value < this.min) {
-			this.min = value;
-		}
+		this.min = Math.min(this.min, value);
 	}
 
 	@Override
@@ -55,11 +51,7 @@ public class DoubleMinimum implements SimpleAccumulator<Double> {
 
 	@Override
 	public void merge(Accumulator<Double, Double> other) {
-		double otherMin = other.getLocalValue();
-
-		if (otherMin < this.min) {
-			this.min = otherMin;
-		}
+		this.min = Math.min(this.min, other.getLocalValue());
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMinimum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMinimum.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+/**
+ * An accumulator that finds the minimum {@code double} value.
+ */
+public class DoubleMinimum implements SimpleAccumulator<Double> {
+
+	private static final long serialVersionUID = 1L;
+
+	private double min = Double.POSITIVE_INFINITY;
+
+	/**
+	 * Consider using {@link #add(double)} instead for primitive double values
+	 */
+	@Override
+	public void add(Double value) {
+		if (value < this.min) {
+			this.min = value;
+		}
+	}
+
+	public void add(double value) {
+		if (value < this.min) {
+			this.min = value;
+		}
+	}
+
+	@Override
+	public Double getLocalValue() {
+		return this.min;
+	}
+
+	@Override
+	public void resetLocal() {
+		this.min = Double.POSITIVE_INFINITY;
+	}
+
+	@Override
+	public void merge(Accumulator<Double, Double> other) {
+		double otherMin = other.getLocalValue();
+
+		if (otherMin < this.min) {
+			this.min = otherMin;
+		}
+	}
+
+	@Override
+	public DoubleMinimum clone() {
+		DoubleMinimum clone = new DoubleMinimum();
+		clone.min = this.min;
+		return clone;
+	}
+
+	@Override
+	public String toString() {
+		return "DoubleMinimum " + this.min;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMaximum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMaximum.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+/**
+ * An accumulator that finds the maximum {@code integer} value.
+ */
+public class IntMaximum implements SimpleAccumulator<Integer> {
+
+	private static final long serialVersionUID = 1L;
+
+	private int max = Integer.MIN_VALUE;
+
+	/**
+	 * Consider using {@link #add(int)} instead for primitive integer values
+	 */
+	@Override
+	public void add(Integer value) {
+		if (value > this.max) {
+			this.max = value;
+		}
+	}
+
+	public void add(int value) {
+		if (value > this.max) {
+			this.max = value;
+		}
+	}
+
+	@Override
+	public Integer getLocalValue() {
+		return this.max;
+	}
+
+	@Override
+	public void resetLocal() {
+		this.max = Integer.MIN_VALUE;
+	}
+
+	@Override
+	public void merge(Accumulator<Integer, Integer> other) {
+		int otherMax = other.getLocalValue();
+
+		if (otherMax > this.max) {
+			this.max = otherMax;
+		}
+	}
+
+	@Override
+	public IntMaximum clone() {
+		IntMaximum clone = new IntMaximum();
+		clone.max = this.max;
+		return clone;
+	}
+
+	@Override
+	public String toString() {
+		return "IntMaximum " + this.max;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMaximum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMaximum.java
@@ -32,15 +32,11 @@ public class IntMaximum implements SimpleAccumulator<Integer> {
 	 */
 	@Override
 	public void add(Integer value) {
-		if (value > this.max) {
-			this.max = value;
-		}
+		this.max = Math.max(this.max, value);
 	}
 
 	public void add(int value) {
-		if (value > this.max) {
-			this.max = value;
-		}
+		this.max = Math.max(this.max, value);
 	}
 
 	@Override
@@ -55,11 +51,7 @@ public class IntMaximum implements SimpleAccumulator<Integer> {
 
 	@Override
 	public void merge(Accumulator<Integer, Integer> other) {
-		int otherMax = other.getLocalValue();
-
-		if (otherMax > this.max) {
-			this.max = otherMax;
-		}
+		this.max = Math.max(this.max, other.getLocalValue());
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMinimum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMinimum.java
@@ -32,15 +32,11 @@ public class IntMinimum implements SimpleAccumulator<Integer> {
 	 */
 	@Override
 	public void add(Integer value) {
-		if (value < this.min) {
-			this.min = value;
-		}
+		this.min = Math.min(this.min, value);
 	}
 
 	public void add(int value) {
-		if (value < this.min) {
-			this.min = value;
-		}
+		this.min = Math.min(this.min, value);
 	}
 
 	@Override
@@ -55,11 +51,7 @@ public class IntMinimum implements SimpleAccumulator<Integer> {
 
 	@Override
 	public void merge(Accumulator<Integer, Integer> other) {
-		int otherMin = other.getLocalValue();
-
-		if (otherMin < this.min) {
-			this.min = otherMin;
-		}
+		this.min = Math.min(this.min, other.getLocalValue());
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMinimum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/IntMinimum.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+/**
+ * An accumulator that finds the minimum {@code integer} value.
+ */
+public class IntMinimum implements SimpleAccumulator<Integer> {
+
+	private static final long serialVersionUID = 1L;
+
+	private int min = Integer.MAX_VALUE;
+
+	/**
+	 * Consider using {@link #add(int)} instead for primitive integer values
+	 */
+	@Override
+	public void add(Integer value) {
+		if (value < this.min) {
+			this.min = value;
+		}
+	}
+
+	public void add(int value) {
+		if (value < this.min) {
+			this.min = value;
+		}
+	}
+
+	@Override
+	public Integer getLocalValue() {
+		return this.min;
+	}
+
+	@Override
+	public void resetLocal() {
+		this.min = Integer.MAX_VALUE;
+	}
+
+	@Override
+	public void merge(Accumulator<Integer, Integer> other) {
+		int otherMin = other.getLocalValue();
+
+		if (otherMin < this.min) {
+			this.min = otherMin;
+		}
+	}
+
+	@Override
+	public IntMinimum clone() {
+		IntMinimum clone = new IntMinimum();
+		clone.min = this.min;
+		return clone;
+	}
+
+	@Override
+	public String toString() {
+		return "IntMinimum " + this.min;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMaximum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMaximum.java
@@ -32,15 +32,11 @@ public class LongMaximum implements SimpleAccumulator<Long> {
 	 */
 	@Override
 	public void add(Long value) {
-		if (value > this.max) {
-			this.max = value;
-		}
+		this.max = Math.max(this.max, value);
 	}
 
 	public void add(long value) {
-		if (value > this.max) {
-			this.max = value;
-		}
+		this.max = Math.max(this.max, value);
 	}
 
 	@Override
@@ -55,11 +51,7 @@ public class LongMaximum implements SimpleAccumulator<Long> {
 
 	@Override
 	public void merge(Accumulator<Long, Long> other) {
-		long otherMax = other.getLocalValue();
-
-		if (otherMax > this.max) {
-			this.max = otherMax;
-		}
+		this.max = Math.max(this.max, other.getLocalValue());
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMaximum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMaximum.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+/**
+ * An accumulator that finds the maximum {@code long} value.
+ */
+public class LongMaximum implements SimpleAccumulator<Long> {
+
+	private static final long serialVersionUID = 1L;
+
+	private long max = Long.MIN_VALUE;
+
+	/**
+	 * Consider using {@link #add(long)} instead for primitive long values
+	 */
+	@Override
+	public void add(Long value) {
+		if (value > this.max) {
+			this.max = value;
+		}
+	}
+
+	public void add(long value) {
+		if (value > this.max) {
+			this.max = value;
+		}
+	}
+
+	@Override
+	public Long getLocalValue() {
+		return this.max;
+	}
+
+	@Override
+	public void resetLocal() {
+		this.max = Long.MIN_VALUE;
+	}
+
+	@Override
+	public void merge(Accumulator<Long, Long> other) {
+		long otherMax = other.getLocalValue();
+
+		if (otherMax > this.max) {
+			this.max = otherMax;
+		}
+	}
+
+	@Override
+	public LongMaximum clone() {
+		LongMaximum clone = new LongMaximum();
+		clone.max = this.max;
+		return clone;
+	}
+
+	@Override
+	public String toString() {
+		return "LongMaximum " + this.max;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMinimum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMinimum.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+/**
+ * An accumulator that finds the minimum {@code long} value.
+ */
+public class LongMinimum implements SimpleAccumulator<Long> {
+
+	private static final long serialVersionUID = 1L;
+
+	private long min = Long.MAX_VALUE;
+
+	/**
+	 * Consider using {@link #add(long)} instead for primitive long values
+	 */
+	@Override
+	public void add(Long value) {
+		if (value < this.min) {
+			this.min = value;
+		}
+	}
+
+	public void add(long value) {
+		if (value < this.min) {
+			this.min = value;
+		}
+	}
+
+	@Override
+	public Long getLocalValue() {
+		return this.min;
+	}
+
+	@Override
+	public void resetLocal() {
+		this.min = Long.MAX_VALUE;
+	}
+
+	@Override
+	public void merge(Accumulator<Long, Long> other) {
+		long otherMin = other.getLocalValue();
+
+		if (otherMin < this.min) {
+			this.min = otherMin;
+		}
+	}
+
+	@Override
+	public LongMinimum clone() {
+		LongMinimum clone = new LongMinimum();
+		clone.min = this.min;
+		return clone;
+	}
+
+	@Override
+	public String toString() {
+		return "LongMinimum " + this.min;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMinimum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/LongMinimum.java
@@ -32,15 +32,11 @@ public class LongMinimum implements SimpleAccumulator<Long> {
 	 */
 	@Override
 	public void add(Long value) {
-		if (value < this.min) {
-			this.min = value;
-		}
+		this.min = Math.min(this.min, value);
 	}
 
 	public void add(long value) {
-		if (value < this.min) {
-			this.min = value;
-		}
+		this.min = Math.min(this.min, value);
 	}
 
 	@Override
@@ -55,11 +51,7 @@ public class LongMinimum implements SimpleAccumulator<Long> {
 
 	@Override
 	public void merge(Accumulator<Long, Long> other) {
-		long otherMin = other.getLocalValue();
-
-		if (otherMin < this.min) {
-			this.min = otherMin;
-		}
+		this.min = Math.min(this.min, other.getLocalValue());
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/DoubleMaximumTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/DoubleMaximumTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DoubleMaximumTest {
+
+	@Test
+	public void testGet() {
+		DoubleMaximum max = new DoubleMaximum();
+		assertEquals(Double.NEGATIVE_INFINITY, max.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testResetLocal() {
+		DoubleMaximum max = new DoubleMaximum();
+		double value = 13.57902468;
+
+		max.add(value);
+		assertEquals(value, max.getLocalValue(), 0.0);
+
+		max.resetLocal();
+		assertEquals(Double.NEGATIVE_INFINITY, max.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testAdd() {
+		DoubleMaximum max = new DoubleMaximum();
+
+		max.add(1234.5768);
+		max.add(9876.5432);
+		max.add(-987.6543);
+		max.add(-123.4567);
+
+		assertEquals(9876.5432, max.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testMerge() {
+		DoubleMaximum max1 = new DoubleMaximum();
+		max1.add(1234.5768);
+
+		DoubleMaximum max2 = new DoubleMaximum();
+		max2.add(5678.9012);
+
+		max2.merge(max1);
+		assertEquals(5678.9012, max2.getLocalValue(), 0.0);
+
+		max1.merge(max2);
+		assertEquals(5678.9012, max1.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testClone() {
+		DoubleMaximum max = new DoubleMaximum();
+		double value = 3.14159265359;
+
+		max.add(value);
+
+		DoubleMaximum clone = max.clone();
+		assertEquals(value, clone.getLocalValue(), 0.0);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/DoubleMinimumTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/DoubleMinimumTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DoubleMinimumTest {
+
+	@Test
+	public void testGet() {
+		DoubleMinimum min = new DoubleMinimum();
+		assertEquals(Double.POSITIVE_INFINITY, min.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testResetLocal() {
+		DoubleMinimum min = new DoubleMinimum();
+		double value = 13.57902468;
+
+		min.add(value);
+		assertEquals(value, min.getLocalValue(), 0.0);
+
+		min.resetLocal();
+		assertEquals(Double.POSITIVE_INFINITY, min.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testAdd() {
+		DoubleMinimum min = new DoubleMinimum();
+
+		min.add(1234.5768);
+		min.add(9876.5432);
+		min.add(-987.6543);
+		min.add(-123.4567);
+
+		assertEquals(-987.6543, min.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testMerge() {
+		DoubleMinimum min1 = new DoubleMinimum();
+		min1.add(1234.5768);
+
+		DoubleMinimum min2 = new DoubleMinimum();
+		min2.add(5678.9012);
+
+		min2.merge(min1);
+		assertEquals(1234.5768, min2.getLocalValue(), 0.0);
+
+		min1.merge(min2);
+		assertEquals(1234.5768, min1.getLocalValue(), 0.0);
+	}
+
+	@Test
+	public void testClone() {
+		DoubleMinimum min = new DoubleMinimum();
+		double value = 3.14159265359;
+
+		min.add(value);
+
+		DoubleMinimum clone = min.clone();
+		assertEquals(value, clone.getLocalValue(), 0.0);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/IntMaximumTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/IntMaximumTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IntMaximumTest {
+
+	@Test
+	public void testGet() {
+		IntMaximum max = new IntMaximum();
+		assertEquals(Integer.MIN_VALUE, max.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testResetLocal() {
+		IntMaximum max = new IntMaximum();
+		int value = 13;
+
+		max.add(value);
+		assertEquals(value, max.getLocalValue().intValue());
+
+		max.resetLocal();
+		assertEquals(Integer.MIN_VALUE, max.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testAdd() {
+		IntMaximum max = new IntMaximum();
+
+		max.add(1234);
+		max.add(9876);
+		max.add(-987);
+		max.add(-123);
+
+		assertEquals(9876, max.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testMerge() {
+		IntMaximum max1 = new IntMaximum();
+		max1.add(1234);
+
+		IntMaximum max2 = new IntMaximum();
+		max2.add(5678);
+
+		max2.merge(max1);
+		assertEquals(5678, max2.getLocalValue().intValue());
+
+		max1.merge(max2);
+		assertEquals(5678, max1.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testClone() {
+		IntMaximum max = new IntMaximum();
+		int value = 42;
+
+		max.add(value);
+
+		IntMaximum clone = max.clone();
+		assertEquals(value, clone.getLocalValue().intValue());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/IntMinimumTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/IntMinimumTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IntMinimumTest {
+
+	@Test
+	public void testGet() {
+		IntMinimum min = new IntMinimum();
+		assertEquals(Integer.MAX_VALUE, min.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testResetLocal() {
+		IntMinimum min = new IntMinimum();
+		int value = 13;
+
+		min.add(value);
+		assertEquals(value, min.getLocalValue().intValue());
+
+		min.resetLocal();
+		assertEquals(Integer.MAX_VALUE, min.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testAdd() {
+		IntMinimum min = new IntMinimum();
+
+		min.add(1234);
+		min.add(9876);
+		min.add(-987);
+		min.add(-123);
+
+		assertEquals(-987, min.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testMerge() {
+		IntMinimum min1 = new IntMinimum();
+		min1.add(1234);
+
+		IntMinimum min2 = new IntMinimum();
+		min2.add(5678);
+
+		min2.merge(min1);
+		assertEquals(1234, min2.getLocalValue().intValue());
+
+		min1.merge(min2);
+		assertEquals(1234, min1.getLocalValue().intValue());
+	}
+
+	@Test
+	public void testClone() {
+		IntMinimum min = new IntMinimum();
+		int value = 42;
+
+		min.add(value);
+
+		IntMinimum clone = min.clone();
+		assertEquals(value, clone.getLocalValue().intValue());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/LongMaximumTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/LongMaximumTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LongMaximumTest {
+
+	@Test
+	public void testGet() {
+		LongMaximum max = new LongMaximum();
+		assertEquals(Long.MIN_VALUE, max.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testResetLocal() {
+		LongMaximum max = new LongMaximum();
+		long value = 9876543210L;
+
+		max.add(value);
+		assertEquals(value, max.getLocalValue().longValue());
+
+		max.resetLocal();
+		assertEquals(Long.MIN_VALUE, max.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testAdd() {
+		LongMaximum max = new LongMaximum();
+
+		max.add(1234567890);
+		max.add(9876543210L);
+		max.add(-9876543210L);
+		max.add(-1234567890);
+
+		assertEquals(9876543210L, max.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testMerge() {
+		LongMaximum max1 = new LongMaximum();
+		max1.add(1234567890987654321L);
+
+		LongMaximum max2 = new LongMaximum();
+		max2.add(5678909876543210123L);
+
+		max2.merge(max1);
+		assertEquals(5678909876543210123L, max2.getLocalValue().longValue());
+
+		max1.merge(max2);
+		assertEquals(5678909876543210123L, max1.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testClone() {
+		LongMaximum max = new LongMaximum();
+		long value = 4242424242424242L;
+
+		max.add(value);
+
+		LongMaximum clone = max.clone();
+		assertEquals(value, clone.getLocalValue().longValue());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/LongMinimumTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/LongMinimumTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LongMinimumTest {
+
+	@Test
+	public void testGet() {
+		LongMinimum min = new LongMinimum();
+		assertEquals(Long.MAX_VALUE, min.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testResetLocal() {
+		LongMinimum min = new LongMinimum();
+		long value = 9876543210L;
+
+		min.add(value);
+		assertEquals(value, min.getLocalValue().longValue());
+
+		min.resetLocal();
+		assertEquals(Long.MAX_VALUE, min.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testAdd() {
+		LongMinimum min = new LongMinimum();
+
+		min.add(1234567890);
+		min.add(9876543210L);
+		min.add(-9876543210L);
+		min.add(-1234567890);
+
+		assertEquals(-9876543210L, min.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testMerge() {
+		LongMinimum min1 = new LongMinimum();
+		min1.add(1234567890987654321L);
+
+		LongMinimum min2 = new LongMinimum();
+		min2.add(5678909876543210123L);
+
+		min2.merge(min1);
+		assertEquals(1234567890987654321L, min2.getLocalValue().longValue());
+
+		min1.merge(min2);
+		assertEquals(1234567890987654321L, min1.getLocalValue().longValue());
+	}
+
+	@Test
+	public void testClone() {
+		LongMinimum min = new LongMinimum();
+		long value = 4242424242424242L;
+
+		min.add(value);
+
+		LongMinimum clone = min.clone();
+		assertEquals(value, clone.getLocalValue().longValue());
+	}
+}


### PR DESCRIPTION
Flink already contains DoubleCounter, IntCounter, and LongCounter for adding numbers. This adds equivalent accumulators for storing the minimum and maximum double, int, and long values.