### PR TITLE
[FLINK-3737] testWikipediaEditsSource() adding check before executing test

### DIFF
--- a/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
+++ b/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
@@ -29,6 +29,11 @@ import static org.junit.Assert.fail;
 
 public class WikipediaEditsSourceTest {
 
+	/**
+	 * NOTE: if you are behind a firewall you may need to use a SOCKS Proxy for this test
+	 *
+	 * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html">Socks Proxy</a>
+	 */
 	@Test(timeout = 120 * 1000)
 	public void testWikipediaEditsSource() throws Exception {
 


### PR DESCRIPTION
WikipediaEditsSourceTest.testWikipediaEditsSource() fails without SOCKS proxy when developer is behind firewall.  Adding comment to make this easier for developers to track down in the future.

Also, submitted similar change to flink-web,
https://github.com/apache/flink-web/pull/18