### PR TITLE
[FLINK-3735] Make DataSetUnionRule match only for union-all

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetUnionRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetUnionRule.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.table.plan.rules.dataSet
 
-import org.apache.calcite.plan.{Convention, RelOptRule, RelTraitSet}
+import org.apache.calcite.plan.{RelOptRuleCall, Convention, RelOptRule, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.logical.LogicalUnion
@@ -32,21 +32,29 @@ class DataSetUnionRule
       "FlinkUnionRule")
   {
 
-    def convert(rel: RelNode): RelNode = {
-
-      val union: LogicalUnion = rel.asInstanceOf[LogicalUnion]
-      val traitSet: RelTraitSet = rel.getTraitSet.replace(DataSetConvention.INSTANCE)
-      val convLeft: RelNode = RelOptRule.convert(union.getInput(0), DataSetConvention.INSTANCE)
-      val convRight: RelNode = RelOptRule.convert(union.getInput(1), DataSetConvention.INSTANCE)
-
-      new DataSetUnion(
-        rel.getCluster,
-        traitSet,
-        convLeft,
-        convRight,
-        rel.getRowType)
-    }
+  /**
+   * Only translate UNION ALL
+   */
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val union: LogicalUnion = call.rel(0).asInstanceOf[LogicalUnion]
+    union.all
   }
+
+  def convert(rel: RelNode): RelNode = {
+
+    val union: LogicalUnion = rel.asInstanceOf[LogicalUnion]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(DataSetConvention.INSTANCE)
+    val convLeft: RelNode = RelOptRule.convert(union.getInput(0), DataSetConvention.INSTANCE)
+    val convRight: RelNode = RelOptRule.convert(union.getInput(1), DataSetConvention.INSTANCE)
+
+    new DataSetUnion(
+      rel.getCluster,
+      traitSet,
+      convLeft,
+      convRight,
+      rel.getRowType)
+  }
+}
 
 object DataSetUnionRule {
   val INSTANCE: RelOptRule = new DataSetUnionRule


### PR DESCRIPTION
Currently `UnionToDistinctRule` converts all unions to union-all + distinct, so this is just an extra check to make sure that unions are not translated in case the rule is removed or won't match.