### PR TITLE
[FLINK-2544] Add Java 8 version for building PowerMock tests to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ mvn clean package -DskipTests # this will take up to 10 minutes
 
 Flink is now installed in `build-target`
 
-*NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.0.3 creates the libraries properly.*
+*NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.0.3 creates the libraries properly.
+To build unit tests with Java 8, use Java 8u51 or above to prevent failures in unit tests that use the PowerMock runner.*
 
 ## Developing Flink
 

--- a/docs/setup/building.md
+++ b/docs/setup/building.md
@@ -34,6 +34,9 @@ In order to build Flink you need the source code. Either [download the source of
 
 In addition you need **Maven 3** and a **JDK** (Java Development Kit). Flink requires **at least Java 7** to build. We recommend using Java 8.
 
+*NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.0.3 creates the libraries properly.
+To build unit tests with Java 8, use Java 8u51 or above to prevent failures in unit tests that use the PowerMock runner.*
+
 To clone from git, enter:
 
 ~~~bash


### PR DESCRIPTION
Java 8 update 11 introduced a stricter bytecode verifier that leads to failures in unit tests that use the PowerMock runner. The tests run correctly in Java 8u51 or above. This PR updates the README with a note about the Java versions needed to run unit tests that use the PowerMock runner.