### PR TITLE
Refactor MockStreamSourceContext

### DIFF
--- a/flink-streaming-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-streaming-connectors/flink-connector-rabbitmq/pom.xml
@@ -61,6 +61,14 @@ under the License.
 			<version>${guava.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/flink-streaming-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-streaming-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.SerializedCheckpointData;
+import org.apache.flink.streaming.api.functions.source.MockSourceContext;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -363,36 +364,20 @@ public class RMQSourceTest {
 		}
 	}
 
-	private static class DummySourceContext implements SourceFunction.SourceContext<String> {
+	private static class DummySourceContext extends MockSourceContext<String> {
 
 		private static final Object lock = new Object();
 
 		private static long numElementsCollected;
 
 		public DummySourceContext() {
+			super(lock);
 			numElementsCollected = 0;
 		}
 
 		@Override
 		public void collect(String element) {
 			numElementsCollected++;
-		}
-
-		@Override
-		public void collectWithTimestamp(java.lang.String element, long timestamp) {
-		}
-
-		@Override
-		public void emitWatermark(Watermark mark) {
-		}
-
-		@Override
-		public Object getCheckpointLock() {
-			return lock;
-		}
-
-		@Override
-		public void close() {
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/ListSourceContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/ListSourceContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.functions;
 
+import org.apache.flink.streaming.api.functions.source.MockSourceContext;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 
@@ -28,9 +29,7 @@ import java.util.List;
  * 
  * @param <T> Type of the collected elements.
  */
-public class ListSourceContext<T> implements SourceFunction.SourceContext<T> {
-	
-	private final Object lock = new Object();
+public class ListSourceContext<T> extends MockSourceContext<T> {
 	
 	private final List<T> target;
 
@@ -63,20 +62,5 @@ public class ListSourceContext<T> implements SourceFunction.SourceContext<T> {
 	@Override
 	public void collectWithTimestamp(T element, long timestamp) {
 		target.add(element);
-	}
-
-	@Override
-	public void emitWatermark(Watermark mark) {
-		// don't do anything
-	}
-
-	@Override
-	public Object getCheckpointLock() {
-		return lock;
-	}
-
-	@Override
-	public void close() {
-
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunctionTest.java
@@ -46,22 +46,9 @@ public class FileMonitoringFunctionTest {
 		}.start();
 
 		fileMonitoringFunction.run(
-				new SourceFunction.SourceContext<Tuple3<String, Long, Long>>() {
-
+				new MockSourceContext<Tuple3<String,Long,Long>>() {
 					@Override
 					public void collect(Tuple3<String, Long, Long> element) {}
-
-					@Override
-					public void collectWithTimestamp(Tuple3<String, Long, Long> element, long timestamp) {}
-
-					@Override
-					public void emitWatermark(Watermark mark) {}
-
-					@Override
-					public Object getCheckpointLock() { return null; }
-
-					@Override
-					public void close() {}
 				});
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/MockSourceContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/MockSourceContext.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.functions.source;
+
+import org.apache.flink.streaming.api.watermark.Watermark;
+
+public abstract class MockSourceContext<T> implements SourceFunction.SourceContext<T> {
+	protected Object lock;
+
+	public MockSourceContext() {
+		this(new Object());
+	}
+	
+	public MockSourceContext(Object lock) {
+		this.lock = lock;
+	}
+
+	@Override
+	public void collectWithTimestamp(T element, long timestamp) {
+		collect(element);
+	}
+
+	@Override
+	public void emitWatermark(Watermark mark) {}
+
+	@Override
+	public Object getCheckpointLock() {
+		return this.lock;
+	}
+
+	@Override
+	public void close() {}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunctionTest.java
@@ -258,10 +258,7 @@ public class SocketTextStreamFunctionTest {
 
 		public void run() {
 			try {
-				SourceFunction.SourceContext<String> ctx = new SourceFunction.SourceContext<String>() {
-					
-					private final Object lock = new Object();
-					
+				SourceFunction.SourceContext<String> ctx = new MockSourceContext<String>() {
 					@Override
 					public void collect(String element) {
 						int pos = numElementsReceived;
@@ -276,22 +273,6 @@ public class SocketTextStreamFunctionTest {
 							assertEquals(expectedData[pos], element);
 						}
 					}
-
-					@Override
-					public void collectWithTimestamp(String element, long timestamp) {
-						collect(element);
-					}
-
-					@Override
-					public void emitWatermark(Watermark mark) {}
-
-					@Override
-					public Object getCheckpointLock() {
-						return lock;
-					}
-
-					@Override
-					public void close() {}
 				};
 				
 				socketSource.run(ctx);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/CollectingSourceContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/CollectingSourceContext.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.streaming.api.functions.source.MockSourceContext;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 
@@ -26,13 +27,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
 
-public class CollectingSourceContext<T extends Serializable> implements SourceFunction.SourceContext<T> {
+public class CollectingSourceContext<T extends Serializable> extends MockSourceContext<T> {
 	
-	private final Object lock;
 	private final Collection<T> collection;
 
-	public CollectingSourceContext(Object lock, Collection<T> collection) {
-		this.lock = lock;
+	public CollectingSourceContext(Collection<T> collection) {
 		this.collection = collection;
 	}
 
@@ -44,22 +43,4 @@ public class CollectingSourceContext<T extends Serializable> implements SourceFu
 			throw new RuntimeException(e.getMessage(), e);
 		}
 	}
-
-	@Override
-	public void collectWithTimestamp(T element, long timestamp) {
-		collect(element);
-	}
-
-	@Override
-	public void emitWatermark(Watermark mark) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Object getCheckpointLock() {
-		return lock;
-	}
-
-	@Override
-	public void close() {}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceFunctionUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceFunctionUtil.java
@@ -55,7 +55,7 @@ public class SourceFunctionUtil {
 			((RichFunction) sourceFunction).open(new Configuration());
 		}
 		try {
-			SourceFunction.SourceContext<T> ctx = new CollectingSourceContext<T>(new Object(), outputs);
+			SourceFunction.SourceContext<T> ctx = new CollectingSourceContext<>(outputs);
 			sourceFunction.run(ctx);
 		} catch (Exception e) {
 			throw new RuntimeException("Cannot invoke source.", e);


### PR DESCRIPTION
This PR refactors the existing  Mock-/DummySourceContext classes into an abstract MockSourceContext classes and extending classes.

if we add a method to the SourceContext interface we now only have to adjust one class instead of 5 + any other mock context that might be added in the future.
