### PR TITLE
Add util for TDD instantiation

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -18,17 +18,12 @@
 
 package org.apache.flink.runtime.taskmanager;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
-import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.DummyActorGateway;
@@ -36,20 +31,18 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.memory.MemoryManager;
 
 import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.runtime.testutils.recordutils.TaskDeploymentDescriptorBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.Serializable;
-import java.net.URL;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
@@ -147,16 +140,9 @@ public class TaskAsyncCallTest {
 		when(networkEnvironment.getPartitionConsumableNotifier()).thenReturn(consumableNotifier);
 		when(networkEnvironment.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
 
-		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-				new JobID(), new JobVertexID(), new ExecutionAttemptID(),
-				new ExecutionConfig(), "Test Task", 0, 1, 0,
-				new Configuration(), new Configuration(),
-				CheckpointsInOrderInvokable.class.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
+		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptorBuilder()
+			.setInvokableClassName(CheckpointsInOrderInvokable.class.getName())
+			.build();
 
 		ActorGateway taskManagerGateway = DummyActorGateway.INSTANCE;
 		return new Task(tdd,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -65,6 +64,7 @@ import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.StoppableInvokable;
+import org.apache.flink.runtime.testutils.recordutils.TaskDeploymentDescriptorBuilder;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
@@ -78,7 +78,6 @@ import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.net.InetSocketAddress;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -160,13 +159,15 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid = new ExecutionAttemptID();
 				final ExecutionConfig executionConfig = new ExecutionConfig();
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(jid, vid, eid, executionConfig,
-						"TestTask", 2, 7, 0, new Configuration(), new Configuration(),
-						TestInvokableCorrect.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
-
+				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid)
+					.setExecutionAttemptID(eid)
+					.setExecutionConfig(executionConfig)
+					.setSubtaskIndex(2)
+					.setSubtaskCount(7)
+					.setInvokableClassName(TestInvokableCorrect.class.getName())
+					.build();
 
 				new Within(d) {
 
@@ -261,19 +262,25 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, vid1, eid1,
-						new ExecutionConfig(), "TestTask1", 1, 5, 0,
-						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid1)
+					.setJobVertexID(vid1)
+					.setExecutionAttemptID(eid1)
+					.setTaskName("TestTask1")
+					.setSubtaskIndex(1)
+					.setSubtaskCount(5)
+					.setInvokableClassName(TestInvokableBlockingCancelable.class.getName())
+					.build();
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, vid2, eid2,
-						new ExecutionConfig(), "TestTask2", 2, 7, 0,
-						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid2)
+					.setJobVertexID(vid2)
+					.setExecutionAttemptID(eid2)
+					.setTaskName("TestTask2")
+					.setSubtaskIndex(2)
+					.setSubtaskCount(7)
+					.setInvokableClassName(TestInvokableBlockingCancelable.class.getName())
+					.build();
 
 				final ActorGateway tm = taskManager;
 
@@ -395,17 +402,25 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, vid1, eid1, new ExecutionConfig(),
-						"TestTask1", 1, 5, 0, new Configuration(), new Configuration(), StoppableInvokable.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid1)
+					.setJobVertexID(vid1)
+					.setExecutionAttemptID(eid1)
+					.setTaskName("TestTask1")
+					.setSubtaskIndex(1)
+					.setSubtaskCount(5)
+					.setInvokableClassName(StoppableInvokable.class.getName())
+					.build();
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, vid2, eid2, new ExecutionConfig(),
-						"TestTask2", 2, 7, 0, new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid2)
+					.setJobVertexID(vid2)
+					.setExecutionAttemptID(eid2)
+					.setTaskName("TestTask2")
+					.setSubtaskIndex(2)
+					.setSubtaskCount(7)
+					.setInvokableClassName(TestInvokableBlockingCancelable.class.getName())
+					.build();
 
 				final ActorGateway tm = taskManager;
 
@@ -521,19 +536,25 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1,
-						new ExecutionConfig(), "Sender", 0, 1, 0,
-						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid1)
+					.setExecutionAttemptID(eid1)
+					.setTaskName("Sender")
+					.setSubtaskIndex(0)
+					.setSubtaskCount(1)
+					.setInvokableClassName(Tasks.Sender.class.getName())
+					.build();
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2,
-						new ExecutionConfig(), "Receiver", 2, 7, 0,
-						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid2)
+					.setExecutionAttemptID(eid2)
+					.setTaskName("Receiver")
+					.setSubtaskIndex(2)
+					.setSubtaskCount(7)
+					.setInvokableClassName(Tasks.Receiver.class.getName())
+					.build();
 
 				new Within(d){
 
@@ -622,18 +643,27 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1,
-						new ExecutionConfig(), "Sender", 0, 1, 0,
-						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
-						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(), new ArrayList<BlobKey>(),
-						Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid1)
+					.setExecutionAttemptID(eid1)
+					.setTaskName("Sender")
+					.setSubtaskIndex(0)
+					.setSubtaskCount(1)
+					.setPartitions(irpdd)
+					.setInvokableClassName(Tasks.Sender.class.getName())
+					.build();
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2,
-						new ExecutionConfig(), "Receiver", 2, 7, 0,
-						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.singletonList(ircdd),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid2)
+					.setExecutionAttemptID(eid2)
+					.setTaskName("Receiver")
+					.setSubtaskIndex(2)
+					.setSubtaskCount(7)
+					.setInputGates(Collections.singletonList(ircdd))
+					.setInvokableClassName(Tasks.Receiver.class.getName())
+					.build();
 
 				new Within(d) {
 
@@ -763,18 +793,27 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid, vid1, eid1,
-						new ExecutionConfig(), "Sender", 0, 1, 0,
-						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
-						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid1)
+					.setExecutionAttemptID(eid1)
+					.setTaskName("Sender")
+					.setSubtaskIndex(0)
+					.setSubtaskCount(1)
+					.setPartitions(irpdd)
+					.setInvokableClassName(Tasks.Sender.class.getName())
+					.build();
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid, vid2, eid2,
-						new ExecutionConfig(), "Receiver", 2, 7, 0,
-						new Configuration(), new Configuration(), Tasks.BlockingReceiver.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.singletonList(ircdd),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid2)
+					.setExecutionAttemptID(eid2)
+					.setTaskName("Receiver")
+					.setSubtaskIndex(2)
+					.setSubtaskCount(7)
+					.setInputGates(Collections.singletonList(ircdd))
+					.setInvokableClassName(Tasks.BlockingReceiver.class.getName())
+					.build();
 
 				new Within(d){
 
@@ -907,15 +946,16 @@ public class TaskManagerTest extends TestLogger {
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-						jid, vid, eid,
-						new ExecutionConfig(), "Receiver", 0, 1, 0,
-						new Configuration(), new Configuration(),
-						Tasks.AgnosticReceiver.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.singletonList(igdd),
-						Collections.<BlobKey>emptyList(),
-						Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid)
+					.setExecutionAttemptID(eid)
+					.setTaskName("Receiver")
+					.setSubtaskIndex(0)
+					.setSubtaskCount(1)
+					.setInputGates(Collections.singletonList(igdd))
+					.setInvokableClassName(Tasks.AgnosticReceiver.class.getName())
+					.build();
 
 				new Within(d) {
 					@Override
@@ -1002,14 +1042,16 @@ public class TaskManagerTest extends TestLogger {
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-						jid, vid, eid, new ExecutionConfig(), "Receiver", 0, 1, 0,
-						new Configuration(), new Configuration(),
-						Tasks.AgnosticReceiver.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.singletonList(igdd),
-						Collections.<BlobKey>emptyList(),
-						Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptorBuilder()
+					.setJobID(jid)
+					.setJobVertexID(vid)
+					.setExecutionAttemptID(eid)
+					.setTaskName("Receiver")
+					.setSubtaskIndex(0)
+					.setSubtaskCount(1)
+					.setInvokableClassName(Tasks.AgnosticReceiver.class.getName())
+					.setInputGates(Collections.singletonList(igdd))
+					.build();
 
 				new Within(new FiniteDuration(120, TimeUnit.SECONDS)) {
 					@Override
@@ -1075,23 +1117,9 @@ public class TaskManagerTest extends TestLogger {
 						false);
 
 				// Single blocking task
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-						new JobID(),
-						new JobVertexID(),
-						new ExecutionAttemptID(),
-						new ExecutionConfig(),
-						"Task",
-						0,
-						1,
-						0,
-						new Configuration(),
-						new Configuration(),
-						Tasks.BlockingNoOpInvokable.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						Collections.<BlobKey>emptyList(),
-						Collections.<URL>emptyList(),
-						0);
+				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptorBuilder()
+					.setInvokableClassName(Tasks.BlockingNoOpInvokable.class.getName())
+					.build();
 
 				// Submit the task
 				new Within(d) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -20,12 +20,8 @@ package org.apache.flink.runtime.taskmanager;
 
 import com.google.common.collect.Maps;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
-import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -41,11 +37,11 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.TaskMessages;
 
+import org.apache.flink.runtime.testutils.recordutils.TaskDeploymentDescriptorBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,8 +49,6 @@ import org.junit.Test;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.lang.reflect.Field;
-import java.net.URL;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -609,7 +603,9 @@ public class TaskTest {
 							LibraryCacheManager libCache,
 							NetworkEnvironment networkEnvironment) {
 		
-		TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(invokable);
+		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptorBuilder()
+			.setInvokableClassName(invokable.getName())
+			.build();
 		
 		return new Task(
 				tdd,
@@ -623,19 +619,6 @@ public class TaskTest {
 				libCache,
 				mock(FileCache.class),
 				new TaskManagerRuntimeInfo("localhost", new Configuration()));
-	}
-
-	private TaskDeploymentDescriptor createTaskDeploymentDescriptor(Class<? extends AbstractInvokable> invokable) {
-		return new TaskDeploymentDescriptor(
-				new JobID(), new JobVertexID(), new ExecutionAttemptID(),
-				new ExecutionConfig(), "Test Task", 0, 1, 0,
-				new Configuration(), new Configuration(),
-				invokable.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/TaskDeploymentDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/TaskDeploymentDescriptorBuilder.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.testutils.recordutils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.util.SerializedValue;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TaskDeploymentDescriptorBuilder {
+	private JobID jobID;
+	private JobVertexID jobVertexID;
+	private ExecutionAttemptID executionId;
+	private ExecutionConfig executionConfig;
+	private String taskName;
+	private Integer subtaskIndex;
+	private Integer subtaskCount;
+	private Integer attemptNumber;
+	private Configuration jobConfiguration;
+	private Configuration taskConfiguration;
+	private String invokableClassName;
+	private List<ResultPartitionDeploymentDescriptor> producedPartitions;
+	private List<InputGateDeploymentDescriptor> inputGates;
+	private List<BlobKey> requiredJarFiles;
+	private List<URL> requiredClasspaths;
+	private Integer targetSlotNumber;
+	private SerializedValue<StateHandle<?>> operatorState;
+	private Long recoveryTimestamp;
+
+	public TaskDeploymentDescriptorBuilder setJobID(JobID jobID) {
+		this.jobID = jobID;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setJobVertexID(JobVertexID vertexID) {
+		this.jobVertexID = vertexID;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setExecutionAttemptID(ExecutionAttemptID executionAttemptID) {
+		this.executionId = executionAttemptID;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setExecutionConfig(ExecutionConfig executionConfig) {
+		this.executionConfig = executionConfig;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setTaskName(String taskName) {
+		this.taskName = taskName;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setSubtaskIndex(int subtaskIndex) {
+		this.subtaskIndex = subtaskIndex;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setSubtaskCount(int subtaskCount) {
+		this.subtaskCount = subtaskCount;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setAttemptNumber(int attemptNumber) {
+		this.attemptNumber = attemptNumber;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setJobConfiguration(Configuration configuration) {
+		this.jobConfiguration = configuration;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setTaskConfiguration(Configuration configuration) {
+		this.taskConfiguration = configuration;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setInvokableClassName(String invokableClassName) {
+		this.invokableClassName = invokableClassName;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setPartitions(List<ResultPartitionDeploymentDescriptor> partitions) {
+		this.producedPartitions = partitions;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setInputGates(List<InputGateDeploymentDescriptor> inputGates) {
+		this.inputGates = inputGates;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setReguiredJarFiles(List<BlobKey> requiredJarFiles) {
+		this.requiredJarFiles = requiredJarFiles;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setClassPaths(List<URL> requiredClasspaths) {
+		this.requiredClasspaths = requiredClasspaths;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setTargetSlotNumber(int targetSlotNumber) {
+		this.targetSlotNumber = targetSlotNumber;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setOperatorState(SerializedValue<StateHandle<?>> operatorState) {
+		this.operatorState = operatorState;
+		return this;
+	}
+
+	public TaskDeploymentDescriptorBuilder setRecoveryTimeStamp(long recoveryTimestamp) {
+		this.recoveryTimestamp = recoveryTimestamp;
+		return this;
+	}
+
+	public TaskDeploymentDescriptor build() {
+		if (invokableClassName == null) {
+			throw new IllegalArgumentException("InvokableClassName must not be null.");
+		}
+		return new TaskDeploymentDescriptor(
+			jobID == null ? new JobID() : jobID,
+			jobVertexID == null ? new JobVertexID() : jobVertexID,
+			executionId == null ? new ExecutionAttemptID() : executionId,
+			executionConfig == null ? new ExecutionConfig() : executionConfig,
+			taskName == null ? "Test Task" : taskName,
+			subtaskIndex == null ? 0 : subtaskIndex,
+			subtaskCount == null ? 1 : subtaskCount,
+			attemptNumber == null ? 0 : attemptNumber,
+			jobConfiguration == null ? new Configuration() : jobConfiguration,
+			taskConfiguration == null ? new Configuration() : taskConfiguration,
+			invokableClassName,
+			producedPartitions == null ? Collections.<ResultPartitionDeploymentDescriptor>emptyList() : producedPartitions,
+			inputGates == null ? Collections.<InputGateDeploymentDescriptor>emptyList() : inputGates,
+			requiredJarFiles == null ? new ArrayList<BlobKey>() : requiredJarFiles,
+			requiredClasspaths == null ? new ArrayList<URL>() : requiredClasspaths,
+			targetSlotNumber == null ? 0 : targetSlotNumber,
+			operatorState,
+			recoveryTimestamp == null ? -1 : recoveryTimestamp
+		);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -20,28 +20,23 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import akka.actor.ActorRef;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
-import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
+import org.apache.flink.runtime.testutils.recordutils.TaskDeploymentDescriptorBuilder;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.Output;
@@ -57,8 +52,6 @@ import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.net.URL;
-import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -133,17 +126,10 @@ public class StreamTaskTest {
 		when(network.getPartitionConsumableNotifier()).thenReturn(consumableNotifier);
 		when(network.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
 
-		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-				new JobID(), new JobVertexID(), new ExecutionAttemptID(),
-				new ExecutionConfig(), "Test Task", 0, 1, 0,
-				new Configuration(),
-				taskConfig.getConfiguration(),
-				invokable.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
+		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptorBuilder()
+			.setInvokableClassName(invokable.getName())
+			.setTaskConfiguration(taskConfig.getConfiguration())
+			.build();
 
 		return new Task(
 				tdd,


### PR DESCRIPTION
This PR is more of a proposal and tries to make TaskDeploymentDescriptor instantiation in tests less tedious.

With a total of 17/18 constructor arguments calling the constructor naturally becomes an unreadable affair. As such i added a TaskDeploymentDescriptorBuilder with a set method for every argument; should an argument not be set when build() is called a default value is used.

I recently tried adding the job name to the TDD and when i saw the number of occurrences i would have to change I came up with this idea.
