### PR TITLE
FLINK-3762: StackOverflowError due to disabled Kryo Reference tracking

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -323,9 +323,8 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 		if (this.kryo == null) {
 			this.kryo = getKryoInstance();
 
-			// disable reference tracking. reference tracking is costly, usually unnecessary, and
-			// inconsistent with Flink's own serialization (which does not do reference tracking)
-			kryo.setReferences(false);
+			// Enable reference tracking. 
+			kryo.setReferences(true);
 			
 			// Throwable and all subclasses should be serialized via java serialization
 			kryo.addDefaultSerializer(Throwable.class, new JavaSerializer());

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoGenericTypeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoGenericTypeSerializerTest.java
@@ -160,9 +160,9 @@ public class KryoGenericTypeSerializerTest extends AbstractGenericTypeSerializer
 	}
 
 	@Test
-	public void validateReferenceMappingDisabled() {
+	public void validateReferenceMappingEnabled() {
 		KryoSerializer<String> serializer = new KryoSerializer<>(String.class, new ExecutionConfig());
 		Kryo kryo = serializer.getKryo();
-		assertFalse(kryo.getReferences());
+		assertTrue(kryo.getReferences());
 	}
 }


### PR DESCRIPTION
As discussed on the dev list,

In `KryoSerializer.java`

Kryo Reference tracking is disabled by default:
```java
    kryo.setReferences(false);
```
This can causes StackOverflowError Exceptions when serializing many objects that may contain recursive objects:
```
java.lang.StackOverflowError
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:48)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:495)
	at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:523)
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:61)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:495)
	at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:523)
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:61)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:495)
	at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:523)
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:61)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:495)
```
By enabling reference tracking, we can fix this problem.

[1]https://gist.github.com/andrewpalumbo/40c7422a5187a24cd03d7d81feb2a419
