### PR TITLE
[FLINK-3759] [table] Table API should throw exception is null value is encountered in non-null mode.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
@@ -907,18 +907,15 @@ class CodeGenerator(
     val resultTypeTerm = primitiveTypeTermForTypeInfo(resultType)
     val defaultValue = primitiveDefaultValue(resultType)
 
-    val wrappedCode = if (nullCheck) {
-      s"""
+    if (nullCheck) {
+      val wrappedCode = s"""
         |$resultTypeTerm $resultTerm = $defaultValue;
         |boolean $nullTerm = true;
         |""".stripMargin
+      GeneratedExpression(resultTerm, nullTerm, wrappedCode, resultType)
     } else {
-      s"""
-        |$resultTypeTerm $resultTerm = $defaultValue;
-        |""".stripMargin
+      throw new CodeGenException("Null literals are not allowed if nullCheck is disabled.")
     }
-
-    GeneratedExpression(resultTerm, nullTerm, wrappedCode, resultType)
   }
 
   // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
As discussed in FLINK-3739 this PR changes the behavior of null literals in non null-check mode.