### PR TITLE
[FLINK-3748] [table] Add CASE function to Table API

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
@@ -65,6 +65,19 @@ trait ImplicitExpressionOperations {
 
   def as(name: Symbol) = Naming(expr, name.name)
 
+  /**
+    * Conditional operator that decides which of two other expressions should be evaluated
+    * based on a evaluated boolean condition.
+    *
+    * e.g. (42 > 5).eval("A", "B") leads to "A"
+    *
+    * @param ifTrue expression to be evaluated if condition holds
+    * @param ifFalse expression to be evaluated if condition does not hold
+    */
+  def eval(ifTrue: Expression, ifFalse: Expression) = {
+    Eval(expr, ifTrue, ifFalse)
+  }
+
   // scalar functions
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
@@ -716,6 +716,9 @@ class CodeGenerator(
         requireBoolean(operand)
         generateNot(nullCheck, operand)
 
+      case CASE =>
+        generateIfElse(nullCheck, operands, resultType)
+
       // casting
       case CAST =>
         val operand = operands.head

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
@@ -134,6 +134,11 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
     case e ~ _ ~ target ~ _ => Naming(e, target.name)
   }
 
+  lazy val eval: PackratParser[Expression] = atom ~
+      ".eval(" ~ expression ~ "," ~ expression ~ ")" ^^ {
+    case condition ~ _ ~ ifTrue ~ _ ~ ifFalse ~ _ => Eval(condition, ifTrue, ifFalse)
+  }
+
   // general function calls
 
   lazy val functionCall = ident ~ "(" ~ rep1sep(expression, ",") ~ ")" ^^ {
@@ -200,7 +205,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
 
   lazy val suffix =
     isNull | isNotNull |
-      sum | min | max | count | avg | cast | nullLiteral |
+      sum | min | max | count | avg | cast | nullLiteral | eval |
       specialFunctionCalls | functionCall | functionCallWithoutArgs |
       specialSuffixFunctionCalls | suffixFunctionCall | suffixFunctionCallWithoutArgs |
       atom

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/call.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/call.scala
@@ -17,8 +17,6 @@
  */
 package org.apache.flink.api.table.expressions
 
-import scala.collection.JavaConversions._
-
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
@@ -35,7 +33,7 @@ case class Call(functionName: String, args: Expression*) extends Expression {
   override def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
     relBuilder.call(
       BuiltInFunctionNames.toSqlOperator(functionName),
-      args.map(_.toRexNode))
+      args.map(_.toRexNode): _*)
   }
 
   override def toString = s"\\$functionName(${args.mkString(", ")})"

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
@@ -55,6 +55,11 @@ object RexNodeTranslator {
         val l = extractAggCalls(b.left, tableEnv)
         val r = extractAggCalls(b.right, tableEnv)
         (b.makeCopy(List(l._1, r._1)), l._2 ::: r._2)
+      case e: Eval =>
+        val c = extractAggCalls(e.condition, relBuilder)
+        val t = extractAggCalls(e.ifTrue, relBuilder)
+        val f = extractAggCalls(e.ifFalse, relBuilder)
+        (e.makeCopy(List(c._1, t._1, f._1)), c._2 ::: t._2 ::: f._2)
 
       // Scalar functions
       case c@Call(name, args@_*) =>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
@@ -56,9 +56,9 @@ object RexNodeTranslator {
         val r = extractAggCalls(b.right, tableEnv)
         (b.makeCopy(List(l._1, r._1)), l._2 ::: r._2)
       case e: Eval =>
-        val c = extractAggCalls(e.condition, relBuilder)
-        val t = extractAggCalls(e.ifTrue, relBuilder)
-        val f = extractAggCalls(e.ifFalse, relBuilder)
+        val c = extractAggCalls(e.condition, tableEnv)
+        val t = extractAggCalls(e.ifTrue, tableEnv)
+        val f = extractAggCalls(e.ifFalse, tableEnv)
         (e.makeCopy(List(c._1, t._1, f._1)), c._2 ::: t._2 ::: f._2)
 
       // Scalar functions

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
@@ -135,7 +135,7 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 	@Test
 	public void testEval() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = getJavaTableEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
 
 		DataSource<Tuple2<Integer, Boolean>> input =
 				env.fromElements(new Tuple2<>(5, true));
@@ -157,7 +157,7 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 	@Test(expected = IllegalArgumentException.class)
 	public void testEvalInvalidTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = getJavaTableEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
 
 		DataSource<Tuple2<Integer, Boolean>> input =
 				env.fromElements(new Tuple2<>(5, true));

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
@@ -132,5 +132,46 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 		}
 	}
 
+	@Test
+	public void testEval() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+
+		DataSource<Tuple2<Integer, Boolean>> input =
+				env.fromElements(new Tuple2<>(5, true));
+
+		Table table =
+				tableEnv.fromDataSet(input, "a, b");
+
+		Table result = table.select(
+				"(b && true).eval('true', 'false')," +
+					"false.eval('true', 'false')," +
+					"true.eval(true.eval(true.eval(10, 4), 4), 4)");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "true,false,10";
+		compareResultAsText(results, expected);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testEvalInvalidTypes() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = getJavaTableEnvironment();
+
+		DataSource<Tuple2<Integer, Boolean>> input =
+				env.fromElements(new Tuple2<>(5, true));
+
+		Table table =
+				tableEnv.fromDataSet(input, "a, b");
+
+		Table result = table.select("(b && true).eval(5, 'false')");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "true,false,3,10";
+		compareResultAsText(results, expected);
+	}
+
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/sql/test/ExpressionsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/sql/test/ExpressionsITCase.scala
@@ -69,4 +69,57 @@ class ExpressionsITCase(
     }
   }
 
+  @Test
+  def testCase(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    val sqlQuery = "SELECT " +
+      "CASE 11 WHEN 1 THEN 'a' ELSE 'b' END," +
+      "CASE WHEN 'a'='a' THEN 1 END," +
+      "CASE 2 WHEN 1 THEN 'a' ELSE 'b' END," +
+      "CASE 2 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END," +
+      "CASE 1 WHEN 1, 2 THEN '1 or 2' WHEN 2 THEN 'not possible' WHEN 3, 2 THEN '3' " +
+      "  ELSE 'none of the above' END" +
+      " FROM MyTable"
+
+    val ds = env.fromElements((1, 0))
+    tEnv.registerDataSet("MyTable", ds, 'a, 'b)
+
+    val result = tEnv.sql(sqlQuery)
+
+    val expected = "b,1,b,bcd,1 or 2"
+    val results = result.toDataSet[Row](getConfig).collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testCaseWithNull(): Unit = {
+    if (!getConfig.getNullCheck) {
+      return
+    }
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = getScalaTableEnvironment
+    TranslationContext.reset()
+
+    val sqlQuery = "SELECT " +
+      "CASE a WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END," +
+      "CASE b WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END," +
+      "CASE 42 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END," +
+      "CASE 1 WHEN 1 THEN true WHEN 2 THEN false ELSE NULL END" +
+      " FROM MyTable"
+
+    val ds = env.fromElements((1, 0))
+    tEnv.registerDataSet("MyTable", ds, 'a, 'b)
+
+    val result = tEnv.sql(sqlQuery)
+
+    val expected = "11,null,null,true"
+    val results = result.toDataSet[Row](getConfig).collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/sql/test/ExpressionsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/sql/test/ExpressionsITCase.scala
@@ -73,14 +73,11 @@ class ExpressionsITCase(
   def testCase(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = getScalaTableEnvironment
-    TranslationContext.reset()
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
     val sqlQuery = "SELECT " +
       "CASE 11 WHEN 1 THEN 'a' ELSE 'b' END," +
-      "CASE WHEN 'a'='a' THEN 1 END," +
       "CASE 2 WHEN 1 THEN 'a' ELSE 'b' END," +
-      "CASE 2 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END," +
       "CASE 1 WHEN 1, 2 THEN '1 or 2' WHEN 2 THEN 'not possible' WHEN 3, 2 THEN '3' " +
       "  ELSE 'none of the above' END" +
       " FROM MyTable"
@@ -90,22 +87,23 @@ class ExpressionsITCase(
 
     val result = tEnv.sql(sqlQuery)
 
-    val expected = "b,1,b,bcd,1 or 2"
-    val results = result.toDataSet[Row](getConfig).collect()
+    val expected = "b,b,1 or 2"
+    val results = result.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
   @Test
   def testCaseWithNull(): Unit = {
-    if (!getConfig.getNullCheck) {
+    if (!config.getNullCheck) {
       return
     }
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = getScalaTableEnvironment
-    TranslationContext.reset()
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
     val sqlQuery = "SELECT " +
+      "CASE WHEN 'a'='a' THEN 1 END," +
+      "CASE 2 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END," +
       "CASE a WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END," +
       "CASE b WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END," +
       "CASE 42 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END," +
@@ -117,8 +115,8 @@ class ExpressionsITCase(
 
     val result = tEnv.sql(sqlQuery)
 
-    val expected = "11,null,null,true"
-    val results = result.toDataSet[Row](getConfig).collect()
+    val expected = "1,bcd,11,null,null,true"
+    val results = result.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
@@ -132,25 +132,29 @@ class ExpressionsITCase(
   @Test
   def testEval(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val t = env.fromElements((5, true)).as('a, 'b)
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val t = env.fromElements((5, true)).toTable(tEnv, 'a, 'b)
       .select(
         ('b && true).eval("true", "false"),
         false.eval("true", "false"),
         true.eval(true.eval(true.eval(10, 4), 4), 4))
 
     val expected = "true,false,10"
-    val results = t.toDataSet[Row](getConfig).collect()
+    val results = t.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
   @Test(expected = classOf[IllegalArgumentException])
   def testEvalInvalidTypes(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val t = env.fromElements((5, true)).as('a, 'b)
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val t = env.fromElements((5, true)).toTable(tEnv, 'a, 'b)
       .select(('b && true).eval(5, "false"))
 
     val expected = "true,false,3,10"
-    val results = t.toDataSet[Row](getConfig).collect()
+    val results = t.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/table/test/ExpressionsITCase.scala
@@ -129,6 +129,31 @@ class ExpressionsITCase(
     }
   }
 
+  @Test
+  def testEval(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val t = env.fromElements((5, true)).as('a, 'b)
+      .select(
+        ('b && true).eval("true", "false"),
+        false.eval("true", "false"),
+        true.eval(true.eval(true.eval(10, 4), 4), 4))
+
+    val expected = "true,false,10"
+    val results = t.toDataSet[Row](getConfig).collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testEvalInvalidTypes(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val t = env.fromElements((5, true)).as('a, 'b)
+      .select(('b && true).eval(5, "false"))
+
+    val expected = "true,false,3,10"
+    val results = t.toDataSet[Row](getConfig).collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
   // Date literals not yet supported
   @Ignore
   @Test


### PR DESCRIPTION
This PR adds an evaluation function to the Table API that allows for if/else branching. It also allows `CASE WHEN` syntax in SQL.

I will update the EBNF grammar in the documentation as part of FLINK-3086 next.