### PR TITLE
[FLINK-3764] [tests] Improve LeaderChangeStateCleanupTest stability

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderRetrievalService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderRetrievalService.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.leaderelection;
 
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
 
@@ -45,7 +46,7 @@ public class TestingLeaderRetrievalService implements LeaderRetrievalService {
 
 	@Override
 	public void start(LeaderRetrievalListener listener) throws Exception {
-		this.listener = listener;
+		this.listener = Preconditions.checkNotNull(listener);
 
 		if (leaderAddress != null) {
 			listener.notifyLeaderAddress(leaderAddress, leaderSessionID);
@@ -58,6 +59,10 @@ public class TestingLeaderRetrievalService implements LeaderRetrievalService {
 	}
 
 	public void notifyListener(String address, UUID leaderSessionID) {
-		listener.notifyLeaderAddress(address, leaderSessionID);
+		if (listener != null) {
+			listener.notifyLeaderAddress(address, leaderSessionID);
+		} else {
+			throw new IllegalStateException("The retrieval service has not been started properly.");
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingResourceManager.java
@@ -85,6 +85,8 @@ public class TestingResourceManager extends StandaloneResourceManager {
 
 		} else if (message instanceof TestingMessages.NotifyOfComponentShutdown$) {
 			waitForShutdown.add(sender());
+		} else if (message instanceof TestingMessages.Alive$) {
+			sender().tell(Messages.getAcknowledge(), self());
 		} else {
 			super.handleMessage(message);
 		}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -211,11 +211,18 @@ class TestingCluster(
 
     val jmsAliveFutures = jobManagerActors map {
       _ map {
-        tm => (tm ? Alive)(timeout)
+        jm => (jm ? Alive)(timeout)
       }
     } getOrElse(Seq())
 
-    val combinedFuture = Future.sequence(tmsAliveFutures ++ jmsAliveFutures)
+    val resourceManagersAliveFutures = resourceManagerActors map {
+      _ map {
+        rm => (rm ? Alive)(timeout)
+      }
+    } getOrElse(Seq())
+
+    val combinedFuture = Future.sequence(tmsAliveFutures ++ jmsAliveFutures ++
+                                           resourceManagersAliveFutures)
 
     Await.ready(combinedFuture, timeout)
   }


### PR DESCRIPTION
The LeaderElectionRetrievalTestingCluster now also waits for the Flink
resource manager to be properly started before trying to send leader
change notification messages to the LeaderRetrievalServices.