### PR TITLE
[FLINK-3774] [shell] Forwards Flink configuration to PlanExecutor

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -177,7 +176,7 @@ public abstract class PlanExecutor {
 	 * @return A remote executor.
 	 */
 	public static PlanExecutor createRemoteExecutor(String hostname, int port, Configuration clientConfiguration,
-			URL[] jarFiles, URL[] globalClasspaths) {
+			List<URL> jarFiles, List<URL> globalClasspaths) {
 		if (hostname == null) {
 			throw new IllegalArgumentException("The hostname must not be null.");
 		}
@@ -187,10 +186,10 @@ public abstract class PlanExecutor {
 		
 		Class<? extends PlanExecutor> reClass = loadExecutorClass(REMOTE_EXECUTOR_CLASS);
 		
-		List<URL> files = (jarFiles == null || jarFiles.length == 0) ?
-				Collections.<URL>emptyList() : Arrays.asList(jarFiles);
-		List<URL> paths = (globalClasspaths == null || globalClasspaths.length == 0) ?
-				Collections.<URL>emptyList() : Arrays.asList(globalClasspaths);
+		List<URL> files = (jarFiles == null) ?
+				Collections.<URL>emptyList() : jarFiles;
+		List<URL> paths = (globalClasspaths == null) ?
+				Collections.<URL>emptyList() : globalClasspaths;
 
 		try {
 			PlanExecutor executor = (clientConfiguration == null) ?

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -61,7 +61,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	protected Configuration clientConfiguration;
 	
 	/** The remote executor lazily created upon first use */
-	private PlanExecutor executor;
+	protected PlanExecutor executor;
 	
 	/** Optional shutdown hook, used in session mode to eagerly terminate the last session */
 	private Thread shutdownHook;
@@ -137,10 +137,10 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		this.port = port;
 		this.clientConfiguration = clientConfig == null ? new Configuration() : clientConfig;
 		if (jarFiles != null) {
-			this.jarFiles = new ArrayList<URL>(jarFiles.length);
-			for (int i = 0; i < jarFiles.length; i++) {
+			this.jarFiles = new ArrayList<>(jarFiles.length);
+			for(String jarFile : jarFiles) {
 				try {
-					this.jarFiles.add(new File(jarFiles[i]).getAbsoluteFile().toURI().toURL());
+					this.jarFiles.add(new File(jarFile).getAbsoluteFile().toURI().toURL());
 				} catch (MalformedURLException e) {
 					throw new IllegalArgumentException("JAR file path invalid", e);
 				}
@@ -187,7 +187,11 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		}
 		else {
 			PlanExecutor le = PlanExecutor.createLocalExecutor(null);
-			return le.getOptimizerPlanAsJSON(p);
+			String plan = le.getOptimizerPlanAsJSON(p);
+
+			le.stop();
+
+			return plan;
 		}
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -30,6 +30,10 @@ import org.apache.flink.configuration.Configuration;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * An {@link ExecutionEnvironment} that sends programs to a cluster for execution. The environment
@@ -51,10 +55,10 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	protected final int port;
 
 	/** The jar files that need to be attached to each job */
-	private final URL[] jarFiles;
+	protected final List<URL> jarFiles;
 
 	/** The configuration used by the client that connects to the cluster */
-	private Configuration clientConfiguration;
+	protected Configuration clientConfiguration;
 	
 	/** The remote executor lazily created upon first use */
 	private PlanExecutor executor;
@@ -63,7 +67,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	private Thread shutdownHook;
 
 	/** The classpaths that need to be attached to each job */
-	private final URL[] globalClasspaths;
+	protected final List<URL> globalClasspaths;
 
 	/**
 	 * Creates a new RemoteEnvironment that points to the master (JobManager) described by the
@@ -133,26 +137,31 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		this.port = port;
 		this.clientConfiguration = clientConfig == null ? new Configuration() : clientConfig;
 		if (jarFiles != null) {
-			this.jarFiles = new URL[jarFiles.length];
+			this.jarFiles = new ArrayList<URL>(jarFiles.length);
 			for (int i = 0; i < jarFiles.length; i++) {
 				try {
-					this.jarFiles[i] = new File(jarFiles[i]).getAbsoluteFile().toURI().toURL();
+					this.jarFiles.add(new File(jarFiles[i]).getAbsoluteFile().toURI().toURL());
 				} catch (MalformedURLException e) {
 					throw new IllegalArgumentException("JAR file path invalid", e);
 				}
 			}
 		}
 		else {
-			this.jarFiles = null;
+			this.jarFiles = Collections.emptyList();
 		}
-		this.globalClasspaths = globalClasspaths;
+
+		if (globalClasspaths == null) {
+			this.globalClasspaths = Collections.emptyList();
+		} else {
+			this.globalClasspaths = Arrays.asList(globalClasspaths);
+		}
 	}
 
 	// ------------------------------------------------------------------------
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		ensureExecutorCreated();
+		PlanExecutor executor = getExecutor();
 
 		Plan p = createProgramPlan(jobName);
 
@@ -190,7 +199,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		installShutdownHook();
 	}
 	
-	private void ensureExecutorCreated() throws Exception {
+	protected PlanExecutor getExecutor() throws Exception {
 		if (executor == null) {
 			executor = PlanExecutor.createRemoteExecutor(host, port, clientConfiguration,
 				jarFiles, globalClasspaths);
@@ -202,6 +211,8 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 			executor.start();
 			installShutdownHook();
 		}
+
+		return executor;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -138,7 +138,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		this.clientConfiguration = clientConfig == null ? new Configuration() : clientConfig;
 		if (jarFiles != null) {
 			this.jarFiles = new ArrayList<>(jarFiles.length);
-			for(String jarFile : jarFiles) {
+			for (String jarFile : jarFiles) {
 				try {
 					this.jarFiles.add(new File(jarFile).getAbsoluteFile().toURI().toURL());
 				} catch (MalformedURLException e) {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.minicluster
 
-import java.util
-
 import akka.actor.{ActorRef, ActorSystem}
 import org.apache.flink.api.common.JobID
 

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/JarHelper.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/JarHelper.java
@@ -164,7 +164,7 @@ public class JarHelper
 		File f = new File(dirOrFile2jar, dirList[i]);
 		jarDir(f,jos,subPath);
 		}
-	} else {
+	} else if (dirOrFile2jar.exists()) {
 		if (dirOrFile2jar.getCanonicalPath().equals(mDestJarName))
 		{
 		if (mVerbose) {System.out.println("skipping " + dirOrFile2jar.getPath());}

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteEnvironment.java
@@ -57,13 +57,19 @@ public class ScalaShellRemoteEnvironment extends RemoteEnvironment {
 
 	@Override
 	protected PlanExecutor getExecutor() throws Exception {
+		// check if we had already started a PlanExecutor. If true, then stop it, because there will
+		// be a new jar file available for the user code classes
+		if (this.executor != null) {
+			this.executor.stop();
+		}
+
 		// write generated classes to disk so that they can be shipped to the cluster
 		URL jarUrl = flinkILoop.writeFilesToDisk().getAbsoluteFile().toURI().toURL();
 
 		List<URL> allJarFiles = new ArrayList<>(jarFiles);
 		allJarFiles.add(jarUrl);
 
-		PlanExecutor executor = PlanExecutor.createRemoteExecutor(
+		this.executor = PlanExecutor.createRemoteExecutor(
 			host,
 			port,
 			clientConfiguration,

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
@@ -71,7 +71,12 @@ class FlinkILoop(
     ScalaShellRemoteEnvironment.resetContextEnvironments()
     
     // create our environment that submits against the cluster (local or remote)
-    val remoteBenv = new ScalaShellRemoteEnvironment(host, port, this, clientConfig)
+    val remoteBenv = new ScalaShellRemoteEnvironment(
+      host,
+      port,
+      this,
+      clientConfig,
+      this.getExternalJars(): _*)
     val remoteSenv = new ScalaShellRemoteStreamEnvironment(host, port, this);
     // prevent further instantiation of environments
     ScalaShellRemoteEnvironment.disableAllContextAndOtherEnvironments()

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.PlanExecutor;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.api.scala.FlinkILoop;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import scala.Option;
+import scala.tools.nsc.Settings;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PlanExecutor.class)
+public class FlinkILoopTest extends TestLogger {
+
+	@Test
+	public void testConfigurationForwarding() throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setString("foobar", "foobar");
+		FlinkILoop flinkILoop = new FlinkILoop("localhost", 6123, configuration, Option.<String[]>empty());
+
+		final TestPlanExecutor testPlanExecutor = new TestPlanExecutor();
+
+		PowerMockito.mockStatic(PlanExecutor.class);
+		BDDMockito.given(PlanExecutor.createRemoteExecutor(
+			Matchers.anyString(),
+			Matchers.anyInt(),
+			Matchers.any(Configuration.class),
+			Matchers.any(java.util.List.class),
+			Matchers.any(java.util.List.class)
+		)).willAnswer(new Answer<PlanExecutor>() {
+			@Override
+			public PlanExecutor answer(InvocationOnMock invocation) throws Throwable {
+				testPlanExecutor.setHost((String)invocation.getArguments()[0]);
+				testPlanExecutor.setPort((Integer)invocation.getArguments()[1]);
+				testPlanExecutor.setConfiguration((Configuration)invocation.getArguments()[2]);
+				testPlanExecutor.setJars((List<String>)invocation.getArguments()[3]);
+				testPlanExecutor.setGlobalClasspaths((List<String>)invocation.getArguments()[4]);
+
+				return testPlanExecutor;
+			}
+		});
+
+		flinkILoop.settings_$eq(new Settings());
+		flinkILoop.createInterpreter();
+
+		ExecutionEnvironment env = flinkILoop.scalaBenv().getJavaEnv();
+
+		env.fromElements(1).output(new DiscardingOutputFormat<Integer>());
+
+		env.execute("Test job");
+
+		Configuration forwardedConfiguration = testPlanExecutor.getConfiguration();
+
+		assertEquals(configuration, forwardedConfiguration);
+	}
+
+	static class TestPlanExecutor extends PlanExecutor {
+
+		private String host;
+		private int port;
+		private Configuration configuration;
+		private List<String> jars;
+		private List<String> globalClasspaths;
+
+		@Override
+		public void start() throws Exception {
+
+		}
+
+		@Override
+		public void stop() throws Exception {
+
+		}
+
+		@Override
+		public boolean isRunning() {
+			return false;
+		}
+
+		@Override
+		public JobExecutionResult executePlan(Plan plan) throws Exception {
+			return null;
+		}
+
+		@Override
+		public String getOptimizerPlanAsJSON(Plan plan) throws Exception {
+			return null;
+		}
+
+		@Override
+		public void endSession(JobID jobID) throws Exception {
+
+		}
+
+		public String getHost() {
+			return host;
+		}
+
+		public void setHost(String host) {
+			this.host = host;
+		}
+
+		public int getPort() {
+			return port;
+		}
+
+		public void setPort(int port) {
+			this.port = port;
+		}
+
+		public Configuration getConfiguration() {
+			return configuration;
+		}
+
+		public void setConfiguration(Configuration configuration) {
+			this.configuration = configuration;
+		}
+
+		public List<String> getJars() {
+			return jars;
+		}
+
+		public void setJars(List<String> jars) {
+			this.jars = jars;
+		}
+
+		public List<String> getGlobalClasspaths() {
+			return globalClasspaths;
+		}
+
+		public void setGlobalClasspaths(List<String> globalClasspaths) {
+			this.globalClasspaths = globalClasspaths;
+		}
+	}
+
+}

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -37,6 +37,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import scala.Option;
 import scala.tools.nsc.Settings;
+import scala.tools.nsc.settings.MutableSettings;
 
 import java.util.List;
 
@@ -74,7 +75,10 @@ public class FlinkILoopTest extends TestLogger {
 			}
 		});
 
-		flinkILoop.settings_$eq(new Settings());
+		Settings settings = new Settings();
+		((MutableSettings.BooleanSetting)settings.usejavacp()).value_$eq(true);
+
+		flinkILoop.settings_$eq(settings);
 		flinkILoop.createInterpreter();
 
 		ExecutionEnvironment env = flinkILoop.scalaBenv().getJavaEnv();

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.mockito.Matchers;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -39,7 +38,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import scala.Option;
 import scala.tools.nsc.Settings;
 
-import java.io.File;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [X] General
  - The pull request references the related JIRA issue
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

The ScalaShellRemoteEnvironment did not properly forward the given Flink configuration
to the PlanExecutor. Consequently, it was not possible to configure the Client to connect
to an HA cluster. This PR corrects the forwarding.