### PR TITLE
[FLINK-3230] Add producer for Amazon Kinesis Streams (flink -> kinesis)

### DIFF
--- a/docs/apis/streaming/connectors/filesystem_sink.md
+++ b/docs/apis/streaming/connectors/filesystem_sink.md
@@ -5,7 +5,7 @@ title: "HDFS Connector"
 sub-nav-group: streaming
 sub-nav-parent: connectors
 sub-nav-pos: 3
-sub-nav-title: HDFS
+sub-nav-title: Filesystem Sink
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -26,7 +26,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The Kinesis connector allows to produce data into an [Amazon AWS Kinesis Stream](http://aws.amazon.com/kinesis/streams/).
+The Kinesis connector allows to produce data into an [Amazon AWS Kinesis Stream](http://aws.amazon.com/kinesis/streams/). 
 
 To use the connector, add the following Maven dependency to your project:
 
@@ -46,6 +46,10 @@ See linking with them for cluster execution [here]({{site.baseurl}}/apis/cluster
 
 
 #### Usage of Producer
+
+The `FlinkKinesisProducer` is used for sending data from a Flink stream into a Kinesis stream. Note that the producer is not participating in 
+Flink's checkpointing and doesn't provide exactly-once processing guarantees. In case of a failure, data will be written again
+to Kinesis, leading to duplicates. This behavior is usually called "at-least-once" semantics.
 
 To produce data into a Kinesis stream, make sure that you have a stream created with the status "ACTIVE" in the AWS dashboard.
 

--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -1,0 +1,92 @@
+---
+title: "Amazon AWS Kinesis Streams Connector"
+
+# Sub-level navigation
+sub-nav-group: streaming
+sub-nav-parent: connectors
+sub-nav-pos: 5
+sub-nav-title: Amazon Kinesis Streams
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+The Kinesis connector allows to produce data into an [Amazon AWS Kinesis Stream](http://aws.amazon.com/kinesis/streams/).
+
+To use the connector, add the following Maven dependency to your project:
+
+{% highlight xml %}
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-connector-kinesis{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version }}</version>
+</dependency>
+{% endhighlight %}
+
+**The `flink-connector-kinesis{{ site.scala_version_suffix }}` has a dependency on code licensed under the [Amazon Software License](https://aws.amazon.com/asl/) (ASL).
+Linking to the flink-connector-kinesis will include ASL licensed code into your application.**
+
+Note that the streaming connectors are not part of the binary distribution. 
+See linking with them for cluster execution [here]({{site.baseurl}}/apis/cluster_execution.html#linking-with-modules-not-contained-in-the-binary-distribution).
+
+
+#### Usage of Producer
+
+To produce data into a Kinesis stream, make sure that you have a stream created with the status "ACTIVE" in the AWS dashboard.
+
+For the monitoring to work, the user accessing the stream needs access to the Cloud watch service.
+
+The Kinesis producer expects at least the following arguments: `FlinkKinesisProducer(String region, String accessKey, String secretKey, final SerializationSchema<OUT> schema)`.
+
+
+Instead of a `SerializationSchema`, it also supports a `KinesisSerializationSchema`. The `KinesisSerializationSchema` allows to send the data to multiple streams. This is 
+done using the `KinesisSerializationSchema.getTargetStream(T element)` method. Returning `null` there will instruct the producer to write the element to the default stream.
+Otherwise, the returned stream name is used.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+FlinkKinesisProducer<String> kinesis = new FlinkKinesisProducer<>("<aws region>",
+        "<accessKey>", "<secretKey>", new SimpleStringSchema());
+
+kinesis.setFailOnError(true);
+kinesis.setDefaultStream("test-flink");
+kinesis.setDefaultPartition("0");
+
+DataStream<String> simpleStringStream = ...;
+simpleStringStream.addSink(kinesis);
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val kinesis = new FlinkKinesisProducer[String]("<aws region>",
+        "<accessKey>", "<secretKey>", new SimpleStringSchema());
+
+kinesis.setFailOnError(true);
+kinesis.setDefaultStream("test-flink");
+kinesis.setDefaultPartition("0");
+
+val simpleStringStream: DataStream[String] = ...;
+simpleStringStream.addSink(kinesis);
+{% endhighlight %}
+</div>
+</div>
+
+
+		
+		

--- a/flink-streaming-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kinesis/pom.xml
@@ -30,15 +30,13 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-connector-twitter_2.10</artifactId>
-	<name>flink-connector-twitter</name>
-
-	<packaging>jar</packaging>
-
+	<artifactId>flink-connector-kinesis_2.10</artifactId>
+	<name>flink-connector-kinesis</name>
 	<properties>
-		<hbc-core.version>2.2.0</hbc-core.version>
+		<kinesis-producer.version>0.10.2</kinesis-producer.version>
 	</properties>
 
+	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
@@ -46,51 +44,15 @@ under the License.
 			<artifactId>flink-streaming-java_2.10</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
+		<!-- Note:
+			This dependency is licenced under the Amazon Software License.
+			Flink includes the "flink-connector-kinesis" only as an optional dependency for that reason.
+		-->
 		<dependency>
-			<groupId>com.twitter</groupId>
-			<artifactId>hbc-core</artifactId>
-			<version>${hbc-core.version}</version>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>amazon-kinesis-producer</artifactId>
+			<version>${kinesis-producer.version}</version>
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<!-- Override artifactSet configuration to build fat-jar with all dependencies packed. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<configuration>
-							<artifactSet>
-								<includes combine.children="append">
-									<!-- We include all dependencies that transitively depend on guava -->
-									<include>com.twitter:hbc-core</include>
-									<include>com.twitter:joauth</include>
-									<include>org.apache.httpcomponents:httpclient</include>
-									<include>org.apache.httpcomponents:httpcore</include>
-								</includes>
-							</artifactSet>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
-							</transformers>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.kinesis;
+
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.services.kinesis.producer.Attempt;
+import com.amazonaws.services.kinesis.producer.KinesisProducer;
+import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
+import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.util.serialization.SerializationSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The FlinkKinesisProducer allows to produce from a Flink DataStream into Kinesis.
+ *
+ * @param <OUT> Data type to produce into Kinesis Streams
+ */
+public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FlinkKinesisProducer.class);
+
+	/* AWS region of the stream */
+	private final String region;
+
+	/* Access and secret key of the user */
+	private final String accessKey;
+	private final String secretKey;
+
+	/* Flag controlling the error behavior of the producer */
+	private boolean failOnError = false;
+
+	/* Name of the default stream to produce to. Can be overwritten by the serialization schema */
+	private String defaultStream;
+
+	/* Default partition id. Can be overwritten by the serialization schema */
+	private String defaultPartition;
+
+	/* Schema for turning the OUT type into a byte array. */
+	private final KinesisSerializationSchema<OUT> schema;
+
+	/* Optional custom partitioner */
+	private KinesisPartitioner<OUT> customPartitioner = null;
+
+
+	// --------------------------- Runtime fields ---------------------------
+
+
+	/* Our Kinesis instance for each parallel Flink sink */
+	private transient KinesisProducer producer;
+
+	/* Callback handling failures */
+	private transient FutureCallback<UserRecordResult> callback;
+
+	/* Field for async exception */
+	private transient Throwable thrownException;
+
+
+	// --------------------------- Initialization and configuration  ---------------------------
+
+
+	/**
+	 * Create a new FlinkKinesisProducer.
+	 * This is a constructor supporting Flink's {@see SerializationSchema}.
+	 *
+	 * @param region AWS region of the stream
+	 * @param accessKey Access key of a user with permission to access the stream (ideally also with access to Cloud Watch)
+	 * @param secretKey Secret key of the user
+	 * @param schema Serialization schema for the data type
+	 */
+	public FlinkKinesisProducer(String region, String accessKey, String secretKey, final SerializationSchema<OUT> schema) {
+		// create a simple wrapper for the serialization schema
+		this(region, accessKey, secretKey, new KinesisSerializationSchema<OUT>() {
+			@Override
+			public ByteBuffer serialize(OUT element) {
+				// wrap into ByteBuffer
+				return ByteBuffer.wrap(schema.serialize(element));
+			}
+			// use default stream and hash key
+			@Override
+			public String getTargetStream(OUT element) {
+				return null;
+			}
+		});
+	}
+
+	public FlinkKinesisProducer(String region, String accessKey, String secretKey, KinesisSerializationSchema<OUT> schema) {
+		this.region = Objects.requireNonNull(region);
+		this.accessKey = Objects.requireNonNull(accessKey);
+		this.secretKey = Objects.requireNonNull(secretKey);
+		ClosureCleaner.ensureSerializable(Objects.requireNonNull(schema));
+		this.schema = schema;
+	}
+
+	/**
+	 * If set to true, the producer will immediately fail with an exception on any error.
+	 * Otherwise, the errors are logged and the producer goes on.
+	 *
+	 * @param failOnError Error behavior flag
+	 */
+	public void setFailOnError(boolean failOnError) {
+		this.failOnError = failOnError;
+	}
+
+	/**
+	 * Set a default stream name.
+	 * @param defaultStream Name of the default Kinesis stream
+	 */
+	public void setDefaultStream(String defaultStream) {
+		this.defaultStream = defaultStream;
+	}
+
+	/**
+	 * Set default partition id
+	 * @param defaultPartition Name of the default partition
+	 */
+	public void setDefaultPartition(String defaultPartition) {
+		this.defaultPartition = defaultPartition;
+	}
+
+	public void setCustomPartitioner(KinesisPartitioner<OUT> partitioner) {
+		Objects.requireNonNull(partitioner);
+		ClosureCleaner.ensureSerializable(partitioner);
+		this.customPartitioner = partitioner;
+	}
+
+
+	// --------------------------- Lifecycle methods ---------------------------
+
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		KinesisProducerConfiguration config = new KinesisProducerConfiguration();
+		config.setRegion(this.region);
+		config.setCredentialsProvider(new StaticCredentialsProvider(new BasicAWSCredentials(this.accessKey, this.secretKey)));
+		producer = new KinesisProducer(config);
+		callback = new FutureCallback<UserRecordResult>() {
+			@Override
+			public void onSuccess(UserRecordResult result) {
+				if(!result.isSuccessful()) {
+					if(failOnError) {
+						thrownException = new RuntimeException("Record was not sent successful");
+					} else {
+						LOG.warn("Record was not sent successful");
+					}
+				}
+			}
+
+			@Override
+			public void onFailure(Throwable t) {
+				if(failOnError) {
+					thrownException = t;
+				} else {
+					LOG.warn("An exception occurred while processing a record", t);
+				}
+			}
+		};
+
+		if(this.customPartitioner != null) {
+			this.customPartitioner.initialize(getRuntimeContext().getIndexOfThisSubtask(), getRuntimeContext().getNumberOfParallelSubtasks());
+		}
+
+		LOG.info("Started Kinesis producer instance for region '{}'", this.region);
+	}
+
+	@Override
+	public void invoke(OUT value) throws Exception {
+		if(this.producer == null) {
+			throw new RuntimeException("Kinesis producer has been closed");
+		}
+		if(thrownException != null) {
+			String errorMessages = "";
+			if(thrownException instanceof UserRecordFailedException) {
+				List<Attempt> attempts = ((UserRecordFailedException) thrownException).getResult().getAttempts();
+				for(Attempt attempt: attempts) {
+					if(attempt.getErrorMessage() != null) {
+						errorMessages += attempt.getErrorMessage() +"\n";
+					}
+				}
+			}
+			if(failOnError) {
+				throw new RuntimeException("An exception was thrown while processing a record: " + errorMessages, thrownException);
+			} else {
+				LOG.warn("An exception was thrown while processing a record: {}", thrownException, errorMessages);
+				thrownException = null; // reset
+			}
+		}
+
+		String stream = defaultStream;
+		String partition = defaultPartition;
+
+		ByteBuffer serialized = schema.serialize(value);
+
+		// maybe set custom stream
+		String customStream = schema.getTargetStream(value);
+		if(customStream != null) {
+			stream = customStream;
+		}
+
+		String explicitHashkey = null;
+		// maybe set custom partition
+		if(customPartitioner != null) {
+			partition = customPartitioner.getPartitionId(value);
+			explicitHashkey = customPartitioner.getExplicitHashKey(value);
+		}
+
+		if(stream == null) {
+			if(failOnError) {
+				throw new RuntimeException("No target stream set");
+			} else {
+				LOG.warn("No target stream set. Skipping record");
+				return;
+			}
+		}
+
+		ListenableFuture<UserRecordResult> cb = producer.addUserRecord(stream, partition, explicitHashkey, serialized);
+		Futures.addCallback(cb, callback);
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		KinesisProducer kp = this.producer;
+		this.producer = null;
+		if(kp != null) {
+			LOG.info("Closing producer. Flushing outstanding {} records", kp.getOutstandingRecordsCount());
+			// try to flush all outstanding records
+			while (kp.getOutstandingRecordsCount() > 0) {
+				kp.flush();
+				try {
+					Thread.sleep(500);
+				} catch (InterruptedException e) {
+					LOG.warn("Flushing was interrupted.");
+					// stop the blocking flushing and destroy producer immediately
+					break;
+				}
+			}
+			LOG.info("Flushing done. Destroying producer instance.");
+			kp.destroy();
+		}
+	}
+
+}

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/KinesisPartitioner.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/KinesisPartitioner.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.kinesis;
+
+
+import java.io.Serializable;
+
+public abstract class KinesisPartitioner<T> implements Serializable {
+
+	/**
+	 * Return a partition id based on the input
+	 * @param element Element to partition
+	 * @return A string representing the partition id
+	 */
+	public abstract String getPartitionId(T element);
+
+	/**
+	 * Optional method for setting an explicit hash key
+	 * @param element Element to get the hash key for
+	 * @return the hash key for the element
+	 */
+	public String getExplicitHashKey(T element) {
+		return null;
+	}
+
+	/**
+	 * Optional initializer.
+	 *
+	 * @param indexOfThisSubtask Index of this partitioner instance
+	 * @param numberOfParallelSubtasks Total number of parallel instances
+	 */
+	public void initialize(int indexOfThisSubtask, int numberOfParallelSubtasks) {
+		//
+	}
+}

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/KinesisSerializationSchema.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/KinesisSerializationSchema.java
@@ -36,7 +36,7 @@ public interface KinesisSerializationSchema<T> extends Serializable {
 
 	/**
 	 * Optional method to determine the target stream based on the element.
-	 * Return "null" to use the default stream
+	 * Return <code>null</code> to use the default stream
 	 *
 	 * @param element The element to determine the target stream from
 	 * @return target stream name

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/KinesisSerializationSchema.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/KinesisSerializationSchema.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.kinesis;
+
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+
+/**
+ * Kinesis-specific serialization schema, allowing users to specify a target stream based
+ * on a record's contents.
+ * @param <T>
+ */
+public interface KinesisSerializationSchema<T> extends Serializable {
+	/**
+	 * Serialize the given element into a ByteBuffer
+	 *
+	 * @param element The element to serialize
+	 * @return Serialized representation of the element
+	 */
+	ByteBuffer serialize(T element);
+
+	/**
+	 * Optional method to determine the target stream based on the element.
+	 * Return "null" to use the default stream
+	 *
+	 * @param element The element to determine the target stream from
+	 * @return target stream name
+	 */
+	String getTargetStream(T element);
+}

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/examples/ProduceIntoKinesis.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/examples/ProduceIntoKinesis.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.kinesis.examples;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisProducer;
+import org.apache.flink.streaming.connectors.kinesis.KinesisPartitioner;
+import org.apache.flink.streaming.connectors.kinesis.KinesisSerializationSchema;
+import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
+
+import java.nio.ByteBuffer;
+
+/**
+ * This is an example on how to produce data into Kinesis
+ */
+public class ProduceIntoKinesis {
+
+	public static void main(String[] args) throws Exception {
+		ParameterTool pt = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(1);
+
+		DataStream<String> simpleStringStream = see.addSource(new EventsGenerator());
+
+		FlinkKinesisProducer<String> kinesis = new FlinkKinesisProducer<>(pt.getRequired("region"),
+				pt.getRequired("accessKey"),
+				pt.getRequired("secretKey"), new SimpleStringSchema());
+
+		kinesis.setFailOnError(true);
+		kinesis.setDefaultStream("test-flink");
+		kinesis.setDefaultPartition("0");
+
+		simpleStringStream.addSink(kinesis);
+
+		see.execute();
+	}
+
+	public static class EventsGenerator implements SourceFunction<String> {
+		private boolean running = true;
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			long seq = 0;
+			while(running) {
+
+				Thread.sleep(10);
+				ctx.collect((seq++) + "-" + RandomStringUtils.randomAlphabetic(12));
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+}

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/examples/ProduceIntoKinesis.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/examples/ProduceIntoKinesis.java
@@ -41,12 +41,14 @@ public class ProduceIntoKinesis {
 
 		DataStream<String> simpleStringStream = see.addSource(new EventsGenerator());
 
-		FlinkKinesisProducer<String> kinesis = new FlinkKinesisProducer<>(pt.getRequired("region"),
+		FlinkKinesisProducer<String> kinesis = new FlinkKinesisProducer<>(
+				pt.getRequired("region"),
 				pt.getRequired("accessKey"),
-				pt.getRequired("secretKey"), new SimpleStringSchema());
+				pt.getRequired("secretKey"),
+				new SimpleStringSchema());
 
 		kinesis.setFailOnError(true);
-		kinesis.setDefaultStream("test-flink");
+		kinesis.setDefaultStream("flink-test");
 		kinesis.setDefaultPartition("0");
 
 		simpleStringStream.addSink(kinesis);
@@ -61,7 +63,6 @@ public class ProduceIntoKinesis {
 		public void run(SourceContext<String> ctx) throws Exception {
 			long seq = 0;
 			while(running) {
-
 				Thread.sleep(10);
 				ctx.collect((seq++) + "-" + RandomStringUtils.randomAlphabetic(12));
 			}

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/resources/log4j.properties
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/resources/log4j.properties
@@ -1,0 +1,27 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, testlogger
+
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger

--- a/flink-streaming-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/ManualTest.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/ManualTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.kinesis;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.kinesis.examples.ProduceIntoKinesis;
+
+import java.nio.ByteBuffer;
+
+/**
+ * This is a manual test for the AWS Kinesis connector in Flink.
+ *
+ * It uses:
+ *  - A custom KinesisSerializationSchema
+ *  - A custom KinesisPartitioner
+ *
+ * Invocation:
+ * --region eu-central-1 --accessKey XXXXXXXXXXXX --secretKey XXXXXXXXXXXXXXXX
+ */
+public class ManualTest {
+
+	public static void main(String[] args) throws Exception {
+		ParameterTool pt = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(4);
+
+		DataStream<String> simpleStringStream = see.addSource(new ProduceIntoKinesis.EventsGenerator());
+
+		FlinkKinesisProducer<String> kinesis = new FlinkKinesisProducer<>(pt.getRequired("region"),
+				pt.getRequired("accessKey"),
+				pt.getRequired("secretKey"),
+				new KinesisSerializationSchema<String>() {
+					@Override
+					public ByteBuffer serialize(String element) {
+						return ByteBuffer.wrap(element.getBytes());
+					}
+
+					// every 10th element goes into a different stream
+					@Override
+					public String getTargetStream(String element) {
+						if(element.endsWith("0")) {
+							return "flink-test-2";
+						}
+						return null; // send to default stream
+					}
+				});
+
+		kinesis.setFailOnError(true);
+		kinesis.setDefaultStream("test-flink");
+		kinesis.setDefaultPartition("0");
+		kinesis.setCustomPartitioner(new KinesisPartitioner<String>() {
+			@Override
+			public String getPartitionId(String element) {
+				int l = element.length();
+				return element.substring(l - 1, l);
+			}
+		});
+		simpleStringStream.addSink(kinesis);
+
+		see.execute();
+	}
+}

--- a/flink-streaming-connectors/pom.xml
+++ b/flink-streaming-connectors/pom.xml
@@ -64,6 +64,18 @@ under the License.
 				<module>flink-connector-filesystem</module>
 			</modules>
 		</profile>
+		<!--
+			We include the kinesis module only optionally because it contains a dependency
+			licenced under the "Amazon Software License".
+			In accordance with the discussion in https://issues.apache.org/jira/browse/LEGAL-198
+			this is an optional module for Flink.
+		-->
+		<profile>
+			<id>include-kinesis</id>
+			<modules>
+				<module>flink-connector-kinesis</module>
+			</modules>
+		</profile>
 	</profiles>
 
 </project>

--- a/tools/create_release_files.sh
+++ b/tools/create_release_files.sh
@@ -182,7 +182,7 @@ deploy_to_maven() {
   # are depending on scala 2.10.
   echo "Deploying Scala 2.10 version"
   cd tools && ./change-scala-version.sh 2.10 && cd ..
-  $MVN clean deploy -Dgpg.executable=$GPG -Prelease,docs-and-source --settings deploysettings.xml -DskipTests -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE -DretryFailedDeploymentCount=10
+  $MVN clean deploy -Dgpg.executable=$GPG -Prelease,docs-and-source,include-kinesis --settings deploysettings.xml -DskipTests -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE -DretryFailedDeploymentCount=10
 
 
   echo "Deploying Scala 2.10 / hadoop 1 version"
@@ -190,7 +190,7 @@ deploy_to_maven() {
 
 
   sleep 4
-  $MVN clean deploy -Dgpg.executable=$GPG -Prelease,docs-and-source --settings deploysettings.xml -DskipTests -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE -DretryFailedDeploymentCount=10
+  $MVN clean deploy -Dgpg.executable=$GPG -Prelease,docs-and-source,include-kinesis --settings deploysettings.xml -DskipTests -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE -DretryFailedDeploymentCount=10
 }
 
 copy_data() {


### PR DESCRIPTION
I've tested this connector against two kinesis streams. Since Kinesis is a hosted service, I can not implement a full integration test that runs with each test.
I'll run further tests once we've added a Kinesis consumer as well.