### PR TITLE
[FLINK-3086] [table] ExpressionParser does not support concatenation of suffix operations

### DIFF
--- a/docs/apis/batch/libs/table.md
+++ b/docs/apis/batch/libs/table.md
@@ -377,42 +377,52 @@ val result = in.distinct();
 ### Expression Syntax
 Some of the operators in previous sections expect one or more expressions. Expressions can be specified using an embedded Scala DSL or as Strings. Please refer to the examples above to learn how expressions can be specified.
 
-This is the complete EBNF grammar for expressions:
+This is the EBNF grammar for expressions:
 
 {% highlight ebnf %}
 
-expression = single expression , { "," , single expression } ;
+expressionList = expression , { "," , expression } ;
 
-single expression = alias | logic ;
+expression = alias ;
 
-alias = logic | logic , "AS" , field reference ;
+alias = logic | ( logic , "AS" , fieldReference ) ;
 
 logic = comparison , [ ( "&&" | "||" ) , comparison ] ;
 
-comparison = term , [ ( "=" | "!=" | ">" | ">=" | "<" | "<=" ) , term ] ;
+comparison = term , [ ( "=" | "===" | "!=" | "!==" | ">" | ">=" | "<" | "<=" ) , term ] ;
 
 term = product , [ ( "+" | "-" ) , product ] ;
 
-unary = [ "!" | "-" ] , suffix ;
+product = unary , [ ( "*" | "/" | "%") , unary ] ;
 
-suffix = atom | aggregation | cast | as ;
+unary = [ "!" | "-" ] , composite ;
 
-aggregation = atom , [ ".sum" | ".min" | ".max" | ".count" | ".avg" ] ;
+composite = suffixed | atom ;
 
-cast = atom , ".cast(" , data type , ")" ;
+suffixed = cast | as | aggregation | nullCheck | evaluate | functionCall ;
 
-data type = "BYTE" | "SHORT" | "INT" | "LONG" | "FLOAT" | "DOUBLE" | "BOOL" | "BOOLEAN" | "STRING" | "DATE" ;
+cast = composite , ".cast(" , dataType , ")" ;
 
-as = atom , ".as(" , field reference , ")" ;
+dataType = "BYTE" | "SHORT" | "INT" | "LONG" | "FLOAT" | "DOUBLE" | "BOOL" | "BOOLEAN" | "STRING" | "DATE" ;
 
-atom = ( "(" , single expression , ")" ) | literal | field reference ;
+as = composite , ".as(" , fieldReference , ")" ;
+
+aggregation = composite , ( ".sum" | ".min" | ".max" | ".count" | ".avg" ) , [ "()" ] ;
+
+nullCheck = composite , ( ".isNull" | ".isNotNull" ) , [ "()" ] ;
+
+evaluate = composite , ".eval(" , expression , "," , expression , ")" ;
+
+functionCall = composite , "." , functionIdentifier , "(" , [ expression , { "," , expression } ] , ")"
+
+atom = ( "(" , expression , ")" ) | literal | nullLiteral | fieldReference ;
+
+nullLiteral = "Null(" , dataType , ")" ;
 
 {% endhighlight %}
 
-Here, `literal` is a valid Java literal and `field reference` specifies a column in the data. The
-column names follow Java identifier syntax.
-
-Only the types `LONG` and `STRING` can be casted to `DATE` and vice versa. A `LONG` casted to `DATE` must be a milliseconds timestamp. A `STRING` casted to `DATE` must have the format "`yyyy-MM-dd HH:mm:ss.SSS`", "`yyyy-MM-dd`", "`HH:mm:ss`", or a milliseconds timestamp. By default, all timestamps refer to the UTC timezone beginning from January 1, 1970, 00:00:00 in milliseconds.
+Here, `literal` is a valid Java literal, `fieldReference` specifies a column in the data, and `functionIdentifier` specifies a supported scalar function. The
+column names and function names follow Java identifier syntax. Expressions specified as Strings can also use prefix notation instead of suffix notation to call operators and functions. 
 
 {% top %}
 

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/AggregationsITCase.java
@@ -17,24 +17,6 @@
  */
 package org.apache.flink.api.java.table.test;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.table.ExpressionParserException;
@@ -180,7 +162,7 @@ public class AggregationsITCase extends MultipleProgramsTestBase {
 		compareResultAsText(results, expected);
 	}
 
-	@Test(expected = ExpressionParserException.class)
+	@Test(expected = UnsupportedOperationException.class)
 	public void testNoNestedAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/table/test/ExpressionsITCase.java
@@ -173,5 +173,30 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 		compareResultAsText(results, expected);
 	}
 
+	@Test
+	public void testComplexExpression() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		DataSource<Tuple3<Integer, Integer, Integer>> input =
+				env.fromElements(new Tuple3<>(5, 5, 4));
+
+		Table table =
+				tableEnv.fromDataSet(input, "a, b, c");
+
+		Table result = table.select(
+				"a.isNull().isNull," +
+					"a.abs() + a.abs().abs().abs().abs()," +
+					"a.cast(STRING) + a.cast(STRING)," +
+					"CAST(ISNULL(b), INT)," +
+					"ISNULL(CAST(b, INT).abs()) === false," +
+					"((((true) === true) || false).cast(STRING) + 'X ').trim");
+
+		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "false,10,55,0,true,trueX";
+		compareResultAsText(results, expected);
+	}
+
 }
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR reworks the Table API `ExpressionParser`. It eliminates inconsistencies, adds more complex tests and ensures that everything from Scala Table API is also support in Java Table API.
Even expressions like `a.abs() + a.abs()` or `((((true) === true) || false).cast(STRING) + 'X ').trim` should not be an issue anymore.