### PR TITLE
[FLINK-3798] [streaming] Clean up RocksDB backend field/method access

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -60,14 +60,14 @@ abstract class AbstractRocksDBState<K, N, S extends State, SD extends StateDescr
 	protected RocksDBStateBackend backend;
 
 	/** The column family of this particular instance of state */
-	ColumnFamilyHandle columnFamily;
+	protected ColumnFamilyHandle columnFamily;
 
 	/**
 	 * Creates a new RocksDB backed state.
 	 *
 	 * @param namespaceSerializer The serializer for the namespace.
 	 */
-	AbstractRocksDBState(ColumnFamilyHandle columnFamily,
+	protected AbstractRocksDBState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			RocksDBStateBackend backend) {
 
@@ -80,7 +80,7 @@ abstract class AbstractRocksDBState<K, N, S extends State, SD extends StateDescr
 	// ------------------------------------------------------------------------
 
 	@Override
-	final public void clear() {
+	public void clear() {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(baos);
 		try {
@@ -92,19 +92,19 @@ abstract class AbstractRocksDBState<K, N, S extends State, SD extends StateDescr
 		}
 	}
 
-	void writeKeyAndNamespace(DataOutputView out) throws IOException {
+	protected void writeKeyAndNamespace(DataOutputView out) throws IOException {
 		backend.keySerializer().serialize(backend.currentKey(), out);
 		out.writeByte(42);
 		namespaceSerializer.serialize(currentNamespace, out);
 	}
 
 	@Override
-	final public void setCurrentNamespace(N namespace) {
+	public void setCurrentNamespace(N namespace) {
 		this.currentNamespace = namespace;
 	}
 
 	@Override
-	final public void dispose() {
+	public void dispose() {
 		// ignore because we don't hold any state ourselves
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -69,7 +69,7 @@ class RocksDBFoldingState<K, N, T, ACC>
 	 * @param stateDesc The state identifier for the state. This contains name
 	 *                     and can create a default state value.
 	 */
-	RocksDBFoldingState(ColumnFamilyHandle columnFamily,
+	public RocksDBFoldingState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			FoldingStateDescriptor<T, ACC> stateDesc,
 			RocksDBStateBackend backend) {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -71,7 +71,7 @@ class RocksDBListState<K, N, V>
 	 * @param stateDesc The state identifier for the state. This contains name
 	 *                     and can create a default state value.
 	 */
-	RocksDBListState(ColumnFamilyHandle columnFamily,
+	public RocksDBListState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			ListStateDescriptor<V> stateDesc,
 			RocksDBStateBackend backend) {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -68,7 +68,7 @@ class RocksDBReducingState<K, N, V>
 	 * @param stateDesc The state identifier for the state. This contains name
 	 *                     and can create a default state value.
 	 */
-	RocksDBReducingState(ColumnFamilyHandle columnFamily,
+	public RocksDBReducingState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			ReducingStateDescriptor<V> stateDesc,
 			RocksDBStateBackend backend) {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -155,7 +155,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 * to store state. The different k/v states that we have don't each have their own RocksDB
 	 * instance. They all write to this instance but to their own column family.
 	 */
-	transient RocksDB db;
+	protected transient RocksDB db;
 
 	/**
 	 * Information about the k/v states as we create them. This is used to retrieve the
@@ -807,7 +807,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 * <p>This also checks whether the {@link StateDescriptor} for a state matches the one
 	 * that we checkpointed, i.e. is already in the map of column families.
 	 */
-	private ColumnFamilyHandle getColumnFamily(StateDescriptor descriptor)  {
+	protected ColumnFamilyHandle getColumnFamily(StateDescriptor descriptor)  {
 
 		Tuple2<ColumnFamilyHandle, StateDescriptor> stateInfo = kvStateInformation.get(descriptor.getName());
 
@@ -832,14 +832,14 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	/**
 	 * Used by k/v states to access the current key.
 	 */
-	Object currentKey() {
+	public Object currentKey() {
 		return currentKey;
 	}
 
 	/**
 	 * Used by k/v states to access the key serializer.
 	 */
-	TypeSerializer keySerializer() {
+	public TypeSerializer keySerializer() {
 		return keySerializer;
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -64,7 +64,7 @@ class RocksDBValueState<K, N, V>
 	 * @param stateDesc The state identifier for the state. This contains name
 	 *                           and can create a default state value.
 	 */
-	RocksDBValueState(ColumnFamilyHandle columnFamily,
+	public RocksDBValueState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			ValueStateDescriptor<V> stateDesc,
 			RocksDBStateBackend backend) {


### PR DESCRIPTION
The RocksDB state backend uses a lot package private methods and fields which makes it very hard to subclass the different parts for added functionality. I think these should be protected instead.

Also the AbstractRocksDBState declares some methods final when there are use-cases when a subclass migh want to call them.

Just to give you an example I am creating a version of the value state which would keep a small cache on heap. For this it would be enough to subclass the RockDBStateBackend and RocksDBVAlue state classes if the above mentioned changes were made. Now I have to use reflection to access package private fields and actually copy classes due to final methods.
Activity