### PR TITLE
[FLINK-3803] [runtime] Pass CheckpointStatsTracker to ExecutionGraph

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTracker.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.checkpoint.stats;
 
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.StateForTask;
-import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import scala.Option;
 
@@ -108,22 +108,19 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 
 	public SimpleCheckpointStatsTracker(
 			int historySize,
-			ExecutionVertex[] tasksToWaitFor) {
+			List<ExecutionJobVertex> tasksToWaitFor) {
 
 		checkArgument(historySize >= 0);
 		this.historySize = historySize;
 
-		// We know upfront, which tasks will ack the checkpoints.
-		if (tasksToWaitFor != null && tasksToWaitFor.length > 0) {
-			taskParallelism = new HashMap<>();
+		// We know upfront which tasks will ack the checkpoints
+		if (tasksToWaitFor != null && !tasksToWaitFor.isEmpty()) {
+			taskParallelism = new HashMap<>(tasksToWaitFor.size());
 
-			for (ExecutionVertex vertex : tasksToWaitFor) {
-				taskParallelism.put(
-						vertex.getJobvertexId(),
-						vertex.getTotalNumberOfParallelSubtasks());
+			for (ExecutionJobVertex vertex : tasksToWaitFor) {
+				taskParallelism.put(vertex.getJobVertexId(), vertex.getParallelism());
 			}
-		}
-		else {
+		} else {
 			taskParallelism = Collections.emptyMap();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.checkpoint.stats.DisabledCheckpointStatsTracker;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -72,7 +73,8 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 					new StandaloneCheckpointIDCounter(),
 					new StandaloneCompletedCheckpointStore(1, ClassLoader.getSystemClassLoader()),
 					RecoveryMode.STANDALONE,
-					new HeapStateStore<CompletedCheckpoint>());
+					new HeapStateStore<CompletedCheckpoint>(),
+					new DisabledCheckpointStatsTracker());
 
 			CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
 			SavepointCoordinator savepointCoordinator = executionGraph.getSavepointCoordinator();


### PR DESCRIPTION
`CheckpointStatsTracker` was instantiated in `ExecutionGraph#enableSnapshotCheckpointing`, where the Flink configuration is not available to parse the configuration. As a result, the configuration was not picked up at all and the default configuration was used.

Instead of instantiating the `CheckpointStatsTracker` in the `ExecutionGraph` method, we directly pass it to it.

I've tested this locally with a checkpointed job and verified that the configuration is picked up as expected. I would like to merge this to `master` and `release-1.0`.