### PR TITLE
[FLINK-3741] [build] Replace maven-scala-plugin with newer scala-maven-plugin

### DIFF
--- a/flink-libraries/flink-ml/pom.xml
+++ b/flink-libraries/flink-ml/pom.xml
@@ -106,9 +106,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.scala-tools</groupId>
-				<artifactId>maven-scala-plugin</artifactId>
-				<version>2.15.2</version>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.2.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -117,14 +117,6 @@
 						</goals>
 					</execution>
 				</executions>
-				<configuration>
-					<sourceDir>src/main/scala</sourceDir>
-					<testSourceDir>src/test/scala</testSourceDir>
-					<jvmArgs>
-						<jvmArg>-Xms64m</jvmArg>
-						<jvmArg>-Xmx1024m</jvmArg>
-					</jvmArgs>
-				</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
I've replaced the older {{maven-scala-plugin}} with the newer {{scala-maven-plugin}} and ran 10 Travis builds. So far none of them failed with the *Error: MissingRequirementError: object scala.runtime in compiler mirror not found.*