### PR TITLE
[FLINK-2220] Join on Pojo without hashCode() silently fails

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1688,6 +1688,19 @@ public class TypeExtractor {
 
 		CompositeType<OUT> pojoType = new PojoTypeInfo<OUT>(clazz, pojoFields);
 
+		//POJO should override hashcode and equals method
+		//in the situation where it used as key for operations.
+		try {
+			clazz.getDeclaredMethod("hashCode");
+		} catch (NoSuchMethodException e) {
+			LOG.info(clazz + " should override hashCode method.");
+		}
+
+		try {
+			clazz.getDeclaredMethod("equals");
+		} catch (NoSuchMethodException e) {
+			LOG.info(clazz + " should override equals method.");
+		}
 		//
 		// Validate the correctness of the pojo.
 		// returning "null" will result create a generic type information.


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [X] General
  - The pull request references the related JIRA issue
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message

Add a check to verify the POJO has overridden the `hashCode()` and `equals()` where it used as a key for operations(join,coGroup,etc).

