### PR TITLE
[FLINK-3840] Remove Testing Files in RocksDB Backend

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -248,6 +248,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 				} else {
 					dirs.add(f);
 				}
+				testDir.delete();
 			}
 			
 			if (dirs.isEmpty()) {


### PR DESCRIPTION
We create random files on initialization to check whether we can write
to the data directory. These files are also removed now.

@gyfora Could you please check whether this solves the problem?