### PR TITLE
Timer coalescing across keys and cleanup of unused trigger tasks

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockRuntimeContext.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockRuntimeContext.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("deprecation")
@@ -187,14 +188,14 @@ public class MockRuntimeContext extends StreamingRuntimeContext {
 	}
 	
 	@Override
-	public void registerTimer(final long time, final Triggerable target) {
+	public ScheduledFuture<?> registerTimer(final long time, final Triggerable target) {
 		if (timer == null) {
 			timer = Executors.newSingleThreadScheduledExecutor();
 		}
 		
 		final long delay = Math.max(time - System.currentTimeMillis(), 0);
 
-		timer.schedule(new Runnable() {
+		return timer.schedule(new Runnable() {
 			@Override
 			public void run() {
 				synchronized (checkpointLock) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.concurrent.ScheduledFuture;
 
 /**
  * Base class for all stream operators. Operators that contain a user function should extend the class 
@@ -246,8 +247,8 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @param time The absolute time in milliseconds.
 	 * @param target The target to be triggered.
 	 */
-	protected void registerTimer(long time, Triggerable target) {
-		container.registerTimer(time, target);
+	protected ScheduledFuture<?> registerTimer(long time, Triggerable target) {
+		return container.registerTimer(time, target);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -39,6 +39,7 @@ import org.apache.flink.streaming.runtime.operators.Triggerable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
 
 import static java.util.Objects.requireNonNull;
 
@@ -88,8 +89,8 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 	 * @param time The absolute time in milliseconds.
 	 * @param target The target to be triggered.
 	 */
-	public void registerTimer(long time, Triggerable target) {
-		operator.registerTimer(time, target);
+	public ScheduledFuture<?> registerTimer(long time, Triggerable target) {
+		return operator.registerTimer(time, target);
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -574,10 +574,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 			//If there are no timers left for this timestamp, remove it from queue and cancel TriggerTask
 			if (processingTimeTimerTimestamps.remove(time,1) == 1) {
-				ScheduledFuture<?> triggerTaskFuture = processingTimeTimerFutures.get(timer);
+				ScheduledFuture<?> triggerTaskFuture = processingTimeTimerFutures.remove(timer.timestamp);
 				if (triggerTaskFuture != null && !triggerTaskFuture.isDone()) {
 					triggerTaskFuture.cancel(false);
-					processingTimeTimerFutures.remove(triggerTaskFuture);
 				}
 			}
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -19,6 +19,8 @@
 package org.apache.flink.streaming.runtime.operators.windowing;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.AppendingState;
@@ -39,6 +41,7 @@ import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
@@ -65,6 +68,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
 
 import static java.util.Objects.requireNonNull;
 
@@ -134,6 +138,8 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 */
 	protected transient TimestampedCollector<OUT> timestampedCollector;
 
+	protected transient Map<Long, ScheduledFuture<?>> processingTimeTimerFutures;
+
 	/**
 	 * To keep track of the current watermark so that we can immediately fire if a trigger
 	 * registers an event time callback for a timestamp that lies in the past.
@@ -149,15 +155,15 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	/**
 	 * Processing time timers that are currently in-flight.
 	 */
-	protected transient Set<Timer<K, W>> processingTimeTimers;
 	protected transient PriorityQueue<Timer<K, W>> processingTimeTimersQueue;
+	protected transient Set<Timer<K, W>> processingTimeTimers;
+	protected transient Multiset<Long> processingTimeTimerTimestamps;
 
 	/**
 	 * Current waiting watermark callbacks.
 	 */
 	protected transient Set<Timer<K, W>> watermarkTimers;
 	protected transient PriorityQueue<Timer<K, W>> watermarkTimersQueue;
-
 	protected transient Map<K, MergingWindowSet<W>> mergingWindowsByKey;
 
 	/**
@@ -213,8 +219,12 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		}
 		if (processingTimeTimers == null) {
 			processingTimeTimers = new HashSet<>();
+			processingTimeTimerTimestamps = HashMultiset.create();
 			processingTimeTimersQueue = new PriorityQueue<>(100);
 		}
+
+		//ScheduledFutures are not checkpointed
+		processingTimeTimerFutures = new HashMap<>();
 
 		context = new Context(null, null);
 
@@ -424,13 +434,17 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	public final void trigger(long time) throws Exception {
 		boolean fire;
 
+		//Remove information about the triggering task
+		processingTimeTimerFutures.remove(time);
+		processingTimeTimerTimestamps.remove(time, processingTimeTimerTimestamps.count(time));
+
 		do {
 			Timer<K, W> timer = processingTimeTimersQueue.peek();
 			if (timer != null && timer.timestamp <= time) {
 				fire = true;
 
-				processingTimeTimers.remove(timer);
 				processingTimeTimersQueue.remove();
+				processingTimeTimers.remove(timer);
 
 				context.key = timer.key;
 				context.window = timer.window;
@@ -525,9 +539,14 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		@Override
 		public void registerProcessingTimeTimer(long time) {
 			Timer<K, W> timer = new Timer<>(time, key, window);
+			// make sure we only put one timer per key into the queue
 			if (processingTimeTimers.add(timer)) {
 				processingTimeTimersQueue.add(timer);
-				getRuntimeContext().registerTimer(time, WindowOperator.this);
+				//If this is the first timer added for this timestamp register a TriggerTask
+				if (processingTimeTimerTimestamps.add(time, 1) == 0) {
+					ScheduledFuture<?> scheduledFuture= getRuntimeContext().registerTimer(time, WindowOperator.this);
+					processingTimeTimerFutures.put(time, scheduledFuture);
+				}
 			}
 		}
 
@@ -542,14 +561,24 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 				// immediately schedule a trigger, so that we don't wait for the next
 				// watermark update to fire the watermark trigger
 				getRuntimeContext().registerTimer(System.currentTimeMillis(), WindowOperator.this);
+				//No need to put it in processingTimeTimerFutures as this timer is never removed
 			}
 		}
 
 		@Override
 		public void deleteProcessingTimeTimer(long time) {
 			Timer<K, W> timer = new Timer<>(time, key, window);
-			if (processingTimeTimers.remove(timer)) {
-				processingTimeTimersQueue.remove(timer);
+
+			processingTimeTimers.remove(timer);
+			processingTimeTimersQueue.remove(timer);
+
+			//If there are no timers left for this timestamp, remove it from queue and cancel TriggerTask
+			if (processingTimeTimerTimestamps.remove(time,1) == 1) {
+				ScheduledFuture<?> triggerTaskFuture = processingTimeTimerFutures.get(timer);
+				if (triggerTaskFuture != null && !triggerTaskFuture.isDone()) {
+					triggerTaskFuture.cancel(false);
+					processingTimeTimerFutures.remove(triggerTaskFuture);
+				}
 			}
 		}
 
@@ -591,6 +620,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 				'}';
 		}
 	}
+
 
 	/**
 	 * Internal class for keeping track of in-flight timers.
@@ -670,19 +700,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		AbstractStateBackend.CheckpointStateOutputView out =
 			getStateBackend().createCheckpointStateOutputView(checkpointId, timestamp);
 
-		out.writeInt(watermarkTimersQueue.size());
-		for (Timer<K, W> timer : watermarkTimersQueue) {
-			keySerializer.serialize(timer.key, out);
-			windowSerializer.serialize(timer.window, out);
-			out.writeLong(timer.timestamp);
-		}
-
-		out.writeInt(processingTimeTimers.size());
-		for (Timer<K, W> timer : processingTimeTimersQueue) {
-			keySerializer.serialize(timer.key, out);
-			windowSerializer.serialize(timer.window, out);
-			out.writeLong(timer.timestamp);
-		}
+		snapshotStateTo(out);
 
 		taskState.setOperatorState(out.closeAndGetHandle());
 
@@ -699,6 +717,10 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		StateHandle<DataInputView> inputState = (StateHandle<DataInputView>) taskState.getOperatorState();
 		DataInputView in = inputState.getState(userClassloader);
 
+		restoreStateFrom(in);
+	}
+
+	private void restoreStateFrom(DataInputView in ) throws IOException {
 		int numWatermarkTimers = in.readInt();
 		watermarkTimers = new HashSet<>(numWatermarkTimers);
 		watermarkTimersQueue = new PriorityQueue<>(Math.max(numWatermarkTimers, 1));
@@ -712,15 +734,45 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		}
 
 		int numProcessingTimeTimers = in.readInt();
-		processingTimeTimers = new HashSet<>(numProcessingTimeTimers);
 		processingTimeTimersQueue = new PriorityQueue<>(Math.max(numProcessingTimeTimers, 1));
+		processingTimeTimers = new HashSet<>();
 		for (int i = 0; i < numProcessingTimeTimers; i++) {
 			K key = keySerializer.deserialize(in);
 			W window = windowSerializer.deserialize(in);
 			long timestamp = in.readLong();
 			Timer<K, W> timer = new Timer<>(timestamp, key, window);
-			processingTimeTimers.add(timer);
 			processingTimeTimersQueue.add(timer);
+			processingTimeTimers.add(timer);
+		}
+
+		int numProcessingTimeTimerTimestamp = in.readInt();
+		processingTimeTimerTimestamps = HashMultiset.create();
+		for (int i = 0; i< numProcessingTimeTimerTimestamp; i++) {
+			long timestamp = in.readLong();
+			int count = in.readInt();
+			processingTimeTimerTimestamps.add(timestamp, count);
+		}
+	}
+
+	private void snapshotStateTo(DataOutputView out) throws IOException {
+		out.writeInt(watermarkTimersQueue.size());
+		for (Timer<K, W> timer : watermarkTimersQueue) {
+			keySerializer.serialize(timer.key, out);
+			windowSerializer.serialize(timer.window, out);
+			out.writeLong(timer.timestamp);
+		}
+
+		out.writeInt(processingTimeTimers.size());
+		for (Timer<K,W> timer : processingTimeTimers) {
+			keySerializer.serialize(timer.key, out);
+			windowSerializer.serialize(timer.window, out);
+			out.writeLong(timer.timestamp);
+		}
+
+		out.writeInt(processingTimeTimerTimestamps.entrySet().size());
+		for (Multiset.Entry<Long> timerTimestampCounts: processingTimeTimerTimestamps.entrySet()) {
+			out.writeLong(timerTimestampCounts.getElement());
+			out.writeInt(timerTimestampCounts.getCount());
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -28,6 +28,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.streaming.api.datastream.WindowedStream;
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -58,6 +60,8 @@ import org.apache.flink.util.Collector;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -840,6 +844,77 @@ public class WindowOperatorTest {
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
 
 		testHarness.close();
+	}
+
+	@Test
+	public void testRestoreAndSnapshotAreInSync() throws Exception {
+
+		final int WINDOW_SIZE = 3;
+		final int WINDOW_SLIDE = 1;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc = new ReducingStateDescriptor<>("window-contents",
+				new SumReducer(),
+				inputType.createSerializer(new ExecutionConfig()));
+
+		WindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, Tuple2<String, Integer>, TimeWindow> operator = new WindowOperator<>(
+				SlidingEventTimeWindows.of(Time.of(WINDOW_SIZE, TimeUnit.SECONDS), Time.of(WINDOW_SLIDE, TimeUnit.SECONDS)),
+				new TimeWindow.Serializer(),
+				new TupleKeySelector(),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+				stateDesc,
+				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
+				EventTimeTrigger.create());
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+				new OneInputStreamOperatorTestHarness<>(operator);
+
+		testHarness.configureForKeyedStream(new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+		operator.setInputType(inputType, new ExecutionConfig());
+		testHarness.open();
+
+		WindowOperator.Timer<String, TimeWindow> timer1 = new WindowOperator.Timer<>(1L, "key1", new TimeWindow(1L, 2L));
+		WindowOperator.Timer<String, TimeWindow> timer2 = new WindowOperator.Timer<>(3L, "key1", new TimeWindow(1L, 2L));
+		WindowOperator.Timer<String, TimeWindow> timer3 = new WindowOperator.Timer<>(2L, "key1", new TimeWindow(1L, 2L));
+		operator.processingTimeTimers.add(timer1);
+		operator.processingTimeTimers.add(timer2);
+		operator.processingTimeTimers.add(timer3);
+		operator.processingTimeTimersQueue.add(timer1);
+		operator.processingTimeTimersQueue.add(timer2);
+		operator.processingTimeTimersQueue.add(timer3);
+
+		operator.processingTimeTimerTimestamps.add(1L, 10);
+		operator.processingTimeTimerTimestamps.add(2L, 5);
+		operator.processingTimeTimerTimestamps.add(3L, 1);
+
+
+		StreamTaskState snapshot = testHarness.snapshot(0, 0);
+
+		WindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, Tuple2<String, Integer>, TimeWindow> otherOperator = new WindowOperator<>(
+				SlidingEventTimeWindows.of(Time.of(WINDOW_SIZE, TimeUnit.SECONDS), Time.of(WINDOW_SLIDE, TimeUnit.SECONDS)),
+				new TimeWindow.Serializer(),
+				new TupleKeySelector(),
+				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+				stateDesc,
+				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
+				EventTimeTrigger.create());
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> otherTestHarness =
+				new OneInputStreamOperatorTestHarness<>(otherOperator);
+
+		otherTestHarness.configureForKeyedStream(new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+		otherOperator.setInputType(inputType, new ExecutionConfig());
+
+		otherTestHarness.setup();
+		otherTestHarness.restore(snapshot, 0);
+		otherTestHarness.open();
+
+		Assert.assertEquals(operator.processingTimeTimers, otherOperator.processingTimeTimers);
+		Assert.assertArrayEquals(operator.processingTimeTimersQueue.toArray(), otherOperator.processingTimeTimersQueue.toArray());
+		Assert.assertEquals(operator.processingTimeTimerTimestamps, otherOperator.processingTimeTimerTimestamps);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.
- [ ] General
  - The pull request references the related JIRA issue
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message
- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Per timestamp only one TriggerTask is registered at
the runtime context. When the first timer is registered a new TriggerTask
is sheduled. When no timer is registered anymore for a specific timestamp
the corresponding trigger task is canceled and hence removed.

The ScheduledFutures to cancel trigger tasks are not checkpointed. So
cleanup of trigger tasks will not work after a failure.
