### PR TITLE
[FLINK-3776] Flink Scala shell does not allow to set configuration fo…

### DIFF
--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -141,7 +141,7 @@ object FlinkShell {
   ): (String, Int, Option[Either[FlinkMiniCluster, AbstractFlinkYarnCluster]]) = {
     config.executionMode match {
       case ExecutionMode.LOCAL => // Local mode
-        val config = new Configuration()
+        val config = GlobalConfiguration.getConfiguration()
         config.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, 0)
 
         val miniCluster = new LocalFlinkMiniCluster(config, false)


### PR DESCRIPTION
The current version of FlinkShell creates a new Configuration object when creating a LocalFlinkMiniCluster in FlinkShell.fetchConnectionInfo().
Instead of creating a new one, FlinkShell just needs to get a configuration object which was already created when GlobalConfiguration.loadConfiguration() is called (which is before FlinkShell.fetchConnectionInfo() is called).
Therefore, just one line modification figures out this issue as shown in this pull request.