### PR TITLE
[FLINK-3846] [gelly] Graph.removeEdges also removes duplicate edges

### DIFF
--- a/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphMutationsITCase.scala
+++ b/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphMutationsITCase.scala
@@ -211,11 +211,13 @@ MultipleProgramsTestBase(mode) {
   @throws(classOf[Exception])
   def testRemoveEdge() {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val graph: Graph[Long, Long, Long] = Graph.fromDataSet(TestGraphUtils
+    var graph: Graph[Long, Long, Long] = Graph.fromDataSet(TestGraphUtils
       .getLongLongVertexData(env), TestGraphUtils.getLongLongEdgeData(env), env)
-    val newgraph = graph.removeEdge(new Edge[Long, Long](5L, 1L, 51L))
-    val res = newgraph.getEdges.collect().toList
-    expectedResult = "1,2,12\n" + "1,3,13\n" + "2,3,23\n" + "3,4,34\n" + "3,5,35\n" + "4,5,45\n"
+    graph = graph.addEdge(new Vertex[Long, Long](1L, 1L), new Vertex[Long, Long](2L, 2L), 12L)
+    graph = graph.removeEdge(new Edge[Long, Long](5L, 1L, 51L))
+    val res = graph.getEdges.collect().toList
+    expectedResult = "1,2,12\n" + "1,2,12\n" + "1,3,13\n" + "2,3,23\n" + "3,4,34\n" + "3,5,35\n" +
+      "4,5,45\n"
     TestBaseUtils.compareResultAsTuples(res.asJava, expectedResult)
   }
 
@@ -236,12 +238,12 @@ MultipleProgramsTestBase(mode) {
   @throws(classOf[Exception])
   def testRemoveEdges() {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val graph: Graph[Long, Long, Long] = Graph.fromDataSet(TestGraphUtils
+    var graph: Graph[Long, Long, Long] = Graph.fromDataSet(TestGraphUtils
       .getLongLongVertexData(env), TestGraphUtils.getLongLongEdgeData(env), env)
-    val newgraph = graph.removeEdges(List[Edge[Long, Long]](new Edge(1L, 2L, 12L),
-      new Edge(4L, 5L, 45L)))
-    val res = newgraph.getEdges.collect().toList
-    expectedResult = "1,3,13\n" + "2,3,23\n" + "3,4,34\n" + "3,5,35\n" + "5,1,51\n"
+    graph = graph.addEdge(new Vertex[Long, Long](3L, 3L), new Vertex[Long, Long](4L, 4L), 34L)
+    graph = graph.removeEdges(List[Edge[Long, Long]](new Edge(1L, 2L, 12L), new Edge(4L, 5L, 45L)))
+    val res = graph.getEdges.collect().toList
+    expectedResult = "1,3,13\n" + "2,3,23\n" + "3,4,34\n" + "3,4,34\n" + "3,5,35\n" + "5,1,51\n"
     TestBaseUtils.compareResultAsTuples(res.asJava, expectedResult)
   }
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -1459,14 +1459,8 @@ public class Graph<K, VV, EV> {
 		@Override
 		public void coGroup(Iterable<Edge<K, EV>> edge, Iterable<Edge<K, EV>> edgeToBeRemoved,
 							Collector<Edge<K, EV>> out) throws Exception {
-
-			final Iterator<Edge<K, EV>> edgeIterator = edge.iterator();
-			final Iterator<Edge<K, EV>> edgeToBeRemovedIterator = edgeToBeRemoved.iterator();
-			Edge<K, EV> next;
-
-			if (edgeIterator.hasNext()) {
-				if (!edgeToBeRemovedIterator.hasNext()) {
-					next = edgeIterator.next();
+			if (!edgeToBeRemoved.iterator().hasNext()) {
+				for (Edge<K, EV> next : edge) {
 					out.collect(next);
 				}
 			}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -1421,8 +1421,8 @@ public class Graph<K, VV, EV> {
 	 *         the removed edges
 	 */
 	public Graph<K, VV, EV> removeEdge(Edge<K, EV> edge) {
-		DataSet<Edge<K, EV>> newEdges = getEdges().filter(new EdgeRemovalEdgeFilter<K, EV>(edge));
-		return new Graph<K, VV, EV>(this.vertices, newEdges, this.context);
+		DataSet<Edge<K, EV>> newEdges = getEdges().filter(new EdgeRemovalEdgeFilter<>(edge));
+		return new Graph<>(this.vertices, newEdges, this.context);
 	}
 
 	private static final class EdgeRemovalEdgeFilter<K, EV>

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
@@ -471,12 +471,17 @@ public class GraphMutationsITCase extends MultipleProgramsTestBase {
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 				TestGraphUtils.getLongLongEdgeData(env), env);
+
+		// duplicate edge should be preserved in output
+		graph = graph.addEdge(new Vertex<>(1L, 1L), new Vertex<>(2L, 2L), 12L);
+
 		graph = graph.removeEdge(new Edge<>(5L, 1L, 51L));
 
 		DataSet<Edge<Long,Long>> data = graph.getEdges();
 		List<Edge<Long, Long>> result= data.collect();
 
 		expectedResult = "1,2,12\n" +
+				"1,2,12\n" +
 				"1,3,13\n" +
 				"2,3,23\n" +
 				"3,4,34\n" +
@@ -500,12 +505,16 @@ public class GraphMutationsITCase extends MultipleProgramsTestBase {
 		edgesToBeRemoved.add(new Edge<>(5L, 1L, 51L));
 		edgesToBeRemoved.add(new Edge<>(2L, 3L, 23L));
 
+		// duplicate edge should be preserved in output
+		graph = graph.addEdge(new Vertex<>(1L, 1L), new Vertex<>(2L, 2L), 12L);
+
 		graph = graph.removeEdges(edgesToBeRemoved);
 
 		DataSet<Edge<Long,Long>> data = graph.getEdges();
 		List<Edge<Long, Long>> result= data.collect();
 
 		expectedResult = "1,2,12\n" +
+				"1,2,12\n" +
 				"1,3,13\n" +
 				"3,4,34\n" +
 				"3,5,35\n" +


### PR DESCRIPTION
All original edges are now emitted when no matching edge is found in the edge removal set.