### PR TITLE
[FLINK-3845] [gelly] Gelly allows duplicate vertices in Graph.addVertices

### DIFF
--- a/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphMutationsITCase.scala
+++ b/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/operations/GraphMutationsITCase.scala
@@ -79,8 +79,8 @@ MultipleProgramsTestBase(mode) {
     val graph: Graph[Long, Long, Long] = Graph.fromDataSet(TestGraphUtils
       .getLongLongVertexData(env), TestGraphUtils.getLongLongEdgeData(env), env)
 
-    val newgraph = graph.addVertices(List[Vertex[Long, Long]](new Vertex[Long, Long](6L, 6L),
-        new Vertex[Long, Long](7L, 7L)))
+    val newgraph = graph.addVertices(List[Vertex[Long, Long]](new Vertex[Long, Long](5L, 0L),
+      new Vertex[Long, Long](6L, 6L), new Vertex[Long, Long](7L, 7L)))
     val res = newgraph.getVertices.collect().toList
     expectedResult = "1,1\n" + "2,2\n" + "3,3\n" + "4,4\n" + "5,5\n" + "6,6\n" + "7,7\n"
     TestBaseUtils.compareResultAsTuples(res.asJava, expectedResult)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -1272,9 +1272,28 @@ public class Graph<K, VV, EV> {
 	 */
 	public Graph<K, VV, EV> addVertices(List<Vertex<K, VV>> verticesToAdd) {
 		// Add the vertices
-		DataSet<Vertex<K, VV>> newVertices = this.vertices.union(this.context.fromCollection(verticesToAdd)).distinct();
+		DataSet<Vertex<K, VV>> newVertices = this.vertices.coGroup(this.context.fromCollection(verticesToAdd))
+				.where(0).equalTo(0).with(new VerticesUnionCoGroup<K, VV>());
 
-		return new Graph<K, VV, EV>(newVertices, this.edges, this.context);
+		return new Graph<>(newVertices, this.edges, this.context);
+	}
+
+	private static final class VerticesUnionCoGroup<K, VV> implements CoGroupFunction<Vertex<K, VV>, Vertex<K, VV>, Vertex<K, VV>> {
+
+		@Override
+		public void coGroup(Iterable<Vertex<K, VV>> oldVertices, Iterable<Vertex<K, VV>> newVertices,
+							Collector<Vertex<K, VV>> out) throws Exception {
+
+			final Iterator<Vertex<K, VV>> oldVerticesIterator = oldVertices.iterator();
+			final Iterator<Vertex<K, VV>> newVerticesIterator = newVertices.iterator();
+
+			// if there is both an old vertex and a new vertex then only the old vertex is emitted
+			if (oldVerticesIterator.hasNext()) {
+				out.collect(oldVerticesIterator.next());
+			} else {
+				out.collect(newVerticesIterator.next());
+			}
+		}
 	}
 
 	/**

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
@@ -32,8 +32,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static javafx.scene.input.KeyCode.L;
-
 @RunWith(Parameterized.class)
 public class GraphMutationsITCase extends MultipleProgramsTestBase {
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphMutationsITCase.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static javafx.scene.input.KeyCode.L;
+
 @RunWith(Parameterized.class)
 public class GraphMutationsITCase extends MultipleProgramsTestBase {
 
@@ -79,6 +81,9 @@ public class GraphMutationsITCase extends MultipleProgramsTestBase {
 				TestGraphUtils.getLongLongEdgeData(env), env);
 
 		List<Vertex<Long, Long>> vertices = new ArrayList<>();
+		// the first vertex has a duplicate ID from a vertex in the graph and
+		// should not be added to the new graph
+		vertices.add(new Vertex<>(5L, 0L));
 		vertices.add(new Vertex<>(6L, 6L));
 		vertices.add(new Vertex<>(7L, 7L));
 


### PR DESCRIPTION
Vertex sets are now merged with a cogroup so that a new Vertex is only added to the Graph when no existing Vertex exists with the same label.