### PR TITLE
[FLINK-3853] [gelly] Reduce object creation in Gelly utility mappers

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/EdgeToTuple3Map.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/EdgeToTuple3Map.java
@@ -23,13 +23,20 @@ import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
 
+/**
+ * Create a Tuple3 DataSet from an Edge DataSet
+ *
+ * @param <K> edge ID type
+ * @param <EV> edge value type
+ */
 @ForwardedFields("f0; f1; f2")
 public class EdgeToTuple3Map<K, EV> implements MapFunction<Edge<K, EV>, Tuple3<K, K, EV>> {
 
 	private static final long serialVersionUID = 1L;
 
+	@Override
 	public Tuple3<K, K, EV> map(Edge<K, EV> edge) {
-		return new Tuple3<K, K, EV>(edge.f0, edge.f1, edge.f2);
+		return edge;
 	}
 
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/Tuple2ToVertexMap.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/Tuple2ToVertexMap.java
@@ -19,17 +19,28 @@
 package org.apache.flink.graph.utils;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Vertex;
-import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 
+/**
+ * Create a Vertex DataSet from a Tuple2 DataSet
+ *
+ * @param <K> vertex ID type
+ * @param <VV> vertex value type
+ */
 @ForwardedFields("f0; f1")
 public class Tuple2ToVertexMap<K, VV> implements MapFunction<Tuple2<K, VV>, Vertex<K, VV>> {
 
 	private static final long serialVersionUID = 1L;
 
-	public Vertex<K, VV> map(Tuple2<K, VV> vertex) {
-		return new Vertex<K, VV>(vertex.f0, vertex.f1);
+	private Vertex<K, VV> vertex = new Vertex<>();
+
+	@Override
+	public Vertex<K, VV> map(Tuple2<K, VV> tuple) {
+		vertex.f0 = tuple.f0;
+		vertex.f1 = tuple.f1;
+		return vertex;
 	}
 
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/Tuple3ToEdgeMap.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/Tuple3ToEdgeMap.java
@@ -19,23 +19,29 @@
 package org.apache.flink.graph.utils;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
-import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 
 /**
- * create an Edge DataSetfrom a Tuple3 dataset
+ * Create an Edge DataSet from a Tuple3 DataSet
  *
- * @param <K>
- * @param <EV>
+ * @param <K> edge ID type
+ * @param <EV> edge value type
  */
 @ForwardedFields("f0; f1; f2")
 public class Tuple3ToEdgeMap<K, EV> implements MapFunction<Tuple3<K, K, EV>, Edge<K, EV>> {
 
 	private static final long serialVersionUID = 1L;
 
+	private Edge<K, EV> edge = new Edge<>();
+
+	@Override
 	public Edge<K, EV> map(Tuple3<K, K, EV> tuple) {
-		return new Edge<K, EV>(tuple.f0, tuple.f1, tuple.f2);
+		edge.f0 = tuple.f0;
+		edge.f1 = tuple.f1;
+		edge.f2 = tuple.f2;
+		return edge;
 	}
 
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/VertexToTuple2Map.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/VertexToTuple2Map.java
@@ -19,17 +19,24 @@
 package org.apache.flink.graph.utils;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Vertex;
-import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
 
+/**
+ * Create a Tuple2 DataSet from a Vertex DataSet
+ *
+ * @param <K> vertex ID type
+ * @param <VV> vertex value type
+ */
 @ForwardedFields("f0; f1")
 public class VertexToTuple2Map<K, VV> implements MapFunction<Vertex<K, VV>, Tuple2<K, VV>> {
 
 	private static final long serialVersionUID = 1L;
 
+	@Override
 	public Tuple2<K, VV> map(Vertex<K, VV> vertex) {
-		return new Tuple2<K, VV>(vertex.f0, vertex.f1);
+		return vertex;
 	}
 
 }


### PR DESCRIPTION
Gelly contains a set of MapFunction between Vertex and Tuple2 and between Edge and Tuple3. A Vertex is a Tuple2 and an Edge is a Tuple3, and conversion in the opposite direction can be performed with a single object per MapFunction.

This only applies to the Gelly Java API. Scala tuples are not related to Vertex or Edge.