### PR TITLE
Jackson version upgrade: default from 2.4.2 to 2.7.4 (latest stable)

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -105,7 +105,6 @@ under the License.
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-streaming-connectors/flink-connector-elasticsearch2/pom.xml
+++ b/flink-streaming-connectors/flink-connector-elasticsearch2/pom.xml
@@ -55,11 +55,11 @@ under the License.
             <version>${elasticsearch.version}</version>
         </dependency>
 
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>2.7.2</version>
-		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.7.4</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-streaming-connectors/flink-connector-elasticsearch2/pom.xml
+++ b/flink-streaming-connectors/flink-connector-elasticsearch2/pom.xml
@@ -58,7 +58,6 @@ under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.7.4</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ under the License.
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<curator.version>2.8.0</curator.version>
-		<jackson.version>2.4.2</jackson.version>
+		<jackson.version>2.5.5</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ under the License.
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<curator.version>2.8.0</curator.version>
-		<jackson.version>2.5.5</jackson.version>
+		<jackson.version>2.7.4</jackson.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Fix for [FLINK-3855] -- upgrade default Jackson version from 2.4.2 to 2.5.5 (last 2.5 patch); remove unnecessary explicit version ref, and upgrade ES client to latest patch for minor version it refers.

