### PR TITLE
[FLINK-3581] [FLINK-3582] State Iterator and Aligned Time Windows

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -51,7 +51,7 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractRocksDBState.class);
 
 	/** Serializer for the namespace */
-	private final TypeSerializer<N> namespaceSerializer;
+	protected final TypeSerializer<N> namespaceSerializer;
 
 	/** The current namespace, which the next value methods will refer to */
 	private N currentNamespace;
@@ -93,9 +93,9 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	}
 
 	protected void writeKeyAndNamespace(DataOutputView out) throws IOException {
-		backend.keySerializer().serialize(backend.currentKey(), out);
-		out.writeByte(42);
 		namespaceSerializer.serialize(currentNamespace, out);
+		out.writeByte(42);
+		backend.keySerializer().serialize(backend.currentKey(), out);
 	}
 
 	@Override

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateIterator.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateIterator.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateIterator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.WriteOptions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+abstract class RocksDBStateIterator<K, S extends State, N> implements StateIterator<K, S> {
+
+	private final RocksDBStateBackend backend;
+	private final WriteOptions writeOptions;
+	private final ColumnFamilyHandle columnFamily;
+
+	private final byte[] namespaceBytes;
+	protected final RocksIterator rocksIterator;
+
+	private boolean first;
+	private K key;
+	private byte[] compoundKey;
+
+	public RocksDBStateIterator(RocksDBStateBackend backend,
+			WriteOptions writeOptions,
+			ColumnFamilyHandle columnFamily,
+			N namespace,
+			TypeSerializer<N> namespaceSerializer) throws IOException {
+		this.backend = backend;
+		this.writeOptions = writeOptions;
+		this.columnFamily = columnFamily;
+		first = true;
+		key = null;
+
+		rocksIterator = backend.db.newIterator(columnFamily);
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(baos);
+		namespaceSerializer.serialize(namespace, out);
+
+		namespaceBytes = baos.toByteArray();
+
+		out.close();
+		baos.close();
+	}
+
+	@Override
+	public K key() {
+		return key;
+	}
+
+	@Override
+	public void delete() throws Exception {
+		backend.db.remove(columnFamily, writeOptions, compoundKey);
+	}
+
+
+	@Override
+	public boolean advance() throws Exception {
+		if (first) {
+			first = false;
+			rocksIterator.seek(namespaceBytes);
+		} else {
+			rocksIterator.next();
+		}
+
+		if (!rocksIterator.isValid()) {
+			return false;
+		}
+
+		compoundKey = rocksIterator.key();
+		if (!startsWith(compoundKey, namespaceBytes)) {
+			return false;
+		}
+
+		DataInputViewStreamWrapper in = new DataInputViewStreamWrapper(new ByteArrayInputStream(compoundKey));
+		in.skipBytesToRead(namespaceBytes.length);
+		in.readByte();
+		key = (K) backend.keySerializer().deserialize(in);
+		in.close();
+
+		return true;
+	}
+
+	private static boolean startsWith(byte[] source, byte[] match) {
+
+		if (match.length > (source.length)) {
+			return false;
+		}
+
+		for (int i = 0; i < match.length; i++) {
+			if (source[i] != match[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateIterator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateIterator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.state;
+
+/**
+ * Iterator for iterating over the state for all keys in a parallel partition.
+ *
+ * <p>Use {@link #advance()} to progress and {@link #key()} and {@link #state()} to access
+ * the current key and state, respectively. Initially, the iterator is not in any read position,
+ * you have to call {@link #advance()} first, before trying to access the key and/or state.
+ *
+ * @param <K> The type of the Key.
+ * @param <S> The type of {@link State} that we iterate over.
+ */
+public interface StateIterator<K, S> {
+
+	/**
+	 * Returns the key of the current state.
+	 */
+	K key();
+
+	/**
+	 * Returns the current state.
+	 */
+	S state() throws Exception;
+
+	/**
+	 * Delete the state for the current key.
+	 * @throws Exception
+	 */
+	void delete() throws Exception;
+
+	/**
+	 * Advances the iterator to the next key/state. Returns {@code false} if no more keys
+	 * are available.
+	 */
+	boolean advance() throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateBackend;
 import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -309,6 +310,15 @@ public abstract class AbstractStateBackend implements java.io.Serializable {
 		} else {
 			throw new RuntimeException("Cannot merge states for " + stateDescriptor);
 		}
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public <K, N, S extends State> StateIterator<K, S> getPartitionedStateForAllKeys(final N namespace, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S, ?> stateDescriptor) throws Exception {
+		S state = getPartitionedState(namespace, namespaceSerializer, stateDescriptor);
+
+		KvState<K, N, S, ?, ?> kvState = (KvState) state;
+
+		return kvState.getForAllKeys(namespace);
 	}
 
 	public HashMap<String, KvStateSnapshot<?, ?, ?, ?, ?>> snapshotPartitionedState(long checkpointId, long timestamp) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapFoldingStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapFoldingStateIterator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.state.StateIterator;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+@Internal
+public class HeapFoldingStateIterator<K, T, ACC> implements StateIterator<K, FoldingState<T, ACC>> {
+	private final Iterator<Map.Entry<K, ACC>> it;
+	private K key = null;
+	private ProxyFoldingState<T, ACC> state = new ProxyFoldingState<>();
+
+	public HeapFoldingStateIterator(Iterator<Map.Entry<K, ACC>> it) {
+		this.it = it;
+	}
+
+	@Override
+	public K key() {
+		if (key == null) {
+			throw new IllegalStateException("No key set.");
+		}
+		return key;
+	}
+
+	@Override
+	public FoldingState<T, ACC> state() {
+		return state;
+	}
+
+	@Override
+	public boolean advance() {
+		if (!it.hasNext()) {
+			this.key = null;
+			this.state = null;
+			return false;
+		}
+		Map.Entry<K, ACC> nextState = it.next();
+		this.key = nextState.getKey();
+		this.state.state = nextState.getValue();
+		return true;
+	}
+
+	@Override
+	public void delete() throws Exception {
+		it.remove();
+	}
+
+	@Internal
+	private static class ProxyFoldingState<T, ACC> implements FoldingState<T, ACC> {
+		protected ACC state = null;
+
+		@Override
+		public ACC get() throws IOException {
+			if (state == null) {
+				throw new IllegalStateException("No state set.");
+			}
+
+			return state;
+		}
+
+		@Override
+		public void add(T value) throws IOException {
+			throw new UnsupportedOperationException("Cannot update state view.");
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException("Cannot clear state view.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapListStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapListStateIterator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.StateIterator;
+import org.apache.flink.api.common.state.ListState;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+
+@Internal
+public class HeapListStateIterator<K, V> implements StateIterator<K, ListState<V>> {
+	private final Iterator<Map.Entry<K, ArrayList<V>>> it;
+	private K key = null;
+	private ProxyListState<V> state = new ProxyListState<>();
+
+	public HeapListStateIterator(Iterator<Map.Entry<K, ArrayList<V>>> it) {
+		this.it = it;
+	}
+
+	@Override
+	public K key() {
+		if (key == null) {
+			throw new IllegalStateException("No key set.");
+		}
+		return key;
+	}
+
+	@Override
+	public ListState<V> state() {
+		return state;
+	}
+
+	@Override
+	public boolean advance() {
+		if (!it.hasNext()) {
+			this.key = null;
+			this.state = null;
+			return false;
+		}
+		Map.Entry<K, ArrayList<V>> nextState = it.next();
+		this.key = nextState.getKey();
+		this.state.state = nextState.getValue();
+		return true;
+	}
+
+	@Override
+	public void delete() throws Exception {
+		it.remove();
+	}
+
+	@Internal
+	private static class ProxyListState<V> implements ListState<V> {
+		protected Iterable<V> state = null;
+
+		@Override
+		public Iterable<V> get() throws IOException {
+			if (state == null) {
+				throw new IllegalStateException("No state set.");
+			}
+
+			return state;
+		}
+
+		@Override
+		public void add(V value) throws IOException {
+			throw new UnsupportedOperationException("Cannot update state view.");
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException("Cannot clear state view.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapReducingStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapReducingStateIterator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.StateIterator;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+@Internal
+public class HeapReducingStateIterator<K, V> implements StateIterator<K, ReducingState<V>> {
+	private final Iterator<Map.Entry<K, V>> it;
+	private K key = null;
+	private ProxyReducingState<V> state = new ProxyReducingState<>();
+
+	public HeapReducingStateIterator(Iterator<Map.Entry<K, V>> it) {
+		this.it = it;
+	}
+
+	@Override
+	public K key() {
+		if (key == null) {
+			throw new IllegalStateException("No key set.");
+		}
+		return key;
+	}
+
+	@Override
+	public ReducingState<V> state() {
+		return state;
+	}
+
+	@Override
+	public boolean advance() {
+		if (!it.hasNext()) {
+			this.key = null;
+			this.state = null;
+			return false;
+		}
+		Map.Entry<K, V> nextState = it.next();
+		this.key = nextState.getKey();
+		this.state.state = nextState.getValue();
+		return true;
+	}
+
+	@Override
+	public void delete() throws Exception {
+		it.remove();
+	}
+
+	@Internal
+	private static class ProxyReducingState<V> implements ReducingState<V> {
+		protected V state = null;
+
+		@Override
+		public V get() throws IOException {
+			if (state == null) {
+				throw new IllegalStateException("No state set.");
+			}
+
+			return state;
+		}
+
+		@Override
+		public void add(V value) throws IOException {
+			throw new UnsupportedOperationException("Cannot update state view.");
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException("Cannot clear state view.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapValueStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapValueStateIterator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.StateIterator;
+import org.apache.flink.api.common.state.ValueState;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+@Internal
+public class HeapValueStateIterator<K, V> implements StateIterator<K, ValueState<V>> {
+	private final Iterator<Map.Entry<K, V>> it;
+	private K key = null;
+	private ProxyValueState<V> state = new ProxyValueState<>();
+
+	public HeapValueStateIterator(Iterator<Map.Entry<K, V>> it) {
+		this.it = it;
+	}
+
+	@Override
+	public K key() {
+		if (key == null) {
+			throw new IllegalStateException("No key set.");
+		}
+		return key;
+	}
+
+	@Override
+	public ValueState<V> state() {
+		return state;
+	}
+
+	@Override
+	public boolean advance() {
+		if (!it.hasNext()) {
+			this.key = null;
+			this.state = null;
+			return false;
+		}
+		Map.Entry<K, V> nextState = it.next();
+		this.key = nextState.getKey();
+		this.state.state = nextState.getValue();
+		return true;
+	}
+
+	@Override
+	public void delete() throws Exception {
+		it.remove();
+	}
+
+	@Internal
+	private static class ProxyValueState<V> implements ValueState<V> {
+		protected V state = null;
+
+		@Override
+		public V value() throws IOException {
+			if (state == null) {
+				throw new IllegalStateException("No state set.");
+			}
+
+			return state;
+		}
+
+		@Override
+		public void update(V value) throws IOException {
+			throw new UnsupportedOperationException("Cannot update state view.");
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException("Cannot clear state view.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvState.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
 
 /**
  * Key/Value state implementation for user-defined state. The state is backed by a state
@@ -50,6 +51,8 @@ public interface KvState<K, N, S extends State, SD extends StateDescriptor<S, ?>
 	 * @param namespace The namespace.
 	 */
 	void setCurrentNamespace(N namespace);
+
+	StateIterator<K, S> getForAllKeys(N namespace) throws Exception;
 
 	/**
 	 * Creates a snapshot of this state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsFoldingState.java
@@ -21,13 +21,17 @@ package org.apache.flink.runtime.state.filesystem;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.state.FoldingState;
 import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.HeapFoldingStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -93,6 +97,17 @@ public class FsFoldingState<K, N, T, ACC>
 			return value != null ? value : stateDesc.getDefaultValue();
 		}
 		return stateDesc.getDefaultValue();
+	}
+
+	@Override
+	public StateIterator<K, FoldingState<T, ACC>> getForAllKeys(N namespace) {
+		Map<K, ACC> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapFoldingStateIterator<>(Collections.<Map.Entry<K, ACC>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, ACC>> it = namespaceState.entrySet().iterator();
+		return new HeapFoldingStateIterator<>(it);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsListState.java
@@ -20,15 +20,18 @@ package org.apache.flink.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.ArrayListSerializer;
+import org.apache.flink.runtime.state.HeapListStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -94,6 +97,17 @@ public class FsListState<K, N, V>
 			}
 		}
 		return Collections.emptyList();
+	}
+
+	@Override
+	public StateIterator<K, ListState<V>> getForAllKeys(N namespace) {
+		Map<K, ArrayList<V>> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapListStateIterator<>(Collections.<Map.Entry<K, ArrayList<V>>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, ArrayList<V>>> it = namespaceState.entrySet().iterator();
+		return new HeapListStateIterator<>(it);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsReducingState.java
@@ -21,13 +21,17 @@ package org.apache.flink.runtime.state.filesystem;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ReducingState;
 import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.HeapReducingStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -92,6 +96,17 @@ public class FsReducingState<K, N, V>
 			return currentNSState.get(currentKey);
 		}
 		return null;
+	}
+
+	@Override
+	public StateIterator<K, ReducingState<V>> getForAllKeys(N namespace) {
+		Map<K, V> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapReducingStateIterator<>(Collections.<Map.Entry<K, V>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, V>> it = namespaceState.entrySet().iterator();
+		return new HeapReducingStateIterator<>(it);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsValueState.java
@@ -18,14 +18,18 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.HeapValueStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -87,6 +91,18 @@ public class FsValueState<K, N, V>
 		}
 		return stateDesc.getDefaultValue();
 	}
+
+	@Override
+	public StateIterator<K, ValueState<V>> getForAllKeys(N namespace) {
+		Map<K, V> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapValueStateIterator<>(Collections.<Map.Entry<K, V>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, V>> it = namespaceState.entrySet().iterator();
+		return new HeapValueStateIterator<>(it);
+	}
+
 
 	@Override
 	public void update(V value) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemFoldingState.java
@@ -21,12 +21,16 @@ package org.apache.flink.runtime.state.memory;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.state.FoldingState;
 import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.HeapFoldingStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -69,6 +73,17 @@ public class MemFoldingState<K, N, T, ACC>
 			return value != null ? value : stateDesc.getDefaultValue();
 		}
 		return stateDesc.getDefaultValue();
+	}
+
+	@Override
+	public StateIterator<K, FoldingState<T, ACC>> getForAllKeys(N namespace) {
+		Map<K, ACC> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapFoldingStateIterator<>(Collections.<Map.Entry<K, ACC>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, ACC>> it = namespaceState.entrySet().iterator();
+		return new HeapFoldingStateIterator<>(it);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemListState.java
@@ -20,14 +20,17 @@ package org.apache.flink.runtime.state.memory;
 
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.ArrayListSerializer;
+import org.apache.flink.runtime.state.HeapListStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -65,6 +68,17 @@ public class MemListState<K, N, V>
 			}
 		}
 		return Collections.emptyList();
+	}
+
+	@Override
+	public StateIterator<K, ListState<V>> getForAllKeys(N namespace) {
+		Map<K, ArrayList<V>> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapListStateIterator<>(Collections.<Map.Entry<K, ArrayList<V>>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, ArrayList<V>>> it = namespaceState.entrySet().iterator();
+		return new HeapListStateIterator<>(it);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemReducingState.java
@@ -21,12 +21,16 @@ package org.apache.flink.runtime.state.memory;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ReducingState;
 import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.HeapReducingStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -67,6 +71,17 @@ public class MemReducingState<K, N, V>
 			return currentNSState.get(currentKey);
 		}
 		return null;
+	}
+
+	@Override
+	public StateIterator<K, ReducingState<V>> getForAllKeys(N namespace) {
+		Map<K, V> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapReducingStateIterator<>(Collections.<Map.Entry<K, V>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, V>> it = namespaceState.entrySet().iterator();
+		return new HeapReducingStateIterator<>(it);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemValueState.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.runtime.state.memory;
 
+import org.apache.flink.api.common.state.StateIterator;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.HeapValueStateIterator;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -61,6 +65,17 @@ public class MemValueState<K, N, V>
 			return value != null ? value : stateDesc.getDefaultValue();
 		}
 		return stateDesc.getDefaultValue();
+	}
+
+	@Override
+	public StateIterator<K, ValueState<V>> getForAllKeys(N namespace) {
+		Map<K, V> namespaceState = state.get(namespace);
+		if (namespaceState == null) {
+			return new HeapValueStateIterator<>(Collections.<Map.Entry<K, V>>emptyIterator());
+		}
+
+		final Iterator<Map.Entry<K, V>> it = namespaceState.entrySet().iterator();
+		return new HeapValueStateIterator<>(it);
 	}
 
 	@Override
@@ -102,4 +117,5 @@ public class MemValueState<K, N, V>
 			return new MemValueState<>(keySerializer, namespaceSerializer, stateDesc, stateMap);
 		}
 	}
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
@@ -31,7 +31,7 @@ import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 public class EventTimeTrigger extends Trigger<Object, TimeWindow> {
 	private static final long serialVersionUID = 1L;
 
-	private EventTimeTrigger() {}
+	protected EventTimeTrigger() {}
 
 	@Override
 	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AlignedEventTimeWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AlignedEventTimeWindowOperator.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.StateIterator;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskState;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Special-purpose window operator that behaves like {@link WindowOperator} with an
+ * {@link org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger} but with triggering
+ * behaviour aligned for all keys. This means that there is only one window timer per window,
+ * not per key and window. This also means that all windows always fire in lockstep.
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <IN> The type of the incoming elements.
+ * @param <OUT> The type of elements emitted by the {@code InternalWindowFunction}.
+ */
+@Internal
+public class AlignedEventTimeWindowOperator<K, IN, ACC, OUT>
+	extends AbstractUdfStreamOperator<OUT, InternalWindowFunction<ACC, OUT, K, TimeWindow>>
+	implements OneInputStreamOperator<IN, OUT>, InputTypeConfigurable {
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------------------------------------------------------------
+	// Configuration values and user functions
+	// ------------------------------------------------------------------------
+
+	private final WindowAssigner<? super IN, TimeWindow> windowAssigner;
+
+	private final StateDescriptor<? extends AppendingState<IN, ACC>, ?> windowStateDescriptor;
+
+	/**
+	 * This is used to copy the incoming element because it can be put into several window
+	 * buffers.
+	 */
+	private TypeSerializer<IN> inputSerializer;
+
+	/**
+	 * For serializing the window in checkpoints.
+	 */
+	private final TypeSerializer<TimeWindow> windowSerializer;
+
+	// ------------------------------------------------------------------------
+	// State that is not checkpointed
+	// ------------------------------------------------------------------------
+
+	/**
+	 * This is given to the {@code InternalWindowFunction} for emitting elements with a given timestamp.
+	 */
+	private transient TimestampedCollector<OUT> timestampedCollector;
+
+	/**
+	 * To keep track of the current watermark so that we can immediately fire if a trigger
+	 * registers an event time callback for a timestamp that lies in the past.
+	 */
+	private transient long currentWatermark = -1L;
+
+	// ------------------------------------------------------------------------
+	// State that needs to be checkpointed
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Current waiting watermark callbacks.
+	 */
+	private transient Set<TimeWindow> watermarkTimers;
+	private transient PriorityQueue<TimeWindow> watermarkTimersQueue;
+
+	/**
+	 * Creates a new {@code WindowOperator} based on the given policies and user functions.
+	 */
+	public AlignedEventTimeWindowOperator(WindowAssigner<? super IN, TimeWindow> windowAssigner,
+		TypeSerializer<TimeWindow> windowSerializer,
+		StateDescriptor<? extends AppendingState<IN, ACC>, ?> windowStateDescriptor,
+		InternalWindowFunction<ACC, OUT, K, TimeWindow> windowFunction) {
+
+		super(windowFunction);
+
+		this.windowAssigner = requireNonNull(windowAssigner);
+		this.windowSerializer = windowSerializer;
+
+		this.windowStateDescriptor = windowStateDescriptor;
+	}
+
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		currentWatermark = -1;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public final void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
+		inputSerializer = (TypeSerializer<IN>) type.createSerializer(executionConfig);
+	}
+
+	@Override
+	public final void open() throws Exception {
+		super.open();
+
+		timestampedCollector = new TimestampedCollector<>(output);
+
+		if (inputSerializer == null) {
+			throw new IllegalStateException("Input serializer was not set.");
+		}
+
+		// these could already be initialized from restoreState()
+		if (watermarkTimers == null) {
+			watermarkTimers = new HashSet<>();
+			watermarkTimersQueue = new PriorityQueue<>(100, new Comparator<TimeWindow>() {
+				@Override
+				public int compare(TimeWindow o1, TimeWindow o2) {
+					return Long.compare(o1.maxTimestamp(), o2.maxTimestamp());
+				}
+			});
+		}
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		Collection<TimeWindow> elementWindows = windowAssigner.assignWindows(element.getValue(), element.getTimestamp());
+
+		for (TimeWindow window: elementWindows) {
+			AppendingState<IN, ACC> windowState = getPartitionedState(window, windowSerializer, windowStateDescriptor);
+			windowState.add(element.getValue());
+
+			if (window.maxTimestamp() <= currentWatermark) {
+				// late element, we emit just like EventTimeTrigger does
+				timestampedCollector.setAbsoluteTimestamp(window.maxTimestamp());
+
+				ACC contents = windowState.get();
+				userFunction.apply((K) getStateBackend().getCurrentKey(), window, contents, timestampedCollector);
+				windowState.clear();
+
+			} else {
+				if (watermarkTimers.add(window)) {
+					watermarkTimersQueue.add(window);
+				}
+			}
+		}
+	}
+
+	private void fireForAllKeys(TimeWindow window) throws Exception {
+		timestampedCollector.setAbsoluteTimestamp(window.maxTimestamp());
+
+		StateIterator<K, ? extends AppendingState<IN, ACC>> stateIterator = getStateBackend().getPartitionedStateForAllKeys(
+				window,
+				windowSerializer,
+				windowStateDescriptor);
+
+		while (stateIterator.advance()) {
+			AppendingState<IN, ACC> windowState = stateIterator.state();
+			ACC contents = windowState.get();
+			
+			// set key in case user function accesses state
+			getStateBackend().setCurrentKey(stateIterator.key());
+			userFunction.apply(stateIterator.key(), window, contents, timestampedCollector);
+
+			stateIterator.delete();
+		}
+	}
+
+	@Override
+	public final void processWatermark(Watermark mark) throws Exception {
+
+		boolean fire;
+
+		do {
+			TimeWindow timer = watermarkTimersQueue.peek();
+			if (timer != null && timer.maxTimestamp() <= mark.getTimestamp()) {
+				fire = true;
+
+				watermarkTimers.remove(timer);
+				watermarkTimersQueue.remove();
+
+				fireForAllKeys(timer);
+			} else {
+				fire = false;
+			}
+		} while (fire);
+
+		output.emitWatermark(mark);
+
+		this.currentWatermark = mark.getTimestamp();
+	}
+
+	// ------------------------------------------------------------------------
+	//  Checkpointing
+	// ------------------------------------------------------------------------
+
+	@Override
+	public StreamTaskState snapshotOperatorState(long checkpointId, long timestamp) throws Exception {
+		StreamTaskState taskState = super.snapshotOperatorState(checkpointId, timestamp);
+
+		AbstractStateBackend.CheckpointStateOutputView out =
+			getStateBackend().createCheckpointStateOutputView(checkpointId, timestamp);
+
+		out.writeInt(watermarkTimersQueue.size());
+		for (TimeWindow timer : watermarkTimersQueue) {
+			windowSerializer.serialize(timer, out);
+		}
+
+		taskState.setOperatorState(out.closeAndGetHandle());
+
+		return taskState;
+	}
+
+	@Override
+	public void restoreState(StreamTaskState taskState, long recoveryTimestamp) throws Exception {
+		super.restoreState(taskState, recoveryTimestamp);
+
+		final ClassLoader userClassloader = getUserCodeClassloader();
+
+		@SuppressWarnings("unchecked")
+		StateHandle<DataInputView> inputState = (StateHandle<DataInputView>) taskState.getOperatorState();
+		DataInputView in = inputState.getState(userClassloader);
+
+		int numWatermarkTimers = in.readInt();
+		watermarkTimers = new HashSet<>(numWatermarkTimers);
+		watermarkTimersQueue = new PriorityQueue<>(Math.max(numWatermarkTimers, 1),
+				new Comparator<TimeWindow>() {
+					@Override
+					public int compare(TimeWindow o1, TimeWindow o2) {
+						return Long.compare(o1.maxTimestamp(), o2.maxTimestamp());
+					}
+				});
+
+		for (int i = 0; i < numWatermarkTimers; i++) {
+			TimeWindow timer = windowSerializer.deserialize(in);
+			watermarkTimers.add(timer);
+			watermarkTimersQueue.add(timer);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Getters for testing
+	// ------------------------------------------------------------------------
+
+	@VisibleForTesting
+	public WindowAssigner<? super IN, TimeWindow> getWindowAssigner() {
+		return windowAssigner;
+	}
+
+	@VisibleForTesting
+	public StateDescriptor<? extends AppendingState<IN, ACC>, ?> getStateDescriptor() {
+		return windowStateDescriptor;
+	}
+}


### PR DESCRIPTION
This adds two things. A new call `getPartitionedStateForAllKeys` on `AbstractStateBackend` that returns a `StateIterator` that can be used to iterate over all keys with their respective state in a partition. `StateIterator` also has a `delete` method for dropping the state of the current key. There is no method for dropping all state for a given namespace because of limitations with RocksDB.

The second addition is a new special-purpose window operator `AlignedEventTimeWindowOperator` that behaves like `WindowOperator` if a `Sliding/TumblingEventTimeWindows` assigner is used with an `EventTimeTrigger`. The new operator does this without keeping state/timers per window and key, only one timer is kept per window. Upon firing, the new `StateIterator` is used to traverse all keys and emit windows.
