### PR TITLE
[FLINK-3155] Update the versions in docker-contrib

### DIFF
--- a/flink-contrib/docker-flink/base/Dockerfile
+++ b/flink-contrib/docker-flink/base/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 #requirements
 RUN apt-get update; apt-get install -y curl wget supervisor openssh-server openssh-client nano
@@ -24,9 +24,9 @@ RUN apt-get update; apt-get install -y curl wget supervisor openssh-server opens
 #priviledge separation directory
 RUN mkdir /var/run/sshd
 
-#install Java 7 Oracle JDK
+#install Java 8 Oracle JDK
 RUN mkdir -p /usr/java/default && \
-    curl -Ls 'http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-linux-x64.tar.gz' -H 'Cookie: oraclelicense=accept-securebackup-cookie' | \
+    curl -Ls 'http://download.oracle.com/otn-pub/java/jdk/8u91-b14/jdk-8u91-linux-x64.tar.gz' -H 'Cookie: oraclelicense=accept-securebackup-cookie' | \
     tar --strip-components=1 -xz -C /usr/java/default/
 ENV JAVA_HOME /usr/java/default/
 

--- a/flink-contrib/docker-flink/flink/Dockerfile
+++ b/flink-contrib/docker-flink/flink/Dockerfile
@@ -22,11 +22,11 @@ FROM base
 RUN ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''
 RUN cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/*
 
-##Flink 0.10.0 Installation
+##Flink 1.0.2 Installation
 ###Download:
 RUN mkdir ~/downloads && cd ~/downloads && \
-    wget -q -O - http://mirror.switch.ch/mirror/apache/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop27-scala_2.11.tgz| tar -zxvf - -C /usr/local/
-RUN cd /usr/local && ln -s ./flink-0.10.1 flink
+    wget -q -O - http://mirror.switch.ch/mirror/apache/dist/flink/flink-1.0.2/flink-1.0.2-bin-hadoop27-scala_2.11.tgz| tar -zxvf - -C /usr/local/
+RUN cd /usr/local && ln -s ./flink-1.0.2 flink
 
 ENV FLINK_HOME /usr/local/flink
 ENV PATH $PATH:$FLINK_HOME/bin


### PR DESCRIPTION
Successfully ran up the three slave cluster and accessed the web client

[FLINK-3155]
Updates of various part of the docker build to recent versions
* ubuntu trusty -> xenial
* jdk 7u51 -> 8u91
* flink 0.10.1 -> 1.0.2