### PR TITLE
Build a flink-connector-kafka-0.9 test-jar

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-0.9/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/pom.xml
@@ -115,6 +115,39 @@ under the License.
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+						<configuration>
+			              <includes>
+			                <include>**/KafkaTestEnvironmentImpl*</include>
+			              </includes>
+			            </configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-source-plugin</artifactId>
+		        <executions>
+		          <execution>
+		            <id>attach-test-sources</id>
+		            <goals>
+		              <goal>test-jar-no-fork</goal>
+		            </goals>
+		            <configuration>
+		              <includes>
+		                <include>**/KafkaTestEnvironmentImpl*</include>
+		              </includes>
+		            </configuration>
+		          </execution>
+		        </executions>
+		    </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<!-- Enforce single fork execution due to heavy mini cluster use in the tests -->


### PR DESCRIPTION
Build a test-jar of flink-connector-kafka-0.9 so that Flink users can use KafkaTestEnvironmentImpl to write end to end integration tests of their Flink jobs.