### PR TITLE
[FLINK-3869] Relax window fold generic parameters

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/FoldApplyAllWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/FoldApplyAllWindowFunction.java
@@ -36,20 +36,26 @@ import java.io.IOException;
 import java.util.Collections;
 
 @Internal
-public class FoldApplyAllWindowFunction<W extends Window, T, ACC>
-	extends WrappingFunction<AllWindowFunction<ACC, ACC, W>>
-	implements AllWindowFunction<T, ACC, W>, OutputTypeConfigurable<ACC> {
+public class FoldApplyAllWindowFunction<W extends Window, T, ACC, R>
+	extends WrappingFunction<AllWindowFunction<ACC, R, W>>
+	implements AllWindowFunction<T, R, W>, OutputTypeConfigurable<R> {
 
 	private static final long serialVersionUID = 1L;
 
 	private final FoldFunction<T, ACC> foldFunction;
 
 	private byte[] serializedInitialValue;
+
+	private transient TypeInformation<ACC> accTypeInformation;
 	private TypeSerializer<ACC> accSerializer;
 	private transient ACC initialValue;
 
-	public FoldApplyAllWindowFunction(ACC initialValue, FoldFunction<T, ACC> foldFunction, AllWindowFunction<ACC, ACC, W> windowFunction) {
+	public FoldApplyAllWindowFunction(ACC initialValue,
+			FoldFunction<T, ACC> foldFunction,
+			AllWindowFunction<ACC, R, W> windowFunction,
+			TypeInformation<ACC> accTypeInformation) {
 		super(windowFunction);
+		this.accTypeInformation = accTypeInformation;
 		this.foldFunction = foldFunction;
 		this.initialValue = initialValue;
 	}
@@ -57,6 +63,11 @@ public class FoldApplyAllWindowFunction<W extends Window, T, ACC>
 	@Override
 	public void open(Configuration configuration) throws Exception {
 		super.open(configuration);
+
+		if (accSerializer == null) {
+			throw new RuntimeException("No serializer set for the fold accumulator type. " +
+					"Probably the setOutputType method was not called.");
+		}
 
 		if (serializedInitialValue == null) {
 			throw new RuntimeException("No initial value was serialized for the fold " +
@@ -69,7 +80,7 @@ public class FoldApplyAllWindowFunction<W extends Window, T, ACC>
 	}
 
 	@Override
-	public void apply(W window, Iterable<T> values, Collector<ACC> out) throws Exception {
+	public void apply(W window, Iterable<T> values, Collector<R> out) throws Exception {
 		ACC result = accSerializer.copy(initialValue);
 
 		for (T val: values) {
@@ -80,8 +91,10 @@ public class FoldApplyAllWindowFunction<W extends Window, T, ACC>
 	}
 
 	@Override
-	public void setOutputType(TypeInformation<ACC> outTypeInfo, ExecutionConfig executionConfig) {
-		accSerializer = outTypeInfo.createSerializer(executionConfig);
+	public void setOutputType(TypeInformation<R> outTypeInfo, ExecutionConfig executionConfig) {
+		// out type is not used, just use this for the execution config
+
+		accSerializer = accTypeInformation.createSerializer(executionConfig);
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(baos);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/FoldApplyWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/FoldApplyWindowFunction.java
@@ -36,20 +36,28 @@ import java.io.IOException;
 import java.util.Collections;
 
 @Internal
-public class FoldApplyWindowFunction<K, W extends Window, T, ACC>
-	extends WrappingFunction<WindowFunction<ACC, ACC, K, W>>
-	implements WindowFunction<T, ACC, K, W>, OutputTypeConfigurable<ACC> {
+public class FoldApplyWindowFunction<K, W extends Window, T, ACC, R>
+	extends WrappingFunction<WindowFunction<ACC, R, K, W>>
+	implements WindowFunction<T, R, K, W>, OutputTypeConfigurable<R> {
 
 	private static final long serialVersionUID = 1L;
 
 	private final FoldFunction<T, ACC> foldFunction;
 
 	private byte[] serializedInitialValue;
+
+	private transient TypeInformation<ACC> accTypeInformation;
 	private TypeSerializer<ACC> accSerializer;
 	private transient ACC initialValue;
 
-	public FoldApplyWindowFunction(ACC initialValue, FoldFunction<T, ACC> foldFunction, WindowFunction<ACC, ACC, K, W> windowFunction) {
+
+
+	public FoldApplyWindowFunction(ACC initialValue,
+			FoldFunction<T, ACC> foldFunction,
+			WindowFunction<ACC, R, K, W> windowFunction,
+			TypeInformation<ACC> accTypeInformation) {
 		super(windowFunction);
+		this.accTypeInformation = accTypeInformation;
 		this.foldFunction = foldFunction;
 		this.initialValue = initialValue;
 	}
@@ -58,9 +66,14 @@ public class FoldApplyWindowFunction<K, W extends Window, T, ACC>
 	public void open(Configuration configuration) throws Exception {
 		super.open(configuration);
 
+		if (accSerializer == null) {
+			throw new RuntimeException("No serializer set for the fold accumulator type. " +
+					"Probably the setOutputType method was not called.");
+		}
+
 		if (serializedInitialValue == null) {
 			throw new RuntimeException("No initial value was serialized for the fold " +
-				"window function. Probably the setOutputType method was not called.");
+					"window function. Probably the setOutputType method was not called.");
 		}
 
 		ByteArrayInputStream bais = new ByteArrayInputStream(serializedInitialValue);
@@ -69,7 +82,7 @@ public class FoldApplyWindowFunction<K, W extends Window, T, ACC>
 	}
 
 	@Override
-	public void apply(K key, W window, Iterable<T> values, Collector<ACC> out) throws Exception {
+	public void apply(K key, W window, Iterable<T> values, Collector<R> out) throws Exception {
 		ACC result = accSerializer.copy(initialValue);
 
 		for (T val: values) {
@@ -80,8 +93,10 @@ public class FoldApplyWindowFunction<K, W extends Window, T, ACC>
 	}
 
 	@Override
-	public void setOutputType(TypeInformation<ACC> outTypeInfo, ExecutionConfig executionConfig) {
-		accSerializer = outTypeInfo.createSerializer(executionConfig);
+	public void setOutputType(TypeInformation<R> outTypeInfo, ExecutionConfig executionConfig) {
+		// out type is not used, just use this for the execution config
+
+		accSerializer = accTypeInformation.createSerializer(executionConfig);
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(baos);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/FoldApplyWindowFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/FoldApplyWindowFunctionTest.java
@@ -56,27 +56,28 @@ public class FoldApplyWindowFunctionTest {
 
 		int initValue = 1;
 
-		FoldApplyWindowFunction<Integer, TimeWindow, Integer, Integer> foldWindowFunction = new FoldApplyWindowFunction<>(
-			initValue,
-			new FoldFunction<Integer, Integer>() {
-				private static final long serialVersionUID = -4849549768529720587L;
+		FoldApplyWindowFunction<Integer, TimeWindow, Integer, Integer, Integer> foldWindowFunction = new FoldApplyWindowFunction<>(
+				initValue,
+				new FoldFunction<Integer, Integer>() {
+					private static final long serialVersionUID = -4849549768529720587L;
 
-				@Override
-				public Integer fold(Integer accumulator, Integer value) throws Exception {
-					return accumulator + value;
-				}
-			},
-			new WindowFunction<Integer, Integer, Integer, TimeWindow>() {
-				@Override
-				public void apply(Integer integer,
-					TimeWindow window,
-					Iterable<Integer> input,
-					Collector<Integer> out) throws Exception {
-					for (Integer in: input) {
-						out.collect(in);
+					@Override
+					public Integer fold(Integer accumulator, Integer value) throws Exception {
+						return accumulator + value;
 					}
-				}
-			}
+				},
+				new WindowFunction<Integer, Integer, Integer, TimeWindow>() {
+					@Override
+					public void apply(Integer integer,
+						TimeWindow window,
+						Iterable<Integer> input,
+						Collector<Integer> out) throws Exception {
+						for (Integer in: input) {
+							out.collect(in);
+						}
+					}
+				},
+				BasicTypeInfo.INT_TYPE_INFO
 		);
 
 		AccumulatingProcessingTimeWindowOperator<Integer, Integer, Integer> windowOperator = new AccumulatingProcessingTimeWindowOperator<>(

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnWindowedStream.scala
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.{DataStream, WindowedStream}
 import org.apache.flink.streaming.api.windowing.windows.Window
+import org.apache.flink.util.Collector
 
 /**
   * Wraps a joined data stream, allowing to use anonymous partial functions to
@@ -77,13 +78,14 @@ class OnWindowedStream[T, K, W <: Window](stream: WindowedStream[T, K, W]) {
     * @return The data stream that is the result of applying the window function to the window.
     */
   @PublicEvolving
-  def applyWith[R: TypeInformation](
-      initialValue: R)(
-      foldFunction: (R, T) => R,
-      windowFunction: (K, W, Stream[R]) => TraversableOnce[R])
+  def applyWith[ACC: TypeInformation, R: TypeInformation](
+      initialValue: ACC)(
+      foldFunction: (ACC, T) => ACC,
+      windowFunction: (K, W, Stream[ACC]) => TraversableOnce[R])
     : DataStream[R] =
+
     stream.apply(initialValue, foldFunction, {
-      (key, window, items, out) =>
+      (key: K, window: W, items: Iterable[ACC], out: Collector[R]) =>
         windowFunction(key, window, items.toStream).foreach(out.collect)
     })
 


### PR DESCRIPTION
Before, the WindowFunction in a fold/apply could not emit a type that
was different from the accumulator type of the fold. This restriction is
unnecessary.