### PR TITLE
[FLINK-3826] Broken test: StreamCheckpointingITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
@@ -267,7 +267,7 @@ public class StreamCheckpointingITCase extends StreamFaultToleranceTestBase {
 			count++;
 			if (!hasFailed && count >= failurePos) {
 				hasFailed = true;
-//				throw new Exception("Test Failure");
+				throw new Exception("Test Failure");
 			}
 			inputCount++;
 		


### PR DESCRIPTION
It uncomments the throw Exception, line 270.