### PR TITLE
[FLINK-3655] Multiple File Paths for InputFileFormat.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
@@ -89,7 +89,7 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T> {
 	public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
 		List<FileStatus> files = this.getFiles();
 
-		final FileSystem fs = this.filePath.getFileSystem();
+		final FileSystem fs = getFilePath().getFileSystem();
 		final long blockSize = this.blockSize == NATIVE_BLOCK_SIZE ? fs.getDefaultBlockSize() : this.blockSize;
 
 		final List<FileInputSplit> inputSplits = new ArrayList<FileInputSplit>(minNumSplits);
@@ -109,7 +109,7 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T> {
 		if (inputSplits.size() < minNumSplits) {
 			LOG.warn(String.format(
 				"With the given block size %d, the file %s cannot be split into %d blocks. Filling up with empty splits...",
-				blockSize, this.filePath, minNumSplits));
+				blockSize, getFilePath(), minNumSplits));
 			FileStatus last = files.get(files.size() - 1);
 			final BlockLocation[] blocks = fs.getFileBlockLocations(last, 0, last.getLen());
 			for (int index = files.size(); index < minNumSplits; index++) {
@@ -124,21 +124,22 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T> {
 		// get all the files that are involved in the splits
 		List<FileStatus> files = new ArrayList<FileStatus>();
 
-		final FileSystem fs = this.filePath.getFileSystem();
-		final FileStatus pathFile = fs.getFileStatus(this.filePath);
+		for (Path filePath: this.filePathList) {
+			final FileSystem fs = filePath.getFileSystem();
+			final FileStatus pathFile = fs.getFileStatus(filePath);
 
-		if (pathFile.isDir()) {
-			// input is directory. list all contained files
-			final FileStatus[] partials = fs.listStatus(this.filePath);
-			for (FileStatus partial : partials) {
-				if (!partial.isDir()) {
-					files.add(partial);
+			if (pathFile.isDir()) {
+				// input is directory. list all contained files
+				final FileStatus[] partials = fs.listStatus(filePath);
+				for (FileStatus partial : partials) {
+					if (!partial.isDir()) {
+						files.add(partial);
+					}
 				}
+			} else {
+				files.add(pathFile);
 			}
-		} else {
-			files.add(pathFile);
 		}
-
 		return files;
 	}
 
@@ -147,20 +148,13 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T> {
 
 		final FileBaseStatistics cachedFileStats = (cachedStats != null && cachedStats instanceof FileBaseStatistics) ?
 			(FileBaseStatistics) cachedStats : null;
-
+			
 		try {
-			final Path filePath = this.filePath;
-
-			// get the filesystem
-			final FileSystem fs = FileSystem.get(filePath.toUri());
 			final ArrayList<FileStatus> allFiles = new ArrayList<FileStatus>(1);
-
-			// let the file input format deal with the up-to-date check and the basic size
-			final FileBaseStatistics stats = getFileStats(cachedFileStats, filePath, fs, allFiles);
+			final FileBaseStatistics stats = getFileStats(cachedFileStats, this.filePathList, allFiles);
 			if (stats == null) {
 				return null;
 			}
-
 			// check whether the file stats are still sequential stats (in that case they are still valid)
 			if (stats instanceof SequentialStatistics) {
 				return (SequentialStatistics) stats;
@@ -169,18 +163,19 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T> {
 		} catch (IOException ioex) {
 			if (LOG.isWarnEnabled()) {
 				LOG.warn(
-					String.format("Could not determine complete statistics for file '%s' due to an I/O error",
-						this.filePath),
+					String.format("Could not determine complete statistics for files in '%s' due to an I/O error",
+					this.filePathList),
 					ioex);
 			}
 		} catch (Throwable t) {
 			if (LOG.isErrorEnabled()) {
 				LOG.error(
-					String.format("Unexpected problem while getting the file statistics for file '%s'",
-						this.filePath),
+					String.format("Unexpected problem while getting the file statistics for file in'%s'",
+					this.filePathList),
 					t);
 			}
 		}
+		
 		// no stats available
 		return null;
 	}
@@ -250,7 +245,7 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T> {
 		super.open(split);
 
 		final long blockSize = this.blockSize == NATIVE_BLOCK_SIZE ?
-			this.filePath.getFileSystem().getDefaultBlockSize() : this.blockSize;
+			split.getPath().getFileSystem().getDefaultBlockSize() : this.blockSize;
 
 		this.blockInfo = this.createBlockInfo();
 		if (this.splitLength > this.blockInfo.getInfoSize()) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.FileStatus;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 
 import org.slf4j.Logger;
@@ -290,32 +289,34 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 		final int oldBufferSize = this.bufferSize;
 		final int oldLineLengthLimit = this.lineLengthLimit;
 		try {
-			final Path filePath = this.filePath;
-		
-			// get the filesystem
-			final FileSystem fs = FileSystem.get(filePath.toUri());
+
 			final ArrayList<FileStatus> allFiles = new ArrayList<FileStatus>(1);
-			
-			// let the file input format deal with the up-to-date check and the basic size
-			final FileBaseStatistics stats = getFileStats(cachedFileStats, filePath, fs, allFiles);
+
+			// let the file input format deal with the up-to-date check and the
+			// basic size
+			final FileBaseStatistics stats = getFileStats(cachedFileStats, this.filePathList, allFiles);
 			if (stats == null) {
 				return null;
 			}
-			
-			// check whether the width per record is already known or the total size is unknown as well
+
+			// check whether the width per record is already known or the total
+			// size is unknown as well
 			// in both cases, we return the stats as they are
-			if (stats.getAverageRecordWidth() != FileBaseStatistics.AVG_RECORD_BYTES_UNKNOWN ||
-					stats.getTotalInputSize() == FileBaseStatistics.SIZE_UNKNOWN) {
+			if (stats.getAverageRecordWidth() != FileBaseStatistics.AVG_RECORD_BYTES_UNKNOWN
+					|| stats.getTotalInputSize() == FileBaseStatistics.SIZE_UNKNOWN) {
 				return stats;
 			}
-			
-			// disabling sampling for unsplittable files since the logic below assumes splitability.
-			// TODO: Add sampling for unsplittable files. Right now, only compressed text files are affected by this limitation.
-			if(unsplittable) {
+
+			// disabling sampling for unsplittable files since the logic below
+			// assumes splitability.
+			// TODO: Add sampling for unsplittable files. Right now, only
+			// compressed text files are affected by this limitation.
+			if (unsplittable) {
 				return stats;
 			}
-			
-			// compute how many samples to take, depending on the defined upper and lower bound
+
+			// compute how many samples to take, depending on the defined upper
+			// and lower bound
 			final int numSamples;
 			if (this.numLineSamples != NUM_SAMPLES_UNDEFINED) {
 				numSamples = this.numLineSamples;
@@ -324,7 +325,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 				final int calcSamples = (int) (stats.getTotalInputSize() / 1024);
 				numSamples = Math.min(DEFAULT_MAX_NUM_SAMPLES, Math.max(DEFAULT_MIN_NUM_SAMPLES, calcSamples));
 			}
-			
+
 			// check if sampling is disabled.
 			if (numSamples == 0) {
 				return stats;
@@ -332,15 +333,16 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 			if (numSamples < 0) {
 				throw new RuntimeException("Error: Invalid number of samples: " + numSamples);
 			}
-			
-			
-			// make sure that the sampling times out after a while if the file system does not answer in time
+
+			// make sure that the sampling times out after a while if the file
+			// system does not answer in time
 			this.openTimeout = 10000;
 			// set a small read buffer size
 			this.bufferSize = 4 * 1024;
-			// prevent overly large records, for example if we have an incorrectly configured delimiter
+			// prevent overly large records, for example if we have an
+			// incorrectly configured delimiter
 			this.lineLengthLimit = MAX_SAMPLE_LEN;
-			
+
 			long offset = 0;
 			long totalNumBytes = 0;
 			long stepSize = stats.getTotalInputSize() / numSamples;
@@ -374,21 +376,20 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 					fileNum++;
 				}
 			}
-			
+
 			// we have the width, store it
-			return new FileBaseStatistics(stats.getLastModificationTime(),
-				stats.getTotalInputSize(), totalNumBytes / (float) samplesTaken);
-			
+			return new FileBaseStatistics(stats.getLastModificationTime(), stats.getTotalInputSize(),
+					totalNumBytes / (float) samplesTaken);
+
 		} catch (IOException ioex) {
 			if (LOG.isWarnEnabled()) {
-				LOG.warn("Could not determine statistics for file '" + this.filePath + "' due to an io error: "
-						+ ioex.getMessage());
+				LOG.warn("Could not determine statistics for file(s) in '" + this.filePathList
+						+ "' due to an io error: " + ioex.getMessage());
 			}
-		}
-		catch (Throwable t) {
+		} catch (Throwable t) {
 			if (LOG.isErrorEnabled()) {
-				LOG.error("Unexpected problen while getting the file statistics for file '" + this.filePath + "': "
-						+ t.getMessage(), t);
+				LOG.error("Unexpected problen while getting the file statistics for file(s) in'" + this.filePathList
+						+ "': " + t.getMessage(), t);
 			}
 		} finally {
 			// restore properties (even on return)
@@ -396,6 +397,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 			this.bufferSize = oldBufferSize;
 			this.lineLengthLimit = oldLineLengthLimit;
 		}
+
 		
 		// no statistics possible
 		return null;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -190,7 +190,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	/**
 	 * The path to the file that contains the input.
 	 */
-	protected Path filePath;
+	protected List<Path> filePathList;
 	
 	/**
 	 * The minimal split size, set by the configure() method.
@@ -229,7 +229,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		if (filePath == null) {
 			throw new IllegalArgumentException("The file path must not be null.");
 		}
-		this.filePath = filePath;
+		setFilePath(filePath);
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -237,9 +237,23 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	// --------------------------------------------------------------------------------------------
 	
 	public Path getFilePath() {
-		return filePath;
+		if (filePathList == null || filePathList.size() < 1) {
+			return null;
+		}
+		return filePathList.get(0);
 	}
-
+	
+	/**
+	 * 
+	 * @return the list of all file paths
+	 */
+	public Path[] getFilePaths() {
+		if (this.filePathList == null) {
+			return new Path[0];
+		}
+		return this.filePathList.toArray(new Path[this.filePathList.size()]);
+	}
+	
 	public void setFilePath(String filePath) {
 		if (filePath == null) {
 			throw new IllegalArgumentException("File path may not be null.");
@@ -262,8 +276,28 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		if (filePath == null) {
 			throw new IllegalArgumentException("File path may not be null.");
 		}
-		
-		this.filePath = filePath;
+		this.filePathList = new ArrayList<Path>();
+		this.filePathList.add(filePath);
+	}
+	
+	/**
+	 * 
+	 * @param filePaths the paths to set
+	 */
+	public void setFilePaths(String... filePaths) {
+		if (filePaths.length < 1) {
+			throw new IllegalArgumentException("At least one file path must be given.");
+		}
+		this.filePathList = new ArrayList<Path>();
+		for (String filePath : filePaths) {
+			if (filePath == null) {
+				throw new IllegalArgumentException("The file path must not be null.");
+			}
+			// can only add non-empty paths
+			if (!filePath.isEmpty()) {
+				this.filePathList.add(new Path(filePath));
+			}
+		}
 	}
 	
 	public long getMinSplitSize() {
@@ -338,13 +372,13 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		String filePath = parameters.getString(FILE_PARAMETER_KEY, null);
 		if (filePath != null) {
 			try {
-				this.filePath = new Path(filePath);
+				setFilePath(filePath);
 			}
 			catch (RuntimeException rex) {
 				throw new RuntimeException("Could not create a valid URI from the given file path name: " + rex.getMessage()); 
 			}
 		}
-		else if (this.filePath == null) {
+		else if (this.filePathList == null) {
 			throw new IllegalArgumentException("File path was not specified in input format, or configuration."); 
 		}
 		
@@ -358,35 +392,21 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 */
 	@Override
 	public FileBaseStatistics getStatistics(BaseStatistics cachedStats) throws IOException {
+
+		final FileBaseStatistics cachedFileStats = (cachedStats != null && cachedStats instanceof FileBaseStatistics)
+				? (FileBaseStatistics) cachedStats : null;
+		final FileBaseStatistics statistics = getFileStats(cachedFileStats, this.filePathList, new ArrayList<FileStatus>(1));
 		
-		final FileBaseStatistics cachedFileStats = (cachedStats != null && cachedStats instanceof FileBaseStatistics) ?
-			(FileBaseStatistics) cachedStats : null;
-				
-		try {
-			final Path path = this.filePath;
-			final FileSystem fs = FileSystem.get(path.toUri());
-			
-			return getFileStats(cachedFileStats, path, fs, new ArrayList<FileStatus>(1));
-		} catch (IOException ioex) {
-			if (LOG.isWarnEnabled()) {
-				LOG.warn("Could not determine statistics for file '" + this.filePath + "' due to an io error: "
-						+ ioex.getMessage());
-			}
-		}
-		catch (Throwable t) {
-			if (LOG.isErrorEnabled()) {
-				LOG.error("Unexpected problem while getting the file statistics for file '" + this.filePath + "': "
-						+ t.getMessage(), t);
-			}
-		}
-		
-		// no statistics available
-		return null;
+		// final sanity check - for backward compatibility
+		return (statistics.fileSize == BaseStatistics.SIZE_UNKNOWN) ? null : statistics;
 	}
 	
+	/**
+	 * @deprecated Should no longer be used because of filePathList and multiple paths
+	 */
+	@Deprecated
 	protected FileBaseStatistics getFileStats(FileBaseStatistics cachedStats, Path filePath, FileSystem fs,
 			ArrayList<FileStatus> files) throws IOException {
-		
 		// get the file info and check whether the cached statistics are still valid.
 		final FileStatus file = fs.getFileStatus(filePath);
 		long totalLength = 0;
@@ -417,6 +437,56 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		}
 		return new FileBaseStatistics(latestModTime, totalLength, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 	}
+	
+	protected FileBaseStatistics getFileStats(FileBaseStatistics cachedStats, final List<Path> filePaths,
+			ArrayList<FileStatus> files) {
+
+		long totalLength = 0;
+		long latestModTime = 0;
+		for (Path filePath : filePaths) {
+			try {
+				final FileSystem fs = FileSystem.get(filePath.toUri());
+				// get the file info and check whether the cached statistics are
+				// still valid.
+				final FileStatus file = fs.getFileStatus(filePath);
+
+				// enumerate all files
+				if (file.isDir()) {
+					totalLength += addFilesInDir(file.getPath(), files, false);
+				} else {
+					files.add(file);
+					testForUnsplittable(file);
+					totalLength += file.getLen();
+				}
+
+				// check the modification time stamp
+				for (FileStatus f : files) {
+					latestModTime = Math.max(f.getModificationTime(), latestModTime);
+				}
+
+				// check whether the cached statistics are still valid, if we
+				// have any
+				if (cachedStats != null && latestModTime <= cachedStats.getLastModificationTime()) {
+					return cachedStats;
+				}
+			} catch (IOException ioex) {
+				if (LOG.isWarnEnabled()) {
+					LOG.warn("Could not determine statistics for file '" + filePath + "' due to an io error: "
+							+ ioex.getMessage());
+				}
+			} catch (Throwable t) {
+				if (LOG.isErrorEnabled()) {
+					LOG.error("Unexpected problem while getting the file statistics for file '" + filePath + "': "
+							+ t.getMessage(), t);
+				}
+			}
+		}
+		// sanity check
+		if (totalLength <= 0) {
+			totalLength = BaseStatistics.SIZE_UNKNOWN;
+		}
+		return new FileBaseStatistics(latestModTime, totalLength, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+	}
 
 	@Override
 	public LocatableInputSplitAssigner getInputSplitAssigner(FileInputSplit[] splits) {
@@ -435,6 +505,22 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 */
 	@Override
 	public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
+		final List<FileInputSplit> inputSplits = new ArrayList<FileInputSplit>(minNumSplits);
+		for (Path file : filePathList) {
+			inputSplits.addAll(createInputSplits(file, minNumSplits));
+		}
+		return inputSplits.toArray(new FileInputSplit[inputSplits.size()]);
+	}
+	
+	/**
+	 * Utility method to create split inputs given a filePath.
+	 * 
+	 * @param filePath the path to traverse
+	 * @param minNumSplits The minimum desired number of file splits
+	 * @return a list of {@link FileInputSplit}
+	 * @throws IOException thrown, if there is an exception
+	 */
+	private List<FileInputSplit> createInputSplits(final Path filePath, int minNumSplits) throws IOException {
 		if (minNumSplits < 1) {
 			throw new IllegalArgumentException("Number of input splits has to be at least 1.");
 		}
@@ -442,18 +528,17 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		// take the desired number of splits into account
 		minNumSplits = Math.max(minNumSplits, this.numSplits);
 		
-		final Path path = this.filePath;
 		final List<FileInputSplit> inputSplits = new ArrayList<FileInputSplit>(minNumSplits);
 
 		// get all the files that are involved in the splits
 		List<FileStatus> files = new ArrayList<FileStatus>();
 		long totalLength = 0;
 
-		final FileSystem fs = path.getFileSystem();
-		final FileStatus pathFile = fs.getFileStatus(path);
+		final FileSystem fs = filePath.getFileSystem();
+		final FileStatus pathFile = fs.getFileStatus(filePath);
 
 		if (pathFile.isDir()) {
-			totalLength += addFilesInDir(path, files, true);
+			totalLength += addFilesInDir(filePath, files, true);
 		} else {
 			testForUnsplittable(pathFile);
 
@@ -477,7 +562,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 						hosts.toArray(new String[hosts.size()]));
 				inputSplits.add(fis);
 			}
-			return inputSplits.toArray(new FileInputSplit[inputSplits.size()]);
+			return inputSplits;
 		}
 		
 
@@ -553,7 +638,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			}
 		}
 
-		return inputSplits.toArray(new FileInputSplit[inputSplits.size()]);
+		return inputSplits;
 	}
 
 	/**
@@ -725,9 +810,9 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	
 
 	public String toString() {
-		return this.filePath == null ? 
+		return this.filePathList == null ? 
 			"File Input (unknown file)" :
-			"File Input (" + this.filePath.toString() + ')';
+			"File Input (" +  this.filePathList + ')';
 	}
 	
 	// ============================================================================================
@@ -925,4 +1010,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 * The config parameter which defines whether input directories are recursively traversed.
 	 */
 	public static final String ENUMERATE_NESTED_FILES_FLAG = "recursive.file.enumeration";
+	
+	public static final String FILE_PARAMETER_DELIMITER_KEY = "input.file.path.delimiter";
+	public static final String FILE_PARAMETER_DELIMITER = ",";
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -357,13 +357,13 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	public void close() throws IOException {
 		if (this.invalidLineCount > 0) {
 			if (LOG.isWarnEnabled()) {
-				LOG.warn("In file \""+ this.filePath + "\" (split start: " + this.splitStart + ") " + this.invalidLineCount +" invalid line(s) were skipped.");
+				LOG.warn("In file \""+ getFilePath() + "\" (split start: " + this.splitStart + ") " + this.invalidLineCount +" invalid line(s) were skipped.");
 			}
 		}
 
 		if (this.commentCount > 0) {
 			if (LOG.isInfoEnabled()) {
-				LOG.info("In file \""+ this.filePath + "\" (split start: " + this.splitStart + ") " + this.commentCount +" comment line(s) were skipped.");
+				LOG.info("In file \""+  getFilePath() + "\" (split start: " + this.splitStart + ") " + this.commentCount +" comment line(s) were skipped.");
 			}
 		}
 		super.close();
@@ -405,7 +405,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 						throw new ParseException("Line could not be parsed: '" + lineAsString + "'\n"
 								+ "ParserError " + parser.getErrorState() + " \n"
 								+ "Expect field types: "+fieldTypesToString() + " \n"
-								+ "in file: " + filePath);
+								+ "in file: " + getFilePath());
 					}
 				}
 				output++;
@@ -418,7 +418,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 						String lineAsString = new String(bytes, offset, numBytes);
 						throw new ParseException("Line could not be parsed: '" + lineAsString+"'\n"
 								+ "Expect field types: "+fieldTypesToString()+" \n"
-								+ "in file: "+filePath);
+								+ "in file: "+ getFilePath());
 					}
 				}
 			}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/BinaryInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/BinaryInputFormatTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.memory.DataInputView;
@@ -72,4 +73,119 @@ public class BinaryInputFormatTest {
 		Assert.assertEquals("3. split has block size length.", blockSize, inputSplits[2].getLength());
 	}
 	
+	private File createBinaryInputFile(String fileName, int blockSize, int numBlocks) throws IOException {
+		// create temporary file with 3 blocks
+		final File tempFile = File.createTempFile(fileName, "tmp");
+		tempFile.deleteOnExit();
+		FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+		try {
+			for (int i = 0; i < blockSize * numBlocks; i++) {
+				fileOutputStream.write(new byte[] { 1 });
+			}
+		} finally {
+			fileOutputStream.close();
+		}
+		return tempFile;
+	}
+	
+	@Test
+	public void testCreateInputSplitsWithMulitpleFiles() throws IOException {
+		final int blockInfoSize = new BlockInfo().getInfoSize();
+		final int blockSize = blockInfoSize + 8;
+		final int BLOCKS1 = 3;
+		final int BLOCKS2 = 5;
+		
+		final File tempFile = createBinaryInputFile("binary_input_format_test", blockSize, BLOCKS1);
+		final File tempFile2 = createBinaryInputFile("binary_input_format_test_2", blockSize, BLOCKS2);
+
+		final Configuration config = new Configuration();
+		config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
+		
+		final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
+		inputFormat.setFilePaths(tempFile.toURI().toString(), tempFile2.toURI().toString());
+		
+		inputFormat.configure(config);
+		
+		final int TOTAL_BLOCKS = BLOCKS1 + BLOCKS2;
+		FileInputSplit[] inputSplits = inputFormat.createInputSplits(TOTAL_BLOCKS);
+		
+		Assert.assertEquals("Returns requested numbers of splits.", TOTAL_BLOCKS, inputSplits.length);
+		for (int index = 0; index < inputSplits.length; index++) {
+			Assert.assertEquals(String.format("%d. split has block size length.", index), 
+					blockSize, inputSplits[index].getLength());
+		}
+	}
+	@Test
+	public void testGetStatisticsNonExistingFile() {
+		try {
+			final MyBinaryInputFormat format = new MyBinaryInputFormat();
+			format.setFilePath("file:///some/none/existing/directory/");
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertNull("The file statistics should be null.", stats);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleNonExistingFile() {
+		try {
+			final MyBinaryInputFormat format = new MyBinaryInputFormat();
+			format.setFilePaths("file:///some/none/existing/directory/", "file:///another/none/existing/directory/");
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertNull("The file statistics should be null.", stats);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsSinglePaths() {
+		try {
+			final int blockInfoSize = new BlockInfo().getInfoSize();
+			final int blockSize = blockInfoSize + 8;
+			final int BLOCKS = 3;
+			
+			final File tempFile = createBinaryInputFile("binary_input_format_test", blockSize, BLOCKS);
+			final Configuration config = new Configuration();
+			config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
+			
+			final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
+			inputFormat.setFilePath(tempFile.toURI().toString());
+			BaseStatistics stats = inputFormat.getStatistics(null);
+			Assert.assertEquals("The file size statistics is wrong", blockSize * BLOCKS, stats.getTotalInputSize());
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testGetStatisticsMultiplePaths() {
+		try {
+			final int blockInfoSize = new BlockInfo().getInfoSize();
+			final int blockSize = blockInfoSize + 8;
+			final int BLOCKS = 3;
+			final int BLOCKS2 = 5;
+			
+			final File tempFile = createBinaryInputFile("binary_input_format_test", blockSize, BLOCKS);
+			final File tempFile2 = createBinaryInputFile("binary_input_format_test_2", blockSize, BLOCKS2);
+			final Configuration config = new Configuration();
+			config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
+			
+			final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
+			inputFormat.setFilePaths(tempFile.toURI().toString(), tempFile2.toURI().toString());
+			BaseStatistics stats = inputFormat.getStatistics(null);
+			Assert.assertEquals("The file size statistics is wrong", blockSize * (BLOCKS + BLOCKS2), stats.getTotalInputSize());
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.types.IntValue;
 
@@ -44,7 +45,124 @@ import static org.junit.Assert.*;
  * Tests for the FileInputFormat
  */
 public class FileInputFormatTest {
+	
+	@Test
+	public void testGetPathWithoutSettingFirst() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		assertNull("This should be null", format.getFilePath());
+	}
+	
+	@Test
+	public void testGetPathsWithoutSettingFirst() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		
+		Path[] paths = format.getFilePaths();
+		assertNotNull("Paths should not be null.", paths);
+		assertEquals("Paths size should be 0.", 0, paths.length);
+	}
+	
+	@Test
+	public void testToStringWithoutPathSet() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		assertEquals("The toString() should be correct.", "File Input (unknown file)", format.toString());
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathsNull() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths((String)null);
+	}
 
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathNullString() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePath((String) null);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathNullPath() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePath((Path) null);
+	}
+	
+	@Test
+	public void testSetPathNonNull() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePath("/some/imaginary/path");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathsOnePathNull() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths("/an/imaginary/path", null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathsEmptyArray() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths(new String[0]);
+	}
+	
+	@Test
+	public void testSetPathsEmptyString() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths("");
+		assertNull("Path should be null.", format.getFilePath());
+		
+		Path[] paths = format.getFilePaths();
+		assertNotNull("Paths should not be null.", paths);
+		assertEquals("Paths size should be 0.", 0, paths.length);
+	}
+	
+	@Test
+	public void testSetPathsOnePath() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String myPath = "/an/imaginary/path"; 
+		format.setFilePaths(myPath);
+		final Path[] filePaths = format.getFilePaths(); 
+		
+		assertEquals("File path count should be equal.", 1, filePaths.length);
+		assertEquals("File path should be equal.", myPath, filePaths[0].toUri().toString());
+		
+		assertEquals("First path should be equal.", myPath, format.getFilePath().toUri().toString());
+	}
+	
+	@Test
+	public void testSetPathsTwoPaths() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String myPath = "/an/imaginary/path"; 
+		final String myPath2 = "/an/imaginary/path2";
+		
+		format.setFilePaths(myPath, myPath2);
+		final Path[] filePaths = format.getFilePaths(); 
+		
+		assertEquals("File path count should be equal.", 2, filePaths.length);
+		assertEquals("File path should be equal.", myPath, filePaths[0].toUri().toString());
+		assertEquals("File path should be equal.", myPath2, filePaths[1].toUri().toString());
+		
+		assertEquals("First path should be equal.", myPath, format.getFilePath().toUri().toString());
+		assertEquals("The toString() should be correct.", "File Input ([/an/imaginary/path, /an/imaginary/path2])", format.toString());
+	}
+
+	@Test
+	public void testSetFileViaConfiguration() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String filePath = "file:///some/none/existing/directory/";
+		Configuration conf = new Configuration();
+		conf.setString("input.file.path", filePath);
+		format.configure(conf);
+		
+		assertEquals("Paths should be equal.", new Path(filePath), format.getFilePath());
+	}
+	
+	@Test (expected=RuntimeException.class)
+	public void testSetFileViaConfigurationEmptyPath() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String filePath = null;
+		Configuration conf = new Configuration();
+		conf.setString("input.file.path", filePath);
+		format.configure(conf);
+	}
 	// ------------------------------------------------------------------------
 	//  Statistics
 	// ------------------------------------------------------------------------
@@ -199,7 +317,182 @@ public class FileInputFormatTest {
 			Assert.fail(ex.getMessage());
 		}
 	}
+	
+	// -- Multiple Files -- //
+	
+	@Test
+	public void testGetStatisticsMultipleNonExistingFile() {
+		try {
+			final DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths("file:///some/none/existing/directory/","file:///another/non/existing/directory/");
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertNull("The file statistics should be null.", stats);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleOneFileNoCachedVersion() {
+		try {
+			final long SIZE = 1024 * 500;
+			String tempFile = TestFileUtils.createTempFile(SIZE);
 
+			final long SIZE2 = 1024 * 505;
+			String tempFile2 = TestFileUtils.createTempFile(SIZE2);
+
+			final long TOTAL_SIZE = SIZE + SIZE2;
+			
+			final DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempFile, tempFile2);
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL_SIZE, stats.getTotalInputSize());
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleFilesMultiplePathsNoCachedVersion() {
+		try {
+			final long SIZE1 = 2077;
+			final long SIZE2 = 31909;
+			final long SIZE3 = 10;
+			final long TOTAL = SIZE1 + SIZE2 + SIZE3;
+			
+			String tempDir = TestFileUtils.createTempFileDir(SIZE1, SIZE2, SIZE3);
+			
+			final long SIZE4 = 2051;
+			final long SIZE5 = 31902;
+			final long SIZE6 = 15;
+			final long TOTAL2 = SIZE4 + SIZE5 + SIZE6;
+			String tempDir2 = TestFileUtils.createTempFileDir(SIZE4, SIZE5, SIZE6);
+
+			final DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL + TOTAL2, stats.getTotalInputSize());
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleOneFileWithCachedVersion() {
+		try {
+			final long SIZE = 50873;
+			final long FAKE_SIZE = 10065;
+			
+			String tempFile = TestFileUtils.createTempFile(SIZE);
+
+			final long SIZE2 = 52573;
+			String tempFile2 = TestFileUtils.createTempFile(SIZE2);
+
+			final long SIZE_TOTAL = SIZE + SIZE2;
+			
+			DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempFile, tempFile2);
+			format.configure(new Configuration());
+			
+			
+			
+			FileBaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", SIZE_TOTAL, stats.getTotalInputSize());
+			
+			format = new DummyFileInputFormat();
+			format.setFilePath(tempFile);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics newStats = format.getStatistics(stats);
+			Assert.assertTrue("Statistics object was changed", newStats == stats);
+
+			// insert fake stats with the correct modification time. the call should return the fake stats
+			format = new DummyFileInputFormat();
+			format.setFilePath(tempFile);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics latest = format.getStatistics(fakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
+			
+			// insert fake stats with the expired modification time. the call should return new accurate stats
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempFile, tempFile2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", SIZE_TOTAL, reGathered.getTotalInputSize());
+			
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleFilesMultiplePathsWithCachedVersion() {
+		try {
+			final long SIZE1 = 2077;
+			final long SIZE2 = 31909;
+			final long SIZE3 = 10;
+
+			final long SIZE4 = 2177;
+			final long SIZE5 = 33909;
+			final long SIZE6 = 18;
+
+			final long TOTAL = SIZE1 + SIZE2 + SIZE3 + SIZE4 + SIZE5 + SIZE6;
+			final long FAKE_SIZE = 10065;
+			
+			String tempDir = TestFileUtils.createTempFileDir(SIZE1, SIZE2, SIZE3);
+			String tempDir2 = TestFileUtils.createTempFileDir(SIZE4, SIZE5, SIZE6);
+			
+			DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL, stats.getTotalInputSize());
+			
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics newStats = format.getStatistics(stats);
+			Assert.assertTrue("Statistics object was changed", newStats == stats);
+
+			// insert fake stats with the correct modification time. the call should return the fake stats
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics latest = format.getStatistics(fakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
+			
+			// insert fake stats with the correct modification time. the call should return the fake stats
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL, reGathered.getTotalInputSize());
+			
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
 	// ------------------------------------------------------------------------
 	//  Unsplittable input files
 	// ------------------------------------------------------------------------
@@ -408,7 +701,7 @@ public class FileInputFormatTest {
 	
 	private class DummyFileInputFormat extends FileInputFormat<IntValue> {
 		private static final long serialVersionUID = 1L;
-
+		
 		@Override
 		public boolean reachedEnd() throws IOException {
 			return true;

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -504,7 +504,7 @@ public abstract class ExecutionEnvironment {
 
 	// ------------------------------------ File Input Format -----------------------------------------
 
-	public <X> DataSource<X> readFile(FileInputFormat<X> inputFormat, String filePath) {
+	public <X> DataSource<X> readFile(FileInputFormat<X> inputFormat, String...filePath) {
 		if (inputFormat == null) {
 			throw new IllegalArgumentException("InputFormat must not be null.");
 		}
@@ -512,7 +512,7 @@ public abstract class ExecutionEnvironment {
 			throw new IllegalArgumentException("The file path must not be null.");
 		}
 
-		inputFormat.setFilePath(new Path(filePath));
+		inputFormat.setFilePaths(filePath);
 		try {
 			return createInput(inputFormat, TypeExtractor.getInputFormatTypes(inputFormat));
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/ExecutionEnvironmentReadFileTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/ExecutionEnvironmentReadFileTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.java;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.apache.flink.api.common.io.DelimitedInputFormat;
+import org.apache.flink.core.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExecutionEnvironmentReadFileTest {
+
+	private DelimitedInputFormat<String> format = null;
+
+	@Before
+	public void setUp() {
+		format = new DelimitedInputFormat<String>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String readRecord(String reuse, byte[] bytes, int offset, int numBytes) throws IOException {
+				return new String(bytes, offset, numBytes);
+			}
+		};
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testReadFilesNullInputFormat() throws IOException {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		final String tempFile = "/my/imaginary_file";
+
+		env.readFile(null, tempFile);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testReadFilesNullFile() throws IOException {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.readFile(format, (String) null);
+	}
+
+	@Test
+	public void testReadFilesOneFile() throws IOException {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		final String tempFile = "/my/imaginary_file";
+
+		DataSet<String> data = env.readFile(format, tempFile);
+
+		assertNotNull("DataSet should not be null.", data);
+
+		Path[] filePaths = format.getFilePaths();
+
+		assertNotNull("Should not be null.", filePaths);
+		assertEquals("The number of file paths should be correct.", 1, filePaths.length);
+		assertEquals("File paths should be correct.", tempFile, filePaths[0].toUri().toString());
+	}
+	
+	@Test
+	public void testReadFiles() throws IOException {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		final String tempFile = "/my/imaginary_file";
+		final String tempFile2 = "/my/imaginary_file2";
+
+		DataSet<String> data = env.readFile(format, tempFile, tempFile2);
+
+		assertNotNull("DataSet should not be null.", data);
+
+		Path[] filePaths = format.getFilePaths();
+
+		assertNotNull("Should not be null.", filePaths);
+		assertEquals("The number of file paths should be correct.", 2, filePaths.length);
+		assertEquals("File paths should be correct.", tempFile, filePaths[0].toUri().toString());
+		assertEquals("File paths should be correct.", tempFile2, filePaths[1].toUri().toString());
+	}
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -378,10 +378,10 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def readFile[T : ClassTag : TypeInformation](
       inputFormat: FileInputFormat[T],
-      filePath: String): DataSet[T] = {
+      filePaths: String*): DataSet[T] = {
     require(inputFormat != null, "InputFormat must not be null.")
-    require(filePath != null, "File path must not be null.")
-    inputFormat.setFilePath(new Path(filePath))
+    require(filePaths != null, "File path must not be null.")
+    inputFormat.setFilePaths(filePaths:_*)
     createInput(inputFormat, implicitly[TypeInformation[T]])
   }
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/ExecutionEnvironmentReadFileTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/ExecutionEnvironmentReadFileTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala
+
+import org.junit.Test
+import org.apache.flink.api.common.io.DelimitedInputFormat
+import org.junit.Assert._
+
+class ExecutionEnvironmentReadFileTest {
+
+  @Test
+  def testReadFileWithMultipleFiles(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val format = new DelimitedInputFormat[String]() {
+      def readRecord(reuse: String, bytes: Array[Byte], offset: Int, numBytes: Int) : String =  {
+        new String(bytes, offset, numBytes)
+      }
+    }
+
+    val tempFile = "/my/imaginary_file"
+    val tempFile2 = "/my/imaginary_file2"
+
+    val data = env.readFile(format, tempFile, tempFile2)
+    val filePaths = format.getFilePaths
+    
+    assertNotNull("Should not be null", data)
+    assertEquals("The number of file paths should be correct", 2, filePaths.length);
+    assertEquals("File paths should be correct", tempFile, filePaths(0).toUri().toString());
+    assertEquals("File paths should be correct", tempFile2, filePaths(1).toUri().toString());
+  }
+}


### PR DESCRIPTION
I had to create a new PR, because I messed up my branches.

This addresses [FLINK-3655] Multiple File Paths for InputFileFormat but does not implement file name globbing.

Also, this branch does not use guava.

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-3655] Multiple File Paths for InputFileFormat.")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Removed Guava.
