### PR TITLE
[FLINK-3782] ByteArrayOutputStream and ObjectOutputStream should close

### DIFF
--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
@@ -80,7 +80,8 @@ public class CollectionInputFormatTest {
 
 	@Test
 	public void testSerializability() {
-		try {
+		try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			 ObjectOutputStream out = new ObjectOutputStream(buffer)) {
 			Collection<ElementType> inputCollection = new ArrayList<ElementType>();
 			ElementType element1 = new ElementType(1);
 			ElementType element2 = new ElementType(2);
@@ -94,9 +95,6 @@ public class CollectionInputFormatTest {
 	
 			CollectionInputFormat<ElementType> inputFormat = new CollectionInputFormat<ElementType>(inputCollection,
 					info.createSerializer(new ExecutionConfig()));
-
-			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-			ObjectOutputStream out = new ObjectOutputStream(buffer);
 
 			out.writeObject(inputFormat);
 
@@ -125,6 +123,7 @@ public class CollectionInputFormatTest {
 			e.printStackTrace();
 			fail(e.toString());
 		}
+
 	}
 	
 	@Test
@@ -204,13 +203,11 @@ public class CollectionInputFormatTest {
 	
 	@Test
 	public void testSerializationFailure() {
-		try {
+		try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			ObjectOutputStream out = new ObjectOutputStream(buffer)) {
 			// a mock serializer that fails when writing
 			CollectionInputFormat<ElementType> inFormat = new CollectionInputFormat<ElementType>(
 					Collections.singleton(new ElementType()), new TestSerializer(false, true));
-			
-			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-			ObjectOutputStream out = new ObjectOutputStream(buffer);
 			
 			try {
 				out.writeObject(inFormat);
@@ -231,13 +228,12 @@ public class CollectionInputFormatTest {
 	
 	@Test
 	public void testDeserializationFailure() {
-		try {
+		try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			 ObjectOutputStream out = new ObjectOutputStream(buffer)) {
 			// a mock serializer that fails when writing
 			CollectionInputFormat<ElementType> inFormat = new CollectionInputFormat<ElementType>(
 					Collections.singleton(new ElementType()), new TestSerializer(true, false));
-			
-			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-			ObjectOutputStream out = new ObjectOutputStream(buffer);
+
 			out.writeObject(inFormat);
 			out.close();
 			


### PR DESCRIPTION
[FLINK-3782] ByteArrayOutputStream and ObjectOutputStream should close

ByteArrayOutputStream close method does nothing and has no use, so is usually never called.However I am using try with resources for both to take care of closing closeable resources automatically.