### PR TITLE
[FLINK-3488] Kafka08ITCase.testBigRecordJob fails on Travis

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -840,7 +840,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 		// add producing topology
 		Properties producerProps = new Properties();
-		producerProps.setProperty("max.request.size", Integer.toString(1024 * 1024 * 14));
+		producerProps.setProperty("max.request.size", Integer.toString(1024 * 1024 * 15));
 		producerProps.setProperty("retries", "3");
 		producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerConnectionStrings);
 


### PR DESCRIPTION
[FLINK-3488] Kafka08ITCase.testBigRecordJob fails on Travis

The Kafka08ITCase.testBigRecordJob calls runBigRecordTestTopology, but message size is 14680100 bytes when serialized, which is larger than the maximum request size configured with the max.request.size configuration(1024*1024*14 or 14680064).Increased max.request.size for the  testBigRecordJob test.