### PR TITLE
[FLINK-3914] [runtime] fixed race when attempting to create temp dir

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -108,7 +108,7 @@ public class BlobUtils {
 	static File getIncomingDirectory(File storageDir) {
 		final File incomingDir = new File(storageDir, "incoming");
 
-		if (!incomingDir.exists() && !incomingDir.mkdirs()) {
+		if (!incomingDir.mkdirs() && !incomingDir.exists()) {
 			throw new RuntimeException("Cannot create directory for incoming files " + incomingDir.getAbsolutePath());
 		}
 


### PR DESCRIPTION
Flipped logic to prevent race on first few calls.