### PR TITLE
[script] Simple fix of typo from JobManager to TaskManager in taskmanager.sh file

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 ################################################################################
 
-# Start/stop a Flink JobManager.
+# Start/stop a Flink TaskManager.
 USAGE="Usage: taskmanager.sh (start|stop|stop-all)"
 
 STARTSTOP=$1


### PR DESCRIPTION
Very simple fix for typo on comment in the task manager.sh file.

From `JobManager` to `TaskManager`.