### PR TITLE
[FLINK-3926][TypeSystem]Incorrect implementation of getFieldIndex in TupleTypeInfo

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -84,11 +84,12 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 	@Override
 	@PublicEvolving
 	public int getFieldIndex(String fieldName) {
-		int fieldIndex = Integer.parseInt(fieldName.substring(1));
-		if (fieldIndex >= getArity()) {
-			return -1;
+		for (int i = 0; i < fieldNames.length; i++) {
+			if (fieldNames[i].equals(fieldName)) {
+				return i;
+			}
 		}
-		return fieldIndex;
+		return -1;
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
The origin code assumes filed name as `f{i}` which is not always true. 

Finding a field `a` would result in `NumberFormatException`