### PR TITLE
[FLINK-3892] ConnectionUtils may die with NullPointerException

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -240,7 +240,11 @@ public class ConnectionUtils {
 			}
 		}
 
-		final byte[] targetAddressBytes = targetAddress.getAddress().getAddress();
+		final InetAddress address = targetAddress.getAddress();
+		if (address == null) {
+			return null;
+		}
+		final byte[] targetAddressBytes = address.getAddress();
 
 		// for each network interface
 		Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces();


### PR DESCRIPTION
Fix discovered in the course of #1978.
