### PR TITLE
[FLINK-3933] [streaming API] Add AbstractDeserializationSchema

### DIFF
--- a/docs/apis/streaming/connectors/kafka.md
+++ b/docs/apis/streaming/connectors/kafka.md
@@ -142,18 +142,24 @@ for querying the list of topics and partitions.
 For this to work, the consumer needs to be able to access the consumers from the machine submitting the job to the Flink cluster.
 If you experience any issues with the Kafka consumer on the client side, the client log might contain information about failed requests, etc.
 
-##### The `DeserializationSchema`
+##### **The `DeserializationSchema`**
 
-The `FlinkKafkaConsumer08` needs to know how to turn the data in Kafka into Java objects. The 
+The Flink Kafka Consumer needs to know how to turn the binary data in Kafka into Java/Scala objects. The 
 `DeserializationSchema` allows users to specify such a schema. The `T deserialize(byte[] message)`
 method gets called for each Kafka message, passing the value from Kafka.
+
+It is usually helpful to start from the `AbstractDeserializationSchema`, which takes care of describing the
+produced Java/Scala type to Flink's type system. Users that implement a vanilla `DeserializationSchema` need
+to implement the `getProducedType(...)` method themselves.
 
 For accessing both the key and value of the Kafka message, the `KeyedDeserializationSchema` has
 the following deserialize method ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset)`.
 
 For convenience, Flink provides the following schemas:
 1. `TypeInformationSerializationSchema` (and `TypeInformationKeyValueSerializationSchema`) which creates 
-    a schema based on a Flink `TypeInformation`.
+    a schema based on a Flink's `TypeInformation`. This is useful if the data is both written and read by Flink.
+    This schema is a performant Flink-specific alternative to other generic serialization approaches.
+ 
 2. `JsonDeserializationSchema` (and `JSONKeyValueDeserializationSchema`) which turns the serialized JSON 
     into an ObjectNode object, from which fields can be accessed using objectNode.get("field").as(Int/String/...)(). 
     The KeyValue objectNode contains a "key" and "value" field which contain all fields, as well as 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -272,7 +272,7 @@ public class TypeExtractor {
 		}
 		return new TypeExtractor().privateCreateTypeInfo(InputFormat.class, inputFormatInterface.getClass(), 0, null, null);
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//  Generic extraction methods
 	// --------------------------------------------------------------------------------------------
@@ -596,7 +596,7 @@ public class TypeExtractor {
 			}
 			
 			if(curT == Tuple0.class) {
-				return new TupleTypeInfo(Tuple0.class, new TypeInformation<?>[0]);
+				return new TupleTypeInfo(Tuple0.class);
 			}
 			
 			// check if immediate child of Tuple has generics

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/AbstractDeserializationSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/AbstractDeserializationSchema.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.serialization;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+
+import java.io.IOException;
+
+/**
+ * The deserialization schema describes how to turn the byte messages delivered by certain
+ * data sources (for example Apache Kafka) into data types (Java/Scala objects) that are
+ * processed by Flink.
+ * 
+ * <p>This base variant of the deserialization schema produces the type information
+ * automatically by extracting it from the generic class arguments.
+ * 
+ * @param <T> The type created by the deserialization schema.
+ */
+public abstract class AbstractDeserializationSchema<T> implements DeserializationSchema<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * De-serializes the byte message.
+	 *
+	 * @param message The message, as a byte array.
+	 * @return The de-serialized message as an object.
+	 */
+	@Override
+	public abstract T deserialize(byte[] message) throws IOException;
+
+	/**
+	 * Method to decide whether the element signals the end of the stream. If
+	 * true is returned the element won't be emitted.
+	 * 
+	 * <p>This default implementation returns always false, meaning the stream is interpreted
+	 * to be unbounded.
+	 *
+	 * @param nextElement The element to test for the end-of-stream signal.
+	 * @return True, if the element signals end of stream, false otherwise.
+	 */
+	@Override
+	public boolean isEndOfStream(T nextElement) {
+		return false;
+	}
+	
+	@Override
+	public TypeInformation<T> getProducedType() {
+		return TypeExtractor.createTypeInfo(AbstractDeserializationSchema.class, getClass(), 0, null, null);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/DeserializationSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/DeserializationSchema.java
@@ -28,6 +28,9 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
  * data sources (for example Apache Kafka) into data types (Java/Scala objects) that are
  * processed by Flink.
  * 
+ * <p>Note: In most cases, one should start from {@link AbstractDeserializationSchema}, which
+ * takes care of producing the return type information automatically.
+ * 
  * @param <T> The type created by the deserialization schema.
  */
 @Public

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/SimpleStringSchema.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/SimpleStringSchema.java
@@ -25,8 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
  * Very simple serialization schema for strings.
  */
 @PublicEvolving
-public class SimpleStringSchema implements DeserializationSchema<String>,
-		SerializationSchema<String> {
+public class SimpleStringSchema implements DeserializationSchema<String>, SerializationSchema<String> {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractDeserializationSchemaTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractDeserializationSchemaTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.util.serialization.AbstractDeserializationSchema;
+
+import org.codehaus.jackson.map.util.JSONPObject;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+@SuppressWarnings("serial")
+public class AbstractDeserializationSchemaTest {
+
+	@Test
+	public void testTypeExtractionTuple() {
+		TypeInformation<Tuple2<byte[], byte[]>> type = new TupleSchema().getProducedType();
+		TypeInformation<Tuple2<byte[], byte[]>> expected = TypeInformation.of(new TypeHint<Tuple2<byte[], byte[]>>(){});
+		assertEquals(expected, type);
+	}
+	
+	@Test
+	public void testTypeExtractionTupleAnonymous() {
+		TypeInformation<Tuple2<byte[], byte[]>> type = new AbstractDeserializationSchema<Tuple2<byte[], byte[]>>() {
+			@Override
+			public Tuple2<byte[], byte[]> deserialize(byte[] message) throws IOException {
+				throw new UnsupportedOperationException();
+			}
+		}.getProducedType();
+		
+		TypeInformation<Tuple2<byte[], byte[]>> expected = TypeInformation.of(new TypeHint<Tuple2<byte[], byte[]>>(){});
+		assertEquals(expected, type);
+	}
+
+	@Test
+	public void testTypeExtractionGeneric() {
+		TypeInformation<JSONPObject> type = new JsonSchema().getProducedType();
+		TypeInformation<JSONPObject> expected = TypeInformation.of(new TypeHint<JSONPObject>(){});
+		assertEquals(expected, type);
+	}
+
+	@Test
+	public void testTypeExtractionGenericAnonymous() {
+		TypeInformation<JSONPObject> type = new AbstractDeserializationSchema<JSONPObject>() {
+			@Override
+			public JSONPObject deserialize(byte[] message) throws IOException {
+				throw new UnsupportedOperationException();
+			}
+		}.getProducedType();
+
+		TypeInformation<JSONPObject> expected = TypeInformation.of(new TypeHint<JSONPObject>(){});
+		assertEquals(expected, type);
+	}
+
+	@Test
+	public void testTypeExtractionRawException() {
+		try {
+			new RawSchema().getProducedType();
+			fail();
+		} catch (InvalidTypesException e) {
+			// expected
+		}
+	}
+	
+	// ------------------------------------------------------------------------
+	//  Test types
+	// ------------------------------------------------------------------------
+
+	private static class TupleSchema extends AbstractDeserializationSchema<Tuple2<byte[], byte[]>> {
+
+		@Override
+		public Tuple2<byte[], byte[]> deserialize(byte[] message) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+	}
+	
+	private static class JsonSchema extends AbstractDeserializationSchema<JSONPObject> {
+
+		@Override
+		public JSONPObject deserialize(byte[] message) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static class RawSchema extends AbstractDeserializationSchema {
+
+		@Override
+		public Object deserialize(byte[] message) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds an `AbstractDeserializationSchema` that handles the produced type extraction automatically from the generic types via the TypeExtractor (reflection)

Also adds test and documentation, references the new `AbstractDeserializationSchema` in the docs of the `DeserializationSchema`.