### PR TITLE
[FLINK-3922] [types] Infinite recursion on TypeExtractor

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1245,7 +1245,7 @@ public class TypeExtractor {
 	private static int countTypeInHierarchy(ArrayList<Type> typeHierarchy, Type type) {
 		int count = 0;
 		for (Type t : typeHierarchy) {
-			if (t == type || (isClassType(type) && t == typeToClass(type))) {
+			if (t == type || (isClassType(type) && t == typeToClass(type)) || (isClassType(t) && typeToClass(t) == type)) {
 				count++;
 			}
 		}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -90,6 +90,10 @@ public class PojoTypeExtractionTest {
 		public String[]	fancyArray;			 // generic type
 	}
 
+	public static class FancyCollectionSubtype<T> extends HashSet<T> {
+		private static final long serialVersionUID = -3494469602638179921L;
+	}
+
 	public static class ParentSettingGenerics extends PojoWithGenerics<Integer, Long> {
 		public String field3;
 	}
@@ -808,10 +812,17 @@ public class PojoTypeExtractionTest {
 		Assert.assertTrue(tti.getTypeAt(0) instanceof PojoTypeInfo);
 		Assert.assertTrue(tti.getTypeAt(1) instanceof PojoTypeInfo);
 	}
-	
-	// ------------------------------------------------------------------------
-	
-	public static class FancyCollectionSubtype<T> extends HashSet<T> {
-		private static final long serialVersionUID = -3494469602638179921L;
+
+	public static class PojoWithRecursiveGenericField<K,V> {
+		public PojoWithRecursiveGenericField<K,V> parent;
+		public PojoWithRecursiveGenericField(){}
 	}
+
+	@Test
+	public void testPojoWithRecursiveGenericField() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(PojoWithRecursiveGenericField.class);
+		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation().getClass());
+	}
+
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -825,4 +825,36 @@ public class PojoTypeExtractionTest {
 		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
+	public static class MutualPojoA {
+		public MutualPojoB field;
+	}
+
+	public static class MutualPojoB {
+		public MutualPojoA field;
+	}
+
+	@Test
+	public void testPojosWithMutualRecursion() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(MutualPojoB.class);
+		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		TypeInformation<?> pti = ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation();
+		Assert.assertTrue(pti instanceof PojoTypeInfo);
+		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
+	}
+
+	public static class Container<T> {
+		public T field;
+	}
+
+	public static class MyType extends Container<Container<Object>> {}
+
+	@Test
+	public void testRecursivePojoWithTypeVariable() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(MyType.class);
+		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		TypeInformation<?> pti = ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation();
+		Assert.assertTrue(pti instanceof PojoTypeInfo);
+		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
+	}
+
 }


### PR DESCRIPTION
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Fixes a special bug if a parameterized Pojo contains a recursive field of same type.

