### PR TITLE
[FLINK-3927][yarn] make container id consistent across Hadoop versions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
@@ -353,7 +353,7 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceID> extend
 		ResourceID resourceID = msg.resourceId();
 		try {
 			Preconditions.checkNotNull(resourceID);
-			WorkerType newWorker = workerRegistered(msg.resourceId());
+			WorkerType newWorker = workerRegistered(resourceID);
 			WorkerType oldWorker = registeredWorkers.put(resourceID, newWorker);
 			if (oldWorker != null) {
 				LOG.warn("Worker {} had been registered before.", resourceID);
@@ -363,7 +363,7 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceID> extend
 				self());
 		} catch (Exception e) {
 			// This may happen on duplicate task manager registration message to the job manager
-			LOG.warn("TaskManager resource registration failed for {}", resourceID);
+			LOG.warn("TaskManager resource registration failed for {}", resourceID, e);
 
 			// tell the JobManager about the failure
 			String eStr = ExceptionUtils.stringifyException(e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceID.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 
@@ -32,10 +33,15 @@ public class ResourceID implements Serializable {
 	private final String resourceId;
 
 	public ResourceID(String resourceId) {
+		Preconditions.checkNotNull(resourceId, "ResourceID must not be null");
 		this.resourceId = resourceId;
 	}
 
-	public String getResourceId() {
+	/**
+	 * Gets the Resource Id as string
+	 * @return Stringified version of the ResourceID
+	 */
+	public final String getResourceIdString() {
 		return resourceId;
 	}
 
@@ -48,10 +54,10 @@ public class ResourceID implements Serializable {
 	}
 
 	@Override
-	public boolean equals(Object o) {
+	public final boolean equals(Object o) {
 		if (this == o) {
 			return true;
-		} else if (o == null || getClass() != o.getClass()) {
+		} else if (o == null || !(o instanceof ResourceID)) {
 			return false;
 		} else {
 			return resourceId.equals(((ResourceID) o).resourceId);
@@ -59,7 +65,7 @@ public class ResourceID implements Serializable {
 	}
 
 	@Override
-	public int hashCode() {
+	public final int hashCode() {
 		return resourceId.hashCode();
 	}
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -440,8 +440,8 @@ class JobManager(
 
       val taskManager = msg.getTaskManager
       val resourceId = msg.getResourceID
-      log.warn(s"TaskManager's resource id $resourceId is not registered with ResourceManager. " +
-        s"Refusing registration.")
+      log.warn(s"TaskManager's resource id $resourceId failed to register at ResourceManager. " +
+        s"Refusing registration because of\n${msg.getMessage}.")
 
       taskManager ! decorateMessage(
         RefuseRegistration(new IllegalStateException(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/RegisteredYarnWorkerNode.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/RegisteredYarnWorkerNode.java
@@ -24,22 +24,23 @@ import org.apache.hadoop.yarn.api.records.Container;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A representation of a registered Yarn container managed by the {@link YarnFlinkResourceManager}.
+ */
 public class RegisteredYarnWorkerNode extends ResourceID {
-	
+
 	/** The container on which the worker runs */
 	private final Container yarnContainer;
 
-	public RegisteredYarnWorkerNode(
-		ResourceID resourceId, Container yarnContainer)
-	{
-		super(resourceId.getResourceId());
+	public RegisteredYarnWorkerNode(Container yarnContainer) {
+		super(yarnContainer.getId().toString());
 		this.yarnContainer = requireNonNull(yarnContainer);
 	}
 
 	public Container yarnContainer() {
 		return yarnContainer;
 	}
-	
+
 	// ------------------------------------------------------------------------
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnContainerInLaunch.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnContainerInLaunch.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.hadoop.yarn.api.records.Container;
 
 import static java.util.Objects.requireNonNull;
@@ -26,17 +27,22 @@ import static java.util.Objects.requireNonNull;
  * This class describes a container in which a TaskManager is being launched (or
  * has been launched) but where the TaskManager has not properly registered, yet.
  */
-public class YarnContainerInLaunch {
-	
+public class YarnContainerInLaunch extends ResourceID {
+
 	private final Container container;
-	
+
 	private final long timestamp;
-	
+
+	public YarnContainerInLaunch(Container container) {
+		this(container, System.currentTimeMillis());
+	}
+
 	public YarnContainerInLaunch(Container container, long timestamp) {
+		super(container.getId().toString());
 		this.container = requireNonNull(container);
 		this.timestamp = timestamp;
 	}
-	
+
 	// ------------------------------------------------------------------------
 
 	public Container container() {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
@@ -21,7 +21,6 @@ package org.apache.flink.yarn;
 import java.io.IOException;
 import java.security.PrivilegedAction;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -29,6 +28,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
@@ -87,8 +87,9 @@ public class YarnTaskManagerRunner {
 		}
 
 		// Infer the resource identifier from the environment variable
-		String containerID = Objects.requireNonNull(System.getenv(Environment.CONTAINER_ID.key()));
+		String containerID = Preconditions.checkNotNull(envs.get(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID));
 		final ResourceID resourceId = new ResourceID(containerID);
+		LOG.info("ResourceID assigned for this container: {}", resourceId);
 
 		ugi.doAs(new PrivilegedAction<Object>() {
 			@Override


### PR DESCRIPTION
Fixes a bug where the container id generation would vary across Hadoop versions of the client/cluster. The ResourceManager assumes a persistent resource id.