### PR TITLE
[FLINK-2673] [type system] Add a comparator for Scala Option type

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeComparator.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeComparator.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeutils.TypeComparator
+import org.apache.flink.core.memory.{DataInputView, DataOutputView, MemorySegment}
+
+/**
+  * Comparator for [[Option]] values. Note that [[None]] is lesser than any [[Some]] values.
+  */
+@Internal
+class OptionTypeComparator[A](
+  private val ascending: Boolean,
+  private val typeComparator: TypeComparator[A]
+) extends TypeComparator[Option[A]] {
+  private var reference: Option[A] = _
+
+  override def hash(record: Option[A]) = record.hashCode()
+
+  override def compare(first: Option[A], second: Option[A]) = {
+    first match {
+      case Some(firstValue: A) =>
+        second match {
+          case Some(secondValue: A) => typeComparator.compare(firstValue, secondValue)
+          case None =>
+            if (ascending) {
+              1
+            } else {
+              -1
+            }
+        }
+      case None =>
+        second match {
+          case Some(secondValue) =>
+            if (ascending) {
+              -1
+            } else {
+              1
+            }
+          case None => 0
+        }
+    }
+  }
+
+  override def compareSerialized(firstSource: DataInputView, secondSource: DataInputView) = {
+    val firstSome = firstSource.readBoolean()
+    val secondSome = secondSource.readBoolean()
+
+    if (firstSome) {
+      if (secondSome) {
+        typeComparator.compareSerialized(firstSource, secondSource)
+      } else {
+        if (ascending) {
+          1
+        } else {
+          -1
+        }
+      }
+    } else {
+      if (secondSome) {
+        if (ascending) {
+          -1
+        } else {
+          1
+        }
+      } else {
+        0
+      }
+    }
+  }
+
+  override def extractKeys(record: AnyRef, target: Array[AnyRef], index: Int) = {
+    target(index) = record
+    1
+  }
+
+  override def setReference(toCompare: Option[A]) = {
+    reference = toCompare
+  }
+
+  override def equalToReference(candidate: Option[A]) = {
+    compare(reference, candidate) == 0
+  }
+
+  override def compareToReference(referencedComparator: TypeComparator[Option[A]]) = {
+    compare(referencedComparator.asInstanceOf[this.type].reference, reference)
+  }
+
+  override lazy val getFlatComparators = {
+    Array(this).asInstanceOf[Array[TypeComparator[_]]]
+  }
+
+  override def getNormalizeKeyLen = 1 + typeComparator.getNormalizeKeyLen
+
+  override def putNormalizedKey(
+    record: Option[A],
+    target: MemorySegment,
+    offset: Int,
+    numBytes: Int
+  ) = {
+    if (numBytes >= 1) {
+      record match {
+        case Some(v: A) =>
+          target.put(offset, OptionTypeComparator.OneInByte)
+          typeComparator.putNormalizedKey(v, target, offset + 1, numBytes - 1)
+        case None =>
+          target.put(offset, OptionTypeComparator.ZeroInByte)
+          var i = 1
+          while (i < numBytes) {
+            target.put(offset + i, OptionTypeComparator.ZeroInByte)
+            i += 1
+          }
+      }
+    }
+  }
+
+  override def invertNormalizedKey() = !ascending
+
+  override def readWithKeyDenormalization(reuse: Option[A], source: DataInputView) = {
+    throw new UnsupportedOperationException
+  }
+
+  override def writeWithKeyNormalization(record: Option[A], target: DataOutputView) = {
+    throw new UnsupportedOperationException
+  }
+
+  override def isNormalizedKeyPrefixOnly(keyBytes: Int) = {
+    typeComparator.isNormalizedKeyPrefixOnly(keyBytes - 1)
+  }
+
+  override def supportsSerializationWithKeyNormalization() = false
+
+  override def supportsNormalizedKey() = typeComparator.supportsNormalizedKey()
+
+  override def duplicate() = new OptionTypeComparator[A](ascending, typeComparator)
+}
+
+object OptionTypeComparator {
+  val ZeroInByte = 0.asInstanceOf[Byte]
+  val OneInByte = 1.asInstanceOf[Byte]
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionTypeComparatorTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionTypeComparatorTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase
+import org.apache.flink.api.common.typeutils.base.{StringComparator, StringSerializer}
+
+class OptionTypeComparatorTest extends ComparatorTestBase[Option[String]] {
+  override protected def createComparator(ascending: Boolean) = {
+    new OptionTypeComparator[String](ascending, new StringComparator(ascending))
+  }
+
+  override protected def createSerializer() = new OptionSerializer[String](new StringSerializer)
+
+  override protected def getSortedTestData = Array(None, Some("a"), Some("b"), Some("c"))
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/JoinITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/JoinITCase.scala
@@ -406,4 +406,15 @@ class JoinITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode)
     env.execute()
     expected = "1,(1,1,Hi)\n2,(2,2,Hello)"
   }
+
+  @Test
+  def testWithScalaOptionValues(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = env.fromElements(None, Some("a"), Some("b"))
+    val ds2 = env.fromElements(None, Some("a"))
+    val joinDs = ds1.join(ds2).where("_").equalTo("_")
+    joinDs.writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
+    env.execute()
+    expected = "None,None\nSome(a),Some(a)"
+  }
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

---

I've added `OptionTypeComparator` implementation, unit test cases based on `ComparatorTestBase` and a simple integration test case in `JoinITCase`. I followed [Till's opinion](http://markmail.org/message/vk3t3vpc6j6zbldk) about order between `None` and `Some` values.