### PR TITLE
[FLINK-3953] rename unit-tests execution to default-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -923,7 +923,7 @@ under the License.
 				</configuration>
 				<executions>
 					<execution>
-						<id>unit-tests</id>
+						<id>default-test</id>
 						<phase>test</phase>
 						<goals>
 							<goal>test</goal>


### PR DESCRIPTION
After 38698c0b101cbb48f8c10adf4060983ac07e2f4b, there are now two
executions defined for the Surefire plugin: unit-tests and
integration-tests. In addition, there is an implicit default execution
called default-test. This leads to the unit tests to be executed
twice. This renames unit-tests to default-test to prevent duplicate
execution.