### PR TITLE
[FLINK-3960] ignore EventTimeWindowCheckpointingITCase for now

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -49,6 +49,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -71,6 +72,7 @@ import static org.junit.Assert.*;
  */
 @SuppressWarnings("serial")
 @RunWith(Parameterized.class)
+@Ignore("Disabled because RocksDB fails with a segmentation fault.")
 public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
 	private static final int PARALLELISM = 4;


### PR DESCRIPTION
Until FLINK-3960 is fixed, we need to disable this test to allow other
tests to execute properly.