### PR TITLE
[FLINK-3586] Fix potential overflow of Long AVG aggregation.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/Aggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/Aggregate.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.api.table.runtime.aggregate
 
-import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.table.Row
 
 /**
@@ -43,47 +43,54 @@ import org.apache.flink.api.table.Row
 trait Aggregate[T] extends Serializable {
 
   /**
-   * Initiate the intermediate aggregate value in Row.
-   * @param intermediate
-   */
-  def initiate(intermediate: Row): Unit
-
-  /**
-   * Transform the aggregate field value into intermediate aggregate data.
-   * @param value
-   * @param intermediate
-   */
+    * Transform the aggregate field value into intermediate aggregate data.
+    *
+    * @param value The value to insert into the intermediate aggregate row.
+    * @param intermediate The intermediate aggregate row into which the value is inserted.
+    */
   def prepare(value: Any, intermediate: Row): Unit
 
   /**
-   * Merge intermediate aggregate data into aggregate buffer.
-   * @param intermediate
-   * @param buffer
-   */
+    * Initiate the intermediate aggregate value in Row.
+    *
+    * @param intermediate The intermediate aggregate row to initiate.
+    */
+  def initiate(intermediate: Row): Unit
+
+  /**
+    * Merge intermediate aggregate data into aggregate buffer.
+    *
+    * @param intermediate The intermediate aggregate row to merge.
+    * @param buffer The aggregate buffer into which the intermedidate is merged.
+    */
   def merge(intermediate: Row, buffer: Row): Unit
 
   /**
-   * Calculate the final aggregated result based on aggregate buffer.
-   * @param buffer
-   * @return
-   */
+    * Calculate the final aggregated result based on aggregate buffer.
+    *
+    * @param buffer The aggregate buffer from which the final aggregate is computed.
+    * @return The final result of the aggregate.
+    */
   def evaluate(buffer: Row): T
 
   /**
-   * Intermediate aggregate value types.
-   * @return
-   */
-  def intermediateDataType: Array[SqlTypeName]
+    * Intermediate aggregate value types.
+    *
+    * @return The types of the intermediate fields of this aggregate.
+    */
+  def intermediateDataType: Array[TypeInformation[_]]
 
   /**
-   * Set the aggregate data offset in Row.
-   * @param aggOffset
-   */
+    * Set the aggregate data offset in Row.
+    *
+    * @param aggOffset The offset of this aggregate in the intermediate aggregate rows.
+    */
   def setAggOffsetInRow(aggOffset: Int)
 
   /**
     * Whether aggregate function support partial aggregate.
-   * @return
-   */
+    *
+    * @return True if the aggregate supports partial aggregation, False otherwise.
+    */
   def supportPartial: Boolean = false
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/CountAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/CountAggregate.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.api.table.runtime.aggregate
 
-import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.table.Row
 
 class CountAggregate extends Aggregate[Long] {
@@ -45,9 +45,7 @@ class CountAggregate extends Aggregate[Long] {
     }
   }
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    Array(SqlTypeName.BIGINT)
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.LONG_TYPE_INFO)
 
   override def supportPartial: Boolean = true
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/MaxAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/MaxAggregate.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.api.table.runtime.aggregate
 
-import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.api.table.Row
 
 abstract class MaxAggregate[T: Numeric] extends Aggregate[T] {
@@ -27,6 +27,7 @@ abstract class MaxAggregate[T: Numeric] extends Aggregate[T] {
 
   /**
    * Accessed in MapFunction, prepare the input of partial aggregate.
+   *
    * @param value
    * @param intermediate
    */
@@ -41,6 +42,7 @@ abstract class MaxAggregate[T: Numeric] extends Aggregate[T] {
   /**
    * Accessed in CombineFunction and GroupReduceFunction, merge partial
    * aggregate result into aggregate buffer.
+   *
    * @param intermediate
    * @param buffer
    */
@@ -52,6 +54,7 @@ abstract class MaxAggregate[T: Numeric] extends Aggregate[T] {
 
   /**
    * Return the final aggregated result based on aggregate buffer.
+   *
    * @param buffer
    * @return
    */
@@ -67,11 +70,8 @@ abstract class MaxAggregate[T: Numeric] extends Aggregate[T] {
 }
 
 class ByteMaxAggregate extends MaxAggregate[Byte] {
-  private val intermediateType = Array(SqlTypeName.TINYINT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    intermediateType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.BYTE_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(maxIndex, Byte.MinValue)
@@ -79,11 +79,8 @@ class ByteMaxAggregate extends MaxAggregate[Byte] {
 }
 
 class ShortMaxAggregate extends MaxAggregate[Short] {
-  private val intermediateType = Array(SqlTypeName.SMALLINT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    intermediateType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.SHORT_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(maxIndex, Short.MinValue)
@@ -91,11 +88,8 @@ class ShortMaxAggregate extends MaxAggregate[Short] {
 }
 
 class IntMaxAggregate extends MaxAggregate[Int] {
-  private val intermediateType = Array(SqlTypeName.INTEGER)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    intermediateType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.INT_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(maxIndex, Int.MinValue)
@@ -103,11 +97,8 @@ class IntMaxAggregate extends MaxAggregate[Int] {
 }
 
 class LongMaxAggregate extends MaxAggregate[Long] {
-  private val intermediateType = Array(SqlTypeName.BIGINT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    intermediateType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.LONG_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(maxIndex, Long.MinValue)
@@ -115,11 +106,8 @@ class LongMaxAggregate extends MaxAggregate[Long] {
 }
 
 class FloatMaxAggregate extends MaxAggregate[Float] {
-  private val intermediateType = Array(SqlTypeName.FLOAT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    intermediateType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.FLOAT_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(maxIndex, Float.MinValue)
@@ -127,11 +115,8 @@ class FloatMaxAggregate extends MaxAggregate[Float] {
 }
 
 class DoubleMaxAggregate extends MaxAggregate[Double] {
-  private val intermediateType = Array(SqlTypeName.DOUBLE)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    intermediateType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.DOUBLE_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(maxIndex, Double.MinValue)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/MinAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/MinAggregate.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.api.table.runtime.aggregate
 
-import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.api.table.Row
 
 abstract  class MinAggregate[T: Numeric] extends Aggregate[T]{
@@ -27,6 +27,7 @@ abstract  class MinAggregate[T: Numeric] extends Aggregate[T]{
 
   /**
    * Accessed in MapFunction, prepare the input of partial aggregate.
+   *
    * @param value
    * @param partial
    */
@@ -41,6 +42,7 @@ abstract  class MinAggregate[T: Numeric] extends Aggregate[T]{
   /**
    * Accessed in CombineFunction and GroupReduceFunction, merge partial
    * aggregate result into aggregate buffer.
+   *
    * @param partial
    * @param buffer
    */
@@ -52,6 +54,7 @@ abstract  class MinAggregate[T: Numeric] extends Aggregate[T]{
 
   /**
    * Return the final aggregated result based on aggregate buffer.
+   *
    * @param buffer
    * @return
    */
@@ -67,11 +70,8 @@ abstract  class MinAggregate[T: Numeric] extends Aggregate[T]{
 }
 
 class ByteMinAggregate extends MinAggregate[Byte] {
-  private val partialType = Array(SqlTypeName.TINYINT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.BYTE_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(minIndex, Byte.MaxValue)
@@ -79,11 +79,8 @@ class ByteMinAggregate extends MinAggregate[Byte] {
 }
 
 class ShortMinAggregate extends MinAggregate[Short] {
-  private val partialType = Array(SqlTypeName.SMALLINT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.SHORT_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(minIndex, Short.MaxValue)
@@ -91,11 +88,8 @@ class ShortMinAggregate extends MinAggregate[Short] {
 }
 
 class IntMinAggregate extends MinAggregate[Int] {
-  private val partialType = Array(SqlTypeName.INTEGER)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.INT_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(minIndex, Int.MaxValue)
@@ -103,11 +97,8 @@ class IntMinAggregate extends MinAggregate[Int] {
 }
 
 class LongMinAggregate extends MinAggregate[Long] {
-  private val partialType = Array(SqlTypeName.BIGINT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.LONG_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(minIndex, Long.MaxValue)
@@ -115,11 +106,8 @@ class LongMinAggregate extends MinAggregate[Long] {
 }
 
 class FloatMinAggregate extends MinAggregate[Float] {
-  private val partialType = Array(SqlTypeName.FLOAT)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.FLOAT_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(minIndex, Float.MaxValue)
@@ -127,11 +115,8 @@ class FloatMinAggregate extends MinAggregate[Float] {
 }
 
 class DoubleMinAggregate extends MinAggregate[Double] {
-  private val partialType = Array(SqlTypeName.DOUBLE)
 
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.DOUBLE_TYPE_INFO)
 
   override def initiate(intermediate: Row): Unit = {
     intermediate.setField(minIndex, Double.MaxValue)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/SumAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/SumAggregate.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.api.table.runtime.aggregate
 
-import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.api.table.Row
 
 abstract class SumAggregate[T: Numeric]
@@ -57,49 +57,25 @@ abstract class SumAggregate[T: Numeric]
 }
 
 class ByteSumAggregate extends SumAggregate[Byte] {
-  private val partialType = Array(SqlTypeName.TINYINT)
-
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.BYTE_TYPE_INFO)
 }
 
 class ShortSumAggregate extends SumAggregate[Short] {
-  private val partialType = Array(SqlTypeName.SMALLINT)
-
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.SHORT_TYPE_INFO)
 }
 
 class IntSumAggregate extends SumAggregate[Int] {
-  private val partialType = Array(SqlTypeName.INTEGER)
-
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.INT_TYPE_INFO)
 }
 
 class LongSumAggregate extends SumAggregate[Long] {
-  private val partialType = Array(SqlTypeName.BIGINT)
-
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.LONG_TYPE_INFO)
 }
 
 class FloatSumAggregate extends SumAggregate[Float] {
-  private val partialType = Array(SqlTypeName.FLOAT)
-
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.FLOAT_TYPE_INFO)
 }
 
 class DoubleSumAggregate extends SumAggregate[Double] {
-  private val partialType = Array(SqlTypeName.DOUBLE)
-
-  override def intermediateDataType: Array[SqlTypeName] = {
-    partialType
-  }
+  override def intermediateDataType = Array(BasicTypeInfo.DOUBLE_TYPE_INFO)
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/AggregateTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/AggregateTestBase.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.runtime.aggregate
+
+import org.apache.flink.api.table.Row
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+abstract class AggregateTestBase[T] {
+
+  private val offset = 2
+  private val rowArity: Int = offset + aggregator.intermediateDataType.length
+
+  def inputValueSets: Seq[Seq[_]]
+
+  def expectedResults: Seq[T]
+
+  def aggregator: Aggregate[T]
+
+  private def createAggregator(): Aggregate[T] = {
+    val agg = aggregator
+    agg.setAggOffsetInRow(offset)
+    agg
+  }
+
+  private def createRow(): Row = {
+    new Row(rowArity)
+  }
+
+  @Test
+  def testAggregate(): Unit = {
+
+    // iterate over input sets
+    for((vals, expected) <- inputValueSets.zip(expectedResults)) {
+
+      // prepare mapper
+      val rows: Seq[Row] = prepare(vals)
+
+      val result = if (aggregator.supportPartial) {
+        // test with combiner
+        val (firstVals, secondVals) = rows.splitAt(rows.length / 2)
+        val combined = partialAgg(firstVals) :: partialAgg(secondVals) :: Nil
+        finalAgg(combined)
+
+      } else {
+        // test without combiner
+        finalAgg(rows)
+      }
+
+      assertEquals(expected, result)
+
+    }
+  }
+
+  private def prepare(vals: Seq[_]): Seq[Row] = {
+
+    val agg = createAggregator()
+
+    vals.map { v =>
+      val row = createRow()
+      agg.prepare(v, row)
+      row
+    }
+  }
+
+  private def partialAgg(rows: Seq[Row]): Row = {
+
+    val agg = createAggregator()
+    val aggBuf = createRow()
+
+    agg.initiate(aggBuf)
+    rows.foreach(v => agg.merge(v, aggBuf))
+
+    aggBuf
+  }
+
+  private def finalAgg(rows: Seq[Row]): T = {
+
+    val agg = createAggregator()
+    val aggBuf = createRow()
+
+    agg.initiate(aggBuf)
+    rows.foreach(v => agg.merge(v, aggBuf))
+
+    agg.evaluate(partialAgg(rows))
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/AvgAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/AvgAggregateTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.runtime.aggregate
+
+abstract class AvgAggregateTestBase[T: Numeric] extends AggregateTestBase[T] {
+
+  private val numeric: Numeric[T] = implicitly[Numeric[T]]
+
+  def minVal: T
+  def maxVal: T
+
+  override def inputValueSets: Seq[Seq[T]] = Seq(
+    Seq(
+      minVal,
+      minVal,
+      null.asInstanceOf[T],
+      minVal,
+      minVal,
+      null.asInstanceOf[T],
+      minVal,
+      minVal,
+      minVal
+    ),
+    Seq(
+      maxVal,
+      maxVal,
+      null.asInstanceOf[T],
+      maxVal,
+      maxVal,
+      null.asInstanceOf[T],
+      maxVal,
+      maxVal,
+      maxVal
+    ),
+    Seq(
+      minVal,
+      maxVal,
+      null.asInstanceOf[T],
+      numeric.fromInt(0),
+      numeric.negate(maxVal),
+      numeric.negate(minVal),
+      null.asInstanceOf[T]
+    )
+  )
+
+  override def expectedResults: Seq[T] = Seq(
+    minVal,
+    maxVal,
+    numeric.fromInt(0)
+  )
+}
+
+class ByteAvgAggregateTest extends AvgAggregateTestBase[Byte] {
+
+  override def minVal = (Byte.MinValue + 1).toByte
+  override def maxVal = (Byte.MaxValue - 1).toByte
+
+  override def aggregator = new ByteAvgAggregate()
+}
+
+class ShortAvgAggregateTest extends AvgAggregateTestBase[Short] {
+
+  override def minVal = (Short.MinValue + 1).toShort
+  override def maxVal = (Short.MaxValue - 1).toShort
+
+  override def aggregator = new ShortAvgAggregate()
+}
+
+class IntAvgAggregateTest extends AvgAggregateTestBase[Int] {
+
+  override def minVal = Int.MinValue + 1
+  override def maxVal = Int.MaxValue - 1
+
+  override def aggregator = new IntAvgAggregate()
+}
+
+class LongAvgAggregateTest extends AvgAggregateTestBase[Long] {
+
+  override def minVal = Long.MinValue + 1
+  override def maxVal = Long.MaxValue - 1
+
+  override def aggregator = new LongAvgAggregate()
+}
+
+class FloatAvgAggregateTest extends AvgAggregateTestBase[Float] {
+
+  override def minVal = Float.MinValue
+  override def maxVal = Float.MaxValue
+
+  override def aggregator = new FloatAvgAggregate()
+}
+
+class DoubleAvgAggregateTest extends AvgAggregateTestBase[Double] {
+
+  override def minVal = Float.MinValue
+  override def maxVal = Float.MaxValue
+
+  override def aggregator = new DoubleAvgAggregate()
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/CountAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/CountAggregateTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.runtime.aggregate
+
+class CountAggregateTest extends AggregateTestBase[Long] {
+
+  override def inputValueSets: Seq[Seq[_]] = Seq(
+    Seq("a", "b", null, "c", null, "d", "e", null, "f")
+  )
+
+  override def expectedResults: Seq[Long] = Seq(6L)
+
+  override def aggregator: Aggregate[Long] = new CountAggregate()
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/MaxAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/MaxAggregateTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.runtime.aggregate
+
+abstract class MaxAggregateTestBase[T: Numeric] extends AggregateTestBase[T] {
+
+  private val numeric: Numeric[T] = implicitly[Numeric[T]]
+
+  def minVal: T
+  def maxVal: T
+
+  override def inputValueSets: Seq[Seq[T]] = Seq(
+    Seq(
+      numeric.fromInt(1),
+      null.asInstanceOf[T],
+      maxVal,
+      numeric.fromInt(-99),
+      numeric.fromInt(3),
+      numeric.fromInt(56),
+      numeric.fromInt(0),
+      minVal,
+      numeric.fromInt(-20),
+      numeric.fromInt(17),
+      null.asInstanceOf[T]
+    )
+  )
+
+  override def expectedResults: Seq[T] = Seq(maxVal)
+}
+
+class ByteMaxAggregateTest extends MaxAggregateTestBase[Byte] {
+
+  override def minVal = (Byte.MinValue + 1).toByte
+  override def maxVal = (Byte.MaxValue - 1).toByte
+
+  override def aggregator: Aggregate[Byte] = new ByteMaxAggregate()
+}
+
+class ShortMaxAggregateTest extends MaxAggregateTestBase[Short] {
+
+  override def minVal = (Short.MinValue + 1).toShort
+  override def maxVal = (Short.MaxValue - 1).toShort
+
+  override def aggregator: Aggregate[Short] = new ShortMaxAggregate()
+}
+
+class IntMaxAggregateTest extends MaxAggregateTestBase[Int] {
+
+  override def minVal = Int.MinValue + 1
+  override def maxVal = Int.MaxValue - 1
+
+  override def aggregator: Aggregate[Int] = new IntMaxAggregate()
+}
+
+class LongMaxAggregateTest extends MaxAggregateTestBase[Long] {
+
+  override def minVal = Long.MinValue + 1
+  override def maxVal = Long.MaxValue - 1
+
+  override def aggregator: Aggregate[Long] = new LongMaxAggregate()
+}
+
+class FloatMaxAggregateTest extends MaxAggregateTestBase[Float] {
+
+  override def minVal = Float.MinValue / 2
+  override def maxVal = Float.MaxValue / 2
+
+  override def aggregator: Aggregate[Float] = new FloatMaxAggregate()
+}
+
+class DoubleMaxAggregateTest extends MaxAggregateTestBase[Double] {
+
+  override def minVal = Double.MinValue / 2
+  override def maxVal = Double.MaxValue / 2
+
+  override def aggregator: Aggregate[Double] = new DoubleMaxAggregate()
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/MinAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/MinAggregateTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.runtime.aggregate
+
+abstract class MinAggregateTestBase[T: Numeric] extends AggregateTestBase[T] {
+
+  private val numeric: Numeric[T] = implicitly[Numeric[T]]
+
+  def minVal: T
+  def maxVal: T
+
+  override def inputValueSets: Seq[Seq[T]] = Seq(
+    Seq(
+      numeric.fromInt(1),
+      null.asInstanceOf[T],
+      maxVal,
+      numeric.fromInt(-99),
+      numeric.fromInt(3),
+      numeric.fromInt(56),
+      numeric.fromInt(0),
+      minVal,
+      numeric.fromInt(-20),
+      numeric.fromInt(17),
+      null.asInstanceOf[T]
+    )
+  )
+
+  override def expectedResults: Seq[T] = Seq(minVal)
+}
+
+class ByteMinAggregateTest extends MinAggregateTestBase[Byte] {
+
+  override def minVal = (Byte.MinValue + 1).toByte
+  override def maxVal = (Byte.MaxValue - 1).toByte
+
+  override def aggregator: Aggregate[Byte] = new ByteMinAggregate()
+}
+
+class ShortMinAggregateTest extends MinAggregateTestBase[Short] {
+
+  override def minVal = (Short.MinValue + 1).toShort
+  override def maxVal = (Short.MaxValue - 1).toShort
+
+  override def aggregator: Aggregate[Short] = new ShortMinAggregate()
+}
+
+class IntMinAggregateTest extends MinAggregateTestBase[Int] {
+
+  override def minVal = Int.MinValue + 1
+  override def maxVal = Int.MaxValue - 1
+
+  override def aggregator: Aggregate[Int] = new IntMinAggregate()
+}
+
+class LongMinAggregateTest extends MinAggregateTestBase[Long] {
+
+  override def minVal = Long.MinValue + 1
+  override def maxVal = Long.MaxValue - 1
+
+  override def aggregator: Aggregate[Long] = new LongMinAggregate()
+}
+
+class FloatMinAggregateTest extends MinAggregateTestBase[Float] {
+
+  override def minVal = Float.MinValue / 2
+  override def maxVal = Float.MaxValue / 2
+
+  override def aggregator: Aggregate[Float] = new FloatMinAggregate()
+}
+
+class DoubleMinAggregateTest extends MinAggregateTestBase[Double] {
+
+  override def minVal = Double.MinValue / 2
+  override def maxVal = Double.MaxValue / 2
+
+  override def aggregator: Aggregate[Double] = new DoubleMinAggregate()
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/SumAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/aggregate/SumAggregateTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.runtime.aggregate
+
+abstract class SumAggregateTestBase[T: Numeric] extends AggregateTestBase[T] {
+
+  private val numeric: Numeric[T] = implicitly[Numeric[T]]
+
+  def maxVal: T
+  private val minVal = numeric.negate(maxVal)
+
+  override def inputValueSets: Seq[Seq[T]] = Seq(
+    Seq(
+      minVal,
+      numeric.fromInt(1),
+      null.asInstanceOf[T],
+      numeric.fromInt(2),
+      numeric.fromInt(3),
+      numeric.fromInt(4),
+      numeric.fromInt(5),
+      numeric.fromInt(-10),
+      numeric.fromInt(-20),
+      numeric.fromInt(17),
+      null.asInstanceOf[T],
+      maxVal
+    )
+  )
+
+  override def expectedResults: Seq[T] = Seq(numeric.fromInt(2))
+
+}
+
+class ByteSumAggregateTest extends SumAggregateTestBase[Byte] {
+
+  override def maxVal = (Byte.MaxValue / 2).toByte
+
+  override def aggregator: Aggregate[Byte] = new ByteSumAggregate
+}
+
+class ShortSumAggregateTest extends SumAggregateTestBase[Short] {
+
+  override def maxVal = (Short.MaxValue / 2).toShort
+
+  override def aggregator: Aggregate[Short] = new ShortSumAggregate
+}
+
+class IntSumAggregateTest extends SumAggregateTestBase[Int] {
+
+  override def maxVal = Int.MaxValue / 2
+
+  override def aggregator: Aggregate[Int] = new IntSumAggregate
+}
+
+class LongSumAggregateTest extends SumAggregateTestBase[Long] {
+
+  override def maxVal = Long.MaxValue / 2
+
+  override def aggregator: Aggregate[Long] = new LongSumAggregate
+}
+
+class FloatSumAggregateTest extends SumAggregateTestBase[Float] {
+
+  override def maxVal = 12345.6789f
+
+  override def aggregator: Aggregate[Float] = new FloatSumAggregate
+}
+
+class DoubleSumAggregateTest extends SumAggregateTestBase[Double] {
+
+  override def maxVal = 12345.6789d
+
+  override def aggregator: Aggregate[Double] = new DoubleSumAggregate
+}


### PR DESCRIPTION
Fixes a potential overflow of Long `AVG` aggregates in the Table API (intermediate sum is computed using `BigInteger` instead of `Long`).

Aggregates are refactored to specify their intermediate types as `TypeInformation` instead of SQL types. Intermediate results are not exposed to Calcite and Flink internal. So SQL types are not required and need to be converted into `TypeInformation` in any case.

Adds unit tests for `MIN`, `MAX´, `COUNT`, `SUM`, and `AVG` aggregates.

- [X] General
- [X] Documentation
  - No functionality added
  - Some ScalaDocs extended

- [X] Tests & Build
  - Unit tests for existing Aggregates added