### PR TITLE
[FLINK-2814] Fix for DualInputPlanNode cannot be cast to SingleInputPlanNode

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/WorksetIterationNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/WorksetIterationNode.java
@@ -434,7 +434,7 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 		for (PlanNode solutionSetCandidate : solutionSetDeltaCandidates) {
 			for (PlanNode worksetCandidate : worksetCandidates) {
 				// check whether they have the same operator at their latest branching point
-				if (this.singleRoot.areBranchCompatible(solutionSetCandidate, worksetCandidate)) {
+				if (this.singleRoot.areBranchCompatible(solutionSetCandidate, worksetCandidate) && solutionSetCandidate instanceof SingleInputPlanNode) {
 					
 					SingleInputPlanNode siSolutionDeltaCandidate = (SingleInputPlanNode) solutionSetCandidate;
 					boolean immediateDeltaUpdate;


### PR DESCRIPTION
[FLINK-2814] Fix for DeltaIteration: DualInputPlanNode cannot be cast to SingleInputPlanNode
