### PR TITLE
[FLINK-3965] [gelly] Delegating GraphAlgorithm

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1749,7 +1749,7 @@ public abstract class DataSet<T> {
 	// --------------------------------------------------------------------------------------------
 	
 	protected static void checkSameExecutionContext(DataSet<?> set1, DataSet<?> set2) {
-		if (set1.context != set2.context) {
+		if (set1.getExecutionEnvironment() != set2.getExecutionEnvironment()) {
 			throw new IllegalArgumentException("The two inputs have different execution contexts.");
 		}
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/DelegatingGraphAlgorithm.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/DelegatingGraphAlgorithm.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph;
+
+import javassist.util.proxy.MethodFilter;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.flink.api.java.DataSet;
+import org.objenesis.ObjenesisStd;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link GraphAlgorithm} transforms an input {@link Graph} into an output of
+ * type {@code T}. A {@code DelegatingGraphAlgorithm} wraps the algorithm
+ * result with a delegating proxy object. The delegated object can be replaced
+ * when the same algorithm is run on the same input with a mergeable configuration.
+ * This allows algorithms to be composed of implicitly reusable algorithms
+ * without publicly sharing intermediate {@link DataSet}s.
+ *
+ * @param <K> ID type
+ * @param <VV> vertex value type
+ * @param <EV> edge value type
+ * @param <T> output type
+ */
+public abstract class DelegatingGraphAlgorithm<K, VV, EV, T>
+implements GraphAlgorithm<K, VV, EV, T> {
+
+	// each algorithm and input pair may map to multiple configurations
+	private static Map<DelegatingGraphAlgorithm, List<DelegatingGraphAlgorithm>> cache =
+		Collections.synchronizedMap(new HashMap<DelegatingGraphAlgorithm, List<DelegatingGraphAlgorithm>>());
+
+	private Graph<K,VV,EV> input;
+
+	private Delegate<T> delegate;
+
+	/**
+	 * Algorithms are identified by name rather than by class to allow subclassing.
+	 *
+	 * @return name of the algorithm, which may be shared by multiple classes
+	 *		 implementing the same algorithm and generating the same output
+	 */
+	protected abstract String getAlgorithmName();
+
+	/**
+	 * An algorithm must first test whether the configurations can be merged
+	 * before merging individual fields.
+	 *
+	 * @param other the algorithm with which to compare and merge
+	 * @returns true iff configuration has been merged and output can be reused
+	 */
+	protected abstract boolean mergeConfiguration(DelegatingGraphAlgorithm other);
+
+	/**
+	 * The implementation of the algorithm, renamed from {@link GraphAlgorithm#run(Graph)}.
+	 *
+	 * @param input the input graph
+	 * @return the algorithm's output
+	 * @throws Exception
+	 */
+	protected abstract T runInternal(Graph<K, VV, EV> input) throws Exception;
+
+	@Override
+	public final int hashCode() {
+		return new HashCodeBuilder(17, 37)
+			.append(input)
+			.append(getAlgorithmName())
+			.toHashCode();
+	}
+
+	@Override
+	public final boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+
+		if (obj == this) {
+			return true;
+		}
+
+		if (! DelegatingGraphAlgorithm.class.isAssignableFrom(obj.getClass())) {
+			return false;
+		}
+
+		DelegatingGraphAlgorithm rhs = (DelegatingGraphAlgorithm) obj;
+
+		return new EqualsBuilder()
+			.append(input, rhs.input)
+			.append(getAlgorithmName(), rhs.getAlgorithmName())
+			.isEquals();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public final T run(Graph<K, VV, EV> input)
+			throws Exception {
+		this.input = input;
+
+		if (cache.containsKey(this)) {
+			for (DelegatingGraphAlgorithm<K, VV, EV, T> other : cache.get(this)) {
+				if (mergeConfiguration(other)) {
+					// configuration has been merged so generate new output
+					T output = runInternal(input);
+
+					// update delegatee object and reuse delegate
+					other.delegate.setObject(output);
+					delegate = other.delegate;
+
+					return delegate.getProxy();
+				}
+			}
+		}
+
+		// no mergeable configuration found so generate new output
+		T output = runInternal(input);
+
+		// create a new delegate to wrap the algorithm output
+		delegate = new Delegate<T>(output);
+
+		// cache this result
+		if (cache.containsKey(this)) {
+			cache.get(this).add(this);
+		} else {
+			cache.put(this, new ArrayList(Collections.singletonList(this)));
+		}
+
+		return delegate.getProxy();
+	}
+
+	/**
+	 * Wraps an object with a proxy delegate whose method handler invokes all
+	 * method calls on the wrapped object. This object can be later replaced.
+	 *
+	 * @param <X>
+	 */
+	private static class Delegate<X> {
+		private X obj;
+
+		private X proxy = null;
+
+		/**
+		 * Set the initial delegated object.
+		 *
+		 * @param obj delegated object
+		 */
+		public Delegate(X obj) {
+			setObject(obj);
+		}
+
+		/**
+		 * Change the delegated object.
+		 *
+		 * @param obj delegated object
+		 */
+		public void setObject(X obj) {
+			this.obj = obj;
+		}
+
+		/**
+		 * Instantiates and returns a proxy object which subclasses the
+		 * delegated object. The proxy's method handler invokes all methods
+		 * on the delegated object that is set at the time of invocation.
+		 *
+		 * @return delegating proxy
+		 */
+		public X getProxy() {
+			if (proxy != null) {
+				return proxy;
+			}
+
+			ProxyFactory factory = new ProxyFactory();
+			factory.setSuperclass(obj.getClass());
+
+			// create the class and instantiate an instance without calling a constructor
+			Class<? extends X> proxyClass = factory.createClass(new MethodFilter() {
+				@Override
+				public boolean isHandled(Method method) {
+					return true;
+				}
+			});
+			proxy = new ObjenesisStd().newInstance(proxyClass);
+
+			// create and set a handler to invoke all method calls on the delegated object
+			((ProxyObject) proxy).setHandler(new MethodHandler() {
+				@Override
+				public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
+					// method visibility may be restricted
+					thisMethod.setAccessible(true);
+					return thisMethod.invoke(obj, args);
+				}
+			});
+
+			return proxy;
+		}
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPair.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPair.java
@@ -24,10 +24,11 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.JoinEdgeDegreeWithVertexDegree;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingDataSet;
+import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 
@@ -40,7 +41,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class EdgeDegreesPair<K, VV, EV>
-implements GraphAlgorithm<K, VV, EV, DataSet<Edge<K, Tuple3<EV, Degrees, Degrees>>>> {
+extends GraphAlgorithmDelegatingDataSet<K, VV, EV, Edge<K, Tuple3<EV, Degrees, Degrees>>> {
 
 	// Optional configuration
 	private int parallelism = PARALLELISM_DEFAULT;
@@ -58,7 +59,27 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Edge<K, Tuple3<EV, Degrees, Degrees
 	}
 
 	@Override
-	public DataSet<Edge<K, Tuple3<EV, Degrees, Degrees>>> run(Graph<K, VV, EV> input)
+	protected String getAlgorithmName() {
+		return EdgeDegreesPair.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other) {
+		Preconditions.checkNotNull(other);
+
+		if (! EdgeDegreesPair.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		EdgeDegreesPair rhs = (EdgeDegreesPair) other;
+
+		parallelism = Math.min(parallelism, rhs.parallelism);
+
+		return true;
+	}
+
+	@Override
+	public DataSet<Edge<K, Tuple3<EV, Degrees, Degrees>>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// s, t, d(s)
 		DataSet<Edge<K, Tuple2<EV, Degrees>>> edgeSourceDegrees = input

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegrees.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegrees.java
@@ -23,10 +23,11 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.JoinEdgeWithVertexDegree;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingDataSet;
+import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 
@@ -39,7 +40,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class EdgeSourceDegrees<K, VV, EV>
-implements GraphAlgorithm<K, VV, EV, DataSet<Edge<K, Tuple2<EV, Degrees>>>> {
+extends GraphAlgorithmDelegatingDataSet<K, VV, EV, Edge<K, Tuple2<EV, Degrees>>> {
 
 	// Optional configuration
 	private int parallelism = PARALLELISM_DEFAULT;
@@ -57,7 +58,27 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Edge<K, Tuple2<EV, Degrees>>>> {
 	}
 
 	@Override
-	public DataSet<Edge<K, Tuple2<EV, Degrees>>> run(Graph<K, VV, EV> input)
+	protected String getAlgorithmName() {
+		return EdgeSourceDegrees.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other) {
+		Preconditions.checkNotNull(other);
+
+		if (! EdgeSourceDegrees.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		EdgeSourceDegrees rhs = (EdgeSourceDegrees) other;
+
+		parallelism = Math.min(parallelism, rhs.parallelism);
+
+		return true;
+	}
+
+	@Override
+	public DataSet<Edge<K, Tuple2<EV, Degrees>>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// s, d(s)
 		DataSet<Vertex<K, Degrees>> vertexDegrees = input

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
@@ -30,13 +30,15 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.EdgeOrder;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
 import org.apache.flink.graph.utils.Murmur3_32;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingDataSet;
+import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.types.ByteValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 
@@ -48,10 +50,10 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class VertexDegrees<K, VV, EV>
-implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, Degrees>>> {
+extends GraphAlgorithmDelegatingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 
 	// Optional configuration
-	private boolean includeZeroDegreeVertices = false;
+	private OptionalBoolean includeZeroDegreeVertices = new OptionalBoolean(false, true);
 
 	private int parallelism = PARALLELISM_DEFAULT;
 
@@ -65,7 +67,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, Degrees>>> {
 	 * @return this
 	 */
 	public VertexDegrees<K, VV, EV> setIncludeZeroDegreeVertices(boolean includeZeroDegreeVertices) {
-		this.includeZeroDegreeVertices = includeZeroDegreeVertices;
+		this.includeZeroDegreeVertices.set(includeZeroDegreeVertices);
 
 		return this;
 	}
@@ -83,7 +85,36 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, Degrees>>> {
 	}
 
 	@Override
-	public DataSet<Vertex<K, Degrees>> run(Graph<K, VV, EV> input)
+	protected String getAlgorithmName() {
+		return VertexOutDegree.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other) {
+		Preconditions.checkNotNull(other);
+
+		if (! VertexDegrees.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		VertexDegrees rhs = (VertexDegrees) other;
+
+		// verify that configurations can be merged
+
+		if (includeZeroDegreeVertices.conflictsWith(rhs.includeZeroDegreeVertices)) {
+			return false;
+		}
+
+		// merge configurations
+
+		includeZeroDegreeVertices.mergeWith(rhs.includeZeroDegreeVertices);
+		parallelism = Math.min(parallelism, rhs.parallelism);
+
+		return true;
+	}
+
+	@Override
+	public DataSet<Vertex<K, Degrees>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// s, t, bitmask
 		DataSet<Tuple3<K, K, ByteValue>> edgesWithOrder = input.getEdges()
@@ -103,7 +134,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, Degrees>>> {
 				.setParallelism(parallelism)
 				.name("Degree count");
 
-		if (includeZeroDegreeVertices) {
+		if (includeZeroDegreeVertices.get()) {
 			vertexDegrees = input.getVertices()
 				.leftOuterJoin(vertexDegrees)
 				.where(0)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexOutDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexOutDegree.java
@@ -20,11 +20,12 @@ package org.apache.flink.graph.asm.degree.annotate.directed;
 
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.DegreeCount;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.JoinVertexWithVertexDegree;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.MapEdgeToSourceId;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingDataSet;
+import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.Preconditions;
 
@@ -38,10 +39,10 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class VertexOutDegree<K, VV, EV>
-implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
+extends GraphAlgorithmDelegatingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 
 	// Optional configuration
-	private boolean includeZeroDegreeVertices = false;
+	private OptionalBoolean includeZeroDegreeVertices = new OptionalBoolean(false, true);
 
 	private int parallelism = PARALLELISM_DEFAULT;
 
@@ -55,7 +56,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 	 * @return this
 	 */
 	public VertexOutDegree<K, VV, EV> setIncludeZeroDegreeVertices(boolean includeZeroDegreeVertices) {
-		this.includeZeroDegreeVertices = includeZeroDegreeVertices;
+		this.includeZeroDegreeVertices.set(includeZeroDegreeVertices);
 
 		return this;
 	}
@@ -76,7 +77,36 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 	}
 
 	@Override
-	public DataSet<Vertex<K, LongValue>> run(Graph<K, VV, EV> input)
+	protected String getAlgorithmName() {
+		return VertexOutDegree.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other) {
+		Preconditions.checkNotNull(other);
+
+		if (! VertexOutDegree.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		VertexOutDegree rhs = (VertexOutDegree) other;
+
+		// verify that configurations can be merged
+
+		if (includeZeroDegreeVertices.conflictsWith(rhs.includeZeroDegreeVertices)) {
+			return false;
+		}
+
+		// merge configurations
+
+		includeZeroDegreeVertices.mergeWith(rhs.includeZeroDegreeVertices);
+		parallelism = Math.min(parallelism, rhs.parallelism);
+
+		return true;
+	}
+
+	@Override
+	public DataSet<Vertex<K, LongValue>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// s
 		DataSet<Vertex<K, LongValue>> sourceIds = input
@@ -92,7 +122,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 				.setParallelism(parallelism)
 				.name("Degree count");
 
-		if (includeZeroDegreeVertices) {
+		if (includeZeroDegreeVertices.get()) {
 			sourceDegree = input.getVertices()
 				.leftOuterJoin(sourceDegree)
 				.where(0)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
@@ -20,10 +20,11 @@ package org.apache.flink.graph.asm.degree.annotate.undirected;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.graph.DelegatingGraphAlgorithm;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.types.OptionalBoolean;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.DegreeCount;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.JoinVertexWithVertexDegree;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.MapEdgeToSourceId;
@@ -41,12 +42,12 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class VertexDegree<K, VV, EV>
-implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
+extends DelegatingGraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 
 	// Optional configuration
-	private boolean includeZeroDegreeVertices = false;
+	private OptionalBoolean includeZeroDegreeVertices = new OptionalBoolean(false);
 
-	private boolean reduceOnTargetId = false;
+	private OptionalBoolean reduceOnTargetId = new OptionalBoolean(false);
 
 	private int parallelism = PARALLELISM_DEFAULT;
 
@@ -60,7 +61,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 	 * @return this
 	 */
 	public VertexDegree<K, VV, EV> setIncludeZeroDegreeVertices(boolean includeZeroDegreeVertices) {
-		this.includeZeroDegreeVertices = includeZeroDegreeVertices;
+		this.includeZeroDegreeVertices.set(includeZeroDegreeVertices);
 
 		return this;
 	}
@@ -75,7 +76,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 	 * @return this
 	 */
 	public VertexDegree<K, VV, EV> setReduceOnTargetId(boolean reduceOnTargetId) {
-		this.reduceOnTargetId = reduceOnTargetId;
+		this.reduceOnTargetId.set(reduceOnTargetId);
 
 		return this;
 	}
@@ -96,9 +97,39 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 	}
 
 	@Override
-	public DataSet<Vertex<K, LongValue>> run(Graph<K, VV, EV> input)
+	protected String getAlgorithmName() {
+		return VertexDegree.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(DelegatingGraphAlgorithm other) {
+		Preconditions.checkNotNull(other);
+
+		if (! VertexDegree.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		VertexDegree rhs = (VertexDegree) other;
+
+		// verify that configurations can be merged
+
+		if (includeZeroDegreeVertices.isMismatchedWith(rhs.includeZeroDegreeVertices)) {
+			return false;
+		}
+
+		// merge configurations
+
+		includeZeroDegreeVertices.mergeWith(rhs.includeZeroDegreeVertices);
+		reduceOnTargetId.mergeWith(rhs.reduceOnTargetId);
+		parallelism = Math.min(parallelism, rhs.parallelism);
+
+		return true;
+	}
+
+	@Override
+	public DataSet<Vertex<K, LongValue>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
-		MapFunction<Edge<K, EV>, Vertex<K, LongValue>> mapEdgeToId = reduceOnTargetId ?
+		MapFunction<Edge<K, EV>, Vertex<K, LongValue>> mapEdgeToId = reduceOnTargetId.get() ?
 			new MapEdgeToTargetId<K, EV>() : new MapEdgeToSourceId<K, EV>();
 
 		// v
@@ -115,8 +146,9 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 				.setParallelism(parallelism)
 				.name("Degree count");
 
-		if (includeZeroDegreeVertices) {
-			degree = input.getVertices()
+		if (includeZeroDegreeVertices.get()) {
+			degree = input
+				.getVertices()
 				.leftOuterJoin(degree)
 				.where(0)
 				.equalTo(0)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
@@ -42,12 +42,12 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class VertexDegree<K, VV, EV>
-extends DelegatingGraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
+extends DelegatingGraphAlgorithm<K, VV, EV, Vertex<K, LongValue>> {
 
 	// Optional configuration
-	private OptionalBoolean includeZeroDegreeVertices = new OptionalBoolean(false);
+	private OptionalBoolean includeZeroDegreeVertices = new OptionalBoolean(false, true);
 
-	private OptionalBoolean reduceOnTargetId = new OptionalBoolean(false);
+	private OptionalBoolean reduceOnTargetId = new OptionalBoolean(false, false);
 
 	private int parallelism = PARALLELISM_DEFAULT;
 
@@ -113,7 +113,7 @@ extends DelegatingGraphAlgorithm<K, VV, EV, DataSet<Vertex<K, LongValue>>> {
 
 		// verify that configurations can be merged
 
-		if (includeZeroDegreeVertices.isMismatchedWith(rhs.includeZeroDegreeVertices)) {
+		if (includeZeroDegreeVertices.conflictsWith(rhs.includeZeroDegreeVertices)) {
 			return false;
 		}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
@@ -20,11 +20,11 @@ package org.apache.flink.graph.asm.degree.annotate.undirected;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.graph.DelegatingGraphAlgorithm;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingDataSet;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
-import org.apache.flink.graph.types.OptionalBoolean;
+import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.DegreeCount;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.JoinVertexWithVertexDegree;
 import org.apache.flink.graph.asm.degree.annotate.DegreeAnnotationFunctions.MapEdgeToSourceId;
@@ -42,7 +42,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class VertexDegree<K, VV, EV>
-extends DelegatingGraphAlgorithm<K, VV, EV, Vertex<K, LongValue>> {
+extends GraphAlgorithmDelegatingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 
 	// Optional configuration
 	private OptionalBoolean includeZeroDegreeVertices = new OptionalBoolean(false, true);
@@ -102,7 +102,7 @@ extends DelegatingGraphAlgorithm<K, VV, EV, Vertex<K, LongValue>> {
 	}
 
 	@Override
-	protected boolean mergeConfiguration(DelegatingGraphAlgorithm other) {
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other) {
 		Preconditions.checkNotNull(other);
 
 		if (! VertexDegree.class.isAssignableFrom(other.getClass())) {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateGraphIds.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateGraphIds.java
@@ -87,14 +87,22 @@ extends GraphAlgorithmDelegatingGraph<OLD, VV, EV, NEW, VV, EV> {
 
 		TranslateGraphIds rhs = (TranslateGraphIds) other;
 
+		// verify that configurations can be merged
+
+		if (translator != rhs.translator) {
+			return false;
+		}
+
+		// merge configurations
+
 		parallelism = Math.min(parallelism, rhs.parallelism);
 
 		return true;
 	}
 
-
 	@Override
-	public Graph<NEW, VV, EV> runInternal(Graph<OLD, VV, EV> input) throws Exception {
+	public Graph<NEW, VV, EV> runInternal(Graph<OLD, VV, EV> input)
+			throws Exception {
 		// Vertices
 		DataSet<Vertex<NEW, VV>> translatedVertices = translateVertexIds(input.getVertices(), translator, parallelism);
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateGraphIds.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateGraphIds.java
@@ -21,8 +21,8 @@ package org.apache.flink.graph.asm.translate;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingGraph;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
@@ -38,7 +38,7 @@ import static org.apache.flink.graph.asm.translate.Translate.translateVertexIds;
  * @param <EV> edge value type
  */
 public class TranslateGraphIds<OLD, NEW, VV, EV>
-implements GraphAlgorithm<OLD, VV, EV, Graph<NEW, VV, EV>> {
+extends GraphAlgorithmDelegatingGraph<OLD, VV, EV, NEW, VV, EV> {
 
 	// Required configuration
 	private TranslateFunction<OLD,NEW> translator;
@@ -73,7 +73,28 @@ implements GraphAlgorithm<OLD, VV, EV, Graph<NEW, VV, EV>> {
 	}
 
 	@Override
-	public Graph<NEW, VV, EV> run(Graph<OLD, VV, EV> input) throws Exception {
+	protected String getAlgorithmName() {
+		return TranslateGraphIds.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingGraph other) {
+		Preconditions.checkNotNull(other);
+
+		if (! TranslateGraphIds.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		TranslateGraphIds rhs = (TranslateGraphIds) other;
+
+		parallelism = Math.min(parallelism, rhs.parallelism);
+
+		return true;
+	}
+
+
+	@Override
+	public Graph<NEW, VV, EV> runInternal(Graph<OLD, VV, EV> input) throws Exception {
 		// Vertices
 		DataSet<Vertex<NEW, VV>> translatedVertices = translateVertexIds(input.getVertices(), translator, parallelism);
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
@@ -25,12 +25,12 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
 import org.apache.flink.graph.library.clustering.directed.LocalClusteringCoefficient.Result;
 import org.apache.flink.graph.utils.Murmur3_32;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingDataSet;
 import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.Collector;
@@ -55,7 +55,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class LocalClusteringCoefficient<K extends Comparable<K> & CopyableValue<K>, VV, EV>
-implements GraphAlgorithm<K, VV, EV, DataSet<Result<K>>> {
+extends GraphAlgorithmDelegatingDataSet<K, VV, EV, Result<K>> {
 
 	// Optional configuration
 	private int littleParallelism = PARALLELISM_DEFAULT;
@@ -74,6 +74,25 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Result<K>>> {
 
 		return this;
 	}
+	@Override
+	protected String getAlgorithmName() {
+		return LocalClusteringCoefficient.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other) {
+		Preconditions.checkNotNull(other);
+
+		if (! LocalClusteringCoefficient.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		LocalClusteringCoefficient rhs = (LocalClusteringCoefficient) other;
+
+		littleParallelism = Math.min(littleParallelism, rhs.littleParallelism);
+
+		return true;
+	}
 
 	/*
 	 * Implementation notes:
@@ -86,12 +105,11 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Result<K>>> {
 	 */
 
 	@Override
-	public DataSet<Result<K>> run(Graph<K, VV, EV> input)
+	public DataSet<Result<K>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// u, v, w, bitmask
 		DataSet<TriangleListing.Result<K>> triangles = input
 			.run(new TriangleListing<K,VV,EV>()
-				.setSortTriangleVertices(false)
 				.setLittleParallelism(littleParallelism));
 
 		// u, edge count

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/JaccardIndex.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/JaccardIndex.java
@@ -28,10 +28,10 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.asm.degree.annotate.undirected.EdgeTargetDegree;
 import org.apache.flink.graph.library.similarity.JaccardIndex.Result;
 import org.apache.flink.graph.utils.Murmur3_32;
+import org.apache.flink.graph.utils.proxy.GraphAlgorithmDelegatingDataSet;
 import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
@@ -61,7 +61,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class JaccardIndex<K extends CopyableValue<K>, VV, EV>
-implements GraphAlgorithm<K, VV, EV, DataSet<Result<K>>> {
+extends GraphAlgorithmDelegatingDataSet<K, VV, EV, Result<K>> {
 
 	public static final int DEFAULT_GROUP_SIZE = 64;
 
@@ -153,6 +153,39 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Result<K>>> {
 		return this;
 	}
 
+	@Override
+	protected String getAlgorithmName() {
+		return JaccardIndex.class.getName();
+	}
+
+	@Override
+	protected boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other) {
+		Preconditions.checkNotNull(other);
+
+		if (! JaccardIndex.class.isAssignableFrom(other.getClass())) {
+			return false;
+		}
+
+		JaccardIndex rhs = (JaccardIndex) other;
+
+		// verify that configurations can be merged
+
+		if (unboundedScores != rhs.unboundedScores ||
+			minimumScoreNumerator != rhs.minimumScoreNumerator ||
+			minimumScoreDenominator != rhs.minimumScoreDenominator ||
+			maximumScoreNumerator != rhs.maximumScoreNumerator ||
+			maximumScoreDenominator != rhs.maximumScoreDenominator) {
+			return false;
+		}
+
+		// merge configurations
+
+		groupSize = Math.max(groupSize, rhs.groupSize);
+		littleParallelism = Math.min(littleParallelism, rhs.littleParallelism);
+
+		return true;
+	}
+
 	/*
 	 * Implementation notes:
 	 *
@@ -162,7 +195,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<Result<K>>> {
 	 */
 
 	@Override
-	public DataSet<Result<K>> run(Graph<K, VV, EV> input)
+	public DataSet<Result<K>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// s, t, d(t)
 		DataSet<Edge<K, Tuple2<EV, LongValue>>> neighborDegree = input

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/OptionalBoolean.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/OptionalBoolean.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.types;
+
+/**
+ * A boolean value with a third, "unset" state.
+ */
+public class OptionalBoolean {
+
+	private final boolean defaultValue;
+
+	private Boolean value = null;
+
+	/**
+	 * An {@code OptionalBoolean} has three possible states: true, false, and
+	 * "unset". The value is set when merged with a value of true or false. The
+	 * state returns to unset either explicitly or when true is merged with false.
+	 *
+	 * @param defaultValue the value to return when the object's state is unset
+	 */
+	public OptionalBoolean(boolean defaultValue) {
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * Get the boolean state.
+	 *
+	 * @return boolean state
+	 */
+	public boolean get() {
+		return (value == null) ? defaultValue : value;
+	}
+
+	/**
+	 * Set the boolean state.
+	 *
+	 * @param value boolean state
+	 */
+	public void set(boolean value) {
+		this.value = value;
+	}
+
+	/**
+	 * Reset to the unset state.
+	 */
+	public void unset() {
+		this.value = null;
+	}
+
+	/**
+	 * The mismatched states are true with false and false with true.
+	 *
+	 * @param other object to test for mismatch
+	 * @return whether the objects are mismatched
+	 */
+	public boolean isMismatchedWith(OptionalBoolean other) {
+		return (value != null && other.value != null && !value.equals(other.value));
+	}
+
+	/**
+	 * State transitions:
+	 *  if the states are the same then keep the same state
+	 *  if the states are mismatched then change to the unset state
+	 *  if in an unset state then change to the other state
+	 *
+	 * @param other object from which to merge state
+	 */
+	public void mergeWith(OptionalBoolean other) {
+		if ((value == null && other.value == null) || isMismatchedWith(other)) {
+			value = null;
+		} else {
+			value = (value == null) ? other.value : value;
+		}
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/Delegate.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/Delegate.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.utils.proxy;
+
+import javassist.util.proxy.MethodFilter;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import org.objenesis.ObjenesisStd;
+
+import java.lang.reflect.Method;
+
+/**
+ * Wraps an object with a proxy delegate whose method handler invokes all
+ * method calls on the wrapped object. This object can be later replaced.
+ *
+ * @param <X>
+ */
+public class Delegate<X> {
+	private X obj;
+
+	private X proxy = null;
+
+	/**
+	 * Set the initial delegated object.
+	 *
+	 * @param obj delegated object
+	 */
+	public Delegate(X obj) {
+		setObject(obj);
+	}
+
+	/**
+	 * Change the delegated object.
+	 *
+	 * @param obj delegated object
+	 */
+	public void setObject(X obj) {
+		this.obj = obj;
+	}
+
+	/**
+	 * Instantiates and returns a proxy object which subclasses the
+	 * delegated object. The proxy's method handler invokes all methods
+	 * on the delegated object that is set at the time of invocation.
+	 *
+	 * @return delegating proxy
+	 */
+	@SuppressWarnings("unchecked")
+	public X getProxy() {
+		if (proxy != null) {
+			return proxy;
+		}
+
+		ProxyFactory factory = new ProxyFactory();
+		factory.setSuperclass(obj.getClass());
+
+		// create the class and instantiate an instance without calling a constructor
+		Class<? extends X> proxyClass = factory.createClass(new MethodFilter() {
+			@Override
+			public boolean isHandled(Method method) {
+				return true;
+			}
+		});
+		proxy = new ObjenesisStd().newInstance(proxyClass);
+
+		// create and set a handler to invoke all method calls on the delegated object
+		((ProxyObject) proxy).setHandler(new MethodHandler() {
+			@Override
+			public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
+				// method visibility may be restricted
+				thisMethod.setAccessible(true);
+				return thisMethod.invoke(obj, args);
+			}
+		});
+
+		return proxy;
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/GraphAlgorithmDelegatingDataSet.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/GraphAlgorithmDelegatingDataSet.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *	 http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.graph;
+package org.apache.flink.graph.utils.proxy;
 
-import javassist.util.proxy.MethodFilter;
-import javassist.util.proxy.MethodHandler;
-import javassist.util.proxy.ProxyFactory;
-import javassist.util.proxy.ProxyObject;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.flink.api.java.DataSet;
-import org.objenesis.ObjenesisStd;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.GraphAlgorithm;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,7 +32,7 @@ import java.util.Map;
 
 /**
  * A {@link GraphAlgorithm} transforms an input {@link Graph} into an output of
- * type {@code T}. A {@code DelegatingGraphAlgorithm} wraps the resultant
+ * type {@code T}. A {@code GraphAlgorithmDelegatingDataSet} wraps the resultant
  * {@link DataSet} with a delegating proxy object. The delegated object can be
  * replaced when the same algorithm is run on the same input with a mergeable
  * configuration. This allows algorithms to be composed of implicitly reusable
@@ -47,12 +43,12 @@ import java.util.Map;
  * @param <EV> edge value type
  * @param <T> output type
  */
-public abstract class DelegatingGraphAlgorithm<K, VV, EV, T>
+public abstract class GraphAlgorithmDelegatingDataSet<K, VV, EV, T>
 implements GraphAlgorithm<K, VV, EV, DataSet<T>> {
 
 	// each algorithm and input pair may map to multiple configurations
-	private static Map<DelegatingGraphAlgorithm, List<DelegatingGraphAlgorithm>> cache =
-		Collections.synchronizedMap(new HashMap<DelegatingGraphAlgorithm, List<DelegatingGraphAlgorithm>>());
+	private static Map<GraphAlgorithmDelegatingDataSet, List<GraphAlgorithmDelegatingDataSet>> cache =
+		Collections.synchronizedMap(new HashMap<GraphAlgorithmDelegatingDataSet, List<GraphAlgorithmDelegatingDataSet>>());
 
 	private Graph<K,VV,EV> input;
 
@@ -71,10 +67,10 @@ implements GraphAlgorithm<K, VV, EV, DataSet<T>> {
 	 * before merging individual fields.
 	 *
 	 * @param other the algorithm with which to compare and merge
-	 * @returns true if and only if configuration has been merged and the
+	 * @return true if and only if configuration has been merged and the
 	 *          algorithm's output can be reused
 	 */
-	protected abstract boolean mergeConfiguration(DelegatingGraphAlgorithm other);
+	protected abstract boolean mergeConfiguration(GraphAlgorithmDelegatingDataSet other);
 
 	/**
 	 * The implementation of the algorithm, renamed from {@link GraphAlgorithm#run(Graph)}.
@@ -103,11 +99,11 @@ implements GraphAlgorithm<K, VV, EV, DataSet<T>> {
 			return true;
 		}
 
-		if (! DelegatingGraphAlgorithm.class.isAssignableFrom(obj.getClass())) {
+		if (! GraphAlgorithmDelegatingDataSet.class.isAssignableFrom(obj.getClass())) {
 			return false;
 		}
 
-		DelegatingGraphAlgorithm rhs = (DelegatingGraphAlgorithm) obj;
+		GraphAlgorithmDelegatingDataSet rhs = (GraphAlgorithmDelegatingDataSet) obj;
 
 		return new EqualsBuilder()
 			.append(input, rhs.input)
@@ -122,7 +118,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<T>> {
 		this.input = input;
 
 		if (cache.containsKey(this)) {
-			for (DelegatingGraphAlgorithm<K, VV, EV, T> other : cache.get(this)) {
+			for (GraphAlgorithmDelegatingDataSet<K, VV, EV, T> other : cache.get(this)) {
 				if (mergeConfiguration(other)) {
 					// configuration has been merged so generate new output
 					DataSet<T> output = runInternal(input);
@@ -140,7 +136,7 @@ implements GraphAlgorithm<K, VV, EV, DataSet<T>> {
 		DataSet<T> output = runInternal(input);
 
 		// create a new delegate to wrap the algorithm output
-		delegate = new Delegate<DataSet<T>>(output);
+		delegate = new Delegate<>(output);
 
 		// cache this result
 		if (cache.containsKey(this)) {
@@ -150,72 +146,5 @@ implements GraphAlgorithm<K, VV, EV, DataSet<T>> {
 		}
 
 		return delegate.getProxy();
-	}
-
-	/**
-	 * Wraps an object with a proxy delegate whose method handler invokes all
-	 * method calls on the wrapped object. This object can be later replaced.
-	 *
-	 * @param <X>
-	 */
-	private static class Delegate<X> {
-		private X obj;
-
-		private X proxy = null;
-
-		/**
-		 * Set the initial delegated object.
-		 *
-		 * @param obj delegated object
-		 */
-		public Delegate(X obj) {
-			setObject(obj);
-		}
-
-		/**
-		 * Change the delegated object.
-		 *
-		 * @param obj delegated object
-		 */
-		public void setObject(X obj) {
-			this.obj = obj;
-		}
-
-		/**
-		 * Instantiates and returns a proxy object which subclasses the
-		 * delegated object. The proxy's method handler invokes all methods
-		 * on the delegated object that is set at the time of invocation.
-		 *
-		 * @return delegating proxy
-		 */
-		public X getProxy() {
-			if (proxy != null) {
-				return proxy;
-			}
-
-			ProxyFactory factory = new ProxyFactory();
-			factory.setSuperclass(obj.getClass());
-
-			// create the class and instantiate an instance without calling a constructor
-			Class<? extends X> proxyClass = factory.createClass(new MethodFilter() {
-				@Override
-				public boolean isHandled(Method method) {
-					return true;
-				}
-			});
-			proxy = new ObjenesisStd().newInstance(proxyClass);
-
-			// create and set a handler to invoke all method calls on the delegated object
-			((ProxyObject) proxy).setHandler(new MethodHandler() {
-				@Override
-				public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
-					// method visibility may be restricted
-					thisMethod.setAccessible(true);
-					return thisMethod.invoke(obj, args);
-				}
-			});
-
-			return proxy;
-		}
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/GraphAlgorithmDelegatingGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/GraphAlgorithmDelegatingGraph.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.utils.proxy;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.GraphAlgorithm;
+import org.apache.flink.graph.Vertex;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link GraphAlgorithm} transforms an input {@link Graph} into an output of
+ * type {@code T}. A {@code GraphAlgorithmDelegatingGraph} wraps the resultant
+ * {@link Graph} with a delegating proxy object. The delegated object can be
+ * replaced when the same algorithm is run on the same input with a mergeable
+ * configuration. This allows algorithms to be composed of implicitly reusable
+ * algorithms without publicly sharing intermediate {@link DataSet}s.
+ *
+ * @param <IN_K> input ID type
+ * @param <IN_VV> input vertex value type
+ * @param <IN_EV> input edge value type
+ * @param <OUT_K> output ID type
+ * @param <OUT_VV> output vertex value type
+ * @param <OUT_EV> output edge value type
+ */
+public abstract class GraphAlgorithmDelegatingGraph<IN_K, IN_VV, IN_EV, OUT_K, OUT_VV, OUT_EV>
+implements GraphAlgorithm<IN_K, IN_VV, IN_EV, Graph<OUT_K, OUT_VV, OUT_EV>> {
+
+	// each algorithm and input pair may map to multiple configurations
+	private static Map<GraphAlgorithmDelegatingGraph, List<GraphAlgorithmDelegatingGraph>> cache =
+		Collections.synchronizedMap(new HashMap<GraphAlgorithmDelegatingGraph, List<GraphAlgorithmDelegatingGraph>>());
+
+	private Graph<IN_K, IN_VV, IN_EV> input;
+
+	private Delegate<DataSet<Vertex<OUT_K, OUT_VV>>> verticesDelegate;
+
+	private Delegate<DataSet<Edge<OUT_K, OUT_EV>>> edgesDelegate;
+
+	/**
+	 * Algorithms are identified by name rather than by class to allow subclassing.
+	 *
+	 * @return name of the algorithm, which may be shared by multiple classes
+	 *		 implementing the same algorithm and generating the same output
+	 */
+	protected abstract String getAlgorithmName();
+
+	/**
+	 * An algorithm must first test whether the configurations can be merged
+	 * before merging individual fields.
+	 *
+	 * @param other the algorithm with which to compare and merge
+	 * @return true if and only if configuration has been merged and the
+	 *          algorithm's output can be reused
+	 */
+	protected abstract boolean mergeConfiguration(GraphAlgorithmDelegatingGraph other);
+
+	/**
+	 * The implementation of the algorithm, renamed from {@link GraphAlgorithm#run(Graph)}.
+	 *
+	 * @param input the input graph
+	 * @return the algorithm's output
+	 * @throws Exception
+	 */
+	protected abstract Graph<OUT_K, OUT_VV, OUT_EV> runInternal(Graph<IN_K, IN_VV, IN_EV> input) throws Exception;
+
+	@Override
+	public final int hashCode() {
+		return new HashCodeBuilder(17, 37)
+			.append(input)
+			.append(getAlgorithmName())
+			.toHashCode();
+	}
+
+	@Override
+	public final boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+
+		if (obj == this) {
+			return true;
+		}
+
+		if (! GraphAlgorithmDelegatingGraph.class.isAssignableFrom(obj.getClass())) {
+			return false;
+		}
+
+		GraphAlgorithmDelegatingGraph rhs = (GraphAlgorithmDelegatingGraph) obj;
+
+		return new EqualsBuilder()
+			.append(input, rhs.input)
+			.append(getAlgorithmName(), rhs.getAlgorithmName())
+			.isEquals();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public final Graph<OUT_K, OUT_VV, OUT_EV> run(Graph<IN_K, IN_VV, IN_EV> input)
+			throws Exception {
+		this.input = input;
+
+		if (cache.containsKey(this)) {
+			for (GraphAlgorithmDelegatingGraph<IN_K, IN_VV, IN_EV, OUT_K, OUT_VV, OUT_EV> other : cache.get(this)) {
+				if (mergeConfiguration(other)) {
+					// configuration has been merged so generate new output
+					Graph<OUT_K, OUT_VV, OUT_EV> output = runInternal(input);
+
+					// update delegatee object and reuse delegate
+					other.verticesDelegate.setObject(output.getVertices());
+					verticesDelegate = other.verticesDelegate;
+
+					other.edgesDelegate.setObject(output.getEdges());
+					edgesDelegate = other.edgesDelegate;
+
+					return Graph.fromDataSet(verticesDelegate.getProxy(), edgesDelegate.getProxy(), output.getContext());
+				}
+			}
+		}
+
+		// no mergeable configuration found so generate new output
+		Graph<OUT_K, OUT_VV, OUT_EV> output = runInternal(input);
+
+		// create a new delegate to wrap the algorithm output
+		verticesDelegate = new Delegate<>(output.getVertices());
+		edgesDelegate = new Delegate<>(output.getEdges());
+
+		// cache this result
+		if (cache.containsKey(this)) {
+			cache.get(this).add(this);
+		} else {
+			cache.put(this, new ArrayList(Collections.singletonList(this)));
+		}
+
+		return Graph.fromDataSet(verticesDelegate.getProxy(), edgesDelegate.getProxy(), output.getContext());
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/OptionalBoolean.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/proxy/OptionalBoolean.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.graph.types;
+package org.apache.flink.graph.utils.proxy;
 
 import org.apache.flink.graph.GraphAlgorithm;
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegreeTest.java
@@ -52,7 +52,7 @@ extends AsmTestBase {
 
 		DataSet<Vertex<IntValue, LongValue>> targetDegrees = undirectedSimpleGraph
 			.run(new VertexDegree<IntValue, NullValue, NullValue>()
-			.setReduceOnTargetId(true));
+				.setReduceOnTargetId(true));
 
 		TestBaseUtils.compareResultAsText(targetDegrees.collect(), expectedResult);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/OptionalBooleanTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/OptionalBooleanTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.types;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OptionalBooleanTest {
+
+	@Test
+	public void testIsMismatchedWith()
+			throws Exception {
+		OptionalBoolean u = new OptionalBoolean(true);
+		OptionalBoolean t = new OptionalBoolean(true);
+		OptionalBoolean f = new OptionalBoolean(true);
+
+		t.set(true);
+		f.set(false);
+
+		// true, true
+		assertFalse(t.isMismatchedWith(t));
+
+		// true, false
+		assertTrue(t.isMismatchedWith(f));
+
+		// true, unknown
+		assertFalse(t.isMismatchedWith(u));
+
+		// false, true
+		assertTrue(f.isMismatchedWith(t));
+
+		// false, false
+		assertFalse(f.isMismatchedWith(f));
+
+		// false, unknown
+		assertFalse(f.isMismatchedWith(u));
+
+		// unknown, true
+		assertFalse(u.isMismatchedWith(t));
+
+		// unknown, false
+		assertFalse(u.isMismatchedWith(f));
+
+		// unknown, unknown
+		assertFalse(u.isMismatchedWith(u));
+	}
+
+	@Test
+	public void testMergeWith()
+			throws Exception {
+		OptionalBoolean u_t = new OptionalBoolean(true);
+		OptionalBoolean u_f = new OptionalBoolean(false);
+		OptionalBoolean t_t = new OptionalBoolean(true);
+		OptionalBoolean t_f = new OptionalBoolean(false);
+		OptionalBoolean f_t = new OptionalBoolean(true);
+		OptionalBoolean f_f = new OptionalBoolean(false);
+
+		t_t.set(true);
+		t_f.set(true);
+		f_t.set(false);
+		f_f.set(false);
+
+		// true, true => true
+		t_t.mergeWith(t_t);
+		assertTrue(t_t.get());
+
+		// true, false => default false
+		t_f.mergeWith(f_f);
+		assertFalse(t_f.get());
+		t_f.set(true);
+
+		// true, false => default true
+		t_t.mergeWith(f_f);
+		assertTrue(t_t.get());
+		t_t.set(true);
+
+		// true, unknown => true
+		t_t.mergeWith(u_f);
+		assertTrue(t_t.get());
+
+		// false, true => default false
+		f_f.mergeWith(t_t);
+		assertFalse(f_f.get());
+		f_f.set(false);
+
+		// false, true => default true
+		f_t.mergeWith(t_t);
+		assertTrue(f_t.get());
+		f_t.set(false);
+
+		// false, false => false
+		f_f.mergeWith(f_f);
+		assertFalse(f_f.get());
+
+		// false, unknown => false
+		f_f.mergeWith(u_t);
+		assertFalse(f_f.get());
+
+		// unknown, true => true
+		u_t.mergeWith(t_f);
+		assertTrue(u_t.get());
+		u_t.unset();
+
+		// unknown, false => false
+		u_f.mergeWith(f_t);
+		assertFalse(u_f.get());
+		u_f.unset();
+
+		// unknown, unknown => default true
+		u_t.mergeWith(u_f);
+		assertTrue(u_t.get());
+		u_t.unset();
+
+		// unknown, unknown => default false
+		u_f.mergeWith(u_t);
+		assertFalse(u_f.get());
+		u_f.unset();
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/utils/proxy/OptionalBooleanTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/utils/proxy/OptionalBooleanTest.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.graph.types;
+package org.apache.flink.graph.utils.proxy;
 
-import org.apache.flink.graph.types.OptionalBoolean.State;
+import org.apache.flink.graph.utils.proxy.OptionalBoolean.State;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
A DelegatingGraphAlgorithm wraps a GraphAlgorithm result with a delegating proxy object. The delegated object can be replaced when the same algorithm is run on the same input with a mergeable configuration. This allows algorithms to be composed of implicitly reusable algorithms without publicly sharing intermediate DataSets.