### PR TITLE
[FLINK-3972] subclasses of ResourceID may not to be serializable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceID.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 /**
  * Class for Resource Ids assigned at the FlinkResourceManager.
  */
-public class ResourceID implements Serializable {
+public final class ResourceID implements ResourceIDRetrievable, Serializable {
 
 	private static final long serialVersionUID = 42L;
 
@@ -47,9 +47,13 @@ public class ResourceID implements Serializable {
 
 	@Override
 	public final boolean equals(Object o) {
-		return this == o ||
-				(o != null && o.getClass() == ResourceID.class && 
-					this.resourceId.equals(((ResourceID) o).resourceId));
+		if (this == o) {
+			return true;
+		} else if (o == null || o.getClass() != getClass()) {
+			return false;
+		} else {
+			return resourceId.equals(((ResourceID) o).resourceId);
+		}
 	}
 
 	@Override
@@ -59,12 +63,19 @@ public class ResourceID implements Serializable {
 
 	@Override
 	public String toString() {
-		return "ResourceID (" + resourceId + ')';
+		return "ResourceID{" +
+			"resourceId='" + resourceId + '\'' +
+			'}';
 	}
 
-	// ------------------------------------------------------------------------
-	//  factory
-	// ------------------------------------------------------------------------
+	/**
+	 * A ResourceID can always retrieve a ResourceID.
+	 * @return This instance.
+	 */
+	@Override
+	public ResourceID getResourceID() {
+		return this;
+	}
 	
 	/**
 	 * Generate a random resource id.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceIDRetrievable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceIDRetrievable.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.clusterframework.types;
+
+/**
+ * An interface to retrieve the ResourceID of an object.
+ */
+public interface ResourceIDRetrievable {
+
+	ResourceID getResourceID();
+
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/RegisteredYarnWorkerNode.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/RegisteredYarnWorkerNode.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.hadoop.yarn.api.records.Container;
 
 import static java.util.Objects.requireNonNull;
@@ -27,14 +28,18 @@ import static java.util.Objects.requireNonNull;
 /**
  * A representation of a registered Yarn container managed by the {@link YarnFlinkResourceManager}.
  */
-public class RegisteredYarnWorkerNode extends ResourceID {
+public class RegisteredYarnWorkerNode implements ResourceIDRetrievable {
+
 
 	/** The container on which the worker runs */
 	private final Container yarnContainer;
 
+	/** The resource id associated with this worker type */
+	private final ResourceID resourceID;
+
 	public RegisteredYarnWorkerNode(Container yarnContainer) {
-		super(yarnContainer.getId().toString());
 		this.yarnContainer = requireNonNull(yarnContainer);
+		this.resourceID = YarnFlinkResourceManager.extractResourceID(yarnContainer);
 	}
 
 	public Container yarnContainer() {
@@ -48,5 +53,10 @@ public class RegisteredYarnWorkerNode extends ResourceID {
 		return "RegisteredYarnWorkerNode{" +
 			"yarnContainer=" + yarnContainer +
 			'}';
+	}
+
+	@Override
+	public ResourceID getResourceID() {
+		return resourceID;
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnContainerInLaunch.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnContainerInLaunch.java
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.hadoop.yarn.api.records.Container;
 
 import static java.util.Objects.requireNonNull;
@@ -27,20 +28,23 @@ import static java.util.Objects.requireNonNull;
  * This class describes a container in which a TaskManager is being launched (or
  * has been launched) but where the TaskManager has not properly registered, yet.
  */
-public class YarnContainerInLaunch extends ResourceID {
+public class YarnContainerInLaunch implements ResourceIDRetrievable {
 
 	private final Container container;
 
 	private final long timestamp;
+
+	/** The resource id associated with this worker type */
+	private final ResourceID resourceID;
 
 	public YarnContainerInLaunch(Container container) {
 		this(container, System.currentTimeMillis());
 	}
 
 	public YarnContainerInLaunch(Container container, long timestamp) {
-		super(container.getId().toString());
 		this.container = requireNonNull(container);
 		this.timestamp = timestamp;
+		this.resourceID = YarnFlinkResourceManager.extractResourceID(container);
 	}
 
 	// ------------------------------------------------------------------------
@@ -58,5 +62,10 @@ public class YarnContainerInLaunch extends ResourceID {
 	@Override
 	public String toString() {
 		return "ContainerInLaunch @ " + timestamp + ": " + container;
+	}
+
+	@Override
+	public ResourceID getResourceID() {
+		return resourceID;
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkResourceManager.java
@@ -215,7 +215,7 @@ public class YarnFlinkResourceManager extends FlinkResourceManager<RegisteredYar
 			final long now = System.currentTimeMillis();
 			for (Container c : containersFromPreviousAttempts) {
 				YarnContainerInLaunch containerInLaunch = new YarnContainerInLaunch(c, now);
-				containersInLaunch.put(containerInLaunch, containerInLaunch);
+				containersInLaunch.put(containerInLaunch.getResourceID(), containerInLaunch);
 			}
 
 			// adjust the progress indicator
@@ -388,7 +388,8 @@ public class YarnFlinkResourceManager extends FlinkResourceManager<RegisteredYar
 			if (numRegistered + containersInLaunch.size() < numRequired) {
 				// start a TaskManager
 				final YarnContainerInLaunch containerInLaunch = new YarnContainerInLaunch(container);
-				containersInLaunch.put(containerInLaunch, containerInLaunch);
+				final ResourceID resourceID = containerInLaunch.getResourceID();
+				containersInLaunch.put(resourceID, containerInLaunch);
 
 				String message = "Launching TaskManager in container " + containerInLaunch
 					+ " on host " + container.getNodeId().getHost();
@@ -398,12 +399,12 @@ public class YarnFlinkResourceManager extends FlinkResourceManager<RegisteredYar
 				try {
 					// set a special environment variable to uniquely identify this container
 					taskManagerLaunchContext.getEnvironment()
-						.put(ENV_FLINK_CONTAINER_ID, containerInLaunch.getResourceIdString());
+						.put(ENV_FLINK_CONTAINER_ID, resourceID.getResourceIdString());
 					nodeManagerClient.startContainer(container, taskManagerLaunchContext);
 				}
 				catch (Throwable t) {
 					// failed to launch the container
-					containersInLaunch.remove(containerInLaunch);
+					containersInLaunch.remove(resourceID);
 
 					// return container, a new one will be requested eventually
 					LOG.error("Could not start TaskManager in container " + containerInLaunch, t);
@@ -515,6 +516,15 @@ public class YarnFlinkResourceManager extends FlinkResourceManager<RegisteredYar
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
+
+	/**
+	 * Extracts a unique ResourceID from the Yarn Container.
+	 * @param container The Yarn container
+	 * @return The ResourceID for the container
+	 */
+	static ResourceID extractResourceID(Container container) {
+		return new ResourceID(container.getId().toString());
+	}
 
 	private void updateProgress() {
 		final int required = getDesignatedWorkerPoolSize();


### PR DESCRIPTION
WorkerTypes are currently subclasses of ResourceID. ResourceID implements Serializable but not necessarily its subclasses. This may lead to problems when these subclasses are used as ResourceIDs, i.e. serialization may fail with NotSerializableExceptions. Currently, subclasses are never send over the wire but they might be in the future.

Instead of relying on subclasses of ResourceID for the WorkerTypes, we can let them implement an interface to retrieve the ResourceID of a WorkerType.