### PR TITLE
[FLINK-3129] Add tooling to ensure interface stability

### DIFF
--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -34,4 +34,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -112,6 +112,26 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Exclude removed CONFIG_KEY from ccheck -->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<parameter>
+						<excludes combine.children="append">
+							<exclude>org.apache.flink.api.common.ExecutionConfig#CONFIG_KEY</exclude>
+						</excludes>
+					</parameter>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -82,6 +82,10 @@ public class ExecutionConfig implements Serializable {
 
 	private static final long DEFAULT_RESTART_DELAY = 10000L;
 
+	// This field was used as a key for storing the EC in the Job Configuration
+	@Deprecated
+	public static final String CONFIG_KEY = "runtime.config";
+
 	// --------------------------------------------------------------------------------------------
 
 	/** Defines how data exchange happens - batch or pipelined */

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -82,10 +82,6 @@ public class ExecutionConfig implements Serializable {
 
 	private static final long DEFAULT_RESTART_DELAY = 10000L;
 
-	// This field was used as a key for storing the EC in the Job Configuration
-	@Deprecated
-	public static final String CONFIG_KEY = "runtime.config";
-
 	// --------------------------------------------------------------------------------------------
 
 	/** Defines how data exchange happens - batch or pipelined */

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -64,6 +64,7 @@ public interface RuntimeContext {
 	 * 
 	 * @return The metric group for this parallel subtask.
 	 */
+	@PublicEvolving
 	MetricGroup getMetricGroup();
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -355,6 +355,12 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String YARN_APPLICATION_MASTER_ENV_PREFIX = "yarn.application-master.env.";
 
+	// these default values are not used anymore, but remain here until Flink 2.0
+	@Deprecated
+	public static final String DEFAULT_YARN_APPLICATION_MASTER_PORT = "deprecated";
+	@Deprecated
+	public static final int DEFAULT_YARN_MIN_HEAP_CUTOFF = -1;
+
 	/**
 	 * Similar to the {@see YARN_APPLICATION_MASTER_ENV_PREFIX}, this configuration prefix allows
 	 * setting custom environment variables.

--- a/flink-core/src/main/java/org/apache/flink/types/DoubleValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/DoubleValue.java
@@ -30,7 +30,7 @@ import org.apache.flink.core.memory.DataOutputView;
  * type {@code double}.
  */
 @Public
-public class DoubleValue implements Comparable<DoubleValue>, ResettableValue<DoubleValue>, CopyableValue<DoubleValue> {
+public class DoubleValue implements Comparable<DoubleValue>, ResettableValue<DoubleValue>, CopyableValue<DoubleValue>, Key<DoubleValue> {
 	private static final long serialVersionUID = 1L;
 
 	private double value;

--- a/flink-core/src/main/java/org/apache/flink/types/FloatValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/FloatValue.java
@@ -30,7 +30,7 @@ import org.apache.flink.core.memory.DataOutputView;
  * type {@code float}.
  */
 @Public
-public class FloatValue implements Comparable<FloatValue>, ResettableValue<FloatValue>, CopyableValue<FloatValue> {
+public class FloatValue implements Comparable<FloatValue>, ResettableValue<FloatValue>, CopyableValue<FloatValue>, Key<FloatValue> {
 	private static final long serialVersionUID = 1L;
 
 	private float value;

--- a/flink-core/src/main/java/org/apache/flink/types/Key.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Key.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * This interface has to be implemented by all data types that act as key. Keys are used to establish
+ * relationships between values. A key must always be {@link java.lang.Comparable} to other keys of
+ * the same type. In addition, keys must implement a correct {@link java.lang.Object#hashCode()} method
+ * and {@link java.lang.Object#equals(Object)} method to ensure that grouping on keys works properly.
+ * <p>
+ * This interface extends {@link org.apache.flink.types.Value} and requires to implement
+ * the serialization of its value.
+ *
+ * @see org.apache.flink.types.Value
+ * @see org.apache.flink.core.io.IOReadableWritable
+ * @see java.lang.Comparable
+ *
+ * @deprecated The Key type is a relict of a deprecated and removed API and will be removed
+ *             in future (2.0) versions as well.
+ */
+@Deprecated
+@PublicEvolving
+public interface Key<T> extends Value, Comparable<T> {
+
+	/**
+	 * All keys must override the hash-code function to generate proper deterministic hash codes,
+	 * based on their contents.
+	 *
+	 * @return The hash code of the key
+	 */
+	public int hashCode();
+
+	/**
+	 * Compares the object on equality with another object.
+	 *
+	 * @param other The other object to compare against.
+	 *
+	 * @return True, iff this object is identical to the other object, false otherwise.
+	 */
+	public boolean equals(Object other);
+}

--- a/flink-core/src/main/java/org/apache/flink/types/NormalizableKey.java
+++ b/flink-core/src/main/java/org/apache/flink/types/NormalizableKey.java
@@ -36,7 +36,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * key length.
  */
 @Public
-public interface NormalizableKey<T> extends Comparable<T> {
+public interface NormalizableKey<T> extends Comparable<T>, Key<T> {
 
 	/**
 	 * Gets the maximal length of normalized keys that the data type would produce to determine

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -133,6 +133,13 @@ under the License.
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<plugin>
 				<!--Build uber jar-->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
@@ -272,7 +279,6 @@ under the License.
 					</links>
 				</configuration>
 			</plugin>
-
 		</plugins>
 	</build>
 </project>

--- a/flink-java8/pom.xml
+++ b/flink-java8/pom.xml
@@ -143,6 +143,13 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	
 		<pluginManagement>

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -72,6 +72,14 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-shaded-curator/pom.xml
+++ b/flink-shaded-curator/pom.xml
@@ -37,4 +37,17 @@
 	<name>flink-shaded-curator</name>
 
 	<packaging>pom</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -162,6 +162,15 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -217,6 +217,28 @@ under the License.
 				</configuration>
 			</plugin>
 
+			<!-- Exclude generated classes from api compatibilty checks -->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>0.7.0</version>
+				<configuration>
+					<parameter>
+						<excludes>
+							<exclude>*\$\$anon\$*</exclude>
+						</excludes>
+					</parameter>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!-- Generate the test-jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -221,7 +221,6 @@ under the License.
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
-				<version>0.7.0</version>
 				<configuration>
 					<parameter>
 						<excludes>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -265,7 +265,13 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
-
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -746,6 +746,60 @@ under the License.
 		<plugins>
 
 			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>0.7.0</version>
+				<configuration>
+					<oldVersion>
+						<dependency>
+							<groupId>org.apache.flink</groupId>
+							<artifactId>${project.artifactId}</artifactId>
+							<version>1.0.0</version>
+							<type>${project.packaging}</type>
+						</dependency>
+					</oldVersion>
+					<newVersion>
+						<file>
+							<path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+						</file>
+					</newVersion>
+					<parameter>
+						<onlyModified>true</onlyModified>
+						<includes>
+							<include>@org.apache.flink.annotation.Public</include>
+						</includes>
+						<excludes>
+							<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
+							<exclude>@org.apache.flink.annotation.Internal</exclude>
+						</excludes>
+						<accessModifier>public</accessModifier>
+						<breakBuildOnModifications>false</breakBuildOnModifications>
+						<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+						<onlyBinaryIncompatible>false</onlyBinaryIncompatible>
+						<includeSynthetic>true</includeSynthetic>
+						<ignoreMissingClasses>false</ignoreMissingClasses>
+						<skipPomModules>true</skipPomModules>
+					</parameter>
+					<skip>false</skip>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.flink</groupId>
+							<artifactId>flink-annotations</artifactId>
+							<version>${project.version}</version>
+						</dependency>
+					</dependencies>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.4</version><!--$NO-MVN-MAN-VER$-->

--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,6 @@ under the License.
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -774,10 +774,13 @@ under the License.
 						<accessModifier>public</accessModifier>
 						<breakBuildOnModifications>false</breakBuildOnModifications>
 						<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+						<breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
 						<onlyBinaryIncompatible>false</onlyBinaryIncompatible>
 						<includeSynthetic>true</includeSynthetic>
 						<ignoreMissingClasses>false</ignoreMissingClasses>
 						<skipPomModules>true</skipPomModules>
+						<!-- Don't break build on newly added maven modules -->
+						<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
 					</parameter>
 					<skip>false</skip>
 					<dependencies>


### PR DESCRIPTION
This pull request adds a maven module for ensuring interface stability (japicmp).

I needed to revert some of the changes since 1.0:
- I made the `getMetricGroup()` in the `RuntimeContext` an evolving API.
- I added two deprecated config constants again.
- I reintroduced the deprecated `Key` interface.

Once this has been merged, I'll file JIRAs for 2.0 to remove these changes.
