### PR TITLE
[FLINK-3886] Give a better error when the application Main class is not public.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -484,6 +484,10 @@ public class PackagedProgram {
 	
 	private static void callMainMethod(Class<?> entryClass, String[] args) throws ProgramInvocationException {
 		Method mainMethod;
+		if (!Modifier.isPublic(entryClass.getModifiers())) {
+			throw new ProgramInvocationException("The class " + entryClass.getName() + " must be public.");
+		}
+
 		try {
 			mainMethod = entryClass.getMethod("main", String[].class);
 		} catch (NoSuchMethodException e) {


### PR DESCRIPTION
A simple fix that reduces the time needed to find the cause of this simple developer error.