### PR TITLE
[FLINK-3779] Add support for queryable state

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -313,6 +313,20 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 - `env.log.dir`: (Defaults to the `log` directory under Flink's home) Defines the directory where the Flink logs are saved. It has to be an absolute path.
 
+## Queryable State
+
+### Server
+
+- `query.server.port`: Port to bind queryable state server to (Default: `0`, binds to random port).
+- `query.server.network-threads`: Number of network (Netty's event loop) Threads for queryable state server (Default: `0`, picks number of slots).
+- `query.server.query-threads`: Number of query Threads for queryable state server (Default: `0`, picks number of slots).
+
+### Client
+
+- `query.client.network-threads`: Number of network (Netty's event loop) Threads for queryable state client (Default: `0`, picks number of available cores as returned by `Runtime.getRuntime().availableProcessors()`).
+- `query.client.lookup.num-retries`: Number of retries on KvState lookup failure due to unavailable JobManager (Default: `3`).
+- `query.client.lookup.retry-delay`: Retry delay in milliseconds on KvState lookup failure due to unavailable JobManager (Default: `1000`).
+
 ## Metrics
 
 - `metrics.reporters`: The list of named reporters, i.e. "foo,bar".

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
@@ -32,8 +31,6 @@ import org.rocksdb.WriteOptions;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * {@link FoldingState} implementation that stores state in RocksDB.
@@ -44,14 +41,11 @@ import static java.util.Objects.requireNonNull;
  * @param <ACC> The type of the value in the folding state.
  */
 public class RocksDBFoldingState<K, N, T, ACC>
-	extends AbstractRocksDBState<K, N, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>>
+	extends AbstractRocksDBState<K, N, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>, ACC>
 	implements FoldingState<T, ACC> {
 
 	/** Serializer for the values */
 	private final TypeSerializer<ACC> valueSerializer;
-
-	/** This holds the name of the state and can create an initial default value for the state. */
-	private final FoldingStateDescriptor<T, ACC> stateDesc;
 
 	/** User-specified fold function */
 	private final FoldFunction<T, ACC> foldFunction;
@@ -74,9 +68,8 @@ public class RocksDBFoldingState<K, N, T, ACC>
 			FoldingStateDescriptor<T, ACC> stateDesc,
 			RocksDBStateBackend backend) {
 
-		super(columnFamily, namespaceSerializer, backend);
-		
-		this.stateDesc = requireNonNull(stateDesc);
+		super(columnFamily, namespaceSerializer, stateDesc, backend);
+
 		this.valueSerializer = stateDesc.getSerializer();
 		this.foldFunction = stateDesc.getFoldFunction();
 
@@ -125,5 +118,5 @@ public class RocksDBFoldingState<K, N, T, ACC>
 			throw new RuntimeException("Error while adding data to RocksDB", e);
 		}
 	}
-}
 
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
@@ -33,8 +32,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * {@link ListState} implementation that stores state in RocksDB.
@@ -48,14 +45,11 @@ import static java.util.Objects.requireNonNull;
  * @param <V> The type of the values in the list state.
  */
 public class RocksDBListState<K, N, V>
-	extends AbstractRocksDBState<K, N, ListState<V>, ListStateDescriptor<V>>
+	extends AbstractRocksDBState<K, N, ListState<V>, ListStateDescriptor<V>, V>
 	implements ListState<V> {
 
 	/** Serializer for the values */
 	private final TypeSerializer<V> valueSerializer;
-
-	/** This holds the name of the state and can create an initial default value for the state. */
-	private final ListStateDescriptor<V> stateDesc;
 
 	/**
 	 * We disable writes to the write-ahead-log here. We can't have these in the base class
@@ -75,8 +69,7 @@ public class RocksDBListState<K, N, V>
 			ListStateDescriptor<V> stateDesc,
 			RocksDBStateBackend backend) {
 		
-		super(columnFamily, namespaceSerializer, backend);
-		this.stateDesc = requireNonNull(stateDesc);
+		super(columnFamily, namespaceSerializer, stateDesc, backend);
 		this.valueSerializer = stateDesc.getSerializer();
 
 		writeOptions = new WriteOptions();
@@ -129,5 +122,5 @@ public class RocksDBListState<K, N, V>
 			throw new RuntimeException("Error while adding data to RocksDB", e);
 		}
 	}
-}
 
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
@@ -32,8 +31,6 @@ import org.rocksdb.WriteOptions;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * {@link ReducingState} implementation that stores state in RocksDB.
@@ -43,14 +40,11 @@ import static java.util.Objects.requireNonNull;
  * @param <V> The type of value that the state state stores.
  */
 public class RocksDBReducingState<K, N, V>
-	extends AbstractRocksDBState<K, N, ReducingState<V>, ReducingStateDescriptor<V>>
+	extends AbstractRocksDBState<K, N, ReducingState<V>, ReducingStateDescriptor<V>, V>
 	implements ReducingState<V> {
 
 	/** Serializer for the values */
 	private final TypeSerializer<V> valueSerializer;
-
-	/** This holds the name of the state and can create an initial default value for the state. */
-	private final ReducingStateDescriptor<V> stateDesc;
 
 	/** User-specified reduce function */
 	private final ReduceFunction<V> reduceFunction;
@@ -73,8 +67,7 @@ public class RocksDBReducingState<K, N, V>
 			ReducingStateDescriptor<V> stateDesc,
 			RocksDBStateBackend backend) {
 		
-		super(columnFamily, namespaceSerializer, backend);
-		this.stateDesc = requireNonNull(stateDesc);
+		super(columnFamily, namespaceSerializer, stateDesc, backend);
 		this.valueSerializer = stateDesc.getSerializer();
 		this.reduceFunction = stateDesc.getReduceFunction();
 
@@ -123,5 +116,5 @@ public class RocksDBReducingState<K, N, V>
 			throw new RuntimeException("Error while adding data to RocksDB", e);
 		}
 	}
-}
 
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncKVSnapshotTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncKVSnapshotTest.java
@@ -23,13 +23,14 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -295,8 +296,9 @@ public class RocksDBAsyncKVSnapshotTest {
 
 			// also get the state in open, this way we are sure that it was created before
 			// we trigger the test checkpoint
-			ValueState<String> state = getPartitionedState(null,
-					VoidSerializer.INSTANCE,
+			ValueState<String> state = getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
 					new ValueStateDescriptor<>("count",
 							StringSerializer.INSTANCE, "hello"));
 
@@ -306,8 +308,9 @@ public class RocksDBAsyncKVSnapshotTest {
 		public void processElement(StreamRecord<String> element) throws Exception {
 			// we also don't care
 
-			ValueState<String> state = getPartitionedState(null,
-					VoidSerializer.INSTANCE,
+			ValueState<String> state = getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
 					new ValueStateDescriptor<>("count",
 							StringSerializer.INSTANCE, "hello"));
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
@@ -311,6 +312,11 @@ public class RocksDBStateBackendConfigTest {
 		when(env.getJobID()).thenReturn(new JobID());
 		when(env.getUserClassLoader()).thenReturn(RocksDBStateBackendConfigTest.class.getClassLoader());
 		when(env.getIOManager()).thenReturn(ioMan);
+
+		TaskInfo taskInfo = mock(TaskInfo.class);
+		when(env.getTaskInfo()).thenReturn(taskInfo);
+
+		when(taskInfo.getIndexOfThisSubtask()).thenReturn(0);
 		return env;
 	}
 }

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -23,11 +23,12 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.Assume;
 import org.junit.Before;
@@ -176,7 +177,10 @@ public class RocksDBStateBackendConfigTest {
 				rocksDbBackend.initializeForJob(getMockEnvironment(), "foobar", IntSerializer.INSTANCE);
 
 				// actually get a state to see whether we can write to the storage directory
-				rocksDbBackend.getPartitionedState(null, VoidSerializer.INSTANCE, new ValueStateDescriptor<>("test", String.class, ""));
+				rocksDbBackend.getPartitionedState(
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE,
+						new ValueStateDescriptor<>("test", String.class, ""));
 			}
 			catch (Exception e) {
 				e.printStackTrace();

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.Preconditions;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -54,6 +55,9 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	/** The serializer for the type. May be eagerly initialized in the constructor,
 	 * or lazily once the type is serialized or an ExecutionConfig is provided. */
 	protected TypeSerializer<T> serializer;
+
+	/** Name for queries against state created from this StateDescriptor. */
+	private String queryableStateName;
 
 	/** The default value returned by the state when no other value is bound to a key */
 	protected transient T defaultValue;
@@ -154,6 +158,43 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	}
 
 	/**
+	 * Sets the name for queries of state created from this descriptor.
+	 *
+	 * <p>If a name is set, the created state will be published for queries
+	 * during runtime. The name needs to be unique per job. If there is another
+	 * state instance published under the same name, the job will fail during runtime.
+	 *
+	 * @param queryableStateName State name for queries (unique name per job)
+	 * @throws IllegalStateException If queryable state name already set
+	 */
+	public void setQueryable(String queryableStateName) {
+		if (this.queryableStateName == null) {
+			this.queryableStateName = Preconditions.checkNotNull(queryableStateName, "Registration name");
+		} else {
+			throw new IllegalStateException("Queryable state name already set");
+		}
+	}
+
+	/**
+	 * Returns the queryable state name.
+	 *
+	 * @return Queryable state name or <code>null</code> if not set.
+	 */
+	public String getQueryableStateName() {
+		return queryableStateName;
+	}
+
+	/**
+	 * Returns whether the state created from this descriptor is queryable.
+	 *
+	 * @return <code>true</code> if state is queryable, <code>false</code>
+	 * otherwise.
+	 */
+	public boolean isQueryable() {
+		return queryableStateName != null;
+	}
+
+	/**
 	 * Creates a new {@link State} on the given {@link StateBackend}.
 	 *
 	 * @param stateBackend The {@code StateBackend} on which to create the {@link State}.
@@ -221,6 +262,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 				"{name=" + name +
 				", defaultValue=" + defaultValue +
 				", serializer=" + serializer +
+				(isQueryable() ? ", queryableStateName=" + queryableStateName + "" : "") +
 				'}';
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1066,6 +1066,44 @@ public final class ConfigConstants {
 	/** ZooKeeper default leader port. */
 	public static final int DEFAULT_ZOOKEEPER_LEADER_PORT = 3888;
 
+	// ------------------------- Queryable state ------------------------------
+
+	/** Port to bind KvState server to. */
+	public static final String QUERYABLE_STATE_SERVER_PORT = "query.server.port";
+
+	/** Number of network (event loop) threads for the KvState server. */
+	public static final String QUERYABLE_STATE_SERVER_NETWORK_THREADS = "query.server.network-threads";
+
+	/** Number of query threads for the KvState server. */
+	public static final String QUERYABLE_STATE_SERVER_QUERY_THREADS = "query.server.query-threads";
+
+	/** Default port to bind KvState server to (0 => pick random free port). */
+	public static final int DEFAULT_QUERYABLE_STATE_SERVER_PORT = 0;
+
+	/** Default Number of network (event loop) threads for the KvState server (0 => #slots). */
+	public static final int DEFAULT_QUERYABLE_STATE_SERVER_NETWORK_THREADS = 0;
+
+	/** Default number of query threads for the KvState server (0 => #slots). */
+	public static final int DEFAULT_QUERYABLE_STATE_SERVER_QUERY_THREADS = 0;
+
+	/** Number of network (event loop) threads for the KvState client. */
+	public static final String QUERYABLE_STATE_CLIENT_NETWORK_THREADS = "query.client.network-threads";
+
+	/** Number of retries on location lookup failures. */
+	public static final String QUERYABLE_STATE_CLIENT_LOOKUP_RETRIES = "query.client.lookup.num-retries";
+
+	/** Retry delay on location lookup failures (millis). */
+	public static final String QUERYABLE_STATE_CLIENT_LOOKUP_RETRY_DELAY = "query.client.lookup.retry-delay";
+
+	/** Default number of query threads for the KvState client (0 => #cores) */
+	public static final int DEFAULT_QUERYABLE_STATE_CLIENT_NETWORK_THREADS = 0;
+
+	/** Default number of retries on location lookup failures. */
+	public static final int DEFAULT_QUERYABLE_STATE_CLIENT_LOOKUP_RETRIES = 3;
+
+	/** Default retry delay on location lookup failures. */
+	public static final int DEFAULT_QUERYABLE_STATE_CLIENT_LOOKUP_RETRY_DELAY = 1000;
+
 	// ----------------------------- Environment Variables ----------------------------
 
 	/** The environment variable name which contains the location of the configuration directory */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -33,6 +33,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 
@@ -146,6 +148,13 @@ public interface Environment {
 	 * @return the registry
 	 */
 	AccumulatorRegistry getAccumulatorRegistry();
+
+	/**
+	 * Returns the registry for {@link KvState} instances.
+	 *
+	 * @return KvState registry
+	 */
+	TaskKvStateRegistry getTaskKvStateRegistry();
 
 	/**
 	 * Confirms that the invokable has successfully completed all steps it needed to

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.messages.ExecutionGraphMessages;
+import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.runtime.util.SerializedThrowable;
@@ -224,6 +225,9 @@ public class ExecutionGraph {
 	/** The execution context which is used to execute futures. */
 	private ExecutionContext executionContext;
 
+	/** Registered KvState instances reported by the TaskManagers. */
+	private transient KvStateLocationRegistry kvStateLocationRegistry;
+
 	// ------ Fields that are only relevant for archived execution graphs ------------
 	private String jsonPlan;
 
@@ -304,6 +308,8 @@ public class ExecutionGraph {
 		this.restartStrategy = restartStrategy;
 
 		metricGroup.gauge(RESTARTING_TIME_METRIC_NAME, new RestartTimeGauge());
+
+		this.kvStateLocationRegistry = new KvStateLocationRegistry(jobId, getAllVertices());
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -443,6 +449,10 @@ public class ExecutionGraph {
 
 	public SavepointCoordinator getSavepointCoordinator() {
 		return savepointCoordinator;
+	}
+
+	public KvStateLocationRegistry getKvStateLocationRegistry() {
+		return kvStateLocationRegistry;
 	}
 
 	public RestartStrategy getRestartStrategy() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -22,6 +22,7 @@ import akka.dispatch.OnFailure;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.InstanceConnectionInfo;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
@@ -35,11 +36,21 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState;
 import org.apache.flink.runtime.messages.TaskMessages.FailTask;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.query.KvStateMessage;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.KvStateRegistryListener;
+import org.apache.flink.runtime.query.KvStateServerAddress;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskManager;
+import org.apache.flink.runtime.query.netty.AtomicKvStateRequestStats;
+import org.apache.flink.runtime.query.netty.KvStateServer;
+import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
@@ -84,6 +95,12 @@ public class NetworkEnvironment {
 
 	private PartitionStateChecker partitionStateChecker;
 
+	/** Server for {@link org.apache.flink.runtime.state.KvState} requests. */
+	private KvStateServer kvStateServer;
+
+	/** Registry for {@link org.apache.flink.runtime.state.KvState} instances. */
+	private KvStateRegistry kvStateRegistry;
+
 	private boolean isShutdown;
 
 	/**
@@ -92,17 +109,21 @@ public class NetworkEnvironment {
 	 */
 	private final ExecutionContext executionContext;
 
+	private final InstanceConnectionInfo connectionInfo;
+
 	/**
 	 * Initializes all network I/O components.
 	 */
 	public NetworkEnvironment(
-		ExecutionContext executionContext,
-		FiniteDuration jobManagerTimeout,
-		NetworkEnvironmentConfiguration config) throws IOException {
+			ExecutionContext executionContext,
+			FiniteDuration jobManagerTimeout,
+			NetworkEnvironmentConfiguration config,
+			InstanceConnectionInfo connectionInfo) throws IOException {
 
 		this.executionContext = executionContext;
 		this.configuration = checkNotNull(config);
 		this.jobManagerTimeout = checkNotNull(jobManagerTimeout);
+		this.connectionInfo = checkNotNull(connectionInfo);
 
 		// create the network buffers - this is the operation most likely to fail upon
 		// mis-configuration, so we do this first
@@ -151,6 +172,10 @@ public class NetworkEnvironment {
 		return configuration.partitionRequestInitialAndMaxBackoff();
 	}
 
+	public TaskKvStateRegistry createKvStateTaskRegistry(JobID jobId, JobVertexID jobVertexId) {
+		return kvStateRegistry.createTaskRegistry(jobId, jobVertexId);
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Association / Disassociation with JobManager / TaskManager
 	// --------------------------------------------------------------------------------------------
@@ -183,7 +208,9 @@ public class NetworkEnvironment {
 			if (this.partitionConsumableNotifier == null &&
 				this.partitionManager == null &&
 				this.taskEventDispatcher == null &&
-				this.connectionManager == null)
+				this.connectionManager == null &&
+				this.kvStateRegistry == null &&
+				this.kvStateServer == null)
 			{
 				// good, not currently associated. start the individual components
 
@@ -211,6 +238,29 @@ public class NetworkEnvironment {
 				catch (Throwable t) {
 					throw new IOException("Failed to instantiate network connection manager: " + t.getMessage(), t);
 				}
+
+				try {
+					kvStateRegistry = new KvStateRegistry();
+
+					kvStateServer = new KvStateServer(
+							connectionInfo.address(),
+							0,
+							1,
+							10,
+							kvStateRegistry,
+							new AtomicKvStateRequestStats());
+
+					kvStateServer.start();
+
+					KvStateRegistryListener listener = new JobManagerKvStateRegistryListener(
+							jobManagerGateway,
+							kvStateServer.getAddress());
+
+					kvStateRegistry.registerListener(listener);
+				} catch (Throwable t) {
+					throw new IOException("Failed to instantiate KvState management components: "
+							+ t.getMessage(), t);
+				}
 			}
 			else {
 				throw new IllegalStateException(
@@ -226,6 +276,19 @@ public class NetworkEnvironment {
 			}
 
 			LOG.debug("Disassociating NetworkEnvironment from TaskManager. Cleaning all intermediate results.");
+
+			// Shut down KvStateRegistry
+			kvStateRegistry = null;
+
+			// Shut down KvStateServer
+			if (kvStateServer != null) {
+				try {
+					kvStateServer.shutDown();
+				} catch (Throwable t) {
+					throw new IOException("Cannot shutdown KvStateNettyServer", t);
+				}
+				kvStateServer = null;
+			}
 
 			// terminate all network connections
 			if (connectionManager != null) {
@@ -509,6 +572,60 @@ public class NetworkEnvironment {
 					jobId, partitionId, executionAttemptID, resultId);
 
 			jobManager.tell(msg, taskManager);
+		}
+	}
+
+	/**
+	 * Simple {@link KvStateRegistry} listener, which forwards registrations to
+	 * the JobManager.
+	 */
+	private static class JobManagerKvStateRegistryListener implements KvStateRegistryListener {
+
+		private ActorGateway jobManager;
+
+		private KvStateServerAddress kvStateServerAddress;
+
+		public JobManagerKvStateRegistryListener(
+				ActorGateway jobManager,
+				KvStateServerAddress kvStateServerAddress) {
+
+			this.jobManager = Preconditions.checkNotNull(jobManager, "JobManager");
+			this.kvStateServerAddress = Preconditions.checkNotNull(kvStateServerAddress, "KvStateServerAddress");
+		}
+
+		@Override
+		public void notifyKvStateRegistered(
+				JobID jobId,
+				JobVertexID jobVertexId,
+				int keyGroupIndex,
+				String registrationName,
+				KvStateID kvStateId) {
+
+			Object msg = new KvStateMessage.NotifyKvStateRegistered(
+					jobId,
+					jobVertexId,
+					keyGroupIndex,
+					registrationName,
+					kvStateId,
+					kvStateServerAddress);
+
+			jobManager.tell(msg);
+		}
+
+		@Override
+		public void notifyKvStateUnregistered(
+				JobID jobId,
+				JobVertexID jobVertexId,
+				int keyGroupIndex,
+				String registrationName) {
+
+			Object msg = new KvStateMessage.NotifyKvStateUnregistered(
+					jobId,
+					jobVertexId,
+					keyGroupIndex,
+					registrationName);
+
+			jobManager.tell(msg);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
@@ -57,7 +57,7 @@ public class NettyBufferPool implements ByteBufAllocator {
 	 * @param numberOfArenas Number of arenas (recommended: 2 * number of task
 	 *                       slots)
 	 */
-	NettyBufferPool(int numberOfArenas) {
+	public NettyBufferPool(int numberOfArenas) {
 		checkArgument(numberOfArenas >= 1, "Number of arenas");
 		this.numberOfArenas = numberOfArenas;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/AkkaKvStateLocationLookupService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/AkkaKvStateLocationLookupService.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.dispatch.Futures;
+import akka.dispatch.Mapper;
+import akka.dispatch.Recover;
+import akka.pattern.Patterns;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.AkkaActorGateway;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+import scala.reflect.ClassTag$;
+
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+/**
+ * Akka-based {@link KvStateLocationLookupService} that retrieves the current
+ * JobManager address and uses it for lookups.
+ */
+class AkkaKvStateLocationLookupService implements KvStateLocationLookupService, LeaderRetrievalListener {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KvStateLocationLookupService.class);
+
+	/** Future returned when no JobManager is available */
+	private static final Future<ActorGateway> UNKNOWN_JOB_MANAGER = Futures.failed(new UnknownJobManager());
+
+	/** Leader retrieval service to retrieve the current job manager. */
+	private final LeaderRetrievalService leaderRetrievalService;
+
+	/** The actor system used to resolve the JobManager address. */
+	private final ActorSystem actorSystem;
+
+	/** Timeout for JobManager ask-requests. */
+	private final FiniteDuration askTimeout;
+
+	/** Retry strategy factory on future failures. */
+	private final LookupRetryStrategyFactory retryStrategyFactory;
+
+	/** Current job manager future. */
+	private volatile Future<ActorGateway> jobManagerFuture = UNKNOWN_JOB_MANAGER;
+
+	/**
+	 * Creates the Akka-based {@link KvStateLocationLookupService}.
+	 *
+	 * @param leaderRetrievalService Leader retrieval service to use.
+	 * @param actorSystem            Actor system to use.
+	 * @param askTimeout             Timeout for JobManager ask-requests.
+	 * @param retryStrategyFactory   Retry strategy if no JobManager available.
+	 */
+	AkkaKvStateLocationLookupService(
+			LeaderRetrievalService leaderRetrievalService,
+			ActorSystem actorSystem,
+			FiniteDuration askTimeout,
+			LookupRetryStrategyFactory retryStrategyFactory) {
+
+		this.leaderRetrievalService = Preconditions.checkNotNull(leaderRetrievalService, "Leader retrieval service");
+		this.actorSystem = Preconditions.checkNotNull(actorSystem, "Actor system");
+		this.askTimeout = Preconditions.checkNotNull(askTimeout, "Ask Timeout");
+		this.retryStrategyFactory = Preconditions.checkNotNull(retryStrategyFactory, "Retry strategy factory");
+	}
+
+	public void start() {
+		try {
+			leaderRetrievalService.start(this);
+		} catch (Exception e) {
+			LOG.error("Failed to start leader retrieval service", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	public void shutDown() {
+		try {
+			leaderRetrievalService.stop();
+		} catch (Exception e) {
+			LOG.error("Failed to stop leader retrieval service", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Future<KvStateLocation> getKvStateLookupInfo(final JobID jobId, final String registrationName) {
+		return getKvStateLookupInfo(jobId, registrationName, retryStrategyFactory.createRetryStrategy());
+	}
+
+	/**
+	 * Returns a future holding the {@link KvStateLocation} for the given job
+	 * and KvState registration name.
+	 *
+	 * <p>If there is currently no JobManager registered with the service, the
+	 * request is retried. The retry behaviour is specified by the
+	 * {@link LookupRetryStrategy} of the lookup service.
+	 *
+	 * @param jobId               JobID the KvState instance belongs to
+	 * @param registrationName    Name under which the KvState has been registered
+	 * @param lookupRetryStrategy Retry strategy to use for retries on UnknownJobManager failures.
+	 * @return Future holding the {@link KvStateLocation}
+	 */
+	@SuppressWarnings("unchecked")
+	private Future<KvStateLocation> getKvStateLookupInfo(
+			final JobID jobId,
+			final String registrationName,
+			final LookupRetryStrategy lookupRetryStrategy) {
+
+		return jobManagerFuture
+				.flatMap(new Mapper<ActorGateway, Future<Object>>() {
+					@Override
+					public Future<Object> apply(ActorGateway jobManager) {
+						// Lookup the KvStateLocation
+						Object msg = new KvStateMessage.LookupKvStateLocation(jobId, registrationName);
+						return jobManager.ask(msg, askTimeout);
+					}
+				}, actorSystem.dispatcher())
+				.mapTo(ClassTag$.MODULE$.<KvStateLocation>apply(KvStateLocation.class))
+				.recoverWith(new Recover<Future<KvStateLocation>>() {
+					@Override
+					public Future<KvStateLocation> recover(Throwable failure) throws Throwable {
+						// If the Future fails with UnknownJobManager, retry
+						// the request. Otherwise all Futures will be failed
+						// during the start up phase, when the JobManager did
+						// not notify this service yet or leadership is lost
+						// intermittently.
+						if (failure instanceof UnknownJobManager && lookupRetryStrategy.tryRetry()) {
+							return Patterns.after(
+									lookupRetryStrategy.getRetryDelay(),
+									actorSystem.scheduler(),
+									actorSystem.dispatcher(),
+									new Callable<Future<KvStateLocation>>() {
+										@Override
+										public Future<KvStateLocation> call() throws Exception {
+											return getKvStateLookupInfo(
+													jobId,
+													registrationName,
+													lookupRetryStrategy);
+										}
+									});
+						} else {
+							return Futures.failed(failure);
+						}
+					}
+				}, actorSystem.dispatcher());
+	}
+
+	@Override
+	public void notifyLeaderAddress(String leaderAddress, final UUID leaderSessionID) {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Received leader address notification {}:{}", leaderAddress, leaderSessionID);
+		}
+
+		if (leaderAddress == null) {
+			jobManagerFuture = UNKNOWN_JOB_MANAGER;
+		} else {
+			jobManagerFuture = AkkaUtils.getActorRefFuture(leaderAddress, actorSystem, askTimeout)
+					.map(new Mapper<ActorRef, ActorGateway>() {
+						@Override
+						public ActorGateway apply(ActorRef actorRef) {
+							return new AkkaActorGateway(actorRef, leaderSessionID);
+						}
+					}, actorSystem.dispatcher());
+		}
+	}
+
+	@Override
+	public void handleError(Exception exception) {
+		jobManagerFuture = Futures.failed(exception);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Retry strategy for failed lookups.
+	 *
+	 * <p>Usage:
+	 * <pre>
+	 * LookupRetryStrategy retryStrategy = LookupRetryStrategyFactory.create();
+	 *
+	 * if (retryStrategy.tryRetry()) {
+	 *     // OK to retry
+	 *     FiniteDuration retryDelay = retryStrategy.getRetryDelay();
+	 * }
+	 * </pre>
+	 */
+	interface LookupRetryStrategy {
+
+		/**
+		 * Returns the current retry.
+		 *
+		 * @return Current retry delay.
+		 */
+		FiniteDuration getRetryDelay();
+
+		/**
+		 * Tries another retry and returns whether it is allowed or not.
+		 *
+		 * @return Whether it is allowed to do another restart or not.
+		 */
+		boolean tryRetry();
+
+	}
+
+	/**
+	 * Factory for retry strategies.
+	 */
+	interface LookupRetryStrategyFactory {
+
+		/**
+		 * Creates a new retry strategy.
+		 *
+		 * @return The retry strategy.
+		 */
+		LookupRetryStrategy createRetryStrategy();
+
+	}
+
+	/**
+	 * Factory for disabled retries.
+	 */
+	static class DisabledLookupRetryStrategyFactory implements LookupRetryStrategyFactory {
+
+		private static final DisabledLookupRetryStrategy RETRY_STRATEGY = new DisabledLookupRetryStrategy();
+
+		@Override
+		public LookupRetryStrategy createRetryStrategy() {
+			return RETRY_STRATEGY;
+		}
+
+		private static class DisabledLookupRetryStrategy implements LookupRetryStrategy {
+
+			@Override
+			public FiniteDuration getRetryDelay() {
+				return FiniteDuration.Zero();
+			}
+
+			@Override
+			public boolean tryRetry() {
+				return false;
+			}
+		}
+
+	}
+
+	/**
+	 * Factory for fixed delay retries.
+	 */
+	static class FixedDelayLookupRetryStrategyFactory implements LookupRetryStrategyFactory {
+
+		private final int maxRetries;
+		private final FiniteDuration retryDelay;
+
+		FixedDelayLookupRetryStrategyFactory(int maxRetries, FiniteDuration retryDelay) {
+			this.maxRetries = maxRetries;
+			this.retryDelay = retryDelay;
+		}
+
+		@Override
+		public LookupRetryStrategy createRetryStrategy() {
+			return new FixedDelayLookupRetryStrategy(maxRetries, retryDelay);
+		}
+
+		private static class FixedDelayLookupRetryStrategy implements LookupRetryStrategy {
+
+			private final Object retryLock = new Object();
+			private final int maxRetries;
+			private final FiniteDuration retryDelay;
+			private int numRetries;
+
+			public FixedDelayLookupRetryStrategy(int maxRetries, FiniteDuration retryDelay) {
+				Preconditions.checkArgument(maxRetries >= 0, "Negative number maximum retries");
+				this.maxRetries = maxRetries;
+				this.retryDelay = Preconditions.checkNotNull(retryDelay, "Retry delay");
+			}
+
+			@Override
+			public FiniteDuration getRetryDelay() {
+				synchronized (retryLock) {
+					return retryDelay;
+				}
+			}
+
+			@Override
+			public boolean tryRetry() {
+				synchronized (retryLock) {
+					if (numRetries < maxRetries) {
+						numRetries++;
+						return true;
+					} else {
+						return false;
+					}
+				}
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateID.java
@@ -16,31 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobgraph;
+package org.apache.flink.runtime.query;
 
+import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.util.AbstractID;
 
-import javax.xml.bind.DatatypeConverter;
-
 /**
- * A class for statistically unique job vertex IDs.
+ * Identifier for {@link KvState} instances.
+ *
+ * <p>Assigned when registering state at the {@link KvStateRegistry}.
  */
-public class JobVertexID extends AbstractID {
-	
+public class KvStateID extends AbstractID {
+
 	private static final long serialVersionUID = 1L;
-	
-	public JobVertexID() {
+
+	public KvStateID() {
 		super();
 	}
-	public JobVertexID(byte[] bytes) {
-		super(bytes);
-	}
 
-	public JobVertexID(long lowerPart, long upperPart) {
+	public KvStateID(long lowerPart, long upperPart) {
 		super(lowerPart, upperPart);
 	}
 
-	public static JobVertexID fromHexString(String hexString) {
-		return new JobVertexID(DatatypeConverter.parseHexBinary(hexString));
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateLocation.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Location information for all key groups of a {@link KvState} instance.
+ *
+ * <p>This is populated by the {@link KvStateLocationRegistry} and used by the
+ * {@link QueryableStateClient} to target queries.
+ */
+public class KvStateLocation implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** JobID the KvState instances belong to. */
+	private final JobID jobId;
+
+	/** JobVertexID the KvState instances belong to. */
+	private final JobVertexID jobVertexId;
+
+	/** Number of key groups of the operator the KvState instances belong to. */
+	private final int numKeyGroups;
+
+	/** Name under which the KvState instances have been registered. */
+	private final String registrationName;
+
+	/** IDs for each KvState instance where array index corresponds to key group index. */
+	private final KvStateID[] kvStateIds;
+
+	/**
+	 * Server address for each KvState instance where array index corresponds to
+	 * key group index.
+	 */
+	private final KvStateServerAddress[] kvStateAddresses;
+
+	/** Current number of registered key groups. */
+	private int numRegisteredKeyGroups;
+
+	/**
+	 * Creates the location information
+	 *
+	 * @param jobId            JobID the KvState instances belong to
+	 * @param jobVertexId      JobVertexID the KvState instances belong to
+	 * @param numKeyGroups     Number of key groups of the operator
+	 * @param registrationName Name under which the KvState instances have been registered
+	 */
+	public KvStateLocation(JobID jobId, JobVertexID jobVertexId, int numKeyGroups, String registrationName) {
+		this.jobId = Preconditions.checkNotNull(jobId, "JobID");
+		this.jobVertexId = Preconditions.checkNotNull(jobVertexId, "JobVertexID");
+		Preconditions.checkArgument(numKeyGroups >= 0, "Negative number of key groups");
+		this.numKeyGroups = numKeyGroups;
+		this.registrationName = Preconditions.checkNotNull(registrationName, "Registration name");
+		this.kvStateIds = new KvStateID[numKeyGroups];
+		this.kvStateAddresses = new KvStateServerAddress[numKeyGroups];
+	}
+
+	/**
+	 * Returns the JobID the KvState instances belong to.
+	 *
+	 * @return JobID the KvState instances belong to
+	 */
+	public JobID getJobId() {
+		return jobId;
+	}
+
+	/**
+	 * Returns the JobVertexID the KvState instances belong to.
+	 *
+	 * @return JobVertexID the KvState instances belong to
+	 */
+	public JobVertexID getJobVertexId() {
+		return jobVertexId;
+	}
+
+	/**
+	 * Returns the number of key groups of the operator the KvState instances belong to.
+	 *
+	 * @return Number of key groups of the operator the KvState instances belong to
+	 */
+	public int getNumKeyGroups() {
+		return numKeyGroups;
+	}
+
+	/**
+	 * Returns the name under which the KvState instances have been registered.
+	 *
+	 * @return Name under which the KvState instances have been registered.
+	 */
+	public String getRegistrationName() {
+		return registrationName;
+	}
+
+	/**
+	 * Returns the current number of registered key groups.
+	 *
+	 * @return Number of registered key groups.
+	 */
+	public int getNumRegisteredKeyGroups() {
+		return numRegisteredKeyGroups;
+	}
+
+	/**
+	 * Returns the registered KvStateID for the key group index or
+	 * <code>null</code> if none is registered yet.
+	 *
+	 * @param keyGroupIndex Key group index to get ID for.
+	 * @return KvStateID for the key group index or <code>null</code> if none
+	 * is registered yet
+	 * @throws IndexOutOfBoundsException If key group index < 0 or >= Number of key groups
+	 */
+	public KvStateID getKvStateID(int keyGroupIndex) {
+		if (keyGroupIndex < 0 || keyGroupIndex >= numKeyGroups) {
+			throw new IndexOutOfBoundsException("Key group index");
+		}
+
+		return kvStateIds[keyGroupIndex];
+	}
+
+	/**
+	 * Returns the registered KvStateServerAddress for the key group index or
+	 * <code>null</code> if none is registered yet.
+	 *
+	 * @param keyGroupIndex Key group index to get server address for.
+	 * @return KvStateServerAddress for the key group index or <code>null</code>
+	 * if none is registered yet
+	 * @throws IndexOutOfBoundsException If key group index < 0 or >= Number of key groups
+	 */
+	public KvStateServerAddress getKvStateServerAddress(int keyGroupIndex) {
+		if (keyGroupIndex < 0 || keyGroupIndex >= numKeyGroups) {
+			throw new IndexOutOfBoundsException("Key group index");
+		}
+
+		return kvStateAddresses[keyGroupIndex];
+	}
+
+	/**
+	 * Registers a KvState instance for the given key group index.
+	 *
+	 * @param keyGroupIndex  Key group index to register
+	 * @param kvStateId      ID of the KvState instance at the key group index.
+	 * @param kvStateAddress Server address of the KvState instance at the key group index.
+	 * @throws IndexOutOfBoundsException If key group index < 0 or >= Number of key groups
+	 */
+	void registerKvState(int keyGroupIndex, KvStateID kvStateId, KvStateServerAddress kvStateAddress) {
+		if (keyGroupIndex < 0 || keyGroupIndex >= numKeyGroups) {
+			throw new IndexOutOfBoundsException("Key group index");
+		}
+
+		if (kvStateIds[keyGroupIndex] == null && kvStateAddresses[keyGroupIndex] == null) {
+			numRegisteredKeyGroups++;
+		}
+
+		kvStateIds[keyGroupIndex] = kvStateId;
+		kvStateAddresses[keyGroupIndex] = kvStateAddress;
+	}
+
+	/**
+	 * Registers a KvState instance for the given key group index.
+	 *
+	 * @param keyGroupIndex Key group index to unregister.
+	 * @throws IndexOutOfBoundsException If key group index < 0 or >= Number of key groups
+	 * @throws IllegalArgumentException If no location information registered for key group index.
+	 */
+	void unregisterKvState(int keyGroupIndex) {
+		if (keyGroupIndex < 0 || keyGroupIndex >= numKeyGroups) {
+			throw new IndexOutOfBoundsException("Key group index");
+		}
+
+		if (kvStateIds[keyGroupIndex] == null || kvStateAddresses[keyGroupIndex] == null) {
+			throw new IllegalArgumentException("Not registered. Probably registration/unregistration race.");
+		}
+
+		numRegisteredKeyGroups--;
+
+		kvStateIds[keyGroupIndex] = null;
+		kvStateAddresses[keyGroupIndex] = null;
+	}
+
+	@Override
+	public String toString() {
+		return "KvStateLocation{" +
+				"jobId=" + jobId +
+				", jobVertexId=" + jobVertexId +
+				", parallelism=" + numKeyGroups +
+				", kvStateIds=" + Arrays.toString(kvStateIds) +
+				", kvStateAddresses=" + Arrays.toString(kvStateAddresses) +
+				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) { return true; }
+		if (o == null || getClass() != o.getClass()) { return false; }
+
+		KvStateLocation that = (KvStateLocation) o;
+
+		if (numKeyGroups != that.numKeyGroups) { return false; }
+		if (!jobId.equals(that.jobId)) { return false; }
+		if (!jobVertexId.equals(that.jobVertexId)) { return false; }
+		if (!registrationName.equals(that.registrationName)) { return false; }
+		if (!Arrays.equals(kvStateIds, that.kvStateIds)) { return false; }
+		return Arrays.equals(kvStateAddresses, that.kvStateAddresses);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = jobId.hashCode();
+		result = 31 * result + jobVertexId.hashCode();
+		result = 31 * result + numKeyGroups;
+		result = 31 * result + registrationName.hashCode();
+		result = 31 * result + Arrays.hashCode(kvStateIds);
+		result = 31 * result + Arrays.hashCode(kvStateAddresses);
+		return result;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateLocationLookupService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateLocationLookupService.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import scala.concurrent.Future;
+
+/**
+ * {@link KvStateLocation} lookup service.
+ */
+public interface KvStateLocationLookupService {
+
+	/**
+	 * Starts the lookup service.
+	 */
+	void start();
+
+	/**
+	 * Shuts down the lookup service.
+	 */
+	void shutDown();
+
+	/**
+	 * Returns a future holding the {@link KvStateLocation} for the given job
+	 * and KvState registration name.
+	 *
+	 * @param jobId            JobID the KvState instance belongs to
+	 * @param registrationName Name under which the KvState has been registered
+	 * @return Future holding the {@link KvStateLocation}
+	 */
+	Future<KvStateLocation> getKvStateLookupInfo(JobID jobId, String registrationName);
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateLocationRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateLocationRegistry.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.execution.SuppressRestartsException;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple registry, which maps {@link KvState} registration notifications to
+ * {@link KvStateLocation} instances.
+ */
+public class KvStateLocationRegistry {
+
+	/** JobID this coordinator belongs to. */
+	private final JobID jobId;
+
+	/** Job vertices for determining parallelism per key. */
+	private final Map<JobVertexID, ExecutionJobVertex> jobVertices;
+
+	/**
+	 * Location info keyed by registration name. The name needs to be unique
+	 * per JobID, i.e. two operators cannot register KvState with the same
+	 * name.
+	 */
+	private final Map<String, KvStateLocation> lookupTable = new HashMap<>();
+
+	/**
+	 * Creates the registry for the job.
+	 *
+	 * @param jobId       JobID this coordinator belongs to.
+	 * @param jobVertices Job vertices map of all vertices of this job.
+	 */
+	public KvStateLocationRegistry(JobID jobId, Map<JobVertexID, ExecutionJobVertex> jobVertices) {
+		this.jobId = Preconditions.checkNotNull(jobId, "JobID");
+		this.jobVertices = Preconditions.checkNotNull(jobVertices, "Job vertices");
+	}
+
+	/**
+	 * Returns the {@link KvStateLocation} for the registered KvState instance
+	 * or <code>null</code> if no location information is available.
+	 *
+	 * @param registrationName Name under which the KvState instance is registered.
+	 * @return Location information or <code>null</code>.
+	 */
+	public KvStateLocation getKvStateLocation(String registrationName) {
+		return lookupTable.get(registrationName);
+	}
+
+	/**
+	 * Notifies the registry about a registered KvState instance.
+	 *
+	 * @param jobVertexId JobVertexID the KvState instance belongs to
+	 * @param keyGroupIndex Key group index the KvState instance belongs to
+	 * @param registrationName Name under which the KvState has been registered
+	 * @param kvStateId ID of the registered KvState instance
+	 * @param kvStateServerAddress Server address where to find the KvState instance
+	 *
+	 * @throws IllegalArgumentException If JobVertexID does not belong to job
+	 * @throws IllegalArgumentException If state has been registered with same
+	 * name by another operator.
+	 * @throws IndexOutOfBoundsException If key group index is out of bounds.
+	 */
+	public void notifyKvStateRegistered(
+			JobVertexID jobVertexId,
+			int keyGroupIndex,
+			String registrationName,
+			KvStateID kvStateId,
+			KvStateServerAddress kvStateServerAddress) {
+
+		KvStateLocation location = lookupTable.get(registrationName);
+
+		if (location == null) {
+			// First registration for this operator, create the location info
+			ExecutionJobVertex vertex = jobVertices.get(jobVertexId);
+
+			if (vertex != null) {
+				int parallelism = vertex.getParallelism();
+				location = new KvStateLocation(jobId, jobVertexId, parallelism, registrationName);
+				lookupTable.put(registrationName, location);
+			} else {
+				throw new IllegalArgumentException("Unknown JobVertexID " + jobVertexId);
+			}
+		}
+
+		// Duplicated name if vertex IDs don't match
+		if (!location.getJobVertexId().equals(jobVertexId)) {
+			IllegalStateException duplicate = new IllegalStateException(
+					"Registration name clash. KvState with name '" + registrationName +
+							"' has already been registered by another operator (" +
+							location.getJobVertexId() + ").");
+
+			ExecutionJobVertex vertex = jobVertices.get(jobVertexId);
+			if (vertex != null) {
+				vertex.fail(new SuppressRestartsException(duplicate));
+			}
+
+			throw duplicate;
+		}
+
+		location.registerKvState(keyGroupIndex, kvStateId, kvStateServerAddress);
+	}
+
+	/**
+	 * Notifies the registry about an unregistered KvState instance.
+	 *
+	 * @param jobVertexId JobVertexID the KvState instance belongs to
+	 * @param keyGroupIndex Key group index the KvState instance belongs to
+	 * @param registrationName Name under which the KvState has been registered
+	 * @throws IllegalArgumentException If another operator registered the state instance
+	 * @throws IllegalArgumentException If the registration name is not known
+	 */
+	public void notifyKvStateUnregistered(
+			JobVertexID jobVertexId,
+			int keyGroupIndex,
+			String registrationName) {
+
+		KvStateLocation location = lookupTable.get(registrationName);
+
+		if (location != null) {
+			// Duplicate name if vertex IDs don't match
+			if (!location.getJobVertexId().equals(jobVertexId)) {
+				throw new IllegalArgumentException("Another operator (" +
+						location.getJobVertexId() + ") registered the KvState " +
+						"under '" + registrationName + "'.");
+			}
+
+			location.unregisterKvState(keyGroupIndex);
+
+			if (location.getNumRegisteredKeyGroups() == 0) {
+				lookupTable.remove(registrationName);
+			}
+		} else {
+			throw new IllegalArgumentException("Unknown registration name '" +
+					registrationName + "'. " + "Probably registration/unregistration race.");
+		}
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateMessage.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * Actor messages for {@link KvState} lookup and registration.
+ */
+public interface KvStateMessage extends Serializable {
+
+	// ------------------------------------------------------------------------
+	// Lookup
+	// ------------------------------------------------------------------------
+
+	class LookupKvStateLocation implements KvStateMessage {
+
+		private static final long serialVersionUID = 1L;
+
+		/** JobID the KvState instance belongs to. */
+		private final JobID jobId;
+
+		/** Name under which the KvState has been registered. */
+		private final String registrationName;
+
+		/**
+		 * Requests a {@link KvStateLocation} for the specified JobID and
+		 * {@link KvState} registration name.
+		 *
+		 * @param jobId            JobID the KvState instance belongs to
+		 * @param registrationName Name under which the KvState has been registered
+		 */
+		public LookupKvStateLocation(JobID jobId, String registrationName) {
+			this.jobId = Preconditions.checkNotNull(jobId, "JobID");
+			this.registrationName = Preconditions.checkNotNull(registrationName, "Name");
+		}
+
+		/**
+		 * Returns the JobID the KvState instance belongs to.
+		 *
+		 * @return JobID the KvState instance belongs to
+		 */
+		public JobID getJobId() {
+			return jobId;
+		}
+
+		/**
+		 * Returns the name under which the KvState has been registered.
+		 *
+		 * @return Name under which the KvState has been registered
+		 */
+		public String getRegistrationName() {
+			return registrationName;
+		}
+
+		@Override
+		public String toString() {
+			return "LookupKvStateLocation{" +
+					"jobId=" + jobId +
+					", registrationName='" + registrationName + '\'' +
+					'}';
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Registration
+	// ------------------------------------------------------------------------
+
+	class NotifyKvStateRegistered implements KvStateMessage {
+
+		private static final long serialVersionUID = 1L;
+
+		/** JobID the KvState instance belongs to. */
+		private final JobID jobId;
+
+		/** JobVertexID the KvState instance belongs to. */
+		private final JobVertexID jobVertexId;
+
+		/** Key group index the KvState instance belongs to. */
+		private final int keyGroupIndex;
+
+		/** Name under which the KvState has been registered. */
+		private final String registrationName;
+
+		/** ID of the registered KvState instance. */
+		private final KvStateID kvStateId;
+
+		/** Server address where to find the KvState instance. */
+		private final KvStateServerAddress kvStateServerAddress;
+
+		/**
+		 * Notifies the JobManager about a registered {@link KvState} instance.
+		 *
+		 * @param jobId                JobID the KvState instance belongs to
+		 * @param jobVertexId          JobVertexID the KvState instance belongs to
+		 * @param keyGroupIndex        Key group index the KvState instance belongs to
+		 * @param registrationName     Name under which the KvState has been registered
+		 * @param kvStateId            ID of the registered KvState instance
+		 * @param kvStateServerAddress Server address where to find the KvState instance
+		 */
+		public NotifyKvStateRegistered(
+				JobID jobId,
+				JobVertexID jobVertexId,
+				int keyGroupIndex,
+				String registrationName,
+				KvStateID kvStateId,
+				KvStateServerAddress kvStateServerAddress) {
+
+			this.jobId = Preconditions.checkNotNull(jobId, "JobID");
+			this.jobVertexId = Preconditions.checkNotNull(jobVertexId, "JobVertexID");
+			Preconditions.checkArgument(keyGroupIndex >= 0, "Negative key group index");
+			this.keyGroupIndex = keyGroupIndex;
+			this.registrationName = Preconditions.checkNotNull(registrationName, "Registration name");
+			this.kvStateId = Preconditions.checkNotNull(kvStateId, "KvStateID");
+			this.kvStateServerAddress = Preconditions.checkNotNull(kvStateServerAddress, "KvStateServerAddress");
+		}
+
+		/**
+		 * Returns the JobID the KvState instance belongs to.
+		 *
+		 * @return JobID the KvState instance belongs to
+		 */
+		public JobID getJobId() {
+			return jobId;
+		}
+
+		/**
+		 * Returns the JobVertexID the KvState instance belongs to
+		 *
+		 * @return JobVertexID the KvState instance belongs to
+		 */
+		public JobVertexID getJobVertexId() {
+			return jobVertexId;
+		}
+
+		/**
+		 * Returns the key group index the KvState instance belongs to.
+		 *
+		 * @return Key group index the KvState instance belongs to
+		 */
+		public int getKeyGroupIndex() {
+			return keyGroupIndex;
+		}
+
+		/**
+		 * Returns the name under which the KvState has been registered.
+		 *
+		 * @return Name under which the KvState has been registered
+		 */
+		public String getRegistrationName() {
+			return registrationName;
+		}
+
+		/**
+		 * Returns the ID of the registered KvState instance.
+		 *
+		 * @return ID of the registered KvState instance
+		 */
+		public KvStateID getKvStateId() {
+			return kvStateId;
+		}
+
+		/**
+		 * Returns the server address where to find the KvState instance.
+		 *
+		 * @return Server address where to find the KvState instance
+		 */
+		public KvStateServerAddress getKvStateServerAddress() {
+			return kvStateServerAddress;
+		}
+
+		@Override
+		public String toString() {
+			return "NotifyKvStateRegistered{" +
+					"jobId=" + jobId +
+					", jobVertexId=" + jobVertexId +
+					", keyGroupIndex=" + keyGroupIndex +
+					", registrationName='" + registrationName + '\'' +
+					", kvStateId=" + kvStateId +
+					", kvStateServerAddress=" + kvStateServerAddress +
+					'}';
+		}
+	}
+
+	class NotifyKvStateUnregistered implements KvStateMessage {
+
+		private static final long serialVersionUID = 1L;
+
+		/** JobID the KvState instance belongs to. */
+		private final JobID jobId;
+
+		/** JobVertexID the KvState instance belongs to. */
+		private final JobVertexID jobVertexId;
+
+		/** Key group index the KvState instance belongs to. */
+		private final int keyGroupIndex;
+
+		/** Name under which the KvState has been registered. */
+		private final String registrationName;
+
+		/**
+		 * Notifies the JobManager about an unregistered {@link KvState} instance.
+		 *
+		 * @param jobId                JobID the KvState instance belongs to
+		 * @param jobVertexId          JobVertexID the KvState instance belongs to
+		 * @param keyGroupIndex        Key group index the KvState instance belongs to
+		 * @param registrationName     Name under which the KvState has been registered
+		 */
+		public NotifyKvStateUnregistered(
+				JobID jobId,
+				JobVertexID jobVertexId,
+				int keyGroupIndex,
+				String registrationName) {
+
+			this.jobId = Preconditions.checkNotNull(jobId, "JobID");
+			this.jobVertexId = Preconditions.checkNotNull(jobVertexId, "JobVertexID");
+			Preconditions.checkArgument(keyGroupIndex >= 0, "Negative key group index");
+			this.keyGroupIndex = keyGroupIndex;
+			this.registrationName = Preconditions.checkNotNull(registrationName, "Registration name");
+		}
+
+		/**
+		 * Returns the JobID the KvState instance belongs to.
+		 *
+		 * @return JobID the KvState instance belongs to
+		 */
+		public JobID getJobId() {
+			return jobId;
+		}
+
+		/**
+		 * Returns the JobVertexID the KvState instance belongs to
+		 *
+		 * @return JobVertexID the KvState instance belongs to
+		 */
+		public JobVertexID getJobVertexId() {
+			return jobVertexId;
+		}
+
+		/**
+		 * Returns the key group index the KvState instance belongs to.
+		 *
+		 * @return Key group index the KvState instance belongs to
+		 */
+		public int getKeyGroupIndex() {
+			return keyGroupIndex;
+		}
+
+		/**
+		 * Returns the name under which the KvState has been registered.
+		 *
+		 * @return Name under which the KvState has been registered
+		 */
+		public String getRegistrationName() {
+			return registrationName;
+		}
+
+		@Override
+		public String toString() {
+			return "NotifyKvStateUnregistered{" +
+					"jobId=" + jobId +
+					", jobVertexId=" + jobVertexId +
+					", keyGroupIndex=" + keyGroupIndex +
+					", registrationName='" + registrationName + '\'' +
+					'}';
+		}
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateRegistry.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.query.netty.KvStateServer;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.runtime.taskmanager.Task;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A registry for {@link KvState} instances per task manager.
+ *
+ * <p>This is currently only used for KvState queries: KvState instances, which
+ * are marked as queryable in their state descriptor are registered here and
+ * can be queried by the {@link KvStateServer}.
+ *
+ * <p>KvState is registered when it is created/restored and unregistered when
+ * the owning operator stops running.
+ */
+public class KvStateRegistry {
+
+	/** All registered KvState instances. */
+	private final ConcurrentHashMap<KvStateID, KvState<?, ?, ?, ?, ?>> registeredKvStates =
+			new ConcurrentHashMap<>();
+
+	/** Registry listener to be notified on registration/unregistration. */
+	private final AtomicReference<KvStateRegistryListener> listener = new AtomicReference<>();
+
+	/**
+	 * Registers a listener with the registry.
+	 *
+	 * @param listener The registry listener.
+	 * @throws IllegalStateException If there is a registered listener
+	 */
+	public void registerListener(KvStateRegistryListener listener) {
+		if (!this.listener.compareAndSet(null, listener)) {
+			throw new IllegalStateException("Listener already registered.");
+		}
+	}
+
+	/**
+	 * Registers the KvState instance identified by the given 4-tuple of JobID,
+	 * JobVertexID, key group index, and registration name.
+	 *
+	 * @param kvStateId KvStateID to identify the KvState instance
+	 * @param kvState   KvState instance to register
+	 * @throws IllegalStateException If there is a KvState instance registered
+	 *                               with the same ID.
+	 */
+
+	/**
+	 * Registers the KvState instance and returns the assigned ID.
+	 *
+	 * @param jobId            JobId the KvState instance belongs to
+	 * @param jobVertexId      JobVertexID the KvState instance belongs to
+	 * @param keyGroupIndex    Key group index the KvState instance belongs to
+	 * @param registrationName Name under which the KvState is registered
+	 * @param kvState          KvState instance to be registered
+	 * @return Assigned KvStateID
+	 */
+	public KvStateID registerKvState(
+			JobID jobId,
+			JobVertexID jobVertexId,
+			int keyGroupIndex,
+			String registrationName,
+			KvState<?, ?, ?, ?, ?> kvState) {
+
+		KvStateID kvStateId = new KvStateID();
+
+		if (registeredKvStates.putIfAbsent(kvStateId, kvState) == null) {
+			KvStateRegistryListener listener = this.listener.get();
+			if (listener != null) {
+				listener.notifyKvStateRegistered(
+						jobId,
+						jobVertexId,
+						keyGroupIndex,
+						registrationName,
+						kvStateId);
+			}
+
+			return kvStateId;
+		} else {
+			throw new IllegalStateException(kvStateId + " is already registered.");
+		}
+	}
+
+	/**
+	 * Unregisters the KvState instance identified by the given KvStateID.
+	 *
+	 * @param jobId     JobId the KvState instance belongs to
+	 * @param kvStateId KvStateID to identify the KvState instance
+	 */
+	public void unregisterKvState(
+			JobID jobId,
+			JobVertexID jobVertexId,
+			int keyGroupIndex,
+			String registrationName,
+			KvStateID kvStateId) {
+
+		if (registeredKvStates.remove(kvStateId) != null) {
+			KvStateRegistryListener listener = this.listener.get();
+			if (listener != null) {
+				listener.notifyKvStateUnregistered(
+						jobId,
+						jobVertexId,
+						keyGroupIndex,
+						registrationName);
+			}
+		}
+	}
+
+	/**
+	 * Returns the KvState instance identified by the given KvStateID or
+	 * <code>null</code> if none is registered.
+	 *
+	 * @param kvStateId KvStateID to identify the KvState instance
+	 * @return KvState instance identified by the KvStateID or <code>null</code>
+	 */
+	public KvState<?, ?, ?, ?, ?> getKvState(KvStateID kvStateId) {
+		return registeredKvStates.get(kvStateId);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a {@link TaskKvStateRegistry} facade for the {@link Task}
+	 * identified by the given JobID and JobVertexID instance.
+	 *
+	 * @param jobId JobID of the task
+	 * @param jobVertexId JobVertexID of the task
+	 * @return A {@link TaskKvStateRegistry} facade for the task
+	 */
+	public TaskKvStateRegistry createTaskRegistry(JobID jobId, JobVertexID jobVertexId) {
+		return new TaskKvStateRegistry(this, jobId, jobVertexId);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateRegistryListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateRegistryListener.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+/**
+ * A listener for a {@link KvStateRegistry}.
+ *
+ * <p>The registry calls these methods when KvState instances are registered
+ * and unregistered.
+ */
+public interface KvStateRegistryListener {
+
+	/**
+	 * Notifies the listener about a registered KvState instance.
+	 *
+	 * @param jobId            Job ID the KvState instance belongs to
+	 * @param jobVertexId      JobVertexID the KvState instance belongs to
+	 * @param keyGroupIndex    Key group index the KvState instance belongs to
+	 * @param registrationName Name under which the KvState is registered
+	 * @param kvStateId        ID of the KvState instance
+	 */
+	void notifyKvStateRegistered(
+			JobID jobId,
+			JobVertexID jobVertexId,
+			int keyGroupIndex,
+			String registrationName,
+			KvStateID kvStateId);
+
+	/**
+	 * Notifies the listener about an unregistered KvState instance.
+	 *
+	 * @param jobId            Job ID the KvState instance belongs to
+	 * @param jobVertexId      JobVertexID the KvState instance belongs to
+	 * @param keyGroupIndex    Key group index the KvState instance belongs to
+	 * @param registrationName Name under which the KvState is registered
+	 */
+	void notifyKvStateUnregistered(
+			JobID jobId,
+			JobVertexID jobVertexId,
+			int keyGroupIndex,
+			String registrationName);
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateServerAddress.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/KvStateServerAddress.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.runtime.query.netty.KvStateServer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+
+/**
+ * The (host, port)-address of a {@link KvStateServer}.
+ */
+public class KvStateServerAddress implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** KvStateServer host address. */
+	private final InetAddress hostAddress;
+
+	/** KvStateServer port. */
+	private final int port;
+
+	/**
+	 * Creates a KvStateServerAddress for the given KvStateServer host address
+	 * and port.
+	 *
+	 * @param hostAddress KvStateServer host address
+	 * @param port        KvStateServer port
+	 */
+	public KvStateServerAddress(InetAddress hostAddress, int port) {
+		this.hostAddress = Preconditions.checkNotNull(hostAddress, "Host address");
+		Preconditions.checkArgument(port > 0 && port <= 65535, "Port " + port + " is out of range 1-65535");
+		this.port = port;
+	}
+
+	/**
+	 * Returns the host address of the KvStateServer.
+	 *
+	 * @return KvStateServer host address
+	 */
+	public InetAddress getHost() {
+		return hostAddress;
+	}
+
+	/**
+	 * Returns the port of the KvStateServer.
+	 *
+	 * @return KvStateServer port
+	 */
+	public int getPort() {
+		return port;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) { return true; }
+		if (o == null || getClass() != o.getClass()) { return false; }
+
+		KvStateServerAddress that = (KvStateServerAddress) o;
+
+		return port == that.port && hostAddress.equals(that.hostAddress);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = hostAddress.hashCode();
+		result = 31 * result + port;
+		return result;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateClient.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import akka.actor.ActorSystem;
+import akka.dispatch.Futures;
+import akka.dispatch.Mapper;
+import akka.dispatch.Recover;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.query.AkkaKvStateLocationLookupService.FixedDelayLookupRetryStrategyFactory;
+import org.apache.flink.runtime.query.AkkaKvStateLocationLookupService.LookupRetryStrategyFactory;
+import org.apache.flink.runtime.query.netty.DisabledKvStateRequestStats;
+import org.apache.flink.runtime.query.netty.KvStateClient;
+import org.apache.flink.runtime.query.netty.KvStateServer;
+import org.apache.flink.runtime.query.netty.UnknownKeyOrNamespace;
+import org.apache.flink.runtime.query.netty.UnknownKvStateID;
+import org.apache.flink.runtime.util.LeaderRetrievalUtils;
+import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.Some;
+import scala.Tuple2;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.net.ConnectException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Client for queryable state.
+ *
+ * <p>You can mark state as queryable via {@link StateDescriptor#setQueryable(String)}.
+ * The state instance created from this descriptor will be published for queries
+ * when it's created on the TaskManagers and the location will be reported to
+ * the JobManager.
+ *
+ * <p>The client resolves the location of the requested KvState via the
+ * JobManager. Resolved locations are cached. When the server address of the
+ * requested KvState instance is determined, the client sends out a request to
+ * the server.
+ */
+public class QueryableStateClient {
+
+	private static final Logger LOG = LoggerFactory.getLogger(QueryableStateClient.class);
+
+	/**
+	 * {@link KvStateLocation} lookup to resolve the address of KvState instances.
+	 */
+	private final KvStateLocationLookupService lookupService;
+
+	/**
+	 * Network client for queries against {@link KvStateServer} instances.
+	 */
+	private final KvStateClient kvStateClient;
+
+	/**
+	 * Execution context.
+	 */
+	private final ExecutionContext executionContext;
+
+	/**
+	 * Cache for {@link KvStateLocation} instances keyed by job and name.
+	 */
+	private final ConcurrentMap<Tuple2<JobID, String>, Future<KvStateLocation>> lookupCache =
+			new ConcurrentHashMap<>();
+
+	/** This is != null, iff we started the actor system. */
+	private final ActorSystem actorSystem;
+
+	/**
+	 * Creates a client from the given configuration.
+	 *
+	 * <p>This will create multiple Thread pools: one for the started actor
+	 * system and another for the network client.
+	 *
+	 * @param config Configuration to use.
+	 * @throws Exception Failures are forwarded
+	 */
+	public QueryableStateClient(Configuration config) throws Exception {
+		Preconditions.checkNotNull(config, "Configuration");
+
+		// Create a leader retrieval service
+		LeaderRetrievalService leaderRetrievalService = LeaderRetrievalUtils
+				.createLeaderRetrievalService(config);
+
+		// Get the ask timeout
+		String askTimeoutString = config.getString(
+				ConfigConstants.AKKA_ASK_TIMEOUT,
+				ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT);
+
+		Duration timeout = FiniteDuration.apply(askTimeoutString);
+		if (!timeout.isFinite()) {
+			throw new IllegalConfigurationException(ConfigConstants.AKKA_ASK_TIMEOUT
+					+ " is not a finite timeout ('" + askTimeoutString + "')");
+		}
+
+		FiniteDuration askTimeout = (FiniteDuration) timeout;
+
+		int lookupRetries = config.getInteger(
+				ConfigConstants.QUERYABLE_STATE_CLIENT_LOOKUP_RETRIES,
+				ConfigConstants.DEFAULT_QUERYABLE_STATE_CLIENT_LOOKUP_RETRIES);
+
+		int lookupRetryDelayMillis = config.getInteger(
+				ConfigConstants.QUERYABLE_STATE_CLIENT_LOOKUP_RETRY_DELAY,
+				ConfigConstants.DEFAULT_QUERYABLE_STATE_CLIENT_LOOKUP_RETRY_DELAY);
+
+		// Retries if no JobManager is around
+		LookupRetryStrategyFactory retryStrategy = new FixedDelayLookupRetryStrategyFactory(
+				lookupRetries,
+				FiniteDuration.apply(lookupRetryDelayMillis, "ms"));
+
+		// Create the actor system
+		@SuppressWarnings("unchecked")
+		Option<Tuple2<String, Object>> remoting = new Some(new Tuple2<>("", 0));
+		this.actorSystem = AkkaUtils.createActorSystem(config, remoting);
+
+		AkkaKvStateLocationLookupService lookupService = new AkkaKvStateLocationLookupService(
+				leaderRetrievalService,
+				actorSystem,
+				askTimeout,
+				retryStrategy);
+
+		int numEventLoopThreads = config.getInteger(
+				ConfigConstants.QUERYABLE_STATE_CLIENT_NETWORK_THREADS,
+				ConfigConstants.DEFAULT_QUERYABLE_STATE_CLIENT_NETWORK_THREADS);
+
+		if (numEventLoopThreads == 0) {
+			numEventLoopThreads = Runtime.getRuntime().availableProcessors();
+		}
+
+		// Create the network client
+		KvStateClient networkClient = new KvStateClient(
+				numEventLoopThreads,
+				new DisabledKvStateRequestStats());
+
+		this.lookupService = lookupService;
+		this.kvStateClient = networkClient;
+		this.executionContext = actorSystem.dispatcher();
+
+		this.lookupService.start();
+	}
+
+	/**
+	 * Creates a client.
+	 *
+	 * @param lookupService    Location lookup service
+	 * @param kvStateClient    Network client for queries
+	 * @param executionContext Execution context for futures
+	 */
+	public QueryableStateClient(
+			KvStateLocationLookupService lookupService,
+			KvStateClient kvStateClient,
+			ExecutionContext executionContext) {
+
+		this.lookupService = Preconditions.checkNotNull(lookupService, "KvStateLocationLookupService");
+		this.kvStateClient = Preconditions.checkNotNull(kvStateClient, "KvStateClient");
+		this.executionContext = Preconditions.checkNotNull(executionContext, "ExecutionContext");
+		this.actorSystem = null;
+
+		this.lookupService.start();
+	}
+
+	/**
+	 * Returns the execution context of this client.
+	 *
+	 * @return The execution context used by the client.
+	 */
+	public ExecutionContext getExecutionContext() {
+		return executionContext;
+	}
+
+	/**
+	 * Shuts down the client and all components.
+	 */
+	public void shutDown() {
+		try {
+			lookupService.shutDown();
+		} catch (Throwable t) {
+			LOG.error("Failed to shut down KvStateLookupService", t);
+		}
+
+		try {
+			kvStateClient.shutDown();
+		} catch (Throwable t) {
+			LOG.error("Failed to shut down KvStateClient", t);
+		}
+
+		if (actorSystem != null) {
+			try {
+				actorSystem.shutdown();
+			} catch (Throwable t) {
+				LOG.error("Failed to shut down ActorSystem");
+			}
+		}
+	}
+
+	/**
+	 * Returns a future holding the serialized request result.
+	 *
+	 * <p>If the server does not serve a KvState instance with the given ID,
+	 * the Future will be failed with a {@link UnknownKvStateID}.
+	 *
+	 * <p>If the KvState instance does not hold any data for the given key
+	 * and namespace, the Future will be failed with a {@link UnknownKeyOrNamespace}.
+	 *
+	 * <p>All other failures are forwarded to the Future.
+	 *
+	 * @param jobId                     JobID of the job the queryable state
+	 *                                  belongs to
+	 * @param queryableStateName        Name under which the state is queryable
+	 * @param keyHashCode               Integer hash code of the key (result of
+	 *                                  a call to {@link Object#hashCode()}
+	 * @param serializedKeyAndNamespace Serialized key and namespace to query
+	 *                                  KvState instance with
+	 * @return Future holding the serialized result
+	 */
+	@SuppressWarnings("unchecked")
+	public Future<byte[]> getKvState(
+			final JobID jobId,
+			final String queryableStateName,
+			final int keyHashCode,
+			final byte[] serializedKeyAndNamespace) {
+
+		return getKvState(jobId, queryableStateName, keyHashCode, serializedKeyAndNamespace, false)
+				.recoverWith(new Recover<Future<byte[]>>() {
+					@Override
+					public Future<byte[]> recover(Throwable failure) throws Throwable {
+						if (failure instanceof UnknownKvStateID ||
+								failure instanceof UnknownKvStateKeyGroupLocation ||
+								failure instanceof UnknownKvStateLocation ||
+								failure instanceof ConnectException) {
+							// These failures are likely to be caused by out-of-sync
+							// KvStateLocation. Therefore we retry this query and
+							// force look up the location.
+							return getKvState(
+									jobId,
+									queryableStateName,
+									keyHashCode,
+									serializedKeyAndNamespace,
+									true);
+						} else {
+							return Futures.failed(failure);
+						}
+					}
+				}, executionContext);
+	}
+
+	/**
+	 * Returns a future holding the serialized request result.
+	 *
+	 * @param jobId                     JobID of the job the queryable state
+	 *                                  belongs to
+	 * @param queryableStateName        Name under which the state is queryable
+	 * @param keyHashCode               Integer hash code of the key (result of
+	 *                                  a call to {@link Object#hashCode()}
+	 * @param serializedKeyAndNamespace Serialized key and namespace to query
+	 *                                  KvState instance with
+	 * @param forceLookup               Flag to force lookup of the {@link KvStateLocation}
+	 * @return Future holding the serialized result
+	 */
+	private Future<byte[]> getKvState(
+			final JobID jobId,
+			final String queryableStateName,
+			final int keyHashCode,
+			final byte[] serializedKeyAndNamespace,
+			boolean forceLookup) {
+
+		return getKvStateLookupInfo(jobId, queryableStateName, forceLookup)
+				.flatMap(new Mapper<KvStateLocation, Future<byte[]>>() {
+					@Override
+					public Future<byte[]> apply(KvStateLocation lookup) {
+						int keyGroupIndex = MathUtils.murmurHash(keyHashCode) % lookup.getNumKeyGroups();
+
+						KvStateServerAddress serverAddress = lookup.getKvStateServerAddress(keyGroupIndex);
+						if (serverAddress == null) {
+							return Futures.failed(new UnknownKvStateKeyGroupLocation());
+						} else {
+							// Query server
+							KvStateID kvStateId = lookup.getKvStateID(keyGroupIndex);
+							return kvStateClient.getKvState(serverAddress, kvStateId, serializedKeyAndNamespace);
+						}
+					}
+				}, executionContext);
+	}
+
+	/**
+	 * Lookup the {@link KvStateLocation} for the given job and queryable state
+	 * name.
+	 *
+	 * <p>The job manager will be queried for the location only if forced or no
+	 * cached location can be found. There are no guarantees about
+	 *
+	 * @param jobId              JobID the state instance belongs to.
+	 * @param queryableStateName Name under which the state instance has been published.
+	 * @param forceUpdate        Flag to indicate whether to force a update via the lookup service.
+	 * @return Future holding the KvStateLocation
+	 */
+	private Future<KvStateLocation> getKvStateLookupInfo(
+			JobID jobId,
+			final String queryableStateName,
+			boolean forceUpdate) {
+
+		if (forceUpdate) {
+			Future<KvStateLocation> lookupFuture = lookupService
+					.getKvStateLookupInfo(jobId, queryableStateName);
+			lookupCache.put(new Tuple2<>(jobId, queryableStateName), lookupFuture);
+			return lookupFuture;
+		} else {
+			Tuple2<JobID, String> cacheKey = new Tuple2<>(jobId, queryableStateName);
+			final Future<KvStateLocation> cachedFuture = lookupCache.get(cacheKey);
+
+			if (cachedFuture == null) {
+				Future<KvStateLocation> lookupFuture = lookupService
+						.getKvStateLookupInfo(jobId, queryableStateName);
+
+				Future<KvStateLocation> previous = lookupCache.putIfAbsent(cacheKey, lookupFuture);
+				if (previous == null) {
+					return lookupFuture;
+				} else {
+					return previous;
+				}
+			} else {
+				return cachedFuture;
+			}
+		}
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/TaskKvStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/TaskKvStateRegistry.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper for KvState registrations of a single task.
+ */
+public class TaskKvStateRegistry {
+
+	/** KvStateRegistry for KvState instance registrations. */
+	private final KvStateRegistry registry;
+
+	/** JobID of the task. */
+	private final JobID jobId;
+
+	/** JobVertexID of the task. */
+	private final JobVertexID jobVertexId;
+
+	/** List of all registered KvState instances of this task. */
+	private final List<KvStateInfo> registeredKvStates = new ArrayList<>();
+
+	TaskKvStateRegistry(KvStateRegistry registry, JobID jobId, JobVertexID jobVertexId) {
+		this.registry = Preconditions.checkNotNull(registry, "KvStateRegistry");
+		this.jobId = Preconditions.checkNotNull(jobId, "JobID");
+		this.jobVertexId = Preconditions.checkNotNull(jobVertexId, "JobVertexID");
+	}
+
+	/**
+	 * Registers the KvState instance at the KvStateRegistry.
+	 *
+	 * @param keyGroupIndex    KeyGroupIndex the KvState instance belongs to
+	 * @param registrationName The registration name (not necessarily the same
+	 *                         as the KvState name defined in the state
+	 *                         descriptor used to create the KvState instance)
+	 * @param kvState          The
+	 */
+	public void registerKvState(int keyGroupIndex, String registrationName, KvState<?, ?, ?, ?, ?> kvState) {
+		KvStateID kvStateId = registry.registerKvState(jobId, jobVertexId, keyGroupIndex, registrationName, kvState);
+		registeredKvStates.add(new KvStateInfo(keyGroupIndex, registrationName, kvStateId));
+	}
+
+	/**
+	 * Unregisters all registered KvState instances from the KvStateRegistry.
+	 */
+	public void unregisterAll() {
+		for (KvStateInfo kvState : registeredKvStates) {
+			registry.unregisterKvState(jobId, jobVertexId, kvState.keyGroupIndex, kvState.registrationName, kvState.kvStateId);
+		}
+	}
+
+	/**
+	 * 3-tuple holding registered KvState meta data.
+	 */
+	private static class KvStateInfo {
+
+		private final int keyGroupIndex;
+
+		private final String registrationName;
+
+		private final KvStateID kvStateId;
+
+		public KvStateInfo(int keyGroupIndex, String registrationName, KvStateID kvStateId) {
+			this.keyGroupIndex = keyGroupIndex;
+			this.registrationName = registrationName;
+			this.kvStateId = kvStateId;
+		}
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/UnknownJobManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/UnknownJobManager.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+/**
+ * Exception to fail Future with if no JobManager is currently registered at
+ * the {@link KvStateLocationLookupService}.
+ */
+class UnknownJobManager extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public UnknownJobManager() {
+		super("Unknown JobManager. Either the JobManager has not registered yet " +
+				"or has lost leadership.");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/UnknownKvStateKeyGroupLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/UnknownKvStateKeyGroupLocation.java
@@ -16,19 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.taskmanager
+package org.apache.flink.runtime.query;
 
-import org.apache.flink.core.memory.MemoryType
-import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
-import org.apache.flink.runtime.io.network.netty.NettyConfig
+/**
+ * Exception thrown if there is no location information available for the given
+ * key group in a {@link KvStateLocation} instance.
+ */
+class UnknownKvStateKeyGroupLocation extends Exception {
 
-case class NetworkEnvironmentConfiguration(
-  numNetworkBuffers: Int,
-  networkBufferSize: Int,
-  memoryType: MemoryType,
-  ioMode: IOMode,
-  queryServerPort: Int,
-  queryServerNetworkThreads: Int,
-  queryServerQueryThreads: Int,
-  nettyConfig: Option[NettyConfig] = None,
-  partitionRequestInitialAndMaxBackoff: (Integer, Integer) = (500, 3000))
+	private static final long serialVersionUID = 1L;
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/UnknownKvStateLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/UnknownKvStateLocation.java
@@ -16,19 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.taskmanager
+package org.apache.flink.runtime.query;
 
-import org.apache.flink.core.memory.MemoryType
-import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
-import org.apache.flink.runtime.io.network.netty.NettyConfig
+/**
+ * Thrown if there is no {@link KvStateLocation} found for the requested
+ * registration name.
+ *
+ * <p>This indicates that the requested KvState instance is not registered
+ * under this name (yet).
+ */
+public class UnknownKvStateLocation extends Exception {
 
-case class NetworkEnvironmentConfiguration(
-  numNetworkBuffers: Int,
-  networkBufferSize: Int,
-  memoryType: MemoryType,
-  ioMode: IOMode,
-  queryServerPort: Int,
-  queryServerNetworkThreads: Int,
-  queryServerQueryThreads: Int,
-  nettyConfig: Option[NettyConfig] = None,
-  partitionRequestInitialAndMaxBackoff: (Integer, Integer) = (500, 3000))
+	private static final long serialVersionUID = 1L;
+
+	public UnknownKvStateLocation(String registrationName) {
+		super("No KvStateLocation found for KvState instance with name '" + registrationName + "'.");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/AtomicKvStateRequestStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/AtomicKvStateRequestStats.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Atomic {@link KvStateRequestStats} implementation.
+ */
+public class AtomicKvStateRequestStats implements KvStateRequestStats {
+
+	/**
+	 * Number of active connections.
+	 */
+	private final AtomicLong numConnections = new AtomicLong();
+
+	/**
+	 * Total number of reported requests.
+	 */
+	private final AtomicLong numRequests = new AtomicLong();
+
+	/**
+	 * Total number of successful requests (<= reported requests).
+	 */
+	private final AtomicLong numSuccessful = new AtomicLong();
+
+	/**
+	 * Total duration of all successful requests.
+	 */
+	private final AtomicLong successfulDuration = new AtomicLong();
+
+	/**
+	 * Total number of failed requests (<= reported requests).
+	 */
+	private final AtomicLong numFailed = new AtomicLong();
+
+	@Override
+	public void reportActiveConnection() {
+		numConnections.incrementAndGet();
+	}
+
+	@Override
+	public void reportInactiveConnection() {
+		numConnections.decrementAndGet();
+	}
+
+	@Override
+	public void reportRequest() {
+		numRequests.incrementAndGet();
+	}
+
+	@Override
+	public void reportSuccessfulRequest(long durationTotalMillis) {
+		numSuccessful.incrementAndGet();
+		successfulDuration.addAndGet(durationTotalMillis);
+	}
+
+	@Override
+	public void reportFailedRequest() {
+		numFailed.incrementAndGet();
+	}
+
+	public long getNumConnections() {
+		return numConnections.get();
+	}
+
+	public long getNumRequests() {
+		return numRequests.get();
+	}
+
+	public long getNumSuccessful() {
+		return numSuccessful.get();
+	}
+
+	public long getNumFailed() {
+		return numFailed.get();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/ChunkedByteBuf.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/ChunkedByteBuf.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.stream.ChunkedInput;
+import io.netty.handler.stream.ChunkedWriteHandler;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A {@link ByteBuf} instance to be consumed in chunks by {@link ChunkedWriteHandler},
+ * respecting the high and low watermarks.
+ *
+ * @see <a href="http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#10.0">Low/High Watermarks</a>
+ */
+class ChunkedByteBuf implements ChunkedInput<ByteBuf> {
+
+	/** The buffer to chunk */
+	private final ByteBuf buf;
+
+	/** Size of chunks */
+	private final int chunkSize;
+
+	/** Closed flag */
+	private boolean isClosed;
+
+	/** End of input flag */
+	private boolean isEndOfInput;
+
+	public ChunkedByteBuf(ByteBuf buf, int chunkSize) {
+		this.buf = Preconditions.checkNotNull(buf, "Buffer");
+		Preconditions.checkArgument(chunkSize > 0, "Non-positive chunk size");
+		this.chunkSize = chunkSize;
+	}
+
+	@Override
+	public boolean isEndOfInput() throws Exception {
+		return isClosed || isEndOfInput;
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (!isClosed) {
+			// If we did not consume the whole buffer yet, we have to release
+			// it here. Otherwise, it's the responsibility of the consumer.
+			if (!isEndOfInput) {
+				buf.release();
+			}
+
+			isClosed = true;
+		}
+	}
+
+	@Override
+	public ByteBuf readChunk(ChannelHandlerContext ctx) throws Exception {
+		if (isClosed) {
+			return null;
+		} else if (buf.readableBytes() <= chunkSize) {
+			isEndOfInput = true;
+
+			// Don't retain as the consumer is responsible to release it
+			return buf.slice();
+		} else {
+			// Return a chunk sized slice of the buffer. The ref count is
+			// shared with the original buffer. That's why we need to retain
+			// a reference here.
+			return buf.readSlice(chunkSize).retain();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "ChunkedByteBuf{" +
+				"buf=" + buf +
+				", chunkSize=" + chunkSize +
+				", isClosed=" + isClosed +
+				", isEndOfInput=" + isEndOfInput +
+				'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/DisabledKvStateRequestStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/DisabledKvStateRequestStats.java
@@ -16,31 +16,30 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobgraph;
-
-import org.apache.flink.util.AbstractID;
-
-import javax.xml.bind.DatatypeConverter;
+package org.apache.flink.runtime.query.netty;
 
 /**
- * A class for statistically unique job vertex IDs.
+ * Disabled {@link KvStateRequestStats} implementation.
  */
-public class JobVertexID extends AbstractID {
-	
-	private static final long serialVersionUID = 1L;
-	
-	public JobVertexID() {
-		super();
-	}
-	public JobVertexID(byte[] bytes) {
-		super(bytes);
+public class DisabledKvStateRequestStats implements KvStateRequestStats {
+
+	@Override
+	public void reportActiveConnection() {
 	}
 
-	public JobVertexID(long lowerPart, long upperPart) {
-		super(lowerPart, upperPart);
+	@Override
+	public void reportInactiveConnection() {
 	}
 
-	public static JobVertexID fromHexString(String hexString) {
-		return new JobVertexID(DatatypeConverter.parseHexBinary(hexString));
+	@Override
+	public void reportRequest() {
+	}
+
+	@Override
+	public void reportSuccessfulRequest(long durationTotalMillis) {
+	}
+
+	@Override
+	public void reportFailedRequest() {
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateClient.java
@@ -1,0 +1,575 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import akka.dispatch.Futures;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
+import org.apache.flink.runtime.io.network.netty.NettyBufferPool;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.query.KvStateServerAddress;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.util.Preconditions;
+import scala.concurrent.Future;
+import scala.concurrent.Promise;
+
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayDeque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Netty-based client querying {@link KvStateServer} instances.
+ *
+ * <p>This client can be used by multiple threads concurrently. Operations are
+ * executed asynchronously and return Futures to their result.
+ *
+ * <p>The incoming pipeline looks as follows:
+ * <pre>
+ * Socket.read() -> LengthFieldBasedFrameDecoder -> KvStateServerHandler
+ * </pre>
+ *
+ * <p>Received binary messages are expected to contain a frame length field. Netty's
+ * {@link LengthFieldBasedFrameDecoder} is used to fully receive the frame before
+ * giving it to our {@link KvStateClientHandler}.
+ *
+ * <p>Connections are established and closed by the client. The server only
+ * closes the connection on a fatal failure that cannot be recovered.
+ */
+public class KvStateClient {
+
+	/** Netty's Bootstrap. */
+	private final Bootstrap bootstrap;
+
+	/** Statistics tracker */
+	private final KvStateRequestStats stats;
+
+	/** Established connections. */
+	private final ConcurrentHashMap<KvStateServerAddress, EstablishedConnection> establishedConnections =
+			new ConcurrentHashMap<>();
+
+	/** Pending connections. */
+	private final ConcurrentHashMap<KvStateServerAddress, PendingConnection> pendingConnections =
+			new ConcurrentHashMap<>();
+
+	/** Atomic shut down flag. */
+	private final AtomicBoolean shutDown = new AtomicBoolean();
+
+	/**
+	 * Creates a client with the specified number of event loop threads.
+	 *
+	 * @param numEventLoopThreads Number of event loop threads (minimum 1).
+	 */
+	public KvStateClient(int numEventLoopThreads, KvStateRequestStats stats) {
+		Preconditions.checkArgument(numEventLoopThreads >= 1, "Non-positive number of event loop threads.");
+		NettyBufferPool bufferPool = new NettyBufferPool(numEventLoopThreads);
+
+		ThreadFactory threadFactory = new ThreadFactoryBuilder()
+				.setDaemon(true)
+				.setNameFormat("Flink KvStateClient Event Loop Thread %d")
+				.build();
+
+		NioEventLoopGroup nioGroup = new NioEventLoopGroup(numEventLoopThreads, threadFactory);
+
+		this.bootstrap = new Bootstrap()
+				.group(nioGroup)
+				.channel(NioSocketChannel.class)
+				.option(ChannelOption.ALLOCATOR, bufferPool)
+				.handler(new ChannelInitializer<SocketChannel>() {
+					@Override
+					protected void initChannel(SocketChannel ch) throws Exception {
+						ch.pipeline()
+								.addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4))
+								// ChunkedWriteHandler respects Channel writability
+								.addLast(new ChunkedWriteHandler());
+					}
+				});
+
+		this.stats = Preconditions.checkNotNull(stats, "Statistics tracker");
+	}
+
+	/**
+	 * Returns a future holding the serialized request result.
+	 *
+	 * <p>If the server does not serve a KvState instance with the given ID,
+	 * the Future will be failed with a {@link UnknownKvStateID}.
+	 *
+	 * <p>If the KvState instance does not hold any data for the given key
+	 * and namespace, the Future will be failed with a {@link UnknownKeyOrNamespace}.
+	 *
+	 * <p>All other failures are forwarded to the Future.
+	 *
+	 * @param serverAddress Address of the server to query
+	 * @param kvStateId ID of the KvState instance to query
+	 * @param serializedKeyAndNamespace Serialized key and namespace to query KvState instance with
+	 * @return Future holding the serialized result
+	 */
+	public Future<byte[]> getKvState(
+			KvStateServerAddress serverAddress,
+			KvStateID kvStateId,
+			byte[] serializedKeyAndNamespace) {
+
+		if (shutDown.get()) {
+			return Futures.failed(new IllegalStateException("Shut down"));
+		}
+
+		EstablishedConnection connection = establishedConnections.get(serverAddress);
+
+		if (connection != null) {
+			return connection.getKvState(kvStateId, serializedKeyAndNamespace);
+		} else {
+			PendingConnection pendingConnection = pendingConnections.get(serverAddress);
+			if (pendingConnection != null) {
+				// There was a race, use the existing pending connection.
+				return pendingConnection.getKvState(kvStateId, serializedKeyAndNamespace);
+			} else {
+				// We try to connect to the server.
+				PendingConnection pending = new PendingConnection(serverAddress);
+				PendingConnection previous = pendingConnections.putIfAbsent(serverAddress, pending);
+
+				if (previous == null) {
+					// OK, we are responsible to connect.
+					bootstrap.connect(serverAddress.getHost(), serverAddress.getPort())
+							.addListener(pending);
+
+					return pending.getKvState(kvStateId, serializedKeyAndNamespace);
+				} else {
+					// There was a race, use the existing pending connection.
+					return previous.getKvState(kvStateId, serializedKeyAndNamespace);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Shuts down the client and closes all connections.
+	 *
+	 * <p>After a call to this method, all returned futures will be failed.
+	 */
+	public void shutDown() {
+		if (shutDown.compareAndSet(false, true)) {
+			for (Map.Entry<KvStateServerAddress, EstablishedConnection> conn : establishedConnections.entrySet()) {
+				if (establishedConnections.remove(conn.getKey(), conn.getValue())) {
+					conn.getValue().close();
+				}
+			}
+
+			for (Map.Entry<KvStateServerAddress, PendingConnection> conn : pendingConnections.entrySet()) {
+				if (pendingConnections.remove(conn.getKey()) != null) {
+					conn.getValue().close();
+				}
+			}
+
+			if (bootstrap != null) {
+				EventLoopGroup group = bootstrap.group();
+				if (group != null) {
+					group.shutdownGracefully();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Closes the connection to the given server address if it exists.
+	 *
+	 * <p>If there is a request to the server a new connection will be established.
+	 *
+	 * @param serverAddress Target address of the connection to close
+	 */
+	public void closeConnection(KvStateServerAddress serverAddress) {
+		PendingConnection pending = pendingConnections.get(serverAddress);
+		if (pending != null) {
+			pending.close();
+		}
+
+		EstablishedConnection established = establishedConnections.remove(serverAddress);
+		if (established != null) {
+			established.close();
+		}
+	}
+
+	/**
+	 * A pending connection that is in the process of connecting.
+	 */
+	private class PendingConnection implements ChannelFutureListener {
+
+		/** Lock to guard the connect call, channel hand in, etc. */
+		private final Object connectLock = new Object();
+
+		/** Address of the server we are connecting to. */
+		private final KvStateServerAddress serverAddress;
+
+		/** Queue of requests while connecting. */
+		private final ArrayDeque<PendingRequest> queuedRequests = new ArrayDeque<>();
+
+		/** The established connection after the connect succeeds. */
+		private EstablishedConnection established;
+
+		/** Closed flag. */
+		private boolean closed;
+
+		/** Failure cause if something goes wrong. */
+		private Throwable failureCause;
+
+		/**
+		 * Creates a pending connection to the given server.
+		 *
+		 * @param serverAddress Address of the server to connect to.
+		 */
+		private PendingConnection(KvStateServerAddress serverAddress) {
+			this.serverAddress = serverAddress;
+		}
+
+		@Override
+		public void operationComplete(ChannelFuture future) throws Exception {
+			// Callback from the Bootstrap's connect call.
+			if (future.isSuccess()) {
+				handInChannel(future.channel());
+			} else {
+				close(future.cause());
+			}
+		}
+
+		/**
+		 * Returns a future holding the serialized request result.
+		 *
+		 * <p>If the channel has been established, forward the call to the
+		 * established channel, otherwise queue it for when the channel is
+		 * handed in.
+		 *
+		 * @param kvStateId                 ID of the KvState instance to query
+		 * @param serializedKeyAndNamespace Serialized key and namespace to query KvState instance
+		 *                                  with
+		 * @return Future holding the serialized result
+		 */
+		public Future<byte[]> getKvState(KvStateID kvStateId, byte[] serializedKeyAndNamespace) {
+			synchronized (connectLock) {
+				if (failureCause != null) {
+					return Futures.failed(failureCause);
+				} else if (closed) {
+					return Futures.failed(new ClosedChannelException());
+				} else {
+					if (established != null) {
+						return established.getKvState(kvStateId, serializedKeyAndNamespace);
+					} else {
+						// Queue this and handle when connected
+						PendingRequest pending = new PendingRequest(kvStateId, serializedKeyAndNamespace);
+						queuedRequests.add(pending);
+						return pending.promise.future();
+					}
+				}
+			}
+		}
+
+		/**
+		 * Hands in a channel after a successful connection.
+		 *
+		 * @param channel Channel to hand in
+		 */
+		private void handInChannel(Channel channel) {
+			synchronized (connectLock) {
+				if (closed || failureCause != null) {
+					// Close the channel and we are done. Any queued requests
+					// are removed on the close/failure call and after that no
+					// new ones can be enqueued.
+					channel.close();
+				} else {
+					established = new EstablishedConnection(serverAddress, channel);
+
+					PendingRequest pending;
+					while ((pending = queuedRequests.poll()) != null) {
+						Future<byte[]> resultFuture = established.getKvState(
+								pending.kvStateId,
+								pending.serializedKeyAndNamespace);
+
+						pending.promise.completeWith(resultFuture);
+					}
+
+					// Publish the channel for the general public
+					establishedConnections.put(serverAddress, established);
+					pendingConnections.remove(serverAddress);
+
+					// Check shut down for possible race with shut down. We
+					// don't want any lingering connections after shut down,
+					// which can happen if we don't check this here.
+					if (shutDown.get()) {
+						if (establishedConnections.remove(serverAddress, established)) {
+							established.close();
+						}
+					}
+				}
+			}
+		}
+
+		/**
+		 * Close the connecting channel with a ClosedChannelException.
+		 */
+		private void close() {
+			close(new ClosedChannelException());
+		}
+
+		/**
+		 * Close the connecting channel with an Exception (can be
+		 * <code>null</code>) or forward to the established channel.
+		 */
+		private void close(Throwable cause) {
+			synchronized (connectLock) {
+				if (!closed) {
+					if (failureCause == null) {
+						failureCause = cause;
+					}
+
+					if (established != null) {
+						established.close();
+					} else {
+						PendingRequest pending;
+						while ((pending = queuedRequests.poll()) != null) {
+							pending.promise.tryFailure(cause);
+						}
+					}
+
+					closed = true;
+				}
+			}
+		}
+
+		/**
+		 * A pending request queued while the channel is connecting.
+		 */
+		private final class PendingRequest {
+
+			private final KvStateID kvStateId;
+			private final byte[] serializedKeyAndNamespace;
+			private final Promise<byte[]> promise;
+
+			private PendingRequest(KvStateID kvStateId, byte[] serializedKeyAndNamespace) {
+				this.kvStateId = kvStateId;
+				this.serializedKeyAndNamespace = serializedKeyAndNamespace;
+				this.promise = Futures.promise();
+			}
+		}
+
+		@Override
+		public String toString() {
+			synchronized (connectLock) {
+				return "PendingConnection{" +
+						"serverAddress=" + serverAddress +
+						", queuedRequests=" + queuedRequests.size() +
+						", established=" + (established != null) +
+						", closed=" + closed +
+						'}';
+			}
+		}
+	}
+
+	/**
+	 * An established connection that wraps the actual channel instance and is
+	 * registered at the {@link KvStateClientHandler} for callbacks.
+	 */
+	private class EstablishedConnection implements KvStateClientHandlerCallback {
+
+		/** Address of the server we are connected to. */
+		private final KvStateServerAddress serverAddress;
+
+		/** The actual TCP channel. */
+		private final Channel channel;
+
+		/** Pending requests keyed by request ID. */
+		private final ConcurrentHashMap<Long, PromiseAndTimestamp> pendingRequests = new ConcurrentHashMap<>();
+
+		/** Current request number used to assign unique request IDs. */
+		private final AtomicLong requestCount = new AtomicLong();
+
+		/** Reference to a failure that was reported by the channel. */
+		private final AtomicReference<Throwable> failureCause = new AtomicReference<>();
+
+		/**
+		 * Creates an established connection with the given channel.
+		 *
+		 * @param serverAddress Address of the server connected to
+		 * @param channel The actual TCP channel
+		 */
+		EstablishedConnection(KvStateServerAddress serverAddress, Channel channel) {
+			this.serverAddress = Preconditions.checkNotNull(serverAddress, "KvStateServerAddress");
+			this.channel = Preconditions.checkNotNull(channel, "Channel");
+
+			// Add the client handler with the callback
+			channel.pipeline().addLast("KvStateClientHandler", new KvStateClientHandler(this));
+
+			stats.reportActiveConnection();
+		}
+
+		/**
+		 * Close the channel with a ClosedChannelException.
+		 */
+		void close() {
+			close(new ClosedChannelException());
+		}
+
+		/**
+		 * Close the channel with a cause.
+		 *
+		 * @param cause The cause to close the channel with.
+		 * @return Channel close future
+		 */
+		private boolean close(Throwable cause) {
+			if (failureCause.compareAndSet(null, cause)) {
+				channel.close();
+				stats.reportInactiveConnection();
+
+				for (long requestId : pendingRequests.keySet()) {
+					PromiseAndTimestamp pending = pendingRequests.remove(requestId);
+					if (pending != null && pending.promise.tryFailure(cause)) {
+						stats.reportFailedRequest();
+					}
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Returns a future holding the serialized request result.
+		 *
+		 * @param kvStateId                 ID of the KvState instance to query
+		 * @param serializedKeyAndNamespace Serialized key and namespace to query KvState instance
+		 *                                  with
+		 * @return Future holding the serialized result
+		 */
+		Future<byte[]> getKvState(KvStateID kvStateId, byte[] serializedKeyAndNamespace) {
+			PromiseAndTimestamp requestPromiseTs = new PromiseAndTimestamp(
+					Futures.<byte[]>promise(),
+					System.nanoTime());
+
+			try {
+				final long requestId = requestCount.getAndIncrement();
+				pendingRequests.put(requestId, requestPromiseTs);
+
+				stats.reportRequest();
+
+				ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequest(
+						channel.alloc(),
+						requestId,
+						kvStateId,
+						serializedKeyAndNamespace);
+
+				channel.writeAndFlush(buf).addListener(new ChannelFutureListener() {
+					@Override
+					public void operationComplete(ChannelFuture future) throws Exception {
+						if (!future.isSuccess()) {
+							// Fail promise if not failed to write
+							PromiseAndTimestamp pending = pendingRequests.remove(requestId);
+							if (pending != null && pending.promise.tryFailure(future.cause())) {
+								stats.reportFailedRequest();
+							}
+						}
+					}
+				});
+
+				// Check failure for possible race. We don't want any lingering
+				// promises after a failure, which can happen if we don't check
+				// this here. Note that close is treated as a failure as well.
+				Throwable failure = failureCause.get();
+				if (failure != null) {
+					// Remove from pending requests to guard against concurrent
+					// removal and to make sure that we only count it once as failed.
+					PromiseAndTimestamp p = pendingRequests.remove(requestId);
+					if (p != null && p.promise.tryFailure(failure)) {
+						stats.reportFailedRequest();
+					}
+				}
+			} catch (Throwable t) {
+				requestPromiseTs.promise.tryFailure(t);
+			}
+
+			return requestPromiseTs.promise.future();
+		}
+
+		@Override
+		public void onRequestResult(long requestId, byte[] serializedValue) {
+			PromiseAndTimestamp pending = pendingRequests.remove(requestId);
+			if (pending != null && pending.promise.trySuccess(serializedValue)) {
+				long durationMillis = (System.nanoTime() - pending.timestamp) / 1_000_000;
+				stats.reportSuccessfulRequest(durationMillis);
+			}
+		}
+
+		@Override
+		public void onRequestFailure(long requestId, Throwable cause) {
+			PromiseAndTimestamp pending = pendingRequests.remove(requestId);
+			if (pending != null && pending.promise.tryFailure(cause)) {
+				stats.reportFailedRequest();
+			}
+		}
+
+		@Override
+		public void onFailure(Throwable cause) {
+			if (close(cause)) {
+				// Remove from established channels, otherwise future
+				// requests will be handled by this failed channel.
+				establishedConnections.remove(serverAddress, this);
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "EstablishedConnection{" +
+					"serverAddress=" + serverAddress +
+					", channel=" + channel +
+					", pendingRequests=" + pendingRequests.size() +
+					", requestCount=" + requestCount +
+					", failureCause=" + failureCause +
+					'}';
+		}
+
+		/**
+		 * Pair of promise and a timestamp.
+		 */
+		private class PromiseAndTimestamp {
+
+			private final Promise<byte[]> promise;
+			private final long timestamp;
+
+			public PromiseAndTimestamp(Promise<byte[]> promise, long timestamp) {
+				this.promise = promise;
+				this.timestamp = timestamp;
+			}
+		}
+
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateClientHandler.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestFailure;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestResult;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.channels.ClosedChannelException;
+
+/**
+ * This handler expects responses from {@link KvStateServerHandler}.
+ *
+ * <p>It deserializes the response and calls the registered callback, which is
+ * responsible for actually handling the result (see {@link KvStateClient.EstablishedConnection}).
+ */
+class KvStateClientHandler extends ChannelInboundHandlerAdapter {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KvStateClientHandler.class);
+
+	private final KvStateClientHandlerCallback callback;
+
+	/**
+	 * Creates a {@link KvStateClientHandler} with the callback.
+	 *
+	 * @param callback Callback for responses.
+	 */
+	KvStateClientHandler(KvStateClientHandlerCallback callback) {
+		this.callback = callback;
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		try {
+			ByteBuf buf = (ByteBuf) msg;
+			KvStateRequestType msgType = KvStateRequestSerializer.deserializeHeader(buf);
+
+			if (msgType == KvStateRequestType.REQUEST_RESULT) {
+				KvStateRequestResult result = KvStateRequestSerializer.deserializeKvStateRequestResult(buf);
+				callback.onRequestResult(result.getRequestId(), result.getSerializedResult());
+			} else if (msgType == KvStateRequestType.REQUEST_FAILURE) {
+				KvStateRequestFailure failure = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+				callback.onRequestFailure(failure.getRequestId(), failure.getCause());
+			} else if (msgType == KvStateRequestType.SERVER_FAILURE) {
+				throw KvStateRequestSerializer.deserializeServerFailure(buf);
+			} else {
+				throw new IllegalStateException("Unexpected response type '" + msgType + "'");
+			}
+		} catch (Throwable t1) {
+			try {
+				callback.onFailure(t1);
+			} catch (Throwable t2) {
+				LOG.error("Failed to notify callback about failure", t2);
+			}
+		} finally {
+			ReferenceCountUtil.release(msg);
+		}
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		try {
+			callback.onFailure(cause);
+		} catch (Throwable t) {
+			LOG.error("Failed to notify callback about failure", t);
+		}
+	}
+
+	@Override
+	public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+		// Only the client is expected to close the channel. Otherwise it
+		// indicates a failure. Note that this will be invoked in both cases
+		// though. If the callback closed the channel, the callback must be
+		// ignored.
+		try {
+			callback.onFailure(new ClosedChannelException());
+		} catch (Throwable t) {
+			LOG.error("Failed to notify callback about failure", t);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateClientHandlerCallback.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateClientHandlerCallback.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import org.apache.flink.runtime.query.netty.message.KvStateRequest;
+
+/**
+ * Callback for {@link KvStateClientHandler}.
+ */
+interface KvStateClientHandlerCallback {
+
+	/**
+	 * Called on a successful {@link KvStateRequest}.
+	 *
+	 * @param requestId       ID of the request
+	 * @param serializedValue Serialized value for the request
+	 */
+	void onRequestResult(long requestId, byte[] serializedValue);
+
+	/**
+	 * Called on a failed {@link KvStateRequest}.
+	 *
+	 * @param requestId ID of the request
+	 * @param cause     Cause of the request failure
+	 */
+	void onRequestFailure(long requestId, Throwable cause);
+
+	/**
+	 * Called on any failure, which is not related to a specific request.
+	 *
+	 * <p>This can be for example a caught Exception in the channel pipeline
+	 * or an unexpected channel close.
+	 *
+	 * @param cause Cause of the failure
+	 */
+	void onFailure(Throwable cause);
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateRequestStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateRequestStats.java
@@ -16,31 +16,38 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobgraph;
-
-import org.apache.flink.util.AbstractID;
-
-import javax.xml.bind.DatatypeConverter;
+package org.apache.flink.runtime.query.netty;
 
 /**
- * A class for statistically unique job vertex IDs.
+ * Simple statistics for {@link KvStateServer} monitoring.
  */
-public class JobVertexID extends AbstractID {
-	
-	private static final long serialVersionUID = 1L;
-	
-	public JobVertexID() {
-		super();
-	}
-	public JobVertexID(byte[] bytes) {
-		super(bytes);
-	}
+public interface KvStateRequestStats {
 
-	public JobVertexID(long lowerPart, long upperPart) {
-		super(lowerPart, upperPart);
-	}
+	/**
+	 * Reports an active connection.
+	 */
+	void reportActiveConnection();
 
-	public static JobVertexID fromHexString(String hexString) {
-		return new JobVertexID(DatatypeConverter.parseHexBinary(hexString));
-	}
+	/**
+	 * Reports an inactive connection.
+	 */
+	void reportInactiveConnection();
+
+	/**
+	 * Reports an incoming request.
+	 */
+	void reportRequest();
+
+	/**
+	 * Reports a successfully handled request.
+	 *
+	 * @param durationTotalMillis Duration of the request (in milliseconds).
+	 */
+	void reportSuccessfulRequest(long durationTotalMillis);
+
+	/**
+	 * Reports a failure during a request.
+	 */
+	void reportFailedRequest();
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServer.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.util.concurrent.Future;
+import org.apache.flink.runtime.io.network.netty.NettyBufferPool;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.KvStateServerAddress;
+import org.apache.flink.runtime.query.netty.message.KvStateRequest;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Netty-based server answering {@link KvStateRequest} messages.
+ *
+ * <p>Requests are handled by asynchronous query tasks (see {@link KvStateServerHandler.AsyncKvStateQueryTask})
+ * that are executed by a separate query Thread pool. This pool is shared among
+ * all TCP connections.
+ *
+ * <p>The incoming pipeline looks as follows:
+ * <pre>
+ * Socket.read() -> LengthFieldBasedFrameDecoder -> KvStateServerHandler
+ * </pre>
+ *
+ * <p>Received binary messages are expected to contain a frame length field. Netty's
+ * {@link LengthFieldBasedFrameDecoder} is used to fully receive the frame before
+ * giving it to our {@link KvStateServerHandler}.
+ *
+ * <p>Connections are established and closed by the client. The server only
+ * closes the connection on a fatal failure that cannot be recovered. A
+ * server-side connection close is considered a failure by the client.
+ */
+public class KvStateServer {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KvStateServer.class);
+
+	/** Server config: low water mark */
+	private static final int LOW_WATER_MARK = 8 * 1024;
+
+	/** Server config: high water mark */
+	private static final int HIGH_WATER_MARK = 32 * 1024;
+
+	/** Netty's ServerBootstrap. */
+	private final ServerBootstrap bootstrap;
+
+	/** Query executor thread pool. */
+	private final ExecutorService queryExecutor;
+
+	/** Address of this server. */
+	private KvStateServerAddress serverAddress;
+
+	/**
+	 * Creates the {@link KvStateServer}.
+	 *
+	 * <p>The server needs to be started via {@link #start()} in order to bind
+	 * to the configured bind address.
+	 *
+	 * @param bindAddress         Address to bind to
+	 * @param bindPort            Port to bind to. Pick random port if 0.
+	 * @param numEventLoopThreads Number of event loop threads
+	 * @param numQueryThreads     Number of query threads
+	 * @param kvStateRegistry     KvStateRegistry to query for KvState instances
+	 * @param stats               Statistics tracker
+	 */
+	public KvStateServer(
+			InetAddress bindAddress,
+			int bindPort,
+			int numEventLoopThreads,
+			int numQueryThreads,
+			KvStateRegistry kvStateRegistry,
+			KvStateRequestStats stats) {
+
+		Preconditions.checkArgument(bindPort >= 0 && bindPort <= 65536, "Port " + bindPort +
+				" is out of valid port range (0-65536).");
+
+		Preconditions.checkArgument(numEventLoopThreads >= 1, "Non-positive number of event loop threads.");
+		Preconditions.checkArgument(numQueryThreads >= 1, "Non-positive number of query threads.");
+
+		Preconditions.checkNotNull(kvStateRegistry, "KvStateRegistry");
+		Preconditions.checkNotNull(stats, "KvStateRequestStats");
+
+		NettyBufferPool bufferPool = new NettyBufferPool(numEventLoopThreads);
+
+		ThreadFactory threadFactory = new ThreadFactoryBuilder()
+				.setDaemon(true)
+				.setNameFormat("Flink KvStateServer EventLoop Thread %d")
+				.build();
+
+		NioEventLoopGroup nioGroup = new NioEventLoopGroup(numEventLoopThreads, threadFactory);
+
+		queryExecutor = createQueryExecutor(numQueryThreads);
+
+		// Shared between all channels
+		KvStateServerHandler serverHandler = new KvStateServerHandler(
+				kvStateRegistry,
+				queryExecutor,
+				stats);
+
+		bootstrap = new ServerBootstrap()
+				// Bind address and port
+				.localAddress(bindAddress, bindPort)
+				// NIO server channels
+				.group(nioGroup)
+				.channel(NioServerSocketChannel.class)
+				// Server channel Options
+				.option(ChannelOption.ALLOCATOR, bufferPool)
+				// Child channel options
+				.childOption(ChannelOption.ALLOCATOR, bufferPool)
+				.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, LOW_WATER_MARK)
+				.childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, HIGH_WATER_MARK)
+				// See initializer for pipeline details
+				.childHandler(new KvStateServerChannelInitializer(serverHandler));
+	}
+
+	/**
+	 * Starts the server by binding to the configured bind address (blocking).
+	 *
+	 * @throws InterruptedException If interrupted during the bind operation
+	 */
+	public void start() throws InterruptedException {
+		Channel channel = bootstrap.bind().sync().channel();
+
+		InetSocketAddress localAddress = (InetSocketAddress) channel.localAddress();
+		serverAddress = new KvStateServerAddress(localAddress.getAddress(), localAddress.getPort());
+	}
+
+	/**
+	 * Returns the address of this server.
+	 *
+	 * @return Server address
+	 * @throws IllegalStateException If server has not been started yet
+	 */
+	public KvStateServerAddress getAddress() {
+		if (serverAddress == null) {
+			throw new IllegalStateException("KvStateServer not started yet.");
+		}
+
+		return serverAddress;
+	}
+
+	/**
+	 * Shuts down the server and all related thread pools.
+	 */
+	public void shutDown() {
+		if (bootstrap != null) {
+			EventLoopGroup group = bootstrap.group();
+			if (group != null) {
+				Future<?> shutDownFuture = group.shutdownGracefully(0, 10, TimeUnit.SECONDS);
+				try {
+					shutDownFuture.await();
+				} catch (InterruptedException e) {
+					LOG.error("Interrupted during shut down", e);
+				}
+			}
+		}
+
+		if (queryExecutor != null) {
+			queryExecutor.shutdown();
+		}
+
+		serverAddress = null;
+	}
+
+	/**
+	 * Creates a thread pool for the query execution.
+	 *
+	 * @param numQueryThreads Number of query threads.
+	 * @return Thread pool for query execution
+	 */
+	private static ExecutorService createQueryExecutor(int numQueryThreads) {
+		ThreadFactory threadFactory = new ThreadFactoryBuilder()
+				.setDaemon(true)
+				.setNameFormat("Flink KvStateServer Query Thread %d")
+				.build();
+
+		return Executors.newFixedThreadPool(numQueryThreads, threadFactory);
+	}
+
+	/**
+	 * Channel pipeline initializer.
+	 *
+	 * <p>The request handler is shared, whereas the other handlers are created
+	 * per channel.
+	 */
+	private static final class KvStateServerChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+		/** The shared request handler. */
+		private final KvStateServerHandler sharedRequestHandler;
+
+		/**
+		 * Creates the channel pipeline initializer with the shared request handler.
+		 *
+		 * @param sharedRequestHandler Shared request handler.
+		 */
+		public KvStateServerChannelInitializer(KvStateServerHandler sharedRequestHandler) {
+			this.sharedRequestHandler = Preconditions.checkNotNull(sharedRequestHandler, "Request handler");
+		}
+
+		@Override
+		protected void initChannel(SocketChannel ch) throws Exception {
+			ch.pipeline()
+					.addLast(new ChunkedWriteHandler())
+					.addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4))
+					.addLast(sharedRequestHandler);
+		}
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServerHandler.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.netty.message.KvStateRequest;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestType;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.util.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This handler dispatches asynchronous tasks, which query {@link KvState}
+ * instances and write the result to the channel.
+ *
+ * <p>The network threads receive the message, deserialize it and dispatch the
+ * query task. The actual query is handled in a separate thread as it might
+ * otherwise block the network threads (file I/O etc.).
+ */
+@ChannelHandler.Sharable
+class KvStateServerHandler extends ChannelInboundHandlerAdapter {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KvStateServerHandler.class);
+
+	/** KvState registry holding references to the KvState instances. */
+	private final KvStateRegistry registry;
+
+	/** Thread pool for query execution. */
+	private final ExecutorService queryExecutor;
+
+	/** Exposed server statistics. */
+	private final KvStateRequestStats stats;
+
+	/**
+	 * Create the handler.
+	 *
+	 * @param kvStateRegistry Registry to query.
+	 * @param queryExecutor   Thread pool for query execution.
+	 * @param stats           Exposed server statistics.
+	 */
+	KvStateServerHandler(
+			KvStateRegistry kvStateRegistry,
+			ExecutorService queryExecutor,
+			KvStateRequestStats stats) {
+
+		this.registry = Objects.requireNonNull(kvStateRegistry, "KvStateRegistry");
+		this.queryExecutor = Objects.requireNonNull(queryExecutor, "Query thread pool");
+		this.stats = Objects.requireNonNull(stats, "KvStateRequestStats");
+	}
+
+	@Override
+	public void channelActive(ChannelHandlerContext ctx) throws Exception {
+		stats.reportActiveConnection();
+	}
+
+	@Override
+	public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+		stats.reportInactiveConnection();
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		KvStateRequest request = null;
+
+		try {
+			ByteBuf buf = (ByteBuf) msg;
+			KvStateRequestType msgType = KvStateRequestSerializer.deserializeHeader(buf);
+
+			if (msgType == KvStateRequestType.REQUEST) {
+				// ------------------------------------------------------------
+				// Request
+				// ------------------------------------------------------------
+				request = KvStateRequestSerializer.deserializeKvStateRequest(buf);
+
+				stats.reportRequest();
+
+				KvState<?, ?, ?, ?, ?> kvState = registry.getKvState(request.getKvStateId());
+
+				if (kvState != null) {
+					// Execute actual query async, because it is possibly
+					// blocking (e.g. file I/O).
+					//
+					// A submission failure is not treated as fatal.
+					queryExecutor.submit(new AsyncKvStateQueryTask(ctx, request, kvState, stats));
+				} else {
+					ByteBuf unknown = KvStateRequestSerializer.serializeKvStateRequestFailure(
+							ctx.alloc(),
+							request.getRequestId(),
+							new UnknownKvStateID(request.getKvStateId()));
+
+					ctx.writeAndFlush(unknown);
+
+					stats.reportFailedRequest();
+				}
+			} else {
+				// ------------------------------------------------------------
+				// Unexpected
+				// ------------------------------------------------------------
+				ByteBuf failure = KvStateRequestSerializer.serializeServerFailure(
+						ctx.alloc(),
+						new IllegalArgumentException("Unexpected message type " + msgType
+								+ ". KvStateServerHandler expects "
+								+ KvStateRequestType.REQUEST + " messages."));
+
+				ctx.writeAndFlush(failure);
+			}
+		} catch (Throwable t) {
+			String stringifiedCause = ExceptionUtils.stringifyException(t);
+
+			ByteBuf err;
+			if (request != null) {
+				String errMsg = "Failed to handle incoming request with ID " +
+						request.getRequestId() + ". Caused by: " + stringifiedCause;
+				err = KvStateRequestSerializer.serializeKvStateRequestFailure(
+						ctx.alloc(),
+						request.getRequestId(),
+						new RuntimeException(errMsg));
+
+				stats.reportFailedRequest();
+			} else {
+				String errMsg = "Failed to handle incoming message. Caused by: " + stringifiedCause;
+				err = KvStateRequestSerializer.serializeServerFailure(
+						ctx.alloc(),
+						new RuntimeException(errMsg));
+			}
+
+			ctx.writeAndFlush(err);
+		} finally {
+			// IMPORTANT: We have to always recycle the incoming buffer.
+			// Otherwise we will leak memory out of Netty's buffer pool.
+			//
+			// If any operation ever holds on to the buffer, it is the
+			// responsibility of that operation to retain the buffer and
+			// release it later.
+			ReferenceCountUtil.release(msg);
+		}
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		String stringifiedCause = ExceptionUtils.stringifyException(cause);
+		String msg = "Exception in server pipeline. Caused by: " + stringifiedCause;
+
+		ByteBuf err = KvStateRequestSerializer.serializeServerFailure(
+				ctx.alloc(),
+				new RuntimeException(msg));
+
+		ctx.writeAndFlush(err).addListener(ChannelFutureListener.CLOSE);
+	}
+
+	/**
+	 * Task to execute the actual query against the {@link KvState} instance.
+	 */
+	private static class AsyncKvStateQueryTask implements Runnable {
+
+		private final ChannelHandlerContext ctx;
+
+		private final KvStateRequest request;
+
+		private final KvState<?, ?, ?, ?, ?> kvState;
+
+		private final KvStateRequestStats stats;
+
+		private final long creationNanos;
+
+		public AsyncKvStateQueryTask(
+				ChannelHandlerContext ctx,
+				KvStateRequest request,
+				KvState<?, ?, ?, ?, ?> kvState,
+				KvStateRequestStats stats) {
+
+			this.ctx = Objects.requireNonNull(ctx, "Channel handler context");
+			this.request = Objects.requireNonNull(request, "State query");
+			this.kvState = Objects.requireNonNull(kvState, "KvState");
+			this.stats = Objects.requireNonNull(stats, "State query stats");
+			this.creationNanos = System.nanoTime();
+		}
+
+		@Override
+		public void run() {
+			boolean success = false;
+
+			try {
+				if (!ctx.channel().isActive()) {
+					return;
+				}
+
+				// Query the KvState instance
+				byte[] serializedKeyAndNamespace = request.getSerializedKeyAndNamespace();
+				byte[] serializedResult = kvState.getSerializedValue(serializedKeyAndNamespace);
+
+				if (serializedResult != null) {
+					// We found some data, success!
+					ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequestResult(
+							ctx.alloc(),
+							request.getRequestId(),
+							serializedResult);
+
+					int highWatermark = ctx.channel().config().getWriteBufferHighWaterMark();
+
+					ChannelFuture write;
+					if (buf.readableBytes() <= highWatermark) {
+						write = ctx.writeAndFlush(buf);
+					} else {
+						write = ctx.writeAndFlush(new ChunkedByteBuf(buf, highWatermark));
+					}
+
+					write.addListener(new QueryResultWriteListener());
+
+					success = true;
+				} else {
+					// No data for the key/namespace. This is considered to be
+					// a failure.
+					ByteBuf unknownKey = KvStateRequestSerializer.serializeKvStateRequestFailure(
+							ctx.alloc(),
+							request.getRequestId(),
+							new UnknownKeyOrNamespace());
+
+					ctx.writeAndFlush(unknownKey);
+				}
+			} catch (Throwable t) {
+				try {
+					String stringifiedCause = ExceptionUtils.stringifyException(t);
+					String errMsg = "Failed to query state backend for query " +
+							request.getRequestId() + ". Caused by: " + stringifiedCause;
+
+					ByteBuf err = KvStateRequestSerializer.serializeKvStateRequestFailure(
+							ctx.alloc(), request.getRequestId(), new RuntimeException(errMsg));
+
+					ctx.writeAndFlush(err);
+				} catch (IOException e) {
+					LOG.error("Failed to respond with the error after failed to query state backend", e);
+				}
+			} finally {
+				if (!success) {
+					stats.reportFailedRequest();
+				}
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "AsyncKvStateQueryTask{" +
+					", request=" + request +
+					", creationNanos=" + creationNanos +
+					'}';
+		}
+
+		/**
+		 * Callback after query result has been written.
+		 *
+		 * <p>Gathers stats and logs errors.
+		 */
+		private class QueryResultWriteListener implements ChannelFutureListener {
+
+			@Override
+			public void operationComplete(ChannelFuture future) throws Exception {
+				long durationMillis = (System.nanoTime() - creationNanos) / 1_000_000;
+
+				if (future.isSuccess()) {
+					stats.reportSuccessfulRequest(durationMillis);
+				} else {
+					if (LOG.isDebugEnabled()) {
+						LOG.debug("Query " + request + " failed after " + durationMillis + " ms", future.cause());
+					}
+
+					stats.reportFailedRequest();
+				}
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/UnknownKeyOrNamespace.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/UnknownKeyOrNamespace.java
@@ -16,31 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobgraph;
-
-import org.apache.flink.util.AbstractID;
-
-import javax.xml.bind.DatatypeConverter;
+package org.apache.flink.runtime.query.netty;
 
 /**
- * A class for statistically unique job vertex IDs.
+ * Thrown if the KvState does not hold any state for the given key or namespace.
  */
-public class JobVertexID extends AbstractID {
-	
+public class UnknownKeyOrNamespace extends IllegalStateException {
+
 	private static final long serialVersionUID = 1L;
-	
-	public JobVertexID() {
-		super();
-	}
-	public JobVertexID(byte[] bytes) {
-		super(bytes);
-	}
 
-	public JobVertexID(long lowerPart, long upperPart) {
-		super(lowerPart, upperPart);
-	}
-
-	public static JobVertexID fromHexString(String hexString) {
-		return new JobVertexID(DatatypeConverter.parseHexBinary(hexString));
+	UnknownKeyOrNamespace() {
+		super("KvState does not hold any state for key/namespace.");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/UnknownKvStateID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/UnknownKvStateID.java
@@ -16,31 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobgraph;
+package org.apache.flink.runtime.query.netty;
 
-import org.apache.flink.util.AbstractID;
-
-import javax.xml.bind.DatatypeConverter;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.util.Preconditions;
 
 /**
- * A class for statistically unique job vertex IDs.
+ * Thrown if no KvState with the given ID cannot found by the server handler.
  */
-public class JobVertexID extends AbstractID {
-	
+public class UnknownKvStateID extends IllegalStateException {
+
 	private static final long serialVersionUID = 1L;
-	
-	public JobVertexID() {
-		super();
-	}
-	public JobVertexID(byte[] bytes) {
-		super(bytes);
-	}
 
-	public JobVertexID(long lowerPart, long upperPart) {
-		super(lowerPart, upperPart);
-	}
-
-	public static JobVertexID fromHexString(String hexString) {
-		return new JobVertexID(DatatypeConverter.parseHexBinary(hexString));
+	public UnknownKvStateID(KvStateID kvStateId) {
+		super("No KvState registered with ID " + Preconditions.checkNotNull(kvStateId, "KvStateID") +
+				" at TaskManager.");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty.message;
+
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A {@link KvState} instance request for a specific key and namespace.
+ */
+public final class KvStateRequest {
+
+	/** ID for this request. */
+	private final long requestId;
+
+	/** ID of the requested KvState instance. */
+	private final KvStateID kvStateId;
+
+	/** Serialized key and namespace to request from the KvState instance. */
+	private final byte[] serializedKeyAndNamespace;
+
+	/**
+	 * Creates a KvState instance request.
+	 *
+	 * @param requestId                 ID for this request
+	 * @param kvStateId                 ID of the requested KvState instance
+	 * @param serializedKeyAndNamespace Serialized key and namespace to request from the KvState
+	 *                                  instance
+	 */
+	KvStateRequest(long requestId, KvStateID kvStateId, byte[] serializedKeyAndNamespace) {
+		this.requestId = requestId;
+		this.kvStateId = Preconditions.checkNotNull(kvStateId, "KvStateID");
+		this.serializedKeyAndNamespace = Preconditions.checkNotNull(serializedKeyAndNamespace, "Serialized key and namespace");
+	}
+
+	/**
+	 * Returns the request ID.
+	 *
+	 * @return Request ID
+	 */
+	public long getRequestId() {
+		return requestId;
+	}
+
+	/**
+	 * Returns the ID of the requested KvState instance.
+	 *
+	 * @return ID of the requested KvState instance
+	 */
+	public KvStateID getKvStateId() {
+		return kvStateId;
+	}
+
+	/**
+	 * Returns the serialized key and namespace to request from the KvState
+	 * instance.
+	 *
+	 * @return Serialized key and namespace to request from the KvState instance
+	 */
+	public byte[] getSerializedKeyAndNamespace() {
+		return serializedKeyAndNamespace;
+	}
+
+	@Override
+	public String toString() {
+		return "KvStateRequest{" +
+				"requestId=" + requestId +
+				", kvStateId=" + kvStateId +
+				", serializedKeyAndNamespace.length=" + serializedKeyAndNamespace.length +
+				'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestFailure.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestFailure.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty.message;
+
+/**
+ * A failure response to a {@link KvStateRequest}.
+ */
+public final class KvStateRequestFailure {
+
+	/** ID of the request responding to. */
+	private final long requestId;
+
+	/** Failure cause. Not allowed to be a user type. */
+	private final Throwable cause;
+
+	/**
+	 * Creates a failure response to a {@link KvStateRequest}.
+	 *
+	 * @param requestId ID for the request responding to
+	 * @param cause     Failure cause (not allowed to be a user type)
+	 */
+	KvStateRequestFailure(long requestId, Throwable cause) {
+		this.requestId = requestId;
+		this.cause = cause;
+	}
+
+	/**
+	 * Returns the request ID responding to.
+	 *
+	 * @return Request ID responding to
+	 */
+	public long getRequestId() {
+		return requestId;
+	}
+
+	/**
+	 * Returns the failure cause.
+	 *
+	 * @return Failure cause
+	 */
+	public Throwable getCause() {
+		return cause;
+	}
+
+	@Override
+	public String toString() {
+		return "KvStateRequestFailure{" +
+				"requestId=" + requestId +
+				", cause=" + cause +
+				'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestResult.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty.message;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A successful response to a {@link KvStateRequest} containing the serialized
+ * result for the requested key and namespace.
+ */
+public final class KvStateRequestResult {
+
+	/** ID of the request responding to. */
+	private final long requestId;
+
+	/**
+	 * Serialized result for the requested key and namespace. If no result was
+	 * available for the specified key and namespace, this is <code>null</code>.
+	 */
+	private final byte[] serializedResult;
+
+	/**
+	 * Creates a successful {@link KvStateRequestResult} response.
+	 *
+	 * @param requestId        ID of the request responding to
+	 * @param serializedResult Serialized result or <code>null</code> if none
+	 */
+	KvStateRequestResult(long requestId, byte[] serializedResult) {
+		this.requestId = requestId;
+		this.serializedResult = Preconditions.checkNotNull(serializedResult, "Serialization result");
+	}
+
+	/**
+	 * Returns the request ID responding to.
+	 *
+	 * @return Request ID responding to
+	 */
+	public long getRequestId() {
+		return requestId;
+	}
+
+	/**
+	 * Returns the serialized result or <code>null</code> if none available.
+	 *
+	 * @return Serialized result or <code>null</code> if none available.
+	 */
+	public byte[] getSerializedResult() {
+		return serializedResult;
+	}
+
+	@Override
+	public String toString() {
+		return "KvStateRequestResult{" +
+				"requestId=" + requestId +
+				", serializedResult.length=" + serializedResult.length +
+				'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
@@ -1,0 +1,518 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty.message;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.query.netty.KvStateClient;
+import org.apache.flink.runtime.query.netty.KvStateServer;
+import org.apache.flink.runtime.util.DataInputDeserializer;
+import org.apache.flink.runtime.util.DataOutputSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Serialization and deserialization of messages exchanged between
+ * {@link KvStateClient} and {@link KvStateServer}.
+ *
+ * <p>The binary messages have the following format:
+ *
+ * <pre>
+ *                     <------ Frame ------------------------->
+ *                    +----------------------------------------+
+ *                    |        HEADER (8)      | PAYLOAD (VAR) |
+ * +------------------+----------------------------------------+
+ * | FRAME LENGTH (4) | VERSION (4) | TYPE (4) | CONTENT (VAR) |
+ * +------------------+----------------------------------------+
+ * </pre>
+ *
+ * <p>The concrete content of a message depends on the {@link KvStateRequestType}.
+ */
+public final class KvStateRequestSerializer {
+
+	/** The serialization version ID. */
+	private static final int VERSION = 0x79a1b710;
+
+	/** Byte length of the header. */
+	private static final int HEADER_LENGTH = 8;
+
+	// ------------------------------------------------------------------------
+	// Serialization
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Allocates a buffer and serializes the KvState request into it.
+	 *
+	 * @param alloc                     ByteBuf allocator for the buffer to
+	 *                                  serialize message into
+	 * @param requestId                 ID for this request
+	 * @param kvStateId                 ID of the requested KvState instance
+	 * @param serializedKeyAndNamespace Serialized key and namespace to request
+	 *                                  from the KvState instance.
+	 * @return Serialized KvState request message
+	 */
+	public static ByteBuf serializeKvStateRequest(
+			ByteBufAllocator alloc,
+			long requestId,
+			KvStateID kvStateId,
+			byte[] serializedKeyAndNamespace) {
+
+		// Header + request ID + KvState ID + Serialized namespace
+		int frameLength = HEADER_LENGTH + 8 + (8 + 8) + (4 + serializedKeyAndNamespace.length);
+		ByteBuf buf = alloc.ioBuffer(frameLength + 4); // +4 for frame length
+
+		buf.writeInt(frameLength);
+
+		writeHeader(buf, KvStateRequestType.REQUEST);
+
+		buf.writeLong(requestId);
+		buf.writeLong(kvStateId.getLowerPart());
+		buf.writeLong(kvStateId.getUpperPart());
+		buf.writeInt(serializedKeyAndNamespace.length);
+		buf.writeBytes(serializedKeyAndNamespace);
+
+		return buf;
+	}
+
+	/**
+	 * Allocates a buffer and serializes the KvState request result into it.
+	 *
+	 * @param alloc             ByteBuf allocator for the buffer to serialize message into
+	 * @param requestId         ID for this request
+	 * @param serializedResult  Serialized Result
+	 * @return Serialized KvState request result message
+	 */
+	public static ByteBuf serializeKvStateRequestResult(
+			ByteBufAllocator alloc,
+			long requestId,
+			byte[] serializedResult) {
+
+		Preconditions.checkNotNull(serializedResult, "Serialized result");
+
+		// Header + request ID + serialized result
+		int frameLength = HEADER_LENGTH + 8 + 4 + serializedResult.length;
+
+		ByteBuf buf = alloc.ioBuffer(frameLength);
+
+		buf.writeInt(frameLength);
+		writeHeader(buf, KvStateRequestType.REQUEST_RESULT);
+		buf.writeLong(requestId);
+
+		buf.writeInt(serializedResult.length);
+		buf.writeBytes(serializedResult);
+
+		return buf;
+	}
+
+	/**
+	 * Allocates a buffer and serializes the KvState request failure into it.
+	 *
+	 * @param alloc ByteBuf allocator for the buffer to serialize message into
+	 * @param requestId ID of the request responding to
+	 * @param cause Failure cause
+	 * @return Serialized KvState request failure message
+	 * @throws IOException Serialization failures are forwarded
+	 */
+	public static ByteBuf serializeKvStateRequestFailure(
+			ByteBufAllocator alloc,
+			long requestId,
+			Throwable cause) throws IOException {
+
+		ByteBuf buf = alloc.ioBuffer();
+
+		// Frame length is set at the end
+		buf.writeInt(0);
+
+		writeHeader(buf, KvStateRequestType.REQUEST_FAILURE);
+
+		// Message
+		buf.writeLong(requestId);
+
+		try (ByteBufOutputStream bbos = new ByteBufOutputStream(buf);
+				ObjectOutputStream out = new ObjectOutputStream(bbos)) {
+
+			out.writeObject(cause);
+		}
+
+		// Set frame length
+		int frameLength = buf.readableBytes() - 4;
+		buf.setInt(0, frameLength);
+
+		return buf;
+	}
+
+	/**
+	 * Allocates a buffer and serializes the server failure into it.
+	 *
+	 * <p>The cause must not be or contain any user types as causes.
+	 *
+	 * @param alloc ByteBuf allocator for the buffer to serialize message into
+	 * @param cause Failure cause
+	 * @return Serialized server failure message
+	 * @throws IOException Serialization failures are forwarded
+	 */
+	public static ByteBuf serializeServerFailure(ByteBufAllocator alloc, Throwable cause) throws IOException {
+		ByteBuf buf = alloc.ioBuffer();
+
+		// Frame length is set at end
+		buf.writeInt(0);
+
+		writeHeader(buf, KvStateRequestType.SERVER_FAILURE);
+
+		try (ByteBufOutputStream bbos = new ByteBufOutputStream(buf);
+				ObjectOutputStream out = new ObjectOutputStream(bbos)) {
+
+			out.writeObject(cause);
+		}
+
+		// Set frame length
+		int frameLength = buf.readableBytes() - 4;
+		buf.setInt(0, frameLength);
+
+		return buf;
+	}
+
+	// ------------------------------------------------------------------------
+	// Deserialization
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Deserializes the header and returns the request type.
+	 *
+	 * @param buf Buffer to deserialize (expected to be at header position)
+	 * @return Deserialzied request type
+	 * @throws IllegalArgumentException If unexpected message version or message type
+	 */
+	public static KvStateRequestType deserializeHeader(ByteBuf buf) {
+		// Check the version
+		int version = buf.readInt();
+		if (version != VERSION) {
+			throw new IllegalArgumentException("Illegal message version " + version +
+					". Expected: " + VERSION + ".");
+		}
+
+		// Get the message type
+		int msgType = buf.readInt();
+		KvStateRequestType[] values = KvStateRequestType.values();
+		if (msgType >= 0 && msgType <= values.length) {
+			return values[msgType];
+		} else {
+			throw new IllegalArgumentException("Illegal message type with index " + msgType);
+		}
+	}
+
+	/**
+	 * Deserializes the KvState request message.
+	 *
+	 * <p><strong>Important</strong>: the returned buffer is sliced from the
+	 * incoming ByteBuf stream and retained. Therefore, it needs to be recycled
+	 * by the consumer.
+	 *
+	 * @param buf Buffer to deserialize (expected to be positioned after header)
+	 * @return Deserialized KvStateRequest
+	 */
+	public static KvStateRequest deserializeKvStateRequest(ByteBuf buf) {
+		long requestId = buf.readLong();
+		KvStateID kvStateId = new KvStateID(buf.readLong(), buf.readLong());
+
+		// Serialized key and namespace
+		int length = buf.readInt();
+
+		if (length < 0) {
+			throw new IllegalArgumentException("Negative length for serialized key and namespace. " +
+					"This indicates a serialization error.");
+		}
+
+		// Copy the buffer in order to be able to safely recycle the ByteBuf
+		byte[] serializedKeyAndNamespace = new byte[length];
+		if (length > 0) {
+			buf.readBytes(serializedKeyAndNamespace);
+		}
+
+		return new KvStateRequest(requestId, kvStateId, serializedKeyAndNamespace);
+	}
+
+	/**
+	 * Deserializes the KvState request result.
+	 *
+	 * @param buf Buffer to deserialize (expected to be positioned after header)
+	 * @return Deserialized KvStateRequestResult
+	 */
+	public static KvStateRequestResult deserializeKvStateRequestResult(ByteBuf buf) {
+		long requestId = buf.readLong();
+
+		// Serialized KvState
+		int length = buf.readInt();
+
+		if (length < 0) {
+			throw new IllegalArgumentException("Negative length for serialized result. " +
+					"This indicates a serialization error.");
+		}
+
+		byte[] serializedValue = new byte[length];
+
+		if (length > 0) {
+			buf.readBytes(serializedValue);
+		}
+
+		return new KvStateRequestResult(requestId, serializedValue);
+	}
+
+	/**
+	 * Deserializes the KvState request failure.
+	 *
+	 * @param buf Buffer to deserialize (expected to be positioned after header)
+	 * @return Deserialized KvStateRequestFailure
+	 */
+	public static KvStateRequestFailure deserializeKvStateRequestFailure(ByteBuf buf) throws IOException, ClassNotFoundException {
+		long requestId = buf.readLong();
+
+		Throwable cause;
+		try (ByteBufInputStream bbis = new ByteBufInputStream(buf);
+				ObjectInputStream in = new ObjectInputStream(bbis)) {
+
+			cause = (Throwable) in.readObject();
+		}
+
+		return new KvStateRequestFailure(requestId, cause);
+	}
+
+	/**
+	 * Deserializes the KvState request failure.
+	 *
+	 * @param buf Buffer to deserialize (expected to be positioned after header)
+	 * @return Deserialized KvStateRequestFailure
+	 * @throws IOException            Serialization failure are forwarded
+	 * @throws ClassNotFoundException If Exception type can not be loaded
+	 */
+	public static Throwable deserializeServerFailure(ByteBuf buf) throws IOException, ClassNotFoundException {
+		try (ByteBufInputStream bbis = new ByteBufInputStream(buf);
+				ObjectInputStream in = new ObjectInputStream(bbis)) {
+
+			return (Throwable) in.readObject();
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Generic serialization utils
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Serializes the key and namespace into a {@link ByteBuffer}.
+	 *
+	 * <p>The serialized format matches the RocksDB state backend key format, i.e.
+	 * the key and namespace don't have to be deserialized for RocksDB lookups.
+	 *
+	 * @param key                 Key to serialize
+	 * @param keySerializer       Serializer for the key
+	 * @param namespace           Namespace to serialize
+	 * @param namespaceSerializer Serializer for the namespace
+	 * @param <K>                 Key type
+	 * @param <N>                 Namespace type
+	 * @return Buffer holding the serialized key and namespace
+	 * @throws IOException Serialization errors are forwarded
+	 */
+	public static <K, N> byte[] serializeKeyAndNamespace(
+			K key,
+			TypeSerializer<K> keySerializer,
+			N namespace,
+			TypeSerializer<N> namespaceSerializer) throws IOException {
+
+		DataOutputSerializer dos = new DataOutputSerializer(32);
+
+		keySerializer.serialize(key, dos);
+		dos.writeByte(42);
+		namespaceSerializer.serialize(namespace, dos);
+
+		return dos.getCopyOfBuffer();
+	}
+
+	/**
+	 * Deserializes the key and namespace into a {@link Tuple2}.
+	 *
+	 * @param serializedKeyAndNamespace Serialized key and namespace
+	 * @param keySerializer             Serializer for the key
+	 * @param namespaceSerializer       Serializer for the namespace
+	 * @param <K>                       Key type
+	 * @param <N>                       Namespace
+	 * @return Tuple2 holding deserialized key and namespace
+	 * @throws IOException           Serialization errors are forwarded
+	 * @throws IllegalStateException If unexpected magic number between key and namespace
+	 */
+	public static <K, N> Tuple2<K, N> deserializeKeyAndNamespace(
+			byte[] serializedKeyAndNamespace,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer) throws IOException {
+
+		DataInputDeserializer dis = new DataInputDeserializer(
+				serializedKeyAndNamespace,
+				0,
+				serializedKeyAndNamespace.length);
+
+		K key = keySerializer.deserialize(dis);
+		byte magicNumber = dis.readByte();
+		if (magicNumber != 42) {
+			throw new IllegalArgumentException("Unexpected magic number " + magicNumber +
+					". This indicates a mismatch in the key serializers used by the " +
+					"KvState instance and this access.");
+		}
+		N namespace = namespaceSerializer.deserialize(dis);
+
+		if (dis.available() > 0) {
+			throw new IllegalArgumentException("Unconsumed bytes in the serialized key " +
+					"and namespace. This indicates a mismatch in the key/namespace " +
+					"serializers used by the KvState instance and this access.");
+		}
+
+		return new Tuple2<>(key, namespace);
+	}
+
+	/**
+	 * Serializes the value with the given serializer.
+	 *
+	 * @param value      Value of type T to serialize
+	 * @param serializer Serializer for T
+	 * @param <T>        Type of the value
+	 * @return Serialized value or <code>null</code> if value <code>null</code>
+	 * @throws IOException On failure during serialization
+	 */
+	public static <T> byte[] serializeValue(T value, TypeSerializer<T> serializer) throws IOException {
+		if (value != null) {
+			// Serialize
+			DataOutputSerializer dos = new DataOutputSerializer(32);
+			serializer.serialize(value, dos);
+			return dos.getCopyOfBuffer();
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Deserializes the value with the given serializer.
+	 *
+	 * @param serializedValue Serialized value of type T
+	 * @param serializer      Serializer for T
+	 * @param <T>             Type of the value
+	 * @return Deserialized value or <code>null</code> if the serialized value
+	 * is <code>null</code>
+	 * @throws IOException On failure during deserialization
+	 */
+	public static <T> T deserializeValue(byte[] serializedValue, TypeSerializer<T> serializer) throws IOException {
+		if (serializedValue == null) {
+			return null;
+		} else {
+			DataInputDeserializer deser = new DataInputDeserializer(serializedValue, 0, serializedValue.length);
+			return serializer.deserialize(deser);
+		}
+	}
+
+	/**
+	 * Serializes all values of the Iterable with the given serializer.
+	 *
+	 * @param values     Values of type T to serialize
+	 * @param serializer Serializer for T
+	 * @param <T>        Type of the values
+	 * @return Serialized values or <code>null</code> if values <code>null</code> or empty
+	 * @throws IOException On failure during serialization
+	 */
+	public static <T> byte[] serializeList(Iterable<T> values, TypeSerializer<T> serializer) throws IOException {
+		if (values != null) {
+			Iterator<T> it = values.iterator();
+
+			if (it.hasNext()) {
+				// Serialize
+				DataOutputSerializer dos = new DataOutputSerializer(32);
+
+				while (it.hasNext()) {
+					serializer.serialize(it.next(), dos);
+
+					// This byte added here in order to have the binary format
+					// prescribed by RocksDB.
+					dos.write(0);
+				}
+
+				return dos.getCopyOfBuffer();
+			} else {
+				return null;
+			}
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Deserializes all values with the given serializer.
+	 *
+	 * @param serializedValue Serialized value of type List<T>
+	 * @param serializer      Serializer for T
+	 * @param <T>             Type of the value
+	 * @return Deserialized list or <code>null</code> if the serialized value
+	 * is <code>null</code>
+	 * @throws IOException On failure during deserialization
+	 */
+	public static <T> List<T> deserializeList(byte[] serializedValue, TypeSerializer<T> serializer) throws IOException {
+		if (serializedValue != null) {
+			DataInputDeserializer in = new DataInputDeserializer(serializedValue, 0, serializedValue.length);
+
+			List<T> result = new ArrayList<>();
+			while (in.available() > 0) {
+				result.add(serializer.deserialize(in));
+
+				// The expected binary format has a single byte separator. We
+				// want a consistent binary format in order to not need any
+				// special casing during deserialization. A "cleaner" format
+				// would skip this extra byte, but would require a memory copy
+				// for RocksDB, which stores the data serialized in this way
+				// for lists.
+				if (in.available() > 0) {
+					in.readByte();
+				}
+			}
+
+			return result;
+		} else {
+			return null;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Helper for writing the header.
+	 *
+	 * @param buf         Buffer to serialize header into
+	 * @param requestType Result type to serialize
+	 */
+	private static void writeHeader(ByteBuf buf, KvStateRequestType requestType) {
+		buf.writeInt(VERSION);
+		buf.writeInt(requestType.ordinal());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestType.java
@@ -16,31 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobgraph;
+package org.apache.flink.runtime.query.netty.message;
 
-import org.apache.flink.util.AbstractID;
-
-import javax.xml.bind.DatatypeConverter;
+import org.apache.flink.runtime.query.netty.KvStateServer;
 
 /**
- * A class for statistically unique job vertex IDs.
+ * Expected message types when communicating with the {@link KvStateServer}.
  */
-public class JobVertexID extends AbstractID {
-	
-	private static final long serialVersionUID = 1L;
-	
-	public JobVertexID() {
-		super();
-	}
-	public JobVertexID(byte[] bytes) {
-		super(bytes);
-	}
+public enum KvStateRequestType {
 
-	public JobVertexID(long lowerPart, long upperPart) {
-		super(lowerPart, upperPart);
-	}
+	/** Request a KvState instance. */
+	REQUEST,
 
-	public static JobVertexID fromHexString(String hexString) {
-		return new JobVertexID(DatatypeConverter.parseHexBinary(hexString));
-	}
+	/** Successful response to a KvStateRequest. */
+	REQUEST_RESULT,
+
+	/** Failure response to a KvStateRequest. */
+	REQUEST_FAILURE,
+
+	/** Generic server failure. */
+	SERVER_FAILURE
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/package-info.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/package-info.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains all Netty-based client/server classes used to query
+ * KvState instances.
+ *
+ * <h2>Server and Client</h2>
+ *
+ * <p>Both server and client expect received binary messages to contain a frame
+ * length field. Netty's {@link io.netty.handler.codec.LengthFieldBasedFrameDecoder}
+ * is used to fully receive the frame before giving it to the respective client
+ * or server handler.
+ *
+ * <p>Connection establishment and release happens by the client. The server
+ * only closes a connection if a fatal failure happens that cannot be resolved
+ * otherwise.
+ *
+ * <p>The is a single server per task manager and a single client can be shared
+ * by multiple Threads.
+ *
+ * <p>See also:
+ * <ul>
+ * <li>{@link org.apache.flink.runtime.query.netty.KvStateServer}</li>
+ * <li>{@link org.apache.flink.runtime.query.netty.KvStateServerHandler}</li>
+ * <li>{@link org.apache.flink.runtime.query.netty.KvStateClient}</li>
+ * <li>{@link org.apache.flink.runtime.query.netty.KvStateClientHandler}</li>
+ * </ul>
+ *
+ * <h2>Serialization</h2>
+ *
+ * <p>The exchanged binary messages have the following format:
+ *
+ * <pre>
+ *                     <------ Frame ------------------------->
+ *                    +----------------------------------------+
+ *                    |        HEADER (8)      | PAYLOAD (VAR) |
+ * +------------------+----------------------------------------+
+ * | FRAME LENGTH (4) | VERSION (4) | TYPE (4) | CONTENT (VAR) |
+ * +------------------+----------------------------------------+
+ * </pre>
+ *
+ * <p>For frame decoding, both server and client use Netty's {@link
+ * io.netty.handler.codec.LengthFieldBasedFrameDecoder}. Message serialization
+ * is done via static helpers in {@link org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer}.
+ * The serialization helpers return {@link io.netty.buffer.ByteBuf} instances,
+ * which are ready to be sent to the client or server respectively as they
+ * contain the frame length.
+ *
+ * <p>See also:
+ * <ul>
+ * <li>{@link org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer}</li>
+ * </ul>
+ *
+ * <h2>Statistics</h2>
+ *
+ * <p>Both server and client keep track of request statistics via {@link
+ * org.apache.flink.runtime.query.netty.KvStateRequestStats}.
+ *
+ * <p>See also:
+ * <ul>
+ * <li>{@link org.apache.flink.runtime.query.netty.KvStateRequestStats}</li>
+ * </ul>
+ */
+package org.apache.flink.runtime.query.netty;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/package-info.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/package-info.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains all KvState query related classes.
+ *
+ * <h2>TaskManager and JobManager</h2>
+ *
+ * <p>State backends register queryable state instances at the {@link
+ * org.apache.flink.runtime.query.KvStateRegistry}.
+ * There is one registry per TaskManager. Registered KvState instances are
+ * reported to the JobManager, where they are aggregated at the {@link
+ * org.apache.flink.runtime.query.KvStateLocationRegistry}.
+ *
+ * <p>Instances of {@link org.apache.flink.runtime.query.KvStateLocation} contain
+ * all information needed for a client to query a KvState instance.
+ *
+ * <p>See also:
+ * <ul>
+ * <li>{@link org.apache.flink.runtime.query.KvStateRegistry}</li>
+ * <li>{@link org.apache.flink.runtime.query.TaskKvStateRegistry}</li>
+ * <li>{@link org.apache.flink.runtime.query.KvStateLocation}</li>
+ * <li>{@link org.apache.flink.runtime.query.KvStateLocationRegistry}</li>
+ * </ul>
+ *
+ * <h2>Client</h2>
+ *
+ * The {@link org.apache.flink.runtime.query.QueryableStateClient} is used
+ * to query KvState instances. The client takes care of {@link
+ * org.apache.flink.runtime.query.KvStateLocation} lookup and caching. Queries
+ * are then dispatched via the network client.
+ *
+ * <h3>JobManager Communication</h3>
+ *
+ * <p>The JobManager is queried for {@link org.apache.flink.runtime.query.KvStateLocation}
+ * instances via the {@link org.apache.flink.runtime.query.KvStateLocationLookupService}.
+ * The client caches resolved locations and dispatches queries directly to the
+ * TaskManager.
+ *
+ * <h3>TaskManager Communication</h3>
+ *
+ * <p>After the location has been resolved, the TaskManager is queried via the
+ * {@link org.apache.flink.runtime.query.netty.KvStateClient}.
+ */
+package org.apache.flink.runtime.query;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericFoldingState.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.functions.FoldFunction;
@@ -69,6 +70,11 @@ public class GenericFoldingState<K, N, T, ACC, Backend extends AbstractStateBack
 	}
 
 	@Override
+	public byte[] getSerializedValue(byte[] serializedKeyAndNamespace) throws Exception {
+		return wrappedState.getSerializedValue(serializedKeyAndNamespace);
+	}
+
+	@Override
 	public KvStateSnapshot<K, N, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>, Backend> snapshot(
 		long checkpointId,
 		long timestamp) throws Exception {
@@ -81,6 +87,11 @@ public class GenericFoldingState<K, N, T, ACC, Backend extends AbstractStateBack
 	@Override
 	public void dispose() {
 		wrappedState.dispose();
+	}
+
+	@Override
+	public FoldingStateDescriptor<T, ACC> getStateDescriptor() {
+		throw new UnsupportedOperationException("Not supported by generic state type");
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericListState.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.ListState;
@@ -65,6 +66,11 @@ public class GenericListState<K, N, T, Backend extends AbstractStateBackend, W e
 	}
 
 	@Override
+	public byte[] getSerializedValue(byte[] serializedKeyAndNamespace) throws Exception {
+		return wrappedState.getSerializedValue(serializedKeyAndNamespace);
+	}
+
+	@Override
 	public KvStateSnapshot<K, N, ListState<T>, ListStateDescriptor<T>, Backend> snapshot(
 		long checkpointId,
 		long timestamp) throws Exception {
@@ -77,6 +83,11 @@ public class GenericListState<K, N, T, Backend extends AbstractStateBackend, W e
 	@Override
 	public void dispose() {
 		wrappedState.dispose();
+	}
+
+	@Override
+	public ListStateDescriptor<T> getStateDescriptor() {
+		throw new UnsupportedOperationException("Not supported by generic state type");
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericReducingState.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
@@ -68,6 +69,11 @@ public class GenericReducingState<K, N, T, Backend extends AbstractStateBackend,
 	}
 
 	@Override
+	public byte[] getSerializedValue(byte[] serializedKeyAndNamespace) throws Exception {
+		return wrappedState.getSerializedValue(serializedKeyAndNamespace);
+	}
+
+	@Override
 	public KvStateSnapshot<K, N, ReducingState<T>, ReducingStateDescriptor<T>, Backend> snapshot(
 		long checkpointId,
 		long timestamp) throws Exception {
@@ -80,6 +86,11 @@ public class GenericReducingState<K, N, T, Backend extends AbstractStateBackend,
 	@Override
 	public void dispose() {
 		wrappedState.dispose();
+	}
+
+	@Override
+	public ReducingStateDescriptor<T> getStateDescriptor() {
+		throw new UnsupportedOperationException("Not supported by generic state type");
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KvState.java
@@ -52,6 +52,19 @@ public interface KvState<K, N, S extends State, SD extends StateDescriptor<S, ?>
 	void setCurrentNamespace(N namespace);
 
 	/**
+	 * Returns the serialized value for the given key and namespace.
+	 *
+	 * <p>If no value is associated with key and namespace, <code>null</code>
+	 * is returned.
+	 *
+	 * @param serializedKeyAndNamespace Serialized key and namespace
+	 * @return Serialized value or <code>null</code> if no value is associated
+	 * with the key and namespace.
+	 * @throws Exception Exceptions during serialization are forwarded
+	 */
+	byte[] getSerializedValue(byte[] serializedKeyAndNamespace) throws Exception;
+
+	/**
 	 * Creates a snapshot of this state.
 	 * 
 	 * @param checkpointId The ID of the checkpoint for which the snapshot should be created.
@@ -67,4 +80,10 @@ public interface KvState<K, N, S extends State, SD extends StateDescriptor<S, ?>
 	 * Disposes the key/value state, releasing all occupied resources.
 	 */
 	void dispose();
+
+	/**
+	 * Returns the state descriptor from which the KvState instance was created.
+	 */
+	SD getStateDescriptor();
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespace.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespace.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+/**
+ * Uninstantiable placeholder class for state without a namespace.
+ */
+public final class VoidNamespace {
+
+	public static final VoidNamespace INSTANCE = new VoidNamespace();
+
+	private VoidNamespace() {
+	}
+
+	public static VoidNamespace get() {
+		return INSTANCE;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceSerializer.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+/**
+ * Serializer for {@link VoidNamespace}.
+ */
+public final class VoidNamespaceSerializer extends TypeSerializerSingleton<VoidNamespace> {
+
+	private static final long serialVersionUID = 1L;
+
+	public static final VoidNamespaceSerializer INSTANCE = new VoidNamespaceSerializer();
+
+	@Override
+	public boolean isImmutableType() {
+		return true;
+	}
+
+	@Override
+	public VoidNamespace createInstance() {
+		return VoidNamespace.get();
+	}
+
+	@Override
+	public VoidNamespace copy(VoidNamespace from) {
+		return VoidNamespace.get();
+	}
+
+	@Override
+	public VoidNamespace copy(VoidNamespace from, VoidNamespace reuse) {
+		return VoidNamespace.get();
+	}
+
+	@Override
+	public int getLength() {
+		return 0;
+	}
+
+	@Override
+	public void serialize(VoidNamespace record, DataOutputView target) throws IOException {
+		// Make progress in the stream, write one byte.
+		//
+		// We could just skip writing anything here, because of the way this is
+		// used with the state backends, but if it is ever used somewhere else
+		// (even though it is unlikely to happen), it would be a problem.
+		target.write(0);
+	}
+
+	@Override
+	public VoidNamespace deserialize(DataInputView source) throws IOException {
+		source.readByte();
+		return VoidNamespace.get();
+	}
+
+	@Override
+	public VoidNamespace deserialize(VoidNamespace reuse, DataInputView source) throws IOException {
+		source.readByte();
+		return VoidNamespace.get();
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		target.write(source.readByte());
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof VoidNamespaceSerializer;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsListState.java
@@ -18,13 +18,15 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
-import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
 import org.apache.flink.runtime.state.ArrayListSerializer;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.runtime.state.KvStateSnapshot;
+import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -81,23 +83,26 @@ public class FsListState<K, N, V>
 	@Override
 	public Iterable<V> get() {
 		if (currentNSState == null) {
+			Preconditions.checkState(currentNamespace != null, "No namespace set");
 			currentNSState = state.get(currentNamespace);
 		}
-		return currentNSState != null ?
-			currentNSState.get(currentKey) : null;
+		if (currentNSState != null) {
+			Preconditions.checkState(currentKey != null, "No key set");
+			return currentNSState.get(currentKey);
+		} else {
+			return null;
+		}
 	}
 
 	@Override
 	public void add(V value) {
-		if (currentKey == null) {
-			throw new RuntimeException("No key available.");
-		}
+		Preconditions.checkState(currentKey != null, "No key set");
 
 		if (currentNSState == null) {
-			currentNSState = new HashMap<>();
+			Preconditions.checkState(currentNamespace != null, "No namespace set");
+			currentNSState = createNewNamespaceMap();
 			state.put(currentNamespace, currentNSState);
 		}
-
 
 		ArrayList<V> list = currentNSState.get(currentKey);
 		if (list == null) {
@@ -110,6 +115,19 @@ public class FsListState<K, N, V>
 	@Override
 	public KvStateSnapshot<K, N, ListState<V>, ListStateDescriptor<V>, FsStateBackend> createHeapSnapshot(Path filePath) {
 		return new Snapshot<>(getKeySerializer(), getNamespaceSerializer(), new ArrayListSerializer<>(stateDesc.getSerializer()), stateDesc, filePath);
+	}
+
+	@Override
+	public byte[] getSerializedValue(K key, N namespace) throws Exception {
+		Preconditions.checkNotNull(key, "Key");
+		Preconditions.checkNotNull(namespace, "Namespace");
+
+		Map<K, ArrayList<V>> stateByKey = state.get(namespace);
+		if (stateByKey != null) {
+			return KvStateRequestSerializer.serializeList(stateByKey.get(key), stateDesc.getSerializer());
+		} else {
+			return null;
+		}
 	}
 
 	public static class Snapshot<K, N, V> extends AbstractFsStateSnapshot<K, N, ArrayList<V>, ListState<V>, ListStateDescriptor<V>> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -31,9 +31,8 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.AbstractStateBackend;
-
+import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.slf4j.Logger;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.util.SerializedValue;
 
@@ -75,6 +76,8 @@ public class RuntimeEnvironment implements Environment {
 
 	private final AccumulatorRegistry accumulatorRegistry;
 
+	private final TaskKvStateRegistry kvStateRegistry;
+
 	private final TaskManagerRuntimeInfo taskManagerInfo;
 	private final TaskMetricGroup metrics;
 
@@ -95,6 +98,7 @@ public class RuntimeEnvironment implements Environment {
 			IOManager ioManager,
 			BroadcastVariableManager bcVarManager,
 			AccumulatorRegistry accumulatorRegistry,
+			TaskKvStateRegistry kvStateRegistry,
 			InputSplitProvider splitProvider,
 			Map<String, Future<Path>> distCacheEntries,
 			ResultPartitionWriter[] writers,
@@ -116,6 +120,7 @@ public class RuntimeEnvironment implements Environment {
 		this.ioManager = checkNotNull(ioManager);
 		this.bcVarManager = checkNotNull(bcVarManager);
 		this.accumulatorRegistry = checkNotNull(accumulatorRegistry);
+		this.kvStateRegistry = checkNotNull(kvStateRegistry);
 		this.splitProvider = checkNotNull(splitProvider);
 		this.distCacheEntries = checkNotNull(distCacheEntries);
 		this.writers = checkNotNull(writers);
@@ -196,6 +201,11 @@ public class RuntimeEnvironment implements Environment {
 	@Override
 	public AccumulatorRegistry getAccumulatorRegistry() {
 		return accumulatorRegistry;
+	}
+
+	@Override
+	public TaskKvStateRegistry getTaskKvStateRegistry() {
+		return kvStateRegistry;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -57,6 +57,7 @@ import org.apache.flink.runtime.messages.TaskMessages.FailTask;
 import org.apache.flink.runtime.messages.TaskMessages.TaskInFinalState;
 import org.apache.flink.runtime.messages.TaskMessages.UpdateTaskExecutionState;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StateUtils;
 import org.apache.flink.util.SerializedValue;
@@ -519,10 +520,14 @@ public class Task implements Runnable {
 			TaskInputSplitProvider splitProvider = new TaskInputSplitProvider(jobManager,
 					jobId, vertexId, executionId, userCodeClassLoader, actorAskTimeout);
 
+			TaskKvStateRegistry kvStateRegistry = network
+					.createKvStateTaskRegistry(jobId, getJobVertexId());
+
 			Environment env = new RuntimeEnvironment(jobId, vertexId, executionId,
 					executionConfig, taskInfo, jobConfiguration, taskConfiguration,
 					userCodeClassLoader, memoryManager, ioManager,
 					broadcastVariableManager, accumulatorRegistry,
+					kvStateRegistry,
 					splitProvider, distributedCacheEntries,
 					writers, inputGates, jobManager, taskManagerConfig, metrics, this);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/DataInputDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/DataInputDeserializer.java
@@ -95,6 +95,14 @@ public class DataInputDeserializer implements DataInputView, java.io.Serializabl
 	// ----------------------------------------------------------------------------------------
 	//                               Data Input
 	// ----------------------------------------------------------------------------------------
+
+	public int available() {
+		if (position < end) {
+			return end - position - 1;
+		} else {
+			return 0;
+		}
+	}
 	
 	@Override
 	public boolean readBoolean() throws IOException {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -92,7 +92,7 @@ abstract class FlinkMiniCluster(
 
   val numJobManagers = getNumberOfJobManagers
 
-  val numTaskManagers = configuration.getInteger(
+  var numTaskManagers = configuration.getInteger(
     ConfigConstants.LOCAL_NUMBER_TASK_MANAGER,
     ConfigConstants.DEFAULT_LOCAL_NUMBER_TASK_MANAGER)
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.io.network.netty.NettyConfig
 import org.apache.flink.runtime.jobmanager.{MemoryArchivist, JobManager}
 import org.apache.flink.runtime.messages.JobManagerMessages
-import org.apache.flink.runtime.messages.JobManagerMessages.{StoppingFailure, StoppingResponse, RunningJobsStatus, RunningJobs}
+import org.apache.flink.runtime.messages.JobManagerMessages.{CancellationFailure, CancellationResponse, StoppingFailure, StoppingResponse, RunningJobsStatus, RunningJobs}
 import org.apache.flink.runtime.taskmanager.TaskManager
 import org.apache.flink.runtime.util.EnvironmentInformation
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -2097,11 +2097,26 @@ object TaskManager {
 
     val ioMode : IOMode = if (syncOrAsync == "async") IOMode.ASYNC else IOMode.SYNC
 
+    val queryServerPort =  configuration.getInteger(
+      ConfigConstants.QUERYABLE_STATE_SERVER_PORT,
+      ConfigConstants.DEFAULT_QUERYABLE_STATE_SERVER_PORT)
+
+    val queryServerNetworkThreads =  configuration.getInteger(
+      ConfigConstants.QUERYABLE_STATE_SERVER_NETWORK_THREADS,
+      ConfigConstants.DEFAULT_QUERYABLE_STATE_SERVER_NETWORK_THREADS)
+
+    val queryServerQueryThreads =  configuration.getInteger(
+      ConfigConstants.QUERYABLE_STATE_SERVER_QUERY_THREADS,
+      ConfigConstants.DEFAULT_QUERYABLE_STATE_SERVER_QUERY_THREADS)
+
     val networkConfig = NetworkEnvironmentConfiguration(
       numNetworkBuffers,
       pageSize,
       memType,
       ioMode,
+      queryServerPort,
+      queryServerNetworkThreads,
+      queryServerQueryThreads,
       nettyConfig)
 
     // ----> timeouts, library caching, profiling

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1809,7 +1809,11 @@ object TaskManager {
     val executionContext = ExecutionContext.fromExecutor(new ForkJoinPool())
 
     // we start the network first, to make sure it can allocate its buffers first
-    val network = new NetworkEnvironment(executionContext, taskManagerConfig.timeout, netConfig)
+    val network = new NetworkEnvironment(
+      executionContext,
+      taskManagerConfig.timeout,
+      netConfig,
+      connectionInfo)
 
     // computing the amount of memory to use depends on how much memory is available
     // it strictly needs to happen AFTER the network stack has been initialized

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -80,7 +80,7 @@ public class NetworkEnvironmentTest {
 			NettyConfig nettyConf = new NettyConfig(InetAddress.getLocalHost(), port, BUFFER_SIZE, 1, new Configuration());
 			NetworkEnvironmentConfiguration config = new NetworkEnvironmentConfiguration(
 					NUM_BUFFERS, BUFFER_SIZE, MemoryType.HEAP,
-					IOManager.IOMode.SYNC, new Some<>(nettyConf),
+					IOManager.IOMode.SYNC, 0, 0, 0, new Some<>(nettyConf),
 					new Tuple2<>(0, 0));
 
 			NetworkEnvironment env = new NetworkEnvironment(
@@ -174,6 +174,9 @@ public class NetworkEnvironmentTest {
 				1024,
 				MemoryType.HEAP,
 				IOManager.IOMode.SYNC,
+				0,
+				0,
+				0,
 				Some.<NettyConfig>empty(),
 				new Tuple2<>(0, 0));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.DummyActorGateway;
+import org.apache.flink.runtime.instance.InstanceConnectionInfo;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
@@ -85,7 +86,8 @@ public class NetworkEnvironmentTest {
 			NetworkEnvironment env = new NetworkEnvironment(
 				TestingUtils.defaultExecutionContext(),
 				new FiniteDuration(30, TimeUnit.SECONDS),
-				config);
+				config,
+				new InstanceConnectionInfo(InetAddress.getLocalHost(), port));
 
 			assertFalse(env.isShutdown());
 			assertFalse(env.isAssociated());
@@ -178,7 +180,8 @@ public class NetworkEnvironmentTest {
 		NetworkEnvironment env = new NetworkEnvironment(
 				TestingUtils.defaultExecutionContext(),
 				new FiniteDuration(30, TimeUnit.SECONDS),
-				config);
+				config,
+				new InstanceConnectionInfo(InetAddress.getLocalHost(), 12232));
 
 		// Associate the environment with the mock actors
 		env.associateWithTaskManagerAndJobManager(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -18,57 +18,83 @@
 
 package org.apache.flink.runtime.jobmanager;
 
+import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
-
 import com.typesafe.config.Config;
-
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
 import org.apache.flink.runtime.messages.JobManagerMessages.LeaderSessionMessage;
+import org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState;
 import org.apache.flink.runtime.messages.JobManagerMessages.StopJob;
 import org.apache.flink.runtime.messages.JobManagerMessages.StoppingFailure;
 import org.apache.flink.runtime.messages.JobManagerMessages.StoppingSuccess;
 import org.apache.flink.runtime.messages.JobManagerMessages.SubmitJob;
-import org.apache.flink.runtime.messages.JobManagerMessages.RequestPartitionState;
 import org.apache.flink.runtime.messages.TaskMessages.PartitionState;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.KvStateMessage.LookupKvStateLocation;
+import org.apache.flink.runtime.query.KvStateMessage.NotifyKvStateRegistered;
+import org.apache.flink.runtime.query.KvStateMessage.NotifyKvStateUnregistered;
+import org.apache.flink.runtime.query.KvStateServerAddress;
+import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
+import org.apache.flink.runtime.testingUtils.TestingJobManager;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.ExecutionGraphFound;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobStatus;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.RequestExecutionGraph;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunningOrFinished;
+import org.apache.flink.runtime.testingUtils.TestingTaskManager;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.StoppableInvokable;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import scala.Some;
 import scala.Tuple2;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.FiniteDuration;
+import scala.reflect.ClassTag$;
 
 import java.net.InetAddress;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.apache.flink.runtime.messages.JobManagerMessages.JobResultSuccess;
+import static org.apache.flink.runtime.messages.JobManagerMessages.JobSubmitSuccess;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.AllVerticesRunning;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.JobStatusIs;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenAtLeastNumTaskManagerAreRegistered;
 import static org.apache.flink.runtime.testingUtils.TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT;
 import static org.apache.flink.runtime.testingUtils.TestingUtils.startTestingCluster;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -141,13 +167,13 @@ public class JobManagerTest {
 								jobGraph,
 								ListeningBehaviour.EXECUTION_RESULT),
 							testActorGateway);
-						expectMsgClass(JobManagerMessages.JobSubmitSuccess.class);
+						expectMsgClass(JobSubmitSuccess.class);
 
 						jobManagerGateway.tell(
 							new WaitForAllVerticesToBeRunningOrFinished(jid),
 							testActorGateway);
 
-						expectMsgClass(TestingJobManagerMessages.AllVerticesRunning.class);
+						expectMsgClass(AllVerticesRunning.class);
 
 						// This is the mock execution ID of the task requesting the state of the partition
 						final ExecutionAttemptID receiver = new ExecutionAttemptID();
@@ -267,17 +293,17 @@ public class JobManagerTest {
 								jobGraph,
 								ListeningBehaviour.EXECUTION_RESULT),
 							testActorGateway);
-						expectMsgClass(JobManagerMessages.JobSubmitSuccess.class);
+						expectMsgClass(JobSubmitSuccess.class);
 
 						jobManagerGateway.tell(new WaitForAllVerticesToBeRunning(jid), testActorGateway);
-						expectMsgClass(TestingJobManagerMessages.AllVerticesRunning.class);
+						expectMsgClass(AllVerticesRunning.class);
 
 						jobManagerGateway.tell(new StopJob(jid), testActorGateway);
 
 						// - The test ----------------------------------------------------------------------
 						expectMsgClass(StoppingSuccess.class);
 
-						expectMsgClass(JobManagerMessages.JobResultSuccess.class);
+						expectMsgClass(JobResultSuccess.class);
 					} finally {
 						if (cluster != null) {
 							cluster.shutdown();
@@ -319,10 +345,10 @@ public class JobManagerTest {
 								jobGraph,
 								ListeningBehaviour.EXECUTION_RESULT),
 							testActorGateway);
-						expectMsgClass(JobManagerMessages.JobSubmitSuccess.class);
+						expectMsgClass(JobSubmitSuccess.class);
 
 						jobManagerGateway.tell(new WaitForAllVerticesToBeRunning(jid), testActorGateway);
-						expectMsgClass(TestingJobManagerMessages.AllVerticesRunning.class);
+						expectMsgClass(AllVerticesRunning.class);
 
 						jobManagerGateway.tell(new StopJob(jid), testActorGateway);
 
@@ -342,4 +368,206 @@ public class JobManagerTest {
 		}};
 	}
 
+	/**
+	 * Tests that the JobManager handles {@link org.apache.flink.runtime.query.KvStateMessage}
+	 * instances as expected.
+	 */
+	@Test
+	public void testKvStateMessages() throws Exception {
+		Deadline deadline = new FiniteDuration(100, TimeUnit.SECONDS).fromNow();
+
+		Configuration config = new Configuration();
+		config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, "100ms");
+
+		UUID leaderSessionId = null;
+		ActorGateway jobManager = new AkkaActorGateway(
+				JobManager.startJobManagerActors(
+						config,
+						system,
+						TestingJobManager.class,
+						MemoryArchivist.class)._1(),
+				leaderSessionId);
+
+		LeaderRetrievalService leaderRetrievalService = new StandaloneLeaderRetrievalService(
+				AkkaUtils.getAkkaURL(system, jobManager.actor()));
+
+		Configuration tmConfig = new Configuration();
+		tmConfig.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 4);
+		tmConfig.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 8);
+
+		ActorRef taskManager = TaskManager.startTaskManagerComponentsAndActor(
+				tmConfig,
+				ResourceID.generate(),
+				system,
+				"localhost",
+				scala.Option.<String>empty(),
+				scala.Option.apply(leaderRetrievalService),
+				true,
+				TestingTaskManager.class);
+
+		Future<Object> registrationFuture = jobManager
+				.ask(new NotifyWhenAtLeastNumTaskManagerAreRegistered(1), deadline.timeLeft());
+
+		Await.ready(registrationFuture, deadline.timeLeft());
+
+		//
+		// Location lookup
+		//
+		LookupKvStateLocation lookupNonExistingJob = new LookupKvStateLocation(
+				new JobID(),
+				"any-name");
+
+		Future<KvStateLocation> lookupFuture = jobManager
+				.ask(lookupNonExistingJob, deadline.timeLeft())
+				.mapTo(ClassTag$.MODULE$.<KvStateLocation>apply(KvStateLocation.class));
+
+		try {
+			Await.result(lookupFuture, deadline.timeLeft());
+			fail("Did not throw expected Exception");
+		} catch (IllegalStateException ignored) {
+			// Expected
+		}
+
+		JobGraph jobGraph = new JobGraph("croissant");
+		JobVertex jobVertex1 = new JobVertex("cappuccino");
+		jobVertex1.setParallelism(4);
+		jobVertex1.setInvokableClass(Tasks.BlockingNoOpInvokable.class);
+
+		JobVertex jobVertex2 = new JobVertex("americano");
+		jobVertex2.setParallelism(4);
+		jobVertex2.setInvokableClass(Tasks.BlockingNoOpInvokable.class);
+
+		jobGraph.addVertex(jobVertex1);
+		jobGraph.addVertex(jobVertex2);
+
+		Future<JobSubmitSuccess> submitFuture = jobManager
+				.ask(new SubmitJob(jobGraph, ListeningBehaviour.DETACHED), deadline.timeLeft())
+				.mapTo(ClassTag$.MODULE$.<JobSubmitSuccess>apply(JobSubmitSuccess.class));
+
+		Await.result(submitFuture, deadline.timeLeft());
+
+		Object lookupUnknownRegistrationName = new LookupKvStateLocation(
+				jobGraph.getJobID(),
+				"unknown");
+
+		lookupFuture = jobManager
+				.ask(lookupUnknownRegistrationName, deadline.timeLeft())
+				.mapTo(ClassTag$.MODULE$.<KvStateLocation>apply(KvStateLocation.class));
+
+		try {
+			Await.result(lookupFuture, deadline.timeLeft());
+			fail("Did not throw expected Exception");
+		} catch (UnknownKvStateLocation ignored) {
+			// Expected
+		}
+
+		//
+		// Registration
+		//
+		NotifyKvStateRegistered registerNonExistingJob = new NotifyKvStateRegistered(
+				new JobID(),
+				new JobVertexID(),
+				0,
+				"any-name",
+				new KvStateID(),
+				new KvStateServerAddress(InetAddress.getLocalHost(), 1233));
+
+		jobManager.tell(registerNonExistingJob);
+
+		LookupKvStateLocation lookupAfterRegistration = new LookupKvStateLocation(
+				registerNonExistingJob.getJobId(),
+				registerNonExistingJob.getRegistrationName());
+
+		lookupFuture = jobManager
+				.ask(lookupAfterRegistration, deadline.timeLeft())
+				.mapTo(ClassTag$.MODULE$.<KvStateLocation>apply(KvStateLocation.class));
+
+		try {
+			Await.result(lookupFuture, deadline.timeLeft());
+			fail("Did not throw expected Exception");
+		} catch (IllegalStateException ignored) {
+			// Expected
+		}
+
+		NotifyKvStateRegistered registerForExistingJob = new NotifyKvStateRegistered(
+				jobGraph.getJobID(),
+				jobVertex1.getID(),
+				0,
+				"register-me",
+				new KvStateID(),
+				new KvStateServerAddress(InetAddress.getLocalHost(), 1293));
+
+		jobManager.tell(registerForExistingJob);
+
+		lookupAfterRegistration = new LookupKvStateLocation(
+				registerForExistingJob.getJobId(),
+				registerForExistingJob.getRegistrationName());
+
+		lookupFuture = jobManager
+				.ask(lookupAfterRegistration, deadline.timeLeft())
+				.mapTo(ClassTag$.MODULE$.<KvStateLocation>apply(KvStateLocation.class));
+
+		KvStateLocation location = Await.result(lookupFuture, deadline.timeLeft());
+		assertNotNull(location);
+
+		assertEquals(jobGraph.getJobID(), location.getJobId());
+		assertEquals(jobVertex1.getID(), location.getJobVertexId());
+		assertEquals(jobVertex1.getParallelism(), location.getNumKeyGroups());
+		assertEquals(1, location.getNumRegisteredKeyGroups());
+		int keyGroupIndex = registerForExistingJob.getKeyGroupIndex();
+		assertEquals(registerForExistingJob.getKvStateId(), location.getKvStateID(keyGroupIndex));
+		assertEquals(registerForExistingJob.getKvStateServerAddress(), location.getKvStateServerAddress(keyGroupIndex));
+
+		//
+		// Unregistration
+		//
+		NotifyKvStateUnregistered unregister = new NotifyKvStateUnregistered(
+				registerForExistingJob.getJobId(),
+				registerForExistingJob.getJobVertexId(),
+				registerForExistingJob.getKeyGroupIndex(),
+				registerForExistingJob.getRegistrationName());
+
+		jobManager.tell(unregister);
+
+		lookupFuture = jobManager
+				.ask(lookupAfterRegistration, deadline.timeLeft())
+				.mapTo(ClassTag$.MODULE$.<KvStateLocation>apply(KvStateLocation.class));
+
+		try {
+			Await.result(lookupFuture, deadline.timeLeft());
+			fail("Did not throw expected Exception");
+		} catch (UnknownKvStateLocation ignored) {
+			// Expected
+		}
+
+		//
+		// Duplicate registration fails task
+		//
+		NotifyKvStateRegistered register = new NotifyKvStateRegistered(
+				jobGraph.getJobID(),
+				jobVertex1.getID(),
+				0,
+				"duplicate-me",
+				new KvStateID(),
+				new KvStateServerAddress(InetAddress.getLocalHost(), 1293));
+
+		NotifyKvStateRegistered duplicate = new NotifyKvStateRegistered(
+				jobGraph.getJobID(),
+				jobVertex2.getID(), // <--- different operator, but...
+				0,
+				"duplicate-me", // ...same name
+				new KvStateID(),
+				new KvStateServerAddress(InetAddress.getLocalHost(), 1293));
+
+		Future<TestingJobManagerMessages.JobStatusIs> failedFuture = jobManager
+				.ask(new NotifyWhenJobStatus(jobGraph.getJobID(), JobStatus.FAILED), deadline.timeLeft())
+				.mapTo(ClassTag$.MODULE$.<JobStatusIs>apply(JobStatusIs.class));
+
+		jobManager.tell(register);
+		jobManager.tell(duplicate);
+
+		// Wait for failure
+		JobStatusIs jobStatus = Await.result(failedFuture, deadline.timeLeft());
+		assertEquals(JobStatus.FAILED, jobStatus.state());
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java.orig
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java.orig
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.execution.Environment;
@@ -49,9 +49,12 @@ public class DummyEnvironment implements Environment {
 	private final JobVertexID jobVertexId = new JobVertexID();
 	private final ExecutionAttemptID executionId = new ExecutionAttemptID();
 	private final ExecutionConfig executionConfig = new ExecutionConfig();
+<<<<<<< 9a73dbc71b83080b7deccc62b8b6ffa9f102e847
 	private final TaskInfo taskInfo;
+=======
 	private final KvStateRegistry kvStateRegistry = new KvStateRegistry();
 	private final TaskKvStateRegistry taskKvStateRegistry;
+>>>>>>> [FLINK-3779] [runtime] Add KvStateRegistry for queryable KvState
 
 	public DummyEnvironment(String taskName, int numSubTasks, int subTaskIndex) {
 		this.taskInfo = new TaskInfo(taskName, subTaskIndex, numSubTasks, 0);
@@ -144,20 +147,20 @@ public class DummyEnvironment implements Environment {
 	}
 
 	@Override
+<<<<<<< 9a73dbc71b83080b7deccc62b8b6ffa9f102e847
+	public void acknowledgeCheckpoint(long checkpointId) {}
+=======
 	public TaskKvStateRegistry getTaskKvStateRegistry() {
 		return taskKvStateRegistry;
 	}
 
 	@Override
-	public void acknowledgeCheckpoint(long checkpointId) {}
+	public void acknowledgeCheckpoint(long checkpointId) {
+	}
+>>>>>>> [FLINK-3779] [runtime] Add KvStateRegistry for queryable KvState
 
 	@Override
 	public void acknowledgeCheckpoint(long checkpointId, StateHandle<?> state) {}
-
-	@Override
-	public void failExternally(Throwable cause) {
-		throw new UnsupportedOperationException("DummyEnvironment does not support external task failure.");
-	}
 
 	@Override
 	public ResultPartitionWriter getWriter(int index) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/AkkaKvStateLocationLookupServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/AkkaKvStateLocationLookupServiceTest.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.Status;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.akka.FlinkUntypedActor;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
+import org.apache.flink.runtime.query.AkkaKvStateLocationLookupService.LookupRetryStrategy;
+import org.apache.flink.runtime.query.AkkaKvStateLocationLookupService.LookupRetryStrategyFactory;
+import org.apache.flink.runtime.query.KvStateMessage.LookupKvStateLocation;
+import org.apache.flink.util.Preconditions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class AkkaKvStateLocationLookupServiceTest {
+
+	/** The default timeout. */
+	private static final FiniteDuration TIMEOUT = new FiniteDuration(10, TimeUnit.SECONDS);
+
+	/** Test actor system shared between the tests. */
+	private static ActorSystem testActorSystem;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		testActorSystem = AkkaUtils.createLocalActorSystem(new Configuration());
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		if (testActorSystem != null) {
+			testActorSystem.shutdown();
+		}
+	}
+
+	/**
+	 * Tests responses if no leader notification has been reported or leadership
+	 * has been lost (leaderAddress = <code>null</code>).
+	 */
+	@Test
+	public void testNoJobManagerRegistered() throws Exception {
+		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+		Queue<LookupKvStateLocation> received = new LinkedBlockingQueue<>();
+
+		AkkaKvStateLocationLookupService lookupService = new AkkaKvStateLocationLookupService(
+				leaderRetrievalService,
+				testActorSystem,
+				TIMEOUT,
+				new AkkaKvStateLocationLookupService.DisabledLookupRetryStrategyFactory());
+
+		lookupService.start();
+
+		//
+		// No leader registered initially => fail with UnknownJobManager
+		//
+		try {
+			JobID jobId = new JobID();
+			String name = "coffee";
+
+			Future<KvStateLocation> locationFuture = lookupService.getKvStateLookupInfo(jobId, name);
+
+			Await.result(locationFuture, TIMEOUT);
+			fail("Did not throw expected Exception");
+		} catch (UnknownJobManager ignored) {
+			// Expected
+		}
+
+		assertEquals("Received unexpected lookup", 0, received.size());
+
+		//
+		// Leader registration => communicate with new leader
+		//
+		UUID leaderSessionId = null;
+		KvStateLocation expected = new KvStateLocation(new JobID(), new JobVertexID(), 8282, "tea");
+
+		ActorRef testActor = LookupResponseActor.create(received, leaderSessionId, expected);
+
+		String testActorAddress = AkkaUtils.getAkkaURL(testActorSystem, testActor);
+
+		// Notify the service about a leader
+		leaderRetrievalService.notifyListener(testActorAddress, leaderSessionId);
+
+		JobID jobId = new JobID();
+		String name = "tea";
+
+		// Verify that the leader response is handled
+		KvStateLocation location = Await.result(lookupService.getKvStateLookupInfo(jobId, name), TIMEOUT);
+		assertEquals(expected, location);
+
+		// Verify that the correct message was sent to the leader
+		assertEquals(1, received.size());
+
+		verifyLookupMsg(received.poll(), jobId, name);
+
+		//
+		// Leader loss => fail with UnknownJobManager
+		//
+		leaderRetrievalService.notifyListener(null, null);
+
+		try {
+			Future<KvStateLocation> locationFuture = lookupService
+					.getKvStateLookupInfo(new JobID(), "coffee");
+
+			Await.result(locationFuture, TIMEOUT);
+			fail("Did not throw expected Exception");
+		} catch (UnknownJobManager ignored) {
+			// Expected
+		}
+
+		// No new messages received
+		assertEquals(0, received.size());
+	}
+
+	/**
+	 * Tests that messages are properly decorated with the leader session ID.
+	 */
+	@Test
+	public void testLeaderSessionIdChange() throws Exception {
+		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+		Queue<LookupKvStateLocation> received = new LinkedBlockingQueue<>();
+
+		AkkaKvStateLocationLookupService lookupService = new AkkaKvStateLocationLookupService(
+				leaderRetrievalService,
+				testActorSystem,
+				TIMEOUT,
+				new AkkaKvStateLocationLookupService.DisabledLookupRetryStrategyFactory());
+
+		lookupService.start();
+
+		// Create test actors with random leader session IDs
+		KvStateLocation expected1 = new KvStateLocation(new JobID(), new JobVertexID(), 8282, "salt");
+		UUID leaderSessionId1 = UUID.randomUUID();
+		ActorRef testActor1 = LookupResponseActor.create(received, leaderSessionId1, expected1);
+		String testActorAddress1 = AkkaUtils.getAkkaURL(testActorSystem, testActor1);
+
+		KvStateLocation expected2 = new KvStateLocation(new JobID(), new JobVertexID(), 22321, "pepper");
+		UUID leaderSessionId2 = UUID.randomUUID();
+		ActorRef testActor2 = LookupResponseActor.create(received, leaderSessionId1, expected2);
+		String testActorAddress2 = AkkaUtils.getAkkaURL(testActorSystem, testActor2);
+
+		JobID jobId = new JobID();
+
+		//
+		// Notify about first leader
+		//
+		leaderRetrievalService.notifyListener(testActorAddress1, leaderSessionId1);
+
+		KvStateLocation location = Await.result(lookupService.getKvStateLookupInfo(jobId, "rock"), TIMEOUT);
+		assertEquals(expected1, location);
+
+		assertEquals(1, received.size());
+		verifyLookupMsg(received.poll(), jobId, "rock");
+
+		//
+		// Notify about second leader
+		//
+		leaderRetrievalService.notifyListener(testActorAddress2, leaderSessionId2);
+
+		location = Await.result(lookupService.getKvStateLookupInfo(jobId, "roll"), TIMEOUT);
+		assertEquals(expected2, location);
+
+		assertEquals(1, received.size());
+		verifyLookupMsg(received.poll(), jobId, "roll");
+	}
+
+	/**
+	 * Tests that lookups are retried when no leader notification is available.
+	 */
+	@Test
+	public void testRetryOnUnknownJobManager() throws Exception {
+		final Queue<LookupRetryStrategy> retryStrategies = new LinkedBlockingQueue<>();
+
+		LookupRetryStrategyFactory retryStrategy =
+				new LookupRetryStrategyFactory() {
+					@Override
+					public LookupRetryStrategy createRetryStrategy() {
+						return retryStrategies.poll();
+					}
+				};
+
+		final TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+
+		AkkaKvStateLocationLookupService lookupService = new AkkaKvStateLocationLookupService(
+				leaderRetrievalService,
+				testActorSystem,
+				TIMEOUT,
+				retryStrategy);
+
+		lookupService.start();
+
+		//
+		// Test call to retry
+		//
+		final AtomicBoolean hasRetried = new AtomicBoolean();
+		retryStrategies.add(
+				new LookupRetryStrategy() {
+					@Override
+					public FiniteDuration getRetryDelay() {
+						return FiniteDuration.Zero();
+					}
+
+					@Override
+					public boolean tryRetry() {
+						if (hasRetried.compareAndSet(false, true)) {
+							return true;
+						}
+						return false;
+					}
+				});
+
+		Future<KvStateLocation> locationFuture = lookupService.getKvStateLookupInfo(new JobID(), "yessir");
+
+		Await.ready(locationFuture, TIMEOUT);
+		assertTrue("Did not retry ", hasRetried.get());
+
+		//
+		// Test leader notification after retry
+		//
+		Queue<LookupKvStateLocation> received = new LinkedBlockingQueue<>();
+
+		KvStateLocation expected = new KvStateLocation(new JobID(), new JobVertexID(), 12122, "garlic");
+		ActorRef testActor = LookupResponseActor.create(received, null, expected);
+		final String testActorAddress = AkkaUtils.getAkkaURL(testActorSystem, testActor);
+
+		retryStrategies.add(new LookupRetryStrategy() {
+			@Override
+			public FiniteDuration getRetryDelay() {
+				return FiniteDuration.apply(100, TimeUnit.MILLISECONDS);
+			}
+
+			@Override
+			public boolean tryRetry() {
+				leaderRetrievalService.notifyListener(testActorAddress, null);
+				return true;
+			}
+		});
+
+		KvStateLocation location = Await.result(lookupService.getKvStateLookupInfo(new JobID(), "yessir"), TIMEOUT);
+		assertEquals(expected, location);
+	}
+
+	@Test
+	public void testUnexpectedResponseType() throws Exception {
+		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+		Queue<LookupKvStateLocation> received = new LinkedBlockingQueue<>();
+
+		AkkaKvStateLocationLookupService lookupService = new AkkaKvStateLocationLookupService(
+				leaderRetrievalService,
+				testActorSystem,
+				TIMEOUT,
+				new AkkaKvStateLocationLookupService.DisabledLookupRetryStrategyFactory());
+
+		lookupService.start();
+
+		// Create test actors with random leader session IDs
+		String expected = "unexpected-response-type";
+		ActorRef testActor = LookupResponseActor.create(received, null, expected);
+		String testActorAddress = AkkaUtils.getAkkaURL(testActorSystem, testActor);
+
+		leaderRetrievalService.notifyListener(testActorAddress, null);
+
+		try {
+			Await.result(lookupService.getKvStateLookupInfo(new JobID(), "spicy"), TIMEOUT);
+			fail("Did not throw expected Exception");
+		} catch (Throwable ignored) {
+			// Expected
+		}
+	}
+
+	private final static class LookupResponseActor extends FlinkUntypedActor {
+
+		/** Received lookup messages */
+		private final Queue<LookupKvStateLocation> receivedLookups;
+
+		/** Responses on KvStateMessage.LookupKvStateLocation messages */
+		private final Queue<Object> lookupResponses;
+
+		/** The leader session ID */
+		private UUID leaderSessionId;
+
+		public LookupResponseActor(
+				Queue<LookupKvStateLocation> receivedLookups,
+				UUID leaderSessionId, Object... lookupResponses) {
+
+			this.receivedLookups = Preconditions.checkNotNull(receivedLookups, "Received lookups");
+			this.leaderSessionId = leaderSessionId;
+			this.lookupResponses = new ArrayDeque<>();
+
+			if (lookupResponses != null) {
+				for (Object resp : lookupResponses) {
+					this.lookupResponses.add(resp);
+				}
+			}
+		}
+
+		@Override
+		public void handleMessage(Object message) throws Exception {
+			if (message instanceof LookupKvStateLocation) {
+				// Add to received lookups queue
+				receivedLookups.add((LookupKvStateLocation) message);
+
+				Object msg = lookupResponses.poll();
+				if (msg != null) {
+					if (msg instanceof Throwable) {
+						sender().tell(new Status.Failure((Throwable) msg), self());
+					} else {
+						sender().tell(new Status.Success(msg), self());
+					}
+				}
+			} else if (message instanceof UUID) {
+				this.leaderSessionId = (UUID) message;
+			} else {
+				LOG.debug("Received unhandled message: {}", message);
+			}
+		}
+
+		@Override
+		protected UUID getLeaderSessionID() {
+			return leaderSessionId;
+		}
+
+		private static ActorRef create(
+				Queue<LookupKvStateLocation> receivedLookups,
+				UUID leaderSessionId,
+				Object... lookupResponses) {
+
+			return testActorSystem.actorOf(Props.create(
+					LookupResponseActor.class,
+					receivedLookups,
+					leaderSessionId,
+					lookupResponses));
+		}
+	}
+
+	private static void verifyLookupMsg(
+			LookupKvStateLocation lookUpMsg,
+			JobID expectedJobId,
+			String expectedName) {
+
+		assertNotNull(lookUpMsg);
+		assertEquals(expectedJobId, lookUpMsg.getJobId());
+		assertEquals(expectedName, lookUpMsg.getRegistrationName());
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationRegistryTest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KvStateLocationRegistryTest {
+
+	/**
+	 * Simple test registering/unregistereing state and looking it up again.
+	 */
+	@Test
+	public void testRegisterAndLookup() throws Exception {
+		String[] registrationNames = new String[] {
+				"TAsIrGnc7MULwVupNKZ0",
+				"086133IrGn0Ii2853237" };
+
+		ExecutionJobVertex[] vertices = new ExecutionJobVertex[] {
+				createJobVertex(32),
+				createJobVertex(13) };
+
+		// IDs for each key group of each vertex
+		KvStateID[][] ids = new KvStateID[vertices.length][];
+		for (int i = 0; i < ids.length; i++) {
+			ids[i] = new KvStateID[vertices[i].getParallelism()];
+			for (int j = 0; j < vertices[i].getParallelism(); j++) {
+				ids[i][j] = new KvStateID();
+			}
+		}
+
+		KvStateServerAddress server = new KvStateServerAddress(InetAddress.getLocalHost(), 12032);
+
+		// Create registry
+		Map<JobVertexID, ExecutionJobVertex> vertexMap = createVertexMap(vertices);
+		KvStateLocationRegistry registry = new KvStateLocationRegistry(new JobID(), vertexMap);
+
+		// Register
+		for (int i = 0; i < vertices.length; i++) {
+			int numKeyGroups = vertices[i].getParallelism();
+			for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+				// Register
+				registry.notifyKvStateRegistered(
+						vertices[i].getJobVertexId(),
+						keyGroupIndex,
+						registrationNames[i],
+						ids[i][keyGroupIndex],
+						server);
+			}
+		}
+
+		// Verify all registrations
+		for (int i = 0; i < vertices.length; i++) {
+			KvStateLocation location = registry.getKvStateLocation(registrationNames[i]);
+			assertNotNull(location);
+
+			int parallelism = vertices[i].getParallelism();
+			for (int keyGroupIndex = 0; keyGroupIndex < parallelism; keyGroupIndex++) {
+				assertEquals(ids[i][keyGroupIndex], location.getKvStateID(keyGroupIndex));
+				assertEquals(server, location.getKvStateServerAddress(keyGroupIndex));
+			}
+		}
+
+		// Unregister
+		for (int i = 0; i < vertices.length; i++) {
+			int numKeyGroups = vertices[i].getParallelism();
+			JobVertexID jobVertexId = vertices[i].getJobVertexId();
+			for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+				registry.notifyKvStateUnregistered(jobVertexId, keyGroupIndex, registrationNames[i]);
+			}
+		}
+
+		for (int i = 0; i < registrationNames.length; i++) {
+			assertNull(registry.getKvStateLocation(registrationNames[i]));
+		}
+	}
+
+	/**
+	 * Tests that registrations with duplicate names throw an Exception.
+	 */
+	@Test
+	public void testRegisterDuplicateName() throws Exception {
+		ExecutionJobVertex[] vertices = new ExecutionJobVertex[] {
+				createJobVertex(32),
+				createJobVertex(13) };
+
+		Map<JobVertexID, ExecutionJobVertex> vertexMap = createVertexMap(vertices);
+
+		String registrationName = "duplicated-name";
+		KvStateLocationRegistry registry = new KvStateLocationRegistry(new JobID(), vertexMap);
+
+		// First operator registers
+		registry.notifyKvStateRegistered(
+				vertices[0].getJobVertexId(),
+				0,
+				registrationName,
+				new KvStateID(),
+				new KvStateServerAddress(InetAddress.getLocalHost(), 12328));
+
+		try {
+			// Second operator registers same name
+			registry.notifyKvStateRegistered(
+					vertices[1].getJobVertexId(),
+					0,
+					registrationName,
+					new KvStateID(),
+					new KvStateServerAddress(InetAddress.getLocalHost(), 12032));
+
+			fail("Did not throw expected Exception after duplicated name");
+		} catch (IllegalStateException ignored) {
+			// Expected
+		}
+	}
+
+	/**
+	 * Tests exception on unregistration before registration.
+	 */
+	@Test
+	public void testUnregisterBeforeRegister() throws Exception {
+		ExecutionJobVertex vertex = createJobVertex(4);
+		Map<JobVertexID, ExecutionJobVertex> vertexMap = createVertexMap(vertex);
+
+		KvStateLocationRegistry registry = new KvStateLocationRegistry(new JobID(), vertexMap);
+		try {
+			registry.notifyKvStateUnregistered(vertex.getJobVertexId(), 0, "any-name");
+			fail("Did not throw expected Exception, because of missing registration");
+		} catch (IllegalArgumentException ignored) {
+			// Expected
+		}
+	}
+
+	/**
+	 * Tests failures during unregistration.
+	 */
+	@Test
+	public void testUnregisterFailures() throws Exception {
+		String name = "IrGnc73237TAs";
+
+		ExecutionJobVertex[] vertices = new ExecutionJobVertex[] {
+				createJobVertex(32),
+				createJobVertex(13) };
+
+		Map<JobVertexID, ExecutionJobVertex> vertexMap = new HashMap<>();
+		for (ExecutionJobVertex vertex : vertices) {
+			vertexMap.put(vertex.getJobVertexId(), vertex);
+		}
+
+		KvStateLocationRegistry registry = new KvStateLocationRegistry(new JobID(), vertexMap);
+
+		// First operator registers name
+		registry.notifyKvStateRegistered(
+				vertices[0].getJobVertexId(),
+				0,
+				name,
+				new KvStateID(),
+				mock(KvStateServerAddress.class));
+
+		try {
+			// Unregister not registered keyGroupIndex
+			int notRegisteredKeyGroupIndex = 2;
+
+			registry.notifyKvStateUnregistered(
+					vertices[0].getJobVertexId(),
+					notRegisteredKeyGroupIndex,
+					name);
+
+			fail("Did not throw expected Exception");
+		} catch (IllegalArgumentException expected) {
+		}
+
+		try {
+			// Wrong operator tries to unregister
+			registry.notifyKvStateUnregistered(
+					vertices[1].getJobVertexId(),
+					0,
+					name);
+
+			fail("Did not throw expected Exception");
+		} catch (IllegalArgumentException expected) {
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	
+	private ExecutionJobVertex createJobVertex(int parallelism) {
+		JobVertexID id = new JobVertexID();
+		ExecutionJobVertex vertex = mock(ExecutionJobVertex.class);
+
+		when(vertex.getJobVertexId()).thenReturn(id);
+		when(vertex.getParallelism()).thenReturn(parallelism);
+
+		return vertex;
+	}
+
+	private Map<JobVertexID, ExecutionJobVertex> createVertexMap(ExecutionJobVertex... vertices) {
+		Map<JobVertexID, ExecutionJobVertex> vertexMap = new HashMap<>();
+		for (ExecutionJobVertex vertex : vertices) {
+			vertexMap.put(vertex.getJobVertexId(), vertex);
+		}
+		return vertexMap;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static org.junit.Assert.assertEquals;
+
+public class KvStateLocationTest {
+
+	/**
+	 * Simple test registering/unregistereing state and looking it up again.
+	 */
+	@Test
+	public void testRegisterAndLookup() throws Exception {
+		JobID jobId = new JobID();
+		JobVertexID jobVertexId = new JobVertexID();
+		int numKeyGroups = 123;
+		String registrationName = "asdasdasdasd";
+
+		KvStateLocation location = new KvStateLocation(jobId, jobVertexId, numKeyGroups, registrationName);
+
+		KvStateID[] kvStateIds = new KvStateID[numKeyGroups];
+		KvStateServerAddress[] serverAddresses = new KvStateServerAddress[numKeyGroups];
+
+		InetAddress host = InetAddress.getLocalHost();
+
+		// Register
+		for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+			kvStateIds[keyGroupIndex] = new KvStateID();
+			serverAddresses[keyGroupIndex] = new KvStateServerAddress(host, 1024 + keyGroupIndex);
+
+			location.registerKvState(keyGroupIndex, kvStateIds[keyGroupIndex], serverAddresses[keyGroupIndex]);
+			assertEquals(keyGroupIndex + 1, location.getNumRegisteredKeyGroups());
+		}
+
+		// Lookup
+		for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+			assertEquals(kvStateIds[keyGroupIndex], location.getKvStateID(keyGroupIndex));
+			assertEquals(serverAddresses[keyGroupIndex], location.getKvStateServerAddress(keyGroupIndex));
+		}
+
+		// Overwrite
+		for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+			kvStateIds[keyGroupIndex] = new KvStateID();
+			serverAddresses[keyGroupIndex] = new KvStateServerAddress(host, 1024 + keyGroupIndex);
+
+			location.registerKvState(keyGroupIndex, kvStateIds[keyGroupIndex], serverAddresses[keyGroupIndex]);
+			assertEquals(numKeyGroups, location.getNumRegisteredKeyGroups());
+		}
+
+		// Lookup
+		for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+			assertEquals(kvStateIds[keyGroupIndex], location.getKvStateID(keyGroupIndex));
+			assertEquals(serverAddresses[keyGroupIndex], location.getKvStateServerAddress(keyGroupIndex));
+		}
+
+		// Unregister
+		for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+			location.unregisterKvState(keyGroupIndex);
+			assertEquals(numKeyGroups - keyGroupIndex - 1, location.getNumRegisteredKeyGroups());
+		}
+
+		// Lookup
+		for (int keyGroupIndex = 0; keyGroupIndex < numKeyGroups; keyGroupIndex++) {
+			assertEquals(null, location.getKvStateID(keyGroupIndex));
+			assertEquals(null, location.getKvStateServerAddress(keyGroupIndex));
+		}
+
+		assertEquals(0, location.getNumRegisteredKeyGroups());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/QueryableStateClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/QueryableStateClientTest.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query;
+
+import akka.actor.ActorSystem;
+import akka.dispatch.Futures;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.query.netty.AtomicKvStateRequestStats;
+import org.apache.flink.runtime.query.netty.KvStateClient;
+import org.apache.flink.runtime.query.netty.KvStateServer;
+import org.apache.flink.runtime.query.netty.UnknownKvStateID;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.memory.MemValueState;
+import org.apache.flink.util.MathUtils;
+import org.junit.AfterClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class QueryableStateClientTest {
+
+	private static final ActorSystem testActorSystem = AkkaUtils.createLocalActorSystem(new Configuration());
+
+	private static final FiniteDuration timeout = new FiniteDuration(100, TimeUnit.SECONDS);
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		if (testActorSystem != null) {
+			testActorSystem.shutdown();
+		}
+	}
+
+	/**
+	 * All failures should lead to a retry with a forced location lookup.
+	 *
+	 * UnknownKvStateID, UnknownKvStateKeyGroupLocation, UnknownKvStateLocation,
+	 * ConnectException are checked explicitly as these indicate out-of-sync
+	 * KvStateLocation.
+	 */
+	@Test
+	public void testForceLookupOnOutdatedLocation() throws Exception {
+		KvStateLocationLookupService lookupService = mock(KvStateLocationLookupService.class);
+		KvStateClient networkClient = mock(KvStateClient.class);
+
+		QueryableStateClient client = new QueryableStateClient(
+				lookupService,
+				networkClient,
+				testActorSystem.dispatcher());
+
+		try {
+			JobID jobId = new JobID();
+			int numKeyGroups = 4;
+
+			//
+			// UnknownKvStateLocation
+			//
+			String query1 = "lucky";
+
+			Future<KvStateLocation> unknownKvStateLocation = Futures.failed(
+					new UnknownKvStateLocation(query1));
+
+			when(lookupService.getKvStateLookupInfo(eq(jobId), eq(query1)))
+					.thenReturn(unknownKvStateLocation);
+
+			Future<byte[]> result = client.getKvState(
+					jobId,
+					query1,
+					0,
+					new byte[0]);
+
+			try {
+				Await.result(result, timeout);
+				fail("Did not throw expected UnknownKvStateLocation exception");
+			} catch (UnknownKvStateLocation ignored) {
+				// Expected
+			}
+
+			verify(lookupService, times(2)).getKvStateLookupInfo(eq(jobId), eq(query1));
+
+			//
+			// UnknownKvStateKeyGroupLocation
+			//
+			String query2 = "unlucky";
+
+			Future<KvStateLocation> unknownKeyGroupLocation = Futures.successful(
+					new KvStateLocation(jobId, new JobVertexID(), numKeyGroups, query2));
+
+			when(lookupService.getKvStateLookupInfo(eq(jobId), eq(query2)))
+					.thenReturn(unknownKeyGroupLocation);
+
+			result = client.getKvState(jobId, query2, 0, new byte[0]);
+
+			try {
+				Await.result(result, timeout);
+				fail("Did not throw expected UnknownKvStateKeyGroupLocation exception");
+			} catch (UnknownKvStateKeyGroupLocation ignored) {
+				// Expected
+			}
+
+			verify(lookupService, times(2)).getKvStateLookupInfo(eq(jobId), eq(query2));
+
+			//
+			// UnknownKvStateID
+			//
+			String query3 = "water";
+			KvStateID kvStateId = new KvStateID();
+			Future<byte[]> unknownKvStateId = Futures.failed(new UnknownKvStateID(kvStateId));
+
+			KvStateServerAddress serverAddress = new KvStateServerAddress(InetAddress.getLocalHost(), 12323);
+			KvStateLocation location = new KvStateLocation(jobId, new JobVertexID(), numKeyGroups, query3);
+			for (int i = 0; i < numKeyGroups; i++) {
+				location.registerKvState(i, kvStateId, serverAddress);
+			}
+
+			when(lookupService.getKvStateLookupInfo(eq(jobId), eq(query3)))
+					.thenReturn(Futures.successful(location));
+
+			when(networkClient.getKvState(eq(serverAddress), eq(kvStateId), any(byte[].class)))
+					.thenReturn(unknownKvStateId);
+
+			result = client.getKvState(jobId, query3, 0, new byte[0]);
+
+			try {
+				Await.result(result, timeout);
+				fail("Did not throw expected UnknownKvStateID exception");
+			} catch (UnknownKvStateID ignored) {
+				// Expected
+			}
+
+			verify(lookupService, times(2)).getKvStateLookupInfo(eq(jobId), eq(query3));
+
+			//
+			// ConnectException
+			//
+			String query4 = "space";
+			Future<byte[]> connectException = Futures.failed(new ConnectException());
+			kvStateId = new KvStateID();
+
+			serverAddress = new KvStateServerAddress(InetAddress.getLocalHost(), 11123);
+			location = new KvStateLocation(jobId, new JobVertexID(), numKeyGroups, query4);
+			for (int i = 0; i < numKeyGroups; i++) {
+				location.registerKvState(i, kvStateId, serverAddress);
+			}
+
+			when(lookupService.getKvStateLookupInfo(eq(jobId), eq(query4)))
+					.thenReturn(Futures.successful(location));
+
+			when(networkClient.getKvState(eq(serverAddress), eq(kvStateId), any(byte[].class)))
+					.thenReturn(connectException);
+
+			result = client.getKvState(jobId, query4, 0, new byte[0]);
+
+			try {
+				Await.result(result, timeout);
+				fail("Did not throw expected ConnectException exception");
+			} catch (ConnectException ignored) {
+				// Expected
+			}
+
+			verify(lookupService, times(2)).getKvStateLookupInfo(eq(jobId), eq(query4));
+
+			//
+			// Other Exceptions don't lead to a retry no retry
+			//
+			String query5 = "universe";
+			Future<KvStateLocation> exception = Futures.failed(new RuntimeException("Test exception"));
+			when(lookupService.getKvStateLookupInfo(eq(jobId), eq(query5)))
+					.thenReturn(exception);
+
+			client.getKvState(jobId, query5, 0, new byte[0]);
+
+			verify(lookupService, times(1)).getKvStateLookupInfo(eq(jobId), eq(query5));
+		} finally {
+			client.shutDown();
+		}
+	}
+
+	/**
+	 * Tests queries against multiple servers.
+	 *
+	 * <p>The servers are populated with different keys and the client queries
+	 * all available keys from all servers.
+	 */
+	@Test
+	public void testIntegrationWithKvStateServer() throws Exception {
+		// Config
+		int numServers = 2;
+		int numKeys = 1024;
+
+		JobID jobId = new JobID();
+		JobVertexID jobVertexId = new JobVertexID();
+
+		KvStateServer[] servers = new KvStateServer[numServers];
+		AtomicKvStateRequestStats[] serverStats = new AtomicKvStateRequestStats[numServers];
+
+		QueryableStateClient client = null;
+		KvStateClient networkClient = null;
+		AtomicKvStateRequestStats networkClientStats = new AtomicKvStateRequestStats();
+
+		try {
+			KvStateRegistry[] registries = new KvStateRegistry[numServers];
+			KvStateID[] kvStateIds = new KvStateID[numServers];
+			List<MemValueState<Integer, VoidNamespace, Integer>> kvStates = new ArrayList<>();
+
+			// Start the servers
+			for (int i = 0; i < numServers; i++) {
+				registries[i] = new KvStateRegistry();
+				serverStats[i] = new AtomicKvStateRequestStats();
+				servers[i] = new KvStateServer(InetAddress.getLocalHost(), 0, 1, 1, registries[i], serverStats[i]);
+				servers[i].start();
+
+				// Register state
+				MemValueState<Integer, VoidNamespace, Integer> kvState = new MemValueState<>(
+						IntSerializer.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE,
+						new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null));
+
+				kvStates.add(kvState);
+
+				kvStateIds[i] = registries[i].registerKvState(
+						jobId,
+						new JobVertexID(),
+						i, // key group index
+						"choco",
+						kvState);
+			}
+
+			int[] expectedRequests = new int[numServers];
+
+			for (int key = 0; key < numKeys; key++) {
+				int targetKeyGroupIndex = MathUtils.murmurHash(key) % numServers;
+				expectedRequests[targetKeyGroupIndex]++;
+
+				MemValueState<Integer, VoidNamespace, Integer> kvState = kvStates.get(targetKeyGroupIndex);
+
+				kvState.setCurrentKey(key);
+				kvState.setCurrentNamespace(VoidNamespace.INSTANCE);
+				kvState.update(1337 + key);
+			}
+
+			// Location lookup service
+			KvStateLocation location = new KvStateLocation(jobId, jobVertexId, numServers, "choco");
+			for (int keyGroupIndex = 0; keyGroupIndex < numServers; keyGroupIndex++) {
+				location.registerKvState(keyGroupIndex, kvStateIds[keyGroupIndex], servers[keyGroupIndex].getAddress());
+			}
+
+			KvStateLocationLookupService lookupService = mock(KvStateLocationLookupService.class);
+			when(lookupService.getKvStateLookupInfo(eq(jobId), eq("choco")))
+					.thenReturn(Futures.successful(location));
+
+			// The client
+			networkClient = new KvStateClient(1, networkClientStats);
+
+			client = new QueryableStateClient(lookupService, networkClient, testActorSystem.dispatcher());
+
+			// Send all queries
+			List<Future<byte[]>> futures = new ArrayList<>(numKeys);
+			for (int key = 0; key < numKeys; key++) {
+				byte[] serializedKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+						key,
+						IntSerializer.INSTANCE,
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE);
+
+				futures.add(client.getKvState(jobId, "choco", key, serializedKeyAndNamespace));
+			}
+
+			// Verify results
+			Future<Iterable<byte[]>> future = Futures.sequence(futures, testActorSystem.dispatcher());
+			Iterable<byte[]> results = Await.result(future, timeout);
+
+			int index = 0;
+			for (byte[] buffer : results) {
+				int deserializedValue = KvStateRequestSerializer.deserializeValue(buffer, IntSerializer.INSTANCE);
+				assertEquals(1337 + index, deserializedValue);
+				index++;
+			}
+
+			// Verify requests
+			for (int i = 0; i < numServers; i++) {
+				int numRetries = 10;
+				for (int retry = 0; retry < numRetries; retry++) {
+					try {
+						assertEquals("Unexpected number of requests", expectedRequests[i], serverStats[i].getNumRequests());
+						assertEquals("Unexpected success requests", expectedRequests[i], serverStats[i].getNumSuccessful());
+						assertEquals("Unexpected failed requests", 0, serverStats[i].getNumFailed());
+						break;
+					} catch (Throwable t) {
+						// Retry
+						if (retry == numRetries-1) {
+							throw t;
+						} else {
+							Thread.sleep(100);
+						}
+					}
+				}
+			}
+		} finally {
+			if (client != null) {
+				client.shutDown();
+			}
+
+			if (networkClient != null) {
+				networkClient.shutDown();
+			}
+
+			for (KvStateServer server : servers) {
+				if (server != null) {
+					server.shutDown();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Tests that the QueryableState client correctly caches location lookups
+	 * keyed by both job and name. This test is mainly due to a previous bug due
+	 * to which cache entries were by name only. This is a problem, because the
+	 * same client can be used to query multiple jobs.
+	 */
+	@Test
+	public void testLookupMultipleJobIds() throws Exception {
+		String name = "unique-per-job";
+
+		// Exact contents don't matter here
+		KvStateLocation location = new KvStateLocation(new JobID(), new JobVertexID(), 1, name);
+		location.registerKvState(0, new KvStateID(), new KvStateServerAddress(InetAddress.getLocalHost(), 892));
+
+		JobID jobId1 = new JobID();
+		JobID jobId2 = new JobID();
+
+		KvStateLocationLookupService lookupService = mock(KvStateLocationLookupService.class);
+
+		when(lookupService.getKvStateLookupInfo(any(JobID.class), anyString()))
+				.thenReturn(Futures.successful(location));
+
+		KvStateClient networkClient = mock(KvStateClient.class);
+		when(networkClient.getKvState(any(KvStateServerAddress.class), any(KvStateID.class), any(byte[].class)))
+				.thenReturn(Futures.successful(new byte[0]));
+
+		QueryableStateClient client = new QueryableStateClient(
+				lookupService,
+				networkClient,
+				testActorSystem.dispatcher());
+
+		// Query ies with same name, but different job IDs should lead to a
+		// single lookup per query and job ID.
+		client.getKvState(jobId1, name, 0, new byte[0]);
+		client.getKvState(jobId2, name, 0, new byte[0]);
+
+		verify(lookupService, times(1)).getKvStateLookupInfo(eq(jobId1), eq(name));
+		verify(lookupService, times(1)).getKvStateLookupInfo(eq(jobId2), eq(name));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateClientHandlerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.junit.Test;
+
+import java.nio.channels.ClosedChannelException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class KvStateClientHandlerTest {
+
+	/**
+	 * Tests that on reads the expected callback methods are called and read
+	 * buffers are recycled.
+	 */
+	@Test
+	public void testReadCallbacksAndBufferRecycling() throws Exception {
+		KvStateClientHandlerCallback callback = mock(KvStateClientHandlerCallback.class);
+
+		EmbeddedChannel channel = new EmbeddedChannel(new KvStateClientHandler(callback));
+
+		//
+		// Request success
+		//
+		ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequestResult(
+				channel.alloc(),
+				1222112277,
+				new byte[0]);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify callback
+		channel.writeInbound(buf);
+		verify(callback, times(1)).onRequestResult(eq(1222112277L), any(byte[].class));
+		assertEquals("Buffer not recycled", 0, buf.refCnt());
+
+		//
+		// Request failure
+		//
+		buf = KvStateRequestSerializer.serializeKvStateRequestFailure(
+				channel.alloc(),
+				1222112278,
+				new RuntimeException("Expected test Exception"));
+		buf.skipBytes(4); // skip frame length
+
+		// Verify callback
+		channel.writeInbound(buf);
+		verify(callback, times(1)).onRequestFailure(eq(1222112278L), any(RuntimeException.class));
+		assertEquals("Buffer not recycled", 0, buf.refCnt());
+
+		//
+		// Server failure
+		//
+		buf = KvStateRequestSerializer.serializeServerFailure(
+				channel.alloc(),
+				new RuntimeException("Expected test Exception"));
+		buf.skipBytes(4); // skip frame length
+
+		// Verify callback
+		channel.writeInbound(buf);
+		verify(callback, times(1)).onFailure(any(RuntimeException.class));
+
+		//
+		// Unexpected messages
+		//
+		buf = channel.alloc().buffer(4).writeInt(1223823);
+
+		// Verify callback
+		channel.writeInbound(buf);
+		verify(callback, times(2)).onFailure(any(IllegalStateException.class));
+		assertEquals("Buffer not recycled", 0, buf.refCnt());
+
+		//
+		// Exception caught
+		//
+		channel.pipeline().fireExceptionCaught(new RuntimeException("Expected test Exception"));
+		verify(callback, times(3)).onFailure(any(RuntimeException.class));
+
+		//
+		// Channel inactive
+		//
+		channel.pipeline().fireChannelInactive();
+		verify(callback, times(4)).onFailure(any(ClosedChannelException.class));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateClientTest.java
@@ -1,0 +1,718 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.KvStateServerAddress;
+import org.apache.flink.runtime.query.netty.message.KvStateRequest;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestType;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.memory.MemValueState;
+import org.apache.flink.util.NetUtils;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class KvStateClientTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KvStateClientTest.class);
+
+	// Thread pool for client bootstrap (shared between tests)
+	private static final NioEventLoopGroup NIO_GROUP = new NioEventLoopGroup();
+
+	private final static FiniteDuration TEST_TIMEOUT = new FiniteDuration(100, TimeUnit.SECONDS);
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		if (NIO_GROUP != null) {
+			NIO_GROUP.shutdownGracefully();
+		}
+	}
+
+	/**
+	 * Tests simple queries, of which half succeed and half fail.
+	 */
+	@Test
+	public void testSimpleRequests() throws Exception {
+		Deadline deadline = TEST_TIMEOUT.fromNow();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateClient client = null;
+		Channel serverChannel = null;
+
+		try {
+			client = new KvStateClient(1, stats);
+
+			// Random result
+			final byte[] expected = new byte[1024];
+			ThreadLocalRandom.current().nextBytes(expected);
+
+			final LinkedBlockingQueue<ByteBuf> received = new LinkedBlockingQueue<>();
+			final AtomicReference<Channel> channel = new AtomicReference<>();
+
+			serverChannel = createServerChannel(new ChannelInboundHandlerAdapter() {
+				@Override
+				public void channelActive(ChannelHandlerContext ctx) throws Exception {
+					channel.set(ctx.channel());
+				}
+
+				@Override
+				public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+					received.add((ByteBuf) msg);
+				}
+			});
+
+			KvStateServerAddress serverAddress = getKvStateServerAddress(serverChannel);
+
+			List<Future<byte[]>> futures = new ArrayList<>();
+
+			int numQueries = 1024;
+
+			for (int i = 0; i < numQueries; i++) {
+				futures.add(client.getKvState(serverAddress, new KvStateID(), new byte[0]));
+			}
+
+			// Respond to messages
+			Exception testException = new RuntimeException("Expected test Exception");
+
+			for (int i = 0; i < numQueries; i++) {
+				ByteBuf buf = received.poll(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+				assertNotNull("Receive timed out", buf);
+
+				Channel ch = channel.get();
+				assertNotNull("Channel not active", ch);
+
+				assertEquals(KvStateRequestType.REQUEST, KvStateRequestSerializer.deserializeHeader(buf));
+				KvStateRequest request = KvStateRequestSerializer.deserializeKvStateRequest(buf);
+
+				buf.release();
+
+				if (i % 2 == 0) {
+					ByteBuf response = KvStateRequestSerializer.serializeKvStateRequestResult(
+							serverChannel.alloc(),
+							request.getRequestId(),
+							expected);
+
+					ch.writeAndFlush(response);
+				} else {
+					ByteBuf response = KvStateRequestSerializer.serializeKvStateRequestFailure(
+							serverChannel.alloc(),
+							request.getRequestId(),
+							testException);
+
+					ch.writeAndFlush(response);
+				}
+			}
+
+			for (int i = 0; i < numQueries; i++) {
+				if (i % 2 == 0) {
+					byte[] serializedResult = Await.result(futures.get(i), deadline.timeLeft());
+					assertArrayEquals(expected, serializedResult);
+				} else {
+					try {
+						Await.result(futures.get(i), deadline.timeLeft());
+						fail("Did not throw expected Exception");
+					} catch (RuntimeException ignored) {
+						// Expected
+					}
+				}
+			}
+
+			assertEquals(numQueries, stats.getNumRequests());
+			int expectedRequests = numQueries / 2;
+
+			// Counts can take some time to propagate
+			while (deadline.hasTimeLeft() && (stats.getNumSuccessful() != expectedRequests ||
+					stats.getNumFailed() != expectedRequests)) {
+				Thread.sleep(100);
+			}
+
+			assertEquals(expectedRequests, stats.getNumSuccessful());
+			assertEquals(expectedRequests, stats.getNumFailed());
+		} finally {
+			if (client != null) {
+				client.shutDown();
+			}
+
+			if (serverChannel != null) {
+				serverChannel.close();
+			}
+
+			assertEquals("Channel leak", 0, stats.getNumConnections());
+		}
+	}
+
+	/**
+	 * Tests that a request to an unavailable host is failed with ConnectException.
+	 */
+	@Test
+	public void testRequestUnavailableHost() throws Exception {
+		Deadline deadline = TEST_TIMEOUT.fromNow();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+		KvStateClient client = null;
+
+		try {
+			client = new KvStateClient(1, stats);
+
+			int availablePort = NetUtils.getAvailablePort();
+
+			KvStateServerAddress serverAddress = new KvStateServerAddress(
+					InetAddress.getLocalHost(),
+					availablePort);
+
+			Future<byte[]> future = client.getKvState(serverAddress, new KvStateID(), new byte[0]);
+
+			try {
+				Await.result(future, deadline.timeLeft());
+				fail("Did not throw expected ConnectException");
+			} catch (ConnectException ignored) {
+				// Expected
+			}
+		} finally {
+			if (client != null) {
+				client.shutDown();
+			}
+
+			assertEquals("Channel leak", 0, stats.getNumConnections());
+		}
+	}
+
+	/**
+	 * Multiple threads concurrently fire queries.
+	 */
+	@Test
+	public void testConcurrentQueries() throws Exception {
+		Deadline deadline = TEST_TIMEOUT.fromNow();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		ExecutorService executor = null;
+		KvStateClient client = null;
+		Channel serverChannel = null;
+
+		final byte[] serializedResult = new byte[1024];
+		ThreadLocalRandom.current().nextBytes(serializedResult);
+
+		try {
+			int numQueryTasks = 4;
+			final int numQueriesPerTask = 1024;
+
+			executor = Executors.newFixedThreadPool(numQueryTasks);
+
+			client = new KvStateClient(1, stats);
+
+			serverChannel = createServerChannel(new ChannelInboundHandlerAdapter() {
+				@Override
+				public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+					ByteBuf buf = (ByteBuf) msg;
+					assertEquals(KvStateRequestType.REQUEST, KvStateRequestSerializer.deserializeHeader(buf));
+					KvStateRequest request = KvStateRequestSerializer.deserializeKvStateRequest(buf);
+
+					buf.release();
+
+					ByteBuf response = KvStateRequestSerializer.serializeKvStateRequestResult(
+							ctx.alloc(),
+							request.getRequestId(),
+							serializedResult);
+
+					ctx.channel().writeAndFlush(response);
+				}
+			});
+
+			final KvStateServerAddress serverAddress = getKvStateServerAddress(serverChannel);
+
+			final KvStateClient finalClient = client;
+			Callable<List<Future<byte[]>>> queryTask = new Callable<List<Future<byte[]>>>() {
+				@Override
+				public List<Future<byte[]>> call() throws Exception {
+					List<Future<byte[]>> results = new ArrayList<>(numQueriesPerTask);
+
+					for (int i = 0; i < numQueriesPerTask; i++) {
+						results.add(finalClient.getKvState(
+								serverAddress,
+								new KvStateID(),
+								new byte[0]));
+					}
+
+					return results;
+				}
+			};
+
+			// Submit query tasks
+			List<java.util.concurrent.Future<List<Future<byte[]>>>> futures = new ArrayList<>();
+			for (int i = 0; i < numQueryTasks; i++) {
+				futures.add(executor.submit(queryTask));
+			}
+
+			// Verify results
+			for (java.util.concurrent.Future<List<Future<byte[]>>> future : futures) {
+				List<Future<byte[]>> results = future.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+				for (Future<byte[]> result : results) {
+					byte[] actual = Await.result(result, deadline.timeLeft());
+					assertArrayEquals(serializedResult, actual);
+				}
+			}
+
+			int totalQueries = numQueryTasks * numQueriesPerTask;
+
+			// Counts can take some time to propagate
+			while (deadline.hasTimeLeft() && (stats.getNumSuccessful() != totalQueries ||
+					stats.getNumFailed() != totalQueries)) {
+				Thread.sleep(100);
+			}
+
+			assertEquals(totalQueries, stats.getNumRequests());
+			assertEquals(totalQueries, stats.getNumSuccessful());
+		} finally {
+			if (executor != null) {
+				executor.shutdown();
+			}
+
+			if (serverChannel != null) {
+				serverChannel.close();
+			}
+
+			if (client != null) {
+				client.shutDown();
+			}
+
+			assertEquals("Channel leak", 0, stats.getNumConnections());
+		}
+	}
+
+	/**
+	 * Tests that a server failure closes the connection and removes it from
+	 * the established connections.
+	 */
+	@Test
+	public void testFailureClosesChannel() throws Exception {
+		Deadline deadline = TEST_TIMEOUT.fromNow();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateClient client = null;
+		Channel serverChannel = null;
+
+		try {
+			client = new KvStateClient(1, stats);
+
+			final LinkedBlockingQueue<ByteBuf> received = new LinkedBlockingQueue<>();
+			final AtomicReference<Channel> channel = new AtomicReference<>();
+
+			serverChannel = createServerChannel(new ChannelInboundHandlerAdapter() {
+				@Override
+				public void channelActive(ChannelHandlerContext ctx) throws Exception {
+					channel.set(ctx.channel());
+				}
+
+				@Override
+				public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+					received.add((ByteBuf) msg);
+				}
+			});
+
+			KvStateServerAddress serverAddress = getKvStateServerAddress(serverChannel);
+
+			// Requests
+			List<Future<byte[]>> futures = new ArrayList<>();
+			futures.add(client.getKvState(serverAddress, new KvStateID(), new byte[0]));
+			futures.add(client.getKvState(serverAddress, new KvStateID(), new byte[0]));
+
+			ByteBuf buf = received.poll(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			assertNotNull("Receive timed out", buf);
+			buf.release();
+
+			buf = received.poll(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			assertNotNull("Receive timed out", buf);
+			buf.release();
+
+			assertEquals(1, stats.getNumConnections());
+
+			Channel ch = channel.get();
+			assertNotNull("Channel not active", ch);
+
+			// Respond with failure
+			ch.writeAndFlush(KvStateRequestSerializer.serializeServerFailure(
+					serverChannel.alloc(),
+					new RuntimeException("Expected test server failure")));
+
+			try {
+				Await.result(futures.remove(0), deadline.timeLeft());
+				fail("Did not throw expected server failure");
+			} catch (RuntimeException ignored) {
+				// Expected
+			}
+
+			try {
+				Await.result(futures.remove(0), deadline.timeLeft());
+				fail("Did not throw expected server failure");
+			} catch (RuntimeException ignored) {
+				// Expected
+			}
+
+			assertEquals(0, stats.getNumConnections());
+
+			// Counts can take some time to propagate
+			while (deadline.hasTimeLeft() && (stats.getNumSuccessful() != 0 ||
+					stats.getNumFailed() != 2)) {
+				Thread.sleep(100);
+			}
+
+			assertEquals(2, stats.getNumRequests());
+			assertEquals(0, stats.getNumSuccessful());
+			assertEquals(2, stats.getNumFailed());
+		} finally {
+			if (client != null) {
+				client.shutDown();
+			}
+
+			if (serverChannel != null) {
+				serverChannel.close();
+			}
+
+			assertEquals("Channel leak", 0, stats.getNumConnections());
+		}
+	}
+
+	/**
+	 * Tests that a server channel close, closes the connection and removes it
+	 * from the established connections.
+	 */
+	@Test
+	public void testServerClosesChannel() throws Exception {
+		Deadline deadline = TEST_TIMEOUT.fromNow();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateClient client = null;
+		Channel serverChannel = null;
+
+		try {
+			client = new KvStateClient(1, stats);
+
+			final AtomicBoolean received = new AtomicBoolean();
+			final AtomicReference<Channel> channel = new AtomicReference<>();
+
+			serverChannel = createServerChannel(new ChannelInboundHandlerAdapter() {
+				@Override
+				public void channelActive(ChannelHandlerContext ctx) throws Exception {
+					channel.set(ctx.channel());
+				}
+
+				@Override
+				public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+					received.set(true);
+				}
+			});
+
+			KvStateServerAddress serverAddress = getKvStateServerAddress(serverChannel);
+
+			// Requests
+			Future<byte[]> future = client.getKvState(serverAddress, new KvStateID(), new byte[0]);
+
+			while (!received.get() && deadline.hasTimeLeft()) {
+				Thread.sleep(50);
+			}
+			assertTrue("Receive timed out", received.get());
+
+			assertEquals(1, stats.getNumConnections());
+
+			channel.get().close().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+
+			try {
+				Await.result(future, deadline.timeLeft());
+				fail("Did not throw expected server failure");
+			} catch (ClosedChannelException ignored) {
+				// Expected
+			}
+
+			assertEquals(0, stats.getNumConnections());
+
+			// Counts can take some time to propagate
+			while (deadline.hasTimeLeft() && (stats.getNumSuccessful() != 0 ||
+					stats.getNumFailed() != 1)) {
+				Thread.sleep(100);
+			}
+
+			assertEquals(1, stats.getNumRequests());
+			assertEquals(0, stats.getNumSuccessful());
+			assertEquals(1, stats.getNumFailed());
+		} finally {
+			if (client != null) {
+				client.shutDown();
+			}
+
+			if (serverChannel != null) {
+				serverChannel.close();
+			}
+
+			assertEquals("Channel leak", 0, stats.getNumConnections());
+		}
+	}
+
+	/**
+	 * Tests multiple clients querying multiple servers until 100k queries have
+	 * been processed. At this point, the client is shut down and its verified
+	 * that all ongoing requests are failed.
+	 */
+	@Test
+	public void testClientServerIntegration() throws Exception {
+		// Config
+		final int numServers = 2;
+		final int numServerEventLoopThreads = 2;
+		final int numServerQueryThreads = 2;
+
+		final int numClientEventLoopThreads = 4;
+		final int numClientsTasks = 8;
+
+		final int batchSize = 16;
+
+		final FiniteDuration timeout = new FiniteDuration(10, TimeUnit.SECONDS);
+
+		AtomicKvStateRequestStats clientStats = new AtomicKvStateRequestStats();
+
+		KvStateClient client = null;
+		ExecutorService clientTaskExecutor = null;
+		final KvStateServer[] server = new KvStateServer[numServers];
+
+		try {
+			client = new KvStateClient(numClientEventLoopThreads, clientStats);
+			clientTaskExecutor = Executors.newFixedThreadPool(numClientsTasks);
+
+			// Create state
+			ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+			desc.setQueryable("any");
+
+			MemValueState<Integer, VoidNamespace, Integer> kvState = new MemValueState<>(
+					IntSerializer.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					desc);
+
+			// Create servers
+			KvStateRegistry[] registry = new KvStateRegistry[numServers];
+			AtomicKvStateRequestStats[] serverStats = new AtomicKvStateRequestStats[numServers];
+			final KvStateID[] ids = new KvStateID[numServers];
+
+			for (int i = 0; i < numServers; i++) {
+				registry[i] = new KvStateRegistry();
+				serverStats[i] = new AtomicKvStateRequestStats();
+				server[i] = new KvStateServer(
+						InetAddress.getLocalHost(),
+						0,
+						numServerEventLoopThreads,
+						numServerQueryThreads,
+						registry[i],
+						serverStats[i]);
+
+				server[i].start();
+
+				// Value per server
+				kvState.setCurrentKey(1010 + i);
+				kvState.setCurrentNamespace(VoidNamespace.INSTANCE);
+				kvState.update(201 + i);
+
+				// Register KvState (one state instance for all server)
+				ids[i] = registry[i].registerKvState(new JobID(), new JobVertexID(), 0, "any", kvState);
+			}
+
+			final KvStateClient finalClient = client;
+			Callable<Void> queryTask = new Callable<Void>() {
+				@Override
+				public Void call() throws Exception {
+					while (true) {
+						if (Thread.interrupted()) {
+							throw new InterruptedException();
+						}
+
+						// Random server permutation
+						List<Integer> random = new ArrayList<>();
+						for (int j = 0; j < batchSize; j++) {
+							random.add(j);
+						}
+						Collections.shuffle(random);
+
+						// Dispatch queries
+						List<Future<byte[]>> futures = new ArrayList<>(batchSize);
+
+						for (int j = 0; j < batchSize; j++) {
+							int targetServer = random.get(j) % numServers;
+
+							byte[] serializedKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+									1010 + targetServer,
+									IntSerializer.INSTANCE,
+									VoidNamespace.INSTANCE,
+									VoidNamespaceSerializer.INSTANCE);
+
+							futures.add(finalClient.getKvState(
+									server[targetServer].getAddress(),
+									ids[targetServer],
+									serializedKeyAndNamespace));
+						}
+
+						// Verify results
+						for (int j = 0; j < batchSize; j++) {
+							int targetServer = random.get(j) % numServers;
+
+							Future<byte[]> future = futures.get(j);
+							byte[] buf = Await.result(future, timeout);
+							int value = KvStateRequestSerializer.deserializeValue(buf, IntSerializer.INSTANCE);
+							assertEquals(201 + targetServer, value);
+						}
+					}
+				}
+			};
+
+			// Submit tasks
+			List<java.util.concurrent.Future<Void>> taskFutures = new ArrayList<>();
+			for (int i = 0; i < numClientsTasks; i++) {
+				taskFutures.add(clientTaskExecutor.submit(queryTask));
+			}
+
+			long numRequests;
+			while ((numRequests = clientStats.getNumRequests()) < 100_000) {
+				Thread.sleep(100);
+				LOG.info("Number of requests {}/100_000", numRequests);
+			}
+
+			// Shut down
+			client.shutDown();
+
+			for (java.util.concurrent.Future<Void> future : taskFutures) {
+				try {
+					future.get();
+					fail("Did not throw expected Exception after shut down");
+				} catch (ExecutionException t) {
+					if (t.getCause() instanceof ClosedChannelException ||
+							t.getCause() instanceof IllegalStateException) {
+						// Expected
+					} else {
+						t.printStackTrace();
+						fail("Failed with unexpected Exception type: " + t.getClass().getName());
+					}
+				}
+			}
+
+			assertEquals("Connection leak (client)", 0, clientStats.getNumConnections());
+			for (int i = 0; i < numServers; i++) {
+				boolean success = false;
+				int numRetries = 0;
+				while (!success) {
+					try {
+						assertEquals("Connection leak (server)", 0, serverStats[i].getNumConnections());
+						success = true;
+					} catch (Throwable t) {
+						if (numRetries < 10) {
+							LOG.info("Retrying connection leak check (server)");
+							Thread.sleep((numRetries + 1) * 50);
+							numRetries++;
+						} else {
+							throw t;
+						}
+					}
+				}
+			}
+		} finally {
+			if (client != null) {
+				client.shutDown();
+			}
+
+			for (int i = 0; i < numServers; i++) {
+				if (server[i] != null) {
+					server[i].shutDown();
+				}
+			}
+
+			if (clientTaskExecutor != null) {
+				clientTaskExecutor.shutdown();
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	private Channel createServerChannel(final ChannelHandler... handlers) throws UnknownHostException, InterruptedException {
+		ServerBootstrap bootstrap = new ServerBootstrap()
+				// Bind address and port
+				.localAddress(InetAddress.getLocalHost(), 0)
+				// NIO server channels
+				.group(NIO_GROUP)
+				.channel(NioServerSocketChannel.class)
+				// See initializer for pipeline details
+				.childHandler(new ChannelInitializer<SocketChannel>() {
+					@Override
+					protected void initChannel(SocketChannel ch) throws Exception {
+						ch.pipeline()
+								.addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4))
+								.addLast(handlers);
+					}
+				});
+
+		return bootstrap.bind().sync().channel();
+	}
+
+	private KvStateServerAddress getKvStateServerAddress(Channel serverChannel) {
+		InetSocketAddress localAddress = (InetSocketAddress) serverChannel.localAddress();
+
+		return new KvStateServerAddress(localAddress.getAddress(), localAddress.getPort());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerHandlerTest.java
@@ -1,0 +1,622 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestFailure;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestResult;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestType;
+import org.apache.flink.runtime.state.KvState;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.memory.MemValueState;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KvStateServerHandlerTest {
+
+	/** Shared Thread pool for query execution */
+	private final static ExecutorService TEST_THREAD_POOL = Executors.newSingleThreadExecutor();
+
+	private final static int READ_TIMEOUT_MILLIS = 10000;
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		if (TEST_THREAD_POOL != null) {
+			TEST_THREAD_POOL.shutdown();
+		}
+	}
+
+	/**
+	 * Tests a simple successful query via an EmbeddedChannel.
+	 */
+	@Test
+	public void testSimpleQuery() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		// Register state
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		desc.setQueryable("any");
+
+		MemValueState<Integer, VoidNamespace, Integer> kvState = new MemValueState<>(
+				IntSerializer.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE,
+				desc);
+
+		KvStateID kvStateId = registry.registerKvState(
+				new JobID(),
+				new JobVertexID(),
+				0,
+				"vanilla",
+				kvState);
+
+		// Update the KvState and request it
+		int expectedValue = 712828289;
+
+		int key = 99812822;
+		kvState.setCurrentKey(key);
+		kvState.setCurrentNamespace(VoidNamespace.INSTANCE);
+
+		kvState.update(expectedValue);
+
+		byte[] serializedKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+				key,
+				IntSerializer.INSTANCE,
+				VoidNamespace.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE);
+
+		long requestId = Integer.MAX_VALUE + 182828L;
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				requestId,
+				kvStateId,
+				serializedKeyAndNamespace);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.REQUEST_RESULT, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestResult response = KvStateRequestSerializer.deserializeKvStateRequestResult(buf);
+
+		assertEquals(requestId, response.getRequestId());
+
+		int actualValue = KvStateRequestSerializer.deserializeValue(response.getSerializedResult(), IntSerializer.INSTANCE);
+		assertEquals(expectedValue, actualValue);
+
+		assertEquals(1, stats.getNumRequests());
+		assertEquals(1, stats.getNumSuccessful());
+	}
+
+	/**
+	 * Tests the failure response with {@link UnknownKvStateID} as cause on
+	 * queries for unregistered KvStateIDs.
+	 */
+	@Test
+	public void testQueryUnknownKvStateID() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		long requestId = Integer.MAX_VALUE + 182828L;
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				requestId,
+				new KvStateID(),
+				new byte[0]);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.REQUEST_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestFailure response = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+
+		assertEquals(requestId, response.getRequestId());
+
+		assertTrue("Did not respond with expected failure cause", response.getCause() instanceof UnknownKvStateID);
+
+		assertEquals(1, stats.getNumRequests());
+		assertEquals(1, stats.getNumFailed());
+	}
+
+	/**
+	 * Tests the failure response with {@link UnknownKeyOrNamespace} as cause
+	 * on queries for non-existing keys.
+	 */
+	@Test
+	public void testQueryUnknownKey() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		// Register state
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		desc.setQueryable("any");
+
+		MemValueState<Integer, VoidNamespace, Integer> kvState = new MemValueState<>(
+				IntSerializer.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE,
+				desc);
+
+		KvStateID kvStateId = registry.registerKvState(
+				new JobID(),
+				new JobVertexID(),
+				0,
+				"vanilla",
+				kvState);
+
+		byte[] serializedKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+				1238283,
+				IntSerializer.INSTANCE,
+				VoidNamespace.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE);
+
+		long requestId = Integer.MAX_VALUE + 22982L;
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				requestId,
+				kvStateId,
+				serializedKeyAndNamespace);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.REQUEST_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestFailure response = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+
+		assertEquals(requestId, response.getRequestId());
+
+		assertTrue("Did not respond with expected failure cause", response.getCause() instanceof UnknownKeyOrNamespace);
+
+		assertEquals(1, stats.getNumRequests());
+		assertEquals(1, stats.getNumFailed());
+	}
+
+	/**
+	 * Tests the failure response on a failure on the {@link KvState#getSerializedValue(byte[])}
+	 * call.
+	 */
+	@Test
+	public void testFailureOnGetSerializedValue() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		// Failing KvState
+		KvState<?, ?, ?, ?, ?> kvState = mock(KvState.class);
+		when(kvState.getSerializedValue(any(byte[].class)))
+				.thenThrow(new RuntimeException("Expected test Exception"));
+
+		KvStateID kvStateId = registry.registerKvState(
+				new JobID(),
+				new JobVertexID(),
+				0,
+				"vanilla",
+				kvState);
+
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				282872,
+				kvStateId,
+				new byte[0]);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.REQUEST_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestFailure response = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+
+		assertTrue(response.getCause().getMessage().contains("Expected test Exception"));
+
+		assertEquals(1, stats.getNumRequests());
+		assertEquals(1, stats.getNumFailed());
+	}
+
+	/**
+	 * Tests that the channel is closed if an Exception reaches the channel
+	 * handler.
+	 */
+	@Test
+	public void testCloseChannelOnExceptionCaught() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+		channel.pipeline().fireExceptionCaught(new RuntimeException("Expected test Exception"));
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.SERVER_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		Throwable response = KvStateRequestSerializer.deserializeServerFailure(buf);
+
+		assertTrue(response.getMessage().contains("Expected test Exception"));
+
+		channel.closeFuture().await(READ_TIMEOUT_MILLIS);
+		assertFalse(channel.isActive());
+	}
+
+	/**
+	 * Tests the failure response on a rejected execution, because the query
+	 * executor has been closed.
+	 */
+	@Test
+	public void testQueryExecutorShutDown() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		ExecutorService closedExecutor = Executors.newSingleThreadExecutor();
+		closedExecutor.shutdown();
+		assertTrue(closedExecutor.isShutdown());
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, closedExecutor, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		// Register state
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		desc.setQueryable("any");
+
+		MemValueState<Integer, VoidNamespace, Integer> kvState = new MemValueState<>(
+				IntSerializer.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE,
+				desc);
+
+		KvStateID kvStateId = registry.registerKvState(
+				new JobID(),
+				new JobVertexID(),
+				0,
+				"vanilla",
+				kvState);
+
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				282872,
+				kvStateId,
+				new byte[0]);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.REQUEST_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestFailure response = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+
+		assertTrue(response.getCause().getMessage().contains("RejectedExecutionException"));
+
+		assertEquals(1, stats.getNumRequests());
+		assertEquals(1, stats.getNumFailed());
+	}
+
+	/**
+	 * Tests response on unexpected messages.
+	 */
+	@Test
+	public void testUnexpectedMessage() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		// Write the request and wait for the response
+		ByteBuf unexpectedMessage = Unpooled.buffer(8);
+		unexpectedMessage.writeInt(4);
+		unexpectedMessage.writeInt(123238213);
+
+		channel.writeInbound(unexpectedMessage);
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.SERVER_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		Throwable response = KvStateRequestSerializer.deserializeServerFailure(buf);
+
+		assertEquals(0, stats.getNumRequests());
+		assertEquals(0, stats.getNumFailed());
+
+		unexpectedMessage = KvStateRequestSerializer.serializeKvStateRequestResult(
+				channel.alloc(),
+				192,
+				new byte[0]);
+
+		channel.writeInbound(unexpectedMessage);
+
+		buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.SERVER_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		response = KvStateRequestSerializer.deserializeServerFailure(buf);
+
+		assertTrue("Unexpected failure cause " + response.getClass().getName(), response instanceof IllegalArgumentException);
+
+		assertEquals(0, stats.getNumRequests());
+		assertEquals(0, stats.getNumFailed());
+	}
+
+	/**
+	 * Tests that incoming buffer instances are recycled.
+	 */
+	@Test
+	public void testIncomingBufferIsRecycled() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				282872,
+				new KvStateID(),
+				new byte[0]);
+
+		assertEquals(1, request.refCnt());
+
+		// Write regular request
+		channel.writeInbound(request);
+		assertEquals("Buffer not recycled", 0, request.refCnt());
+
+		// Write unexpected msg
+		ByteBuf unexpected = channel.alloc().buffer(8);
+		unexpected.writeInt(4);
+		unexpected.writeInt(4);
+
+		assertEquals(1, unexpected.refCnt());
+
+		channel.writeInbound(unexpected);
+		assertEquals("Buffer not recycled", 0, unexpected.refCnt());
+	}
+
+	/**
+	 * Tests the failure response if the serializers don't match.
+	 */
+	@Test
+	public void testSerializerMismatch() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		// Register state
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		desc.setQueryable("any");
+
+		MemValueState<Integer, VoidNamespace, Integer> kvState = new MemValueState<>(
+				IntSerializer.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE,
+				desc);
+
+		KvStateID kvStateId = registry.registerKvState(
+				new JobID(),
+				new JobVertexID(),
+				0,
+				"vanilla",
+				kvState);
+
+		int key = 99812822;
+
+		// Update the KvState
+		kvState.setCurrentKey(key);
+		kvState.setCurrentNamespace(VoidNamespace.INSTANCE);
+		kvState.update(712828289);
+
+		byte[] wrongKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+				"wrong-key-type",
+				StringSerializer.INSTANCE,
+				"wrong-namespace-type",
+				StringSerializer.INSTANCE);
+
+		byte[] wrongNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+				key,
+				IntSerializer.INSTANCE,
+				"wrong-namespace-type",
+				StringSerializer.INSTANCE);
+
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				182828,
+				kvStateId,
+				wrongKeyAndNamespace);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		ByteBuf buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.REQUEST_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestFailure response = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+		assertEquals(182828, response.getRequestId());
+		assertTrue(response.getCause().getMessage().contains("IllegalArgumentException"));
+
+		// Repeat with wrong namespace only
+		request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				182829,
+				kvStateId,
+				wrongNamespace);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		buf = (ByteBuf) readInboundBlocking(channel);
+		buf.skipBytes(4); // skip frame length
+
+		// Verify the response
+		assertEquals(KvStateRequestType.REQUEST_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		response = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+		assertEquals(182829, response.getRequestId());
+		assertTrue(response.getCause().getMessage().contains("IllegalArgumentException"));
+
+		assertEquals(2, stats.getNumRequests());
+		assertEquals(2, stats.getNumFailed());
+	}
+
+	/**
+	 * Tests that large responses are chunked.
+	 */
+	@Test
+	public void testChunkedResponse() throws Exception {
+		KvStateRegistry registry = new KvStateRegistry();
+		KvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+		KvStateServerHandler handler = new KvStateServerHandler(registry, TEST_THREAD_POOL, stats);
+		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
+
+		// Register state
+		ValueStateDescriptor<byte[]> desc = new ValueStateDescriptor<>("any", BytePrimitiveArraySerializer.INSTANCE, null);
+		desc.setQueryable("any");
+
+		MemValueState<Integer, VoidNamespace, byte[]> kvState = new MemValueState<>(
+				IntSerializer.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE,
+				desc);
+
+		KvStateID kvStateId = registry.registerKvState(
+				new JobID(),
+				new JobVertexID(),
+				0,
+				"vanilla",
+				kvState);
+
+		// Update KvState
+		byte[] bytes = new byte[2 * channel.config().getWriteBufferHighWaterMark()];
+
+		byte current = 0;
+		for (int i = 0; i < bytes.length; i++) {
+			bytes[i] = current++;
+		}
+
+		int key = 99812822;
+		kvState.setCurrentKey(key);
+		kvState.setCurrentNamespace(VoidNamespace.INSTANCE);
+		kvState.update(bytes);
+
+		// Request
+		byte[] serializedKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+				key,
+				IntSerializer.INSTANCE,
+				VoidNamespace.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE);
+
+		long requestId = Integer.MAX_VALUE + 182828L;
+		ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+				channel.alloc(),
+				requestId,
+				kvStateId,
+				serializedKeyAndNamespace);
+
+		// Write the request and wait for the response
+		channel.writeInbound(request);
+
+		Object msg = readInboundBlocking(channel);
+		assertTrue("Not ChunkedByteBuf", msg instanceof ChunkedByteBuf);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Queries the embedded channel for data.
+	 */
+	private Object readInboundBlocking(EmbeddedChannel channel) throws InterruptedException, TimeoutException {
+		final int sleepMillis = 50;
+
+		int sleptMillis = 0;
+
+		Object msg = null;
+		while (sleptMillis < READ_TIMEOUT_MILLIS &&
+				(msg = channel.readOutbound()) == null) {
+
+			Thread.sleep(sleepMillis);
+			sleptMillis += sleepMillis;
+		}
+
+		if (msg == null) {
+			throw new TimeoutException();
+		} else {
+			return msg;
+		}
+	}
+
+	/**
+	 * Frame length decoder (expected by the serialized messages).
+	 */
+	private ChannelHandler getFrameDecoder() {
+		return new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.query.KvStateID;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.KvStateServerAddress;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestResult;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestType;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.memory.MemValueState;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class KvStateServerTest {
+
+	// Thread pool for client bootstrap (shared between tests)
+	private static final NioEventLoopGroup NIO_GROUP = new NioEventLoopGroup();
+
+	private final static int TIMEOUT_MILLIS = 10000;
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		if (NIO_GROUP != null) {
+			NIO_GROUP.shutdownGracefully();
+		}
+	}
+
+	/**
+	 * Tests a simple successful query via a SocketChannel.
+	 */
+	@Test
+	public void testSimpleRequest() throws Exception {
+		KvStateServer server = null;
+		Bootstrap bootstrap = null;
+
+		try {
+			KvStateRegistry registry = new KvStateRegistry();
+			KvStateRequestStats stats = new AtomicKvStateRequestStats();
+
+			server = new KvStateServer(InetAddress.getLocalHost(), 0, 1, 1, registry, stats);
+			server.start();
+
+			KvStateServerAddress serverAddress = server.getAddress();
+
+			// Register state
+			MemValueState<Integer, VoidNamespace, Integer> kvState = new MemValueState<>(
+					IntSerializer.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null));
+
+			KvStateID kvStateId = registry.registerKvState(
+					new JobID(),
+					new JobVertexID(),
+					0,
+					"vanilla",
+					kvState);
+
+			// Update KvState
+			int expectedValue = 712828289;
+
+			int key = 99812822;
+			kvState.setCurrentKey(key);
+			kvState.setCurrentNamespace(VoidNamespace.INSTANCE);
+			kvState.update(expectedValue);
+
+			// Request
+			byte[] serializedKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+					key,
+					IntSerializer.INSTANCE,
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE);
+
+			// Connect to the server
+			final BlockingQueue<ByteBuf> responses = new LinkedBlockingQueue<>();
+			bootstrap = createBootstrap(
+					new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4),
+					new ChannelInboundHandlerAdapter() {
+						@Override
+						public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+							responses.add((ByteBuf) msg);
+						}
+					});
+
+			Channel channel = bootstrap
+					.connect(serverAddress.getHost(), serverAddress.getPort())
+					.sync().channel();
+
+			long requestId = Integer.MAX_VALUE + 182828L;
+			ByteBuf request = KvStateRequestSerializer.serializeKvStateRequest(
+					channel.alloc(),
+					requestId,
+					kvStateId,
+					serializedKeyAndNamespace);
+
+			channel.writeAndFlush(request);
+
+			ByteBuf buf = responses.poll(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+			assertEquals(KvStateRequestType.REQUEST_RESULT, KvStateRequestSerializer.deserializeHeader(buf));
+			KvStateRequestResult response = KvStateRequestSerializer.deserializeKvStateRequestResult(buf);
+
+			assertEquals(requestId, response.getRequestId());
+			int actualValue = KvStateRequestSerializer.deserializeValue(response.getSerializedResult(), IntSerializer.INSTANCE);
+			assertEquals(expectedValue, actualValue);
+		} finally {
+			if (server != null) {
+				server.shutDown();
+			}
+
+			if (bootstrap != null) {
+				EventLoopGroup group = bootstrap.group();
+				if (group != null) {
+					group.shutdownGracefully();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Creates a client bootstrap.
+	 */
+	private Bootstrap createBootstrap(final ChannelHandler... handlers) {
+		return new Bootstrap().group(NIO_GROUP).channel(NioSocketChannel.class)
+				.handler(new ChannelInitializer<SocketChannel>() {
+					@Override
+					protected void initChannel(SocketChannel ch) throws Exception {
+						ch.pipeline().addLast(handlers);
+					}
+				});
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.query.netty.message;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.query.KvStateID;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class KvStateRequestSerializerTest {
+
+	private final ByteBufAllocator alloc = UnpooledByteBufAllocator.DEFAULT;
+
+	/**
+	 * Tests KvState request serialization.
+	 */
+	@Test
+	public void testKvStateRequestSerialization() throws Exception {
+		long requestId = Integer.MAX_VALUE + 1337L;
+		KvStateID kvStateId = new KvStateID();
+		byte[] serializedKeyAndNamespace = randomByteArray(1024);
+
+		ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequest(
+				alloc,
+				requestId,
+				kvStateId,
+				serializedKeyAndNamespace);
+
+		int frameLength = buf.readInt();
+		assertEquals(KvStateRequestType.REQUEST, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequest request = KvStateRequestSerializer.deserializeKvStateRequest(buf);
+		assertEquals(buf.readerIndex(), frameLength + 4);
+
+		assertEquals(requestId, request.getRequestId());
+		assertEquals(kvStateId, request.getKvStateId());
+		assertArrayEquals(serializedKeyAndNamespace, request.getSerializedKeyAndNamespace());
+	}
+
+	/**
+	 * Tests KvState request serialization with zero-length serialized key and namespace.
+	 */
+	@Test
+	public void testKvStateRequestSerializationWithZeroLengthKeyAndNamespace() throws Exception {
+		byte[] serializedKeyAndNamespace = new byte[0];
+
+		ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequest(
+				alloc,
+				1823,
+				new KvStateID(),
+				serializedKeyAndNamespace);
+
+		int frameLength = buf.readInt();
+		assertEquals(KvStateRequestType.REQUEST, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequest request = KvStateRequestSerializer.deserializeKvStateRequest(buf);
+		assertEquals(buf.readerIndex(), frameLength + 4);
+
+		assertArrayEquals(serializedKeyAndNamespace, request.getSerializedKeyAndNamespace());
+	}
+
+	/**
+	 * Tests that we don't try to be smart about <code>null</code> key and namespace.
+	 * They should be treated explicitly.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testNullPointerExceptionOnNullSerializedKeyAndNamepsace() throws Exception {
+		new KvStateRequest(0, new KvStateID(), null);
+	}
+
+	/**
+	 * Tests KvState request result serialization.
+	 */
+	@Test
+	public void testKvStateRequestResultSerialization() throws Exception {
+		long requestId = Integer.MAX_VALUE + 72727278L;
+		byte[] serializedResult = randomByteArray(1024);
+
+		ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequestResult(
+				alloc,
+				requestId,
+				serializedResult);
+
+		int frameLength = buf.readInt();
+		assertEquals(KvStateRequestType.REQUEST_RESULT, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestResult request = KvStateRequestSerializer.deserializeKvStateRequestResult(buf);
+		assertEquals(buf.readerIndex(), frameLength + 4);
+
+		assertEquals(requestId, request.getRequestId());
+
+		assertArrayEquals(serializedResult, request.getSerializedResult());
+	}
+
+	/**
+	 * Tests KvState request result serialization with zero-length serialized result.
+	 */
+	@Test
+	public void testKvStateRequestResultSerializationWithZeroLengthSerializedResult() throws Exception {
+		byte[] serializedResult = new byte[0];
+
+		ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequestResult(
+				alloc,
+				72727278,
+				serializedResult);
+
+		int frameLength = buf.readInt();
+
+		assertEquals(KvStateRequestType.REQUEST_RESULT, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestResult request = KvStateRequestSerializer.deserializeKvStateRequestResult(buf);
+		assertEquals(buf.readerIndex(), frameLength + 4);
+
+		assertArrayEquals(serializedResult, request.getSerializedResult());
+	}
+
+	/**
+	 * Tests that we don't try to be smart about <code>null</code> results.
+	 * They should be treated explicitly.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testNullPointerExceptionOnNullSerializedResult() throws Exception {
+		new KvStateRequestResult(0, null);
+	}
+
+	/**
+	 * Tests KvState request failure serialization.
+	 */
+	@Test
+	public void testKvStateRequestFailureSerialization() throws Exception {
+		long requestId = Integer.MAX_VALUE + 1111222L;
+		IllegalStateException cause = new IllegalStateException("Expected test");
+
+		ByteBuf buf = KvStateRequestSerializer.serializeKvStateRequestFailure(
+				alloc,
+				requestId,
+				cause);
+
+		int frameLength = buf.readInt();
+		assertEquals(KvStateRequestType.REQUEST_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		KvStateRequestFailure request = KvStateRequestSerializer.deserializeKvStateRequestFailure(buf);
+		assertEquals(buf.readerIndex(), frameLength + 4);
+
+		assertEquals(requestId, request.getRequestId());
+		assertEquals(cause.getClass(), request.getCause().getClass());
+		assertEquals(cause.getMessage(), request.getCause().getMessage());
+	}
+
+	/**
+	 * Tests KvState server failure serialization.
+	 */
+	@Test
+	public void testServerFailureSerialization() throws Exception {
+		IllegalStateException cause = new IllegalStateException("Expected test");
+
+		ByteBuf buf = KvStateRequestSerializer.serializeServerFailure(alloc, cause);
+
+		int frameLength = buf.readInt();
+		assertEquals(KvStateRequestType.SERVER_FAILURE, KvStateRequestSerializer.deserializeHeader(buf));
+		Throwable request = KvStateRequestSerializer.deserializeServerFailure(buf);
+		assertEquals(buf.readerIndex(), frameLength + 4);
+
+		assertEquals(cause.getClass(), request.getClass());
+		assertEquals(cause.getMessage(), request.getMessage());
+	}
+
+	/**
+	 * Tests key and namespace serialization utils.
+	 */
+	@Test
+	public void testKeyAndNamespaceSerialization() throws Exception {
+		TypeSerializer<Long> keySerializer = LongSerializer.INSTANCE;
+		TypeSerializer<String> namespaceSerializer = StringSerializer.INSTANCE;
+
+		long expectedKey = Integer.MAX_VALUE + 12323L;
+		String expectedNamespace = "knilf";
+
+		byte[] serializedKeyAndNamespace = KvStateRequestSerializer.serializeKeyAndNamespace(
+				expectedKey, keySerializer, expectedNamespace, namespaceSerializer);
+
+		Tuple2<Long, String> actual = KvStateRequestSerializer.deserializeKeyAndNamespace(
+				serializedKeyAndNamespace, keySerializer, namespaceSerializer);
+
+		assertEquals(expectedKey, actual.f0.longValue());
+		assertEquals(expectedNamespace, actual.f1);
+	}
+
+	/**
+	 * Tests value serialization utils.
+	 */
+	@Test
+	public void testValueSerialization() throws Exception {
+		TypeSerializer<Long> valueSerializer = LongSerializer.INSTANCE;
+		long expectedValue = Long.MAX_VALUE - 1292929292L;
+
+		byte[] serializedValue = KvStateRequestSerializer.serializeValue(expectedValue, valueSerializer);
+		long actualValue = KvStateRequestSerializer.deserializeValue(serializedValue, valueSerializer);
+
+		assertEquals(expectedValue, actualValue);
+	}
+
+	/**
+	 * Tests list serialization utils.
+	 */
+	@Test
+	public void testListSerialization() throws Exception {
+		TypeSerializer<Long> valueSerializer = LongSerializer.INSTANCE;
+
+		// List
+		int numElements = 10;
+
+		List<Long> expectedValues = new ArrayList<>();
+		for (int i = 0; i < numElements; i++) {
+			expectedValues.add(ThreadLocalRandom.current().nextLong());
+		}
+
+		byte[] serializedValues = KvStateRequestSerializer.serializeList(expectedValues, valueSerializer);
+		List<Long> actualValues = KvStateRequestSerializer.deserializeList(serializedValues, valueSerializer);
+		assertEquals(expectedValues, actualValues);
+
+		// Single value
+		long expectedValue = ThreadLocalRandom.current().nextLong();
+		byte[] serializedValue = KvStateRequestSerializer.serializeValue(expectedValue, valueSerializer);
+		List<Long> actualValue = KvStateRequestSerializer.deserializeList(serializedValue, valueSerializer);
+		assertEquals(1, actualValue.size());
+		assertEquals(expectedValue, actualValue.get(0).longValue());
+	}
+
+	private byte[] randomByteArray(int capacity) {
+		byte[] bytes = new byte[capacity];
+		ThreadLocalRandom.current().nextBytes(bytes);
+		return bytes;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
@@ -282,4 +282,10 @@ public class FileStateBackendTest extends StateBackendTestBase<FsStateBackend> {
 		is.close();
 	}
 
+	@Test
+	public void testConcurrentMapIfQueryable() throws Exception {
+		backend.initializeForJob(new DummyEnvironment("test", 1, 0), "test_op", IntSerializer.INSTANCE);
+		StateBackendTestBase.testConcurrentMapIfQueryable(backend);
+	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.junit.Test;
 
@@ -152,5 +154,11 @@ public class MemoryStateBackendTest extends StateBackendTestBase<MemoryStateBack
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	@Test
+	public void testConcurrentMapIfQueryable() throws Exception {
+		backend.initializeForJob(new DummyEnvironment("test", 1, 0), "test_op", IntSerializer.INSTANCE);
+		StateBackendTestBase.testConcurrentMapIfQueryable(backend);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.memory.MemoryManager;
 
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.util.SerializedValue;
 import org.junit.Before;
@@ -149,6 +150,8 @@ public class TaskAsyncCallTest {
 		when(networkEnvironment.getPartitionManager()).thenReturn(partitionManager);
 		when(networkEnvironment.getPartitionConsumableNotifier()).thenReturn(consumableNotifier);
 		when(networkEnvironment.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
+		when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
+				.thenReturn(mock(TaskKvStateRegistry.class));
 
 		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
 				new JobID(), "Job Name", new JobVertexID(), new ExecutionAttemptID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -108,7 +108,8 @@ public class TaskManagerComponentsStartupShutdownTest {
 			final NetworkEnvironment network = new NetworkEnvironment(
 				TestingUtils.defaultExecutionContext(),
 				timeout,
-				netConf);
+				netConf,
+				connectionInfo);
 			final int numberOfSlots = 1;
 
 			LeaderRetrievalService leaderRetrievalService = new StandaloneLeaderRetrievalService(jobManager.path().toString());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -98,8 +98,8 @@ public class TaskManagerComponentsStartupShutdownTest {
 					config);
 
 			final NetworkEnvironmentConfiguration netConf = new NetworkEnvironmentConfiguration(
-					32, BUFFER_SIZE, MemoryType.HEAP, IOManager.IOMode.SYNC, Option.<NettyConfig>empty(),
-					new Tuple2<Integer, Integer>(0, 0));
+					32, BUFFER_SIZE, MemoryType.HEAP, IOManager.IOMode.SYNC, 0, 0, 0,
+					Option.<NettyConfig>empty(), new Tuple2<Integer, Integer>(0, 0));
 
 			final InstanceConnectionInfo connectionInfo = new InstanceConnectionInfo(InetAddress.getLocalHost(), 10000);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -19,9 +19,9 @@
 package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -45,12 +44,12 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.TaskMessages;
-
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.util.SerializedValue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
@@ -69,7 +68,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -603,6 +601,8 @@ public class TaskTest {
 		when(network.getPartitionManager()).thenReturn(partitionManager);
 		when(network.getPartitionConsumableNotifier()).thenReturn(consumableNotifier);
 		when(network.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
+		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
+				.thenReturn(mock(TaskKvStateRegistry.class));
 		
 		return createTask(invokable, libCache, network);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/QueryableStateStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/QueryableStateStream.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Queryable state stream instance.
+ *
+ * @param <K>  State key type
+ * @param <V>  State value type
+ */
+@PublicEvolving
+public class QueryableStateStream<K, V> {
+
+	/** Name under which the state is queryable. */
+	private final String queryableStateName;
+
+	/** Key serializer for the state instance. */
+	private final TypeSerializer<K> keySerializer;
+
+	/** Value serializer for the state instance. */
+	private final TypeSerializer<V> valueSerializer;
+
+	/**
+	 * Creates a queryable state stream.
+	 *
+	 * @param queryableStateName Name under which to publish the queryable state instance
+	 * @param valueSerializer Value serializer for the state instance
+	 * @param keySerializer Key serializer for the state instance
+	 */
+	public QueryableStateStream(
+			String queryableStateName,
+			TypeSerializer<V> valueSerializer,
+			TypeSerializer<K> keySerializer) {
+
+		this.queryableStateName = Preconditions.checkNotNull(queryableStateName, "Queryable state name");
+		this.valueSerializer = Preconditions.checkNotNull(valueSerializer, "Value serializer");
+		this.keySerializer = Preconditions.checkNotNull(keySerializer, "Key serializer");
+	}
+
+	/**
+	 * Returns the name under which the state can be queried.
+	 *
+	 * @return Name under which state can be queried.
+	 */
+	public String getQueryableStateName() {
+		return queryableStateName;
+	}
+
+	/**
+	 * Returns the value serializer for the queryable state instance.
+	 *
+	 * @return Value serializer for the state instance
+	 */
+	public TypeSerializer<V> getValueSerializer() {
+		return valueSerializer;
+	}
+
+	/**
+	 * Returns the key serializer for the queryable state instance.
+	 *
+	 * @return Key serializer for the state instance.
+	 */
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializer;
+	}
+
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.query;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Internal operator handling queryable state instances (setup and update).
+ *
+ * @param <S>  State type
+ * @param <IN> Input type
+ */
+@Internal
+abstract class AbstractQueryableStateOperator<S extends State, IN>
+		extends AbstractStreamOperator<IN>
+		implements OneInputStreamOperator<IN, IN> {
+
+	/** State descriptor for the queryable state instance. */
+	protected final StateDescriptor<? extends S, ?> stateDescriptor;
+
+	/**
+	 * Name under which the queryable state is registered.
+	 */
+	protected final String registrationName;
+
+	/**
+	 * The state instance created on open. This is updated by the subclasses
+	 * of this class, because the state update interface depends on the state
+	 * type (e.g. AppendingState#add(IN) vs. ValueState#update(OUT)).
+	 */
+	protected transient S state;
+
+	public AbstractQueryableStateOperator(
+			String registrationName,
+			StateDescriptor<? extends S, ?> stateDescriptor) {
+
+		this.registrationName = Preconditions.checkNotNull(registrationName, "Registration name");
+		this.stateDescriptor = Preconditions.checkNotNull(stateDescriptor, "State descriptor");
+
+		if (stateDescriptor.isQueryable()) {
+			String name = stateDescriptor.getQueryableStateName();
+			if (!name.equals(registrationName)) {
+				throw new IllegalArgumentException("StateDescriptor already marked as " +
+						"queryable with name '" + name + "', but created operator with name '" +
+						registrationName + "'.");
+			} // else: all good, already registered with same name
+		} else {
+			stateDescriptor.setQueryable(registrationName);
+		}
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+		state = getPartitionedState(stateDescriptor);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		// Nothing to do
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.query;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * Internal operator handling queryable AppendingState instances.
+ *
+ * @param <IN> Input type
+ */
+@Internal
+public class QueryableAppendingStateOperator<IN> extends AbstractQueryableStateOperator<AppendingState<IN, ?>, IN> {
+
+	public QueryableAppendingStateOperator(
+			String registrationName,
+			StateDescriptor<? extends AppendingState<IN, ?>, ?> stateDescriptor) {
+
+		super(registrationName, stateDescriptor);
+	}
+
+	@Override
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		state.add(element.getValue());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.query;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * Internal operator handling queryable ValueState instances.
+ *
+ * @param <IN> Input type
+ */
+@Internal
+public class QueryableValueStateOperator<IN> extends AbstractQueryableStateOperator<ValueState<IN>, IN> {
+
+	public QueryableValueStateOperator(
+			String registrationName,
+			StateDescriptor<ValueState<IN>, IN> stateDescriptor) {
+
+		super(registrationName, stateDescriptor);
+	}
+
+	@Override
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		state.update(element.getValue());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -23,19 +23,19 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.runtime.state.KvStateSnapshot;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.KvStateSnapshot;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.operators.Triggerable;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskState;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -189,7 +189,6 @@ public abstract class AbstractStreamOperator<OUT>
 			}
 		}
 
-
 		return state;
 	}
 	
@@ -271,7 +270,7 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @throws Exception Thrown, if the state backend cannot create the key/value state.
 	 */
 	protected <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
-		return getStateBackend().getPartitionedState(null, VoidSerializer.INSTANCE, stateDescriptor);
+		return getStateBackend().getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -33,7 +33,6 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -45,6 +44,8 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -555,7 +556,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 			TupleSerializer<Tuple2<W, W>> tupleSerializer = new TupleSerializer<>((Class) Tuple2.class, new TypeSerializer[] {windowSerializer, windowSerializer} );
 			ListStateDescriptor<Tuple2<W, W>> mergeStateDescriptor = new ListStateDescriptor<>("merging-window-set", tupleSerializer);
-			ListState<Tuple2<W, W>> mergeState = getStateBackend().getPartitionedState(null, VoidSerializer.INSTANCE, mergeStateDescriptor);
+			ListState<Tuple2<W, W>> mergeState = getStateBackend().getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, mergeStateDescriptor);
 
 			mergingWindows = new MergingWindowSet<>((MergingWindowAssigner<? super IN, W>) windowAssigner, mergeState);
 			mergeState.clear();
@@ -863,7 +864,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			ListStateDescriptor<Tuple2<W, W>> mergeStateDescriptor = new ListStateDescriptor<>("merging-window-set", tupleSerializer);
 			for (Map.Entry<K, MergingWindowSet<W>> key: mergingWindowsByKey.entrySet()) {
 				setKeyContext(key.getKey());
-				ListState<Tuple2<W, W>> mergeState = getStateBackend().getPartitionedState(null, VoidSerializer.INSTANCE, mergeStateDescriptor);
+				ListState<Tuple2<W, W>> mergeState = getStateBackend().getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, mergeStateDescriptor);
 				mergeState.clear();
 				key.getValue().persist(mergeState);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -29,14 +29,13 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.execution.Environment;
-
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.memory.MemListState;
 import org.junit.Test;
-
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -44,8 +43,12 @@ import java.util.Collections;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class StreamingRuntimeContextTest {
 	
@@ -179,8 +182,10 @@ public class StreamingRuntimeContextTest {
 					public ListState<String> answer(InvocationOnMock invocationOnMock) throws Throwable {
 						ListStateDescriptor<String> descr =
 							(ListStateDescriptor<String>) invocationOnMock.getArguments()[0];
-						return new MemListState<String, Void, String>(
-								StringSerializer.INSTANCE, VoidSerializer.INSTANCE, descr);
+						MemListState<String, VoidNamespace, String> listState = new MemListState<>(
+								StringSerializer.INSTANCE, VoidNamespaceSerializer.INSTANCE, descr);
+						listState.setCurrentNamespace(VoidNamespace.INSTANCE);
+						return listState;
 					}
 				});
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
@@ -134,11 +135,15 @@ public class InterruptSensitiveRestoreTest {
 	}
 	
 	private static Task createTask(TaskDeploymentDescriptor tdd) throws IOException {
+		NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
+		when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
+				.thenReturn(mock(TaskKvStateRegistry.class));
+
 		return new Task(
 				tdd,
 				mock(MemoryManager.class),
 				mock(IOManager.class),
-				mock(NetworkEnvironment.class),
+				networkEnvironment,
 				mock(BroadcastVariableManager.class),
 				mock(ActorGateway.class),
 				mock(ActorGateway.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -47,6 +47,8 @@ import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 
@@ -91,6 +93,8 @@ public class StreamMockEnvironment implements Environment {
 
 	private final AccumulatorRegistry accumulatorRegistry;
 
+	private final TaskKvStateRegistry kvStateRegistry;
+
 	private final int bufferSize;
 
 	private final ExecutionConfig executionConfig;
@@ -110,6 +114,9 @@ public class StreamMockEnvironment implements Environment {
 
 		this.executionConfig = executionConfig;
 		this.accumulatorRegistry = new AccumulatorRegistry(jobID, getExecutionId());
+
+		KvStateRegistry registry = new KvStateRegistry();
+		this.kvStateRegistry = registry.createTaskRegistry(jobID, getJobVertexId());
 	}
 
 	public StreamMockEnvironment(Configuration jobConfig, Configuration taskConfig, long memorySize,
@@ -291,6 +298,11 @@ public class StreamMockEnvironment implements Environment {
 	@Override
 	public AccumulatorRegistry getAccumulatorRegistry() {
 		return accumulatorRegistry;
+	}
+
+	@Override
+	public TaskKvStateRegistry getTaskKvStateRegistry() {
+		return kvStateRegistry;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -19,11 +19,9 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import akka.actor.ActorRef;
-
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -41,6 +39,8 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -49,10 +49,8 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.ExceptionUtils;
-
 import org.apache.flink.util.SerializedValue;
 import org.junit.Test;
-
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
@@ -64,14 +62,13 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class StreamTaskTest {
 
@@ -134,6 +131,8 @@ public class StreamTaskTest {
 		when(network.getPartitionManager()).thenReturn(partitionManager);
 		when(network.getPartitionConsumableNotifier()).thenReturn(consumableNotifier);
 		when(network.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
+		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
+				.thenReturn(mock(TaskKvStateRegistry.class));
 
 		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
 				new JobID(), "Job Name", new JobVertexID(), new ExecutionAttemptID(),

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -18,13 +18,15 @@
 
 package org.apache.flink.streaming.api.scala
 
-import org.apache.flink.annotation.{PublicEvolving, Internal, Public}
+import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
 import org.apache.flink.api.common.functions._
+import org.apache.flink.api.common.state.{FoldingStateDescriptor, ListStateDescriptor, ReducingStateDescriptor, ValueStateDescriptor}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream, KeyedStream => KeyedJavaStream, WindowedStream => WindowedJavaStream}
+import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream, KeyedStream => KeyedJavaStream, QueryableStateStream, WindowedStream => WindowedJavaStream}
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction.AggregationType
 import org.apache.flink.streaming.api.functions.aggregation.{ComparableAggregator, SumAggregator}
+import org.apache.flink.streaming.api.functions.query.{QueryableAppendingStateOperator, QueryableValueStateOperator}
 import org.apache.flink.streaming.api.operators.StreamGroupedReduce
 import org.apache.flink.streaming.api.scala.function.StatefulFunction
 import org.apache.flink.streaming.api.windowing.assigners._
@@ -368,6 +370,118 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     }
 
     flatMap(flatMapper)
+  }
+
+  /**
+    * Publishes the keyed stream as a queryable ValueState instance.
+    *
+    * @param queryableStateName Name under which to the publish the queryable state instance
+    * @return Queryable state instance
+    */
+  @PublicEvolving
+  def asQueryableState(queryableStateName: String) : QueryableStateStream[K, T] = {
+    val stateDescriptor = new ValueStateDescriptor(
+      queryableStateName,
+      dataType.createSerializer(executionConfig),
+      null.asInstanceOf[T])
+
+    asQueryableState(queryableStateName, stateDescriptor)
+  }
+
+  /**
+    * Publishes the keyed stream as a queryable ValueState instance.
+    *
+    * @param queryableStateName Name under which to the publish the queryable state instance
+    * @param stateDescriptor State descriptor to create state instance from
+    * @return Queryable state instance
+    */
+  @PublicEvolving
+  def asQueryableState(
+      queryableStateName: String,
+      stateDescriptor: ValueStateDescriptor[T]) : QueryableStateStream[K, T] = {
+
+    transform(
+      s"Queryable state: $queryableStateName",
+      new QueryableValueStateOperator(queryableStateName, stateDescriptor))(dataType)
+
+    stateDescriptor.initializeSerializerUnlessSet(executionConfig)
+
+    new QueryableStateStream(
+      queryableStateName,
+      stateDescriptor.getSerializer,
+      getKeyType.createSerializer(executionConfig))
+  }
+
+  /**
+    * Publishes the keyed stream as a queryable ListState instance.
+    *
+    * @param queryableStateName Name under which to the publish the queryable state instance
+    * @param stateDescriptor State descriptor to create state instance from
+    * @return Queryable state instance
+    */
+  @PublicEvolving
+  def asQueryableState(
+     queryableStateName: String,
+      stateDescriptor: ListStateDescriptor[T]) : QueryableStateStream[K, T]  = {
+
+    transform(
+      s"Queryable state: $queryableStateName",
+      new QueryableAppendingStateOperator(queryableStateName, stateDescriptor))(dataType)
+
+    stateDescriptor.initializeSerializerUnlessSet(executionConfig)
+
+    new QueryableStateStream(
+      queryableStateName,
+      stateDescriptor.getSerializer,
+      getKeyType.createSerializer(executionConfig))
+  }
+
+  /**
+    * Publishes the keyed stream as a queryable FoldingState instance.
+    *
+    * @param queryableStateName Name under which to the publish the queryable state instance
+    * @param stateDescriptor State descriptor to create state instance from
+    * @return Queryable state instance
+    */
+  @PublicEvolving
+  def asQueryableState[ACC](
+      queryableStateName: String,
+      stateDescriptor: FoldingStateDescriptor[T, ACC]) : QueryableStateStream[K, ACC] =  {
+
+    transform(
+      s"Queryable state: $queryableStateName",
+      new QueryableAppendingStateOperator(queryableStateName, stateDescriptor))(dataType)
+
+    stateDescriptor.initializeSerializerUnlessSet(executionConfig)
+
+    new QueryableStateStream(
+      queryableStateName,
+      stateDescriptor.getSerializer,
+      getKeyType.createSerializer(executionConfig))
+  }
+
+  /**
+    * Publishes the keyed stream as a queryable ReducingState instance.
+    *
+    * @param queryableStateName Name under which to the publish the queryable state instance
+    * @param stateDescriptor State descriptor to create state instance from
+    * @return Queryable state instance
+    */
+  @PublicEvolving
+  def asQueryableState(
+      queryableStateName: String,
+      stateDescriptor: ReducingStateDescriptor[T]) : QueryableStateStream[K, T] = {
+
+    transform(
+      s"Queryable state: $queryableStateName",
+      new QueryableAppendingStateOperator(queryableStateName, stateDescriptor))(dataType)
+
+    stateDescriptor.initializeSerializerUnlessSet(executionConfig)
+
+    new QueryableStateStream(
+      queryableStateName,
+      stateDescriptor.getSerializer,
+      getKeyType.createSerializer(executionConfig))
   }
   
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
@@ -1,0 +1,1237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.query;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.PoisonPill;
+import akka.dispatch.Futures;
+import akka.dispatch.Mapper;
+import akka.dispatch.OnSuccess;
+import akka.dispatch.Recover;
+import akka.pattern.Patterns;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.execution.SuppressRestartsException;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.JobManagerMessages.CancellationSuccess;
+import org.apache.flink.runtime.messages.JobManagerMessages.JobFound;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.KvStateMessage;
+import org.apache.flink.runtime.query.QueryableStateClient;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.ResponseRunningTasks;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.QueryableStateStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.ForkableFlinkMiniCluster;
+import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.FiniteDuration;
+import scala.reflect.ClassTag$;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.ExecutionGraphFound;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.JobStatusIs;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobStatus;
+import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.RequestExecutionGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class QueryableStateITCase extends TestLogger {
+
+	private final static FiniteDuration TEST_TIMEOUT = new FiniteDuration(100, TimeUnit.SECONDS);
+
+	private final static ActorSystem TEST_ACTOR_SYSTEM = AkkaUtils.createDefaultActorSystem();
+
+	private final static int NUM_TMS = 2;
+	private final static int NUM_SLOTS_PER_TM = 4;
+	private final static int NUM_SLOTS = NUM_TMS * NUM_SLOTS_PER_TM;
+
+	/**
+	 * Shared between all the test. Make sure to have at least NUM_SLOTS
+	 * available after your test finishes, e.g. cancel the job you submitted.
+	 */
+	private static ForkableFlinkMiniCluster cluster;
+
+	@BeforeClass
+	public static void setup() {
+		try {
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 4);
+			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
+			config.setInteger(ConfigConstants.QUERYABLE_STATE_CLIENT_NETWORK_THREADS, 1);
+			config.setInteger(ConfigConstants.QUERYABLE_STATE_SERVER_NETWORK_THREADS, 1);
+
+			cluster = new ForkableFlinkMiniCluster(config, false);
+			cluster.start(true);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		try {
+			cluster.shutdown();
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+
+		if (TEST_ACTOR_SYSTEM != null) {
+			TEST_ACTOR_SYSTEM.shutdown();
+		}
+	}
+
+	/**
+	 * Runs a simple topology producing random (key, 1) pairs at the sources (where
+	 * number of keys is in fixed in range 0...numKeys). The records are keyed and
+	 * a reducing queryable state instance is created, which sums up the records.
+	 *
+	 * After submitting the job in detached mode, the QueryableStateCLient is used
+	 * to query the counts of each key in rounds until all keys have non-zero counts.
+	 */
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testQueryableState() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+		final int numKeys = 1024;
+
+		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
+
+		JobID jobId = null;
+
+		try {
+			//
+			// Test program
+			//
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestKeyRangeSource(numKeys));
+
+			// Reducing state
+			ReducingStateDescriptor<Tuple2<Integer, Long>> reducingState = new ReducingStateDescriptor<>(
+					"any-name",
+					new SumReduce(),
+					source.getType());
+
+			final String queryName = "hakuna-matata";
+
+			final QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState(queryName, reducingState);
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			cluster.submitJobDetached(jobGraph);
+
+			//
+			// Start querying
+			//
+			jobId = jobGraph.getJobID();
+
+			final AtomicLongArray counts = new AtomicLongArray(numKeys);
+
+			final FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+
+			boolean allNonZero = false;
+			while (!allNonZero && deadline.hasTimeLeft()) {
+				allNonZero = true;
+
+				final List<Future<byte[]>> futures = new ArrayList<>(numKeys);
+
+				for (int i = 0; i < numKeys; i++) {
+					final int key = i;
+
+					if (counts.get(key) > 0) {
+						// Skip this one
+						continue;
+					} else {
+						allNonZero = false;
+					}
+
+					final byte[] serializedKey = KvStateRequestSerializer.serializeKeyAndNamespace(
+							key,
+							queryableState.getKeySerializer(),
+							VoidNamespace.INSTANCE,
+							VoidNamespaceSerializer.INSTANCE);
+
+					Future<byte[]> serializedResult = getKvStateWithRetries(
+							client,
+							jobId,
+							queryName,
+							key,
+							serializedKey,
+							retryDelay);
+
+					serializedResult.onSuccess(new OnSuccess<byte[]>() {
+						@Override
+						public void onSuccess(byte[] result) throws Throwable {
+							Tuple2<Integer, Long> value = KvStateRequestSerializer.deserializeValue(
+									result,
+									queryableState.getValueSerializer());
+
+							counts.set(key, value.f1);
+
+							assertEquals("Key mismatch", key, value.f0.intValue());
+						}
+					}, TEST_ACTOR_SYSTEM.dispatcher());
+
+					futures.add(serializedResult);
+				}
+
+				Future<Iterable<byte[]>> futureSequence = Futures.sequence(
+						futures,
+						TEST_ACTOR_SYSTEM.dispatcher());
+
+				Await.ready(futureSequence, deadline.timeLeft());
+			}
+
+			assertTrue("Not all keys are non-zero", allNonZero);
+
+			// All should be non-zero
+			for (int i = 0; i < numKeys; i++) {
+				long count = counts.get(i);
+				assertTrue("Count at position " + i + " is " + count, count > 0);
+			}
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+
+			client.shutDown();
+		}
+	}
+
+	/**
+	 * Queries a random key and waits for some checkpoints to complete. After
+	 * that the task manager where this key was held is killed. Then query the
+	 * key again and check for the expected Exception. Finally, add another
+	 * task manager and re-query the key (expecting a count >= the previous
+	 * one).
+	 */
+	@Test
+	public void testQueryableStateWithTaskManagerFailure() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+		final int numKeys = 1024;
+
+		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
+
+		JobID jobId = null;
+
+		try {
+			//
+			// Test program
+			//
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+			env.getCheckpointConfig().setCheckpointInterval(1000);
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestKeyRangeSource(numKeys));
+
+			// Reducing state
+			ReducingStateDescriptor<Tuple2<Integer, Long>> reducingState = new ReducingStateDescriptor<>(
+					"any-name",
+					new SumReduce(),
+					source.getType());
+
+			final String queryName = "hakuna-matata";
+
+			final QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState(queryName, reducingState);
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			cluster.submitJobDetached(jobGraph);
+
+			//
+			// Start querying
+			//
+			jobId = jobGraph.getJobID();
+
+			final int key = ThreadLocalRandom.current().nextInt(numKeys);
+
+			// Query a random key
+			final byte[] serializedKey = KvStateRequestSerializer.serializeKeyAndNamespace(
+					key,
+					queryableState.getKeySerializer(),
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE);
+
+			long countForKey = 0;
+
+			boolean success = false;
+			while (!success && deadline.hasTimeLeft()) {
+				final FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+				Future<byte[]> serializedResultFuture = getKvStateWithRetries(
+						client,
+						jobId,
+						queryName,
+						key,
+						serializedKey,
+						retryDelay);
+
+				byte[] serializedResult = Await.result(serializedResultFuture, deadline.timeLeft());
+
+				Tuple2<Integer, Long> result = KvStateRequestSerializer.deserializeValue(
+						serializedResult,
+						queryableState.getValueSerializer());
+
+				countForKey = result.f1;
+
+				assertEquals("Key mismatch", key, result.f0.intValue());
+				success = countForKey > 1000; // Wait for some progress
+			}
+
+			assertTrue("No progress for count", countForKey > 1000);
+
+			long currentCheckpointId = TestKeyRangeSource.LATEST_CHECKPOINT_ID.get();
+			long waitUntilCheckpointId = currentCheckpointId + 5;
+
+			// Wait for some checkpoint after the query result
+			while (deadline.hasTimeLeft() &&
+					TestKeyRangeSource.LATEST_CHECKPOINT_ID.get() < waitUntilCheckpointId) {
+				Thread.sleep(500);
+			}
+
+			assertTrue("Did not complete enough checkpoints to continue",
+					TestKeyRangeSource.LATEST_CHECKPOINT_ID.get() >= waitUntilCheckpointId);
+
+			//
+			// Find out on which TaskManager the KvState is located and kill that TaskManager
+			//
+			// This is the subtask index
+			int keyGroupIndex = MathUtils.murmurHash(key) % NUM_SLOTS;
+
+			// Find out which task manager holds this key
+			Future<ExecutionGraph> egFuture = cluster.getLeaderGateway(deadline.timeLeft())
+					.ask(new RequestExecutionGraph(jobId), deadline.timeLeft())
+					.mapTo(ClassTag$.MODULE$.<ExecutionGraphFound>apply(ExecutionGraphFound.class))
+					.map(new Mapper<TestingJobManagerMessages.ExecutionGraphFound, ExecutionGraph>() {
+						@Override
+						public ExecutionGraph apply(ExecutionGraphFound found) {
+							return found.executionGraph();
+						}
+					}, TEST_ACTOR_SYSTEM.dispatcher());
+			ExecutionGraph eg = Await.result(egFuture, deadline.timeLeft());
+
+			Future<KvStateLocation> locationFuture = cluster
+					.getLeaderGateway(deadline.timeLeft())
+					.ask(new KvStateMessage.LookupKvStateLocation(jobId, queryName), deadline.timeLeft())
+					.mapTo(ClassTag$.MODULE$.<KvStateLocation>apply(KvStateLocation.class));
+
+			KvStateLocation location = Await.result(locationFuture, deadline.timeLeft());
+
+			ExecutionAttemptID executionId = eg.getJobVertex(location.getJobVertexId())
+					.getTaskVertices()[keyGroupIndex]
+					.getCurrentExecutionAttempt()
+					.getAttemptId();
+
+			List<ActorRef> taskManagers = cluster.getTaskManagersAsJava();
+			ActorRef taskManagerToKill = null;
+			for (ActorRef taskManager : taskManagers) {
+				Future<ResponseRunningTasks> runningFuture = Patterns.ask(
+						taskManager,
+						TestingTaskManagerMessages.getRequestRunningTasksMessage(),
+						deadline.timeLeft().toMillis())
+						.mapTo(ClassTag$.MODULE$.<ResponseRunningTasks>apply(ResponseRunningTasks.class));
+
+				ResponseRunningTasks running = Await.result(runningFuture, deadline.timeLeft());
+
+				if (running.asJava().containsKey(executionId)) {
+					taskManagerToKill = taskManager;
+					break;
+				}
+			}
+
+			assertNotNull("Did not find TaskManager holding the key", taskManagerToKill);
+
+			// Kill the task manager
+			taskManagerToKill.tell(PoisonPill.getInstance(), ActorRef.noSender());
+
+			success = false;
+			for (int i = 0; i < 10 && !success; i++) {
+				try {
+					// Wait for the expected error. We might have to retry if
+					// the query is very fast.
+					Await.result(client.getKvState(jobId, queryName, key, serializedKey), deadline.timeLeft());
+					Thread.sleep(500);
+				} catch (Throwable ignored) {
+					success = true;
+				}
+			}
+
+			assertTrue("Query did not fail", success);
+
+			// Now start another task manager
+			cluster.addTaskManager();
+
+			final FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+			Future<byte[]> serializedResultFuture = getKvStateWithRetries(
+					client,
+					jobId,
+					queryName,
+					key,
+					serializedKey,
+					retryDelay);
+
+			byte[] serializedResult = Await.result(serializedResultFuture, deadline.timeLeft());
+
+			Tuple2<Integer, Long> result = KvStateRequestSerializer.deserializeValue(
+					serializedResult,
+					queryableState.getValueSerializer());
+
+			assertTrue("Count moved backwards", result.f1 >= countForKey);
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+
+			client.shutDown();
+		}
+	}
+
+	/**
+	 * Tests that duplicate query registrations fail the job at the JobManager.
+	 */
+	@Test
+	public void testDuplicateRegistrationFailsJob() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+		final int numKeys = 1024;
+
+		JobID jobId = null;
+
+		try {
+			//
+			// Test program
+			//
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestKeyRangeSource(numKeys));
+
+			// Reducing state
+			ReducingStateDescriptor<Tuple2<Integer, Long>> reducingState = new ReducingStateDescriptor<>(
+					"any-name",
+					new SumReduce(),
+					source.getType());
+
+			final String queryName = "duplicate-me";
+
+			final QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState(queryName, reducingState);
+
+			final QueryableStateStream<Integer, Tuple2<Integer, Long>> duplicate =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState(queryName);
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			jobId = jobGraph.getJobID();
+
+			Future<TestingJobManagerMessages.JobStatusIs> failedFuture = cluster
+					.getLeaderGateway(deadline.timeLeft())
+					.ask(new NotifyWhenJobStatus(jobId, JobStatus.FAILED), deadline.timeLeft())
+					.mapTo(ClassTag$.MODULE$.<JobStatusIs>apply(JobStatusIs.class));
+
+			cluster.submitJobDetached(jobGraph);
+
+			JobStatusIs jobStatus = Await.result(failedFuture, deadline.timeLeft());
+			assertEquals(JobStatus.FAILED, jobStatus.state());
+
+			// Get the job and check the cause
+			JobFound jobFound = Await.result(
+					cluster.getLeaderGateway(deadline.timeLeft())
+							.ask(new JobManagerMessages.RequestJob(jobId), deadline.timeLeft())
+							.mapTo(ClassTag$.MODULE$.<JobFound>apply(JobFound.class)),
+					deadline.timeLeft());
+
+			Throwable failureCause = jobFound.executionGraph().getFailureCause();
+
+			assertTrue("Not instance of SuppressRestartsException", failureCause instanceof SuppressRestartsException);
+			assertTrue("Not caused by IllegalStateException", failureCause.getCause() instanceof IllegalStateException);
+			Throwable duplicateException = failureCause.getCause();
+			assertTrue("Exception does not contain registration name", duplicateException.getMessage().contains(queryName));
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+		}
+	}
+
+	/**
+	 * Tests simple value state queryable state instance. Each source emits
+	 * (subtaskIndex, 0)..(subtaskIndex, numElements) tuples, which are then
+	 * queried. The tests succeeds after each subtask index is queried with
+	 * value numElements (the latest element updated the state).
+	 */
+	@Test
+	public void testValueState() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+
+		final int numElements = 1024;
+
+		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
+
+		JobID jobId = null;
+		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestAscendingValueSource(numElements));
+
+			// Value state
+			ValueStateDescriptor<Tuple2<Integer, Long>> valueState = new ValueStateDescriptor<>(
+					"any",
+					source.getType(),
+					null);
+
+			QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState("hakuna", valueState);
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			jobId = jobGraph.getJobID();
+
+			cluster.submitJobDetached(jobGraph);
+
+			// Now query
+			long expected = numElements;
+
+			FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+			for (int key = 0; key < NUM_SLOTS; key++) {
+				final byte[] serializedKey = KvStateRequestSerializer.serializeKeyAndNamespace(
+						key,
+						queryableState.getKeySerializer(),
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE);
+
+				boolean success = false;
+				while (deadline.hasTimeLeft() && !success) {
+					Future<byte[]> future = getKvStateWithRetries(client,
+							jobId,
+							queryableState.getQueryableStateName(),
+							key,
+							serializedKey,
+							retryDelay);
+
+					byte[] serializedValue = Await.result(future, deadline.timeLeft());
+
+					Tuple2<Integer, Long> value = KvStateRequestSerializer.deserializeValue(
+							serializedValue,
+							queryableState.getValueSerializer());
+
+					assertEquals("Key mismatch", key, value.f0.intValue());
+					if (expected == value.f1) {
+						success = true;
+					} else {
+						// Retry
+						Thread.sleep(50);
+					}
+				}
+
+				assertTrue("Did not succeed query", success);
+			}
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+
+			client.shutDown();
+		}
+	}
+
+	/**
+	 * Tests simple value state queryable state instance. Each source emits
+	 * (subtaskIndex, 0)..(subtaskIndex, numElements) tuples, which are then
+	 * queried. The tests succeeds after each subtask index is queried with
+	 * value numElements (the latest element updated the state).
+	 *
+	 * This is the same as the simple value state test, but uses the API shortcut.
+	 */
+	@Test
+	public void testValueStateShortcut() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+
+		final int numElements = 1024;
+
+		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
+
+		JobID jobId = null;
+		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestAscendingValueSource(numElements));
+
+			// Value state shortcut
+			QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState("matata");
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			jobId = jobGraph.getJobID();
+
+			cluster.submitJobDetached(jobGraph);
+
+			// Now query
+			long expected = numElements;
+
+			FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+			for (int key = 0; key < NUM_SLOTS; key++) {
+				final byte[] serializedKey = KvStateRequestSerializer.serializeKeyAndNamespace(
+						key,
+						queryableState.getKeySerializer(),
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE);
+
+				boolean success = false;
+				while (deadline.hasTimeLeft() && !success) {
+					Future<byte[]> future = getKvStateWithRetries(client,
+							jobId,
+							queryableState.getQueryableStateName(),
+							key,
+							serializedKey,
+							retryDelay);
+
+					byte[] serializedValue = Await.result(future, deadline.timeLeft());
+
+					Tuple2<Integer, Long> value = KvStateRequestSerializer.deserializeValue(
+							serializedValue,
+							queryableState.getValueSerializer());
+
+					assertEquals("Key mismatch", key, value.f0.intValue());
+					if (expected == value.f1) {
+						success = true;
+					} else {
+						// Retry
+						Thread.sleep(50);
+					}
+				}
+
+				assertTrue("Did not succeed query", success);
+			}
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+
+			client.shutDown();
+		}
+	}
+
+	/**
+	 * Tests simple list state queryable state instance. Each source emits
+	 * (subtaskIndex, 0)..(subtaskIndex, numElements) tuples, which are then
+	 * queried. The tests succeeds after each subtask index is queried with
+	 * a list of size numElements and each emitted tuple is part of the list.
+	 */
+	@Test
+	public void testListState() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+
+		final int numElements = 128;
+
+		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
+
+		JobID jobId = null;
+		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestAscendingValueSource(numElements));
+
+			// List state
+			ListStateDescriptor<Tuple2<Integer, Long>> listState = new ListStateDescriptor<>(
+					"any",
+					source.getType());
+
+			QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState("timon", listState);
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			jobId = jobGraph.getJobID();
+
+			cluster.submitJobDetached(jobGraph);
+
+			// Now query
+			long expected = numElements + 1; // +1 for 0-value
+
+			FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+			for (int key = 0; key < NUM_SLOTS; key++) {
+				final byte[] serializedKey = KvStateRequestSerializer.serializeKeyAndNamespace(
+						key,
+						queryableState.getKeySerializer(),
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE);
+
+				boolean success = false;
+				while (deadline.hasTimeLeft() && !success) {
+					Future<byte[]> future = getKvStateWithRetries(client,
+							jobId,
+							queryableState.getQueryableStateName(),
+							key,
+							serializedKey,
+							retryDelay);
+
+					byte[] serializedValue = Await.result(future, deadline.timeLeft());
+
+					List<Tuple2<Integer, Long>> list = KvStateRequestSerializer.deserializeList(
+							serializedValue,
+							queryableState.getValueSerializer());
+
+					if (list.size() == expected) {
+						for (int i = 0; i < expected; i++) {
+							Tuple2<Integer, Long> elem = list.get(i);
+							assertEquals("Key mismatch", key, elem.f0.intValue());
+							assertEquals("Value mismatch", i, elem.f1.longValue());
+						}
+
+						success = true;
+					} else {
+						// Retry
+						Thread.sleep(50);
+					}
+				}
+
+				assertTrue("Did not succeed query", success);
+			}
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+
+			client.shutDown();
+		}
+	}
+
+	/**
+	 * Tests simple folding state queryable state instance. Each source emits
+	 * (subtaskIndex, 0)..(subtaskIndex, numElements) tuples, which are then
+	 * queried. The folding state sums these up and maps them to Strings. The
+	 * test succeeds after each subtask index is queried with result n*(n+1)/2
+	 * (as a String).
+	 */
+	@Test
+	public void testFoldingState() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+
+		final int numElements = 1024;
+
+		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
+
+		JobID jobId = null;
+		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestAscendingValueSource(numElements));
+
+			// Folding state
+			FoldingStateDescriptor<Tuple2<Integer, Long>, String> foldingState =
+					new FoldingStateDescriptor<>(
+							"any",
+							"0",
+							new SumFold(),
+							StringSerializer.INSTANCE);
+
+			QueryableStateStream<Integer, String> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState("pumba", foldingState);
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			jobId = jobGraph.getJobID();
+
+			cluster.submitJobDetached(jobGraph);
+
+			// Now query
+			String expected = Integer.toString(numElements * (numElements + 1) / 2);
+
+			FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+			for (int key = 0; key < NUM_SLOTS; key++) {
+				final byte[] serializedKey = KvStateRequestSerializer.serializeKeyAndNamespace(
+						key,
+						queryableState.getKeySerializer(),
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE);
+
+				boolean success = false;
+				while (deadline.hasTimeLeft() && !success) {
+					Future<byte[]> future = getKvStateWithRetries(client,
+							jobId,
+							queryableState.getQueryableStateName(),
+							key,
+							serializedKey,
+							retryDelay);
+
+					byte[] serializedValue = Await.result(future, deadline.timeLeft());
+
+					String value = KvStateRequestSerializer.deserializeValue(
+							serializedValue,
+							queryableState.getValueSerializer());
+
+					if (expected.equals(value)) {
+						success = true;
+					} else {
+						// Retry
+						Thread.sleep(50);
+					}
+				}
+
+				assertTrue("Did not succeed query", success);
+			}
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+
+			client.shutDown();
+		}
+	}
+
+	/**
+	 * Tests simple reducing state queryable state instance. Each source emits
+	 * (subtaskIndex, 0)..(subtaskIndex, numElements) tuples, which are then
+	 * queried. The reducing state instance sums these up. The test succeeds
+	 * after each subtask index is queried with result n*(n+1)/2.
+	 */
+	@Test
+	public void testReducingState() throws Exception {
+		// Config
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+
+		final int numElements = 1024;
+
+		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
+
+		JobID jobId = null;
+		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_SLOTS);
+			// Very important, because cluster is shared between tests and we
+			// don't explicitly check that all slots are available before
+			// submitting.
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
+
+			DataStream<Tuple2<Integer, Long>> source = env
+					.addSource(new TestAscendingValueSource(numElements));
+
+			// Reducing state
+			ReducingStateDescriptor<Tuple2<Integer, Long>> reducingState =
+					new ReducingStateDescriptor<>(
+							"any",
+							new SumReduce(),
+							source.getType());
+
+			QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
+					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {
+						@Override
+						public Integer getKey(Tuple2<Integer, Long> value) throws Exception {
+							return value.f0;
+						}
+					}).asQueryableState("jungle", reducingState);
+
+			// Submit the job graph
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			jobId = jobGraph.getJobID();
+
+			cluster.submitJobDetached(jobGraph);
+
+			// Wait until job is running
+
+			// Now query
+			long expected = numElements * (numElements + 1) / 2;
+
+			FiniteDuration retryDelay = new FiniteDuration(1, TimeUnit.SECONDS);
+			for (int key = 0; key < NUM_SLOTS; key++) {
+				final byte[] serializedKey = KvStateRequestSerializer.serializeKeyAndNamespace(
+						key,
+						queryableState.getKeySerializer(),
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE);
+
+				boolean success = false;
+				while (deadline.hasTimeLeft() && !success) {
+					Future<byte[]> future = getKvStateWithRetries(client,
+							jobId,
+							queryableState.getQueryableStateName(),
+							key,
+							serializedKey,
+							retryDelay);
+
+					byte[] serializedValue = Await.result(future, deadline.timeLeft());
+
+					Tuple2<Integer, Long> value = KvStateRequestSerializer.deserializeValue(
+							serializedValue,
+							queryableState.getValueSerializer());
+
+					assertEquals("Key mismatch", key, value.f0.intValue());
+					if (expected == value.f1) {
+						success = true;
+					} else {
+						// Retry
+						Thread.sleep(50);
+					}
+				}
+
+				assertTrue("Did not succeed query", success);
+			}
+		} finally {
+			// Free cluster resources
+			if (jobId != null) {
+				Future<CancellationSuccess> cancellation = cluster
+						.getLeaderGateway(deadline.timeLeft())
+						.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft())
+						.mapTo(ClassTag$.MODULE$.<CancellationSuccess>apply(CancellationSuccess.class));
+
+				Await.ready(cancellation, deadline.timeLeft());
+			}
+
+			client.shutDown();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Future<byte[]> getKvStateWithRetries(
+			final QueryableStateClient client,
+			final JobID jobId,
+			final String queryName,
+			final int key,
+			final byte[] serializedKey,
+			final FiniteDuration retryDelay) {
+
+		return client.getKvState(jobId, queryName, key, serializedKey)
+				.recoverWith(new Recover<Future<byte[]>>() {
+					@Override
+					public Future<byte[]> recover(Throwable failure) throws Throwable {
+						if (failure instanceof AssertionError) {
+							return Futures.failed(failure);
+						} else {
+							// At startup some failures are expected
+							// due to races. Make sure that they don't
+							// fail this test.
+							return Patterns.after(
+									retryDelay,
+									TEST_ACTOR_SYSTEM.scheduler(),
+									TEST_ACTOR_SYSTEM.dispatcher(),
+									new Callable<Future<byte[]>>() {
+										@Override
+										public Future<byte[]> call() throws Exception {
+											return getKvStateWithRetries(
+													client,
+													jobId,
+													queryName,
+													key,
+													serializedKey,
+													retryDelay);
+										}
+									});
+						}
+					}
+				}, TEST_ACTOR_SYSTEM.dispatcher());
+	}
+
+	/**
+	 * Test source producing (key, 0)..(key, maxValue) with key being the sub
+	 * task index.
+	 *
+	 * <p>After all tuples have been emitted, the source waits to be cancelled
+	 * and does not immediately finish.
+	 */
+	private static class TestAscendingValueSource extends RichParallelSourceFunction<Tuple2<Integer, Long>> {
+
+		private final long maxValue;
+		private volatile boolean isRunning = true;
+
+		public TestAscendingValueSource(long maxValue) {
+			Preconditions.checkArgument(maxValue >= 0);
+			this.maxValue = maxValue;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+		}
+
+		@Override
+		public void run(SourceContext<Tuple2<Integer, Long>> ctx) throws Exception {
+			// f0 => key
+			int key = getRuntimeContext().getIndexOfThisSubtask();
+			Tuple2<Integer, Long> record = new Tuple2<>(key, 0L);
+
+			long currentValue = 0;
+			while (isRunning && currentValue <= maxValue) {
+				synchronized (ctx.getCheckpointLock()) {
+					record.f1 = currentValue;
+					ctx.collect(record);
+				}
+
+				currentValue++;
+			}
+
+			while (isRunning) {
+				synchronized (this) {
+					this.wait();
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+
+			synchronized (this) {
+				this.notifyAll();
+			}
+		}
+
+	}
+
+	/**
+	 * Test source producing (key, 1) tuples with random key in key range (numKeys).
+	 */
+	private static class TestKeyRangeSource extends RichParallelSourceFunction<Tuple2<Integer, Long>>
+			implements CheckpointListener {
+
+		private final static AtomicLong LATEST_CHECKPOINT_ID = new AtomicLong();
+		private final int numKeys;
+		private final ThreadLocalRandom random = ThreadLocalRandom.current();
+		private volatile boolean isRunning = true;
+
+		public TestKeyRangeSource(int numKeys) {
+			this.numKeys = numKeys;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+			if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+				LATEST_CHECKPOINT_ID.set(0);
+			}
+		}
+
+		@Override
+		public void run(SourceContext<Tuple2<Integer, Long>> ctx) throws Exception {
+			// f0 => key
+			Tuple2<Integer, Long> record = new Tuple2<>(0, 1L);
+
+			while (isRunning) {
+				synchronized (ctx.getCheckpointLock()) {
+					record.f0 = random.nextInt(numKeys);
+					ctx.collect(record);
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) throws Exception {
+			if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+				LATEST_CHECKPOINT_ID.set(checkpointId);
+			}
+		}
+	}
+
+	private static class SumFold implements FoldFunction<Tuple2<Integer, Long>, String> {
+		@Override
+		public String fold(String accumulator, Tuple2<Integer, Long> value) throws Exception {
+			long acc = Long.valueOf(accumulator);
+			acc += value.f1;
+			return Long.toString(acc);
+		}
+	}
+
+	private static class SumReduce implements ReduceFunction<Tuple2<Integer, Long>> {
+		@Override
+		public Tuple2<Integer, Long> reduce(Tuple2<Integer, Long> value1, Tuple2<Integer, Long> value2) throws Exception {
+			value1.f1 += value2.f1;
+			return value1;
+		}
+	}
+
+}


### PR DESCRIPTION
First of all, thanks to @tillrohrmann, @aljoscha, and @StephanEwen for discussions during and before implementing this first version. The initial design document can be found here: https://docs.google.com/document/d/1NkQuhIKYmcprIU5Vjp04db1HgmYSsZtCMxgDi_iTN-g

**In a nutshell, this feature allows users to query Flink's managed partitioned state from outside of Flink. This eliminates the need for distributed operations/transactions with external systems such as key-value stores which are often the bottleneck in practice.**

# APIs

## QueryableStateStream

The following methods have been added as `@PublicEvolving` to `KeyedStream`:

```java
// ValueState
QueryableStateStream asQueryableState(
    String queryableStateName,
    ValueStateDescriptor stateDescriptor)

// Shortcut for explicit ValueStateDescriptor variant
QueryableStateStream asQueryableState(String queryableStateName)

// ListState
QueryableStateStream asQueryableState(
    String queryableStateName,
    ListStateDescriptor stateDescriptor)

// FoldingState
QueryableStateStream asQueryableState(
    String queryableStateName,
    FoldingStateDescriptor stateDescriptor)

// ReducingState
QueryableStateStream asQueryableState(
    String queryableStateName,
    ReducingStateDescriptor stateDescriptor)
```

A call to these methods returns a `QueryableStateStream`, which cannot be further transformed and currently only holds the value and key serializer for the queryable state stream. It's comparable to a sink, after which you cannot do further transformations.

The `QueryableStateStream` gets translated to an operator, which uses all incoming records to update the queryable state instance. If you have a program like `stream.keyBy(0).asQueryableState("query-name")`, all records of the keyed stream will be used to update the state instance, either via `update` for `ValueState` or `add` for `AppendingState`. This acts like the Scala API's `flatMapWithState`. For an example, take a look at `QueryableStateITCase` in `flink-tests`.

I understand that these are quite a few methods to add to the public APIs, but I am not aware of another way to do it if we want to ensure type safety when providing the state descriptor. @aljoscha, you have quite some experience with designing APIs. Is there maybe a better way? And what do you (and others) think about the name `QueryableStateStream`? We could also go for the shorter `QueryableState` or something else even. I'm open to suggestions.

## QueryableStateClient

This is the client used for queries against the KvState instances. The query method is this:

```java
Future<byte[]> getKvState(
    JobID jobID,
    String queryableStateName,
    int keyHashCode,
    byte[] serializedKeyAndNamespace)
```

A call to the method returns a Future eventually holding the serialized state value for the queryable state instance identified by `queryableStateName` of the job with ID `jobID`. The `keyHashCode` is the hash code as returned by `Object.hashCode()` and the `serializedKeyAndNamespace` is the serialized key and namespace. The client is asynchronous and can be shared by multiple Threads. An example can be seen in `QueryableStateITCase` (in `flink-tests`).

The current implementation is low-level in the sense that it only works with serialized data both for providing the key/namespace and the returned results. It's the responsibility of the user (or some follow-up utilities) to set up the serializers for this. The nice thing about this is that the query services don't have to get into the business of worrying about any class loading issues etc.

There are some serialization utils for key/namespace and value serialization included in `KvStateRequestSerializer`.

# Implementation

The following sections highlight the main changes/additions.

## Added `setQueryable(String)` to `StateDescriptor`

KvState instances are published for queries when they have a queryable state name set (see below). For this purpose, I've introduced the `setQueryable(String)` method to the `StateDescriptor` interface. The provided name is different from the state descriptor name we already had before. For queries, only the name provided in `setQueryable(String)` is relevant.

The name needs to be unique per job. If this is not the case, the job fails at runtime with an unrecoverable exception. Unfortunately, this can not be checked before submitting the job.

## Added `byte[] getSerializedValue(byte[] serializedKeyNamespace)` to `KvState`

This method is implemented by all KvState instances for queries. Since all state instances have references to their serializers, they have to worry about serialization and the caller does not.

For Java heap-backed state, we deserialize the key and namespace, access the state for the key/namespace, and serialize the result. For RocksDB backed state, we can directly use the `serializedKeyAndNamespace` to access the serialized result.

Furthermore, with the RocksDB state backend we don't have to worry about concurrent accesses to the state instance whereas we need `ConcurrentHashMap`s for the internal key/namespace maps of `AbstractHeapState` if the state instance is queryable.

## Added `KvStateRegistry` to TaskManager

This is a very simple registry on the TaskManager. The `AbstractStateBackend` registers `KvState` instances at runtime on:
- first call to `getPartitionedState()`, which creates the `State` instance, or
- `injectKeyValueStateSnapshots()`.

At the moment, we essentially have two variants for the state backends: either a RocksDB backed or a Java heap-backed backend (`FileSystemStateBackend`, `MemoryStateBackend`).

A note on restoring: RocksDB state will only be published for queries on `getPartitionedState()` whereas Java heap-backed state is already published on `injectKeyValueStateSnapshots()`. This has to do with the way that the RocksDB state backend organizes the state internally. I didn't want to change a lot there and I think it's a fair compromise for the first version.

## Added `KvStateLocationRegistry` to JobManager

The `KvStateRegistry` of each TaskManager reports the registered state instances to the JobManager, where they are aggregated by the `KvStateLocationRegistry`. The purpose of this is to allow clients to query the JobManager for location information about the state they want to query. There is one `KvStateLocation` for each registered queryable state, which maps each key group index (currently the sub task index) to the server address holding the state instance.

With this, the client can figure out which TaskManager to query for each key. Only when the location is unknown or out-of-sync, there needs to be communication between the client and JobManager.

The lookup of `KvStateLocation` instances happens via Akka.

## Added `KvStateClient` and `KvStateServer` for network transfers

The `KvStateClient` and `KvStateServer` are responsible for the actual data exchange via TCP. Each TaskManager runs a single `KvStateServer`, which queries the local `KvStateRegistry` on incoming requests.

Connections are established and released by the client. Only on failures, does the server close a connection. Each client connection can be shared by multiple Threads.

Both client and server keep track of statistics for their respects (how many requests and how long did they take).

# Limitations

- User docs are sparse. I wanted to wait for some initial feedback with this PR before writing anything.

- The queryable state life-cycle is bound to the life-cycle of the job, e.g. tasks register queryable state on startup and unregister it on dispose. In future versions, it is desirable to decouple this in order to allow queries after a task finishes and to speed up recovery via state replication.

- Notifications about available `KvState` happen via a simple `tell`. This should be improved to be more robust with `ask`s and acknowledgements. This was held simple on purpose in anticipation of possible state replication improvements (see first point), which probably need a differnt model of reporting available state.

- The server and client keep track of statistics for queries. These are currently disabled by default as they would not be exposed anywhere. As soon as there is better support to publish these numbers via the Metrics system, we should enable the stats.
