### PR TITLE
[FLINK-3996] Add addition, subtraction and multiply by scalar to DenseVector.scala and SparseVector.scala

### DIFF
--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -148,18 +148,18 @@ case class DenseVector(
     SparseVector.fromCOO(size, nonZero)
   }
 
-  def +(other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
+  def + (other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
 
-  def -(other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
+  def - (other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
 
-  def *(scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
+  def * (scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
 
 }
 
 object DenseVector {
 
   implicit class scalarVectorMult(scalar: Double) {
-    def *(vector: DenseVector): Vector = vector * scalar
+    def * (vector: DenseVector): Vector = vector * scalar
   }
 
   def apply(values: Double*): DenseVector = {

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -158,6 +158,10 @@ case class DenseVector(
 
 object DenseVector {
 
+  implicit class ScalarVectorMult(scalar: Double) {
+    def *(vector: DenseVector): Vector = vector * scalar
+  }
+
   def apply(values: Double*): DenseVector = {
     new DenseVector(values.toArray)
   }

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -158,7 +158,7 @@ case class DenseVector(
 
 object DenseVector {
 
-  implicit class ScalarVectorMult(scalar: Double) {
+  implicit class scalarVectorMult(scalar: Double) {
     def *(vector: DenseVector): Vector = vector * scalar
   }
 

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/DenseVector.scala
@@ -20,6 +20,8 @@ package org.apache.flink.ml.math
 
 import breeze.linalg.{SparseVector => BreezeSparseVector, DenseVector => BreezeDenseVector, Vector => BreezeVector}
 
+import org.apache.flink.ml.math.Breeze._
+
 /**
  * Dense vector implementation of [[Vector]]. The data is represented in a continuous array of
  * doubles.
@@ -145,6 +147,13 @@ case class DenseVector(
 
     SparseVector.fromCOO(size, nonZero)
   }
+
+  def +(other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
+
+  def -(other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
+
+  def *(scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
+
 }
 
 object DenseVector {

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -177,18 +177,18 @@ case class SparseVector(
     java.util.Arrays.binarySearch(indices, 0, indices.length, index)
   }
 
-  def +(other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
+  def + (other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
 
-  def -(other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
+  def - (other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
 
-  def *(scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
+  def * (scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
 
 }
 
 object SparseVector {
 
   implicit class scalarVectorMult(scalar: Double) {
-    def *(vector: SparseVector): Vector = vector * scalar
+    def * (vector: SparseVector): Vector = vector * scalar
   }
 
   /** Constructs a sparse vector from a coordinate list (COO) representation where each entry

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.ml.math
 
 import breeze.linalg.{SparseVector => BreezeSparseVector, DenseVector => BreezeDenseVector, Vector => BreezeVector}
+import org.apache.flink.ml.math.Breeze._
 
 import scala.util.Sorting
 
@@ -175,6 +176,13 @@ case class SparseVector(
 
     java.util.Arrays.binarySearch(indices, 0, indices.length, index)
   }
+
+  def +(other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
+
+  def -(other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
+
+  def *(scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
+
 }
 
 object SparseVector {

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -187,7 +187,7 @@ case class SparseVector(
 
 object SparseVector {
 
-  implicit class ScalarVectorMult(scalar: Double) {
+  implicit class scalarVectorMult(scalar: Double) {
     def *(vector: SparseVector): Vector = vector * scalar
   }
 

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/SparseVector.scala
@@ -187,6 +187,10 @@ case class SparseVector(
 
 object SparseVector {
 
+  implicit class ScalarVectorMult(scalar: Double) {
+    def *(vector: SparseVector): Vector = vector * scalar
+  }
+
   /** Constructs a sparse vector from a coordinate list (COO) representation where each entry
     * is stored as a tuple of (index, value).
     *

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/Vector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/Vector.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.ml.math
 
 import breeze.linalg.{SparseVector => BreezeSparseVector, DenseVector => BreezeDenseVector, Vector => BreezeVector}
+import org.apache.flink.ml.math.Breeze._
 
 /** Base trait for Vectors
   *
@@ -81,6 +82,13 @@ trait Vector extends Serializable {
       false
     }
   }
+
+  def +(other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
+
+  def -(other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
+
+  def *(scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
+
 }
 
 object Vector{

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/Vector.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/math/Vector.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.ml.math
 
 import breeze.linalg.{SparseVector => BreezeSparseVector, DenseVector => BreezeDenseVector, Vector => BreezeVector}
-import org.apache.flink.ml.math.Breeze._
 
 /** Base trait for Vectors
   *
@@ -82,13 +81,6 @@ trait Vector extends Serializable {
       false
     }
   }
-
-  def +(other: Vector): Vector = (this.asBreeze + other.asBreeze).fromBreeze
-
-  def -(other: Vector): Vector = (this.asBreeze - other.asBreeze).fromBreeze
-
-  def *(scalar: Double): Vector = (scalar * this.asBreeze).fromBreeze
-
 }
 
 object Vector{


### PR DESCRIPTION
Small change to add vector operations.  With this small change, can now do things like:

``` scala
val v1 = DenseVector(0.1, 0.1)
val v2 = DenseVector(0.2, 0.2)
val v3 = v1 + v2
```

instead of what is now has to be done:

``` scala
val v1 = DenseVector(0.1, 0.1)
val v2 = DenseVector(0.2, 0.2)
val v3 = (v1.asBreeze + v2.asBreeze).fromBreeze
```

Did not add a test, not sure if I should add a test to any Suite for such a small change?  There is no JIRA issue on this. @chiwanpark 
