### PR TITLE
[FLINK-3994] [ml, tests] Fix flaky KNN integration tests

### DIFF
--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/nn/KNNITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/nn/KNNITSuite.scala
@@ -42,18 +42,17 @@ class KNNITSuite extends FlatSpec with Matchers with FlinkTestBase {
     }
   }
 
-  val env = ExecutionEnvironment.getExecutionEnvironment
-
-  // prepare data
-  val trainingSet = env.fromCollection(Classification.trainingData).map(_.vector)
-  val testingSet = env.fromElements(DenseVector(0.0, 0.0))
-
   // calculate answer
   val answer = Classification.trainingData.map {
     v => (v.vector, SquaredEuclideanDistanceMetric().distance(DenseVector(0.0, 0.0), v.vector))
   }.sortBy(_._2).take(3).map(_._1).toArray
 
   it should "calculate kNN join correctly without using a Quadtree" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    // prepare data
+    val trainingSet = env.fromCollection(Classification.trainingData).map(_.vector)
+    val testingSet = env.fromElements(DenseVector(0.0, 0.0))
 
     val knn = KNN()
       .setK(3)
@@ -72,6 +71,11 @@ class KNNITSuite extends FlatSpec with Matchers with FlinkTestBase {
   }
 
   it should "calculate kNN join correctly with a Quadtree" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    // prepare data
+    val trainingSet = env.fromCollection(Classification.trainingData).map(_.vector)
+    val testingSet = env.fromElements(DenseVector(0.0, 0.0))
 
     val knn = KNN()
       .setK(3)
@@ -91,6 +95,12 @@ class KNNITSuite extends FlatSpec with Matchers with FlinkTestBase {
 
   it should "throw an exception when using a Quadtree with an incompatible metric" in {
     intercept[IllegalArgumentException] {
+      val env = ExecutionEnvironment.getExecutionEnvironment
+
+      // prepare data
+      val trainingSet = env.fromCollection(Classification.trainingData).map(_.vector)
+      val testingSet = env.fromElements(DenseVector(0.0, 0.0))
+
       val knn = KNN()
         .setK(3)
         .setBlocks(10)


### PR DESCRIPTION
This PR is related to flaky KNN integration tests. The problem is caused by sharing `ExecutionEnvironment` between test cases. I'm not sure about exact reason. This PR makes each test case have own `ExecutionEnvironment`. Tests on my local machine and my Travis-CI [1] is passed with this PR.

I have some doubt because this is not essential fix for the problem. AFAIK and @StephanEwen said, sharing `ExecutionEnvironment` should be supported. Addtionally, `mvn clean verify` has passed without this PR on my local machine.

If there are any other opinions, please leave comment.

[1]: https://travis-ci.org/chiwanpark/flink/builds/134104491

p.s. we need to re-write commit message.