### PR TITLE
[hotfix] Fix JSONDeserializationSchema for Kafka; ParameterTool usability

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -152,7 +152,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	public static ParameterTool fromPropertiesFile(String path) throws IOException {
 		File propertiesFile = new File(path);
 		if(!propertiesFile.exists()) {
-			throw new FileNotFoundException("Properties file "+path+" does not exist");
+			throw new FileNotFoundException("Properties file " + propertiesFile.getAbsolutePath() + " does not exist");
 		}
 		Properties props = new Properties();
 		FileInputStream fis = new FileInputStream(propertiesFile);

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JSONDeserializationSchema.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JSONDeserializationSchema.java
@@ -18,22 +18,20 @@ package org.apache.flink.streaming.util.serialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import java.io.IOException;
 
-import static org.apache.flink.api.java.typeutils.TypeExtractor.getForClass;
 
 /**
  * DeserializationSchema that deserializes a JSON String into an ObjectNode.
  * <p>
  * Fields can be accessed by calling objectNode.get(&lt;name>).as(&lt;type>)
  */
-public class JSONDeserializationSchema implements KeyedDeserializationSchema<ObjectNode> {
+public class JSONDeserializationSchema extends AbstractDeserializationSchema<ObjectNode> {
 	private ObjectMapper mapper;
 
 	@Override
-	public ObjectNode deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset) throws IOException {
+	public ObjectNode deserialize(byte[] message) throws IOException {
 		if (mapper == null) {
 			mapper = new ObjectMapper();
 		}
@@ -45,8 +43,4 @@ public class JSONDeserializationSchema implements KeyedDeserializationSchema<Obj
 		return false;
 	}
 
-	@Override
-	public TypeInformation<ObjectNode> getProducedType() {
-		return getForClass(ObjectNode.class);
-	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JSONDeserializationSchemaTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JSONDeserializationSchemaTest.java
@@ -33,7 +33,7 @@ public class JSONDeserializationSchemaTest {
 		byte[] serializedValue = mapper.writeValueAsBytes(initialValue);
 
 		JSONDeserializationSchema schema = new JSONDeserializationSchema();
-		ObjectNode deserializedValue = schema.deserialize(null, serializedValue, "", 0, 0);
+		ObjectNode deserializedValue = schema.deserialize(serializedValue);
 
 		Assert.assertEquals(4, deserializedValue.get("key").asInt());
 		Assert.assertEquals("world", deserializedValue.get("value").asText());


### PR DESCRIPTION
The JSONDeserializationSchema was implementing the KeyedDeserializationSchema. However, it was not using the key or any other additional metadata.
Therefore, I changed the base class.

Also, the `ParameterTool`'s exception for reading a `.properties` file has been improved.