### PR TITLE
[FLINK-4011] Keep UserCodeClassLoader in archived ExecutionGraphs

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
@@ -52,7 +52,7 @@ public class SerializedValue<T> implements java.io.Serializable {
 	@SuppressWarnings("unchecked")
 	public T deserializeValue(ClassLoader loader) throws IOException, ClassNotFoundException {
 		if (loader == null) {
-			throw new NullPointerException();
+			throw new NullPointerException("No classloader has been passed");
 		}
 
 		return serializedData == null ? null : (T) InstantiationUtil.deserializeObject(serializedData, loader);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -943,7 +943,6 @@ public class ExecutionGraph implements Serializable {
 		}
 
 		// clear the non-serializable fields
-		userClassLoader = null;
 		scheduler = null;
 		checkpointCoordinator = null;
 		executionContext = null;

--- a/flink-tests/src/test/java/org/apache/flink/test/web/WebFrontendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/web/WebFrontendITCase.java
@@ -238,6 +238,19 @@ public class WebFrontendITCase {
 
 			Thread.sleep(20);
 		}
+
+		// ensure we can access job details when its finished (FLINK-4011)
+		try (HttpTestClient client = new HttpTestClient("localhost", port)) {
+			FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
+			client.sendGetRequest("/jobs/" + jid + "/config", timeout);
+			HttpTestClient.SimpleHttpResponse response = client.getNextResponse(timeout);
+
+			assertEquals(HttpResponseStatus.OK, response.getStatus());
+			assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("json"));
+			assertEquals("{\"jid\":\""+jid+"\",\"name\":\"Stoppable streaming test job\"," +
+					"\"execution-config\":{\"execution-mode\":\"PIPELINED\",\"restart-strategy\":\"default\"," +
+					"\"job-parallelism\":-1,\"object-reuse-mode\":false}}", response.getContent());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Currently, completed jobs cannot be accessed in the web frontend, because the classloader passed to `SerializedValue` is always null.

There are different approaches to resolve this issue:
- Use the system classloader to deserialize the EC. This means that as soon as the EC contains user code, we can not deserialize it. The web frontent will show fewer information
- In `ExecutionGraph.prepareForArchiving()`, we deserialize the EC into a special field, then we set the user code classloader free for GCing. This would be a hacky approach because we would have two ECs (serialized, regular instance) in the EG.
- Keep the usercodeclassloader in the EC. This means the classes of the job can not be unloaded from the JobManager JVM until the job has been removed from the JM history.

I'm open for discussing more approaches or alternative solutions.