### PR TITLE
[hotfix] [core] Fix scope format keys

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
@@ -48,10 +48,10 @@ public class MetricRegistry {
 	public static final String KEY_METRICS_REPORTER_ARGUMENTS = "metrics.reporter.arguments";
 	public static final String KEY_METRICS_REPORTER_INTERVAL = "metrics.reporter.interval";
 
-	public static final String KEY_METRICS_SCOPE_NAMING_TM = "metrics.scopeName.tm";
-	public static final String KEY_METRICS_SCOPE_NAMING_JOB = "metrics.scopeName.job";
-	public static final String KEY_METRICS_SCOPE_NAMING_TASK = "metrics.scopeName.task";
-	public static final String KEY_METRICS_SCOPE_NAMING_OPERATOR = "metrics.scopeName.operator";
+	public static final String KEY_METRICS_SCOPE_NAMING_TM = "metrics.scope.tm";
+	public static final String KEY_METRICS_SCOPE_NAMING_JOB = "metrics.scope.job";
+	public static final String KEY_METRICS_SCOPE_NAMING_TASK = "metrics.scope.task";
+	public static final String KEY_METRICS_SCOPE_NAMING_OPERATOR = "metrics.scope.operator";
 
 	// ------------------------------------------------------------------------
 	//  configuration keys


### PR DESCRIPTION
Fixes the scope format keys that were broken in 7ad8375a89374bec80571029e9166f1336bdea8e.