### PR TITLE
[FLINK-4018][streaming-connectors] Configurable idle time between getRecords requests to Kinesis shards

### DIFF
--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -186,10 +186,12 @@ setting keys prefixed by `KinesisConfigConstants.CONFIG_SHARD_GETITERATOR_*` in 
 by per shard consuming threads to fetch records from Kinesis. When a shard has multiple concurrent consumers (when there
 are any other non-Flink consuming applications running), the per shard rate limit may be exceeded. By default, on each call
 of this API, the consumer will retry if Kinesis complains that the data size / transaction limit for the API has exceeded,
-up to a default of 3 attempts. Users can either try to slow down other non-Flink consuming applications, or adjust the maximum
-amount of records to fetch per call by setting the `KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_MAX` key in the supplied
-configuration properties. The retry behaviour of the consumer when calling this API can also be modified by using the
-other keys prefixed by `KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_*`.
+up to a default of 3 attempts. Users can either try to slow down other non-Flink consuming applications, or adjust the throughput
+of the consumer by setting the `KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_MAX` and
+`KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_INTERVAL_MILLIS` keys in the supplied configuration properties. Setting the former
+adjusts the maximum number of records each consuming thread tries to fetch from shards on each call (default is 100), while
+the latter modifies the sleep interval between each fetch (there will be no sleep by default). The retry behaviour of the
+consumer when calling this API can also be modified by using the other keys prefixed by `KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_*`.
 
 ### Kinesis Producer
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/KinesisConfigConstants.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/KinesisConfigConstants.java
@@ -50,6 +50,9 @@ public class KinesisConfigConstants {
 	/** The power constant for exponential backoff between each getRecords attempt */
 	public static final String CONFIG_SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.shard.getrecords.backoff.expconst";
 
+	/** The interval between each getRecords request to a AWS Kinesis shard in milliseconds */
+	public static final String CONFIG_SHARD_GETRECORDS_INTERVAL_MILLIS = "flink.shard.getrecords.intervalmillis";
+
 	/** The maximum number of getShardIterator attempts if we get ProvisionedThroughputExceededException */
 	public static final String CONFIG_SHARD_GETITERATOR_RETRIES = "flink.shard.getiterator.maxretries";
 
@@ -112,6 +115,8 @@ public class KinesisConfigConstants {
 	public static final long DEFAULT_SHARD_GETRECORDS_BACKOFF_MAX = 1000L;
 
 	public static final double DEFAULT_SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final long DEFAULT_SHARD_GETRECORDS_INTERVAL_MILLIS = 0;
 
 	public static final int DEFAULT_SHARD_GETITERATOR_RETRIES = 3;
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -472,10 +472,6 @@ public class KinesisDataFetcher<T> {
 		return configProps;
 	}
 
-	protected int getIndexOfThisConsumerSubtask() {
-		return indexOfThisConsumerSubtask;
-	}
-
 	protected KinesisDeserializationSchema<T> getClonedDeserializationSchema() {
 		try {
 			return InstantiationUtil.clone(deserializationSchema, runtimeContext.getUserCodeClassLoader());

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -472,6 +472,10 @@ public class KinesisDataFetcher<T> {
 		return configProps;
 	}
 
+	protected int getIndexOfThisConsumerSubtask() {
+		return indexOfThisConsumerSubtask;
+	}
+
 	protected KinesisDeserializationSchema<T> getClonedDeserializationSchema() {
 		try {
 			return InstantiationUtil.clone(deserializationSchema, runtimeContext.getUserCodeClassLoader());

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -28,8 +28,6 @@ import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -43,8 +41,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Thread that does the actual data pulling from AWS Kinesis shards. Each thread is in charge of one Kinesis shard only.
  */
 public class ShardConsumer<T> implements Runnable {
-
-	private static final Logger LOG = LoggerFactory.getLogger(ShardConsumer.class);
 
 	private final KinesisDeserializationSchema<T> deserializer;
 
@@ -164,11 +160,6 @@ public class ShardConsumer<T> implements Runnable {
 					break;
 				} else {
 					if (fetchIntervalMillis != 0) {
-						if (LOG.isDebugEnabled()) {
-							LOG.debug(
-								"Consumer {} of subtask {} is sleeping for {} milliseconds before fetching the next batch of records ...",
-								subscribedShardStateIndex, fetcherRef.getIndexOfThisConsumerSubtask(), fetchIntervalMillis);
-						}
 						Thread.sleep(fetchIntervalMillis);
 					}
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -106,37 +106,40 @@ public class KinesisConfigUtil {
 			"Invalid value given for maximum retry attempts for getRecords shard operation. Must be a valid non-negative integer value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_BACKOFF_BASE,
-			"Invalid value given for get records operation base backoff milliseconds. Must be a valid non-negative long value");
+			"Invalid value given for get records operation base backoff milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_BACKOFF_MAX,
-			"Invalid value given for get records operation max backoff milliseconds. Must be a valid non-negative long value");
+			"Invalid value given for get records operation max backoff milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveDoubleProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_BACKOFF_EXPONENTIAL_CONSTANT,
-			"Invalid value given for get records operation backoff exponential constant. Must be a valid non-negative double value");
+			"Invalid value given for get records operation backoff exponential constant. Must be a valid non-negative double value.");
+
+		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_INTERVAL_MILLIS,
+			"Invalid value given for getRecords sleep interval in milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveIntProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETITERATOR_RETRIES,
 			"Invalid value given for maximum retry attempts for getShardIterator shard operation. Must be a valid non-negative integer value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETITERATOR_BACKOFF_BASE,
-			"Invalid value given for get shard iterator operation base backoff milliseconds. Must be a valid non-negative long value");
+			"Invalid value given for get shard iterator operation base backoff milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETITERATOR_BACKOFF_MAX,
-			"Invalid value given for get shard iterator operation max backoff milliseconds. Must be a valid non-negative long value");
+			"Invalid value given for get shard iterator operation max backoff milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveDoubleProperty(config, KinesisConfigConstants.CONFIG_SHARD_GETITERATOR_BACKOFF_EXPONENTIAL_CONSTANT,
-			"Invalid value given for get shard iterator operation backoff exponential constant. Must be a valid non-negative double value");
+			"Invalid value given for get shard iterator operation backoff exponential constant. Must be a valid non-negative double value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_SHARD_DISCOVERY_INTERVAL_MILLIS,
-			"Invalid value given for shard discovery sleep interval in milliseconds. Must be a valid non-negative long value");
+			"Invalid value given for shard discovery sleep interval in milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_STREAM_DESCRIBE_BACKOFF_BASE,
-			"Invalid value given for describe stream operation base backoff milliseconds. Must be a valid non-negative long value");
+			"Invalid value given for describe stream operation base backoff milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_STREAM_DESCRIBE_BACKOFF_MAX,
-			"Invalid value given for describe stream operation max backoff milliseconds. Must be a valid non-negative long value");
+			"Invalid value given for describe stream operation max backoff milliseconds. Must be a valid non-negative long value.");
 
 		validateOptionalPositiveDoubleProperty(config, KinesisConfigConstants.CONFIG_STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT,
-			"Invalid value given for describe stream operation backoff exponential constant. Must be a valid non-negative double value");
+			"Invalid value given for describe stream operation backoff exponential constant. Must be a valid non-negative double value.");
 
 		validateOptionalPositiveLongProperty(config, KinesisConfigConstants.CONFIG_PRODUCER_COLLECTION_MAX_COUNT,
 			"Invalid value given for maximum number of items to pack into a PutRecords request. Must be a valid non-negative long value.");

--- a/flink-streaming-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -251,6 +251,20 @@ public class FlinkKinesisConsumerTest {
 	}
 
 	@Test
+	public void testUnparsableLongForGetRecordsIntervalMillisInConfig() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Invalid value given for getRecords sleep interval in milliseconds");
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(KinesisConfigConstants.CONFIG_AWS_REGION, "us-east-1");
+		testConfig.setProperty(KinesisConfigConstants.CONFIG_AWS_CREDENTIALS_PROVIDER_BASIC_ACCESSKEYID, "accessKeyId");
+		testConfig.setProperty(KinesisConfigConstants.CONFIG_AWS_CREDENTIALS_PROVIDER_BASIC_SECRETKEY, "secretKey");
+		testConfig.setProperty(KinesisConfigConstants.CONFIG_SHARD_GETRECORDS_INTERVAL_MILLIS, "unparsableLong");
+
+		KinesisConfigUtil.validateConfiguration(testConfig);
+	}
+
+	@Test
 	public void testUnparsableIntForGetShardIteratorRetriesInConfig() {
 		exception.expect(IllegalArgumentException.class);
 		exception.expectMessage("Invalid value given for maximum retry attempts for getShardIterator shard operation");


### PR DESCRIPTION
Along with this new configuration and the already existing `KinesisConfigConstants.CONFIG_SHARD_RECORDS_PER_GET`, users will have more control on the desired throughput behaviour for the Kinesis consumer.

The default value for this new configuration is 500 milliseconds idle time.