### PR TITLE
[FLINK-3948] Protect RocksDB cleanup by cleanup lock

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/pom.xml
+++ b/flink-contrib/flink-statebackend-rocksdb/pom.xml
@@ -50,7 +50,7 @@ under the License.
 		<dependency>
 			<groupId>org.rocksdb</groupId>
 			<artifactId>rocksdbjni</artifactId>
-			<version>4.1.0</version>
+			<version>4.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -49,7 +49,6 @@ import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -72,7 +71,6 @@ import static org.junit.Assert.*;
  */
 @SuppressWarnings("serial")
 @RunWith(Parameterized.class)
-@Ignore("Disabled because RocksDB fails with a segmentation fault. See FLINK-3960")
 public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
 	private static final int PARALLELISM = 4;


### PR DESCRIPTION
Before, it could happen that an asynchronous checkpoint was going on
when trying to do cleanup. Now we protect cleanup and asynchronous
checkpointing by a lock.

This was what caused `EventTimeWindowCheckpointingITCase` to fail. I now ran it more than a 100 times on travis and haven't observed a build failure related to this.