### PR TITLE
[FLINK-4020][streaming-connectors] Move shard list querying to open() for Kinesis consumer

### DIFF
--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/KinesisStreamShard.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/KinesisStreamShard.java
@@ -49,7 +49,12 @@ public class KinesisStreamShard implements Serializable {
 		this.streamName = checkNotNull(streamName);
 		this.shard = checkNotNull(shard);
 
-		this.cachedHash = 37 * (streamName.hashCode() + shard.hashCode());
+		// since our description of Kinesis Streams shards can be fully defined with the stream name and shard id,
+		// our hash doesn't need to use hash code of Amazon's description of Shards, which uses other info for calculation
+		int hash = 17;
+		hash = 37 * hash + streamName.hashCode();
+		hash = 37 * hash + shard.getShardId().hashCode();
+		this.cachedHash = hash;
 	}
 
 	public String getStreamName() {

--- a/flink-streaming-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableFlinkKinesisConsumer.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableFlinkKinesisConsumer.java
@@ -20,9 +20,11 @@ package org.apache.flink.streaming.connectors.kinesis.testutils;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisConsumer;
+import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
 import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
 import org.mockito.Mockito;
 
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -34,13 +36,13 @@ public class TestableFlinkKinesisConsumer extends FlinkKinesisConsumer {
 	private final int fakeThisConsumerTaskIndex;
 	private final String fakeThisConsumerTaskName;
 
-
-	public TestableFlinkKinesisConsumer(String fakeStreamName,
+	@SuppressWarnings("unchecked")
+	public TestableFlinkKinesisConsumer(List<String> fakeStreams,
 										int fakeNumFlinkConsumerTasks,
 										int fakeThisConsumerTaskIndex,
 										String fakeThisConsumerTaskName,
 										Properties configProps) {
-		super(fakeStreamName, new SimpleStringSchema(), configProps);
+		super(fakeStreams, new KinesisDeserializationSchemaWrapper(new SimpleStringSchema()), configProps);
 		this.fakeNumFlinkConsumerTasks = fakeNumFlinkConsumerTasks;
 		this.fakeThisConsumerTaskIndex = fakeThisConsumerTaskIndex;
 		this.fakeThisConsumerTaskName = fakeThisConsumerTaskName;


### PR DESCRIPTION
Remove shard list querying from the constructor, and let all subtasks independently discover which shards it should consume from in open(). This change is a prerequisite for [FLINK-3231](https://issues.apache.org/jira/browse/FLINK-3231).

Explanation for some changes that might seem irrelevant:
1. Changed naming of some variables / methods: Since the behaviour of shard assignment to subtasks is now (and will continue to be in the future after FLINK-3231) more like "discovering shards for consuming" instead of "being assigned shards", I've changed the "assignedShards" related namings to "discoveredShards".
2. I've removed some tests, due to the fact that the corresponding parts of the code will be subject to quite a bit of change with the upcoming changes of [FLINK-3231](https://issues.apache.org/jira/browse/FLINK-3231). Tests will be added back with FLINK-3231.