### PR TITLE
[FLINK-3713] [clients, runtime] Use user code class loader when disposing savepoints

### DIFF
--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -31,9 +31,9 @@ and connects by default to the running Flink master (JobManager) that was
 started from the same installation directory.
 
 A prerequisite to using the command line interface is that the Flink
-master (JobManager) has been started (via 
-`<flink-home>/bin/start-local.sh` or 
-`<flink-home>/bin/start-cluster.sh`) or that a YARN environment is 
+master (JobManager) has been started (via
+`<flink-home>/bin/start-local.sh` or
+`<flink-home>/bin/start-cluster.sh`) or that a YARN environment is
 available.
 
 The command line can be used to
@@ -116,11 +116,11 @@ The command line can be used to
 -   Stop a job (streaming jobs only):
 
         ./bin/flink stop <jobID>
-        
-        
+
+
 The difference between cancelling and stopping a (streaming) job is the following:
 
-On a cancel call, the operators in a job immediately receive a `cancel()` method call to cancel them as 
+On a cancel call, the operators in a job immediately receive a `cancel()` method call to cancel them as
 soon as possible.
 If operators are not not stopping after the cancel call, Flink will start interrupting the thread periodically
 until it stops.
@@ -152,21 +152,19 @@ The run command has a savepoint flag to submit a job, which restores its state f
 
 #### **Dispose a savepoint**
 
+{% highlight bash %}
+./bin/flink savepoint -d <savepointPath>
+{% endhighlight %}
+
 Disposes the savepoint at the given path. The savepoint path is returned by the savepoint trigger command.
 
-If the job is running:
+If you use custom state instances (for example custom reducing state or RocksDB state), you have to specify the path to the program JAR with which the savepoint was triggered in order to dispose the savepoint with the user code class loader:
 
 {% highlight bash %}
-./bin/flink savepoint -d <savepointPath> <jobID>
+./bin/flink savepoint -d <savepointPath> -j <jarFile>
 {% endhighlight %}
 
-If the job has terminated:
-
-{% highlight bash %}
-./bin/flink savepoint -d <savepointPath> -j <jobJar> [-c <mainClass> -C <classPath> <args>]
-{% endhighlight %}
-
-The additional arguments for Job ID or JARs are required in order to use the user code class loader of the job the savepoint belongs to.
+Otherwise, you will run into a `ClassNotFoundException`.
 
 ## Usage
 
@@ -313,25 +311,12 @@ Action "savepoint" triggers savepoints for a running job or disposes existing on
 
  Syntax: savepoint [OPTIONS] <Job ID>
  "savepoint" action options:
-    -c,--class <classname>         Class with the program entry point ("main"
-                                   method or "getPlan()" method. Only needed if
-                                   the JAR file does not specify the class in
-                                   its manifest.
-    -C,--classpath <url>           Adds a URL to each user code classloader  on
-                                   all nodes in the cluster. The paths must
-                                   specify a protocol (e.g. file://) and be
-                                   accessible on all nodes (e.g. by means of a
-                                   NFS share). You can use this option multiple
-                                   times for specifying more than one URL. The
-                                   protocol must be supported by the {@link
-                                   java.net.URLClassLoader}.
-    -d,--dispose <savepointPath>   Disposes an existing savepoint.
-    -j,--jarfile <jarfile>         Flink program JAR file.
-
-
- Examples:
- - Trigger savepoint: bin/flink savepoint <Job ID>
- - Dispose savepoint:
-   * For a running job: bin/flink savepoint -d <Path> <Job ID>
-   * For a terminated job: bin/flink savepoint -d <Path> -j <Jar> [-c <mainClass> -C <classPath>]
+    -d,--dispose <arg>            Path of savepoint to dispose.
+    -j,--jarfile <jarfile>        Flink program JAR file.
+    -m,--jobmanager <host:port>   Address of the JobManager (master) to which
+                                  to connect. Use this flag to connect to a
+                                  different JobManager than the one specified
+                                  in the configuration.
+ Options for yarn-cluster mode:
+    -yid,--yarnapplicationId <arg>   Attach to running YARN session
 ~~~

--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -142,7 +142,7 @@ This allows the job to finish processing all inflight data.
 
 Returns the path of the created savepoint. You need this path to restore and dispose savepoints.
 
-#### **Restore a savepoint**:
+#### **Restore a savepoint**
 
 {% highlight bash %}
 ./bin/flink run -s <savepointPath> ...
@@ -150,13 +150,23 @@ Returns the path of the created savepoint. You need this path to restore and dis
 
 The run command has a savepoint flag to submit a job, which restores its state from a savepoint. The savepoint path is returned by the savepoint trigger command.
 
-#### **Dispose a savepoint**:
-
-{% highlight bash %}
-./bin/flink savepoint -d <savepointPath>
-{% endhighlight %}
+#### **Dispose a savepoint**
 
 Disposes the savepoint at the given path. The savepoint path is returned by the savepoint trigger command.
+
+If the job is running:
+
+{% highlight bash %}
+./bin/flink savepoint -d <savepointPath> <jobID>
+{% endhighlight %}
+
+If the job has terminated:
+
+{% highlight bash %}
+./bin/flink savepoint -d <savepointPath> -j <jobJar> [-c <mainClass> -C <classPath> <args>]
+{% endhighlight %}
+
+The additional arguments for Job ID or JARs are required in order to use the user code class loader of the job the savepoint belongs to.
 
 ## Usage
 
@@ -301,19 +311,27 @@ guarantees for a stop request.
 
 Action "savepoint" triggers savepoints for a running job or disposes existing ones.
 
-  Syntax: savepoint [OPTIONS] <Job ID>
-  "savepoint" action options:
-     -d,--dispose <savepointPath>   Disposes an existing savepoint.
-     -m,--jobmanager <host:port>    Address of the JobManager (master) to which
-                                    to connect. Specify 'yarn-cluster' as the
-                                    JobManager to deploy a YARN cluster for the
-                                    job. Use this flag to connect to a different
-                                    JobManager than the one specified in the
-                                    configuration.
-  Additional arguments if -m yarn-cluster is set:
-     -yid <yarnApplicationId>      YARN application ID of Flink YARN session to
-                                   connect to. Must not be set if JobManager HA
-                                   is used. In this case, JobManager RPC
-                                   location is automatically retrieved from
-                                   Zookeeper.
+ Syntax: savepoint [OPTIONS] <Job ID>
+ "savepoint" action options:
+    -c,--class <classname>         Class with the program entry point ("main"
+                                   method or "getPlan()" method. Only needed if
+                                   the JAR file does not specify the class in
+                                   its manifest.
+    -C,--classpath <url>           Adds a URL to each user code classloader  on
+                                   all nodes in the cluster. The paths must
+                                   specify a protocol (e.g. file://) and be
+                                   accessible on all nodes (e.g. by means of a
+                                   NFS share). You can use this option multiple
+                                   times for specifying more than one URL. The
+                                   protocol must be supported by the {@link
+                                   java.net.URLClassLoader}.
+    -d,--dispose <savepointPath>   Disposes an existing savepoint.
+    -j,--jarfile <jarfile>         Flink program JAR file.
+
+
+ Examples:
+ - Trigger savepoint: bin/flink savepoint <Job ID>
+ - Dispose savepoint:
+   * For a running job: bin/flink savepoint -d <Path> <Job ID>
+   * For a terminated job: bin/flink savepoint -d <Path> -j <Jar> [-c <mainClass> -C <classPath>]
 ~~~

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -36,6 +36,7 @@ public class CliFrontendParser {
 
 	private static final Logger LOG = LoggerFactory.getLogger(CliFrontendParser.class);
 
+
 	static final Option HELP_OPTION = new Option("h", "help", false,
 			"Show the help message for the CLI Frontend or the action.");
 
@@ -72,7 +73,7 @@ public class CliFrontendParser {
 			"Path to a savepoint to reset the job back to (for example file:///flink/savepoint-1537).");
 
 	static final Option SAVEPOINT_DISPOSE_OPTION = new Option("d", "dispose", true,
-			"Disposes an existing savepoint.");
+			"Path of savepoint to dispose.");
 
 	// list specific options
 	static final Option RUNNING_OPTION = new Option("r", "running", false,
@@ -111,9 +112,6 @@ public class CliFrontendParser {
 
 		SAVEPOINT_PATH_OPTION.setRequired(false);
 		SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
-
-		SAVEPOINT_DISPOSE_OPTION.setRequired(false);
-		SAVEPOINT_DISPOSE_OPTION.setArgName("savepointPath");
 	}
 
 	private static final Options RUN_OPTIONS = getRunOptions(buildGeneralOptions(new Options()));
@@ -195,8 +193,6 @@ public class CliFrontendParser {
 		options = getJobManagerAddressOption(options);
 		options.addOption(SAVEPOINT_DISPOSE_OPTION);
 		options.addOption(JAR_OPTION);
-		options.addOption(CLASS_OPTION);
-		options.addOption(CLASSPATH_OPTION);
 		return addCustomCliOptions(options, false);
 	}
 
@@ -208,6 +204,7 @@ public class CliFrontendParser {
 		Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
 		return getJobManagerAddressOption(o);
 	}
+
 
 	private static Options getInfoOptionsWithoutDeprecatedOptions(Options options) {
 		options.addOption(CLASS_OPTION);
@@ -229,6 +226,13 @@ public class CliFrontendParser {
 
 	private static Options getStopOptionsWithoutDeprecatedOptions(Options options) {
 		options = getJobManagerAddressOption(options);
+		return options;
+	}
+
+	private static Options getSavepointOptionsWithoutDeprecatedOptions(Options options) {
+		options = getJobManagerAddressOption(options);
+		options.addOption(SAVEPOINT_DISPOSE_OPTION);
+		options.addOption(JAR_OPTION);
 		return options;
 	}
 
@@ -333,16 +337,10 @@ public class CliFrontendParser {
 		System.out.println("\nAction \"savepoint\" triggers savepoints for a running job or disposes existing ones.");
 		System.out.println("\n  Syntax: savepoint [OPTIONS] <Job ID>");
 		formatter.setSyntaxPrefix("  \"savepoint\" action options:");
-		formatter.printHelp(" ", getSavepointOptions(new Options()));
+		formatter.printHelp(" ", getSavepointOptionsWithoutDeprecatedOptions(new Options()));
 
-		System.out.println();
 		printCustomCliOptions(formatter, false);
 
-		System.out.println("\n  Examples:");
-		System.out.println("  - Trigger savepoint: bin/flink savepoint <Job ID>");
-		System.out.println("  - Dispose savepoint:");
-		System.out.println("    * For a running job: bin/flink savepoint -d <Path> <Job ID>");
-		System.out.println("    * For a terminated job: bin/flink savepoint -d <Path> -j <Jar> [-c <mainClass> -C <classPath>]");
 		System.out.println();
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -36,7 +36,6 @@ public class CliFrontendParser {
 
 	private static final Logger LOG = LoggerFactory.getLogger(CliFrontendParser.class);
 
-
 	static final Option HELP_OPTION = new Option("h", "help", false,
 			"Show the help message for the CLI Frontend or the action.");
 
@@ -195,6 +194,9 @@ public class CliFrontendParser {
 	private static Options getSavepointOptions(Options options) {
 		options = getJobManagerAddressOption(options);
 		options.addOption(SAVEPOINT_DISPOSE_OPTION);
+		options.addOption(JAR_OPTION);
+		options.addOption(CLASS_OPTION);
+		options.addOption(CLASSPATH_OPTION);
 		return addCustomCliOptions(options, false);
 	}
 
@@ -206,7 +208,6 @@ public class CliFrontendParser {
 		Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
 		return getJobManagerAddressOption(o);
 	}
-
 
 	private static Options getInfoOptionsWithoutDeprecatedOptions(Options options) {
 		options.addOption(CLASS_OPTION);
@@ -228,12 +229,6 @@ public class CliFrontendParser {
 
 	private static Options getStopOptionsWithoutDeprecatedOptions(Options options) {
 		options = getJobManagerAddressOption(options);
-		return options;
-	}
-
-	private static Options getSavepointOptionsWithoutDeprecatedOptions(Options options) {
-		options = getJobManagerAddressOption(options);
-		options.addOption(SAVEPOINT_DISPOSE_OPTION);
 		return options;
 	}
 
@@ -338,10 +333,16 @@ public class CliFrontendParser {
 		System.out.println("\nAction \"savepoint\" triggers savepoints for a running job or disposes existing ones.");
 		System.out.println("\n  Syntax: savepoint [OPTIONS] <Job ID>");
 		formatter.setSyntaxPrefix("  \"savepoint\" action options:");
-		formatter.printHelp(" ", getSavepointOptionsWithoutDeprecatedOptions(new Options()));
+		formatter.printHelp(" ", getSavepointOptions(new Options()));
 
+		System.out.println();
 		printCustomCliOptions(formatter, false);
 
+		System.out.println("\n  Examples:");
+		System.out.println("  - Trigger savepoint: bin/flink savepoint <Job ID>");
+		System.out.println("  - Dispose savepoint:");
+		System.out.println("    * For a running job: bin/flink savepoint -d <Path> <Job ID>");
+		System.out.println("    * For a terminated job: bin/flink savepoint -d <Path> -j <Jar> [-c <mainClass> -C <classPath>]");
 		System.out.println();
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
@@ -18,7 +18,18 @@
 package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.util.StringUtils;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.client.cli.CliFrontendParser.CLASSPATH_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.CLASS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DISPOSE_OPTION;
 
 /**
@@ -26,26 +37,107 @@ import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DISPOSE_OP
  */
 public class SavepointOptions extends CommandLineOptions {
 
-	private final String[] args;
-	private boolean dispose;
-	private String disposeSavepointPath;
+	private final boolean dispose;
+	private final String disposeSavepointPath;
+	private final String entryPointClass;
+	private final String jarFilePath;
+	private final List<URL> classpaths;
+	private final String[] programArgs;
+	private final JobID jobId;
 
-	public SavepointOptions(CommandLine line) {
+	public SavepointOptions(CommandLine line) throws CliArgsException {
 		super(line);
-		this.args = line.getArgs();
-		this.dispose = line.hasOption(SAVEPOINT_DISPOSE_OPTION.getOpt());
-		this.disposeSavepointPath = line.getOptionValue(SAVEPOINT_DISPOSE_OPTION.getOpt());
-	}
 
-	public String[] getArgs() {
-		return args == null ? new String[0] : args;
+		dispose = line.hasOption(SAVEPOINT_DISPOSE_OPTION.getOpt());
+		String[] args = line.getArgs();
+
+		// Dispose
+		if (dispose) {
+			disposeSavepointPath = line.getOptionValue(SAVEPOINT_DISPOSE_OPTION.getOpt());
+
+			// Jar file
+			jarFilePath = line.getOptionValue(JAR_OPTION.getOpt());
+
+			// Either JAR file or job ID
+			if (jarFilePath != null) {
+				programArgs = args;
+				jobId = null;
+			} else {
+				programArgs = null;
+
+				if (args.length > 0) {
+					try {
+						String jobIdString = args[0];
+						jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
+					} catch (Throwable t) {
+						throw new CliArgsException("Job ID is not a valid ID");
+					}
+				} else {
+					jobId = null;
+				}
+			}
+
+			entryPointClass = line.getOptionValue(CLASS_OPTION.getOpt());
+
+			// Class paths
+			List<URL> classpaths = new ArrayList<>();
+			if (line.hasOption(CLASSPATH_OPTION.getOpt())) {
+				for (String path : line.getOptionValues(CLASSPATH_OPTION.getOpt())) {
+					try {
+						classpaths.add(new URL(path));
+					} catch (MalformedURLException e) {
+						throw new CliArgsException("Bad syntax for classpath: " + path);
+					}
+				}
+			}
+			this.classpaths = classpaths;
+		} else {
+			// Trigger
+			disposeSavepointPath = null;
+			jarFilePath = null;
+			programArgs = null;
+			entryPointClass = null;
+			classpaths = Collections.emptyList();
+
+			if (args.length > 0) {
+				try {
+					String jobIdString = args[0];
+					jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
+				} catch (Throwable t) {
+					throw new CliArgsException("Job ID is not a valid ID");
+				}
+			} else {
+				jobId = null;
+			}
+		}
 	}
 
 	public boolean isDispose() {
 		return dispose;
 	}
 
-	public String getDisposeSavepointPath() {
+	public String getSavepointPath() {
 		return disposeSavepointPath;
 	}
+
+	public JobID getJobId() {
+		return jobId;
+	}
+
+	public String[] getProgramArgs() {
+		return programArgs;
+	}
+
+	public String getJarFilePath() {
+		return jarFilePath;
+	}
+
+	public String getEntryPointClass() {
+		return entryPointClass;
+	}
+
+	public List<URL> getClasspaths() {
+		return classpaths;
+	}
+
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
@@ -18,17 +18,7 @@
 package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.util.StringUtils;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.apache.flink.client.cli.CliFrontendParser.CLASSPATH_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.CLASS_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DISPOSE_OPTION;
 
@@ -37,79 +27,21 @@ import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DISPOSE_OP
  */
 public class SavepointOptions extends CommandLineOptions {
 
-	private final boolean dispose;
-	private final String disposeSavepointPath;
-	private final String entryPointClass;
-	private final String jarFilePath;
-	private final List<URL> classpaths;
-	private final String[] programArgs;
-	private final JobID jobId;
+	private final String[] args;
+	private boolean dispose;
+	private String disposeSavepointPath;
+	private String jarFile;
 
-	public SavepointOptions(CommandLine line) throws CliArgsException {
+	public SavepointOptions(CommandLine line) {
 		super(line);
-
+		args = line.getArgs();
 		dispose = line.hasOption(SAVEPOINT_DISPOSE_OPTION.getOpt());
-		String[] args = line.getArgs();
+		disposeSavepointPath = line.getOptionValue(SAVEPOINT_DISPOSE_OPTION.getOpt());
+		jarFile = line.getOptionValue(JAR_OPTION.getOpt());
+	}
 
-		// Dispose
-		if (dispose) {
-			disposeSavepointPath = line.getOptionValue(SAVEPOINT_DISPOSE_OPTION.getOpt());
-
-			// Jar file
-			jarFilePath = line.getOptionValue(JAR_OPTION.getOpt());
-
-			// Either JAR file or job ID
-			if (jarFilePath != null) {
-				programArgs = args;
-				jobId = null;
-			} else {
-				programArgs = null;
-
-				if (args.length > 0) {
-					try {
-						String jobIdString = args[0];
-						jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
-					} catch (Throwable t) {
-						throw new CliArgsException("Job ID is not a valid ID");
-					}
-				} else {
-					jobId = null;
-				}
-			}
-
-			entryPointClass = line.getOptionValue(CLASS_OPTION.getOpt());
-
-			// Class paths
-			List<URL> classpaths = new ArrayList<>();
-			if (line.hasOption(CLASSPATH_OPTION.getOpt())) {
-				for (String path : line.getOptionValues(CLASSPATH_OPTION.getOpt())) {
-					try {
-						classpaths.add(new URL(path));
-					} catch (MalformedURLException e) {
-						throw new CliArgsException("Bad syntax for classpath: " + path);
-					}
-				}
-			}
-			this.classpaths = classpaths;
-		} else {
-			// Trigger
-			disposeSavepointPath = null;
-			jarFilePath = null;
-			programArgs = null;
-			entryPointClass = null;
-			classpaths = Collections.emptyList();
-
-			if (args.length > 0) {
-				try {
-					String jobIdString = args[0];
-					jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
-				} catch (Throwable t) {
-					throw new CliArgsException("Job ID is not a valid ID");
-				}
-			} else {
-				jobId = null;
-			}
-		}
+	public String[] getArgs() {
+		return args == null ? new String[0] : args;
 	}
 
 	public boolean isDispose() {
@@ -120,24 +52,7 @@ public class SavepointOptions extends CommandLineOptions {
 		return disposeSavepointPath;
 	}
 
-	public JobID getJobId() {
-		return jobId;
-	}
-
-	public String[] getProgramArgs() {
-		return programArgs;
-	}
-
 	public String getJarFilePath() {
-		return jarFilePath;
+		return jarFile;
 	}
-
-	public String getEntryPointClass() {
-		return entryPointClass;
-	}
-
-	public List<URL> getClasspaths() {
-		return classpaths;
-	}
-
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -189,7 +189,7 @@ public class PackagedProgram {
 		}
 		
 		// now that we have an entry point, we can extract the nested jar files (if any)
-		this.extractedTempLibraries = extractContainedLibaries(jarFileUrl);
+		this.extractedTempLibraries = extractContainedLibraries(jarFileUrl);
 		this.classpaths = classpaths;
 		this.userCodeClassLoader = JobWithJars.buildUserCodeClassLoader(getAllLibraries(), classpaths, getClass().getClassLoader());
 		
@@ -642,7 +642,7 @@ public class PackagedProgram {
 	 * @return The file names of the extracted temporary files.
 	 * @throws ProgramInvocationException Thrown, if the extraction process failed.
 	 */
-	private static List<File> extractContainedLibaries(URL jarFile) throws ProgramInvocationException {
+	public static List<File> extractContainedLibraries(URL jarFile) throws ProgramInvocationException {
 		
 		Random rnd = new Random();
 		
@@ -741,7 +741,7 @@ public class PackagedProgram {
 		}
 	}
 	
-	private static void deleteExtractedLibraries(List<File> tempLibraries) {
+	public static void deleteExtractedLibraries(List<File> tempLibraries) {
 		for (File f : tempLibraries) {
 			f.delete();
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
@@ -188,12 +188,13 @@ public class CliFrontendSavepointTest {
 
 		try {
 			String savepointPath = "expectedSavepointPath";
+			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
 
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath)),
+					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
 					Mockito.any(FiniteDuration.class))).thenReturn(triggerResponse.future());
 
 			triggerResponse.success(JobManagerMessages.getDisposeSavepointSuccess());
@@ -201,12 +202,12 @@ public class CliFrontendSavepointTest {
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
 
-			String[] parameters = { "-d", savepointPath };
+			String[] parameters = { "-d", savepointPath, jobId.toString() };
 			int returnCode = frontend.savepoint(parameters);
 
 			assertEquals(0, returnCode);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath)),
+					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
 					Mockito.any(FiniteDuration.class));
 
 			String outMsg = buffer.toString();
@@ -224,12 +225,13 @@ public class CliFrontendSavepointTest {
 
 		try {
 			String savepointPath = "expectedSavepointPath";
+			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
 
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath)),
+					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
 					Mockito.any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 
@@ -241,12 +243,12 @@ public class CliFrontendSavepointTest {
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
 
-			String[] parameters = { "-d", savepointPath };
+			String[] parameters = { "-d", savepointPath, jobId.toString() };
 			int returnCode = frontend.savepoint(parameters);
 
 			assertTrue(returnCode != 0);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath)),
+					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
 					Mockito.any(FiniteDuration.class));
 
 			assertTrue(buffer.toString().contains("expectedTestException"));
@@ -262,12 +264,13 @@ public class CliFrontendSavepointTest {
 
 		try {
 			String savepointPath = "expectedSavepointPath";
+			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
 
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath)),
+					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
 					Mockito.any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 
@@ -276,12 +279,12 @@ public class CliFrontendSavepointTest {
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
 
-			String[] parameters = { "-d", savepointPath };
+			String[] parameters = { "-d", savepointPath, jobId.toString() };
 			int returnCode = frontend.savepoint(parameters);
 
 			assertTrue(returnCode != 0);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath)),
+					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
 					Mockito.any(FiniteDuration.class));
 
 			String errMsg = buffer.toString();

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
@@ -18,20 +18,38 @@
 
 package org.apache.flink.client;
 
+import akka.dispatch.Futures;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CommandLineOptions;
+import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
+import scala.Option;
+import scala.concurrent.Future;
 import scala.concurrent.Promise;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
+import static org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint;
+import static org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepointFailure;
+import static org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
+import static org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointFailure;
+import static org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointSuccess;
+import static org.apache.flink.runtime.messages.JobManagerMessages.getDisposeSavepointSuccess;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,6 +60,9 @@ public class CliFrontendSavepointTest {
 	private static PrintStream stdOut;
 	private static PrintStream stdErr;
 	private static ByteArrayOutputStream buffer;
+
+	@Rule
+	public TemporaryFolder tmp = new TemporaryFolder();
 
 	// ------------------------------------------------------------------------
 	// Trigger savepoint
@@ -58,14 +79,13 @@ public class CliFrontendSavepointTest {
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.TriggerSavepoint(jobId)),
-					Mockito.any(FiniteDuration.class)))
+					Mockito.eq(new TriggerSavepoint(jobId)),
+					any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 
 			String savepointPath = "expectedSavepointPath";
 
-			triggerResponse.success(new JobManagerMessages
-					.TriggerSavepointSuccess(jobId, savepointPath));
+			triggerResponse.success(new TriggerSavepointSuccess(jobId, savepointPath));
 
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
@@ -75,8 +95,8 @@ public class CliFrontendSavepointTest {
 
 			assertEquals(0, returnCode);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.TriggerSavepoint(jobId)),
-					Mockito.any(FiniteDuration.class));
+					Mockito.eq(new TriggerSavepoint(jobId)),
+					any(FiniteDuration.class));
 
 			assertTrue(buffer.toString().contains("expectedSavepointPath"));
 		}
@@ -96,14 +116,13 @@ public class CliFrontendSavepointTest {
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.TriggerSavepoint(jobId)),
-					Mockito.any(FiniteDuration.class)))
+					Mockito.eq(new TriggerSavepoint(jobId)),
+					any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 
 			Exception testException = new Exception("expectedTestException");
 
-			triggerResponse.success(new JobManagerMessages
-					.TriggerSavepointFailure(jobId, testException));
+			triggerResponse.success(new TriggerSavepointFailure(jobId, testException));
 
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
@@ -113,8 +132,8 @@ public class CliFrontendSavepointTest {
 
 			assertTrue(returnCode != 0);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.TriggerSavepoint(jobId)),
-					Mockito.any(FiniteDuration.class));
+					Mockito.eq(new TriggerSavepoint(jobId)),
+					any(FiniteDuration.class));
 
 			assertTrue(buffer.toString().contains("expectedTestException"));
 		}
@@ -152,8 +171,8 @@ public class CliFrontendSavepointTest {
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.TriggerSavepoint(jobId)),
-					Mockito.any(FiniteDuration.class)))
+					Mockito.eq(new TriggerSavepoint(jobId)),
+					any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 
 			triggerResponse.success("UNKNOWN RESPONSE");
@@ -166,8 +185,8 @@ public class CliFrontendSavepointTest {
 
 			assertTrue(returnCode != 0);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.TriggerSavepoint(jobId)),
-					Mockito.any(FiniteDuration.class));
+					Mockito.eq(new TriggerSavepoint(jobId)),
+					any(FiniteDuration.class));
 
 			String errMsg = buffer.toString();
 			assertTrue(errMsg.contains("IllegalStateException"));
@@ -188,27 +207,26 @@ public class CliFrontendSavepointTest {
 
 		try {
 			String savepointPath = "expectedSavepointPath";
-			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
 
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
-					Mockito.any(FiniteDuration.class))).thenReturn(triggerResponse.future());
+					Mockito.eq(new DisposeSavepoint(savepointPath, Option.<List<BlobKey>>empty())),
+					any(FiniteDuration.class))).thenReturn(triggerResponse.future());
 
-			triggerResponse.success(JobManagerMessages.getDisposeSavepointSuccess());
+			triggerResponse.success(getDisposeSavepointSuccess());
 
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
 
-			String[] parameters = { "-d", savepointPath, jobId.toString() };
+			String[] parameters = { "-d", savepointPath };
 			int returnCode = frontend.savepoint(parameters);
 
 			assertEquals(0, returnCode);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
-					Mockito.any(FiniteDuration.class));
+					Mockito.eq(new DisposeSavepoint(savepointPath, Option.<List<BlobKey>>empty())),
+					any(FiniteDuration.class));
 
 			String outMsg = buffer.toString();
 			assertTrue(outMsg.contains(savepointPath));
@@ -219,37 +237,94 @@ public class CliFrontendSavepointTest {
 		}
 	}
 
+	/**
+	 * Tests that a disposal failure due a  ClassNotFoundException triggers a
+	 * note about the JAR option.
+	 */
+	@Test
+	public void testDisposeClassNotFoundException() throws Exception {
+		replaceStdOutAndStdErr();
+
+		try {
+			Future<Object> classNotFoundFailure = Futures
+					.<Object>successful(new DisposeSavepointFailure(new ClassNotFoundException("Test exception")));
+
+			ActorGateway jobManager = mock(ActorGateway.class);
+			when(jobManager.ask(any(DisposeSavepoint.class), any(FiniteDuration.class)))
+					.thenReturn(classNotFoundFailure);
+
+			CliFrontend frontend = new MockCliFrontend(CliFrontendTestUtils.getConfigDir(), jobManager);
+
+			String[] parameters = { "-d", "any-path" };
+
+			int returnCode = frontend.savepoint(parameters);
+			assertTrue(returnCode != 0);
+
+			String out = buffer.toString();
+			assertTrue(out.contains("Please provide the program jar with which you have created " +
+					"the savepoint via -j <JAR> for disposal"));
+		} finally {
+			restoreStdOutAndStdErr();
+		}
+	}
+
+	/**
+	 * Tests disposal with a JAR file.
+	 */
+	@Test
+	public void testDisposeWithJar() throws Exception {
+		replaceStdOutAndStdErr();
+
+		try {
+			ActorGateway jobManager = mock(ActorGateway.class);
+			when(jobManager.ask(any(DisposeSavepoint.class), any(FiniteDuration.class)))
+					.thenReturn(Futures.successful(JobManagerMessages.getDisposeSavepointSuccess()));
+
+			CliFrontend frontend = new MockCliFrontend(CliFrontendTestUtils.getConfigDir(), jobManager);
+
+			// Fake JAR file
+			File f = tmp.newFile();
+			ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f));
+			out.close();
+
+			String[] parameters = { "-d", "any-path", "-j", f.getAbsolutePath() };
+
+			int returnCode = frontend.savepoint(parameters);
+			assertEquals(0, returnCode);
+		} finally {
+			restoreStdOutAndStdErr();
+		}
+	}
+
 	@Test
 	public void testDisposeSavepointFailure() throws Exception {
 		replaceStdOutAndStdErr();
 
 		try {
 			String savepointPath = "expectedSavepointPath";
-			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
 
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
-					Mockito.any(FiniteDuration.class)))
+					Mockito.eq(new DisposeSavepoint(savepointPath, Option.<List<BlobKey>>empty())),
+					any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 
 			Exception testException = new Exception("expectedTestException");
 
-			triggerResponse.success(new JobManagerMessages
-					.DisposeSavepointFailure(testException));
+			triggerResponse.success(new DisposeSavepointFailure(testException));
 
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
 
-			String[] parameters = { "-d", savepointPath, jobId.toString() };
+			String[] parameters = { "-d", savepointPath };
 			int returnCode = frontend.savepoint(parameters);
 
 			assertTrue(returnCode != 0);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
-					Mockito.any(FiniteDuration.class));
+					Mockito.eq(new DisposeSavepoint(savepointPath, Option.<List<BlobKey>>empty())),
+					any(FiniteDuration.class));
 
 			assertTrue(buffer.toString().contains("expectedTestException"));
 		}
@@ -264,14 +339,13 @@ public class CliFrontendSavepointTest {
 
 		try {
 			String savepointPath = "expectedSavepointPath";
-			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
 
 			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 			when(jobManager.ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
-					Mockito.any(FiniteDuration.class)))
+					Mockito.eq(new DisposeSavepoint(savepointPath, Option.<List<BlobKey>>empty())),
+					any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 
 			triggerResponse.success("UNKNOWN RESPONSE");
@@ -279,13 +353,13 @@ public class CliFrontendSavepointTest {
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
 
-			String[] parameters = { "-d", savepointPath, jobId.toString() };
+			String[] parameters = { "-d", savepointPath };
 			int returnCode = frontend.savepoint(parameters);
 
 			assertTrue(returnCode != 0);
 			verify(jobManager, times(1)).ask(
-					Mockito.eq(new JobManagerMessages.DisposeSavepoint(savepointPath, jobId)),
-					Mockito.any(FiniteDuration.class));
+					Mockito.eq(new DisposeSavepoint(savepointPath, Option.<List<BlobKey>>empty())),
+					any(FiniteDuration.class));
 
 			String errMsg = buffer.toString();
 			assertTrue(errMsg.contains("IllegalStateException"));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -49,7 +49,7 @@ public class JarRunHandler extends JarActionHandler {
 		try {
 			Tuple2<JobGraph, ClassLoader> graph = getJobGraphAndClassLoader(pathParams, queryParams);
 			try {
-				JobClient.uploadJarFiles(graph.f0, jobManager, timeout);
+				graph.f0.uploadUserJars(jobManager, timeout);
 			} catch (IOException e) {
 				throw new ProgramInvocationException("Failed to upload jar files to the job manager", e);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -18,6 +18,20 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.util.InstantiationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.FileNotFoundException;
@@ -27,26 +41,23 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
-import org.apache.flink.util.InstantiationUtil;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
-
-import org.apache.flink.api.common.JobID;
-
+import static org.apache.flink.runtime.blob.BlobServerProtocol.BUFFER_SIZE;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_ADDRESSABLE;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.DELETE_OPERATION;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.GET_OPERATION;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.JOB_ID_SCOPE;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.MAX_KEY_LENGTH;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.NAME_ADDRESSABLE;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.PUT_OPERATION;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_ERROR;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_OKAY;
 import static org.apache.flink.runtime.blob.BlobUtils.readFully;
 import static org.apache.flink.runtime.blob.BlobUtils.readLength;
 import static org.apache.flink.runtime.blob.BlobUtils.writeLength;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.BUFFER_SIZE;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.DELETE_OPERATION;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.GET_OPERATION;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.PUT_OPERATION;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.MAX_KEY_LENGTH;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_OKAY;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_ERROR;
 
 /**
  * The BLOB client can communicate with the BLOB server and either upload (PUT), download (GET),
@@ -653,6 +664,80 @@ public final class BlobClient implements Closeable {
 		catch (Throwable t) {
 			BlobUtils.closeSilently(socket, LOG);
 			throw new IOException("DELETE operation failed: " + t.getMessage(), t);
+		}
+	}
+
+	/**
+	 * Retrieves the {@link BlobServer} address from the JobManager and uploads
+	 * the JAR files to it.
+	 *
+	 * @param jobManager Server address of the {@link BlobServer}
+	 * @param askTimeout Ask timeout for blob server address retrieval
+	 * @param jars       List of JAR files to upload
+	 * @throws IOException Thrown if the address retrieval or upload fails
+	 */
+	public static List<BlobKey> uploadJarFiles(
+			ActorGateway jobManager,
+			FiniteDuration askTimeout,
+			List<Path> jars) throws IOException {
+
+		if (jars.isEmpty()) {
+			return Collections.emptyList();
+		} else {
+			Object msg = JobManagerMessages.getRequestBlobManagerPort();
+			Future<Object> futureBlobPort = jobManager.ask(msg, askTimeout);
+
+			try {
+				// Retrieve address
+				Object result = Await.result(futureBlobPort, askTimeout);
+				if (result instanceof Integer) {
+					int port = (Integer) result;
+
+					Option<String> jmHost = jobManager.actor().path().address().host();
+					String jmHostname = jmHost.isDefined() ? jmHost.get() : "localhost";
+					InetSocketAddress serverAddress = new InetSocketAddress(jmHostname, port);
+
+					// Now, upload
+					return uploadJarFiles(serverAddress, jars);
+				} else {
+					throw new Exception("Expected port number (int) as answer, received " + result);
+				}
+			} catch (Exception e) {
+				throw new IOException("Could not retrieve the JobManager's blob port.", e);
+			}
+		}
+	}
+
+	/**
+	 * Uploads the JAR files to a {@link BlobServer} at the given address.
+	 *
+	 * @param serverAddress Server address of the {@link BlobServer}
+	 * @param jars List of JAR files to upload
+	 * @throws IOException Thrown if the upload fails
+	 */
+	public static List<BlobKey> uploadJarFiles(InetSocketAddress serverAddress, List<Path> jars) throws IOException {
+		if (jars.isEmpty()) {
+			return Collections.emptyList();
+		} else {
+			List<BlobKey> blobKeys = new ArrayList<>();
+
+			try (BlobClient blobClient = new BlobClient(serverAddress)) {
+				for (final Path jar : jars) {
+					final FileSystem fs = jar.getFileSystem();
+					FSDataInputStream is = null;
+					try {
+						is = fs.open(jar);
+						final BlobKey key = blobClient.put(is);
+						blobKeys.add(key);
+					} finally {
+						if (is != null) {
+							is.close();
+						}
+					}
+				}
+			}
+
+			return blobKeys;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -23,10 +23,16 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
+import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.util.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -431,4 +437,5 @@ public class BlobServer extends Thread implements BlobService {
 			return new ArrayList<BlobServerConnection>(activeConnections);
 		}
 	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -23,16 +23,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
-import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.util.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
-import scala.concurrent.Await;
-import scala.concurrent.Future;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -732,7 +732,7 @@ public class CheckpointCoordinator {
 		recentPendingCheckpoints.addLast(id);
 	}
 
-	private void dropSubsumedCheckpoints(long timestamp) {
+	private void dropSubsumedCheckpoints(long timestamp) throws Exception {
 		Iterator<Map.Entry<Long, PendingCheckpoint>> entries = pendingCheckpoints.entrySet().iterator();
 		while (entries.hasNext()) {
 			PendingCheckpoint p = entries.next().getValue();
@@ -926,7 +926,7 @@ public class CheckpointCoordinator {
 	//  Periodic scheduling of checkpoints
 	// --------------------------------------------------------------------------------------------
 
-	public void startCheckpointScheduler() {
+	public void startCheckpointScheduler() throws Exception {
 		synchronized (lock) {
 			if (shutdown) {
 				throw new IllegalArgumentException("Checkpoint coordinator is shut down");
@@ -949,7 +949,7 @@ public class CheckpointCoordinator {
 		}
 	}
 
-	public void stopCheckpointScheduler() {
+	public void stopCheckpointScheduler() throws Exception {
 		synchronized (lock) {
 			triggerRequestQueued = false;
 			periodicScheduling = false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
@@ -45,7 +45,7 @@ public class CheckpointCoordinatorDeActivator extends FlinkUntypedActor {
 	}
 
 	@Override
-	public void handleMessage(Object message) {
+	public void handleMessage(Object message) throws Exception {
 		if (message instanceof ExecutionGraphMessages.JobStatusChanged) {
 			JobStatus status = ((ExecutionGraphMessages.JobStatusChanged) message).newJobStatus();
 			

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -97,12 +97,14 @@ public class CompletedCheckpoint implements Serializable {
 
 	// --------------------------------------------------------------------------------------------
 	
-	public void discard(ClassLoader userClassLoader) {
-		for (TaskState state: taskStates.values()) {
-			state.discard(userClassLoader);
+	public void discard(ClassLoader userClassLoader) throws Exception {
+		try {
+			for (TaskState state : taskStates.values()) {
+				state.discard(userClassLoader);
+			}
+		} finally {
+			taskStates.clear();
 		}
-
-		taskStates.clear();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/KeyGroupState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/KeyGroupState.java
@@ -62,12 +62,8 @@ public class KeyGroupState implements Serializable {
 		return stateSize;
 	}
 
-	public void discard(ClassLoader classLoader) {
-		try {
-			keyGroupState.deserializeValue(classLoader).discardState();
-		} catch (Exception e) {
-			LOG.warn("Failed to discard checkpoint state: " + this, e);
-		}
+	public void discard(ClassLoader classLoader) throws Exception {
+		keyGroupState.deserializeValue(classLoader).discardState();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointCoordinatorDeActivator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointCoordinatorDeActivator.java
@@ -45,7 +45,7 @@ public class SavepointCoordinatorDeActivator extends FlinkUntypedActor {
 	}
 
 	@Override
-	public void handleMessage(Object message) {
+	public void handleMessage(Object message) throws Exception {
 		if (message instanceof ExecutionGraphMessages.JobStatusChanged) {
 			JobStatus status = ((ExecutionGraphMessages.JobStatusChanged) message).newJobStatus();
 			

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointStore.java
@@ -32,15 +32,17 @@ public class SavepointStore implements StateStore<CompletedCheckpoint> {
 	public void start() {
 	}
 
-	public void stop() {
+	public void stop() throws Exception {
 		if (stateStore instanceof HeapStateStore) {
 			HeapStateStore<CompletedCheckpoint> heapStateStore = (HeapStateStore<CompletedCheckpoint>) stateStore;
 
-			for (CompletedCheckpoint savepoint : heapStateStore.getAll()) {
-				savepoint.discard(ClassLoader.getSystemClassLoader());
+			try {
+				for (CompletedCheckpoint savepoint : heapStateStore.getAll()) {
+					savepoint.discard(ClassLoader.getSystemClassLoader());
+				}
+			} finally {
+				heapStateStore.clearAll();
 			}
-
-			heapStateStore.clearAll();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -67,7 +67,7 @@ class StandaloneCompletedCheckpointStore implements CompletedCheckpointStore {
 	}
 
 	@Override
-	public void addCheckpoint(CompletedCheckpoint checkpoint) {
+	public void addCheckpoint(CompletedCheckpoint checkpoint) throws Exception {
 		checkpoints.addLast(checkpoint);
 		if (checkpoints.size() > maxNumberOfCheckpointsToRetain) {
 			checkpoints.removeFirst().discard(userClassLoader);
@@ -90,7 +90,7 @@ class StandaloneCompletedCheckpointStore implements CompletedCheckpointStore {
 	}
 
 	@Override
-	public void discardAllCheckpoints() {
+	public void discardAllCheckpoints() throws Exception {
 		for (CompletedCheckpoint checkpoint : checkpoints) {
 			checkpoint.discard(userClassLoader);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
@@ -81,12 +81,8 @@ public class SubtaskState implements Serializable {
 		return duration;
 	}
 
-	public void discard(ClassLoader userClassLoader) {
-		try {
-			state.deserializeValue(userClassLoader).discardState();
-		} catch (Exception e) {
-			LOG.warn("Failed to discard checkpoint state: " + this, e);
-		}
+	public void discard(ClassLoader userClassLoader) throws Exception {
+		state.deserializeValue(userClassLoader).discardState();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
@@ -142,7 +142,7 @@ public class TaskState implements Serializable {
 		return kvStates.size();
 	}
 
-	public void discard(ClassLoader classLoader) {
+	public void discard(ClassLoader classLoader) throws Exception {
 		for (SubtaskState subtaskState : subtaskStates.values()) {
 			subtaskState.discard(classLoader);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
@@ -352,7 +352,7 @@ public class JobClientActor extends FlinkUntypedActor implements LeaderRetrieval
 					LOG.info("Upload jar files to job manager {}.", jobManager.path());
 
 					try {
-						JobClient.uploadJarFiles(jobGraph, jobManagerGateway, timeout);
+						jobGraph.uploadUserJars(jobManagerGateway, timeout);
 					} catch (IOException exception) {
 						getSelf().tell(
 							decorateMessage(new JobManagerMessages.JobResultFailure(

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -745,57 +745,33 @@ class JobManager(
           sender() ! TriggerSavepointFailure(jobId, new IllegalArgumentException("Unknown job."))
       }
 
-    case DisposeSavepoint(savepointPath, jobId) =>
+    case DisposeSavepoint(savepointPath, blobKeys) =>
       val senderRef = sender()
       future {
-        try {
-          log.info(s"Disposing savepoint at '$savepointPath' of job $jobId.")
-
-          val userCodeLoader = try {
-            libraryCacheManager.getClassLoader(jobId)
-          } catch {
-            case e: IllegalStateException =>
-              throw new IllegalArgumentException(s"No class loader available for job $jobId. " +
-                s"Please check that the provided job ID is valid. You can also dispose " +
-                s"the savepoint with the job JAR.")
-          }
-
-          val savepoint = savepointStore.getState(savepointPath)
-          log.debug(s"$savepoint")
-
-          // Discard the associated checkpoint
-          savepoint.discard(userCodeLoader)
-
-          // Dispose the savepoint
-          savepointStore.disposeState(savepointPath)
-
-          senderRef ! DisposeSavepointSuccess
-        } catch {
-          case t: Throwable =>
-            log.error(s"Failed to dispose savepoint at '$savepointPath'.", t)
-
-            senderRef ! DisposeSavepointFailure(t)
-        }
-      }(context.dispatcher)
-
-    case DisposeSavepointWithClassLoader(savepointPath, blobKeys, classPaths) =>
-      val senderRef = sender()
-      future {
-        // We don't need the proper job ID here since we uploaded the JARs for
-        // the disposal ourselves.
-        val jobId = new JobID()
-
         try {
           log.info(s"Disposing savepoint at '$savepointPath'.")
 
-          libraryCacheManager.registerJob(jobId, blobKeys, classPaths)
-
-          val userCodeLoader = libraryCacheManager.getClassLoader(jobId)
           val savepoint = savepointStore.getState(savepointPath)
+
           log.debug(s"$savepoint")
 
-          // Discard the associated checkpoint
-          savepoint.discard(userCodeLoader)
+          if (blobKeys.isDefined) {
+            // We don't need a real ID here for the library cache manager
+            val jid = new JobID()
+
+            try {
+              libraryCacheManager.registerJob(jid, blobKeys.get, java.util.Collections.emptyList())
+              val classLoader = libraryCacheManager.getClassLoader(jid)
+
+              // Discard with user code loader
+              savepoint.discard(classLoader)
+            } finally {
+              libraryCacheManager.unregisterJob(jid)
+            }
+          } else {
+            // Discard with system class loader
+            savepoint.discard(getClass.getClassLoader)
+          }
 
           // Dispose the savepoint
           savepointStore.disposeState(savepointPath)
@@ -806,8 +782,6 @@ class JobManager(
             log.error(s"Failed to dispose savepoint at '$savepointPath'.", t)
 
             senderRef ! DisposeSavepointFailure(t)
-        } finally {
-          libraryCacheManager.unregisterJob(jobId)
         }
       }(context.dispatcher)
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.messages
 
-import java.net.URL
 import java.util.UUID
 
 import akka.actor.ActorRef
@@ -446,25 +445,17 @@ object JobManagerMessages {
   case class TriggerSavepointFailure(jobId: JobID, cause: Throwable)
 
   /**
-    * Disposes a savepoint with the class loader of a running job.
+    * Disposes a savepoint.
     *
     * @param savepointPath The path of the savepoint to dispose.
-    * @param jobId ID of the job to get the class loader from
+    * @param blobKeys BLOB keys if a user program JAR was uploaded for disposal.
+    *                 This is required when we dispose state which contains
+    *                 custom state instances (e.g. reducing state, rocksDB state).
     */
-  case class DisposeSavepoint(savepointPath: String, jobId: JobID) extends RequiresLeaderSessionID
-
-  /**
-    * Disposes a savepoint with the class loader created from the uploaded
-    * blobs and class paths.
-    *
-    * @param savepointPath The path of the savepoint to dispose.
-    * @param blobKeys List of blob keys
-    * @param classPaths List of class path URLs
-    */
-  case class DisposeSavepointWithClassLoader(
-    savepointPath: String,
-    blobKeys: java.util.List[BlobKey],
-    classPaths: java.util.List[URL])  extends RequiresLeaderSessionID
+  case class DisposeSavepoint(
+      savepointPath: String,
+      blobKeys: Option[java.util.List[BlobKey]] = None)
+    extends RequiresLeaderSessionID
 
   /** Response after a successful savepoint dispose. */
   case object DisposeSavepointSuccess

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -18,11 +18,13 @@
 
 package org.apache.flink.runtime.messages
 
+import java.net.URL
 import java.util.UUID
 
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.akka.ListeningBehaviour
+import org.apache.flink.runtime.blob.BlobKey
 import org.apache.flink.runtime.client.{JobStatusMessage, SerializedJobExecutionResult}
 import org.apache.flink.runtime.executiongraph.{ExecutionAttemptID, ExecutionGraph}
 import org.apache.flink.runtime.instance.{Instance, InstanceID}
@@ -444,11 +446,25 @@ object JobManagerMessages {
   case class TriggerSavepointFailure(jobId: JobID, cause: Throwable)
 
   /**
-    * Disposes a savepoint.
+    * Disposes a savepoint with the class loader of a running job.
     *
     * @param savepointPath The path of the savepoint to dispose.
+    * @param jobId ID of the job to get the class loader from
     */
-  case class DisposeSavepoint(savepointPath: String) extends RequiresLeaderSessionID
+  case class DisposeSavepoint(savepointPath: String, jobId: JobID) extends RequiresLeaderSessionID
+
+  /**
+    * Disposes a savepoint with the class loader created from the uploaded
+    * blobs and class paths.
+    *
+    * @param savepointPath The path of the savepoint to dispose.
+    * @param blobKeys List of blob keys
+    * @param classPaths List of class path URLs
+    */
+  case class DisposeSavepointWithClassLoader(
+    savepointPath: String,
+    blobKeys: java.util.List[BlobKey],
+    classPaths: java.util.List[URL])  extends RequiresLeaderSessionID
 
   /** Response after a successful savepoint dispose. */
   case object DisposeSavepointSuccess

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -29,9 +29,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.security.MessageDigest;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -377,6 +380,27 @@ public class BlobClientTest {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, List)} helper.
+	 */
+	@Test
+	public void testUploadJarFilesHelper() throws Exception {
+		final File testFile = File.createTempFile("testfile", ".dat");
+		testFile.deleteOnExit();
+		prepareTestFile(testFile);
+
+		InetSocketAddress serverAddress = new InetSocketAddress("localhost", BLOB_SERVER.getPort());
+
+		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(serverAddress, Collections.singletonList(new Path(testFile.toURI())));
+
+		assertEquals(1, blobKeys.size());
+
+		try (BlobClient blobClient = new BlobClient(serverAddress)) {
+			InputStream is = blobClient.get(blobKeys.get(0));
+			validateGet(is, testFile);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -242,7 +242,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 		}
 
 		@Override
-		public void discard(ClassLoader userClassLoader) {
+		public void discard(ClassLoader userClassLoader) throws Exception {
 			super.discard(userClassLoader);
 
 			if (!isDiscarded) {

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -451,6 +451,25 @@ under the License.
 							</descriptors>
 						</configuration>
 					</execution>
+					<execution>
+						<id>create-custom_kv_state-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.test.classloading.jar.CustomKvStateProgram</mainClass>
+								</manifest>
+							</archive>
+							<finalName>custom_kv_state</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-custom_kv_state-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/flink-tests/src/test/assembly/test-custom_kv_state-assembly.xml
+++ b/flink-tests/src/test/assembly/test-custom_kv_state-assembly.xml
@@ -1,0 +1,38 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!--modify/add include to match your package(s) -->
+			<includes>
+				<include>org/apache/flink/test/classloading/jar/CustomKvStateProgram.class</include>
+				<include>org/apache/flink/test/classloading/jar/CustomKvStateProgram*.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.SavepointStoreFactory;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
@@ -40,8 +41,8 @@ import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
+import org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointFailure;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointSuccess;
@@ -70,6 +71,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.Deadline;
@@ -119,10 +121,6 @@ public class SavepointITCase extends TestLogger {
 	 * <li>Cancel job, dispose the savepoint, and verify that everything
 	 * has been cleaned up</li>
 	 * </ol>
-	 *
-	 *
-	 * Savepoint is diposed via a {@link JobManagerMessages.DisposeSavepointWithClassLoader}
-	 * message.
 	 */
 	@Test
 	public void testTriggerSavepointAndResume() throws Exception {
@@ -349,10 +347,7 @@ public class SavepointITCase extends TestLogger {
 
 			LOG.info("Disposing savepoint " + savepointPath + ".");
 			Future<Object> disposeFuture = jobManager.ask(
-					new JobManagerMessages.DisposeSavepointWithClassLoader(
-							savepointPath,
-							jobGraph.getUserJarBlobKeys(),
-							jobGraph.getClasspaths()),
+					new DisposeSavepoint(savepointPath, Option.<List<BlobKey>>empty()),
 					deadline.timeLeft());
 
 			errMsg = "Failed to dispose savepoint " + savepointPath + ".";
@@ -876,166 +871,6 @@ public class SavepointITCase extends TestLogger {
 		}
 	}
 
-	/**
-	 * Tests that a savepoint of a running job is diposed properly, e.g. via
-	 * {@link JobManagerMessages.DisposeSavepoint} message.
-	 */
-	@Test
-	public void testDisposeWithRunningJob() throws Exception {
-		// Config
-		int numTaskManagers = 1;
-		int numSlotsPerTaskManager = 1;
-		int parallelism = numTaskManagers * numSlotsPerTaskManager;
-
-		// Test deadline
-		final Deadline deadline = new FiniteDuration(5, TimeUnit.MINUTES).fromNow();
-
-		// The number of checkpoints to complete before triggering the savepoint
-		final int numberOfCompletedCheckpoints = 5;
-
-		// Temporary directory for file state backend
-		final File tmpDir = CommonTestUtils.createTempDirectory();
-
-		ForkableFlinkMiniCluster flink = null;
-
-		try {
-			// Flink configuration
-			final Configuration config = new Configuration();
-			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTaskManagers);
-			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlotsPerTaskManager);
-
-			final File checkpointDir = new File(tmpDir, "checkpoints");
-			final File savepointDir = new File(tmpDir, "savepoints");
-
-			if (!checkpointDir.mkdir() || !savepointDir.mkdirs()) {
-				fail("Test setup failed: failed to create temporary directories.");
-			}
-
-			LOG.info("Created temporary checkpoint directory: " + checkpointDir + ".");
-			LOG.info("Created temporary savepoint directory: " + savepointDir + ".");
-
-			config.setString(ConfigConstants.STATE_BACKEND, "filesystem");
-			config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY,
-					checkpointDir.toURI().toString());
-			config.setString(SavepointStoreFactory.SAVEPOINT_BACKEND_KEY, "filesystem");
-			config.setString(SavepointStoreFactory.SAVEPOINT_DIRECTORY_KEY,
-					savepointDir.toURI().toString());
-
-			LOG.info("Flink configuration: " + config + ".");
-
-			// Start Flink
-			flink = new ForkableFlinkMiniCluster(config);
-			LOG.info("Starting Flink cluster.");
-			flink.start();
-
-			// Retrieve the job manager
-			LOG.info("Retrieving JobManager.");
-			ActorGateway jobManager = Await.result(flink.leaderGateway().future(), deadline.timeLeft());
-			LOG.info("JobManager: " + jobManager + ".");
-
-			// Submit the job
-			final JobGraph jobGraph = createJobGraph(parallelism, 0, 1000, 1000);
-			final JobID jobId = jobGraph.getJobID();
-
-			// Wait for the source to be notified about the expected number
-			// of completed checkpoints
-			InfiniteTestSource.CheckpointCompleteLatch = new CountDownLatch(
-					numberOfCompletedCheckpoints);
-
-			LOG.info("Submitting job " + jobGraph.getJobID() + " in detached mode.");
-
-			flink.submitJobDetached(jobGraph);
-
-			LOG.info("Waiting for " + numberOfCompletedCheckpoints +
-					" checkpoint complete notifications.");
-
-			// Wait...
-			InfiniteTestSource.CheckpointCompleteLatch.await();
-
-			LOG.info("Received all " + numberOfCompletedCheckpoints +
-					" checkpoint complete notifications.");
-
-			// ...and then trigger the savepoint
-			LOG.info("Triggering a savepoint.");
-
-			Future<Object> savepointPathFuture = jobManager.ask(
-					new TriggerSavepoint(jobId), deadline.timeLeft());
-
-			final String savepointPath = ((TriggerSavepointSuccess) Await
-					.result(savepointPathFuture, deadline.timeLeft())).savepointPath();
-			LOG.info("Retrieved savepoint path: " + savepointPath + ".");
-
-			// Retrieve the savepoint from the testing job manager
-			LOG.info("Requesting the savepoint.");
-			Future<Object> savepointFuture = jobManager.ask(
-					new RequestSavepoint(savepointPath),
-					deadline.timeLeft());
-
-			CompletedCheckpoint savepoint = ((ResponseSavepoint) Await.result(
-					savepointFuture, deadline.timeLeft())).savepoint();
-			LOG.info("Retrieved savepoint: " + savepoint + ".");
-
-			// Dispose savepoint of running job
-			LOG.info("Disposing savepoint " + savepointPath + ".");
-			Future<Object> disposeFuture = jobManager.ask(
-					new JobManagerMessages.DisposeSavepoint(
-							savepointPath,
-							jobGraph.getJobID()),
-					deadline.timeLeft());
-
-			String errMsg = "Failed to dispose savepoint " + savepointPath + ".";
-			Object resp = Await.result(disposeFuture, deadline.timeLeft());
-			assertTrue(errMsg, resp.getClass() ==
-					getDisposeSavepointSuccess().getClass());
-
-			// Shut down the Flink cluster (thereby canceling the job)
-			LOG.info("Shutting down Flink cluster.");
-			flink.shutdown();
-
-			// The checkpoint files
-			List<File> checkpointFiles = new ArrayList<>();
-
-			for (TaskState stateForTaskGroup : savepoint.getTaskStates().values()) {
-				for (SubtaskState subtaskState : stateForTaskGroup.getStates()) {
-					StreamTaskStateList taskStateList = (StreamTaskStateList) subtaskState.getState()
-							.deserializeValue(ClassLoader.getSystemClassLoader());
-
-					for (StreamTaskState taskState : taskStateList.getState(
-							ClassLoader.getSystemClassLoader())) {
-
-						AbstractFileStateHandle fsState = (AbstractFileStateHandle) taskState.getFunctionState();
-						checkpointFiles.add(new File(fsState.getFilePath().toUri()));
-					}
-				}
-			}
-
-			// The checkpoint of the savepoint should have been discarded
-			for (File f : checkpointFiles) {
-				errMsg = "Checkpoint file " + f + " not cleaned up properly.";
-				assertFalse(errMsg, f.exists());
-			}
-
-			if (checkpointFiles.size() > 0) {
-				File parent = checkpointFiles.get(0).getParentFile();
-				errMsg = "Checkpoint parent directory " + parent + " not cleaned up properly.";
-				assertFalse(errMsg, parent.exists());
-			}
-
-			// All savepoints should have been cleaned up
-			errMsg = "Savepoints directory not cleaned up properly: " +
-					Arrays.toString(savepointDir.listFiles()) + ".";
-			assertNull(errMsg, savepointDir.listFiles());
-		} finally {
-			if (flink != null) {
-				flink.shutdown();
-			}
-
-			if (tmpDir != null) {
-				FileUtils.deleteDirectory(tmpDir);
-			}
-		}
-	}
-	
 	// ------------------------------------------------------------------------
 	// Test program
 	// ------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -18,19 +18,46 @@
 
 package org.apache.flink.test.classloading;
 
-import java.io.File;
-
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.blob.BlobClient;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.checkpoint.SavepointStoreFactory;
+import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint;
+import org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepointFailure;
+import org.apache.flink.runtime.messages.JobManagerMessages.RunningJobsStatus;
+import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
+import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointSuccess;
 import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
 import org.apache.flink.test.testdata.KMeansData;
 import org.apache.flink.test.util.ForkableFlinkMiniCluster;
-import org.junit.Rule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public class ClassLoaderITCase {
@@ -47,114 +74,223 @@ public class ClassLoaderITCase {
 
 	private static final String USERCODETYPE_JAR_PATH = "usercodetype-test-jar.jar";
 
-	@Rule
-	public TemporaryFolder folder = new TemporaryFolder();
+	private static final String CUSTOM_KV_STATE_JAR_PATH = "custom_kv_state-test-jar.jar";
+
+	public static final TemporaryFolder FOLDER = new TemporaryFolder();
+
+	private static ForkableFlinkMiniCluster testCluster;
+
+	private static int parallelism;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		FOLDER.create();
+
+		Configuration config = new Configuration();
+		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
+		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 2);
+		parallelism = 4;
+
+		// we need to use the "filesystem" state backend to ensure FLINK-2543 is not happening again.
+		config.setString(ConfigConstants.STATE_BACKEND, "filesystem");
+		config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY,
+				FOLDER.newFolder().getAbsoluteFile().toURI().toString());
+
+		// Savepoint path
+		config.setString(SavepointStoreFactory.SAVEPOINT_BACKEND_KEY, "filesystem");
+		config.setString(SavepointStoreFactory.SAVEPOINT_DIRECTORY_KEY,
+				FOLDER.newFolder().getAbsoluteFile().toURI().toString());
+
+		testCluster = new ForkableFlinkMiniCluster(config, false);
+		testCluster.start();
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		if (testCluster != null) {
+			testCluster.shutdown();
+		}
+
+		FOLDER.delete();
+	}
 
 	@Test
 	public void testJobsWithCustomClassLoader() {
 		try {
-			Configuration config = new Configuration();
-			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
-			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 2);
+			int port = testCluster.getLeaderRPCPort();
 
-			// we need to use the "filesystem" state backend to ensure FLINK-2543 is not happening again.
-			config.setString(ConfigConstants.STATE_BACKEND, "filesystem");
-			config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY,
-					folder.newFolder().getAbsoluteFile().toURI().toString());
+			PackagedProgram inputSplitTestProg = new PackagedProgram(
+					new File(INPUT_SPLITS_PROG_JAR_FILE),
+					new String[] { INPUT_SPLITS_PROG_JAR_FILE,
+							"", // classpath
+							"localhost",
+							String.valueOf(port),
+							"4" // parallelism
+					});
+			inputSplitTestProg.invokeInteractiveModeForExecution();
 
-			ForkableFlinkMiniCluster testCluster = new ForkableFlinkMiniCluster(config, false);
+			PackagedProgram streamingInputSplitTestProg = new PackagedProgram(
+					new File(STREAMING_INPUT_SPLITS_PROG_JAR_FILE),
+					new String[] { STREAMING_INPUT_SPLITS_PROG_JAR_FILE,
+							"localhost",
+							String.valueOf(port),
+							"4" // parallelism
+					});
+			streamingInputSplitTestProg.invokeInteractiveModeForExecution();
 
-			testCluster.start();
+			String classpath = new File(INPUT_SPLITS_PROG_JAR_FILE).toURI().toURL().toString();
+			PackagedProgram inputSplitTestProg2 = new PackagedProgram(new File(INPUT_SPLITS_PROG_JAR_FILE),
+					new String[] { "",
+							classpath, // classpath
+							"localhost",
+							String.valueOf(port),
+							"4" // parallelism
+					});
+			inputSplitTestProg2.invokeInteractiveModeForExecution();
 
+			// regular streaming job
+			PackagedProgram streamingProg = new PackagedProgram(
+					new File(STREAMING_PROG_JAR_FILE),
+					new String[] {
+							STREAMING_PROG_JAR_FILE,
+							"localhost",
+							String.valueOf(port)
+					});
+			streamingProg.invokeInteractiveModeForExecution();
+
+			// checkpointed streaming job with custom classes for the checkpoint (FLINK-2543)
+			// the test also ensures that user specific exceptions are serializable between JobManager <--> JobClient.
 			try {
-				int port = testCluster.getLeaderRPCPort();
-
-				PackagedProgram inputSplitTestProg = new PackagedProgram(
-						new File(INPUT_SPLITS_PROG_JAR_FILE),
-						new String[] { INPUT_SPLITS_PROG_JAR_FILE,
-										"", // classpath
-										"localhost",
-										String.valueOf(port),
-										"4" // parallelism
-									});
-				inputSplitTestProg.invokeInteractiveModeForExecution();
-
-				PackagedProgram streamingInputSplitTestProg = new PackagedProgram(
-						new File(STREAMING_INPUT_SPLITS_PROG_JAR_FILE),
-						new String[] { STREAMING_INPUT_SPLITS_PROG_JAR_FILE,
-								"localhost",
-								String.valueOf(port),
-								"4" // parallelism
-						});
-				streamingInputSplitTestProg.invokeInteractiveModeForExecution();
-
-				String classpath = new File(INPUT_SPLITS_PROG_JAR_FILE).toURI().toURL().toString();
-				PackagedProgram inputSplitTestProg2 = new PackagedProgram(new File(INPUT_SPLITS_PROG_JAR_FILE),
-						new String[] { "",
-										classpath, // classpath
-										"localhost",
-										String.valueOf(port),
-										"4" // parallelism
-									} );
-				inputSplitTestProg2.invokeInteractiveModeForExecution();
-
-				// regular streaming job
-				PackagedProgram streamingProg = new PackagedProgram(
-						new File(STREAMING_PROG_JAR_FILE),
+				PackagedProgram streamingCheckpointedProg = new PackagedProgram(
+						new File(STREAMING_CHECKPOINTED_PROG_JAR_FILE),
 						new String[] {
-								STREAMING_PROG_JAR_FILE,
+								STREAMING_CHECKPOINTED_PROG_JAR_FILE,
 								"localhost",
-								String.valueOf(port)
-						});
-				streamingProg.invokeInteractiveModeForExecution();
+								String.valueOf(port) });
+				streamingCheckpointedProg.invokeInteractiveModeForExecution();
+			} catch (Exception e) {
+				// we can not access the SuccessException here when executing the tests with maven, because its not available in the jar.
+				assertEquals("Program should terminate with a 'SuccessException'",
+						"org.apache.flink.test.classloading.jar.CheckpointedStreamingProgram.SuccessException",
+						e.getCause().getCause().getClass().getCanonicalName());
+			}
 
-				// checkpointed streaming job with custom classes for the checkpoint (FLINK-2543)
-				// the test also ensures that user specific exceptions are serializable between JobManager <--> JobClient.
-				try {
-					PackagedProgram streamingCheckpointedProg = new PackagedProgram(
-							new File(STREAMING_CHECKPOINTED_PROG_JAR_FILE),
-							new String[] {
-									STREAMING_CHECKPOINTED_PROG_JAR_FILE,
-									"localhost",
-									String.valueOf(port)});
-					streamingCheckpointedProg.invokeInteractiveModeForExecution();
-				}
-				catch (Exception e) {
-					// we can not access the SuccessException here when executing the tests with maven, because its not available in the jar.
-					assertEquals("Program should terminate with a 'SuccessException'",
-							"org.apache.flink.test.classloading.jar.CheckpointedStreamingProgram.SuccessException",
-							e.getCause().getCause().getClass().getCanonicalName());
-				}
+			PackagedProgram kMeansProg = new PackagedProgram(
+					new File(KMEANS_JAR_PATH),
+					new String[] { KMEANS_JAR_PATH,
+							"localhost",
+							String.valueOf(port),
+							"4", // parallelism
+							KMeansData.DATAPOINTS,
+							KMeansData.INITIAL_CENTERS,
+							"25"
+					});
+			kMeansProg.invokeInteractiveModeForExecution();
 
-				PackagedProgram kMeansProg = new PackagedProgram(
-						new File(KMEANS_JAR_PATH),
-						new String[] { KMEANS_JAR_PATH,
-										"localhost",
-										String.valueOf(port),
-										"4", // parallelism
-										KMeansData.DATAPOINTS,
-										KMeansData.INITIAL_CENTERS,
-										"25"
-									});
-				kMeansProg.invokeInteractiveModeForExecution();
-
-				// test FLINK-3633
-				PackagedProgram userCodeTypeProg = new PackagedProgram(
+			// test FLINK-3633
+			final PackagedProgram userCodeTypeProg = new PackagedProgram(
 					new File(USERCODETYPE_JAR_PATH),
 					new String[] { USERCODETYPE_JAR_PATH,
-						"localhost",
-						String.valueOf(port),
+							"localhost",
+							String.valueOf(port),
 					});
 
-				userCodeTypeProg.invokeInteractiveModeForExecution();
-			}
-			finally {
-				testCluster.shutdown();
-			}
-		}
-		catch (Exception e) {
+			userCodeTypeProg.invokeInteractiveModeForExecution();
+		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests disposal of a savepoint, which contains custom user code KvState.
+	 */
+	@Test
+	public void testDisposeSavepointWithCustomKvState() throws Exception {
+		Deadline deadline = new FiniteDuration(100, TimeUnit.SECONDS).fromNow();
+
+		int port = testCluster.getLeaderRPCPort();
+
+		File checkpointDir = FOLDER.newFolder();
+		File outputDir = FOLDER.newFolder();
+
+		final PackagedProgram program = new PackagedProgram(
+				new File(CUSTOM_KV_STATE_JAR_PATH),
+				new String[] {
+						CUSTOM_KV_STATE_JAR_PATH,
+						"localhost",
+						String.valueOf(port),
+						String.valueOf(parallelism),
+						checkpointDir.toURI().toString(),
+						"5000",
+						outputDir.toURI().toString()
+				});
+
+		// Execute detached
+		Thread invokeThread = new Thread(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					program.invokeInteractiveModeForExecution();
+				} catch (ProgramInvocationException ignored) {
+					ignored.printStackTrace();
+				}
+			}
+		});
+
+		invokeThread.start();
+
+		// The job ID
+		JobID jobId = null;
+
+		ActorGateway jm = testCluster.getLeaderGateway(deadline.timeLeft());
+
+		// Wait for running job
+		while (jobId == null && deadline.hasTimeLeft()) {
+			Future<Object> jobsFuture = jm.ask(JobManagerMessages.getRequestRunningJobsStatus(), deadline.timeLeft());
+			RunningJobsStatus runningJobs = (RunningJobsStatus) Await.result(jobsFuture, deadline.timeLeft());
+
+			for (JobStatusMessage runningJob : runningJobs.getStatusMessages()) {
+				jobId = runningJob.getJobId();
+				break;
+			}
+
+			// Retry if job is not available yet
+			if (jobId == null) {
+				Thread.sleep(100);
+			}
+		}
+
+		Future<Object> allRunning = jm.ask(new WaitForAllVerticesToBeRunning(jobId), deadline.timeLeft());
+		Await.ready(allRunning, deadline.timeLeft());
+
+		// Trigger savepoint
+		String savepointPath = null;
+		for (int i = 0; i < 20; i++) {
+			Future<Object> savepointFuture = jm.ask(new TriggerSavepoint(jobId), deadline.timeLeft());
+			Object savepointResponse = Await.result(savepointFuture, deadline.timeLeft());
+
+			if (savepointResponse.getClass() == TriggerSavepointSuccess.class) {
+				savepointPath = ((TriggerSavepointSuccess) savepointResponse).savepointPath();
+			} else {
+				// This can fail if the operators are not opened yet
+				Thread.sleep(500);
+			}
+		}
+
+		assertNotNull(savepointPath, "Failed to trigger savepoint");
+
+		// Upload JAR
+		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jm, deadline.timeLeft(), Collections.singletonList(new Path(CUSTOM_KV_STATE_JAR_PATH)));
+
+		// Dispose savepoint
+		Future<Object> disposeFuture = jm.ask(new DisposeSavepoint(savepointPath, Option.apply(blobKeys)), deadline.timeLeft());
+		Object disposeResponse = Await.result(disposeFuture, deadline.timeLeft());
+
+		if (disposeResponse.getClass() == JobManagerMessages.getDisposeSavepointSuccess().getClass()) {
+			// Success :-)
+		} else if (disposeResponse instanceof DisposeSavepointFailure) {
+			throw new IllegalStateException("Failed to dispose savepoint");
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomKvStateProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomKvStateProgram.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.classloading.jar;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.util.Collector;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A streaming program with a custom reducing KvState.
+ *
+ * <p>This is used to test proper usage of the user code class laoder when
+ * disposing savepoints.
+ */
+public class CustomKvStateProgram {
+
+	public static void main(String[] args) throws Exception {
+		final String jarFile = args[0];
+		final String host = args[1];
+		final int port = Integer.parseInt(args[2]);
+		final int parallelism = Integer.parseInt(args[3]);
+		final String checkpointPath = args[4];
+		final int checkpointingInterval = Integer.parseInt(args[5]);
+		final String outputPath = args[6];
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment(host, port, jarFile);
+		env.setParallelism(parallelism);
+		env.getConfig().disableSysoutLogging();
+		env.enableCheckpointing(checkpointingInterval);
+		env.setStateBackend(new FsStateBackend(checkpointPath));
+
+		DataStream<Integer> source = env.addSource(new InfiniteIntegerSource());
+		source.keyBy(new KeySelector<Integer, Integer>() {
+			private static final long serialVersionUID = -9044152404048903826L;
+
+			@Override
+			public Integer getKey(Integer value) throws Exception {
+				return ThreadLocalRandom.current().nextInt(parallelism);
+			}
+		}).flatMap(new ReducingStateFlatMap()).writeAsText(outputPath);
+
+		env.execute();
+	}
+
+	private static class InfiniteIntegerSource implements ParallelSourceFunction<Integer> {
+		private static final long serialVersionUID = -7517574288730066280L;
+		private volatile boolean running = true;
+
+		@Override
+		public void run(SourceContext<Integer> ctx) throws Exception {
+			int counter = 0;
+			while (running) {
+				synchronized (ctx.getCheckpointLock()) {
+					ctx.collect(counter++);
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+
+	private static class ReducingStateFlatMap extends RichFlatMapFunction<Integer, Integer> {
+
+		private static final long serialVersionUID = -5939722892793950253L;
+		private ReducingState<Integer> kvState;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			ReducingStateDescriptor<Integer> stateDescriptor =
+					new ReducingStateDescriptor<>(
+							"reducing-state",
+							new ReduceSum(),
+							Integer.class);
+
+			this.kvState = getRuntimeContext().getReducingState(stateDescriptor);
+		}
+
+
+		@Override
+		public void flatMap(Integer value, Collector<Integer> out) throws Exception {
+			kvState.add(value);
+		}
+
+		private static class ReduceSum implements ReduceFunction<Integer> {
+			@Override
+			public Integer reduce(Integer value1, Integer value2) throws Exception {
+				return value1 + value2;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Disposing savepoints via the JobManager fails for state handles or descriptors, which contain user classes (for example custom folding state or RocksDB handles).

With this change, the user has to provide the job ID of a running job when disposing a savepoint in order to use the user code class loader of that job or provide the job JARs.

This version breaks the API as the CLI now requires either a JobID or a JAR. I think this is reasonable, because the current approach only works for a subset of the available state variants.

We can port this back for 1.0.4 and make the JobID or JAR arguments optional. What do you think?

I've tested this with a job running on RocksDB state both while the job was running and after it terminated. This was not working with the current 1.0.3 version.

Ideally, we will get rid of the whole disposal business when we make savepoints properly self-contained. I'm going to open a JIRA issue with a proposal to do so soon.