### PR TITLE
[FLINK-3714] Add Support for "Allowed Lateness"

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.windowing.assigners.MergingWindowAssigner;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.Trigger;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.operators.windowing.EvictingWindowOperator;
@@ -87,6 +88,8 @@ public class AllWindowedStream<T, W extends Window> {
 	/** The evictor that is used for evicting elements before window evaluation. */
 	private Evictor<? super T, ? super W> evictor;
 
+	/** The user-specified allowed lateness. */
+	private long allowedLateness = 0l;
 
 	@PublicEvolving
 	public AllWindowedStream(DataStream<T> input,
@@ -106,6 +109,23 @@ public class AllWindowedStream<T, W extends Window> {
 		}
 
 		this.trigger = trigger;
+		return this;
+	}
+
+	/**
+	 * Sets the allowed lateness. If the {@link WindowAssigner} used
+	 * is in processing time, then the allowed lateness is set to 0.
+	 */
+	@PublicEvolving
+	public AllWindowedStream<T, W> setAllowedLateness(Time lateness) {
+		long millis = lateness.toMilliseconds();
+		if (allowedLateness < 0) {
+			throw new IllegalArgumentException("The allowed lateness cannot be negative.");
+		} else if (allowedLateness != 0 && !windowAssigner.isEventTime()) {
+			this.allowedLateness = 0;
+		} else {
+			this.allowedLateness = millis;
+		}
 		return this;
 	}
 
@@ -251,14 +271,16 @@ public class AllWindowedStream<T, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
-			operator = new EvictingWindowOperator<>(windowAssigner,
+			operator =
+				new EvictingWindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalIterableAllWindowFunction<>(function),
 					trigger,
-					evictor);
+					evictor,
+					allowedLateness);
 
 		} else {
 			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>("window-contents",
@@ -266,13 +288,15 @@ public class AllWindowedStream<T, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
-			operator = new WindowOperator<>(windowAssigner,
+			operator =
+				new WindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalIterableAllWindowFunction<>(function),
-					trigger);
+					trigger,
+					allowedLateness);
 		}
 
 		return input.transform(opName, resultType, operator).setParallelism(1);
@@ -335,14 +359,16 @@ public class AllWindowedStream<T, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
-			operator = new EvictingWindowOperator<>(windowAssigner,
+			operator =
+				new EvictingWindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalIterableAllWindowFunction<>(new ReduceApplyAllWindowFunction<>(reduceFunction, function)),
 					trigger,
-					evictor);
+					evictor,
+					allowedLateness);
 
 		} else {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
@@ -351,13 +377,15 @@ public class AllWindowedStream<T, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
-			operator = new WindowOperator<>(windowAssigner,
+			operator =
+				new WindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalSingleValueAllWindowFunction<>(function),
-					trigger);
+					trigger,
+					allowedLateness);
 		}
 
 		return input.transform(opName, resultType, operator).setParallelism(1);
@@ -425,14 +453,16 @@ public class AllWindowedStream<T, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
-			operator = new EvictingWindowOperator<>(windowAssigner,
+			operator =
+				new EvictingWindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalIterableAllWindowFunction<>(new FoldApplyAllWindowFunction<>(initialValue, foldFunction, function)),
 					trigger,
-					evictor);
+					evictor,
+					allowedLateness);
 
 		} else {
 			FoldingStateDescriptor<T, R> stateDesc = new FoldingStateDescriptor<>("window-contents",
@@ -442,13 +472,15 @@ public class AllWindowedStream<T, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
-			operator = new WindowOperator<>(windowAssigner,
+			operator =
+				new WindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalSingleValueAllWindowFunction<>(function),
-					trigger);
+					trigger,
+					allowedLateness);
 		}
 
 		return input.transform(opName, resultType, operator).setParallelism(1);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -89,7 +89,7 @@ public class AllWindowedStream<T, W extends Window> {
 	private Evictor<? super T, ? super W> evictor;
 
 	/** The user-specified allowed lateness. */
-	private long allowedLateness = 0l;
+	private long allowedLateness = Long.MAX_VALUE;
 
 	@PublicEvolving
 	public AllWindowedStream(DataStream<T> input,
@@ -114,7 +114,7 @@ public class AllWindowedStream<T, W extends Window> {
 
 	/**
 	 * Sets the allowed lateness to a user-specified value.
-	 * If not explicitly set, the allowed lateness is 0.
+	 * If not explicitly set, the allowed lateness is {@link Long#MAX_VALUE}.
 	 * Setting the allowed lateness is only valid for event-time windows.
 	 * If a value different than 0 is provided with a processing-time
 	 * {@link WindowAssigner}, then an exception is thrown.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -113,16 +113,17 @@ public class AllWindowedStream<T, W extends Window> {
 	}
 
 	/**
-	 * Sets the allowed lateness. If the {@link WindowAssigner} used
+	 * Sets the allowed lateness. By default this is 0. If the {@link WindowAssigner} used
 	 * is in processing time, then the allowed lateness is set to 0.
 	 */
 	@PublicEvolving
-	public AllWindowedStream<T, W> setAllowedLateness(Time lateness) {
+	public AllWindowedStream<T, W> allowedLateness(Time lateness) {
 		long millis = lateness.toMilliseconds();
 		if (allowedLateness < 0) {
 			throw new IllegalArgumentException("The allowed lateness cannot be negative.");
 		} else if (allowedLateness != 0 && !windowAssigner.isEventTime()) {
-			this.allowedLateness = 0;
+			throw new IllegalArgumentException("When working in processing time, a lateness > 0 has no actual meaning. " +
+				"Please try again with lateness set to 0.");
 		} else {
 			this.allowedLateness = millis;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -113,8 +113,11 @@ public class AllWindowedStream<T, W extends Window> {
 	}
 
 	/**
-	 * Sets the allowed lateness. By default this is 0. If the {@link WindowAssigner} used
-	 * is in processing time, then the allowed lateness is set to 0.
+	 * Sets the allowed lateness to a user-specified value.
+	 * If not explicitly set, the allowed lateness is 0.
+	 * Setting the allowed lateness is only valid for event-time windows.
+	 * If a value different than 0 is provided with a processing-time
+	 * {@link WindowAssigner}, then an exception is thrown.
 	 */
 	@PublicEvolving
 	public AllWindowedStream<T, W> allowedLateness(Time lateness) {
@@ -122,8 +125,7 @@ public class AllWindowedStream<T, W extends Window> {
 		if (allowedLateness < 0) {
 			throw new IllegalArgumentException("The allowed lateness cannot be negative.");
 		} else if (allowedLateness != 0 && !windowAssigner.isEventTime()) {
-			throw new IllegalArgumentException("When working in processing time, a lateness > 0 has no actual meaning. " +
-				"Please try again with lateness set to 0.");
+			throw new IllegalArgumentException("Setting the allowed lateness is only valid for event-time windows.");
 		} else {
 			this.allowedLateness = millis;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeW
 import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeTrigger;
 import org.apache.flink.streaming.api.windowing.triggers.Trigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -98,6 +99,8 @@ public class WindowedStream<T, K, W extends Window> {
 	/** The evictor that is used for evicting elements before window evaluation. */
 	private Evictor<? super T, ? super W> evictor;
 
+	/** The user-specified allowed lateness. */
+	private long allowedLateness = 0l;
 
 	@PublicEvolving
 	public WindowedStream(KeyedStream<T, K> input,
@@ -117,6 +120,23 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		this.trigger = trigger;
+		return this;
+	}
+
+	/**
+	 * Sets the allowed lateness. If the {@link WindowAssigner} used
+	 * is in processing time, then the allowed lateness is set to 0.
+	 */
+	@PublicEvolving
+	public WindowedStream<T, K, W> setAllowedLateness(Time lateness) {
+		long millis = lateness.toMilliseconds();
+		if (allowedLateness < 0) {
+			throw new IllegalArgumentException("The allowed lateness cannot be negative.");
+		} else if (allowedLateness != 0 && !windowAssigner.isEventTime()) {
+			this.allowedLateness = 0;
+		} else {
+			this.allowedLateness = millis;
+		}
 		return this;
 	}
 
@@ -272,14 +292,16 @@ public class WindowedStream<T, K, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
-			operator = new EvictingWindowOperator<>(windowAssigner,
+			operator =
+				new EvictingWindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalIterableWindowFunction<>(function),
 					trigger,
-					evictor);
+					evictor,
+					allowedLateness);
 
 		} else {
 			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>("window-contents",
@@ -287,13 +309,15 @@ public class WindowedStream<T, K, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
-			operator = new WindowOperator<>(windowAssigner,
+			operator =
+				new WindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalIterableWindowFunction<>(function),
-					trigger);
+					trigger,
+					allowedLateness);
 		}
 
 		return input.transform(opName, resultType, operator);
@@ -356,14 +380,16 @@ public class WindowedStream<T, K, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
-			operator = new EvictingWindowOperator<>(windowAssigner,
+			operator =
+				new EvictingWindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)),
 					trigger,
-					evictor);
+					evictor,
+					allowedLateness);
 
 		} else {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
@@ -372,13 +398,15 @@ public class WindowedStream<T, K, W extends Window> {
 
 			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
-			operator = new WindowOperator<>(windowAssigner,
+			operator =
+				new WindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 					keySel,
 					input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 					stateDesc,
 					new InternalSingleValueWindowFunction<>(function),
-					trigger);
+					trigger,
+					allowedLateness);
 		}
 
 		return input.transform(opName, resultType, operator);
@@ -453,7 +481,8 @@ public class WindowedStream<T, K, W extends Window> {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function)),
 				trigger,
-				evictor);
+				evictor,
+				allowedLateness);
 
 		} else {
 			FoldingStateDescriptor<T, R> stateDesc = new FoldingStateDescriptor<>("window-contents",
@@ -469,7 +498,8 @@ public class WindowedStream<T, K, W extends Window> {
 				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(function),
-				trigger);
+				trigger,
+				allowedLateness);
 		}
 
 		return input.transform(opName, resultType, operator);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -124,16 +124,17 @@ public class WindowedStream<T, K, W extends Window> {
 	}
 
 	/**
-	 * Sets the allowed lateness. If the {@link WindowAssigner} used
+	 * Sets the allowed lateness. By default this is 0. If the {@link WindowAssigner} used
 	 * is in processing time, then the allowed lateness is set to 0.
 	 */
 	@PublicEvolving
-	public WindowedStream<T, K, W> setAllowedLateness(Time lateness) {
+	public WindowedStream<T, K, W> allowedLateness(Time lateness) {
 		long millis = lateness.toMilliseconds();
 		if (allowedLateness < 0) {
 			throw new IllegalArgumentException("The allowed lateness cannot be negative.");
 		} else if (allowedLateness != 0 && !windowAssigner.isEventTime()) {
-			this.allowedLateness = 0;
+			throw new IllegalArgumentException("When working in processing time, a lateness > 0 has no actual meaning. " +
+				"Please try again with lateness set to 0.");
 		} else {
 			this.allowedLateness = millis;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -124,8 +124,11 @@ public class WindowedStream<T, K, W extends Window> {
 	}
 
 	/**
-	 * Sets the allowed lateness. By default this is 0. If the {@link WindowAssigner} used
-	 * is in processing time, then the allowed lateness is set to 0.
+	 * Sets the allowed lateness to a user-specified value.
+	 * If not explicitly set, the allowed lateness is 0.
+	 * Setting the allowed lateness is only valid for event-time windows.
+	 * If a value different than 0 is provided with a processing-time
+	 * {@link WindowAssigner}, then an exception is thrown.
 	 */
 	@PublicEvolving
 	public WindowedStream<T, K, W> allowedLateness(Time lateness) {
@@ -133,8 +136,7 @@ public class WindowedStream<T, K, W extends Window> {
 		if (allowedLateness < 0) {
 			throw new IllegalArgumentException("The allowed lateness cannot be negative.");
 		} else if (allowedLateness != 0 && !windowAssigner.isEventTime()) {
-			throw new IllegalArgumentException("When working in processing time, a lateness > 0 has no actual meaning. " +
-				"Please try again with lateness set to 0.");
+			throw new IllegalArgumentException("Setting the allowed lateness is only valid for event-time windows.");
 		} else {
 			this.allowedLateness = millis;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -100,7 +100,7 @@ public class WindowedStream<T, K, W extends Window> {
 	private Evictor<? super T, ? super W> evictor;
 
 	/** The user-specified allowed lateness. */
-	private long allowedLateness = 0l;
+	private long allowedLateness = Long.MAX_VALUE;
 
 	@PublicEvolving
 	public WindowedStream(KeyedStream<T, K> input,
@@ -125,7 +125,7 @@ public class WindowedStream<T, K, W extends Window> {
 
 	/**
 	 * Sets the allowed lateness to a user-specified value.
-	 * If not explicitly set, the allowed lateness is 0.
+	 * If not explicitly set, the allowed lateness is {@link Long#MAX_VALUE}.
 	 * Setting the allowed lateness is only valid for event-time windows.
 	 * If a value different than 0 is provided with a processing-time
 	 * {@link WindowAssigner}, then an exception is thrown.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/EventTimeSessionWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/EventTimeSessionWindows.java
@@ -81,6 +81,11 @@ public class EventTimeSessionWindows extends MergingWindowAssigner<Object, TimeW
 		return new TimeWindow.Serializer();
 	}
 
+	@Override
+	public boolean isEventTime() {
+		return true;
+	}
+
 	/**
 	 * Merge overlapping {@link TimeWindow}s.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
@@ -102,4 +102,9 @@ public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
 	public TypeSerializer<GlobalWindow> getWindowSerializer(ExecutionConfig executionConfig) {
 		return new GlobalWindow.Serializer();
 	}
+
+	@Override
+	public boolean isEventTime() {
+		return false;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/ProcessingTimeSessionWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/ProcessingTimeSessionWindows.java
@@ -81,6 +81,11 @@ public class ProcessingTimeSessionWindows extends MergingWindowAssigner<Object, 
 		return new TimeWindow.Serializer();
 	}
 
+	@Override
+	public boolean isEventTime() {
+		return false;
+	}
+
 	/**
 	 * Merge overlapping {@link TimeWindow}s.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
@@ -109,4 +109,9 @@ public class SlidingEventTimeWindows extends WindowAssigner<Object, TimeWindow> 
 	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
 		return new TimeWindow.Serializer();
 	}
+
+	@Override
+	public boolean isEventTime() {
+		return true;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingProcessingTimeWindows.java
@@ -101,4 +101,9 @@ public class SlidingProcessingTimeWindows extends WindowAssigner<Object, TimeWin
 	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
 		return new TimeWindow.Serializer();
 	}
+
+	@Override
+	public boolean isEventTime() {
+		return false;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
@@ -95,4 +95,9 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
 		return new TimeWindow.Serializer();
 	}
+
+	@Override
+	public boolean isEventTime() {
+		return true;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -86,4 +86,9 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
 		return new TimeWindow.Serializer();
 	}
+
+	@Override
+	public boolean isEventTime() {
+		return false;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
@@ -63,4 +63,10 @@ public abstract class WindowAssigner<T, W extends Window> implements Serializabl
 	 * this {@code WindowAssigner}.
 	 */
 	public abstract TypeSerializer<W> getWindowSerializer(ExecutionConfig executionConfig);
+
+	/**
+	 * Returns {@code true} if elements are assigned to windows based on event time,
+	 * {@code false} otherwise.
+	 */
+	public abstract boolean isEventTime();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
- * An {@link Evictor} that keeps only a certain amount of elements.
+ * An {@link Evictor} that keeps up to a certain amount of elements.
  *
  * @param <W> The type of {@link Window Windows} on which this {@code Evictor} can operate.
  */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
@@ -37,7 +37,7 @@ public class EventTimeTrigger extends Trigger<Object, TimeWindow> {
 	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) throws Exception {
 		ctx.registerEventTimeTimer(window.maxTimestamp());
 
-		return (timestamp < ctx.getCurrentWatermark()) ?
+		return (window.maxTimestamp() <= ctx.getCurrentWatermark()) ?
 			TriggerResult.FIRE_AND_PURGE :
 			TriggerResult.CONTINUE;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
@@ -36,12 +36,17 @@ public class EventTimeTrigger extends Trigger<Object, TimeWindow> {
 	@Override
 	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) throws Exception {
 		ctx.registerEventTimeTimer(window.maxTimestamp());
-		return TriggerResult.CONTINUE;
+
+		return (timestamp < ctx.getCurrentWatermark()) ?
+			TriggerResult.FIRE_AND_PURGE :
+			TriggerResult.CONTINUE;
 	}
 
 	@Override
 	public TriggerResult onEventTime(long time, TimeWindow window, TriggerContext ctx) {
-		return TriggerResult.FIRE_AND_PURGE;
+		return time == window.maxTimestamp() ?
+			TriggerResult.FIRE_AND_PURGE :
+			TriggerResult.CONTINUE;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -133,9 +133,11 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 	/**
 	 * The allowed lateness for elements. This is used for:
-	 * <ul> Deciding if an element should be dropped from a window due to lateness.</ul>
-	 * <ul> Clearing the state of a window if the system time passes
-	 * the {@code window.maxTimestamp + allowedLateness} landmark.</ul>
+	 * <ul>
+	 *     <li>Deciding if an element should be dropped from a window due to lateness.
+	 *     <li>Clearing the state of a window if the system time passes the
+	 *         {@code window.maxTimestamp + allowedLateness} landmark.
+	 * </ul>
 	 */
 	protected final long allowedLateness;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -133,9 +133,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 	/**
 	 * The allowed lateness for elements. This is used for:
-	 * <li> Deciding if an element should be dropped from a window due to lateness. </li>
-	 * <li> Clearing the state of a window if the system time passes
-	 * the {@code window.maxTimestamp + allowedLateness} landmark. </li>
+	 * <ul> Deciding if an element should be dropped from a window due to lateness.</ul>
+	 * <ul> Clearing the state of a window if the system time passes
+	 * the {@code window.maxTimestamp + allowedLateness} landmark.</ul>
 	 */
 	protected final long allowedLateness;
 
@@ -518,7 +518,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	}
 
 	/**
-	 * This method decides if a window is currently active, or not, based on the current
+	 * Decides if a window is currently late or not, based on the current
 	 * watermark, i.e. the current event time, and the allowed lateness.
 	 * @param window
 	 * 					The collection of windows returned by the {@link WindowAssigner}.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
@@ -252,17 +252,14 @@ public class EvictingWindowOperatorTest {
 		testHarness.processWatermark(new Watermark(3999));											 // now is the evictor
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+		expectedOutput.add(new Watermark(1999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 4), 3999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), 3999));
+		expectedOutput.add(new Watermark(3999));
 
-		Assert.assertEquals(expectedOutput.size() + 2, testHarness.getOutput().size());
-		for (Object r: testHarness.getOutput()) {
-			if (r instanceof StreamRecord) {
-				StreamRecord<Tuple2<String, Integer>> res = (StreamRecord<Tuple2<String, Integer>>) r;
-				Assert.assertTrue(expectedOutput.contains(res));
-			}
-		}
 
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(),
+			new EvictingWindowOperatorTest.ResultSortComparator());
 		testHarness.close();
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
@@ -30,9 +30,13 @@ import org.apache.flink.streaming.api.functions.windowing.ReduceIterableWindowFu
 import org.apache.flink.streaming.api.functions.windowing.RichWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.evictors.CountEvictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.CountTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalIterableWindowFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -45,6 +49,7 @@ import org.junit.Test;
 
 import java.util.Comparator;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class EvictingWindowOperatorTest {
@@ -73,7 +78,8 @@ public class EvictingWindowOperatorTest {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new ReduceIterableWindowFunction<String, GlobalWindow, Tuple2<String, Integer>>(new SumReducer())),
 				CountTrigger.of(WINDOW_SLIDE),
-				CountEvictor.of(WINDOW_SIZE));
+				CountEvictor.of(WINDOW_SIZE),
+				0);
 
 		operator.setInputType(inputType, new ExecutionConfig());
 
@@ -144,7 +150,8 @@ public class EvictingWindowOperatorTest {
 			stateDesc,
 			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
 			CountTrigger.of(WINDOW_SLIDE),
-			CountEvictor.of(WINDOW_SIZE));
+			CountEvictor.of(WINDOW_SIZE),
+			0);
 
 		operator.setInputType(inputType, new ExecutionConfig());
 
@@ -194,7 +201,74 @@ public class EvictingWindowOperatorTest {
 		Assert.assertEquals("Close was not called.", 1, closeCalled.get());
 	}
 
-	// ------------------------------------------------------------------------
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testTumblingWindowWithApply() throws Exception {
+		AtomicInteger closeCalled = new AtomicInteger(0);
+
+		final int WINDOW_SIZE = 4;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		ListStateDescriptor<StreamRecord<Tuple2<String, Integer>>> stateDesc = new ListStateDescriptor<>("window-contents",
+			new StreamRecordSerializer<>(inputType.createSerializer(new ExecutionConfig())));
+
+		EvictingWindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, TimeWindow> operator = new EvictingWindowOperator<>(
+			TumblingEventTimeWindows.of(Time.of(WINDOW_SIZE, TimeUnit.SECONDS)),
+			new TimeWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>(closeCalled)),
+			EventTimeTrigger.create(),
+			CountEvictor.of(WINDOW_SIZE),
+			0);
+
+		operator.setInputType(inputType, new ExecutionConfig());
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+			new OneInputStreamOperatorTestHarness<>(operator);
+
+		testHarness.configureForKeyedStream(new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+		long initialTime = 0L;
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 10));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 100));
+
+		testHarness.processWatermark(new Watermark(1999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 1997)); // late so fire and purge -> 3
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 1998)); // late so fire and purge -> 1
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 2310)); // not late
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 2310));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 2310));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 2310));
+
+		testHarness.processWatermark(new Watermark(3999));											 // now is the evictor
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), 3999));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 1), 3999));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), 3999));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), 3999));
+
+		Assert.assertEquals(expectedOutput.size() + 2, testHarness.getOutput().size());
+		for (Object r: testHarness.getOutput()) {
+			if (r instanceof StreamRecord) {
+				StreamRecord<Tuple2<String, Integer>> res = (StreamRecord<Tuple2<String, Integer>>) r;
+				Assert.assertTrue(expectedOutput.contains(res));
+			}
+		}
+
+		testHarness.close();
+	}
+
+		// ------------------------------------------------------------------------
 	//  UDFs
 	// ------------------------------------------------------------------------
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
@@ -240,10 +240,10 @@ public class EvictingWindowOperatorTest {
 
 		testHarness.processWatermark(new Watermark(1999));
 
-		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 1997)); // late so fire and purge -> 3
-		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 1998)); // late so fire and purge -> 1
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 1997));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 1998));
 
-		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 2310)); // not late
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 2310)); // not late but more than 4
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 2310));
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 2310));
@@ -252,9 +252,7 @@ public class EvictingWindowOperatorTest {
 		testHarness.processWatermark(new Watermark(3999));											 // now is the evictor
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
-		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 3), 3999));
-		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 1), 3999));
-		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), 3999));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 4), 3999));
 		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), 3999));
 
 		Assert.assertEquals(expectedOutput.size() + 2, testHarness.getOutput().size());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -1117,27 +1117,21 @@ public class WindowOperatorTest {
 		// create the expected output
 		Tuple2<String, Integer> el1 = new Tuple2<>("key2", 1);
 		Tuple2<String, Integer> el2 = new Tuple2<>("key2", 2);
-		Tuple2<String, Integer> el3 = new Tuple2<>("key2", 3);
+		Tuple2<String, Integer> el4 = new Tuple2<>("key2", 4);
+		Tuple2<String, Integer> el5 = new Tuple2<>("key2", 5);
 
-		Tuple2<String, Integer> el4 = new Tuple2<>("key1", 2);
+		Tuple2<String, Integer> el6 = new Tuple2<>("key1", 2);
 
 		List<StreamRecord<Tuple2<String, Integer>>> expected = new ArrayList<>();
 		expected.add(new StreamRecord<>(el1, initialTime + 1999));
 		expected.add(new StreamRecord<>(el2, initialTime + 2999));
-
-		expected.add(new StreamRecord<>(el3, initialTime + 3999));
-		expected.add(new StreamRecord<>(el1, initialTime + 3999)); // now it is 1 because before it purged
-		expected.add(new StreamRecord<>(el1, initialTime + 3999)); // now it is 1 because before it purged
-		expected.add(new StreamRecord<>(el4, initialTime + 3999));
-
-		expected.add(new StreamRecord<>(el2, initialTime + 4999)); // here is the 2000 and 2400 (which is late and has fire and purge)
-		expected.add(new StreamRecord<>(el1, initialTime + 4999)); // here is the second 2400 (alone because before it was a purge)
-		expected.add(new StreamRecord<>(el1, initialTime + 4999)); // here is the 3900
+		expected.add(new StreamRecord<>(el5, initialTime + 3999));
 		expected.add(new StreamRecord<>(el4, initialTime + 4999));
-
 		expected.add(new StreamRecord<>(el1, initialTime + 5999));
-		expected.add(new StreamRecord<>(el4, initialTime + 5999));
 
+		expected.add(new StreamRecord<>(el6, initialTime + 3999));
+		expected.add(new StreamRecord<>(el6, initialTime + 4999));
+		expected.add(new StreamRecord<>(el6, initialTime + 5999));
 
 		// the +4 is for the watermarks.
 		Assert.assertEquals(expected.size() + 4, testHarness.getOutput().size());
@@ -1154,16 +1148,14 @@ public class WindowOperatorTest {
 		ConcurrentLinkedQueue<Object> actualOutput = testDropDueToLatenessSession(0, EventTimeTrigger.create());
 
 		// create the expected output
-		Tuple3<String, Long, Long> el1 = new Tuple3<>("key2-3", 1000l, 7500l);
-		Tuple3<String, Long, Long> el2 = new Tuple3<>("key2-2", 7000l, 11500l);
-		Tuple3<String, Long, Long> el3 = new Tuple3<>("key2-1", 11600l, 14600l);
-		Tuple3<String, Long, Long> el4 = new Tuple3<>("key2-1", 14500l, 17500l);
+		Tuple3<String, Long, Long> el1 = new Tuple3<>("key2-5", 1000l, 11500l);
+		Tuple3<String, Long, Long> el2 = new Tuple3<>("key2-1", 11600l, 14600l);
+		Tuple3<String, Long, Long> el3 = new Tuple3<>("key2-1", 14500l, 17500l);
 
 		List<StreamRecord<Tuple3<String, Long, Long>>> expected = new ArrayList<>();
-		expected.add(new StreamRecord<>(el1, 7499));
-		expected.add(new StreamRecord<>(el2, 11499));
-		expected.add(new StreamRecord<>(el3, 14599));
-		expected.add(new StreamRecord<>(el4, 17499));
+		expected.add(new StreamRecord<>(el1, 11499));
+		expected.add(new StreamRecord<>(el2, 14599));
+		expected.add(new StreamRecord<>(el3, 17499));
 
 		// the +7 is for the watermarks.
 		Assert.assertEquals(expected.size() + 7, actualOutput.size());
@@ -1210,16 +1202,14 @@ public class WindowOperatorTest {
 		ConcurrentLinkedQueue<Object> actualOutput = testDropDueToLatenessSession(10, EventTimeTrigger.create());
 
 		// create the expected output
-		Tuple3<String, Long, Long> el1 = new Tuple3<>("key2-3", 1000l, 7500l);
-		Tuple3<String, Long, Long> el2 = new Tuple3<>("key2-2", 7000l, 11500l);
-		Tuple3<String, Long, Long> el3 = new Tuple3<>("key2-1", 11600l, 14600l);
-		Tuple3<String, Long, Long> el4 = new Tuple3<>("key2-1", 14500l, 17500l);
+		Tuple3<String, Long, Long> el1 = new Tuple3<>("key2-5", 1000l, 11500l);
+		Tuple3<String, Long, Long> el2 = new Tuple3<>("key2-1", 11600l, 14600l);
+		Tuple3<String, Long, Long> el3 = new Tuple3<>("key2-1", 14500l, 17500l);
 
 		List<StreamRecord<Tuple3<String, Long, Long>>> expected = new ArrayList<>();
-		expected.add(new StreamRecord<>(el1, 7499));
-		expected.add(new StreamRecord<>(el2, 11499));
-		expected.add(new StreamRecord<>(el3, 14599));
-		expected.add(new StreamRecord<>(el4, 17499));
+		expected.add(new StreamRecord<>(el1, 11499));
+		expected.add(new StreamRecord<>(el2, 14599));
+		expected.add(new StreamRecord<>(el3, 17499));
 
 		// the +7 is for the watermarks.
 		Assert.assertEquals(expected.size() + 7, actualOutput.size());
@@ -1262,18 +1252,16 @@ public class WindowOperatorTest {
 		ConcurrentLinkedQueue<Object> actualOutput = testDropDueToLatenessSession(10000, EventTimeTrigger.create());
 
 		// create the expected output
-		Tuple3<String, Long, Long> el1 = new Tuple3<>("key2-3", 1000l, 7500l);
-		Tuple3<String, Long, Long> el2 = new Tuple3<>("key2-2", 7000l, 11500l);
-		Tuple3<String, Long, Long> el3 = new Tuple3<>("key2-1", 11600l, 14600l);
-		Tuple3<String, Long, Long> el4 = new Tuple3<>("key2-1", 10000l, 13000l);
-		Tuple3<String, Long, Long> el5 = new Tuple3<>("key2-1", 14500l, 17500l);
+		Tuple3<String, Long, Long> el1 = new Tuple3<>("key2-5", 1000l, 11500l);
+		Tuple3<String, Long, Long> el2 = new Tuple3<>("key2-1", 11600l, 14600l);
+		Tuple3<String, Long, Long> el3 = new Tuple3<>("key2-1", 10000l, 13000l);
+		Tuple3<String, Long, Long> el4 = new Tuple3<>("key2-1", 14500l, 17500l);
 
 		List<StreamRecord<Tuple3<String, Long, Long>>> expected = new ArrayList<>();
-		expected.add(new StreamRecord<>(el1, 7499));
-		expected.add(new StreamRecord<>(el2, 11499));
-		expected.add(new StreamRecord<>(el3, 14599));
-		expected.add(new StreamRecord<>(el4, 12999));
-		expected.add(new StreamRecord<>(el5, 17499));
+		expected.add(new StreamRecord<>(el1, 11499));
+		expected.add(new StreamRecord<>(el2, 14599));
+		expected.add(new StreamRecord<>(el3, 12999));
+		expected.add(new StreamRecord<>(el4, 17499));
 
 		// the +6 is for the watermarks.
 		Assert.assertEquals(expected.size() + 7, actualOutput.size());

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.functions.aggregation.{ComparableAggregato
 import org.apache.flink.streaming.api.scala.function.AllWindowFunction
 import org.apache.flink.streaming.api.scala.function.util.{ScalaAllWindowFunction, ScalaAllWindowFunctionWrapper, ScalaReduceFunction, ScalaFoldFunction}
 import org.apache.flink.streaming.api.windowing.evictors.Evictor
+import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.Window
 import org.apache.flink.util.Collector
@@ -54,7 +55,18 @@ import org.apache.flink.util.Collector
  */
 @Public
 class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
-  
+
+  /**
+    * Sets the allowed lateness. If the
+    * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner windowAssigner]]
+    * used is in processing time, then the allowed lateness is set to 0.
+    */
+  @PublicEvolving
+  def setAllowedLateness(lateness: Time): AllWindowedStream[T, W] = {
+    javaStream.setAllowedLateness(lateness)
+    this
+  }
+
   /**
    * Sets the [[Trigger]] that should be used to trigger window emission.
    */

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -57,13 +57,13 @@ import org.apache.flink.util.Collector
 class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
 
   /**
-    * Sets the allowed lateness. If the
+    * Sets the allowed lateness. By default this is 0. If the
     * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner windowAssigner]]
     * used is in processing time, then the allowed lateness is set to 0.
     */
   @PublicEvolving
-  def setAllowedLateness(lateness: Time): AllWindowedStream[T, W] = {
-    javaStream.setAllowedLateness(lateness)
+  def allowedLateness(lateness: Time): AllWindowedStream[T, W] = {
+    javaStream.allowedLateness(lateness)
     this
   }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -58,7 +58,7 @@ class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
 
   /**
     * Sets the allowed lateness to a user-specified value.
-    * If not explicitly set, the allowed lateness is 0.
+    * If not explicitly set, the allowed lateness is [[Long.MaxValue]].
     * Setting the allowed lateness is only valid for event-time windows.
     * If a value different than 0 is provided with a processing-time
     * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]],

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -57,9 +57,12 @@ import org.apache.flink.util.Collector
 class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
 
   /**
-    * Sets the allowed lateness. By default this is 0. If the
-    * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner windowAssigner]]
-    * used is in processing time, then the allowed lateness is set to 0.
+    * Sets the allowed lateness to a user-specified value.
+    * If not explicitly set, the allowed lateness is 0.
+    * Setting the allowed lateness is only valid for event-time windows.
+    * If a value different than 0 is provided with a processing-time
+    * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]],
+    * then an exception is thrown.
     */
   @PublicEvolving
   def allowedLateness(lateness: Time): AllWindowedStream[T, W] = {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.functions.aggregation.{ComparableAggregato
 import org.apache.flink.streaming.api.scala.function.WindowFunction
 import org.apache.flink.streaming.api.scala.function.util.{ScalaFoldFunction, ScalaReduceFunction, ScalaWindowFunction, ScalaWindowFunctionWrapper}
 import org.apache.flink.streaming.api.windowing.evictors.Evictor
+import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.Window
 import org.apache.flink.util.Collector
@@ -57,6 +58,17 @@ import org.apache.flink.util.Collector
  */
 @Public
 class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
+
+  /**
+    * Sets the allowed lateness. If the
+    * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner windowAssigner]]
+    * used is in processing time, then the allowed lateness is set to 0.
+    */
+  @PublicEvolving
+  def setAllowedLateness(lateness: Time): WindowedStream[T, K, W] = {
+    javaStream.setAllowedLateness(lateness)
+    this
+  }
 
   /**
    * Sets the [[Trigger]] that should be used to trigger window emission.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -60,9 +60,12 @@ import org.apache.flink.util.Collector
 class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
 
   /**
-    * Sets the allowed lateness. By default this is 0. If the
-    * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner windowAssigner]]
-    * used is in processing time, then the allowed lateness is set to 0.
+    * Sets the allowed lateness to a user-specified value.
+    * If not explicitly set, the allowed lateness is 0.
+    * Setting the allowed lateness is only valid for event-time windows.
+    * If a value different than 0 is provided with a processing-time
+    * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]],
+    * then an exception is thrown.
     */
   @PublicEvolving
   def allowedLateness(lateness: Time): WindowedStream[T, K, W] = {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -60,13 +60,13 @@ import org.apache.flink.util.Collector
 class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
 
   /**
-    * Sets the allowed lateness. If the
+    * Sets the allowed lateness. By default this is 0. If the
     * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner windowAssigner]]
     * used is in processing time, then the allowed lateness is set to 0.
     */
   @PublicEvolving
-  def setAllowedLateness(lateness: Time): WindowedStream[T, K, W] = {
-    javaStream.setAllowedLateness(lateness)
+  def allowedLateness(lateness: Time): WindowedStream[T, K, W] = {
+    javaStream.allowedLateness(lateness)
     this
   }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -61,7 +61,7 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
 
   /**
     * Sets the allowed lateness to a user-specified value.
-    * If not explicitly set, the allowed lateness is 0.
+    * If not explicitly set, the allowed lateness is [[Long.MaxValue]].
     * Setting the allowed lateness is only valid for event-time windows.
     * If a value different than 0 is provided with a processing-time
     * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]],


### PR DESCRIPTION
Allows the user to specify an "allowed lateness" for  elements, before they are dropped as late arrivals.
In addition, it defines a "clean up" time for the window state, which is the end of the window plus the 
aforementioned allowed lateness. When the watermark or the processing time (depending on the widow
assigner) passes this mark, then the window state is purged/cleaned.

The design of this PR was initially discussed also with @aljoscha 