### PR TITLE
[FLINK-4030] Revert Surefire version to 2.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -968,7 +968,8 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<!-- Do NOT use a version >=2.19.X, as test cases may get stuck before execution. See SUREFIRE-1255 -->
+				<version>2.18.1</version>
 				<configuration>
 					<forkCount>${flink.forkCount}</forkCount>
 					<reuseForks>${flink.reuseForks}</reuseForks>


### PR DESCRIPTION
The ScalaShellITCase sometimes gets stuck before test execution with no output
in the logs. We ran about a hundred builds against Surefire 2.18.1 which
confirmed that the failures don't occur with this version.

Waiting for an upstream fix until this can be reverted.