### PR TITLE
[FLINK-4074] Make metric reporters less blocking

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
@@ -170,8 +170,12 @@ public class MetricRegistry {
 	 * @param group       the group that contains the metric
 	 */
 	public void register(Metric metric, String metricName, AbstractMetricGroup group) {
-		if (reporter != null) {
-			reporter.notifyOfAddedMetric(metric, metricName, group);
+		try {
+			if (reporter != null) {
+				reporter.notifyOfAddedMetric(metric, metricName, group);
+			}
+		} catch (Exception e) {
+			LOG.error("Error while registering metric.", e);
 		}
 	}
 
@@ -183,8 +187,12 @@ public class MetricRegistry {
 	 * @param group       the group that contains the metric
 	 */
 	public void unregister(Metric metric, String metricName, AbstractMetricGroup group) {
-		if (reporter != null) {
-			reporter.notifyOfRemovedMetric(metric, metricName, group);
+		try {
+			if (reporter != null) {
+				reporter.notifyOfRemovedMetric(metric, metricName, group);
+			}
+		} catch (Exception e) {
+			LOG.error("Error while registering metric.", e);
 		}
 	}
 

--- a/flink-metric-reporters/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
+++ b/flink-metric-reporters/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
@@ -53,7 +53,7 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 //	public static final String ARG_CONVERSION_RATE = "rateConversion";
 //	public static final String ARG_CONVERSION_DURATION = "durationConversion";
 
-	private boolean cancel = false;
+	private boolean closed = false;
 
 	private DatagramSocket socket;
 	private InetSocketAddress address;
@@ -83,7 +83,7 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 
 	@Override
 	public void close() {
-		cancel = true;
+		closed = true;
 		if (socket != null && !socket.isClosed()) {
 			socket.close();
 		}
@@ -98,14 +98,14 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 		// operator creation and shutdown
 		try {
 			for (Map.Entry<Gauge<?>, String> entry : gauges.entrySet()) {
-				if (cancel) {
+				if (closed) {
 					return;
 				}
 				reportGauge(entry.getValue(), entry.getKey());
 			}
 
 			for (Map.Entry<Counter, String> entry : counters.entrySet()) {
-				if (cancel) {
+				if (closed) {
 					return;
 				}
 				reportCounter(entry.getValue(), entry.getKey());

--- a/flink-metric-reporters/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
+++ b/flink-metric-reporters/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
@@ -53,6 +53,8 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 //	public static final String ARG_CONVERSION_RATE = "rateConversion";
 //	public static final String ARG_CONVERSION_DURATION = "durationConversion";
 
+	private boolean cancel = false;
+
 	private DatagramSocket socket;
 	private InetSocketAddress address;
 
@@ -81,6 +83,7 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 
 	@Override
 	public void close() {
+		cancel = true;
 		if (socket != null && !socket.isClosed()) {
 			socket.close();
 		}
@@ -95,10 +98,16 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 		// operator creation and shutdown
 		try {
 			for (Map.Entry<Gauge<?>, String> entry : gauges.entrySet()) {
+				if (cancel) {
+					return;
+				}
 				reportGauge(entry.getValue(), entry.getKey());
 			}
 
 			for (Map.Entry<Counter, String> entry : counters.entrySet()) {
+				if (cancel) {
+					return;
+				}
 				reportCounter(entry.getValue(), entry.getKey());
 			}
 		}


### PR DESCRIPTION
- adds a cancel flag to the StatsDReporter, which is checked before sending every metric. set to true when stop() is called.
- switched from Timer to ScheduledExecutorService, in the hopes of better forced termination.
- also contains a hotfix preventing exceptions occurring in (un)register to be propagated