### PR TITLE
[FLINK-4027] Flush FlinkKafkaProducer on checkpoints

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/OneShotLatch.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/OneShotLatch.java
@@ -53,10 +53,4 @@ public final class OneShotLatch {
 			}
 		}
 	}
-
-	public boolean hasTriggered() {
-		synchronized (lock) {
-			return triggered;
-		}
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/OneShotLatch.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/OneShotLatch.java
@@ -53,4 +53,10 @@ public final class OneShotLatch {
 			}
 		}
 	}
+
+	public boolean hasTriggered() {
+		synchronized (lock) {
+			return triggered;
+		}
+	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer08.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer08.java
@@ -125,4 +125,17 @@ public class FlinkKafkaProducer08<IN> extends FlinkKafkaProducerBase<IN>  {
 		super(topicId, serializationSchema, producerConfig, customPartitioner);
 	}
 
+	@Override
+	protected void flush() {
+		// The Kafka 0.8 producer doesn't support flushing, therefore, we are using an inefficient
+		// busy wait approach
+		while(pendingRecords > 0) {
+			try {
+				Thread.sleep(10);
+			} catch (InterruptedException e) {
+				throw new RuntimeException("Unable to flush producer, task was interrupted");
+			}
+		}
+	}
+
 }

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -97,7 +97,9 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	@Override
 	public <T> FlinkKafkaProducerBase<T> getProducer(String topic, KeyedSerializationSchema<T> serSchema, Properties props, KafkaPartitioner<T> partitioner) {
-		return new FlinkKafkaProducer08<T>(topic, serSchema, props, partitioner);
+		FlinkKafkaProducer08<T> prod = new FlinkKafkaProducer08<T>(topic, serSchema, props, partitioner);
+		prod.setFlushOnCheckpoint(true);
+		return prod;
 	}
 
 	@Override

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer09.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer09.java
@@ -127,4 +127,11 @@ public class FlinkKafkaProducer09<IN> extends FlinkKafkaProducerBase<IN> {
 	public FlinkKafkaProducer09(String topicId, KeyedSerializationSchema<IN> serializationSchema, Properties producerConfig, KafkaPartitioner<IN> customPartitioner) {
 		super(topicId, serializationSchema, producerConfig, customPartitioner);
 	}
+
+	@Override
+	protected void flush() {
+		if(this.producer != null) {
+			producer.flush();
+		}
+	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer09.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer09.java
@@ -130,7 +130,7 @@ public class FlinkKafkaProducer09<IN> extends FlinkKafkaProducerBase<IN> {
 
 	@Override
 	protected void flush() {
-		if(this.producer != null) {
+		if (this.producer != null) {
 			producer.flush();
 		}
 	}

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -92,7 +92,9 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	@Override
 	public <T> FlinkKafkaProducerBase<T> getProducer(String topic, KeyedSerializationSchema<T> serSchema, Properties props, KafkaPartitioner<T> partitioner) {
-		return new FlinkKafkaProducer09<>(topic, serSchema, props, partitioner);
+		FlinkKafkaProducer09<T> prod = new FlinkKafkaProducer09<>(topic, serSchema, props, partitioner);
+		prod.setFlushOnCheckpoint(true);
+		return prod;
 	}
 
 	@Override

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/AtLeastOnceProducerTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/AtLeastOnceProducerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.kafka.testutils.MockRuntimeContext;
+import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
+import org.apache.flink.streaming.util.serialization.KeyedSerializationSchemaWrapper;
+import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Test ensuring that the producer is not dropping buffered records
+ */
+@SuppressWarnings("unchecked")
+public class AtLeastOnceProducerTest {
+
+	@Test
+	public void testAtLeastOnceProducer() throws Exception {
+		runTest(true);
+	}
+
+	// This test ensures that the actual test fails if the flushing is disabled
+	@Test(expected = AssertionError.class)
+	public void ensureTestFails() throws Exception {
+		runTest(false);
+	}
+
+	private void runTest(boolean flushOnCheckpoint) throws Exception {
+		Properties props = new Properties();
+		final TestingKafkaProducer<String> producer = new TestingKafkaProducer<>("someTopic", new KeyedSerializationSchemaWrapper<>(new SimpleStringSchema()), props);
+		producer.setFlushOnCheckpoint(flushOnCheckpoint);
+		producer.setRuntimeContext(new MockRuntimeContext(0, 1));
+
+		producer.open(new Configuration());
+
+		for(int i = 0; i < 100; i++) {
+			producer.invoke("msg-" + i);
+		}
+		// start a thread confirming all pending records
+		final Tuple1<Throwable> runnableError = new Tuple1<>(null);
+		final Thread threadA = Thread.currentThread();
+		final AtomicBoolean markOne = new AtomicBoolean(false);
+		Runnable confirmer = new Runnable() {
+			@Override
+			public void run() {
+				try {
+					MockProducer mp = producer.getProducerInstance();
+					List<Callback> pending = mp.getPending();
+
+					// we ensure thread A is locked and didn't reach markOne
+					// give thread A some time to really reach the snapshot state
+					Thread.sleep(500);
+					if(markOne.get()) {
+						Assert.fail("Snapshot was confirmed even though messages " +
+								"were still in the buffer");
+					}
+					Assert.assertEquals(100, pending.size());
+
+					// now confirm all checkpoints
+					for(Callback c: pending) {
+						c.onCompletion(null, null);
+					}
+					pending.clear();
+					// wait for the snapshotState() method to return
+					Thread.sleep(100);
+					Assert.assertTrue("Snapshot state didn't return", markOne.get());
+				} catch(Throwable t) {
+					runnableError.f0 = t;
+				}
+			}
+		};
+		Thread threadB = new Thread(confirmer);
+		threadB.start();
+		// this should block:
+		producer.snapshotState(0, 0);
+		// once all pending callbacks are confirmed, we can set this marker to true
+		markOne.set(true);
+		for(int i = 0; i < 99; i++) {
+			producer.invoke("msg-" + i);
+		}
+		// wait at most one second
+		threadB.join(800L);
+		Assert.assertFalse("Thread A reached this point too fast", threadB.isAlive());
+		if(runnableError.f0 != null) {
+			runnableError.f0.printStackTrace();
+			Assert.fail("Error from thread B: " + runnableError.f0 );
+		}
+
+		producer.close();
+	}
+
+
+	private static class TestingKafkaProducer<T> extends FlinkKafkaProducerBase<T> {
+		private MockProducer prod;
+
+		public TestingKafkaProducer(String defaultTopicId, KeyedSerializationSchema<T> serializationSchema, Properties producerConfig) {
+			super(defaultTopicId, serializationSchema, producerConfig, null);
+		}
+
+		@Override
+		protected <K, V> Producer<K, V> getKafkaProducer(Properties props) {
+			this.prod = new MockProducer();
+			return this.prod;
+		}
+
+		public MockProducer getProducerInstance() {
+			return this.prod;
+		}
+	}
+
+	private static class MockProducer<K, V> implements Producer<K, V> {
+		List<Callback> pendingCallbacks = new ArrayList<>();
+
+		@Override
+		public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
+			throw new UnsupportedOperationException("Unexpected");
+		}
+
+		@Override
+		public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+			pendingCallbacks.add(callback);
+			return null;
+		}
+
+		@Override
+		public List<PartitionInfo> partitionsFor(String topic) {
+			List<PartitionInfo> list = new ArrayList<>();
+			list.add(new PartitionInfo(topic, 0, null, null, null));
+			return list;
+		}
+
+		@Override
+		public Map<MetricName, ? extends Metric> metrics() {
+			return null;
+		}
+
+		@Override
+		public void close() {
+
+		}
+
+		public List<Callback> getPending() {
+			return this.pendingCallbacks;
+		}
+	}
+}

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -269,7 +269,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		Properties producerProperties = FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings);
 		producerProperties.setProperty("retries", "3");
 		FlinkKafkaProducerBase<Tuple2<Long, String>> prod = kafkaServer.getProducer(topic, new KeyedSerializationSchemaWrapper<>(sinkSchema), producerProperties, null);
-		prod.setFlushOnCheckpoint(true);
 		stream.addSink(prod);
 
 		// ----------- add consumer dataflow ----------

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -268,7 +268,9 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		});
 		Properties producerProperties = FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings);
 		producerProperties.setProperty("retries", "3");
-		stream.addSink(kafkaServer.getProducer(topic, new KeyedSerializationSchemaWrapper<>(sinkSchema), producerProperties, null));
+		FlinkKafkaProducerBase<Tuple2<Long, String>> prod = kafkaServer.getProducer(topic, new KeyedSerializationSchemaWrapper<>(sinkSchema), producerProperties, null);
+		prod.setFlushOnCheckpoint(true);
+		stream.addSink(prod);
 
 		// ----------- add consumer dataflow ----------
 


### PR DESCRIPTION
A user on the mailing list raised the point that our Kafka producer can be made at-least-once quite easily.
The current producer code doesn't have any guarantees 

We are using the producer's callbacks to account for unacknowledged records. When a checkpoint barrier reaches the sink, it will confirm the checkpoint once all pending records have been acked.