### PR TITLE
[FLINK-4076] BoltWrapper#dispose() should call AbstractStreamOperator#dispose()

### DIFF
--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/BoltWrapper.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/BoltWrapper.java
@@ -292,6 +292,7 @@ public class BoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> implements
 
 	@Override
 	public void dispose() {
+		super.dispose();
 		this.bolt.cleanup();
 	}
 


### PR DESCRIPTION
Add missing method `super.close()` that should be called in sub class `org.apache.flink.storm.wrappers.BoltWrapper` 's override method .