### PR TITLE
[FLINK-4017] [py] Add Aggregation support to Python API

### DIFF
--- a/docs/apis/batch/dataset_transformations.md
+++ b/docs/apis/batch/dataset_transformations.md
@@ -873,7 +873,10 @@ val output = input.groupBy(1).aggregate(SUM, 0).and(MIN, 2)
 <div data-lang="python" markdown="1">
 
 ~~~python
-Not supported.
+from flink.functions.Aggregation import Sum, Min
+
+input = # [...]
+output = input.group_by(1).aggregate(Sum, 0).agg_and(Min, 2)
 ~~~
 
 </div>
@@ -1010,7 +1013,10 @@ val output = input.aggregate(SUM, 0).and(MIN, 2)
 <div data-lang="python" markdown="1">
 
 ~~~python
-Not supported.
+from flink.functions.Aggregation import Sum, Min
+
+input = # [...]
+output = input.aggregate(Sum, 0).agg_and(Min, 2)
 ~~~
 
 </div>

--- a/docs/apis/batch/dataset_transformations.md
+++ b/docs/apis/batch/dataset_transformations.md
@@ -876,7 +876,7 @@ val output = input.groupBy(1).aggregate(SUM, 0).and(MIN, 2)
 from flink.functions.Aggregation import Sum, Min
 
 input = # [...]
-output = input.group_by(1).aggregate(Sum, 0).agg_and(Min, 2)
+output = input.group_by(1).aggregate(Sum, 0).and_agg(Min, 2)
 ~~~
 
 </div>
@@ -1016,7 +1016,7 @@ val output = input.aggregate(SUM, 0).and(MIN, 2)
 from flink.functions.Aggregation import Sum, Min
 
 input = # [...]
-output = input.aggregate(Sum, 0).agg_and(Min, 2)
+output = input.aggregate(Sum, 0).and_agg(Min, 2)
 ~~~
 
 </div>

--- a/docs/apis/batch/python.md
+++ b/docs/apis/batch/python.md
@@ -265,6 +265,19 @@ data.reduce_group(Adder())
       </td>
     </tr>
 
+    <tr>
+      <td><strong>Aggregate</strong></td>
+      <td>
+        <p>Performs a built-in operation (sum, min, max) on one field of all the Tuples in a
+        data set or in each group of a data set. Aggregation can be applied on a full dataset
+        or on a grouped data set.</p>
+{% highlight python %}
+# This code finds the sum of all of the values in the first field and the maximum of all of the values in the second field
+data.aggregate(Aggregation.Sum, 0).agg_and(Aggregation.Max, 1)
+{% endhighlight %}
+      </td>
+    </tr>
+
     </tr>
       <td><strong>Join</strong></td>
       <td>

--- a/docs/apis/batch/python.md
+++ b/docs/apis/batch/python.md
@@ -273,7 +273,7 @@ data.reduce_group(Adder())
         or on a grouped data set.</p>
 {% highlight python %}
 # This code finds the sum of all of the values in the first field and the maximum of all of the values in the second field
-data.aggregate(Aggregation.Sum, 0).agg_and(Aggregation.Max, 1)
+data.aggregate(Aggregation.Sum, 0).and_agg(Aggregation.Max, 1)
 {% endhighlight %}
       </td>
     </tr>

--- a/docs/apis/batch/python.md
+++ b/docs/apis/batch/python.md
@@ -274,6 +274,9 @@ data.reduce_group(Adder())
 {% highlight python %}
 # This code finds the sum of all of the values in the first field and the maximum of all of the values in the second field
 data.aggregate(Aggregation.Sum, 0).and_agg(Aggregation.Max, 1)
+
+# min(), max(), and sum() syntactic sugar functions are also available
+data.sum(0).and_agg(Aggregation.Max, 1)
 {% endhighlight %}
       </td>
     </tr>

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonOperationInfo.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonOperationInfo.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.aggregation.Aggregations;
 import org.apache.flink.api.java.tuple.Tuple;
 import static org.apache.flink.api.java.typeutils.TypeExtractor.getForObject;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
@@ -31,7 +30,6 @@ public class PythonOperationInfo {
 	public String[] keys1; //join/cogroup keys
 	public String[] keys2; //join/cogroup keys
 	public TypeInformation<?> types; //typeinformation about output type
-	public AggregationEntry[] aggregates;
 	public Object[] values;
 	public int count;
 	public String field;
@@ -94,15 +92,6 @@ public class PythonOperationInfo {
 			values[x] = streamer.getRecord();
 		}
 		parallelism = (Integer) streamer.getRecord(true);
-
-		/*
-		aggregates = new AggregationEntry[count];
-		for (int x = 0; x < count; x++) {
-			int encodedAgg = (Integer) streamer.getRecord(true);
-			int field = (Integer) streamer.getRecord(true);
-			aggregates[x] = new AggregationEntry(encodedAgg, field);
-		}
-		*/
 	}
 
 	@Override
@@ -116,7 +105,6 @@ public class PythonOperationInfo {
 		sb.append("Keys1: ").append(Arrays.toString(keys1)).append("\n");
 		sb.append("Keys2: ").append(Arrays.toString(keys2)).append("\n");
 		sb.append("Keys: ").append(Arrays.toString(keys)).append("\n");
-		sb.append("Aggregates: ").append(Arrays.toString(aggregates)).append("\n");
 		sb.append("Count: ").append(count).append("\n");
 		sb.append("Field: ").append(field).append("\n");
 		sb.append("Order: ").append(order.toString()).append("\n");
@@ -128,31 +116,6 @@ public class PythonOperationInfo {
 		sb.append("WriteMode: ").append(writeMode).append("\n");
 		sb.append("toError: ").append(toError).append("\n");
 		return sb.toString();
-	}
-
-	public static class AggregationEntry {
-		public Aggregations agg;
-		public int field;
-
-		public AggregationEntry(int encodedAgg, int field) {
-			switch (encodedAgg) {
-				case 0:
-					agg = Aggregations.MAX;
-					break;
-				case 1:
-					agg = Aggregations.MIN;
-					break;
-				case 2:
-					agg = Aggregations.SUM;
-					break;
-			}
-			this.field = field;
-		}
-
-		@Override
-		public String toString() {
-			return agg.toString() + " - " + field;
-		}
 	}
 
 	public enum DatasizeHint {

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonPlanBinder.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonPlanBinder.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.LocalEnvironment;
 import org.apache.flink.api.java.io.PrintingOutputFormat;
 import org.apache.flink.api.java.io.TupleCsvInputFormat;
-import org.apache.flink.api.java.operators.AggregateOperator;
 import org.apache.flink.api.java.operators.CoGroupRawOperator;
 import org.apache.flink.api.java.operators.CrossOperator.DefaultCross;
 import org.apache.flink.api.java.operators.Grouping;
@@ -274,7 +273,7 @@ public class PythonPlanBinder {
 	 */
 	protected enum Operation {
 		SOURCE_CSV, SOURCE_TEXT, SOURCE_VALUE, SOURCE_SEQ, SINK_CSV, SINK_TEXT, SINK_PRINT,
-		SORT, UNION, FIRST, DISTINCT, GROUPBY, AGGREGATE,
+		SORT, UNION, FIRST, DISTINCT, GROUPBY,
 		REBALANCE, PARTITION_HASH,
 		BROADCAST,
 		COGROUP, CROSS, CROSS_H, CROSS_T, FILTER, FLATMAP, GROUPREDUCE, JOIN, JOIN_H, JOIN_T, MAP, REDUCE, MAPPARTITION
@@ -314,9 +313,6 @@ public class PythonPlanBinder {
 					break;
 				case BROADCAST:
 					createBroadcastVariable(info);
-					break;
-				case AGGREGATE:
-					createAggregationOperation(info);
 					break;
 				case DISTINCT:
 					createDistinctOperation(info);
@@ -451,17 +447,6 @@ public class PythonPlanBinder {
 		c.setString(PLANBINDER_CONFIG_BCVAR_NAME_PREFIX + count, info.name);
 
 		op1.withParameters(c);
-	}
-
-	private void createAggregationOperation(PythonOperationInfo info) throws IOException {
-		DataSet op = (DataSet) sets.get(info.parentID);
-		AggregateOperator ao = op.aggregate(info.aggregates[0].agg, info.aggregates[0].field);
-
-		for (int x = 1; x < info.count; x++) {
-			ao = ao.and(info.aggregates[x].agg, info.aggregates[x].field);
-		}
-
-		sets.put(info.setID, ao.setParallelism(getParallelism(info)).name("Aggregation"));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/Aggregation.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/functions/Aggregation.py
@@ -1,0 +1,100 @@
+# ###############################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from flink.functions.GroupReduceFunction import GroupReduceFunction
+
+class AggregationFunction(GroupReduceFunction):
+    def __init__(self, aggregation, field):
+        super(AggregationFunction, self).__init__()
+        self.aggregations = [aggregation(field)]
+
+    def add_aggregation(self, aggregation, field):
+        """
+        Add an additional aggregation operator
+        :param aggregation: Built-in aggregation operator to apply
+        :param field: Field on which to apply the specified aggregation
+        """
+        self.aggregations.append(aggregation(field))
+
+    def reduce(self, iterator, collector):
+        # Reset each aggregator
+        for aggregator in self.aggregations:
+            aggregator.initialize_aggregation()
+
+        # Tuple that will be filled in with aggregated values
+        item = None
+
+        # Run each value through the aggregator
+        for x in iterator:
+            if item is None:
+                # Get first value that will be filled in
+                item = list(x)
+
+            for aggregator in self.aggregations:
+                aggregator.aggregate(x[aggregator.field])
+
+        # Get results
+        for aggregator in self.aggregations:
+            item[aggregator.field] = aggregator.get_aggregate()
+
+        collector.collect(tuple(item))
+
+
+class AggregationOperator(object):
+    def __init__(self, field):
+        self.field = field
+
+    def initialize_aggregation(self):
+        """Set up or reset the aggregator operator."""
+        self.agg = None
+
+    def aggregate(self, value):
+        """Incorporate a value into the aggregation."""
+        pass
+
+    def get_aggregate(self):
+        """Return the result of the aggregation."""
+        return self.agg
+
+
+class Sum(AggregationOperator):
+    def initialize_aggregation(self):
+        self.agg = 0
+
+    def aggregate(self, value):
+        self.agg += value
+
+
+class Min(AggregationOperator):
+    def aggregate(self, value):
+        if self.agg != None:
+            if value < self.agg:
+                self.agg = value
+        else:
+            self.agg = value
+
+
+class Max(AggregationOperator):
+    def aggregate(self, value):
+        if self.agg != None:
+            if value > self.agg:
+                self.agg = value
+        else:
+            self.agg = value
+
+
+

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/plan/DataSet.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/plan/DataSet.py
@@ -200,7 +200,7 @@ class DataSet(object):
         :param field: The index of the Tuple field on which to perform the function.
         :return: A GroupReduceOperator that represents the aggregated DataSet.
         """
-        child_set = self.reduce_group(aggregation(field), combinable=True)
+        child_set = self.reduce_group(AggregationFunction(aggregation, field), combinable=True)
         child_set._info.name = "PythonAggregate"
         return child_set
 

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/plan/DataSet.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/plan/DataSet.py
@@ -18,7 +18,7 @@
 import copy
 import types as TYPES
 
-from flink.functions.Aggregation import AggregationFunction
+from flink.functions.Aggregation import AggregationFunction, Min, Max, Sum
 from flink.plan.Constants import _Identifier, WriteMode, _createKeyValueTypeInfo, _createArrayTypeInfo
 from flink.plan.OperationInfo import OperationInfo
 from flink.functions.CoGroupFunction import CoGroupFunction
@@ -210,6 +210,30 @@ class DataSet(object):
         self._info.children.append(child)
         self._env._sets.append(child)
         return child_set
+
+    def min(self, field):
+        """
+        Syntactic sugar for the minimum aggregation.
+        :param field: The index of the Tuple field on which to perform the function.
+        :return: An AggregateOperator that represents the aggregated DataSet.
+        """
+        return self.aggregate(Min, field)
+
+    def max(self, field):
+        """
+        Syntactic sugar for the maximum aggregation.
+        :param field: The index of the Tuple field on which to perform the function.
+        :return: An AggregateOperator that represents the aggregated DataSet.
+        """
+        return self.aggregate(Max, field)
+
+    def sum(self, field):
+        """
+        Syntactic sugar for the sum aggregation.
+        :param field: The index of the Tuple field on which to perform the function.
+        :return: An AggregateOperator that represents the aggregated DataSet.
+        """
+        return self.aggregate(Sum, field)
 
     def project(self, *fields):
         """
@@ -740,6 +764,30 @@ class UnsortedGrouping(Grouping):
         self._env._sets.append(child)
         self._info.children.append(child)
         return child_set
+
+    def min(self, field):
+        """
+        Syntactic sugar for the minimum aggregation.
+        :param field: The index of the Tuple field on which to perform the function.
+        :return: An AggregateOperator that represents the aggregated UnsortedGrouping.
+        """
+        return self.aggregate(Min, field)
+
+    def max(self, field):
+        """
+        Syntactic sugar for the maximum aggregation.
+        :param field: The index of the Tuple field on which to perform the function.
+        :return: An AggregateOperator that represents the aggregated UnsortedGrouping.
+        """
+        return self.aggregate(Max, field)
+
+    def sum(self, field):
+        """
+        Syntactic sugar for the sum aggregation.
+        :param field: The index of the Tuple field on which to perform the function.
+        :return: An AggregateOperator that represents the aggregated UnsortedGrouping.
+        """
+        return self.aggregate(Sum, field)
 
     def _finalize(self):
         grouping = self._child_chain[0]

--- a/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
+++ b/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
@@ -21,6 +21,7 @@ from flink.functions.MapFunction import MapFunction
 from flink.functions.CrossFunction import CrossFunction
 from flink.functions.JoinFunction import JoinFunction
 from flink.functions.CoGroupFunction import CoGroupFunction
+from flink.functions.Aggregation import Max, Min, Sum
 from utils import Verify, Verify2
 
 if __name__ == "__main__":
@@ -37,6 +38,12 @@ if __name__ == "__main__":
     d5 = env.from_elements((4.4, 4.3, 1), (4.3, 4.4, 1), (4.2, 4.1, 3), (4.1, 4.1, 3))
 
     d6 = env.from_elements(1, 1, 12)
+
+    #Aggregate
+    d4 \
+        .group_by(2).aggregate(Sum, 0).agg_and(Max, 1).agg_and(Min, 3) \
+        .map_partition(Verify([(3, 0.5, "hello", False), (2, 0.4, "world", False)], "Aggregate")).output()
+
 
     #Join
     class Join(JoinFunction):

--- a/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
+++ b/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
@@ -42,8 +42,11 @@ if __name__ == "__main__":
     #Aggregate
     d4 \
         .group_by(2).aggregate(Sum, 0).agg_and(Max, 1).agg_and(Min, 3) \
-        .map_partition(Verify([(3, 0.5, "hello", False), (2, 0.4, "world", False)], "Aggregate")).output()
+        .map_partition(Verify([(3, 0.5, "hello", False), (2, 0.4, "world", False)], "Grouped Aggregate")).output()
 
+    d5 \
+        .aggregate(Sum, 0).agg_and(Min, 1).agg_and(Max, 2) \
+        .map_partition(Verify([(4.4 + 4.3 + 4.2 + 4.1, 4.1, 3)], "Ungrouped Aggregate")).output()
 
     #Join
     class Join(JoinFunction):

--- a/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
+++ b/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
@@ -41,11 +41,11 @@ if __name__ == "__main__":
 
     #Aggregate
     d4 \
-        .group_by(2).aggregate(Sum, 0).agg_and(Max, 1).agg_and(Min, 3) \
+        .group_by(2).aggregate(Sum, 0).and_agg(Max, 1).and_agg(Min, 3) \
         .map_partition(Verify([(3, 0.5, "hello", False), (2, 0.4, "world", False)], "Grouped Aggregate")).output()
 
     d5 \
-        .aggregate(Sum, 0).agg_and(Min, 1).agg_and(Max, 2) \
+        .aggregate(Sum, 0).and_agg(Min, 1).and_agg(Max, 2) \
         .map_partition(Verify([(4.4 + 4.3 + 4.2 + 4.1, 4.1, 3)], "Ungrouped Aggregate")).output()
 
     #Join

--- a/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
+++ b/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/test_main2.py
@@ -48,6 +48,15 @@ if __name__ == "__main__":
         .aggregate(Sum, 0).and_agg(Min, 1).and_agg(Max, 2) \
         .map_partition(Verify([(4.4 + 4.3 + 4.2 + 4.1, 4.1, 3)], "Ungrouped Aggregate")).output()
 
+    #Aggregate syntactic sugar functions
+    d4 \
+        .group_by(2).sum(0).and_agg(Max, 1).and_agg(Min, 3) \
+        .map_partition(Verify([(3, 0.5, "hello", False), (2, 0.4, "world", False)], "Grouped Aggregate")).output()
+
+    d5 \
+        .sum(0).and_agg(Min, 1).and_agg(Max, 2) \
+        .map_partition(Verify([(4.4 + 4.3 + 4.2 + 4.1, 4.1, 3)], "Ungrouped Aggregate")).output()
+
     #Join
     class Join(JoinFunction):
         def join(self, value1, value2):


### PR DESCRIPTION
Adds Aggregation support in the Python API accessible through `.aggregate()` and `.agg_and()`. (I was unable to use `.and()` in Python because 'and' is a keyword.)