### PR TITLE
[FLINK-4070] [tableApi] Support literals on left side of binary expre…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/Expression.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/Expression.scala
@@ -54,6 +54,12 @@ abstract class Expression extends TreeNode[Expression] {
       s"${this.getClass.getName} cannot be transformed to RexNode"
     )
 
+  /**
+    * To support literals on left side of binary expressions, i.e. 12.toExpr % 'a
+    * @return
+    */
+  def toExpr: Expression = this
+
   def checkEquals(other: Expression): Boolean = {
     if (this.getClass != other.getClass) {
       false

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/SelectITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/SelectITCase.scala
@@ -134,4 +134,22 @@ class SelectITCase(
       .select('a, 'b as 'a).toDataSet[Row].print()
   }
 
+  @Test
+  def testLiteralOnLeft(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
+      .select(3.toExpr + '_1, 4.toExpr >= '_2)
+
+    val results = t.toDataSet[Row].collect()
+
+    val expected = "4,true\n" + "5,true\n" + "6,true\n" + "7,true\n" + "8,true\n" + "9,true\n" +
+      "10,true\n" + "11,true\n" + "12,true\n" + "13,true\n" + "14,false\n" + "15,false\n" +
+      "16,false\n" + "17,false\n" + "18,false\n" + "19,false\n" + "20,false\n" + "21,false\n" +
+      "22,false\n" + "23,false\n" + "24,false\n"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/ScalarFunctionsTest.scala
@@ -213,6 +213,13 @@ class ScalarFunctionsTest {
       "MOD(44, 3)",
       "2")
 
+    testFunction(
+      50.toExpr % 'f4,
+      "mod(50, f4)",
+      "MOD(50, f4)",
+      "6"
+    )
+
   }
 
   @Test


### PR DESCRIPTION
The Table API does not support literals on left side of expressions like `+,_,*,/,%,>,< `. Because there is already such method in Int class, scala compiler would not search for implicit conversion.

So I add a function `toExpr` to Expression, now we can use `12.toExpr % 'f0`. It is a useful feature in some cases.
