### PR TITLE
[FLINK-3647] Change StreamSource to use Processing-Time Clock Service

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -61,7 +61,9 @@ import java.io.IOException;
  *
  * <p> In the above example, two map subtasks produce the intermediate result in parallel, resulting
  * in two partitions (Partition 1 and 2). Each of these partitions is further partitioned into two
- * subpartitions -- one for each parallel reduce subtask.
+ * subpartitions -- one for each parallel reduce subtask. As shown in the Figure, each reduce task
+ * will have an input gate attached to it. This will provide its input, which will consist of one
+ * subpartition from each partition of the intermediate result.
  */
 public interface InputGate {
 

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -425,7 +425,7 @@ public abstract class AbstractFetcher<T, KPH> {
 		//-------------------------------------------------
 		
 		public void start() {
-			triggerContext.registerTimer(System.currentTimeMillis() + interval, this);
+			triggerContext.registerTimer(triggerContext.getCurrentProcessingTime() + interval, this);
 		}
 		
 		@Override
@@ -454,7 +454,7 @@ public abstract class AbstractFetcher<T, KPH> {
 			}
 			
 			// schedule the next watermark
-			triggerContext.registerTimer(System.currentTimeMillis() + interval, this);
+			triggerContext.registerTimer(triggerContext.getCurrentProcessingTime() + interval, this);
 		}
 	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTimestampsTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTimestampsTest.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 @SuppressWarnings("serial")
-public class AbstractFetcherTimestampsTest {
+public class 	AbstractFetcherTimestampsTest {
 	
 	@Test
 	public void testPunctuatedWatermarks() throws Exception {

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockRuntimeContext.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockRuntimeContext.java
@@ -38,15 +38,16 @@ import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.runtime.operators.Triggerable;
+import org.apache.flink.streaming.runtime.tasks.DefaultTimeServiceProvider;
+import org.apache.flink.streaming.runtime.tasks.TimeServiceProvider;
+import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("deprecation")
 public class MockRuntimeContext extends StreamingRuntimeContext {
@@ -57,16 +58,27 @@ public class MockRuntimeContext extends StreamingRuntimeContext {
 	private final ExecutionConfig execConfig;
 	private final Object checkpointLock;
 
-	private ScheduledExecutorService timer;
-	
+	private final TimeServiceProvider timerService;
+
 	public MockRuntimeContext(int numberOfParallelSubtasks, int indexOfThisSubtask) {
 		this(numberOfParallelSubtasks, indexOfThisSubtask, new ExecutionConfig(), null);
 	}
-	
+
 	public MockRuntimeContext(
-			int numberOfParallelSubtasks, int indexOfThisSubtask, 
+		int numberOfParallelSubtasks, int indexOfThisSubtask,
+		ExecutionConfig execConfig,
+		Object checkpointLock) {
+
+		this(numberOfParallelSubtasks, indexOfThisSubtask, execConfig, checkpointLock,
+			DefaultTimeServiceProvider.create(Executors.newSingleThreadScheduledExecutor()));
+	}
+
+	public MockRuntimeContext(
+			int numberOfParallelSubtasks, int indexOfThisSubtask,
 			ExecutionConfig execConfig,
-			Object checkpointLock) {
+			Object checkpointLock,
+			TimeServiceProvider timerService) {
+
 		super(new MockStreamOperator(),
 				new MockEnvironment("no", 4 * MemoryManager.DEFAULT_PAGE_SIZE, null, 16),
 				Collections.<String, Accumulator<?, ?>>emptyMap());
@@ -75,6 +87,7 @@ public class MockRuntimeContext extends StreamingRuntimeContext {
 		this.indexOfThisSubtask = indexOfThisSubtask;
 		this.execConfig = execConfig;
 		this.checkpointLock = checkpointLock;
+		this.timerService = timerService;
 	}
 
 	@Override
@@ -186,16 +199,19 @@ public class MockRuntimeContext extends StreamingRuntimeContext {
 	public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
 		throw new UnsupportedOperationException();
 	}
-	
+
+	public long getCurrentProcessingTime() {
+		Preconditions.checkNotNull(timerService, "The processing time timer has not been initialized.");
+		return timerService.getCurrentProcessingTime();
+	}
+
 	@Override
 	public ScheduledFuture<?> registerTimer(final long time, final Triggerable target) {
-		if (timer == null) {
-			timer = Executors.newSingleThreadScheduledExecutor();
-		}
+		Preconditions.checkNotNull(timerService, "The processing time timer has not been initialized.");
 		
-		final long delay = Math.max(time - System.currentTimeMillis(), 0);
+		final long delay = Math.max(time - timerService.getCurrentProcessingTime(), 0);
 
-		return timer.schedule(new Runnable() {
+		return timerService.registerTimer(delay, new Runnable() {
 			@Override
 			public void run() {
 				synchronized (checkpointLock) {
@@ -207,7 +223,7 @@ public class MockRuntimeContext extends StreamingRuntimeContext {
 					}
 				}
 			}
-		}, delay, TimeUnit.MILLISECONDS);
+		});
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -252,8 +252,8 @@ public abstract class AbstractStreamOperator<OUT>
 	}
 
 	/**
-	 * Register a timer callback. At the specified time the {@link Triggerable} will be invoked.
-	 * This call is guaranteed to not happen concurrently with method calls on the operator.
+	 * Register a timer callback. At the specified time the provided {@link Triggerable} will
+	 * be invoked. This call is guaranteed to not happen concurrently with method calls on the operator.
 	 *
 	 * @param time The absolute time in milliseconds.
 	 * @param target The target to be triggered.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -262,6 +262,10 @@ public abstract class AbstractStreamOperator<OUT>
 		return container.registerTimer(time, target);
 	}
 
+	protected long getCurrentProcessingTime() {
+		return container.getCurrentProcessingTime();
+	}
+
 	/**
 	 * Creates a partitioned state handle, using the state backend configured for this task.
 	 * 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -21,12 +21,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.operators.Triggerable;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * {@link StreamOperator} for streaming sources.
@@ -195,7 +193,6 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 		private final Output<StreamRecord<T>> output;
 		private final StreamRecord<T> reuse;
 		
-		private final ScheduledExecutorService scheduleExecutor;
 		private final ScheduledFuture<?> watermarkTimer;
 		private final long watermarkInterval;
 
@@ -216,29 +213,10 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 			this.output = outputParam;
 			this.watermarkInterval = watermarkInterval;
 			this.reuse = new StreamRecord<T>(null);
-			
-			this.scheduleExecutor = Executors.newScheduledThreadPool(1);
 
-			this.watermarkTimer = scheduleExecutor.scheduleAtFixedRate(new Runnable() {
-				@Override
-				public void run() {
-					final long currentTime = System.currentTimeMillis();
-					
-					if (currentTime > nextWatermarkTime) {
-						// align the watermarks across all machines. this will ensure that we
-						// don't have watermarks that creep along at different intervals because
-						// the machine clocks are out of sync
-						final long watermarkTime = currentTime - (currentTime % watermarkInterval);
-						
-						synchronized (lockingObjectParam) {
-							if (currentTime > nextWatermarkTime) {
-								outputParam.emitWatermark(new Watermark(watermarkTime));
-								nextWatermarkTime += watermarkInterval;
-							}
-						}
-					}
-				}
-			}, 0, watermarkInterval, TimeUnit.MILLISECONDS);
+			long now = owner.getCurrentProcessingTime();
+			this.watermarkTimer = owner.registerTimer(now + watermarkInterval,
+				new WatermarkEmittingTask(owner, lockingObjectParam, outputParam));
 		}
 
 		@Override
@@ -246,14 +224,21 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 			owner.checkAsyncException();
 			
 			synchronized (lockingObject) {
-				final long currentTime = System.currentTimeMillis();
+				final long currentTime = owner.getCurrentProcessingTime();
 				output.collect(reuse.replace(element, currentTime));
-				
+
+				// this is to avoid lock contention in the lockingObject by
+				// sending the watermark before the firing of the watermark
+				// emission task.
+
 				if (currentTime > nextWatermarkTime) {
 					// in case we jumped some watermarks, recompute the next watermark time
 					final long watermarkTime = currentTime - (currentTime % watermarkInterval);
 					nextWatermarkTime = watermarkTime + watermarkInterval;
 					output.emitWatermark(new Watermark(watermarkTime));
+
+					// we do not need to register another timer here
+					// because the emitting task will do so.
 				}
 			}
 		}
@@ -276,7 +261,6 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 
 				// we can shutdown the timer now, no watermarks will be needed any more
 				watermarkTimer.cancel(true);
-				scheduleExecutor.shutdownNow();
 			}
 		}
 
@@ -288,13 +272,47 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 		@Override
 		public void close() {
 			watermarkTimer.cancel(true);
-			scheduleExecutor.shutdownNow();
+		}
+
+		private class WatermarkEmittingTask implements Triggerable {
+
+			private final StreamSource<?, ?> owner;
+			private final Object lockingObject;
+			private final Output<StreamRecord<T>> output;
+
+			private WatermarkEmittingTask(StreamSource<?, ?> src, Object lock, Output<StreamRecord<T>> output) {
+				this.owner = src;
+				this.lockingObject = lock;
+				this.output = output;
+			}
+
+			@Override
+			public void trigger(long timestamp) {
+				final long currentTime = owner.getCurrentProcessingTime();
+
+				if (currentTime > nextWatermarkTime) {
+					// align the watermarks across all machines. this will ensure that we
+					// don't have watermarks that creep along at different intervals because
+					// the machine clocks are out of sync
+					final long watermarkTime = currentTime - (currentTime % watermarkInterval);
+
+					synchronized (lockingObject) {
+						if (currentTime > nextWatermarkTime) {
+							output.emitWatermark(new Watermark(watermarkTime));
+							nextWatermarkTime += watermarkInterval;
+						}
+					}
+				}
+
+				owner.registerTimer(owner.getCurrentProcessingTime() + watermarkInterval,
+					new WatermarkEmittingTask(owner, lockingObject, output));
+			}
 		}
 	}
 
 	/**
 	 * A SourceContext for event time. Sources may directly attach timestamps and generate
-	 * watermarks, but if records are emitted without timestamps, no timetamps are automatically
+	 * watermarks, but if records are emitted without timestamps, no timestamps are automatically
 	 * generated and attached. The records will simply have no timestamp in that case.
 	 * 
 	 * Streaming topologies can use timestamp assigner functions to override the timestamps

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -93,7 +93,15 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 	public ScheduledFuture<?> registerTimer(long time, Triggerable target) {
 		return operator.registerTimer(time, target);
 	}
-	
+
+	/**
+	 * Returns the current processing time as defined by the task's
+	 * {@link org.apache.flink.streaming.runtime.tasks.TimeServiceProvider TimeServiceProvider}
+	 */
+	public long getCurrentProcessingTime() {
+		return operator.getCurrentProcessingTime();
+	}
+
 	// ------------------------------------------------------------------------
 	//  broadcast variables
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/EventTimeSessionWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/EventTimeSessionWindows.java
@@ -51,7 +51,7 @@ public class EventTimeSessionWindows extends MergingWindowAssigner<Object, TimeW
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
+	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
 		return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionTimeout));
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
@@ -43,7 +43,7 @@ public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
 	private GlobalWindows() {}
 
 	@Override
-	public Collection<GlobalWindow> assignWindows(Object element, long timestamp) {
+	public Collection<GlobalWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
 		return Collections.singletonList(GlobalWindow.get());
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/ProcessingTimeSessionWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/ProcessingTimeSessionWindows.java
@@ -51,8 +51,9 @@ public class ProcessingTimeSessionWindows extends MergingWindowAssigner<Object, 
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
-		return Collections.singletonList(new TimeWindow(timestamp, timestamp + sessionTimeout));
+	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
+		long currentProcessingTime = context.getCurrentProcessingTime();
+		return Collections.singletonList(new TimeWindow(currentProcessingTime, currentProcessingTime + sessionTimeout));
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
@@ -58,7 +58,7 @@ public class SlidingEventTimeWindows extends WindowAssigner<Object, TimeWindow> 
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
+	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
 		if (timestamp > Long.MIN_VALUE) {
 			List<TimeWindow> windows = new ArrayList<>((int) (size / slide));
 			long lastStart = timestamp - timestamp % slide;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingProcessingTimeWindows.java
@@ -55,8 +55,8 @@ public class SlidingProcessingTimeWindows extends WindowAssigner<Object, TimeWin
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
-		timestamp = System.currentTimeMillis();
+	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
+		timestamp = context.getCurrentProcessingTime();
 		List<TimeWindow> windows = new ArrayList<>((int) (size / slide));
 		long lastStart = timestamp - timestamp % slide;
 		for (long start = lastStart;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
@@ -54,7 +54,7 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
+	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
 		if (timestamp > Long.MIN_VALUE) {
 			// Long.MIN_VALUE is currently assigned when no timestamp is present
 			long start = timestamp - (timestamp % size);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -51,8 +51,8 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 	}
 
 	@Override
-	public Collection<TimeWindow> assignWindows(Object element, long timestamp) {
-		final long now = System.currentTimeMillis();
+	public Collection<TimeWindow> assignWindows(Object element, long timestamp, WindowAssignerContext context) {
+		final long now = context.getCurrentProcessingTime();
 		long start = now - (now % size);
 		return Collections.singletonList(new TimeWindow(start, start + size));
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssigner.java
@@ -50,8 +50,9 @@ public abstract class WindowAssigner<T, W extends Window> implements Serializabl
 	 *
 	 * @param element The element to which windows should be assigned.
 	 * @param timestamp The timestamp of the element.
+	 * @param context The {@link WindowAssignerContext} in which the assigner operates.
 	 */
-	public abstract Collection<W> assignWindows(T element, long timestamp);
+	public abstract Collection<W> assignWindows(T element, long timestamp, WindowAssignerContext context);
 
 	/**
 	 * Returns the default trigger associated with this {@code WindowAssigner}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssignerContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/WindowAssignerContext.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+
+/**
+ * A context provided to the {@link WindowAssigner} that allows it to query the
+ * current processing time. This is provided to the assigner by its containing
+ * {@link org.apache.flink.streaming.runtime.operators.windowing.WindowOperator},
+ * which, in turn, gets it from the containing
+ * {@link org.apache.flink.streaming.runtime.tasks.StreamTask}.
+ */
+public abstract class WindowAssignerContext {
+
+	/**
+	 * Returns the current processing time, as returned by
+	 * the {@link StreamTask#getCurrentProcessingTime()}.
+	 */
+	public abstract long getCurrentProcessingTime();
+
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
@@ -89,6 +89,8 @@ public class ContinuousEventTimeTrigger<W extends Window> extends Trigger<Object
 	@Override
 	public void clear(W window, TriggerContext ctx) throws Exception {
 		ReducingState<Long> fireTimestamp = ctx.getPartitionedState(stateDesc);
+		long timestamp = fireTimestamp.get();
+		ctx.deleteEventTimeTimer(timestamp);
 		fireTimestamp.clear();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
@@ -33,7 +33,7 @@ public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
 
 	@Override
 	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) {
-		ctx.registerProcessingTimeTimer(window.getEnd());
+		ctx.registerProcessingTimeTimer(window.maxTimestamp());
 		return TriggerResult.CONTINUE;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
 import java.io.Serializable;
 
@@ -127,6 +128,12 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 	public interface TriggerContext {
 
 		/**
+		 * Returns the current processing time, as returned by
+		 * the {@link StreamTask#getCurrentProcessingTime()}.
+		 */
+		long getCurrentProcessingTime();
+
+		/**
 		 * Returns the metric group for this {@link Trigger}. This is the same metric
 		 * group that would be returned from {@link RuntimeContext#getMetricGroup()} in a user
 		 * function.
@@ -170,7 +177,7 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 		void deleteEventTimeTimer(long time);
 	
 		/**
-		 * Retrieves an {@link State} object that can be used to interact with
+		 * Retrieves a {@link State} object that can be used to interact with
 		 * fault-tolerant state that is scoped to the window and key of the current
 		 * trigger invocation.
 		 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -35,12 +35,12 @@ public interface CheckpointBarrierHandler {
 
 	/**
 	 * Returns the next {@link BufferOrEvent} that the operator may consume.
-	 * This call blocks until the next BufferOrEvent is available, ir until the stream
+	 * This call blocks until the next BufferOrEvent is available, or until the stream
 	 * has been determined to be finished.
 	 * 
 	 * @return The next BufferOrEvent, or {@code null}, if the stream is finished.
-	 * @throws java.io.IOException Thrown, if the network or local disk I/O fails.
-	 * @throws java.lang.InterruptedException Thrown, if the thread is interrupted while blocking during
+	 * @throws java.io.IOException Thrown if the network or local disk I/O fails.
+	 * @throws java.lang.InterruptedException Thrown if the thread is interrupted while blocking during
 	 *                                        waiting for the next BufferOrEvent to become available.
 	 */
 	BufferOrEvent getNextNonBlocked() throws IOException, InterruptedException;
@@ -55,13 +55,13 @@ public interface CheckpointBarrierHandler {
 	/**
 	 * Cleans up all internally held resources.
 	 * 
-	 * @throws IOException Thrown, if the cleanup of I/O resources failed.
+	 * @throws IOException Thrown if the cleanup of I/O resources failed.
 	 */
 	void cleanup() throws IOException;
 
 	/**
 	 * Checks if the barrier handler has buffered any data internally.
-	 * @return True, if no data is buffered internally, false otherwise.
+	 * @return {@code True}, if no data is buffered internally, {@code false} otherwise.
 	 */
 	boolean isEmpty();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -76,8 +76,6 @@ public class StreamInputProcessor<IN> {
 
 	private boolean isFinished;
 
-
-
 	private final long[] watermarks;
 	private long lastEmittedWatermark;
 
@@ -101,7 +99,7 @@ public class StreamInputProcessor<IN> {
 			this.barrierHandler = new BarrierTracker(inputGate);
 		}
 		else {
-			throw new IllegalArgumentException("Unrecognized CheckpointingMode: " + checkpointMode);
+			throw new IllegalArgumentException("Unrecognized Checkpointing Mode: " + checkpointMode);
 		}
 		
 		if (checkpointListener != null) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -63,7 +63,7 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
  */
 @Internal
 public class StreamInputProcessor<IN> {
-	
+
 	private final RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers;
 
 	private RecordDeserializer<DeserializationDelegate<StreamElement>> currentRecordDeserializer;
@@ -76,7 +76,7 @@ public class StreamInputProcessor<IN> {
 
 	private boolean isFinished;
 
-	
+
 
 	private final long[] watermarks;
 	private long lastEmittedWatermark;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -83,10 +83,8 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 	@Override
 	@SuppressWarnings("unchecked")
 	public void processElement(StreamRecord<IN> element) throws Exception {
-
-		Collection<W> elementWindows = windowAssigner.assignWindows(
-			element.getValue(),
-			element.getTimestamp());
+		Collection<W> elementWindows = windowAssigner.assignWindows(element.getValue(),
+				element.getTimestamp(), windowAssignerContext);
 
 		final K key = (K) getStateBackend().getCurrentKey();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
@@ -41,8 +41,8 @@ import java.util.Map;
  * {@link #getStateWindow(Window)}.
  *
  * <p>A new window can be added to the set of in-flight windows using
- * {@link #addWindow(Window, MergeFunction)}, this might merge other windows and the caller
- * must react accordingly in {@link MergeFunction#merge(Object, Collection, Object, Collection)
+ * {@link #addWindow(Window, MergeFunction)}. This might merge other windows and the caller
+ * must react accordingly in the {@link MergeFunction#merge(Object, Collection, Object, Collection)
  * and adjust the outside view of windows and state.
  *
  * <p>Windows can be removed from the set of windows using {@link #retireWindow(Window)}.
@@ -70,7 +70,6 @@ public class MergingWindowSet<W extends Window> {
 	 */
 	public MergingWindowSet(MergingWindowAssigner<?, W> windowAssigner) {
 		this.windowAssigner = windowAssigner;
-
 		windows = new HashMap<>();
 	}
 
@@ -127,12 +126,12 @@ public class MergingWindowSet<W extends Window> {
 	 * {@link MergeFunction} is called.
 	 *
 	 * <p>This returns the window that is the representative of the added window after adding.
-	 * This can either be the new window itself, if no merge occured, or the newly merged
+	 * This can either be the new window itself, if no merge occurred, or the newly merged
 	 * window. Adding an element to a window or calling trigger functions should only
 	 * happen on the returned representative. This way, we never have to deal with a new window
 	 * that is immediately swallowed up by another window.
 	 *
-	 * <p>If the new window is merged the {@code MergeFunction} callback arguments also don't
+	 * <p>If the new window is merged, the {@code MergeFunction} callback arguments also don't
 	 * contain the new window as part of the list of merged windows.
 	 *
 	 * @param newWindow The new {@code Window} to add.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/MultiplexingStreamRecordSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/MultiplexingStreamRecordSerializer.java
@@ -30,8 +30,8 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Serializer for {@link StreamRecord} and {@link Watermark}. This does not behave like a normal
- * {@link TypeSerializer}, instead, this is only used at the stream task/opertator level for
- * transmitting StreamRecords} and Watermarks.
+ * {@link TypeSerializer}, instead, this is only used at the stream task/operator level for
+ * transmitting StreamRecords and Watermarks.
  *
  * @param <T> The type of value in the StreamRecord
  */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/DefaultTimeServiceProvider.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/DefaultTimeServiceProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link TimeServiceProvider} which assigns as current processing time the result of calling
+ * {@link System#currentTimeMillis()} and registers timers using a {@link ScheduledThreadPoolExecutor}.
+ */
+public class DefaultTimeServiceProvider extends TimeServiceProvider {
+
+	/** The executor service that schedules and calls the triggers of this task*/
+	private final ScheduledExecutorService timerService;
+
+	public static DefaultTimeServiceProvider create (ScheduledExecutorService executor) {
+		return new DefaultTimeServiceProvider(executor);
+	}
+
+	private DefaultTimeServiceProvider(ScheduledExecutorService threadPoolExecutor) {
+		this.timerService = threadPoolExecutor;
+	}
+
+	@Override
+	public long getCurrentProcessingTime() {
+		return System.currentTimeMillis();
+	}
+
+	@Override
+	public ScheduledFuture<?> registerTimer(long timestamp, Runnable target) {
+		long delay = Math.max(timestamp - getCurrentProcessingTime(), 0);
+		return timerService.schedule(target, delay, TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	public void shutdownService() throws Exception {
+		if (!timerService.isTerminated()) {
+			StreamTask.LOG.info("Timer service is shutting down.");
+		}
+		timerService.shutdownNow();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestTimeServiceProvider.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestTimeServiceProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * This is a {@link TimeServiceProvider} used <b>strictly for testing</b> the
+ * processing time functionality.
+ * */
+public class TestTimeServiceProvider extends TimeServiceProvider {
+
+	private long currentTime = 0;
+
+	private Map<Long, List<Runnable>> registeredTasks = new HashMap<>();
+
+	public void setCurrentTime(long timestamp) {
+		this.currentTime = timestamp;
+
+		// decide which timers to fire and put them in a list
+		// we do not fire them here to be able to accommodate timers
+		// that register other timers. The latter would through an exception.
+
+		Iterator<Map.Entry<Long, List<Runnable>>> it = registeredTasks.entrySet().iterator();
+		List<Runnable> toRun = new ArrayList<>();
+		while (it.hasNext()) {
+			Map.Entry<Long, List<Runnable>> t = it.next();
+			if (t.getKey() <= this.currentTime) {
+				for (Runnable r: t.getValue()) {
+					toRun.add(r);
+				}
+				it.remove();
+			}
+		}
+
+		// now do the actual firing.
+		for (Runnable r: toRun) {
+			r.run();
+		}
+	}
+
+	@Override
+	public long getCurrentProcessingTime() {
+		return currentTime;
+	}
+
+	@Override
+	public ScheduledFuture<?> registerTimer(long timestamp, Runnable target) {
+		List<Runnable> tasks = registeredTasks.get(timestamp);
+		if (tasks == null) {
+			tasks = new ArrayList<>();
+			registeredTasks.put(timestamp, tasks);
+		}
+		tasks.add(target);
+		return null;
+	}
+
+	public int getNoOfRegisteredTimers() {
+		int count = 0;
+		for (List<Runnable> tasks: registeredTasks.values()) {
+			count += tasks.size();
+		}
+		return count;
+	}
+
+	@Override
+	public void shutdownService() throws Exception {
+		this.registeredTasks.clear();
+		this.registeredTasks = null;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TimeServiceProvider.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TimeServiceProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.tasks;
+
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Defines the current processing time and handles all related actions,
+ * such as register timers for tasks to be executed in the future.
+ */
+public abstract class TimeServiceProvider {
+
+	/** Returns the current processing time. */
+	public abstract long getCurrentProcessingTime();
+
+	/** Registers a task to be executed when (processing) time is {@code timestamp}.
+	 * @param timestamp
+	 * 						when the task is to be executed (in processing time)
+	 * @param target
+	 * 						the task to be executed
+	 * @return the result to be returned.
+	 */
+	public abstract ScheduledFuture<?> registerTimer(final long timestamp, final Runnable target);
+
+	/** Shuts down and clean up the timer service provider. */
+	public abstract void shutdownService() throws Exception;
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
@@ -35,14 +35,22 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
+import org.apache.flink.streaming.runtime.tasks.TestTimeServiceProvider;
+import org.apache.flink.streaming.runtime.tasks.TimeServiceProvider;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
 
 import static org.junit.Assert.*;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -58,7 +66,7 @@ public class StreamSourceOperatorTest {
 		
 		final List<StreamElement> output = new ArrayList<>();
 		
-		setupSourceOperator(operator);
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, null);
 		operator.run(new Object(), new CollectorOutput<String>(output));
 		
 		assertEquals(1, output.size());
@@ -75,7 +83,7 @@ public class StreamSourceOperatorTest {
 				new StreamSource<>(new InfiniteSource<String>());
 
 
-		setupSourceOperator(operator);
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, null);
 		operator.cancel();
 
 		// run and exit
@@ -95,7 +103,7 @@ public class StreamSourceOperatorTest {
 				new StreamSource<>(new InfiniteSource<String>());
 
 		
-		setupSourceOperator(operator);
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, null);
 		
 		// trigger an async cancel in a bit
 		new Thread("canceler") {
@@ -128,7 +136,7 @@ public class StreamSourceOperatorTest {
 				new StoppableStreamSource<>(new InfiniteSource<String>());
 
 
-		setupSourceOperator(operator);
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, null);
 		operator.stop();
 
 		// run and stop
@@ -147,7 +155,7 @@ public class StreamSourceOperatorTest {
 				new StoppableStreamSource<>(new InfiniteSource<String>());
 
 
-		setupSourceOperator(operator);
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, null);
 
 		// trigger an async cancel in a bit
 		new Thread("canceler") {
@@ -166,18 +174,59 @@ public class StreamSourceOperatorTest {
 		assertTrue(output.isEmpty());
 	}
 	
-	
+	@Test
+	public void testAutomaticWatermarkContext() throws Exception {
+
+		// regular stream source operator
+		final StoppableStreamSource<String, InfiniteSource<String>> operator =
+			new StoppableStreamSource<>(new InfiniteSource<String>());
+
+		long watermarkInterval = 10;
+		TestTimeServiceProvider timeProvider = new TestTimeServiceProvider();
+		setupSourceOperator(operator, TimeCharacteristic.IngestionTime, watermarkInterval, timeProvider);
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		StreamSource.AutomaticWatermarkContext<String> ctx =
+			new StreamSource.AutomaticWatermarkContext<>(
+				operator,
+				operator.getContainingTask().getCheckpointLock(),
+				new CollectorOutput<String>(output),
+				operator.getExecutionConfig().getAutoWatermarkInterval());
+
+		// periodically emit the watermarks
+		// even though we start from 1 the watermark are still
+		// going to be aligned with the watermark interval.
+
+		for (long i = 1; i < 100; i += watermarkInterval)  {
+			timeProvider.setCurrentTime(i);
+		}
+
+		long nextWatermark = 0;
+		for (StreamElement el : output) {
+			nextWatermark += watermarkInterval;
+			Watermark wm = (Watermark) el;
+			assertTrue(wm.getTimestamp() == nextWatermark);
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	
 	@SuppressWarnings("unchecked")
-	private static <T> void setupSourceOperator(StreamSource<T, ?> operator) {
+	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
+												TimeCharacteristic timeChar,
+												long watermarkInterval,
+												final TimeServiceProvider timeProvider) {
+
 		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.setAutoWatermarkInterval(watermarkInterval);
+
 		StreamConfig cfg = new StreamConfig(new Configuration());
 		
-		cfg.setTimeCharacteristic(TimeCharacteristic.EventTime);
+		cfg.setTimeCharacteristic(timeChar);
 
 		Environment env = new DummyEnvironment("MockTwoInputTask", 1, 0);
-		
+
 		StreamTask<?, ?> mockTask = mock(StreamTask.class);
 		when(mockTask.getName()).thenReturn("Mock Task");
 		when(mockTask.getCheckpointLock()).thenReturn(new Object());
@@ -186,9 +235,44 @@ public class StreamSourceOperatorTest {
 		when(mockTask.getExecutionConfig()).thenReturn(executionConfig);
 		when(mockTask.getAccumulatorMap()).thenReturn(Collections.<String, Accumulator<?, ?>>emptyMap());
 
-		operator.setup(mockTask, cfg, (Output< StreamRecord<T>>) mock(Output.class));
+		doAnswer(new Answer<ScheduledFuture>() {
+			@Override
+			public ScheduledFuture answer(InvocationOnMock invocation) throws Throwable {
+				final long execTime = (Long) invocation.getArguments()[0];
+				final Triggerable target = (Triggerable) invocation.getArguments()[1];
+
+				if (timeProvider == null) {
+					throw new RuntimeException("The time provider is null");
+				}
+
+				timeProvider.registerTimer(execTime, new Runnable() {
+
+					@Override
+					public void run() {
+						try {
+							target.trigger(execTime);
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+					}
+				});
+				return null;
+			}
+		}).when(mockTask).registerTimer(anyLong(), any(Triggerable.class));
+
+		doAnswer(new Answer<Long>() {
+			@Override
+			public Long answer(InvocationOnMock invocation) throws Throwable {
+				if (timeProvider == null) {
+					throw new RuntimeException("The time provider is null");
+				}
+				return timeProvider.getCurrentProcessingTime();
+			}
+		}).when(mockTask).getCurrentProcessingTime();
+
+		operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
 	}
-	
+
 	// ------------------------------------------------------------------------
 	
 	private static final class FiniteSource<T> implements SourceFunction<T>, StoppableFunction {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
+import org.apache.flink.streaming.runtime.tasks.TestTimeServiceProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,6 +45,58 @@ import static org.junit.Assert.*;
 @PrepareForTest(ResultPartitionWriter.class)
 @SuppressWarnings("serial")
 public class StreamTaskTimerTest {
+
+	@Test
+	public void testCustomTimeServiceProvider() throws Throwable {
+		TestTimeServiceProvider tp = new TestTimeServiceProvider();
+
+		final OneInputStreamTask<String, String> mapTask = new OneInputStreamTask<>();
+		mapTask.setTimeService(tp);
+
+		final OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
+			mapTask, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+
+		StreamMap<String, String> mapOperator = new StreamMap<>(new DummyMapFunction<String>());
+		streamConfig.setStreamOperator(mapOperator);
+
+		testHarness.invoke();
+
+		assertTrue(testHarness.getCurrentProcessingTime() == 0);
+
+		tp.setCurrentTime(11);
+		assertTrue(testHarness.getCurrentProcessingTime() == 11);
+
+		tp.setCurrentTime(15);
+		tp.setCurrentTime(16);
+		assertTrue(testHarness.getCurrentProcessingTime() == 16);
+		
+		// register 2 tasks
+		mapTask.registerTimer(30, new Triggerable() {
+			@Override
+			public void trigger(long timestamp) {
+
+			}
+		});
+
+		mapTask.registerTimer(40, new Triggerable() {
+			@Override
+			public void trigger(long timestamp) {
+
+			}
+		});
+
+		assertEquals(2, tp.getNoOfRegisteredTimers());
+
+		tp.setCurrentTime(35);
+		assertEquals(1, tp.getNoOfRegisteredTimers());
+
+		tp.setCurrentTime(40);
+		assertEquals(0, tp.getNoOfRegisteredTimers());
+
+		tp.shutdownService();
+	}
 
 	@Test
 	public void testOpenCloseAndTimestamps() throws Exception {
@@ -174,6 +227,8 @@ public class StreamTaskTimerTest {
 	
 	public static class DummyMapFunction<T> implements MapFunction<T, T> {
 		@Override
-		public T map(T value) { return value; }
+		public T map(T value) {
+			return value;
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -113,6 +113,13 @@ public class StreamTaskTestHarness<OUT> {
 		outputStreamRecordSerializer = new MultiplexingStreamRecordSerializer<OUT>(outputSerializer);
 	}
 
+	public long getCurrentProcessingTime() {
+		if (!(task instanceof StreamTask)) {
+			System.currentTimeMillis();
+		}
+		return ((StreamTask) task).getCurrentProcessingTime();
+	}
+
 	/**
 	 * This must be overwritten for OneInputStreamTask or TwoInputStreamTask test harnesses.
 	 */


### PR DESCRIPTION
This PR changes the AutomaticWatermarkContext to user a pluggable processing time clock. This
allows for better testability of the code.

This PR also contains the solution to FLINK-3646.