### PR TITLE
[FLINK-4087] [metrics] Improved JMX port handling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -303,3 +303,18 @@ Open Font License (OFT) - http://scripts.sil.org/OFL
  - Font Awesome (http://fortawesome.github.io/Font-Awesome/) - Created by Dave Gandy
    -> fonts in "flink-runtime-web/web-dashboard/assets/fonts"
 
+-----------------------------------------------------------------------
+ The ISC License
+-----------------------------------------------------------------------
+ 
+ The Apache Flink project contains code under the ISC license from the following files:
+  - simplejmx (http://256.com/sources/simplejmx/) Copyright (c) - Gray Watson
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby
+granted, provided that this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING
+ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL,
+DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
@@ -44,6 +44,8 @@ public class MetricRegistry {
 	//  configuration keys
 	// ------------------------------------------------------------------------
 
+	public static final String KEY_METRICS_JMX_PORT = "metrics.jmx.port";
+
 	public static final String KEY_METRICS_REPORTER_CLASS = "metrics.reporter.class";
 	public static final String KEY_METRICS_REPORTER_ARGUMENTS = "metrics.reporter.arguments";
 	public static final String KEY_METRICS_REPORTER_INTERVAL = "metrics.reporter.interval";
@@ -85,7 +87,14 @@ public class MetricRegistry {
 		if (className == null) {
 			// by default, create JMX metrics
 			LOG.info("No metrics reporter configured, exposing metrics via JMX");
+			
+			Configuration reporterConfig = new Configuration();
+			String portRange = config.getString(KEY_METRICS_JMX_PORT, null);
+			if (portRange != null) {
+				reporterConfig.setString(KEY_METRICS_JMX_PORT, portRange);
+			}
 			this.reporter = new JMXReporter();
+			this.reporter.open(reporterConfig);
 			this.timer = null;
 		}
 		else {

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/JobGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/JobGroupTest.java
@@ -45,6 +45,7 @@ public class JobGroupTest {
 		assertEquals(
 				"theHostName.taskmanager.test-tm-id.myJobName",
 				jmGroup.getScopeString());
+		registry.shutdown();
 	}
 
 	@Test
@@ -66,6 +67,7 @@ public class JobGroupTest {
 		assertEquals(
 				"some-constant.myJobName",
 				jmGroup.getScopeString());
+		registry.shutdown();
 	}
 
 	@Test
@@ -87,5 +89,6 @@ public class JobGroupTest {
 		assertEquals(
 				"peter.test-tm-id.some-constant." + jid,
 				jmGroup.getScopeString());
+		registry.shutdown();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/MetricGroupRegistrationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/MetricGroupRegistrationTest.java
@@ -39,7 +39,9 @@ public class MetricGroupRegistrationTest {
 		Configuration config = new Configuration();
 		config.setString(MetricRegistry.KEY_METRICS_REPORTER_CLASS, TestReporter1.class.getName());
 
-		MetricGroup root = new TaskManagerMetricGroup(new MetricRegistry(config), "host", "id");
+		MetricRegistry registry = new MetricRegistry(config);
+
+		MetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
 
 		Counter counter = root.counter("counter");
 		assertEquals(counter, TestReporter1.lastPassedMetric);
@@ -54,6 +56,8 @@ public class MetricGroupRegistrationTest {
 		
 		Assert.assertEquals(gauge, TestReporter1.lastPassedMetric);
 		assertEquals("gauge", TestReporter1.lastPassedName);
+
+		registry.shutdown();
 	}
 
 	public static class TestReporter1 extends TestReporter {
@@ -75,8 +79,12 @@ public class MetricGroupRegistrationTest {
 	public void testInvalidMetricName() {
 		Configuration config = new Configuration();
 
-		MetricGroup root = new TaskManagerMetricGroup(new MetricRegistry(config), "host", "id");
+		MetricRegistry registry = new MetricRegistry(config);
+
+		MetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
 		root.counter("=)(/!");
+
+		registry.shutdown();
 	}
 
 	/**
@@ -86,7 +94,9 @@ public class MetricGroupRegistrationTest {
 	public void testDuplicateGroupName() {
 		Configuration config = new Configuration();
 
-		MetricGroup root = new TaskManagerMetricGroup(new MetricRegistry(config), "host", "id");
+		MetricRegistry registry = new MetricRegistry(config);
+
+		MetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
 
 		MetricGroup group1 = root.addGroup("group");
 		MetricGroup group2 = root.addGroup("group");

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/MetricGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/MetricGroupTest.java
@@ -24,15 +24,29 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.MetricRegistry;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 public class MetricGroupTest {
 	
-	private final MetricRegistry registry = new MetricRegistry(new Configuration());
+	private MetricRegistry registry;
 
 	private final MetricRegistry exceptionOnRegister = new ExceptionOnRegisterRegistry();
+
+	@Before
+	public void createRegistry() {
+		this.registry = new MetricRegistry(new Configuration());
+	}
+
+	@After
+	public void shutdownRegistry() {
+		this.registry.shutdown();
+		this.registry = null;
+	}
 
 	@Test
 	public void sameGroupOnNameCollision() {

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/OperatorGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/OperatorGroupTest.java
@@ -47,5 +47,7 @@ public class OperatorGroupTest {
 		assertEquals(
 				"theHostName.taskmanager.test-tm-id.myJobName.myOpName.11",
 				opGroup.getScopeString());
+
+		registry.shutdown();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskGroupTest.java
@@ -27,6 +27,8 @@ import org.apache.flink.metrics.groups.scope.ScopeFormat.TaskManagerScopeFormat;
 import org.apache.flink.metrics.groups.scope.ScopeFormat.TaskScopeFormat;
 import org.apache.flink.util.AbstractID;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -37,6 +39,18 @@ public class TaskGroupTest {
 	// ------------------------------------------------------------------------
 	//  scope tests
 	// ------------------------------------------------------------------------
+	private MetricRegistry registry;
+
+	@Before
+	public void createRegistry() {
+		this.registry = new MetricRegistry(new Configuration());
+	}
+
+	@After
+	public void shutdownRegistry() {
+		this.registry.shutdown();
+		this.registry = null;
+	}
 
 	@Test
 	public void testGenerateScopeDefault() {
@@ -56,6 +70,7 @@ public class TaskGroupTest {
 		assertEquals(
 				"theHostName.taskmanager.test-tm-id.myJobName.aTaskName.13",
 				taskGroup.getScopeString());
+		registry.shutdown();
 	}
 
 	@Test
@@ -82,6 +97,7 @@ public class TaskGroupTest {
 		assertEquals(
 				String.format("test-tm-id.%s.%s.%s", jid, vertexId, executionId),
 				taskGroup.getScopeString());
+		registry.shutdown();
 	}
 
 	@Test
@@ -110,5 +126,6 @@ public class TaskGroupTest {
 		assertEquals(
 				"theHostName.taskmanager.test-tm-id.myJobName." + executionId + ".13",
 				taskGroup.getScopeString());
+		registry.shutdown();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskManagerGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskManagerGroupTest.java
@@ -36,8 +36,10 @@ public class TaskManagerGroupTest {
 
 	@Test
 	public void addAndRemoveJobs() {
+		MetricRegistry registry = new MetricRegistry(new Configuration());
+
 		final TaskManagerMetricGroup group = new TaskManagerMetricGroup(
-				new MetricRegistry(new Configuration()), "localhost", new AbstractID().toString());
+				registry, "localhost", new AbstractID().toString());
 		
 		
 		final JobID jid1 = new JobID();
@@ -87,12 +89,15 @@ public class TaskManagerGroupTest {
 		assertTrue(tmGroup13.parent().isClosed());
 		
 		assertEquals(0, group.numRegisteredJobMetricGroups());
+
+		registry.shutdown();
 	}
 
 	@Test
 	public void testCloseClosesAll() {
+		MetricRegistry registry = new MetricRegistry(new Configuration());
 		final TaskManagerMetricGroup group = new TaskManagerMetricGroup(
-				new MetricRegistry(new Configuration()), "localhost", new AbstractID().toString());
+				registry, "localhost", new AbstractID().toString());
 
 
 		final JobID jid1 = new JobID();
@@ -118,6 +123,8 @@ public class TaskManagerGroupTest {
 		assertTrue(tmGroup11.isClosed());
 		assertTrue(tmGroup12.isClosed());
 		assertTrue(tmGroup21.isClosed());
+
+		registry.shutdown();
 	}
 	
 	// ------------------------------------------------------------------------
@@ -131,6 +138,7 @@ public class TaskManagerGroupTest {
 
 		assertArrayEquals(new String[] { "localhost", "taskmanager", "id" }, group.getScopeComponents());
 		assertEquals("localhost.taskmanager.id", group.getScopeString());
+		registry.shutdown();
 	}
 
 	@Test
@@ -141,5 +149,6 @@ public class TaskManagerGroupTest {
 
 		assertArrayEquals(new String[] { "constant", "host", "foo", "host" }, group.getScopeComponents());
 		assertEquals("constant.host.foo.host", group.getScopeString());
+		registry.shutdown();
 	}
 }

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -103,8 +103,6 @@ KEY_ENV_SSH_OPTS="env.ssh.opts"
 KEY_RECOVERY_MODE="recovery.mode"
 KEY_ZK_HEAP_MB="zookeeper.heap.mb"
 
-KEY_METRICS_JMX_PORT="metrics.jmx.port"
-
 ########################################################################################################################
 # PATHS AND CONFIG
 ########################################################################################################################
@@ -240,10 +238,6 @@ fi
 
 if [ -z "${RECOVERY_MODE}" ]; then
     RECOVERY_MODE=$(readFromConfig ${KEY_RECOVERY_MODE} "standalone" "${YAML_CONF}")
-fi
-
-if [ -z "${JMX_PORT}" ]; then
-    JMX_PORT=$(readFromConfig ${KEY_METRICS_JMX_PORT} 9010 "${YAML_CONF}")
 fi
 
 # Arguments for the JVM. Used for job and task manager JVMs.

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -33,14 +33,12 @@ bin=`cd "$bin"; pwd`
 case $DAEMON in
     (jobmanager)
         CLASS_TO_RUN=org.apache.flink.runtime.jobmanager.JobManager
-        if [ "${ARGS[3]}" == "local" ]; then
-            JMX_ARGS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${JMX_PORT} -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
-        fi
+        JMX_ARGS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=0 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
     ;;
 
     (taskmanager)
         CLASS_TO_RUN=org.apache.flink.runtime.taskmanager.TaskManager
-        JMX_ARGS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${JMX_PORT} -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+        JMX_ARGS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=0 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
     ;;
 
     (zookeeper)
@@ -101,7 +99,6 @@ case $STARTSTOP in
           count="${#active[@]}"
 
           if [ ${count} -gt 0 ]; then
-            JMX_ARGS=""
             echo "[INFO] $count instance(s) of $DAEMON are already running on $HOSTNAME."
           fi
         fi

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/reader/BufferReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/reader/BufferReaderTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.util.event.EventListener;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Task.class)
+@PowerMockIgnore({"javax.management.*"})
 @SuppressWarnings("unchecked")
 public class BufferReaderTest {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
@@ -37,6 +37,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -57,6 +58,7 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Task.class, ResultPartitionWriter.class})
+@PowerMockIgnore({"javax.management.*"})
 public class DataSinkTaskTest extends TaskTestBase {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(DataSinkTaskTest.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSourceTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSourceTaskTest.java
@@ -44,11 +44,13 @@ import org.apache.flink.util.MutableObjectIterator;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Task.class, ResultPartitionWriter.class})
+@PowerMockIgnore({"javax.management.*"})
 public class DataSourceTaskTest extends TaskTestBase {
 
 	private static final int MEMORY_MANAGER_SIZE = 1024 * 1024;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainTaskTest.java
@@ -46,11 +46,13 @@ import org.apache.flink.util.Collector;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Task.class, ResultPartitionWriter.class})
+@PowerMockIgnore({"javax.management.*"})
 public class ChainTaskTest extends TaskTestBase {
 	
 	private static final int MEMORY_MANAGER_SIZE = 1024 * 1024 * 3;


### PR DESCRIPTION
This PR modifies the JMX port handling.

Instead of setting a specific configured port on JVM start-up we use an ephemeral port for the JVM's JMXServer.

Inside the JVM we then spin-up another JMXServer which users can connect to. This JMXServer picks a port from a configured port range; iterating from start to end until it finds an open one.