### PR TITLE
[FLINK-1003] [WIP] Spread out scheduling of tasks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
@@ -365,6 +365,10 @@ public class Instance {
 	public boolean hasResourcesAvailable() {
 		return !isDead && getNumberOfAvailableSlots() > 0;
 	}
+	
+	public double getLoad() {
+		return ((double) getNumberOfAllocatedSlots()) / getTotalNumberOfSlots();
+	}
 
 	// --------------------------------------------------------------------------------------------
 	// Listeners

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulingStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.scheduler;
+
+public enum SchedulingStrategy {
+	LOCAL_FIRST, BALANCE
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -2301,7 +2301,8 @@ object JobManager {
     try {
       blobServer = new BlobServer(configuration)
       instanceManager = new InstanceManager()
-      scheduler = new FlinkScheduler(ExecutionContext.fromExecutor(executorService))
+      scheduler = new FlinkScheduler(ExecutionContext.fromExecutor(executorService),
+         configuration.getBoolean("scheduler.balance-load", false))
       libraryCacheManager = new BlobLibraryCacheManager(blobServer, cleanupInterval)
 
       instanceManager.addInstanceListener(scheduler)


### PR DESCRIPTION
This is a working progress PR with the core functionality implemented but no tests yet.

As this is a highly critical part of the system I would like to get some initial feedback before proceeding to write / change a huge amount of tests :)

About the functionality:

This is an adaptation of https://github.com/apache/flink/pull/60 to the current flink scheduler. Instead of preferring local instances when scheduling new task slots the new scheduling strategy allows users to balance the load on the different task managers.

Every time a new task needs to be scheduled the scheduler considers all instances that satisfy the scheduling constraints (has available nodes + locality constraints) and picks the one with the smallest load. Load is calculated by the percentage of task slots occupied in a given task manager.

I have already ran some cluster tests that seem to work for streaming programs,  but I haven't tested more complex jobs with iterations.
