### PR TITLE
[FLINK-4090] Close of OutputStream should be in finally clause in Fli…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -367,12 +367,20 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	}
 
 	private static void writeYarnProperties(Properties properties, File propertiesFile) {
+		OutputStream out = null;
 		try {
-			OutputStream out = new FileOutputStream(propertiesFile);
+			out = new FileOutputStream(propertiesFile);
 			properties.store(out, "Generated YARN properties file");
-			out.close();
 		} catch (IOException e) {
 			throw new RuntimeException("Error writing the properties file", e);
+		} finally {
+			if (out != null) {
+				try {
+					out.close();
+				} catch (IOException e) {
+					LOG.warn("Exception while closing the FileOutputStream for YARN properties file", e);
+				}
+			}
 		}
 		propertiesFile.setReadable(true, false); // readable for all.
 	}


### PR DESCRIPTION
`try {
      OutputStream out = new FileOutputStream(propertiesFile);
      properties.store(out, "Generated YARN properties file");
      out.close();
    } catch (IOException e) {`
Move the close of out in finally clause.