### PR TITLE
[FLINK-4091] Fix Guava shading in Cassandra connector

### DIFF
--- a/flink-streaming-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-streaming-connectors/flink-connector-cassandra/pom.xml
@@ -68,6 +68,7 @@ under the License.
 								<includes>
 									<include>com.datastax.cassandra:cassandra-driver-core</include>
 									<include>com.datastax.cassandra:cassandra-driver-mapping</include>
+									<include>com.google.guava:guava</include>
 								</includes>
 							</artifactSet>
 							<relocations>

--- a/flink-streaming-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-streaming-connectors/flink-connector-cassandra/pom.xml
@@ -73,7 +73,7 @@ under the License.
 							<relocations>
 								<relocation>
 									<pattern>com.google</pattern>
-									<shadedPattern>org.apache.flink.shaded.com.google</shadedPattern>
+									<shadedPattern>org.apache.flink.cassandra.shaded.com.google</shadedPattern>
 									<excludes>
 										<exclude>com.google.protobuf.**</exclude>
 										<exclude>com.google.inject.**</exclude>


### PR DESCRIPTION
This PR modifies the guava shading in the Cassandra connector. It no longer uses the same pattern as flink-dist which lead to version conflicts.