### PR TITLE
[FLINK-4093] Expose metric interfaces

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/metrics/Counter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/Counter.java
@@ -24,48 +24,36 @@ import org.apache.flink.annotation.PublicEvolving;
  * A Counter is a {@link Metric} that measures a count.
  */
 @PublicEvolving
-public final class Counter implements Metric {
-
-	private long count;
+public interface Counter extends Metric {
 
 	/**
 	 * Increment the current count by 1.
 	 */
-	public void inc() {
-		count++;
-	}
+	void inc();
 
 	/**
 	 * Increment the current count by the given value.
 	 *
 	 * @param n value to increment the current count by
 	 */
-	public void inc(long n) {
-		count += n;
-	}
+	void inc(long n);
 
 	/**
 	 * Decrement the current count by 1.
 	 */
-	public void dec() {
-		count--;
-	}
+	void dec();
 
 	/**
 	 * Decrement the current count by the given value.
 	 *
 	 * @param n value to decrement the current count by
 	 */
-	public void dec(long n) {
-		count -= n;
-	}
+	void dec(long n);
 
 	/**
 	 * Returns the current count.
 	 *
 	 * @return current count
 	 */
-	public long getCount() {
-		return count;
-	}
+	long getCount();
 }

--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
@@ -103,7 +103,6 @@ public interface MetricGroup {
 	 * @param <T>   return type of the gauge
 	 * @return the given gauge
 	 */
-	<T> Gauge<T> gauge(int name, Gauge<T> gauge);
 
 	/**
 	 * Registers a new {@link org.apache.flink.metrics.Gauge} with Flink.
@@ -113,7 +112,7 @@ public interface MetricGroup {
 	 * @param <T>   return type of the gauge
 	 * @return the given gauge
 	 */
-	<T> Gauge<T> gauge(String name, Gauge<T> gauge);
+	<T, G extends Gauge<T>> G gauge(String name, G gauge);
 
 	// ------------------------------------------------------------------------
 	// Groups

--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
@@ -63,7 +63,7 @@ public interface MetricGroup {
 	 * Creates and registers a new {@link org.apache.flink.metrics.Counter} with Flink.
 	 *
 	 * @param name name of the counter
-	 * @return the registered counter
+	 * @return the created counter
 	 */
 	Counter counter(int name);
 
@@ -71,17 +71,37 @@ public interface MetricGroup {
 	 * Creates and registers a new {@link org.apache.flink.metrics.Counter} with Flink.
 	 *
 	 * @param name name of the counter
-	 * @return the registered counter
+	 * @return the created counter
 	 */
 	Counter counter(String name);
 
+	/**
+	 * Registers a {@link org.apache.flink.metrics.Counter} with Flink.
+	 *
+	 * @param name    name of the counter
+	 * @param counter counter to register
+	 * @param <C>     counter type
+	 * @return the given counter
+	 */
+	<C extends Counter> C counter(int name, C counter);
+
+	/**
+	 * Registers a {@link org.apache.flink.metrics.Counter} with Flink.
+	 *
+	 * @param name    name of the counter
+	 * @param counter counter to register
+	 * @param <C>     counter type
+	 * @return the given counter
+	 */
+	<C extends Counter> C counter(String name, C counter);
+	
 	/**
 	 * Registers a new {@link org.apache.flink.metrics.Gauge} with Flink.
 	 *
 	 * @param name  name of the gauge
 	 * @param gauge gauge to register
 	 * @param <T>   return type of the gauge
-	 * @return the registered gauge
+	 * @return the given gauge
 	 */
 	<T> Gauge<T> gauge(int name, Gauge<T> gauge);
 
@@ -91,7 +111,7 @@ public interface MetricGroup {
 	 * @param name  name of the gauge
 	 * @param gauge gauge to register
 	 * @param <T>   return type of the gauge
-	 * @return the registered gauge
+	 * @return the given gauge
 	 */
 	<T> Gauge<T> gauge(String name, Gauge<T> gauge);
 

--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
@@ -103,6 +103,7 @@ public interface MetricGroup {
 	 * @param <T>   return type of the gauge
 	 * @return the given gauge
 	 */
+	<T, G extends Gauge<T>> G gauge(int name, G gauge);
 
 	/**
 	 * Registers a new {@link org.apache.flink.metrics.Gauge} with Flink.

--- a/flink-core/src/main/java/org/apache/flink/metrics/SimpleCounter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/SimpleCounter.java
@@ -15,20 +15,57 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.metrics;
 
-import org.apache.flink.annotation.PublicEvolving;
-
 /**
- * A Gauge is a {@link Metric} that calculates a specific value at a point in time.
+ * A simple low-overhead {@link org.apache.flink.metrics.Counter} that is not thread-safe.
  */
-@PublicEvolving
-public interface Gauge<T> extends Metric {
+public class SimpleCounter implements Counter {
+	private long count;
+
 	/**
-	 * Calculates and returns the measured value.
-	 *
-	 * @return calculated value
+	 * Increment the current count by 1.
 	 */
-	T getValue();
+	@Override
+	public void inc() {
+		count++;
+	}
+
+	/**
+	 * Increment the current count by the given value.
+	 *
+	 * @param n value to increment the current count by
+	 */
+	@Override
+	public void inc(long n) {
+		count += n;
+	}
+
+	/**
+	 * Decrement the current count by 1.
+	 */
+	@Override
+	public void dec() {
+		count--;
+	}
+
+	/**
+	 * Decrement the current count by the given value.
+	 *
+	 * @param n value to decrement the current count by
+	 */
+	@Override
+	public void dec(long n) {
+		count -= n;
+	}
+
+	/**
+	 * Returns the current count.
+	 *
+	 * @return current count
+	 */
+	@Override
+	public long getCount() {
+		return count;
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
@@ -24,6 +24,7 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.MetricRegistry;
+import org.apache.flink.metrics.SimpleCounter;
 
 import org.apache.flink.metrics.groups.scope.ScopeFormat;
 import org.slf4j.Logger;
@@ -146,7 +147,16 @@ public abstract class AbstractMetricGroup implements MetricGroup {
 
 	@Override
 	public Counter counter(String name) {
-		Counter counter = new Counter();
+		return counter(name, new SimpleCounter());
+	}
+	
+	@Override
+	public <C extends Counter> C counter(int name, C counter) {
+		return counter(String.valueOf(name), counter);
+	}
+
+	@Override
+	public <C extends Counter> C counter(String name, C counter) {
 		addMetric(name, counter);
 		return counter;
 	}

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
 
 /**
  * A special {@link MetricGroup} that does not register any metrics at the metrics registry
@@ -42,12 +43,12 @@ public class UnregisteredMetricsGroup implements MetricGroup {
 
 	@Override
 	public Counter counter(int name) {
-		return new Counter();
+		return new SimpleCounter();
 	}
 
 	@Override
 	public Counter counter(String name) {
-		return new Counter();
+		return new SimpleCounter();
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
@@ -51,6 +51,16 @@ public class UnregisteredMetricsGroup implements MetricGroup {
 	}
 
 	@Override
+	public <C extends Counter> C counter(int name, C counter) {
+		return counter;
+	}
+
+	@Override
+	public <C extends Counter> C counter(String name, C counter) {
+		return counter;
+	}
+
+	@Override
 	public <T> Gauge<T> gauge(int name, Gauge<T> gauge) {
 		return gauge;
 	}


### PR DESCRIPTION
This PR allows users to create their own Counters and register them with Flink.

To that end, Counter was refactored into a SimpleCounter class implementing a new Counter interface. Gauge was changed to an interface as well.