### PR TITLE
[hotfix] [metrics] Prevent log flooding from collisions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/metrics/reporter/JMXReporter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/reporter/JMXReporter.java
@@ -113,7 +113,8 @@ public class JMXReporter implements MetricReporter {
 			// implementation error on our side
 			LOG.error("Metric did not comply with JMX MBean naming rules.", e);
 		} catch (InstanceAlreadyExistsException e) {
-			LOG.error("A metric with the name " + jmxName + " was already registered.", e);
+			LOG.debug("A metric with the name " + jmxName + " was already registered.", e);
+			LOG.error("A metric with the name " + jmxName + " was already registered.");
 		} catch (Throwable t) {
 			LOG.error("Failed to register metric", t);
 		}


### PR DESCRIPTION
This is a small change that reduces clutter due to naming collisions when registering metrics. It now only logs stacktraces when the logging level = DEBUG, otherwise just a single line that a collison occurred.