### PR TITLE
[FLINK-3838] Upgrade commons-cli to fix parsing of jar args

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -18,12 +18,11 @@
 package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
-
 import org.apache.flink.client.CliFrontend;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -389,7 +388,7 @@ public class CliFrontendParser {
 
 	public static RunOptions parseRunCommand(String[] args) throws CliArgsException {
 		try {
-			PosixParser parser = new PosixParser();
+			DefaultParser parser = new DefaultParser();
 			CommandLine line = parser.parse(RUN_OPTIONS, args, true);
 			return new RunOptions(line);
 		}
@@ -400,7 +399,7 @@ public class CliFrontendParser {
 
 	public static ListOptions parseListCommand(String[] args) throws CliArgsException {
 		try {
-			PosixParser parser = new PosixParser();
+			DefaultParser parser = new DefaultParser();
 			CommandLine line = parser.parse(LIST_OPTIONS, args, false);
 			return new ListOptions(line);
 		}
@@ -411,7 +410,7 @@ public class CliFrontendParser {
 
 	public static CancelOptions parseCancelCommand(String[] args) throws CliArgsException {
 		try {
-			PosixParser parser = new PosixParser();
+			DefaultParser parser = new DefaultParser();
 			CommandLine line = parser.parse(CANCEL_OPTIONS, args, false);
 			return new CancelOptions(line);
 		}
@@ -422,7 +421,7 @@ public class CliFrontendParser {
 
 	public static StopOptions parseStopCommand(String[] args) throws CliArgsException {
 		try {
-			PosixParser parser = new PosixParser();
+			DefaultParser parser = new DefaultParser();
 			CommandLine line = parser.parse(STOP_OPTIONS, args, false);
 			return new StopOptions(line);
 		} catch (ParseException e) {
@@ -432,7 +431,7 @@ public class CliFrontendParser {
 
 	public static SavepointOptions parseSavepointCommand(String[] args) throws CliArgsException {
 		try {
-			PosixParser parser = new PosixParser();
+			DefaultParser parser = new DefaultParser();
 			CommandLine line = parser.parse(SAVEPOINT_OPTIONS, args, false);
 			return new SavepointOptions(line);
 		}
@@ -443,7 +442,7 @@ public class CliFrontendParser {
 
 	public static InfoOptions parseInfoCommand(String[] args) throws CliArgsException {
 		try {
-			PosixParser parser = new PosixParser();
+			DefaultParser parser = new DefaultParser();
 			CommandLine line = parser.parse(INFO_OPTIONS, args, true);
 			return new InfoOptions(line);
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -98,6 +98,18 @@ public class CliFrontendRunTest {
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
 				assertEquals("expectedSavepointPath", options.getSavepointPath());
 			}
+
+			// test jar arguments
+			{
+				String[] parameters =
+					{"-m", "localhost:6123", getTestJarPath(), "-arg1", "value1", "justavalue", "--arg2", "value2"};
+				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
+				assertEquals("-arg1", options.getProgramArgs()[0]);
+				assertEquals("value1", options.getProgramArgs()[1]);
+				assertEquals("justavalue", options.getProgramArgs()[2]);
+				assertEquals("--arg2", options.getProgramArgs()[3]);
+				assertEquals("value2", options.getProgramArgs()[4]);
+			}
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@ under the License.
 			<dependency>
 				<groupId>commons-cli</groupId>
 				<artifactId>commons-cli</artifactId>
-				<version>1.2</version>
+				<version>1.3.1</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
The jar arguments were not parsed correctly if options were
present. For example, in `./flink run <options> file.jar -arg value` the
jar arguments would be parsed as "arg" and "value". Interestingly, this only
happens when <options> are present.

The issue has been fixed in commons-cli 1.3.1.