### PR TITLE
[FLINK-1946] reduce verbosity of Yarn cluster setup

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -727,8 +727,9 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		yarnClient.submitApplication(appContext);
 
 		LOG.info("Waiting for the cluster to be allocated");
-		int waittime = 0;
+		int waitTime = 0;
 		ApplicationReport report;
+		YarnApplicationState lastAppState = YarnApplicationState.NEW;
 		loop: while( true ) {
 			try {
 				report = yarnClient.getApplicationReport(appId);
@@ -750,13 +751,16 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 					LOG.info("YARN application has been deployed successfully.");
 					break loop;
 				default:
-					LOG.info("Deploying cluster, current state " + appState);
-					if(waittime > 60000) {
+					if (appState != lastAppState) {
+						LOG.info("Deploying cluster, current state " + appState);
+					}
+					if(waitTime > 60000) {
 						LOG.info("Deployment took more than 60 seconds. Please check if the requested resources are available in the YARN cluster");
 					}
 
 			}
-			waittime += 1000;
+			lastAppState = appState;
+			waitTime += 1000;
 			Thread.sleep(1000);
 		}
 		// print the application id for user to cancel themselves.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -186,17 +186,17 @@ public class YarnClusterClient extends ClusterClient {
 
 			logAndSysout("Waiting until all TaskManagers have connected");
 
-			while (true) {
-				GetClusterStatusResponse status = getClusterStatus();
-				if (status != null) {
-					if (status.numRegisteredTaskManagers() < clusterDescriptor.getTaskManagerCount()) {
-						logAndSysout("TaskManager status (" + status.numRegisteredTaskManagers() + "/"
-							+ clusterDescriptor.getTaskManagerCount() + ")");
-					} else {
+			for (GetClusterStatusResponse lastStatus = null;;) {
+				GetClusterStatusResponse currentStatus = getClusterStatus();
+				if (currentStatus != null && !currentStatus.equals(lastStatus)) {
+					logAndSysout("TaskManager status (" + currentStatus.numRegisteredTaskManagers() + "/"
+						+ clusterDescriptor.getTaskManagerCount() + ")");
+					if (currentStatus.numRegisteredTaskManagers() >= clusterDescriptor.getTaskManagerCount()) {
 						logAndSysout("All TaskManagers are connected");
 						break;
 					}
-				} else {
+					lastStatus = currentStatus;
+				} else if (lastStatus == null) {
 					logAndSysout("No status updates from the YARN cluster received so far. Waiting ...");
 				}
 


### PR DESCRIPTION
This removes repeated printing of messages retrieved from the Yarn cluster. Only new messages are printed.