### PR TITLE
[FLINK-4115] FsStateBackend filesystem verification can cause classpath exceptions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -275,7 +275,7 @@ public abstract class FileSystem {
 
 			// Try to create a new file system
 
-			if (!FSDIRECTORY.containsKey(uri.getScheme())) {
+			if (!isFlinkSupportedScheme(uri.getScheme())) {
 				// no build in support for this file system. Falling back to Hadoop's FileSystem impl.
 				Class<?> wrapperClass = getHadoopWrapperClassNameForFileSystem(uri.getScheme());
 				if (wrapperClass != null) {
@@ -313,6 +313,17 @@ public abstract class FileSystem {
 		}
 
 		return fs;
+	}
+
+	/**
+	 * Returns a boolean indicating whether a scheme has built-in Flink support.
+	 *
+	 * @param scheme
+	 *        a file system scheme
+	 * @return a boolean indicating whether the provided scheme has built-in Flink support
+	 */
+	public static boolean isFlinkSupportedScheme(String scheme) {
+		return FSDIRECTORY.containsKey(scheme);
 	}
 
 	//Class must implement Hadoop FileSystem interface. The class is not avaiable in 'flink-core'.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -173,7 +173,6 @@ public class FsStateBackend extends AbstractStateBackend {
 		this.fileStateThreshold = fileStateSizeThreshold;
 		
 		this.basePath = validateAndNormalizeUri(checkpointDataUri);
-		this.filesystem = this.basePath.getFileSystem();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -374,26 +374,31 @@ public class FsStateBackend extends AbstractStateBackend {
 			throw new IllegalArgumentException("Cannot use the root directory for checkpoints.");
 		}
 
-		// we do a bit of work to make sure that the URI for the filesystem refers to exactly the same
-		// (distributed) filesystem on all hosts and includes full host/port information, even if the
-		// original URI did not include that. We count on the filesystem loading from the configuration
-		// to fill in the missing data.
+		if (!FileSystem.isFlinkSupportedScheme(checkpointDataUri.getScheme())) {
+			// skip verification checks for non-flink supported filesystem
+			// this is because the required filesystem classes may not be available to the flink client
+			return new Path(checkpointDataUri);
+		} else {
+			// we do a bit of work to make sure that the URI for the filesystem refers to exactly the same
+			// (distributed) filesystem on all hosts and includes full host/port information, even if the
+			// original URI did not include that. We count on the filesystem loading from the configuration
+			// to fill in the missing data.
 
-		// try to grab the file system for this path/URI
-		FileSystem filesystem = FileSystem.get(checkpointDataUri);
-		if (filesystem == null) {
-			throw new IOException("Could not find a file system for the given scheme in the available configurations.");
-		}
+			// try to grab the file system for this path/URI
+			FileSystem filesystem = FileSystem.get(checkpointDataUri);
+			if (filesystem == null) {
+				throw new IOException("Could not find a file system for the given scheme in the available configurations.");
+			}
 
-		URI fsURI = filesystem.getUri();
-		try {
-			URI baseURI = new URI(fsURI.getScheme(), fsURI.getAuthority(), path, null, null);
-			return new Path(baseURI);
-		}
-		catch (URISyntaxException e) {
-			throw new IOException(
+			URI fsURI = filesystem.getUri();
+			try {
+				URI baseURI = new URI(fsURI.getScheme(), fsURI.getAuthority(), path, null, null);
+				return new Path(baseURI);
+			} catch (URISyntaxException e) {
+				throw new IOException(
 					String.format("Cannot create file system URI for checkpointDataUri %s and filesystem URI %s",
-							checkpointDataUri, fsURI), e);
+						checkpointDataUri, fsURI), e);
+			}
 		}
 	}
 	


### PR DESCRIPTION
There are two changes to FsStateBackend to avoid classpath exceptions when submitting a job from a Flink client which does not have the necessary file system classes on its classpath:

- The filesystem is no longer initialised in the FsStateBackend constructor 
- The verification checks for the checkpoint directory in the FsStateBackend constructor are skipped if Flink does not have built-in support for the URI scheme