### PR TITLE
[FLINK-4122] Disable root shading in Cassandra jar

### DIFF
--- a/flink-streaming-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-streaming-connectors/flink-connector-cassandra/pom.xml
@@ -59,11 +59,12 @@ under the License.
 				<executions>
 					<!-- Run shade goal on package phase -->
 					<execution>
+						<id>shade-flink</id>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>
 						</goals>
-						<configuration>
+						<configuration combine.self="override">
 							<artifactSet>
 								<includes>
 									<include>com.datastax.cassandra:cassandra-driver-core</include>


### PR DESCRIPTION
This PR overrides the root pom's guava shading configuration in the cassandra module, so that the JAR does not contain both shaded versions of guava.