### PR TITLE
[FLINK-4109] [tableAPI] Change the name of ternary condition operator

### DIFF
--- a/docs/apis/table.md
+++ b/docs/apis/table.md
@@ -748,7 +748,7 @@ unary = [ "!" | "-" ] , composite ;
 
 composite = suffixed | atom ;
 
-suffixed = cast | as | aggregation | nullCheck | evaluate | functionCall ;
+suffixed = cast | as | aggregation | nullCheck | if | functionCall ;
 
 cast = composite , ".cast(" , dataType , ")" ;
 
@@ -760,7 +760,7 @@ aggregation = composite , ( ".sum" | ".min" | ".max" | ".count" | ".avg" ) , [ "
 
 nullCheck = composite , ( ".isNull" | ".isNotNull" ) , [ "()" ] ;
 
-evaluate = composite , ".eval(" , expression , "," , expression , ")" ;
+if = composite , ".?(" , expression , "," , expression , ")" ;
 
 functionCall = composite , "." , functionIdentifier , "(" , [ expression , { "," , expression } ] , ")"
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
@@ -69,16 +69,16 @@ trait ImplicitExpressionOperations {
   def desc = Desc(expr)
 
   /**
-    * Conditional operator that decides which of two other expressions should be evaluated
+    * Ternary conditional operator that decides which of two other expressions should be evaluated
     * based on a evaluated boolean condition.
     *
-    * e.g. (42 > 5).eval("A", "B") leads to "A"
+    * e.g. (42 > 5).?("A", "B") leads to "A"
     *
     * @param ifTrue expression to be evaluated if condition holds
     * @param ifFalse expression to be evaluated if condition does not hold
     */
-  def eval(ifTrue: Expression, ifFalse: Expression) = {
-    Eval(expr, ifTrue, ifFalse)
+  def ?(ifTrue: Expression, ifFalse: Expression) = {
+    If(expr, ifTrue, ifFalse)
   }
 
   // scalar functions

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
@@ -51,14 +51,14 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   lazy val IS_NOT_NULL: Keyword = Keyword("isNotNull")
   lazy val CAST: Keyword = Keyword("cast")
   lazy val NULL: Keyword = Keyword("Null")
-  lazy val EVAL: Keyword = Keyword("eval")
+  lazy val IF: Keyword = Keyword("?")
   lazy val ASC: Keyword = Keyword("asc")
   lazy val DESC: Keyword = Keyword("desc")
 
   def functionIdent: ExpressionParser.Parser[String] =
     not(AS) ~ not(COUNT) ~ not(AVG) ~ not(MIN) ~ not(MAX) ~
       not(SUM) ~ not(IS_NULL) ~ not(IS_NOT_NULL) ~ not(CAST) ~ not(NULL) ~
-      not(EVAL) ~> super.ident
+      not(IF) ~> super.ident
 
   // data types
 
@@ -160,8 +160,8 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   }
 
   lazy val suffixEval: PackratParser[Expression] =
-    composite ~ "." ~ EVAL ~ "(" ~ expression ~ "," ~ expression ~ ")" ^^ {
-    case condition ~ _ ~ _ ~ _ ~ ifTrue ~ _ ~ ifFalse ~ _ => Eval(condition, ifTrue, ifFalse)
+    composite ~ "." ~ IF ~ "(" ~ expression ~ "," ~ expression ~ ")" ^^ {
+    case condition ~ _ ~ _ ~ _ ~ ifTrue ~ _ ~ ifFalse ~ _ => If(condition, ifTrue, ifFalse)
   }
 
   lazy val suffixFunctionCall =
@@ -224,8 +224,8 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   }
 
   lazy val prefixEval: PackratParser[Expression] = composite ~
-      EVAL ~ "(" ~ expression ~ "," ~ expression ~ "," ~ expression ~ ")" ^^ {
-    case _ ~ _ ~ condition ~ _ ~ ifTrue ~ _ ~ ifFalse ~ _ => Eval(condition, ifTrue, ifFalse)
+      IF ~ "(" ~ expression ~ "," ~ expression ~ "," ~ expression ~ ")" ^^ {
+    case _ ~ _ ~ condition ~ _ ~ ifTrue ~ _ ~ ifFalse ~ _ => If(condition, ifTrue, ifFalse)
   }
 
   lazy val prefixFunctionCall = functionIdent ~ "(" ~ repsep(expression, ",") ~ ")" ^^ {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/logic.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/logic.scala
@@ -76,7 +76,7 @@ case class Or(left: Expression, right: Expression) extends BinaryPredicate {
   }
 }
 
-case class Eval(
+case class If(
     condition: Expression,
     ifTrue: Expression,
     ifFalse: Expression)
@@ -100,7 +100,7 @@ case class Eval(
       ValidationSuccess
     } else {
       ValidationFailure(
-        s"Eval should have boolean condition and same type of ifTrue and ifFalse, get " +
+        s"If should have boolean condition and same type of ifTrue and ifFalse, get " +
           s"(${condition.resultType}, ${ifTrue.resultType}, ${ifFalse.resultType})")
     }
   }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/table/ExpressionsITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/table/ExpressionsITCase.java
@@ -135,7 +135,7 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 	}
 
 	@Test
-	public void testEval() throws Exception {
+	public void testIf() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
 
@@ -146,9 +146,9 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 				tableEnv.fromDataSet(input, "a, b");
 
 		Table result = table.select(
-				"(b && true).eval('true', 'false')," +
-					"false.eval('true', 'false')," +
-					"true.eval(true.eval(true.eval(10, 4), 4), 4)");
+				"(b && true).?('true', 'false')," +
+					"false.?('true', 'false')," +
+					"true.?(true.?(true.?(10, 4), 4), 4)");
 
 		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
 		List<Row> results = ds.collect();
@@ -157,7 +157,7 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 	}
 
 	@Test(expected = ValidationException.class)
-	public void testEvalInvalidTypes() throws Exception {
+	public void testIfInvalidTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
 
@@ -167,7 +167,7 @@ public class ExpressionsITCase extends TableProgramsTestBase {
 		Table table =
 				tableEnv.fromDataSet(input, "a, b");
 
-		Table result = table.select("(b && true).eval(5, 'false')");
+		Table result = table.select("(b && true).?(5, 'false')");
 
 		DataSet<Row> ds = tableEnv.toDataSet(result, Row.class);
 		List<Row> results = ds.collect();

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/ExpressionsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/ExpressionsITCase.scala
@@ -129,15 +129,15 @@ class ExpressionsITCase(
   }
 
   @Test
-  def testEval(): Unit = {
+  def testIf(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
     val t = env.fromElements((5, true)).toTable(tEnv, 'a, 'b)
       .select(
-        ('b && true).eval("true", "false"),
-        false.eval("true", "false"),
-        true.eval(true.eval(true.eval(10, 4), 4), 4))
+        ('b && true).?("true", "false"),
+        false.?("true", "false"),
+        true.?(true.?(true.?(10, 4), 4), 4))
 
     val expected = "true,false,10"
     val results = t.toDataSet[Row].collect()
@@ -145,12 +145,12 @@ class ExpressionsITCase(
   }
 
   @Test(expected = classOf[ValidationException])
-  def testEvalInvalidTypes(): Unit = {
+  def testIfInvalidTypes(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
     val t = env.fromElements((5, true)).toTable(tEnv, 'a, 'b)
-      .select(('b && true).eval(5, "false"))
+      .select(('b && true).?(5, "false"))
 
     val expected = "true,false,3,10"
     val results = t.toDataSet[Row].collect()


### PR DESCRIPTION
It's better to use "?" than "eval()" for ternary condition operator in Table API since most people comming from Java/C/C++ know what it does. However, "eval()" is ambiguous.

The condition operator looks like this now:

```
(42 > 5).?("A", "B")
(42 > 5) ? ("A", "B")
```

The document has been updated too. 

As it is a public API, I hope it can be reviewed soon and merged before release.