### PR TITLE
[FLINK-4128] compile error about git-commit-id-plugin 

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -323,7 +323,7 @@ under the License.
 					</execution>
 				</executions>
 				<configuration>
-					<dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+					<dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
 					<generateGitPropertiesFile>true</generateGitPropertiesFile>
 					<skipPoms>false</skipPoms>
 					<failOnNoGitDirectory>false</failOnNoGitDirectory>


### PR DESCRIPTION
When I build with latest flink code, I got following error:

> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD FAILURE
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time: 01:06 h
> [INFO] Finished at: 2016-06-28T22:11:58+08:00
> [INFO] Final Memory: 104M/3186M
> [INFO] ------------------------------------------------------------------------
> [ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.1.5:revision (default) on project flink-runtime_2.11: Execution default of goal pl.project13.maven:git-commit-id-plugin:2.1.5:revision failed. NullPointerException -> [Help 1]
> [ERROR]
> [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
> [ERROR] Re-run Maven using the -X switch to enable full debug logging.
> [ERROR]
> [ERROR] For more information about the errors and possible solutions, please read the following articles:
> [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
> [ERROR]
> [ERROR] After correcting the problems, you can resume the build with the command
> [ERROR]   mvn <goals> -rf :flink-runtime_2.11

I think it's because wrong `doGetDirectory` value is provided.  I have fix it and compile is fine for me now.
