### PR TITLE
[FLINK-3618] [gelly] Rename abstract UDF classes in Scatter-Gather implementation

### DIFF
--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/examples/IncrementalSSSPITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/examples/IncrementalSSSPITCase.java
@@ -111,8 +111,8 @@ public class IncrementalSSSPITCase extends MultipleProgramsTestBase {
 
 			// run the scatter gather iteration to propagate info
 			Graph<Long, Double, Double> result = ssspGraph.runScatterGatherIteration(
-					new IncrementalSSSP.VertexDistanceUpdater(),
 					new IncrementalSSSP.InvalidateMessenger(edgeToBeRemoved),
+					new IncrementalSSSP.VertexDistanceUpdater(),
 					IncrementalSSSPData.NUM_VERTICES, parameters);
 
 			DataSet<Vertex<Long, Double>> resultedVertices = result.getVertices();

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -24,9 +24,9 @@ import org.apache.flink.api.java.{tuple => jtuple}
 import org.apache.flink.api.scala._
 import org.apache.flink.graph._
 import org.apache.flink.graph.asm.translate.TranslateFunction
-import org.apache.flink.graph.gsa.{ApplyFunction, GSAConfiguration, GatherFunction, SumFunction}
+import org.apache.flink.graph.gsa.{ApplyFunction, GSAConfiguration, SumFunction, GatherFunction => GSAGatherFunction}
 import org.apache.flink.graph.pregel.{ComputeFunction, MessageCombiner, VertexCentricConfiguration}
-import org.apache.flink.graph.spargel.{MessagingFunction, ScatterGatherConfiguration, VertexUpdateFunction}
+import org.apache.flink.graph.spargel.{ScatterFunction, ScatterGatherConfiguration, GatherFunction => SpargelGatherFunction}
 import org.apache.flink.graph.validation.GraphValidator
 import org.apache.flink.types.{LongValue, NullValue}
 import org.apache.flink.util.Preconditions
@@ -38,8 +38,8 @@ import _root_.scala.reflect.ClassTag
 object Graph {
 
   /**
-  * Creates a Graph from a DataSet of vertices and a DataSet of edges.
-  */
+   * Creates a Graph from a DataSet of vertices and a DataSet of edges.
+   */
   def fromDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](vertices: DataSet[Vertex[K, VV]], edges: DataSet[Edge[K, EV]],
                               env: ExecutionEnvironment): Graph[K, VV, EV] = {
@@ -47,19 +47,19 @@ object Graph {
   }
 
   /**
-  * Creates a Graph from a DataSet of edges.
-  * Vertices are created automatically and their values are set to NullValue.
-  */
+   * Creates a Graph from a DataSet of edges.
+   * Vertices are created automatically and their values are set to NullValue.
+   */
   def fromDataSet[K: TypeInformation : ClassTag, EV: TypeInformation : ClassTag]
   (edges: DataSet[Edge[K, EV]], env: ExecutionEnvironment): Graph[K, NullValue, EV] = {
     wrapGraph(jg.Graph.fromDataSet[K, EV](edges.javaSet, env.getJavaEnv))
   }
 
   /**
-  * Creates a graph from a DataSet of edges.
-  * Vertices are created automatically and their values are set by applying the provided
-  * vertexValueInitializer map function to the vertex ids.
-  */
+   * Creates a graph from a DataSet of edges.
+   * Vertices are created automatically and their values are set by applying the provided
+   * vertexValueInitializer map function to the vertex ids.
+   */
   def fromDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](edges: DataSet[Edge[K, EV]],
   vertexValueInitializer: MapFunction[K, VV], env: ExecutionEnvironment): Graph[K, VV, EV] = {
@@ -68,8 +68,8 @@ object Graph {
   }
 
   /**
-  * Creates a Graph from a Seq of vertices and a Seq of edges.
-  */
+   * Creates a Graph from a Seq of vertices and a Seq of edges.
+   */
   def fromCollection[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](vertices: Seq[Vertex[K, VV]], edges: Seq[Edge[K, EV]], env:
   ExecutionEnvironment): Graph[K, VV, EV] = {
@@ -78,19 +78,19 @@ object Graph {
   }
 
   /**
-  * Creates a Graph from a Seq of edges.
-  * Vertices are created automatically and their values are set to NullValue.
-  */
+   * Creates a Graph from a Seq of edges.
+   * Vertices are created automatically and their values are set to NullValue.
+   */
   def fromCollection[K: TypeInformation : ClassTag, EV: TypeInformation : ClassTag]
   (edges: Seq[Edge[K, EV]], env: ExecutionEnvironment): Graph[K, NullValue, EV] = {
     wrapGraph(jg.Graph.fromCollection[K, EV](edges.asJavaCollection, env.getJavaEnv))
   }
 
   /**
-  * Creates a graph from a Seq of edges.
-  * Vertices are created automatically and their values are set by applying the provided
-  * vertexValueInitializer map function to the vertex ids.
-  */
+   * Creates a graph from a Seq of edges.
+   * Vertices are created automatically and their values are set by applying the provided
+   * vertexValueInitializer map function to the vertex ids.
+   */
   def fromCollection[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](edges: Seq[Edge[K, EV]], vertexValueInitializer: MapFunction[K, VV],
   env: ExecutionEnvironment): Graph[K, VV, EV] = {
@@ -105,7 +105,7 @@ object Graph {
    * The first field of the Tuple3 object for edges will become the source ID,
    * the second field will become the target ID, and the third field will become
    * the edge value. 
-  */
+   */
   def fromTupleDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](vertices: DataSet[(K, VV)], edges: DataSet[(K, K, EV)],
                               env: ExecutionEnvironment): Graph[K, VV, EV] = {
@@ -116,12 +116,12 @@ object Graph {
   }
 
   /**
-  * Creates a Graph from a DataSet of Tuples representing the edges.
-  * The first field of the Tuple3 object for edges will become the source ID,
-  * the second field will become the target ID, and the third field will become
-  * the edge value. 
-  * Vertices are created automatically and their values are set to NullValue.
-  */
+   * Creates a Graph from a DataSet of Tuples representing the edges.
+   * The first field of the Tuple3 object for edges will become the source ID,
+   * the second field will become the target ID, and the third field will become
+   * the edge value.
+   * Vertices are created automatically and their values are set to NullValue.
+   */
   def fromTupleDataSet[K: TypeInformation : ClassTag, EV: TypeInformation : ClassTag]
   (edges: DataSet[(K, K, EV)], env: ExecutionEnvironment): Graph[K, NullValue, EV] = {
     val javaTupleEdges = edges.map(v => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
@@ -129,13 +129,13 @@ object Graph {
   }
 
   /**
-  * Creates a Graph from a DataSet of Tuples representing the edges.
-  * The first field of the Tuple3 object for edges will become the source ID,
-  * the second field will become the target ID, and the third field will become
-  * the edge value. 
-  * Vertices are created automatically and their values are set by applying the provided
-  * vertexValueInitializer map function to the vertex ids.
-  */
+   * Creates a Graph from a DataSet of Tuples representing the edges.
+   * The first field of the Tuple3 object for edges will become the source ID,
+   * the second field will become the target ID, and the third field will become
+   * the edge value.
+   * Vertices are created automatically and their values are set by applying the provided
+   * vertexValueInitializer map function to the vertex ids.
+   */
   def fromTupleDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](edges: DataSet[(K, K, EV)],
   vertexValueInitializer: MapFunction[K, VV], env: ExecutionEnvironment): Graph[K, VV, EV] = {
@@ -144,12 +144,12 @@ object Graph {
       env.getJavaEnv))
   }
 
-    /**
-  * Creates a Graph from a DataSet of Tuple2's representing the edges.
-  * The first field of the Tuple2 object for edges will become the source ID,
-  * the second field will become the target ID. The edge value will be set to NullValue.
-  * Vertices are created automatically and their values are set to NullValue.
-  */
+  /**
+   * Creates a Graph from a DataSet of Tuple2's representing the edges.
+   * The first field of the Tuple2 object for edges will become the source ID,
+   * the second field will become the target ID. The edge value will be set to NullValue.
+   * Vertices are created automatically and their values are set to NullValue.
+   */
   def fromTuple2DataSet[K: TypeInformation : ClassTag](edges: DataSet[(K, K)],
   env: ExecutionEnvironment): Graph[K, NullValue, NullValue] = {
     val javaTupleEdges = edges.map(v => new jtuple.Tuple2(v._1, v._2)).javaSet
@@ -157,12 +157,12 @@ object Graph {
   }
 
   /**
-  * Creates a Graph from a DataSet of Tuple2's representing the edges.
-  * The first field of the Tuple2 object for edges will become the source ID,
-  * the second field will become the target ID. The edge value will be set to NullValue.
-  * Vertices are created automatically and their values are set by applying the provided
-  * vertexValueInitializer map function to the vertex IDs.
-  */
+   * Creates a Graph from a DataSet of Tuple2's representing the edges.
+   * The first field of the Tuple2 object for edges will become the source ID,
+   * the second field will become the target ID. The edge value will be set to NullValue.
+   * Vertices are created automatically and their values are set by applying the provided
+   * vertexValueInitializer map function to the vertex IDs.
+   */
   def fromTuple2DataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag]
   (edges: DataSet[(K, K)], vertexValueInitializer: MapFunction[K, VV],
   env: ExecutionEnvironment): Graph[K, VV, NullValue] = {
@@ -172,52 +172,52 @@ object Graph {
   }
 
   /** Creates a Graph from a CSV file of edges.
-    *
-    * The edge value is read from the CSV file if [[EV]] is not of type [[NullValue]]. Otherwise the
-    * edge value is set to [[NullValue]].
-    *
-    * If the vertex value type [[VV]] is specified (unequal [[NullValue]]), then the vertex values
-    * are read from the file specified by pathVertices. If the path has not been specified then the
-    * vertexValueInitializer is used to initialize the vertex values of the vertices extracted from
-    * the set of edges. If the vertexValueInitializer has not been set either, then the method
-    * fails.
-    *
-    * @param env The Execution Environment.
-    * @param pathEdges The file path containing the edges.
-    * @param pathVertices The file path containing the vertices.
-    * @param lineDelimiterVertices The string that separates lines in the vertices file. It defaults
-    *                              to newline.
-    * @param fieldDelimiterVertices The string that separates vertex Ids from vertex values in the
-    *                               vertices file.
-    * @param quoteCharacterVertices The character to use for quoted String parsing in the vertices
-    *                               file. Disabled by default.
-    * @param ignoreFirstLineVertices Whether the first line in the vertices file should be ignored.
-    * @param ignoreCommentsVertices Lines that start with the given String in the vertices file
-    *                               are ignored, disabled by default.
-    * @param lenientVertices Whether the parser should silently ignore malformed lines in the
-    *                        vertices file.
-    * @param includedFieldsVertices The fields in the vertices file that should be read. By default
-    *                               all fields are read.
-    * @param lineDelimiterEdges The string that separates lines in the edges file. It defaults to
-    *                           newline.
-    * @param fieldDelimiterEdges The string that separates fields in the edges file.
-    * @param quoteCharacterEdges The character to use for quoted String parsing in the edges file.
-    *                            Disabled by default.
-    * @param ignoreFirstLineEdges Whether the first line in the vertices file should be ignored.
-    * @param ignoreCommentsEdges Lines that start with the given String in the edges file are
-    *                            ignored, disabled by default.
-    * @param lenientEdges Whether the parser should silently ignore malformed lines in the edges
-    *                     file.
-    * @param includedFieldsEdges The fields in the edges file that should be read. By default all
-    *                            fields are read.
-    * @param vertexValueInitializer  If no vertex values are provided, this mapper can be used to
-    *                                initialize them, by applying a map transformation on the vertex
-    *                                IDs.
-    * @tparam K Vertex key type
-    * @tparam VV Vertex value type
-    * @tparam EV Edge value type
-    * @return Graph with vertices and edges read from the given files.
-    */
+   *
+   * The edge value is read from the CSV file if [[EV]] is not of type [[NullValue]]. Otherwise the
+   * edge value is set to [[NullValue]].
+   *
+   * If the vertex value type [[VV]] is specified (unequal [[NullValue]]), then the vertex values
+   * are read from the file specified by pathVertices. If the path has not been specified then the
+   * vertexValueInitializer is used to initialize the vertex values of the vertices extracted from
+   * the set of edges. If the vertexValueInitializer has not been set either, then the method
+   * fails.
+   *
+   * @param env The Execution Environment.
+   * @param pathEdges The file path containing the edges.
+   * @param pathVertices The file path containing the vertices.
+   * @param lineDelimiterVertices The string that separates lines in the vertices file. It defaults
+   *                              to newline.
+   * @param fieldDelimiterVertices The string that separates vertex Ids from vertex values in the
+   *                               vertices file.
+   * @param quoteCharacterVertices The character to use for quoted String parsing in the vertices
+   *                               file. Disabled by default.
+   * @param ignoreFirstLineVertices Whether the first line in the vertices file should be ignored.
+   * @param ignoreCommentsVertices Lines that start with the given String in the vertices file
+   *                               are ignored, disabled by default.
+   * @param lenientVertices Whether the parser should silently ignore malformed lines in the
+   *                        vertices file.
+   * @param includedFieldsVertices The fields in the vertices file that should be read. By default
+   *                               all fields are read.
+   * @param lineDelimiterEdges The string that separates lines in the edges file. It defaults to
+   *                           newline.
+   * @param fieldDelimiterEdges The string that separates fields in the edges file.
+   * @param quoteCharacterEdges The character to use for quoted String parsing in the edges file.
+   *                            Disabled by default.
+   * @param ignoreFirstLineEdges Whether the first line in the vertices file should be ignored.
+   * @param ignoreCommentsEdges Lines that start with the given String in the edges file are
+   *                            ignored, disabled by default.
+   * @param lenientEdges Whether the parser should silently ignore malformed lines in the edges
+   *                     file.
+   * @param includedFieldsEdges The fields in the edges file that should be read. By default all
+   *                            fields are read.
+   * @param vertexValueInitializer  If no vertex values are provided, this mapper can be used to
+   *                                initialize them, by applying a map transformation on the vertex
+   *                                IDs.
+   * @tparam K Vertex key type
+   * @tparam VV Vertex value type
+   * @tparam EV Edge value type
+   * @return Graph with vertices and edges read from the given files.
+   */
   // scalastyle:off
   // This method exceeds the max allowed number of parameters -->  
   def fromCsvReader[
@@ -295,6 +295,7 @@ object Graph {
 
 /**
  * Represents a graph consisting of {@link Edge edges} and {@link Vertex vertices}.
+ *
  * @param jgraph the underlying java api Graph.
  * @tparam K the key type for vertex and edge identifiers
  * @tparam VV the value type for vertices
@@ -341,9 +342,9 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
   }
 
   /**
-  * @return a DataSet of Triplets,
-  * consisting of (srcVertexId, trgVertexId, srcVertexValue, trgVertexValue, edgeValue)
-  */
+   * @return a DataSet of Triplets,
+   * consisting of (srcVertexId, trgVertexId, srcVertexValue, trgVertexValue, edgeValue)
+   */
   def getTriplets(): DataSet[Triplet[K, VV, EV]] = {
     wrap(jgraph.getTriplets())
   }
@@ -418,11 +419,11 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
   }
 
   /**
-    * Translate vertex and edge IDs using the given function.
-    *
-    * @param fun implements conversion from K to NEW
-    * @return graph with translated vertex and edge IDs
-    */
+   * Translate vertex and edge IDs using the given function.
+   *
+   * @param fun implements conversion from K to NEW
+   * @return graph with translated vertex and edge IDs
+   */
   def translateGraphIds[NEW: TypeInformation : ClassTag](fun: (K, NEW) => NEW):
   Graph[NEW, VV, EV] = {
     val translator: TranslateFunction[K, NEW] = new TranslateFunction[K, NEW] {
@@ -446,11 +447,11 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
   }
 
   /**
-    * Translate vertex values using the given function.
-    *
-    * @param fun implements conversion from VV to NEW
-    * @return graph with translated vertex values
-    */
+   * Translate vertex values using the given function.
+   *
+   * @param fun implements conversion from VV to NEW
+   * @return graph with translated vertex values
+   */
   def translateVertexValues[NEW: TypeInformation : ClassTag](fun: (VV, NEW) => NEW):
   Graph[K, NEW, EV] = {
     val translator: TranslateFunction[VV, NEW] = new TranslateFunction[VV, NEW] {
@@ -474,11 +475,11 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
   }
 
   /**
-    * Translate edge values using the given function.
-    *
-    * @param fun implements conversion from EV to NEW
-    * @return graph with translated edge values
-    */
+   * Translate edge values using the given function.
+   *
+   * @param fun implements conversion from EV to NEW
+   * @return graph with translated edge values
+   */
   def translateEdgeValues[NEW: TypeInformation : ClassTag](fun: (EV, NEW) => NEW):
   Graph[K, VV, NEW] = {
     val translator: TranslateFunction[EV, NEW] = new TranslateFunction[EV, NEW] {
@@ -503,9 +504,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * of the matched Tuple2 from the input DataSet.
    * @return a new Graph, where the vertex values have been updated according to the
    * result of the vertexJoinFunction.
-   * 
    * @tparam T the type of the second field of the input Tuple2 DataSet.
-  */
+   */
   def joinWithVertices[T: TypeInformation](inputDataSet: DataSet[(K, T)],
   vertexJoinFunction: VertexJoinFunction[VV, T]): Graph[K, VV, EV] = {
     val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
@@ -526,9 +526,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * of the matched Tuple2 from the input DataSet.
    * @return a new Graph, where the vertex values have been updated according to the
    * result of the vertexJoinFunction.
-   * 
    * @tparam T the type of the second field of the input Tuple2 DataSet.
-  */
+   */
   def joinWithVertices[T: TypeInformation](inputDataSet: DataSet[(K, T)], fun: (VV, T) => VV):
   Graph[K, VV, EV] = {
     val newVertexJoin = new VertexJoinFunction[VV, T]() {
@@ -554,11 +553,10 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @param edgeJoinFunction the transformation function to apply.
    * The first parameter is the current edge value and the second parameter is the value
    * of the matched Tuple3 from the input DataSet.
-   * 
    * @tparam T the type of the third field of the input Tuple3 DataSet.
    * @return a new Graph, where the edge values have been updated according to the
    * result of the edgeJoinFunction.
-  */
+   */
   def joinWithEdges[T: TypeInformation](inputDataSet: DataSet[(K, K, T)],
   edgeJoinFunction: EdgeJoinFunction[EV, T]): Graph[K, VV, EV] = {
     val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple3(scalatuple._1,
@@ -577,11 +575,10 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @param fun the transformation function to apply.
    * The first parameter is the current edge value and the second parameter is the value
    * of the matched Tuple3 from the input DataSet.
-   * 
    * @tparam T the type of the third field of the input Tuple3 DataSet.
    * @return a new Graph, where the edge values have been updated according to the
    * result of the edgeJoinFunction.
-  */
+   */
   def joinWithEdges[T: TypeInformation](inputDataSet: DataSet[(K, K, T)], fun: (EV, T) => EV):
   Graph[K, VV, EV] = {
     val newEdgeJoin = new EdgeJoinFunction[EV, T]() {
@@ -611,7 +608,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @tparam T the type of the second field of the input Tuple2 DataSet.
    * @return a new Graph, where the edge values have been updated according to the
    * result of the edgeJoinFunction.
-  */
+   */
   def joinWithEdgesOnSource[T: TypeInformation](inputDataSet: DataSet[(K, T)],
   edgeJoinFunction: EdgeJoinFunction[EV, T]): Graph[K, VV, EV] = {
     val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
@@ -634,7 +631,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @tparam T the type of the second field of the input Tuple2 DataSet.
    * @return a new Graph, where the edge values have been updated according to the
    * result of the edgeJoinFunction.
-  */
+   */
   def joinWithEdgesOnSource[T: TypeInformation](inputDataSet: DataSet[(K, T)], fun: (EV, T) =>
     EV): Graph[K, VV, EV] = {
     val newEdgeJoin = new EdgeJoinFunction[EV, T]() {
@@ -664,7 +661,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @tparam T the type of the second field of the input Tuple2 DataSet.
    * @return a new Graph, where the edge values have been updated according to the
    * result of the edgeJoinFunction.
-  */
+   */
   def joinWithEdgesOnTarget[T: TypeInformation](inputDataSet: DataSet[(K, T)],
   edgeJoinFunction: EdgeJoinFunction[EV, T]): Graph[K, VV, EV] = {
     val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
@@ -687,7 +684,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @tparam T the type of the second field of the input Tuple2 DataSet.
    * @return a new Graph, where the edge values have been updated according to the
    * result of the edgeJoinFunction.
-  */
+   */
   def joinWithEdgesOnTarget[T: TypeInformation](inputDataSet: DataSet[(K, T)], fun: (EV, T) =>
     EV): Graph[K, VV, EV] = {
     val newEdgeJoin = new EdgeJoinFunction[EV, T]() {
@@ -945,30 +942,30 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
   }
 
   /**
-  * Adds the list of vertices, passed as input, to the graph.
-  * If the vertices already exist in the graph, they will not be added once more.
-  *
-  * @param vertices the list of vertices to add
-  * @return the new graph containing the existing and newly added vertices
-  */
+   * Adds the list of vertices, passed as input, to the graph.
+   * If the vertices already exist in the graph, they will not be added once more.
+   *
+   * @param vertices the list of vertices to add
+   * @return the new graph containing the existing and newly added vertices
+   */
   def addVertices(vertices: List[Vertex[K, VV]]): Graph[K, VV, EV] = {
     wrapGraph(jgraph.addVertices(vertices.asJava))
   }
 
   /**
-  * Adds the given list edges to the graph.
-  *
-  * When adding an edge for a non-existing set of vertices,
-  * the edge is considered invalid and ignored.
-  *
-  * @param edges the data set of edges to be added
-  * @return a new graph containing the existing edges plus the newly added edges.
-  */
+   * Adds the given list edges to the graph.
+   *
+   * When adding an edge for a non-existing set of vertices,
+   * the edge is considered invalid and ignored.
+   *
+   * @param edges the data set of edges to be added
+   * @return a new graph containing the existing edges plus the newly added edges.
+   */
   def addEdges(edges: List[Edge[K, EV]]): Graph[K, VV, EV] = {
     wrapGraph(jgraph.addEdges(edges.asJava))
   }
 
-    /**
+  /**
    * Adds the given edge to the graph. If the source and target vertices do
    * not exist in the graph, they will also be added.
    *
@@ -993,7 +990,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
     wrapGraph(jgraph.removeVertex(vertex))
   }
 
-    /**
+  /**
    * Removes the given vertex and its edges from the graph.
    *
    * @param vertices list of vertices to remove
@@ -1037,12 +1034,13 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
   }
 
   /**
-  * Performs Difference on the vertex and edge sets of the input graphs
-  * removes common vertices and edges. If a source/target vertex is removed,
-  * its corresponding edge will also be removed
-  * @param graph the graph to perform difference with
-  * @return a new graph where the common vertices and edges have been removed
-  */
+   * Performs Difference on the vertex and edge sets of the input graphs
+   * removes common vertices and edges. If a source/target vertex is removed,
+   * its corresponding edge will also be removed
+   *
+   * @param graph the graph to perform difference with
+   * @return a new graph where the common vertices and edges have been removed
+   */
   def difference(graph: Graph[K, VV, EV]) = {
     wrapGraph(jgraph.difference(graph.getWrappedGraph))
   }
@@ -1135,36 +1133,34 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * Runs a scatter-gather iteration on the graph.
    * No configuration options are provided.
    *
-   * @param vertexUpdateFunction the vertex update function
-   * @param messagingFunction the messaging function
+   * @param scatterFunction the scatter function
+   * @param gatherFunction the gather function
    * @param maxIterations maximum number of iterations to perform
-   *
    * @return the updated Graph after the scatter-gather iteration has converged or
    *         after maximumNumberOfIterations.
    */
-  def runScatterGatherIteration[M](vertexUpdateFunction: VertexUpdateFunction[K, VV, M],
-                                   messagingFunction: MessagingFunction[K, VV, M, EV],
+  def runScatterGatherIteration[M](scatterFunction: ScatterFunction[K, VV, M, EV],
+                                   gatherFunction: SpargelGatherFunction[K, VV, M],
                                    maxIterations: Int): Graph[K, VV, EV] = {
-    wrapGraph(jgraph.runScatterGatherIteration(vertexUpdateFunction, messagingFunction,
+    wrapGraph(jgraph.runScatterGatherIteration(scatterFunction, gatherFunction,
       maxIterations))
   }
 
   /**
    * Runs a scatter-gather iteration on the graph with configuration options.
    *
-   * @param vertexUpdateFunction the vertex update function
-   * @param messagingFunction the messaging function
+   * @param scatterFunction the scatter function
+   * @param gatherFunction the gather function
    * @param maxIterations maximum number of iterations to perform
    * @param parameters the iteration configuration parameters
-   *
    * @return the updated Graph after the scatter-gather iteration has converged or
    *         after maximumNumberOfIterations.
    */
-  def runScatterGatherIteration[M](vertexUpdateFunction: VertexUpdateFunction[K, VV, M],
-                                   messagingFunction: MessagingFunction[K, VV, M, EV],
+  def runScatterGatherIteration[M](scatterFunction: ScatterFunction[K, VV, M, EV],
+                                   gatherFunction: SpargelGatherFunction[K, VV, M],
                                    maxIterations: Int, parameters: ScatterGatherConfiguration):
   Graph[K, VV, EV] = {
-    wrapGraph(jgraph.runScatterGatherIteration(vertexUpdateFunction, messagingFunction,
+    wrapGraph(jgraph.runScatterGatherIteration(scatterFunction, gatherFunction,
       maxIterations, parameters))
   }
 
@@ -1178,11 +1174,10 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @param applyFunction the apply function updates the vertex values with the aggregates
    * @param maxIterations maximum number of iterations to perform
    * @tparam M the intermediate type used between gather, sum and apply
-   *
    * @return the updated Graph after the gather-sum-apply iteration has converged or
    *         after maximumNumberOfIterations.
    */
-  def runGatherSumApplyIteration[M](gatherFunction: GatherFunction[VV, EV, M], sumFunction:
+  def runGatherSumApplyIteration[M](gatherFunction: GSAGatherFunction[VV, EV, M], sumFunction:
   SumFunction[VV, EV, M], applyFunction: ApplyFunction[K, VV, M], maxIterations: Int): Graph[K,
     VV, EV] = {
     wrapGraph(jgraph.runGatherSumApplyIteration(gatherFunction, sumFunction, applyFunction,
@@ -1199,25 +1194,23 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @param maxIterations maximum number of iterations to perform
    * @param parameters the iteration configuration parameters
    * @tparam M the intermediate type used between gather, sum and apply
-   *
    * @return the updated Graph after the gather-sum-apply iteration has converged or
    *         after maximumNumberOfIterations.
    */
-  def runGatherSumApplyIteration[M](gatherFunction: GatherFunction[VV, EV, M], sumFunction:
+  def runGatherSumApplyIteration[M](gatherFunction: GSAGatherFunction[VV, EV, M], sumFunction:
   SumFunction[VV, EV, M], applyFunction: ApplyFunction[K, VV, M], maxIterations: Int,
                                     parameters: GSAConfiguration): Graph[K, VV, EV] = {
     wrapGraph(jgraph.runGatherSumApplyIteration(gatherFunction, sumFunction, applyFunction,
       maxIterations, parameters))
   }
 
-   /**
+  /**
    * Runs a vertex-centric iteration on the graph.
    * No configuration options are provided.
    *
    * @param computeFunction the compute function
    * @param combineFunction the optional message combiner function
    * @param maxIterations maximum number of iterations to perform
-   *
    * @return the updated Graph after the vertex-centric iteration has converged or
    *         after maximumNumberOfIterations.
    */
@@ -1235,7 +1228,6 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @param combineFunction the optional message combiner function
    * @param maxIterations maximum number of iterations to perform
    * @param parameters the iteration configuration parameters
-   *
    * @return the updated Graph after the vertex-centric iteration has converged or
    *         after maximumNumberOfIterations.
    */

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -45,17 +45,15 @@ import org.apache.flink.graph.asm.translate.TranslateGraphIds;
 import org.apache.flink.graph.asm.translate.TranslateVertexValues;
 import org.apache.flink.graph.gsa.ApplyFunction;
 import org.apache.flink.graph.gsa.GSAConfiguration;
-import org.apache.flink.graph.gsa.GatherFunction;
 import org.apache.flink.graph.gsa.GatherSumApplyIteration;
 import org.apache.flink.graph.gsa.SumFunction;
 import org.apache.flink.graph.pregel.ComputeFunction;
 import org.apache.flink.graph.pregel.MessageCombiner;
 import org.apache.flink.graph.pregel.VertexCentricConfiguration;
 import org.apache.flink.graph.pregel.VertexCentricIteration;
-import org.apache.flink.graph.spargel.MessagingFunction;
+import org.apache.flink.graph.spargel.ScatterFunction;
 import org.apache.flink.graph.spargel.ScatterGatherConfiguration;
 import org.apache.flink.graph.spargel.ScatterGatherIteration;
-import org.apache.flink.graph.spargel.VertexUpdateFunction;
 import org.apache.flink.graph.utils.EdgeToTuple3Map;
 import org.apache.flink.graph.utils.Tuple2ToVertexMap;
 import org.apache.flink.graph.utils.Tuple3ToEdgeMap;
@@ -1652,27 +1650,27 @@ public class Graph<K, VV, EV> {
 	 * Runs a ScatterGather iteration on the graph.
 	 * No configuration options are provided.
 	 *
-	 * @param vertexUpdateFunction the vertex update function
-	 * @param messagingFunction the messaging function
+	 * @param scatterFunction the scatter function
+	 * @param gatherFunction the gather function
 	 * @param maximumNumberOfIterations maximum number of iterations to perform
 	 * 
 	 * @return the updated Graph after the scatter-gather iteration has converged or
 	 * after maximumNumberOfIterations.
 	 */
 	public <M> Graph<K, VV, EV> runScatterGatherIteration(
-			VertexUpdateFunction<K, VV, M> vertexUpdateFunction,
-			MessagingFunction<K, VV, M, EV> messagingFunction,
+			ScatterFunction<K, VV, M, EV> scatterFunction,
+			org.apache.flink.graph.spargel.GatherFunction<K, VV, M> gatherFunction,
 			int maximumNumberOfIterations) {
 
-		return this.runScatterGatherIteration(vertexUpdateFunction, messagingFunction,
+		return this.runScatterGatherIteration(scatterFunction, gatherFunction,
 				maximumNumberOfIterations, null);
 	}
 
 	/**
 	 * Runs a ScatterGather iteration on the graph with configuration options.
-	 * 
-	 * @param vertexUpdateFunction the vertex update function
-	 * @param messagingFunction the messaging function
+	 *
+	 * @param scatterFunction the scatter function
+	 * @param gatherFunction the gather function
 	 * @param maximumNumberOfIterations maximum number of iterations to perform
 	 * @param parameters the iteration configuration parameters
 	 * 
@@ -1680,12 +1678,12 @@ public class Graph<K, VV, EV> {
 	 * after maximumNumberOfIterations.
 	 */
 	public <M> Graph<K, VV, EV> runScatterGatherIteration(
-			VertexUpdateFunction<K, VV, M> vertexUpdateFunction,
-			MessagingFunction<K, VV, M, EV> messagingFunction,
+			ScatterFunction<K, VV, M, EV> scatterFunction,
+			org.apache.flink.graph.spargel.GatherFunction<K, VV, M> gatherFunction,
 			int maximumNumberOfIterations, ScatterGatherConfiguration parameters) {
 
 		ScatterGatherIteration<K, VV, M, EV> iteration = ScatterGatherIteration.withEdges(
-				edges, vertexUpdateFunction, messagingFunction, maximumNumberOfIterations);
+				edges, scatterFunction, gatherFunction, maximumNumberOfIterations);
 
 		iteration.configure(parameters);
 
@@ -1708,7 +1706,7 @@ public class Graph<K, VV, EV> {
 	 * after maximumNumberOfIterations.
 	 */
 	public <M> Graph<K, VV, EV> runGatherSumApplyIteration(
-			GatherFunction<VV, EV, M> gatherFunction, SumFunction<VV, EV, M> sumFunction,
+			org.apache.flink.graph.gsa.GatherFunction gatherFunction, SumFunction<VV, EV, M> sumFunction,
 			ApplyFunction<K, VV, M> applyFunction, int maximumNumberOfIterations) {
 
 		return this.runGatherSumApplyIteration(gatherFunction, sumFunction, applyFunction,
@@ -1729,7 +1727,7 @@ public class Graph<K, VV, EV> {
 	 * after maximumNumberOfIterations.
 	 */
 	public <M> Graph<K, VV, EV> runGatherSumApplyIteration(
-			GatherFunction<VV, EV, M> gatherFunction, SumFunction<VV, EV, M> sumFunction,
+			org.apache.flink.graph.gsa.GatherFunction gatherFunction, SumFunction<VV, EV, M> sumFunction,
 			ApplyFunction<K, VV, M> applyFunction, int maximumNumberOfIterations,
 			GSAConfiguration parameters) {
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/IterationConfiguration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/IterationConfiguration.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.flink.api.common.aggregators.Aggregator;
+import org.apache.flink.graph.spargel.GatherFunction;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -133,8 +134,8 @@ public abstract class IterationConfiguration {
 
 	/**
 	 * Registers a new aggregator. Aggregators registered here are available during the execution of the vertex updates
-	 * via {@link org.apache.flink.graph.spargel.VertexUpdateFunction#getIterationAggregator(String)} and
-	 * {@link org.apache.flink.graph.spargel.VertexUpdateFunction#getPreviousIterationAggregate(String)}.
+	 * via {@link GatherFunction#getIterationAggregator(String)} and
+	 * {@link GatherFunction#getPreviousIterationAggregate(String)}.
 	 * 
 	 * @param name The name of the aggregator, used to retrieve it and its aggregates during execution. 
 	 * @param aggregator The aggregator.

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java
@@ -27,8 +27,8 @@ import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.gsa.ApplyFunction;
 import org.apache.flink.graph.gsa.GatherFunction;
-import org.apache.flink.graph.gsa.SumFunction;
 import org.apache.flink.graph.gsa.Neighbor;
+import org.apache.flink.graph.gsa.SumFunction;
 import org.apache.flink.graph.utils.NullValueEdgeMapper;
 import org.apache.flink.types.NullValue;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSASingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSASingleSourceShortestPaths.java
@@ -25,8 +25,8 @@ import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.gsa.ApplyFunction;
 import org.apache.flink.graph.gsa.GatherFunction;
-import org.apache.flink.graph.gsa.SumFunction;
 import org.apache.flink.graph.gsa.Neighbor;
+import org.apache.flink.graph.gsa.SumFunction;
 
 /**
  * This is an implementation of the Single Source Shortest Paths algorithm, using a gather-sum-apply iteration

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/PageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/PageRank.java
@@ -25,10 +25,10 @@ import org.apache.flink.graph.EdgeJoinFunction;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.spargel.GatherFunction;
 import org.apache.flink.graph.spargel.MessageIterator;
-import org.apache.flink.graph.spargel.MessagingFunction;
+import org.apache.flink.graph.spargel.ScatterFunction;
 import org.apache.flink.graph.spargel.ScatterGatherConfiguration;
-import org.apache.flink.graph.spargel.VertexUpdateFunction;
 import org.apache.flink.types.LongValue;
 
 /**
@@ -65,9 +65,29 @@ public class PageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet<Ve
 		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 		parameters.setOptNumVertices(true);
 
-		return networkWithWeights.runScatterGatherIteration(new VertexRankUpdater<K>(beta),
-				new RankMessenger<K>(), maxIterations, parameters)
+		return networkWithWeights.runScatterGatherIteration(new RankMessenger<K>(),
+				new VertexRankUpdater<K>(beta), maxIterations, parameters)
 				.getVertices();
+	}
+
+	/**
+	 * Distributes the rank of a vertex among all target vertices according to
+	 * the transition probability, which is associated with an edge as the edge
+	 * value.
+	 */
+	@SuppressWarnings("serial")
+	public static final class RankMessenger<K> extends ScatterFunction<K, Double, Double, Double> {
+		@Override
+		public void sendMessages(Vertex<K, Double> vertex) {
+			if (getSuperstepNumber() == 1) {
+				// initialize vertex ranks
+				vertex.setValue(1.0 / this.getNumberOfVertices());
+			}
+
+			for (Edge<K, Double> edge : getEdges()) {
+				sendMessageTo(edge.getTarget(), vertex.getValue() * edge.getValue());
+			}
+		}
 	}
 
 	/**
@@ -75,8 +95,7 @@ public class PageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet<Ve
 	 * ranks from all incoming messages and then applying the dampening formula.
 	 */
 	@SuppressWarnings("serial")
-	public static final class VertexRankUpdater<K> extends VertexUpdateFunction<K, Double, Double> {
-
+	public static final class VertexRankUpdater<K> extends GatherFunction<K, Double, Double> {
 		private final double beta;
 
 		public VertexRankUpdater(double beta) {
@@ -96,30 +115,8 @@ public class PageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet<Ve
 		}
 	}
 
-	/**
-	 * Distributes the rank of a vertex among all target vertices according to
-	 * the transition probability, which is associated with an edge as the edge
-	 * value.
-	 */
-	@SuppressWarnings("serial")
-	public static final class RankMessenger<K> extends MessagingFunction<K, Double, Double, Double> {
-
-		@Override
-		public void sendMessages(Vertex<K, Double> vertex) {
-			if (getSuperstepNumber() == 1) {
-				// initialize vertex ranks
-				vertex.setValue(1.0 / this.getNumberOfVertices());
-			}
-
-			for (Edge<K, Double> edge : getEdges()) {
-				sendMessageTo(edge.getTarget(), vertex.getValue() * edge.getValue());
-			}
-		}
-	}
-
 	@SuppressWarnings("serial")
 	private static final class InitWeights implements EdgeJoinFunction<Double, LongValue> {
-
 		public Double edgeJoin(Double edgeValue, LongValue inputValue) {
 			return edgeValue / (double) inputValue.getValue();
 		}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/TriangleEnumerator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/TriangleEnumerator.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.graph.library;
 
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
-import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.common.functions.JoinFunction;
-import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint;
 import org.apache.flink.api.java.DataSet;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherConfiguration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherConfiguration.java
@@ -29,20 +29,20 @@ import java.util.List;
 /**
  * A ScatterGatherConfiguration object can be used to set the iteration name and
  * degree of parallelism, to register aggregators and use broadcast sets in
- * the {@link org.apache.flink.graph.spargel.VertexUpdateFunction} and {@link org.apache.flink.graph.spargel.MessagingFunction}
+ * the {@link GatherFunction} and {@link ScatterFunction}
  *
  * The VertexCentricConfiguration object is passed as an argument to
  * {@link org.apache.flink.graph.Graph#runScatterGatherIteration (
- * org.apache.flink.graph.spargel.VertexUpdateFunction, org.apache.flink.graph.spargel.MessagingFunction, int,
+ * org.apache.flink.graph.spargel.GatherFunction, org.apache.flink.graph.spargel.ScatterFunction, int,
  * ScatterGatherConfiguration)}.
  */
 public class ScatterGatherConfiguration extends IterationConfiguration {
 
-	/** the broadcast variables for the update function **/
-	private List<Tuple2<String, DataSet<?>>> bcVarsUpdate = new ArrayList<Tuple2<String,DataSet<?>>>();
+	/** the broadcast variables for the scatter function **/
+	private List<Tuple2<String, DataSet<?>>> bcVarsScatter = new ArrayList<>();
 
-	/** the broadcast variables for the messaging function **/
-	private List<Tuple2<String, DataSet<?>>> bcVarsMessaging = new ArrayList<Tuple2<String,DataSet<?>>>();
+	/** the broadcast variables for the gather function **/
+	private List<Tuple2<String, DataSet<?>>> bcVarsGather = new ArrayList<>();
 
 	/** flag that defines whether the degrees option is set **/
 	private boolean optDegrees = false;
@@ -53,43 +53,43 @@ public class ScatterGatherConfiguration extends IterationConfiguration {
 	public ScatterGatherConfiguration() {}
 
 	/**
-	 * Adds a data set as a broadcast set to the messaging function.
+	 * Adds a data set as a broadcast set to the scatter function.
 	 *
-	 * @param name The name under which the broadcast data is available in the messaging function.
+	 * @param name The name under which the broadcast data is available in the scatter function.
 	 * @param data The data set to be broadcasted.
 	 */
-	public void addBroadcastSetForMessagingFunction(String name, DataSet<?> data) {
-		this.bcVarsMessaging.add(new Tuple2<String, DataSet<?>>(name, data));
+	public void addBroadcastSetForScatterFunction(String name, DataSet<?> data) {
+		this.bcVarsScatter.add(new Tuple2<String, DataSet<?>>(name, data));
 	}
 
 	/**
-	 * Adds a data set as a broadcast set to the vertex update function.
+	 * Adds a data set as a broadcast set to the gather function.
 	 *
-	 * @param name The name under which the broadcast data is available in the vertex update function.
+	 * @param name The name under which the broadcast data is available in the gather function.
 	 * @param data The data set to be broadcasted.
 	 */
-	public void addBroadcastSetForUpdateFunction(String name, DataSet<?> data) {
-		this.bcVarsUpdate.add(new Tuple2<String, DataSet<?>>(name, data));
+	public void addBroadcastSetForGatherFunction(String name, DataSet<?> data) {
+		this.bcVarsGather.add(new Tuple2<String, DataSet<?>>(name, data));
 	}
 
 	/**
-	 * Get the broadcast variables of the VertexUpdateFunction.
+	 * Get the broadcast variables of the ScatterFunction.
 	 *
 	 * @return a List of Tuple2, where the first field is the broadcast variable name
 	 * and the second field is the broadcast DataSet.
 	 */
-	public List<Tuple2<String, DataSet<?>>> getUpdateBcastVars() {
-		return this.bcVarsUpdate;
+	public List<Tuple2<String, DataSet<?>>> getScatterBcastVars() {
+		return this.bcVarsScatter;
 	}
 
 	/**
-	 * Get the broadcast variables of the MessagingFunction.
+	 * Get the broadcast variables of the GatherFunction.
 	 *
 	 * @return a List of Tuple2, where the first field is the broadcast variable name
 	 * and the second field is the broadcast DataSet.
 	 */
-	public List<Tuple2<String, DataSet<?>>> getMessagingBcastVars() {
-		return this.bcVarsMessaging;
+	public List<Tuple2<String, DataSet<?>>> getGatherBcastVars() {
+		return this.bcVarsGather;
 	}
 
 	/**
@@ -113,7 +113,7 @@ public class ScatterGatherConfiguration extends IterationConfiguration {
 	}
 
 	/**
-	 * Gets the direction in which messages are sent in the MessagingFunction.
+	 * Gets the direction in which messages are sent in the ScatterFunction.
 	 * By default the messaging direction is OUT.
 	 *
 	 * @return an EdgeDirection, which can be either IN, OUT or ALL.
@@ -123,7 +123,7 @@ public class ScatterGatherConfiguration extends IterationConfiguration {
 	}
 
 	/**
-	 * Sets the direction in which messages are sent in the MessagingFunction.
+	 * Sets the direction in which messages are sent in the ScatterFunction.
 	 * By default the messaging direction is OUT.
 	 *
 	 * @param direction - IN, OUT or ALL

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherIteration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherIteration.java
@@ -53,21 +53,21 @@ import java.util.Map;
  * Scatter-Gather algorithms operate on graphs, which are defined through vertices and edges. The 
  * algorithms send messages along the edges and update the state of vertices based on
  * the old state and the incoming messages. All vertices have an initial state.
- * The computation terminates once no vertex updates it state any more.
+ * The computation terminates once no vertex updates its state any more.
  * Additionally, a maximum number of iterations (supersteps) may be specified.
  * <p>
  * The computation is here represented by two functions:
  * <ul>
- *   <li>The {@link VertexUpdateFunction} receives incoming messages and may updates the state for
+ *   <li>The {@link GatherFunction} receives incoming messages and may updates the state for
  *   the vertex. If a state is updated, messages are sent from this vertex. Initially, all vertices are
  *   considered updated.</li>
- *   <li>The {@link MessagingFunction} takes the new vertex state and sends messages along the outgoing
+ *   <li>The {@link ScatterFunction} takes the new vertex state and sends messages along the outgoing
  *   edges of the vertex. The outgoing edges may optionally have an associated value, such as a weight.</li>
  * </ul>
  * <p>
  *
  * Scatter-Gather graph iterations are are run by calling
- * {@link Graph#runScatterGatherIteration(VertexUpdateFunction, MessagingFunction, int)}.
+ * {@link Graph#runScatterGatherIteration(ScatterFunction, GatherFunction, int)}.
  *
  * @param <K> The type of the vertex key (the vertex identifier).
  * @param <VV> The type of the vertex value (the state of the vertex).
@@ -77,47 +77,47 @@ import java.util.Map;
 public class ScatterGatherIteration<K, VV, Message, EV> 
 	implements CustomUnaryOperation<Vertex<K, VV>, Vertex<K, VV>>
 {
-	private final VertexUpdateFunction<K, VV, Message> updateFunction;
+	private final ScatterFunction<K, VV, Message, EV> scatterFunction;
 
-	private final MessagingFunction<K, VV, Message, EV> messagingFunction;
-	
+	private final GatherFunction<K, VV, Message> gatherFunction;
+
 	private final DataSet<Edge<K, EV>> edgesWithValue;
-	
+
 	private final int maximumNumberOfIterations;
-	
+
 	private final TypeInformation<Message> messageType;
-	
+
 	private DataSet<Vertex<K, VV>> initialVertices;
 
 	private ScatterGatherConfiguration configuration;
 
 	// ----------------------------------------------------------------------------------
-	
-	private ScatterGatherIteration(VertexUpdateFunction<K, VV, Message> uf,
-			MessagingFunction<K, VV, Message, EV> mf,
+
+	private ScatterGatherIteration(ScatterFunction<K, VV, Message, EV> sf,
+			GatherFunction<K, VV, Message> gf,
 			DataSet<Edge<K, EV>> edgesWithValue, 
 			int maximumNumberOfIterations)
 	{
-		Preconditions.checkNotNull(uf);
-		Preconditions.checkNotNull(mf);
+		Preconditions.checkNotNull(sf);
+		Preconditions.checkNotNull(gf);
 		Preconditions.checkNotNull(edgesWithValue);
 		Preconditions.checkArgument(maximumNumberOfIterations > 0, "The maximum number of iterations must be at least one.");
 
-		this.updateFunction = uf;
-		this.messagingFunction = mf;
+		this.scatterFunction = sf;
+		this.gatherFunction = gf;
 		this.edgesWithValue = edgesWithValue;
-		this.maximumNumberOfIterations = maximumNumberOfIterations;		
-		this.messageType = getMessageType(mf);
+		this.maximumNumberOfIterations = maximumNumberOfIterations;
+		this.messageType = getMessageType(sf);
 	}
-	
-	private TypeInformation<Message> getMessageType(MessagingFunction<K, VV, Message, EV> mf) {
-		return TypeExtractor.createTypeInfo(mf, MessagingFunction.class, mf.getClass(), 2);
+
+	private TypeInformation<Message> getMessageType(ScatterFunction<K, VV, Message, EV> mf) {
+		return TypeExtractor.createTypeInfo(mf, ScatterFunction.class, mf.getClass(), 2);
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//  Custom Operator behavior
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Sets the input data set for this operator. In the case of this operator this input data set represents
 	 * the set of vertices with their initial state.
@@ -131,7 +131,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	public void setInput(DataSet<Vertex<K, VV>> inputData) {
 		this.initialVertices = inputData;
 	}
-	
+
 	/**
 	 * Creates the operator that represents this scatter-gather graph computation.
 	 * 
@@ -145,14 +145,14 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 
 		// prepare some type information
 		TypeInformation<K> keyType = ((TupleTypeInfo<?>) initialVertices.getType()).getTypeAt(0);
-		TypeInformation<Tuple2<K, Message>> messageTypeInfo = new TupleTypeInfo<Tuple2<K,Message>>(keyType, messageType);
+		TypeInformation<Tuple2<K, Message>> messageTypeInfo = new TupleTypeInfo<>(keyType, messageType);
 
 		// create a graph
 		Graph<K, VV, EV> graph =
 				Graph.fromDataSet(initialVertices, edgesWithValue, initialVertices.getExecutionEnvironment());
 
 		// check whether the numVertices option is set and, if so, compute the total number of vertices
-		// and set it within the messaging and update functions
+		// and set it within the scatter and gather functions
 
 		DataSet<LongValue> numberOfVertices = null;
 		if (this.configuration != null && this.configuration.isOptNumVertices()) {
@@ -164,13 +164,13 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 		}
 
 		if(this.configuration != null) {
-			messagingFunction.setDirection(this.configuration.getDirection());
+			scatterFunction.setDirection(this.configuration.getDirection());
 		} else {
-			messagingFunction.setDirection(EdgeDirection.OUT);
+			scatterFunction.setDirection(EdgeDirection.OUT);
 		}
 
 		// retrieve the direction in which the updates are made and in which the messages are sent
-		EdgeDirection messagingDirection = messagingFunction.getDirection();
+		EdgeDirection messagingDirection = scatterFunction.getDirection();
 
 		// check whether the degrees option is set and, if so, compute the in and the out degrees and
 		// add them to the vertex value
@@ -186,9 +186,9 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	 * a weight or distance).
 	 * 
 	 * @param edgesWithValue The data set containing edges.
-	 * @param uf The function that updates the state of the vertices from the incoming messages.
-	 * @param mf The function that turns changed vertex states into messages along the edges.
-	 * 
+	 * @param sf The function that turns changed vertex states into messages along the edges.
+	 * @param gf The function that updates the state of the vertices from the incoming messages.
+	 *
 	 * @param <K> The type of the vertex key (the vertex identifier).
 	 * @param <VV> The type of the vertex value (the state of the vertex).
 	 * @param <Message> The type of the message sent between vertices along the edges.
@@ -196,14 +196,11 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	 * 
 	 * @return An in stance of the scatter-gather graph computation operator.
 	 */
-	public static final <K, VV, Message, EV>
-			ScatterGatherIteration<K, VV, Message, EV> withEdges(
-					DataSet<Edge<K, EV>> edgesWithValue,
-					VertexUpdateFunction<K, VV, Message> uf,
-					MessagingFunction<K, VV, Message, EV> mf,
-					int maximumNumberOfIterations)
+	public static final <K, VV, Message, EV> ScatterGatherIteration<K, VV, Message, EV> withEdges(
+		DataSet<Edge<K, EV>> edgesWithValue, ScatterFunction<K, VV, Message, EV> sf,
+		GatherFunction<K, VV, Message> gf, int maximumNumberOfIterations)
 	{
-		return new ScatterGatherIteration<K, VV, Message, EV>(uf, mf, edgesWithValue, maximumNumberOfIterations);
+		return new ScatterGatherIteration<>(sf, gf, edgesWithValue, maximumNumberOfIterations);
 	}
 
 	/**
@@ -226,23 +223,24 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	//  Wrapping UDFs
 	// --------------------------------------------------------------------------------------------
 
-	private static abstract class VertexUpdateUdf<K, VVWithDegrees, Message> extends RichCoGroupFunction<
-		Tuple2<K, Message>, Vertex<K, VVWithDegrees>, Vertex<K, VVWithDegrees>>
-		implements ResultTypeQueryable<Vertex<K, VVWithDegrees>>
+	/*
+	 * UDF that encapsulates the message sending function for graphs where the edges have an associated value.
+	 */
+	private static abstract class ScatterUdfWithEdgeValues<K, VVWithDegrees, VV, Message, EV>
+			extends RichCoGroupFunction<Edge<K, EV>, Vertex<K, VVWithDegrees>, Tuple2<K, Message>>
+			implements ResultTypeQueryable<Tuple2<K, Message>>
 	{
 		private static final long serialVersionUID = 1L;
-		
-		final VertexUpdateFunction<K, VVWithDegrees, Message> vertexUpdateFunction;
 
-		final MessageIterator<Message> messageIter = new MessageIterator<Message>();
-		
-		private transient TypeInformation<Vertex<K, VVWithDegrees>> resultType;
-		
-		
-		private VertexUpdateUdf(VertexUpdateFunction<K, VVWithDegrees, Message> vertexUpdateFunction,
-				TypeInformation<Vertex<K, VVWithDegrees>> resultType)
+		final ScatterFunction<K, VV, Message, EV> scatterFunction;
+
+		private transient TypeInformation<Tuple2<K, Message>> resultType;
+
+
+		private ScatterUdfWithEdgeValues(ScatterFunction<K, VV, Message, EV> scatterFunction,
+				TypeInformation<Tuple2<K, Message>> resultType)
 		{
-			this.vertexUpdateFunction = vertexUpdateFunction;
+			this.scatterFunction = scatterFunction;
 			this.resultType = resultType;
 		}
 
@@ -250,17 +248,115 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 		public void open(Configuration parameters) throws Exception {
 			if (getRuntimeContext().hasBroadcastVariable("number of vertices")) {
 				Collection<LongValue> numberOfVertices = getRuntimeContext().getBroadcastVariable("number of vertices");
-				this.vertexUpdateFunction.setNumberOfVertices(numberOfVertices.iterator().next().getValue());
+				this.scatterFunction.setNumberOfVertices(numberOfVertices.iterator().next().getValue());
 			}
 			if (getIterationRuntimeContext().getSuperstepNumber() == 1) {
-				this.vertexUpdateFunction.init(getIterationRuntimeContext());
+				this.scatterFunction.init(getIterationRuntimeContext());
 			}
-			this.vertexUpdateFunction.preSuperstep();
+			this.scatterFunction.preSuperstep();
 		}
-		
+
 		@Override
 		public void close() throws Exception {
-			this.vertexUpdateFunction.postSuperstep();
+			this.scatterFunction.postSuperstep();
+		}
+
+		@Override
+		public TypeInformation<Tuple2<K, Message>> getProducedType() {
+			return this.resultType;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class ScatterUdfWithEVsSimpleVV<K, VV, Message, EV>
+			extends ScatterUdfWithEdgeValues<K, VV, VV, Message, EV> {
+
+		private ScatterUdfWithEVsSimpleVV(ScatterFunction<K, VV, Message, EV> scatterFunction,
+				TypeInformation<Tuple2<K, Message>> resultType) {
+			super(scatterFunction, resultType);
+		}
+
+		@Override
+		public void coGroup(Iterable<Edge<K, EV>> edges,
+							Iterable<Vertex<K, VV>> state,
+							Collector<Tuple2<K, Message>> out) throws Exception {
+			final Iterator<Vertex<K, VV>> stateIter = state.iterator();
+
+			if (stateIter.hasNext()) {
+				Vertex<K, VV> newVertexState = stateIter.next();
+				scatterFunction.set(edges.iterator(), out, newVertexState.getId());
+				scatterFunction.sendMessages(newVertexState);
+			}
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class ScatterUdfWithEVsVVWithDegrees<K, VV, Message, EV>
+			extends ScatterUdfWithEdgeValues<K, Tuple3<VV, LongValue, LongValue>, VV, Message, EV> {
+
+		private Vertex<K, VV> nextVertex = new Vertex<>();
+
+		private ScatterUdfWithEVsVVWithDegrees(ScatterFunction<K, VV, Message, EV> scatterFunction,
+				TypeInformation<Tuple2<K, Message>> resultType) {
+			super(scatterFunction, resultType);
+		}
+
+		@Override
+		public void coGroup(Iterable<Edge<K, EV>> edges, Iterable<Vertex<K, Tuple3<VV, LongValue, LongValue>>> state,
+							Collector<Tuple2<K, Message>> out) throws Exception {
+
+			final Iterator<Vertex<K, Tuple3<VV, LongValue, LongValue>>> stateIter = state.iterator();
+
+			if (stateIter.hasNext()) {
+				Vertex<K, Tuple3<VV, LongValue, LongValue>> vertexWithDegrees = stateIter.next();
+
+				nextVertex.setField(vertexWithDegrees.f0, 0);
+				nextVertex.setField(vertexWithDegrees.f1.f0, 1);
+
+				scatterFunction.setInDegree(vertexWithDegrees.f1.f1.getValue());
+				scatterFunction.setOutDegree(vertexWithDegrees.f1.f2.getValue());
+
+				scatterFunction.set(edges.iterator(), out, vertexWithDegrees.getId());
+				scatterFunction.sendMessages(nextVertex);
+			}
+		}
+	}
+
+	private static abstract class GatherUdf<K, VVWithDegrees, Message> extends RichCoGroupFunction<
+		Tuple2<K, Message>, Vertex<K, VVWithDegrees>, Vertex<K, VVWithDegrees>>
+		implements ResultTypeQueryable<Vertex<K, VVWithDegrees>>
+	{
+		private static final long serialVersionUID = 1L;
+
+		final GatherFunction<K, VVWithDegrees, Message> gatherFunction;
+
+		final MessageIterator<Message> messageIter = new MessageIterator<>();
+
+		private transient TypeInformation<Vertex<K, VVWithDegrees>> resultType;
+
+
+		private GatherUdf(GatherFunction<K, VVWithDegrees, Message> gatherFunction,
+				TypeInformation<Vertex<K, VVWithDegrees>> resultType)
+		{
+			this.gatherFunction = gatherFunction;
+			this.resultType = resultType;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			if (getRuntimeContext().hasBroadcastVariable("number of vertices")) {
+				Collection<LongValue> numberOfVertices = getRuntimeContext().getBroadcastVariable("number of vertices");
+				this.gatherFunction.setNumberOfVertices(numberOfVertices.iterator().next().getValue());
+			}
+			if (getIterationRuntimeContext().getSuperstepNumber() == 1) {
+				this.gatherFunction.init(getIterationRuntimeContext());
+			}
+			this.gatherFunction.preSuperstep();
+		}
+
+		@Override
+		public void close() throws Exception {
+			this.gatherFunction.postSuperstep();
 		}
 
 		@Override
@@ -270,10 +366,10 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	}
 
 	@SuppressWarnings("serial")
-	private static final class VertexUpdateUdfSimpleVV<K, VV, Message> extends VertexUpdateUdf<K, VV, Message> {
+	private static final class GatherUdfSimpleVV<K, VV, Message> extends GatherUdf<K, VV, Message> {
 
-		private VertexUpdateUdfSimpleVV(VertexUpdateFunction<K, VV, Message> vertexUpdateFunction, TypeInformation<Vertex<K, VV>> resultType) {
-			super(vertexUpdateFunction, resultType);
+		private GatherUdfSimpleVV(GatherFunction<K, VV, Message> gatherFunction, TypeInformation<Vertex<K, VV>> resultType) {
+			super(gatherFunction, resultType);
 		}
 
 		@Override
@@ -289,8 +385,8 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 				Iterator<Tuple2<?, Message>> downcastIter = (Iterator<Tuple2<?, Message>>) (Iterator<?>) messages.iterator();
 				messageIter.setSource(downcastIter);
 
-				vertexUpdateFunction.setOutput(vertexState, out);
-				vertexUpdateFunction.updateVertex(vertexState, messageIter);
+				gatherFunction.setOutput(vertexState, out);
+				gatherFunction.updateVertex(vertexState, messageIter);
 			}
 			else {
 				final Iterator<Tuple2<K, Message>> messageIter = messages.iterator();
@@ -299,7 +395,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 					try {
 						Tuple2<K, Message> next = messageIter.next();
 						message = "Target vertex '" + next.f0 + "' does not exist!.";
-					} catch (Throwable t) {}
+					} catch (Throwable ignored) {}
 					throw new Exception(message);
 				} else {
 					throw new Exception();
@@ -309,31 +405,31 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	}
 
 	@SuppressWarnings("serial")
-	private static final class VertexUpdateUdfVVWithDegrees<K, VV, Message> extends VertexUpdateUdf<K, Tuple3<VV, LongValue, LongValue>, Message> {
+	private static final class GatherUdfVVWithDegrees<K, VV, Message> extends GatherUdf<K, Tuple3<VV, LongValue, LongValue>, Message> {
 
-		private VertexUpdateUdfVVWithDegrees(VertexUpdateFunction<K, Tuple3<VV, LongValue, LongValue>, Message> vertexUpdateFunction,
+		private GatherUdfVVWithDegrees(GatherFunction<K, Tuple3<VV, LongValue, LongValue>, Message> gatherFunction,
 				TypeInformation<Vertex<K, Tuple3<VV, LongValue, LongValue>>> resultType) {
-			super(vertexUpdateFunction, resultType);
+			super(gatherFunction, resultType);
 		}
-		
+
 		@Override
 		public void coGroup(Iterable<Tuple2<K, Message>> messages, Iterable<Vertex<K, Tuple3<VV, LongValue, LongValue>>> vertex,
 							Collector<Vertex<K, Tuple3<VV, LongValue, LongValue>>> out) throws Exception {
 
 			final Iterator<Vertex<K, Tuple3<VV, LongValue, LongValue>>> vertexIter = vertex.iterator();
-		
+
 			if (vertexIter.hasNext()) {
 				Vertex<K, Tuple3<VV, LongValue, LongValue>> vertexWithDegrees = vertexIter.next();
-		
+
 				@SuppressWarnings("unchecked")
 				Iterator<Tuple2<?, Message>> downcastIter = (Iterator<Tuple2<?, Message>>) (Iterator<?>) messages.iterator();
 				messageIter.setSource(downcastIter);
 
-				vertexUpdateFunction.setInDegree(vertexWithDegrees.f1.f1.getValue());
-				vertexUpdateFunction.setOutDegree(vertexWithDegrees.f1.f2.getValue());
+				gatherFunction.setInDegree(vertexWithDegrees.f1.f1.getValue());
+				gatherFunction.setOutDegree(vertexWithDegrees.f1.f2.getValue());
 
-				vertexUpdateFunction.setOutputWithDegrees(vertexWithDegrees, out);
-				vertexUpdateFunction.updateVertexFromScatterGatherIteration(vertexWithDegrees, messageIter);
+				gatherFunction.setOutputWithDegrees(vertexWithDegrees, out);
+				gatherFunction.updateVertexFromScatterGatherIteration(vertexWithDegrees, messageIter);
 			}
 			else {
 				final Iterator<Tuple2<K, Message>> messageIter = messages.iterator();
@@ -342,7 +438,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 					try {
 						Tuple2<K, Message> next = messageIter.next();
 						message = "Target vertex '" + next.f0 + "' does not exist!.";
-					} catch (Throwable t) {}
+					} catch (Throwable ignored) {}
 					throw new Exception(message);
 				} else {
 					throw new Exception();
@@ -350,113 +446,13 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 			}
 		}
 	}
-
-	/*
-	 * UDF that encapsulates the message sending function for graphs where the edges have an associated value.
-	 */
-	private static abstract class MessagingUdfWithEdgeValues<K, VVWithDegrees, VV, Message, EV>
-		extends RichCoGroupFunction<Edge<K, EV>, Vertex<K, VVWithDegrees>, Tuple2<K, Message>>
-		implements ResultTypeQueryable<Tuple2<K, Message>>
-	{
-		private static final long serialVersionUID = 1L;
-		
-		final MessagingFunction<K, VV, Message, EV> messagingFunction;
-		
-		private transient TypeInformation<Tuple2<K, Message>> resultType;
-	
-	
-		private MessagingUdfWithEdgeValues(MessagingFunction<K, VV, Message, EV> messagingFunction,
-				TypeInformation<Tuple2<K, Message>> resultType)
-		{
-			this.messagingFunction = messagingFunction;
-			this.resultType = resultType;
-		}
-		
-		@Override
-		public void open(Configuration parameters) throws Exception {
-			if (getRuntimeContext().hasBroadcastVariable("number of vertices")) {
-				Collection<LongValue> numberOfVertices = getRuntimeContext().getBroadcastVariable("number of vertices");
-				this.messagingFunction.setNumberOfVertices(numberOfVertices.iterator().next().getValue());
-			}
-			if (getIterationRuntimeContext().getSuperstepNumber() == 1) {
-				this.messagingFunction.init(getIterationRuntimeContext());
-			}
-			this.messagingFunction.preSuperstep();
-		}
-		
-		@Override
-		public void close() throws Exception {
-			this.messagingFunction.postSuperstep();
-		}
-		
-		@Override
-		public TypeInformation<Tuple2<K, Message>> getProducedType() {
-			return this.resultType;
-		}
-	}
-
-	@SuppressWarnings("serial")
-	private static final class MessagingUdfWithEVsSimpleVV<K, VV, Message, EV>
-		extends MessagingUdfWithEdgeValues<K, VV, VV, Message, EV> {
-
-		private MessagingUdfWithEVsSimpleVV(MessagingFunction<K, VV, Message, EV> messagingFunction,
-			TypeInformation<Tuple2<K, Message>> resultType) {
-			super(messagingFunction, resultType);
-		}
-
-		@Override
-		public void coGroup(Iterable<Edge<K, EV>> edges,
-							Iterable<Vertex<K, VV>> state,
-							Collector<Tuple2<K, Message>> out) throws Exception {
-			final Iterator<Vertex<K, VV>> stateIter = state.iterator();
-		
-			if (stateIter.hasNext()) {
-				Vertex<K, VV> newVertexState = stateIter.next();
-				messagingFunction.set((Iterator<?>) edges.iterator(), out, newVertexState.getId());
-				messagingFunction.sendMessages(newVertexState);
-			}
-		}
-	}
-
-	@SuppressWarnings("serial")
-	private static final class MessagingUdfWithEVsVVWithDegrees<K, VV, Message, EV>
-		extends MessagingUdfWithEdgeValues<K, Tuple3<VV, LongValue, LongValue>, VV, Message, EV> {
-
-		private Vertex<K, VV> nextVertex = new Vertex<K, VV>();
-
-		private MessagingUdfWithEVsVVWithDegrees(MessagingFunction<K, VV, Message, EV> messagingFunction,
-				TypeInformation<Tuple2<K, Message>> resultType) {
-			super(messagingFunction, resultType);
-		}
-
-		@Override
-		public void coGroup(Iterable<Edge<K, EV>> edges, Iterable<Vertex<K, Tuple3<VV, LongValue, LongValue>>> state,
-				Collector<Tuple2<K, Message>> out) throws Exception {
-
-			final Iterator<Vertex<K, Tuple3<VV, LongValue, LongValue>>> stateIter = state.iterator();
-		
-			if (stateIter.hasNext()) {
-				Vertex<K, Tuple3<VV, LongValue, LongValue>> vertexWithDegrees = stateIter.next();
-
-				nextVertex.setField(vertexWithDegrees.f0, 0);
-				nextVertex.setField(vertexWithDegrees.f1.f0, 1);
-
-				messagingFunction.setInDegree(vertexWithDegrees.f1.f1.getValue());
-				messagingFunction.setOutDegree(vertexWithDegrees.f1.f2.getValue());
-
-				messagingFunction.set((Iterator<?>) edges.iterator(), out, vertexWithDegrees.getId());
-				messagingFunction.sendMessages(nextVertex);
-			}
-		}
-	}
-
 
 	// --------------------------------------------------------------------------------------------
 	//  UTIL methods
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Method that builds the messaging function using a coGroup operator for a simple vertex(without
+	 * Method that builds the scatter function using a coGroup operator for a simple vertex (without
 	 * degrees).
 	 * It afterwards configures the function with a custom name and broadcast variables.
 	 *
@@ -464,17 +460,17 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	 * @param messageTypeInfo
 	 * @param whereArg the argument for the where within the coGroup
 	 * @param equalToArg the argument for the equalTo within the coGroup
-	 * @return the messaging function
+	 * @return the scatter function
 	 */
-	private CoGroupOperator<?, ?, Tuple2<K, Message>> buildMessagingFunction(
+	private CoGroupOperator<?, ?, Tuple2<K, Message>> buildScatterFunction(
 			DeltaIteration<Vertex<K, VV>, Vertex<K, VV>> iteration,
 			TypeInformation<Tuple2<K, Message>> messageTypeInfo, int whereArg, int equalToArg,
 			DataSet<LongValue> numberOfVertices) {
 
-		// build the messaging function (co group)
+		// build the scatter function (co group)
 		CoGroupOperator<?, ?, Tuple2<K, Message>> messages;
-		MessagingUdfWithEdgeValues<K, VV, VV, Message, EV> messenger =
-				new MessagingUdfWithEVsSimpleVV<K, VV, Message, EV>(messagingFunction, messageTypeInfo);
+		ScatterUdfWithEdgeValues<K, VV, VV, Message, EV> messenger =
+				new ScatterUdfWithEVsSimpleVV<>(scatterFunction, messageTypeInfo);
 
 		messages = this.edgesWithValue.coGroup(iteration.getWorkset()).where(whereArg)
 				.equalTo(equalToArg).with(messenger);
@@ -482,7 +478,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 		// configure coGroup message function with name and broadcast variables
 		messages = messages.name("Messaging");
 		if(this.configuration != null) {
-			for (Tuple2<String, DataSet<?>> e : this.configuration.getMessagingBcastVars()) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getScatterBcastVars()) {
 				messages = messages.withBroadcastSet(e.f1, e.f0);
 			}
 			if (this.configuration.isOptNumVertices()) {
@@ -494,7 +490,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	}
 
 	/**
-	 * Method that builds the messaging function using a coGroup operator for a vertex
+	 * Method that builds the scatter function using a coGroup operator for a vertex
 	 * containing degree information.
 	 * It afterwards configures the function with a custom name and broadcast variables.
 	 *
@@ -502,17 +498,17 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 	 * @param messageTypeInfo
 	 * @param whereArg the argument for the where within the coGroup
 	 * @param equalToArg the argument for the equalTo within the coGroup
-	 * @return the messaging function
+	 * @return the scatter function
 	 */
-	private CoGroupOperator<?, ?, Tuple2<K, Message>> buildMessagingFunctionVerticesWithDegrees(
+	private CoGroupOperator<?, ?, Tuple2<K, Message>> buildScatterFunctionVerticesWithDegrees(
 			DeltaIteration<Vertex<K, Tuple3<VV, LongValue, LongValue>>, Vertex<K, Tuple3<VV, LongValue, LongValue>>> iteration,
 			TypeInformation<Tuple2<K, Message>> messageTypeInfo, int whereArg, int equalToArg,
 			DataSet<LongValue> numberOfVertices) {
 
-		// build the messaging function (co group)
+		// build the scatter function (co group)
 		CoGroupOperator<?, ?, Tuple2<K, Message>> messages;
-		MessagingUdfWithEdgeValues<K, Tuple3<VV, LongValue, LongValue>, VV, Message, EV> messenger =
-				new MessagingUdfWithEVsVVWithDegrees<K, VV, Message, EV>(messagingFunction, messageTypeInfo);
+		ScatterUdfWithEdgeValues<K, Tuple3<VV, LongValue, LongValue>, VV, Message, EV> messenger =
+				new ScatterUdfWithEVsVVWithDegrees<>(scatterFunction, messageTypeInfo);
 
 		messages = this.edgesWithValue.coGroup(iteration.getWorkset()).where(whereArg)
 				.equalTo(equalToArg).with(messenger);
@@ -521,7 +517,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 		messages = messages.name("Messaging");
 
 		if (this.configuration != null) {
-			for (Tuple2<String, DataSet<?>> e : this.configuration.getMessagingBcastVars()) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getScatterBcastVars()) {
 				messages = messages.withBroadcastSet(e.f1, e.f0);
 			}
 			if (this.configuration.isOptNumVertices()) {
@@ -543,7 +539,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 		// set up the iteration operator
 		if (this.configuration != null) {
 
-			iteration.name(this.configuration.getName("Scatter-gather iteration (" + updateFunction + " | " + messagingFunction + ")"));
+			iteration.name(this.configuration.getName("Scatter-gather iteration (" + gatherFunction + " | " + scatterFunction + ")"));
 			iteration.parallelism(this.configuration.getParallelism());
 			iteration.setSolutionSetUnManaged(this.configuration.isSolutionSetUnmanagedMemory());
 
@@ -554,7 +550,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 		}
 		else {
 			// no configuration provided; set default name
-			iteration.name("Scatter-gather iteration (" + updateFunction + " | " + messagingFunction + ")");
+			iteration.name("Scatter-gather iteration (" + gatherFunction + " | " + scatterFunction + ")");
 		}
 	}
 
@@ -579,21 +575,21 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 
 		switch (messagingDirection) {
 			case IN:
-				messages = buildMessagingFunction(iteration, messageTypeInfo, 1, 0, numberOfVertices);
+				messages = buildScatterFunction(iteration, messageTypeInfo, 1, 0, numberOfVertices);
 				break;
 			case OUT:
-				messages = buildMessagingFunction(iteration, messageTypeInfo, 0, 0, numberOfVertices);
+				messages = buildScatterFunction(iteration, messageTypeInfo, 0, 0, numberOfVertices);
 				break;
 			case ALL:
-				messages = buildMessagingFunction(iteration, messageTypeInfo, 1, 0, numberOfVertices)
-						.union(buildMessagingFunction(iteration, messageTypeInfo, 0, 0, numberOfVertices)) ;
+				messages = buildScatterFunction(iteration, messageTypeInfo, 1, 0, numberOfVertices)
+						.union(buildScatterFunction(iteration, messageTypeInfo, 0, 0, numberOfVertices)) ;
 				break;
 			default:
 				throw new IllegalArgumentException("Illegal edge direction");
 		}
 
-		VertexUpdateUdf<K, VV, Message> updateUdf =
-				new VertexUpdateUdfSimpleVV<K, VV, Message>(updateFunction, vertexTypes);
+		GatherUdf<K, VV, Message> updateUdf =
+				new GatherUdfSimpleVV<K, VV, Message>(gatherFunction, vertexTypes);
 
 		// build the update function (co group)
 		CoGroupOperator<?, ?, Vertex<K, VV>> updates =
@@ -624,7 +620,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 
 		DataSet<Tuple2<K, Message>> messages;
 
-		this.updateFunction.setOptDegrees(this.configuration.isOptDegrees());
+		this.gatherFunction.setOptDegrees(this.configuration.isOptDegrees());
 
 		DataSet<Tuple2<K, LongValue>> inDegrees = graph.inDegrees();
 		DataSet<Tuple2<K, LongValue>> outDegrees = graph.outDegrees();
@@ -634,7 +630,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 
 					@Override
 					public void join(Tuple2<K, LongValue> first, Tuple2<K, LongValue> second, Collector<Tuple3<K, LongValue, LongValue>> out) {
-						out.collect(new Tuple3<K, LongValue, LongValue>(first.f0, first.f1, second.f1));
+						out.collect(new Tuple3<>(first.f0, first.f1, second.f1));
 					}
 				}).withForwardedFieldsFirst("f0;f1").withForwardedFieldsSecond("f1");
 
@@ -644,9 +640,8 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 					@Override
 					public void join(Vertex<K, VV> vertex, Tuple3<K, LongValue, LongValue> degrees,
 									Collector<Vertex<K, Tuple3<VV, LongValue, LongValue>>> out) throws Exception {
-
-						out.collect(new Vertex<K, Tuple3<VV, LongValue, LongValue>>(vertex.getId(),
-								new Tuple3<VV, LongValue, LongValue>(vertex.getValue(), degrees.f1, degrees.f2)));
+						out.collect(new Vertex<>(vertex.getId(),
+									new Tuple3<>(vertex.getValue(), degrees.f1, degrees.f2)));
 					}
 				}).withForwardedFieldsFirst("f0");
 
@@ -659,22 +654,22 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 
 		switch (messagingDirection) {
 			case IN:
-				messages = buildMessagingFunctionVerticesWithDegrees(iteration, messageTypeInfo, 1, 0, numberOfVertices);
+				messages = buildScatterFunctionVerticesWithDegrees(iteration, messageTypeInfo, 1, 0, numberOfVertices);
 				break;
 			case OUT:
-				messages = buildMessagingFunctionVerticesWithDegrees(iteration, messageTypeInfo, 0, 0, numberOfVertices);
+				messages = buildScatterFunctionVerticesWithDegrees(iteration, messageTypeInfo, 0, 0, numberOfVertices);
 				break;
 			case ALL:
-				messages = buildMessagingFunctionVerticesWithDegrees(iteration, messageTypeInfo, 1, 0, numberOfVertices)
-						.union(buildMessagingFunctionVerticesWithDegrees(iteration, messageTypeInfo, 0, 0, numberOfVertices)) ;
+				messages = buildScatterFunctionVerticesWithDegrees(iteration, messageTypeInfo, 1, 0, numberOfVertices)
+						.union(buildScatterFunctionVerticesWithDegrees(iteration, messageTypeInfo, 0, 0, numberOfVertices)) ;
 				break;
 			default:
 				throw new IllegalArgumentException("Illegal edge direction");
 		}
 
 		@SuppressWarnings({ "unchecked", "rawtypes" })
-		VertexUpdateUdf<K, Tuple3<VV, LongValue, LongValue>, Message> updateUdf =
-				new VertexUpdateUdfVVWithDegrees(updateFunction, vertexTypes);
+		GatherUdf<K, Tuple3<VV, LongValue, LongValue>, Message> updateUdf =
+				new GatherUdfVVWithDegrees(gatherFunction, vertexTypes);
 
 		// build the update function (co group)
 		CoGroupOperator<?, ?, Vertex<K, Tuple3<VV, LongValue, LongValue>>> updates =
@@ -690,7 +685,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 				new MapFunction<Vertex<K, Tuple3<VV, LongValue, LongValue>>, Vertex<K, VV>>() {
 
 					public Vertex<K, VV> map(Vertex<K, Tuple3<VV, LongValue, LongValue>> vertex) {
-						return new Vertex<K, VV>(vertex.getId(), vertex.getValue().f0);
+						return new Vertex<>(vertex.getId(), vertex.getValue().f0);
 					}
 				});
 	}
@@ -700,7 +695,7 @@ public class ScatterGatherIteration<K, VV, Message, EV>
 		// configure coGroup update function with name and broadcast variables
 		updates = updates.name("Vertex State Updates");
 		if (this.configuration != null) {
-			for (Tuple2<String, DataSet<?>> e : this.configuration.getUpdateBcastVars()) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getGatherBcastVars()) {
 				updates = updates.withBroadcastSet(e.f1, e.f0);
 			}
 		}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelCompilerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelCompilerTest.java
@@ -75,8 +75,8 @@ public class SpargelCompilerTest extends CompilerTestBase {
 				Graph<Long, Long, NullValue> graph = Graph.fromDataSet(initialVertices, edges, env);
 
 				DataSet<Vertex<Long, Long>> result = graph.runScatterGatherIteration(
-						new ConnectedComponents.CCUpdater<Long, Long>(),
-						new ConnectedComponents.CCMessenger<Long, Long>(BasicTypeInfo.LONG_TYPE_INFO), 100)
+						new ConnectedComponents.CCMessenger<Long, Long>(BasicTypeInfo.LONG_TYPE_INFO),
+						new ConnectedComponents.CCUpdater<Long, Long>(), 100)
 						.getVertices();
 				
 				result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
@@ -157,12 +157,12 @@ public class SpargelCompilerTest extends CompilerTestBase {
 				Graph<Long, Long, NullValue> graph = Graph.fromDataSet(initialVertices, edges, env);
 
 				ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
-				parameters.addBroadcastSetForMessagingFunction(BC_VAR_NAME, bcVar);
-				parameters.addBroadcastSetForUpdateFunction(BC_VAR_NAME, bcVar);
+				parameters.addBroadcastSetForScatterFunction(BC_VAR_NAME, bcVar);
+				parameters.addBroadcastSetForGatherFunction(BC_VAR_NAME, bcVar);
 
 				DataSet<Vertex<Long, Long>> result = graph.runScatterGatherIteration(
-						new ConnectedComponents.CCUpdater<Long, Long>(),
-						new ConnectedComponents.CCMessenger<Long, Long>(BasicTypeInfo.LONG_TYPE_INFO), 100)
+						new ConnectedComponents.CCMessenger<Long, Long>(BasicTypeInfo.LONG_TYPE_INFO),
+						new ConnectedComponents.CCUpdater<Long, Long>(), 100)
 						.getVertices();
 					
 				result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelTranslationTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelTranslationTest.java
@@ -16,28 +16,27 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.graph.spargel;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.Test;
 import org.apache.flink.api.common.aggregators.LongSumAggregator;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.operators.DeltaIteration;
 import org.apache.flink.api.java.operators.DeltaIterationResultSet;
-import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.operators.TwoInputUdfOperator;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.NullValue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("serial")
 public class SpargelTranslationTest {
@@ -46,28 +45,28 @@ public class SpargelTranslationTest {
 	public void testTranslationPlainEdges() {
 		try {
 			final String ITERATION_NAME = "Test Name";
-			
+
 			final String AGGREGATOR_NAME = "AggregatorName";
-			
+
 			final String BC_SET_MESSAGES_NAME = "borat messages";
-			
+
 			final String BC_SET_UPDATES_NAME = "borat updates";
 
 			final int NUM_ITERATIONS = 13;
-			
+
 			final int ITERATION_parallelism = 77;
-			
-			
+
+
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Long> bcMessaging = env.fromElements(1L);
 			DataSet<Long> bcUpdate = env.fromElements(1L);
-			
+
 			DataSet<Vertex<String, Double>> result;
-			
+
 			// ------------ construct the test program ------------------
 			{
-				
+
 				DataSet<Tuple2<String, Double>> initialVertices = env.fromElements(new Tuple2<>("abc", 3.44));
 
 				DataSet<Tuple2<String, String>> edges = env.fromElements(new Tuple2<>("a", "c"));
@@ -83,41 +82,41 @@ public class SpargelTranslationTest {
 
 				ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
-				parameters.addBroadcastSetForMessagingFunction(BC_SET_MESSAGES_NAME, bcMessaging);
-				parameters.addBroadcastSetForUpdateFunction(BC_SET_UPDATES_NAME, bcUpdate);
+				parameters.addBroadcastSetForScatterFunction(BC_SET_MESSAGES_NAME, bcMessaging);
+				parameters.addBroadcastSetForGatherFunction(BC_SET_UPDATES_NAME, bcUpdate);
 				parameters.setName(ITERATION_NAME);
 				parameters.setParallelism(ITERATION_parallelism);
 				parameters.registerAggregator(AGGREGATOR_NAME, new LongSumAggregator());
 
-				result = graph.runScatterGatherIteration(new UpdateFunction(), new MessageFunctionNoEdgeValue(),
+				result = graph.runScatterGatherIteration(new MessageFunctionNoEdgeValue(), new UpdateFunction(),
 						NUM_ITERATIONS, parameters).getVertices();
 
 				result.output(new DiscardingOutputFormat<Vertex<String, Double>>());
 			}
-			
-			
+
+
 			// ------------- validate the java program ----------------
-			
+
 			assertTrue(result instanceof DeltaIterationResultSet);
-			
+
 			DeltaIterationResultSet<?, ?> resultSet = (DeltaIterationResultSet<?, ?>) result;
 			DeltaIteration<?, ?> iteration = resultSet.getIterationHead();
-			
+
 			// check the basic iteration properties
 			assertEquals(NUM_ITERATIONS, resultSet.getMaxIterations());
 			assertArrayEquals(new int[] {0}, resultSet.getKeyPositions());
 			assertEquals(ITERATION_parallelism, iteration.getParallelism());
 			assertEquals(ITERATION_NAME, iteration.getName());
-			
+
 			assertEquals(AGGREGATOR_NAME, iteration.getAggregators().getAllRegisteredAggregators().iterator().next().getName());
-			
+
 			// validate that the semantic properties are set as they should
 			TwoInputUdfOperator<?, ?, ?, ?> solutionSetJoin = (TwoInputUdfOperator<?, ?, ?, ?>) resultSet.getNextWorkset();
 			assertTrue(solutionSetJoin.getSemanticProperties().getForwardingTargetFields(0, 0).contains(0));
 			assertTrue(solutionSetJoin.getSemanticProperties().getForwardingTargetFields(1, 0).contains(0));
-			
+
 			TwoInputUdfOperator<?, ?, ?, ?> edgesJoin = (TwoInputUdfOperator<?, ?, ?, ?>) solutionSetJoin.getInput1();
-			
+
 			// validate that the broadcast sets are forwarded
 			assertEquals(bcUpdate, solutionSetJoin.getBroadcastSets().get(BC_SET_UPDATES_NAME));
 			assertEquals(bcMessaging, edgesJoin.getBroadcastSets().get(BC_SET_MESSAGES_NAME));
@@ -128,29 +127,29 @@ public class SpargelTranslationTest {
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testTranslationPlainEdgesWithForkedBroadcastVariable() {
 		try {
 			final String ITERATION_NAME = "Test Name";
-			
+
 			final String AGGREGATOR_NAME = "AggregatorName";
-			
+
 			final String BC_SET_MESSAGES_NAME = "borat messages";
-			
+
 			final String BC_SET_UPDATES_NAME = "borat updates";
 
 			final int NUM_ITERATIONS = 13;
-			
+
 			final int ITERATION_parallelism = 77;
-			
-			
+
+
 			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			
+
 			DataSet<Long> bcVar = env.fromElements(1L);
-			
+
 			DataSet<Vertex<String, Double>> result;
-			
+
 			// ------------ construct the test program ------------------
 			{
 
@@ -169,41 +168,41 @@ public class SpargelTranslationTest {
 
 				ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 
-				parameters.addBroadcastSetForMessagingFunction(BC_SET_MESSAGES_NAME, bcVar);
-				parameters.addBroadcastSetForUpdateFunction(BC_SET_UPDATES_NAME, bcVar);
+				parameters.addBroadcastSetForScatterFunction(BC_SET_MESSAGES_NAME, bcVar);
+				parameters.addBroadcastSetForGatherFunction(BC_SET_UPDATES_NAME, bcVar);
 				parameters.setName(ITERATION_NAME);
 				parameters.setParallelism(ITERATION_parallelism);
 				parameters.registerAggregator(AGGREGATOR_NAME, new LongSumAggregator());
-				
-				result = graph.runScatterGatherIteration(new UpdateFunction(), new MessageFunctionNoEdgeValue(),
+
+				result = graph.runScatterGatherIteration(new MessageFunctionNoEdgeValue(), new UpdateFunction(),
 						NUM_ITERATIONS, parameters).getVertices();
 
 				result.output(new DiscardingOutputFormat<Vertex<String, Double>>());
 			}
-			
-			
+
+
 			// ------------- validate the java program ----------------
-			
+
 			assertTrue(result instanceof DeltaIterationResultSet);
-			
+
 			DeltaIterationResultSet<?, ?> resultSet = (DeltaIterationResultSet<?, ?>) result;
 			DeltaIteration<?, ?> iteration = resultSet.getIterationHead();
-			
+
 			// check the basic iteration properties
 			assertEquals(NUM_ITERATIONS, resultSet.getMaxIterations());
 			assertArrayEquals(new int[] {0}, resultSet.getKeyPositions());
 			assertEquals(ITERATION_parallelism, iteration.getParallelism());
 			assertEquals(ITERATION_NAME, iteration.getName());
-			
+
 			assertEquals(AGGREGATOR_NAME, iteration.getAggregators().getAllRegisteredAggregators().iterator().next().getName());
-			
+
 			// validate that the semantic properties are set as they should
 			TwoInputUdfOperator<?, ?, ?, ?> solutionSetJoin = (TwoInputUdfOperator<?, ?, ?, ?>) resultSet.getNextWorkset();
 			assertTrue(solutionSetJoin.getSemanticProperties().getForwardingTargetFields(0, 0).contains(0));
 			assertTrue(solutionSetJoin.getSemanticProperties().getForwardingTargetFields(1, 0).contains(0));
-			
+
 			TwoInputUdfOperator<?, ?, ?, ?> edgesJoin = (TwoInputUdfOperator<?, ?, ?, ?>) solutionSetJoin.getInput1();
-			
+
 			// validate that the broadcast sets are forwarded
 			assertEquals(bcVar, solutionSetJoin.getBroadcastSets().get(BC_SET_UPDATES_NAME));
 			assertEquals(bcVar, edgesJoin.getBroadcastSets().get(BC_SET_MESSAGES_NAME));
@@ -214,18 +213,18 @@ public class SpargelTranslationTest {
 			fail(e.getMessage());
 		}
 	}
-	
-	// --------------------------------------------------------------------------------------------
-	
-	public static class UpdateFunction extends VertexUpdateFunction<String, Double, Long> {
 
-		@Override
-		public void updateVertex(Vertex<String, Double> vertex, MessageIterator<Long> inMessages) {}
-	}
-	
-	public static class MessageFunctionNoEdgeValue extends MessagingFunction<String, Double, Long, NullValue> {
+	// --------------------------------------------------------------------------------------------
+
+	private static class MessageFunctionNoEdgeValue extends ScatterFunction<String, Double, Long, NullValue> {
 
 		@Override
 		public void sendMessages(Vertex<String, Double> vertex) {}
+	}
+
+	private static class UpdateFunction extends GatherFunction<String, Double, Long> {
+
+		@Override
+		public void updateVertex(Vertex<String, Double> vertex, MessageIterator<Long> inMessages) {}
 	}
 }


### PR DESCRIPTION
Rename MessageFunction to ScatterFunction and VertexUpdateFunction to GatherFunction.
    
Change the parameter order in Graph.runScatterGatherIteration(VertexUpdateFunction, MessagingFunction) to Graph.runScatterGatherIteration(ScatterFunction, GatherFunction)