### PR TITLE
[FLINK-4141] remove leaderUpdated() method from ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
@@ -494,9 +494,6 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceIDRetrieva
 
 			jobManager = newJobManagerLeader;
 
-			// inform the framework that we have updated the leader
-			leaderUpdated();
-
 			if (workers.size() > 0) {
 				LOG.info("Received TaskManagers that were registered at the leader JobManager. " +
 						"Trying to consolidate.");
@@ -643,12 +640,6 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceIDRetrieva
 	 *                   restarted.
 	 */
 	protected abstract void initialize() throws Exception;
-
-	/**
-	 * Provides codes to handle an update of the leader (relevant for HA). The framework has to deal
-	 * with the consequences of a leader update.
-	 */
-	protected abstract void leaderUpdated();
 
 	/**
 	 * The framework specific code for shutting down the application. This should report the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/standalone/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/standalone/StandaloneResourceManager.java
@@ -59,11 +59,6 @@ public class StandaloneResourceManager extends FlinkResourceManager<ResourceID> 
 	}
 
 	@Override
-	protected void leaderUpdated() {
-		// nothing to update
-	}
-
-	@Override
 	protected void shutdownApplication(ApplicationStatus finalStatus, String optionalDiagnostics) {
 	}
 

--- a/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnJobManager.scala
+++ b/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnJobManager.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService
 import akka.actor.ActorRef
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.checkpoint.{SavepointStore, CheckpointRecoveryFactory}
+import org.apache.flink.metrics.MetricRegistry
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory
 import org.apache.flink.runtime.instance.InstanceManager
@@ -63,7 +64,8 @@ class TestingYarnJobManager(
     submittedJobGraphs : SubmittedJobGraphStore,
     checkpointRecoveryFactory : CheckpointRecoveryFactory,
     savepointStore: SavepointStore,
-    jobRecoveryTimeout: FiniteDuration)
+    jobRecoveryTimeout: FiniteDuration,
+    metricRegistry : Option[MetricRegistry])
   extends YarnJobManager(
     flinkConfiguration,
     executorService,
@@ -77,5 +79,6 @@ class TestingYarnJobManager(
     submittedJobGraphs,
     checkpointRecoveryFactory,
     savepointStore,
-    jobRecoveryTimeout)
+    jobRecoveryTimeout,
+    metricRegistry)
   with TestingJobManagerLike {}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkResourceManager.java
@@ -29,8 +29,6 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.messages.StopCluster;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.yarn.messages.ContainersAllocated;
 import org.apache.flink.yarn.messages.ContainersComplete;
@@ -181,8 +179,7 @@ public class YarnFlinkResourceManager extends FlinkResourceManager<RegisteredYar
 		LOG.info("Initializing YARN resource master");
 
 		// create the client to communicate with the ResourceManager
-		ActorGateway selfGateway = new AkkaActorGateway(self(), getLeaderSessionID());
-		resourceManagerCallbackHandler = new YarnResourceManagerCallbackHandler(selfGateway);
+		resourceManagerCallbackHandler = new YarnResourceManagerCallbackHandler(self());
 
 		resourceManagerClient = AMRMClientAsync.createAMRMClientAsync(
 			yarnHeartbeatIntervalMillis, resourceManagerCallbackHandler);
@@ -221,12 +218,6 @@ public class YarnFlinkResourceManager extends FlinkResourceManager<RegisteredYar
 			// adjust the progress indicator
 			updateProgress();
 		}
-	}
-
-	@Override
-	protected void leaderUpdated() {
-		AkkaActorGateway newGateway = new AkkaActorGateway(self(), getLeaderSessionID());
-		resourceManagerCallbackHandler.setCurrentLeaderGateway(newGateway);
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/messages/ContainersAllocated.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/messages/ContainersAllocated.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn.messages;
 
-import org.apache.flink.runtime.messages.RequiresLeaderSessionID;
 import org.apache.flink.yarn.YarnFlinkResourceManager;
 import org.apache.hadoop.yarn.api.records.Container;
 
@@ -30,7 +29,7 @@ import java.util.List;
  * 
  * NOTE: This message is not serializable, because the Container object is not serializable.
  */
-public class ContainersAllocated implements RequiresLeaderSessionID {
+public class ContainersAllocated {
 	
 	private final List<Container> containers;
 	

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/messages/ContainersComplete.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/messages/ContainersComplete.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn.messages;
 
-import org.apache.flink.runtime.messages.RequiresLeaderSessionID;
 
 import org.apache.flink.yarn.YarnFlinkResourceManager;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
@@ -31,7 +30,7 @@ import java.util.List;
  * 
  * NOTE: This message is not serializable, because the ContainerStatus object is not serializable.
  */
-public class ContainersComplete implements RequiresLeaderSessionID {
+public class ContainersComplete {
 	
 	private final List<ContainerStatus> containers;
 	


### PR DESCRIPTION
This removes the leaderUpdated method from the framework. Further it
lets the RM client thread communicate directly with the
ResourceManager actor. This is fine since the two are always spawned
together. Failures of the ResourceManager actor will lead to dropped
messages of the RM client thread. Failures of the RM client thread will
inform the JobManager.

The leaderUpdated() method was used to signal the ResourceManager
framework that a new leader was elected. However, the method was not
always called when the leader changed, only when a new leader was
elected. This dropped all messages from the async Yarn RM client
thread (YarnResourceManagerCallbackHandler) for the time that the old
leader had failed and no new leader had been elected. The Yarn RM client
thread used leader tagged messages to communicate with the main Flink
ResourceManager actor.