### PR TITLE
FLINK-3397 Failed streaming jobs should fall back to the most recent

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointCoordinator.java
@@ -115,6 +115,13 @@ public class SavepointCoordinator extends CheckpointCoordinator {
 		return savepointRestorePath;
 	}
 
+	public long getCheckpointId(String savePath) throws Exception {
+		return this.savepointStore.getState(savePath).getCheckpointID();
+	}
+
+	public long getCheckpointTimeStamp(String savePath) throws Exception {
+		return this.savepointStore.getState(savePath).getTimestamp();
+	}
 	// ------------------------------------------------------------------------
 	// Savepoint trigger and reset
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Initial patch to see if this is what is intended out of the JIRA. Thought a PR could help me in getting a better feedback. I tried to tweak and add a test case but I could not. I followed what was done in SavePointITCase and particularly testRestoreFailure(). But am not able to get a flow where there could be a checkpoint and also a save point because this test case allows the notification to happen when the job is removed and that clears all the existing savePoints. So when the test case restores it always goes with the savePoint. 

