### PR TITLE
[FLINK-4134] empty session windows fire for late events

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -133,6 +133,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 				// check if the window is already inactive
 				if (isLate(actualWindow)) {
 					LOG.info("Dropped element " + element + " for window " + actualWindow + " due to lateness.");
+					mergingWindows.retireWindow(actualWindow);
 					continue;
 				}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -335,6 +335,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 				// drop if the window is already late
 				if (isLate(actualWindow)) {
 					LOG.info("Dropped element " + element+ " for window " + actualWindow + " due to lateness.");
+					//mergingWindows.retireWindow(actualWindow);
 					continue;
 				}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -335,7 +335,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 				// drop if the window is already late
 				if (isLate(actualWindow)) {
 					LOG.info("Dropped element " + element+ " for window " + actualWindow + " due to lateness.");
-					//mergingWindows.retireWindow(actualWindow);
+					mergingWindows.retireWindow(actualWindow);
 					continue;
 				}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -1477,6 +1477,8 @@ public class WindowOperatorTest {
 
 		// this is dropped as late
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 10000));
+		// this is also dropped as late (we test that they are not accidentally merged)
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 10100));
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
 		testHarness.processWatermark(new Watermark(20000));


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

…e session accidentally created a triggering empty window