### PR TITLE
[FLINK-4133] Reflect streaming file source changes in documentation

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -207,7 +207,7 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 					Tuple3<List<FileInputSplit>, FileInputSplit, S> restoredState) {
 
 			this.format = checkNotNull(format, "Unspecified FileInputFormat.");
-			this.serializer = checkNotNull(serializer, "Unspecified Serialized.");
+			this.serializer = checkNotNull(serializer, "Unspecified Serializer.");
 
 			this.pendingSplits = new LinkedList<>();
 			this.collector = collector;


### PR DESCRIPTION
The title says it all. 
It documents the continuous file processing semantics recently introduced in the Streaming API.