### PR TITLE
[hotfix] Quickstart docs respect artifactId

### DIFF
--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/BatchJob.java
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/BatchJob.java
@@ -32,9 +32,9 @@ import org.apache.flink.api.java.ExecutionEnvironment;
  * 		mvn clean package
  * in the projects root directory.
  * You will find the jar in
- * 		target/flink-quickstart-${version}.jar
+ * 		target/${artifactId}-${version}.jar
  * From the CLI you can then run
- * 		./bin/flink run -c ${package}.BatchJob target/flink-quickstart-${version}.jar
+ * 		./bin/flink run -c ${package}.BatchJob target/${artifactId}-${version}.jar
  *
  * For more information on the CLI see:
  *

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/StreamingJob.java
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/StreamingJob.java
@@ -33,9 +33,9 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
  * 		mvn clean package
  * in the projects root directory.
  * You will find the jar in
- * 		target/flink-quickstart-${version}.jar
+ * 		target/${artifactId}-${version}.jar
  * From the CLI you can then run
- * 		./bin/flink run -c ${package}.StreamingJob target/flink-quickstart-${version}.jar
+ * 		./bin/flink run -c ${package}.StreamingJob target/${artifactId}-${version}.jar
  *
  * For more information on the CLI see:
  *

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/BatchJob.scala
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/BatchJob.scala
@@ -35,7 +35,7 @@ import org.apache.flink.api.scala._
  * target/flink-quickstart-${version}.jar
  * From the CLI you can then run
  * {{{
- *    ./bin/flink run -c ${package}.BatchJob target/flink-quickstart-${version}.jar
+ *    ./bin/flink run -c ${package}.BatchJob target/${artifactId}-${version}.jar
  * }}}
  *
  * For more information on the CLI see:

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/StreamingJob.scala
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/StreamingJob.scala
@@ -35,7 +35,7 @@ import org.apache.flink.api.scala._
  * target/flink-quickstart-${version}.jar
  * From the CLI you can then run
  * {{{
- *    ./bin/flink run -c ${package}.StreamingJob target/flink-quickstart-${version}.jar
+ *    ./bin/flink run -c ${package}.StreamingJob target/${artifactId}-${version}.jar
  * }}}
  *
  * For more information on the CLI see:


### PR DESCRIPTION
This PR modifies the QuickStart Batch-/StreamingJob docs to contain the name of the generated jar.

The generated jars name depends on the artifact ID, the docs however are hard-coded to "flink-quickstart- ...",