### PR TITLE
[FLINK-4137] Tell Akka to shut down the JVM on fatal errors

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -144,7 +144,7 @@ object AkkaUtils {
       ConfigConstants.DEFAULT_AKKA_LOG_LIFECYCLE_EVENTS)
 
     val jvmExitOnFatalError = if (
-      configuration.getBoolean(ConfigConstants.AKKA_JVM_EXIT_ON_FATAL_ERROR, false)){
+      configuration.getBoolean(ConfigConstants.AKKA_JVM_EXIT_ON_FATAL_ERROR, true)){
       "on"
     } else {
       "off"


### PR DESCRIPTION
Currently, the ProcessReaper might not receive the `Terminated` message when a fatal error like an OOM error leaves the actor system in an inconsistent state.

By changing the default value of the configuration, akka is shutting down the JVM on such errors.

See also the JIRA discussion.