### PR TITLE
[FLINK-4157] Catch Kafka metrics serialization exceptions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -74,7 +73,7 @@ public class AccumulatorRegistry {
 	public AccumulatorSnapshot getSnapshot() {
 		try {
 			return new AccumulatorSnapshot(jobID, taskID, flinkAccumulators, userAccumulators);
-		} catch (IOException e) {
+		} catch (Throwable e) {
 			LOG.warn("Failed to serialize accumulators for task.", e);
 			return null;
 		}


### PR DESCRIPTION
The metrics are an optional feature, so they should not cause exceptions or failures for the system.