### PR TITLE
[FLINK-4167] [metrics] Close IOMetricGroup in TaskMetricGroup

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/IOMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/IOMetricGroup.java
@@ -19,23 +19,23 @@
 package org.apache.flink.metrics.groups;
 
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.MetricRegistry;
 
 /**
- * Special {@link org.apache.flink.metrics.MetricGroup} that contains shareable pre-defined IO-related metrics.
+ * Metric group that contains shareable pre-defined IO-related metrics. The metrics registration is
+ * forwarded to the parent task metric group.
  */
-public class IOMetricGroup extends AbstractMetricGroup {
+public class IOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
 	private final Counter numBytesOut;
 	private final Counter numBytesInLocal;
 	private final Counter numBytesInRemote;
 
-	public IOMetricGroup(MetricRegistry registry, TaskMetricGroup parent) {
-		super(registry, parent.getScopeComponents());
-		this.numBytesOut = parent.counter("numBytesOut");
+	public IOMetricGroup(TaskMetricGroup parent) {
+		super(parent);
 
-		this.numBytesInLocal = parent.counter("numBytesInLocal");
-		this.numBytesInRemote = parent.counter("numBytesInRemote");
+		this.numBytesOut = counter("numBytesOut");
+		this.numBytesInLocal = counter("numBytesInLocal");
+		this.numBytesInRemote = counter("numBytesInRemote");
 	}
 
 	public Counter getBytesOutCounter() {

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/ProxyMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/ProxyMetricGroup.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Metric group which forwards all registration calls to its parent metric group.
+ *
+ * @param <P> Type of the parent metric group
+ */
+@Internal
+public class ProxyMetricGroup<P extends MetricGroup> implements MetricGroup {
+	private final P parentMetricGroup;
+
+	public ProxyMetricGroup(P parentMetricGroup) {
+		this.parentMetricGroup = Preconditions.checkNotNull(parentMetricGroup);
+	}
+
+	@Override
+	public final void close() {
+		parentMetricGroup.close();
+	}
+
+	@Override
+	public final boolean isClosed() {
+		return parentMetricGroup.isClosed();
+	}
+
+	@Override
+	public final Counter counter(int name) {
+		return parentMetricGroup.counter(name);
+	}
+
+	@Override
+	public final Counter counter(String name) {
+		return parentMetricGroup.counter(name);
+	}
+
+	@Override
+	public final <C extends Counter> C counter(int name, C counter) {
+		return parentMetricGroup.counter(name, counter);
+	}
+
+	@Override
+	public final <C extends Counter> C counter(String name, C counter) {
+		return parentMetricGroup.counter(name, counter);
+	}
+
+	@Override
+	public final <T, G extends Gauge<T>> G gauge(int name, G gauge) {
+		return parentMetricGroup.gauge(name, gauge);
+	}
+
+	@Override
+	public final <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+		return parentMetricGroup.gauge(name, gauge);
+	}
+
+	@Override
+	public final <H extends Histogram> H histogram(String name, H histogram) {
+		return parentMetricGroup.histogram(name, histogram);
+	}
+
+	@Override
+	public final <H extends Histogram> H histogram(int name, H histogram) {
+		return parentMetricGroup.histogram(name, histogram);
+	}
+
+	@Override
+	public final MetricGroup addGroup(int name) {
+		return parentMetricGroup.addGroup(name);
+	}
+
+	@Override
+	public final MetricGroup addGroup(String name) {
+		return parentMetricGroup.addGroup(name);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/TaskMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/TaskMetricGroup.java
@@ -92,7 +92,7 @@ public class TaskMetricGroup extends ComponentMetricGroup {
 		this.subtaskIndex = subtaskIndex;
 		this.attemptNumber = attemptNumber;
 
-		this.ioMetrics = new IOMetricGroup(registry, this);
+		this.ioMetrics = new IOMetricGroup(this);
 	}
 
 	// ------------------------------------------------------------------------
@@ -156,7 +156,6 @@ public class TaskMetricGroup extends ComponentMetricGroup {
 	@Override
 	public void close() {
 		super.close();
-		ioMetrics.close();
 
 		parent.removeTaskMetricGroup(executionId);
 	}

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/TaskMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/TaskMetricGroup.java
@@ -156,6 +156,8 @@ public class TaskMetricGroup extends ComponentMetricGroup {
 	@Override
 	public void close() {
 		super.close();
+		ioMetrics.close();
+
 		parent.removeTaskMetricGroup(executionId);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnregisteredTaskMetricsGroup.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnregisteredTaskMetricsGroup.java
@@ -69,16 +69,7 @@ public class UnregisteredTaskMetricsGroup extends TaskMetricGroup {
 	
 	public static class DummyIOMetricGroup extends IOMetricGroup {
 		public DummyIOMetricGroup() {
-			super(EMPTY_REGISTRY, new UnregisteredTaskMetricsGroup());
-		}
-
-		@Override
-		protected void addMetric(String name, Metric metric) {
-		}
-
-		@Override
-		public MetricGroup addGroup(String name) {
-			return new UnregisteredMetricsGroup();
+			super(new UnregisteredTaskMetricsGroup());
 		}
 	}
 }


### PR DESCRIPTION
This closes the `ioMetrics` metric group contained in `TaskMetricGroup`. Not closing this group caused that metrics of this group weren't deregistered after the end of a job.

R @zentol