### PR TITLE
[WIP][FLINK-3599] Code generation for PojoSerializer and PojoComparator

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUUIDTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUUIDTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -25,7 +26,7 @@ import java.util.UUID;
 
 public class WritableSerializerUUIDTest extends SerializerTestBase<WritableID> {
 	@Override
-	protected TypeSerializer<WritableID> createSerializer() {
+	protected TypeSerializer<WritableID> createSerializer(ExecutionConfig config) {
 		return new WritableSerializer<>(WritableID.class);
 	}
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -94,6 +94,18 @@ under the License.
 			<artifactId>asm-all</artifactId>
 			<version>${asm.version}</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.codehaus.janino</groupId>
+			<artifactId>janino</artifactId>
+			<version>2.7.8</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.freemarker</groupId>
+			<artifactId>freemarker</artifactId>
+			<version>2.3.24-incubating</version>
+		</dependency>
 
 		<!-- ================== test dependencies ================== -->
 
@@ -197,7 +209,15 @@ under the License.
 				</executions>
 			</plugin>
 		</plugins>
-		
+
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<includes>
+					<include>**/*.ftl</include>
+				</includes>
+			</resource>
+		</resources>
 	</build>
 
 </project>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -107,11 +107,6 @@ under the License.
 			<version>2.3.25-incubating</version>
 		</dependency>
 
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
 
 		<!-- ================== test dependencies ================== -->
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -98,13 +98,19 @@ under the License.
 		<dependency>
 			<groupId>org.codehaus.janino</groupId>
 			<artifactId>janino</artifactId>
-			<version>2.7.8</version>
+			<version>3.0.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>2.3.24-incubating</version>
+			<version>2.3.25-incubating</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
 		</dependency>
 
 		<!-- ================== test dependencies ================== -->

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -118,7 +118,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private boolean forceAvro = false;
 
-	private boolean forceCodeGeneration = true;
+	private boolean codeGenerationEnabled = true;
 
 	private CodeAnalysisMode codeAnalysisMode = CodeAnalysisMode.DISABLE;
 
@@ -587,15 +587,15 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
      * Force Flink to use the generated serializers and comparators for POJOs.
      */
 	public void enableCodeGeneration() {
-		forceCodeGeneration = true;
+		codeGenerationEnabled = true;
 	}
 
 	public void disableCodeGeneration() {
-		forceCodeGeneration = false;
+		codeGenerationEnabled = false;
 	}
 
 	public boolean isCodeGenerationEnabled() {
-		return forceCodeGeneration;
+		return codeGenerationEnabled;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -118,7 +118,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private boolean forceAvro = false;
 
-	private boolean codeGenerationEnabled = true;
+	private boolean codeGenerationEnabled = false;
 
 	private CodeAnalysisMode codeAnalysisMode = CodeAnalysisMode.DISABLE;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -118,6 +118,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private boolean forceAvro = false;
 
+	private boolean forceCodeGeneration = true;
+
 	private CodeAnalysisMode codeAnalysisMode = CodeAnalysisMode.DISABLE;
 
 	/** If set to true, progress updates are printed to System.out during execution */
@@ -579,6 +581,21 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	public boolean isForceAvroEnabled() {
 		return forceAvro;
+	}
+
+    /**
+     * Force Flink to use the generated serializers and comparators for POJOs.
+     */
+	public void enableCodeGeneration() {
+		forceCodeGeneration = true;
+	}
+
+	public void disableCodeGeneration() {
+		forceCodeGeneration = false;
+	}
+
+	public boolean isCodeGenerationEnabled() {
+		return forceCodeGeneration;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
@@ -223,7 +223,7 @@ public class PojoTypeInfo<T> extends CompositeType<T> {
 	public <X> TypeInformation<X> getTypeAt(String fieldExpression) {
 
 		Matcher matcher = PATTERN_NESTED_FIELDS.matcher(fieldExpression);
-		if(!matcher.matches()) {
+		if (!matcher.matches()) {
 			if (fieldExpression.startsWith(ExpressionKeys.SELECT_ALL_CHAR) || fieldExpression.startsWith(ExpressionKeys.SELECT_ALL_CHAR_SCALA)) {
 				throw new InvalidFieldReferenceException("Wildcard expressions are not allowed here.");
 			} else {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeComparatorProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeComparatorProxy.java
@@ -71,9 +71,7 @@ public class GenTypeComparatorProxy<T> extends CompositeTypeComparator<T> implem
 			this.comparators[i] = other.comparators[i].duplicate();
 		}
 		this.serializer = other.serializer.duplicate();
-		if (other.impl != null) {
-			this.impl = (CompositeTypeComparator<T>) other.impl.duplicate();
-		}
+		this.impl = (CompositeTypeComparator<T>) other.impl.duplicate();
 	}
 
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -167,6 +165,7 @@ public class GenTypeComparatorProxy<T> extends CompositeTypeComparator<T> implem
 		return impl.extractKeys(record, target, index);
 	}
 
+	// Used by generated code.
 	public TypeComparator<T> getImpl() {
 		return impl;
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeComparatorProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeComparatorProxy.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompositeTypeComparator;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -31,6 +32,15 @@ import java.io.ObjectInputStream;
 import java.lang.reflect.Constructor;
 import java.util.List;
 
+/**
+ * This class wraps a generated comparator. It contains both an instance of the comparator and its source code.
+ * The instance of the wrapped comparator is not serialized. During deserialization the source code is compiled.
+ * Note that, the compilation is cached inside InstantiationUtil.
+ *
+ * The reason why the wrapped comparator is not serialized is that, it should be possible to send this class in a
+ * serialized form to a JVM which do not have the class of the wrapped object compiled yet.
+ */
+@Internal
 public class GenTypeComparatorProxy<T> extends CompositeTypeComparator<T> implements java.io.Serializable {
 	private final String code;
 	private final String name;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeComparatorProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeComparatorProxy.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeutils.CompositeTypeComparator;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+public class GenTypeComparatorProxy<T> extends CompositeTypeComparator<T> implements java.io.Serializable {
+	private final String code;
+	private final String name;
+	private final Class<T> clazz;
+	private final TypeComparator<?>[] comparators;
+	private final TypeSerializer<T> serializer;
+
+	transient private CompositeTypeComparator<T> impl = null;
+
+	private void compile() {
+		try {
+			assert impl == null;
+			Class<?> comparatorClazz = InstantiationUtil.compile(clazz.getClassLoader(), name, code);
+			Constructor<?>[] ctors = comparatorClazz.getConstructors();
+			assert ctors.length == 1;
+			impl = (CompositeTypeComparator<T>) ctors[0].newInstance(comparators, serializer, clazz);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to generate serializer: " + name, e);
+		}
+	}
+
+	public GenTypeComparatorProxy(Class<T> clazz, String name, String code,TypeComparator<?>[] comparators,
+									TypeSerializer<T> serializer) {
+		this.name = name;
+		this.code = code;
+		this.clazz = clazz;
+		this.comparators = comparators;
+		this.serializer = serializer;
+		compile();
+	}
+
+	private GenTypeComparatorProxy(GenTypeComparatorProxy<T> other) {
+		this.name = other.name;
+		this.code = other.code;
+		this.clazz = other.clazz;
+		this.comparators = new TypeComparator[other.comparators.length];
+		for (int i = 0; i < other.comparators.length; i++) {
+			this.comparators[i] = other.comparators[i].duplicate();
+		}
+		this.serializer = other.serializer.duplicate();
+		if (other.impl != null) {
+			this.impl = (CompositeTypeComparator<T>) other.impl.duplicate();
+		}
+	}
+
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		compile();
+	}
+
+	@Override
+	public void getFlatComparator(List<TypeComparator> flatComparators) {
+		impl.getFlatComparator(flatComparators);
+	}
+
+	@Override
+	public int hash(T value) {
+		return impl.hash(value);
+	}
+
+	@Override
+	public void setReference(T toCompare) {
+		impl.setReference(toCompare);
+	}
+
+	@Override
+	public boolean equalToReference(T candidate) {
+		return impl.equalToReference(candidate);
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<T> referencedComparator) {
+		return impl.compareToReference(referencedComparator);
+	}
+
+	@Override
+	public int compare(T first, T second) {
+		return impl.compare(first, second);
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		return impl.compareSerialized(firstSource, secondSource);
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return impl.supportsNormalizedKey();
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return impl.getNormalizeKeyLen();
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		return impl.isNormalizedKeyPrefixOnly(keyBytes);
+	}
+
+	@Override
+	public void putNormalizedKey(T value, MemorySegment target, int offset, int numBytes) {
+		impl.putNormalizedKey(value, target, offset, numBytes);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return impl.invertNormalizedKey();
+	}
+
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return impl.supportsSerializationWithKeyNormalization();
+	}
+
+	@Override
+	public void writeWithKeyNormalization(T record, DataOutputView target) throws IOException {
+		impl.writeWithKeyNormalization(record, target);
+	}
+
+	@Override
+	public T readWithKeyDenormalization(T reuse, DataInputView source) throws IOException {
+		return impl.readWithKeyDenormalization(reuse, source);
+	}
+
+	@Override
+	public GenTypeComparatorProxy<T> duplicate() {
+		return new GenTypeComparatorProxy<>(this);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		return impl.extractKeys(record, target, index);
+	}
+
+	public TypeComparator<T> getImpl() {
+		return impl;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
@@ -68,9 +68,7 @@ public class GenTypeSerializerProxy<T> extends TypeSerializer<T> {
 		for (int i = 0; i < this.fieldSerializers.length; i++) {
 			this.fieldSerializers[i] = other.fieldSerializers[i].duplicate();
 		}
-		if (other.impl != null) {
-			this.impl = other.impl.duplicate();
-		}
+		this.impl = other.impl.duplicate();
 	}
 
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputView;
@@ -28,6 +29,15 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.reflect.Constructor;
 
+/**
+ * This class wraps a generated serializer. It contains both an instance of the serializer and its source code.
+ * The instance of the wrapped serializer is not serialized. During deserialization the source code is compiled.
+ * Note that, the compilation is cached inside InstantiationUtil.
+ *
+ * The reason why the wrapped serializer is not serialized is that, it should be possible to send this class in a
+ * serialized form to a JVM which do not have the class of the wrapped object compiled yet.
+ */
+@Internal
 public class GenTypeSerializerProxy<T> extends TypeSerializer<T> {
 	private final String code;
 	private final String name;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
@@ -20,7 +20,9 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
@@ -142,6 +144,11 @@ public class GenTypeSerializerProxy<T> extends TypeSerializer<T> {
 	}
 
 	@Override
+	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		return null;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof GenTypeSerializerProxy) {
 			return impl.equals(((GenTypeSerializerProxy) obj).impl);
@@ -152,5 +159,10 @@ public class GenTypeSerializerProxy<T> extends TypeSerializer<T> {
 	@Override
 	public boolean canEqual(Object obj) {
 		return obj instanceof GenTypeSerializerProxy;
+	}
+
+	@Override
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		return CompatibilityResult.compatible();
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/GenTypeSerializerProxy.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.lang.reflect.Constructor;
+
+public class GenTypeSerializerProxy<T> extends TypeSerializer<T> {
+	private final String code;
+	private final String name;
+	private final Class<T> clazz;
+	private final TypeSerializer<?>[] fieldSerializers;
+	private final ExecutionConfig config;
+
+	transient private TypeSerializer<T> impl = null;
+
+	private void compile() {
+		try {
+			assert impl == null;
+			Class<?> serializerClazz = InstantiationUtil.compile(clazz.getClassLoader(), name, code);
+			Constructor<?>[] ctors = serializerClazz.getConstructors();
+			assert ctors.length == 1;
+			impl = (TypeSerializer<T>) ctors[0].newInstance(clazz, fieldSerializers, config);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to generate serializer: " + name, e);
+		}
+	}
+
+	public GenTypeSerializerProxy(Class<T> clazz, String name, String code, TypeSerializer<?>[] fields,
+									ExecutionConfig config) {
+		this.name = name;
+		this.code = code;
+		this.clazz = clazz;
+		this.config = config;
+		this.fieldSerializers = fields;
+		compile();
+	}
+
+	private GenTypeSerializerProxy(GenTypeSerializerProxy<T> other) {
+		this.name = other.name;
+		this.code = other.code;
+		this.clazz = other.clazz;
+		this.config = other.config;
+		this.fieldSerializers = new TypeSerializer[other.fieldSerializers.length];
+		for (int i = 0; i < this.fieldSerializers.length; i++) {
+			this.fieldSerializers[i] = other.fieldSerializers[i].duplicate();
+		}
+		if (other.impl != null) {
+			this.impl = other.impl.duplicate();
+		}
+	}
+
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		compile();
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return false;
+	}
+
+	@Override
+	public GenTypeSerializerProxy<T> duplicate() {
+		return new GenTypeSerializerProxy<>(this);
+	}
+
+	@Override
+	public T createInstance() {
+		return impl.createInstance();
+	}
+
+	@Override
+	public T copy(T from) {
+		return impl.copy(from);
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		return impl.copy(from, reuse);
+	}
+
+	@Override
+	public int getLength() {
+		return impl.getLength();
+	}
+
+	@Override
+	public void serialize(T value, DataOutputView target) throws IOException {
+		impl.serialize(value, target);
+	}
+
+	@Override
+	public T deserialize(DataInputView source) throws IOException {
+		return impl.deserialize(source);
+	}
+
+	@Override
+	public T deserialize(T reuse, DataInputView source) throws IOException {
+		return impl.deserialize(reuse, source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		impl.copy(source, target);
+	}
+
+	@Override
+	public int hashCode() {
+		return impl.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof GenTypeSerializerProxy) {
+			return impl.equals(((GenTypeSerializerProxy) obj).impl);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof GenTypeSerializerProxy;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparator.java
@@ -129,7 +129,7 @@ public final class PojoComparator<T> extends CompositeTypeComparator<T> implemen
 		this.type = toClone.type;
 
 		try {
-			this.serializer = (TypeSerializer<T>) InstantiationUtil.deserializeObject(
+			this.serializer = InstantiationUtil.deserializeObject(
 					InstantiationUtil.serializeObject(toClone.serializer), Thread.currentThread().getContextClassLoader());
 		} catch (IOException | ClassNotFoundException e) {
 			throw new RuntimeException("Cannot copy serializer", e);

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
@@ -68,13 +68,17 @@ public final class PojoComparatorGenerator<T> {
 		final String fullClassName = packageName + "." + className;
 		code = InstantiationUtil.getCodeForCachedClass(fullClassName);
 		if (code == null) {
-			generateCode(className);
+			try {
+				generateCode(className);
+			} catch (NoSuchMethodException e) {
+				throw new RuntimeException("Unable to generate comparator: " + className, e);
+			}
 		}
 		return new GenTypeComparatorProxy<>(type, fullClassName, code, comparators, serializer);
 	}
 
 
-	private void generateCode(String className) {
+	private void generateCode(String className) throws NoSuchMethodException {
 		String typeName = type.getCanonicalName();
 		StringBuilder members = new StringBuilder();
 		for (int i = 0; i < comparators.length; ++i) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
@@ -161,7 +161,7 @@ public final class PojoComparatorGenerator<T> {
 		}
 		StringBuilder putNormalizedKeys = new StringBuilder();
 		for (int i = 0; i < comparators.length; ++i) {
-			putNormalizedKeys.append(String.format("if (%d >= numLeadingNormalizableKeys || numBytes <= 0) break;\n" +
+			putNormalizedKeys.append(String.format("if (%d >= numLeadingNormalizableKeys || numBytes <= 0) return;\n" +
 				"len = normalizedKeyLengths[%d];\n" +
 				"len = numBytes >= len ? len : numBytes;\n" +
 				"f%d.putNormalizedKey(((" + typeName + ")value)." + accessStringForField(keyFields[i]) +

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompositeTypeComparator;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -30,11 +31,16 @@ import java.util.Map;
 
 import static org.apache.flink.api.java.typeutils.PojoTypeInfo.accessStringForField;
 
+/**
+ * This class is intended to generate source code for comparing POJOs and passing it to a wrapper class.
+ * See GenTypeComparatorProxy for more details.
+ */
+@Internal
 public final class PojoComparatorGenerator {
 	private static final String packageName = "org.apache.flink.api.java.typeutils.runtime.generated";
 
 	public static <T> TypeComparator<T> createComparator(Field[] keyFields, TypeComparator<?>[] comparators,
-														 TypeSerializer<T> serializer, Class<T> type, Integer[] keyFieldIds) {
+														TypeSerializer<T> serializer, Class<T> type, Integer[] keyFieldIds) {
 		// Multiple comparators can be generated for each type based on a list of keys. The list of keys and the type
 		// name should determine the generated comparator. This information is used for caching (avoiding
 		// recompilation). Note that, the name of the field is not sufficient because nested POJOs might have a field
@@ -61,7 +67,7 @@ public final class PojoComparatorGenerator {
 
 
 	private static <T> String generateCode(String className, Field[] keyFields, TypeComparator<?>[] comparators,
-										   TypeSerializer<T> serializer, Class<T> type) throws NoSuchMethodException {
+											TypeSerializer<T> serializer, Class<T> type) throws NoSuchMethodException {
 		String typeName = type.getCanonicalName();
 		StringBuilder members = new StringBuilder();
 		for (int i = 0; i < comparators.length; ++i) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparatorGenerator.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.CompositeTypeComparator;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.api.java.typeutils.PojoTypeInfo.accessStringForField;
+
+public final class PojoComparatorGenerator<T> {
+	private static final String packageName = "org.apache.flink.api.java.typeutils.runtime.generated";
+
+	private transient Field[] keyFields;
+	private transient Integer[] keyFieldIds;
+	private final TypeComparator<?>[] comparators;
+	private final TypeSerializer<T> serializer;
+	private final Class<T> type;
+	private final ExecutionConfig config;
+	private String code;
+
+	public PojoComparatorGenerator(Field[] keyFields, TypeComparator<?>[] comparators, TypeSerializer<T> serializer,
+									Class<T> type, Integer[] keyFieldIds, ExecutionConfig config) {
+		this.keyFields = keyFields;
+		this.comparators = comparators;
+
+		this.type = type;
+		this.serializer = serializer;
+		this.keyFieldIds = keyFieldIds;
+		this.config = config;
+	}
+
+	public TypeComparator<T> createComparator() {
+		// Multiple comparators can be generated for each type based on a list of keys. The list of keys and the type
+		// name should determine the generated comparator. This information is used for caching (avoiding
+		// recompilation). Note that, the name of the field is not sufficient because nested POJOs might have a field
+		// with the name.
+		StringBuilder keyBuilder = new StringBuilder();
+		for(Integer i : keyFieldIds) {
+			keyBuilder.append(i);
+			keyBuilder.append("_");
+		}
+		final String className = type.getCanonicalName().replace('.', '_') + "_GeneratedComparator" +
+			keyBuilder.toString();
+		final String fullClassName = packageName + "." + className;
+		code = InstantiationUtil.getCodeForCachedClass(fullClassName);
+		if (code == null) {
+			generateCode(className);
+		}
+		return new GenTypeComparatorProxy<>(type, fullClassName, code, comparators, serializer);
+	}
+
+
+	private void generateCode(String className) {
+		String typeName = type.getCanonicalName();
+		StringBuilder members = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			String comparatorClass = comparators[i].getClass().getCanonicalName();
+			members.append(String.format("final %s f%d;\n", comparatorClass, i));
+		}
+		StringBuilder initMembers = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			String comparatorClass = comparators[i].getClass().getCanonicalName();
+			initMembers.append(String.format("f%d = (%s)comparators[%d];\n", i, comparatorClass, i));
+		}
+		StringBuilder normalizableKeys = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			normalizableKeys.append(String.format("if (f%d.supportsNormalizedKey()) {\n" +
+				"	if (f%d.invertNormalizedKey() != inverted) break;\n" +
+				"	nKeys++;\n" +
+				"	final int len = f%d.getNormalizeKeyLen();\n" +
+				"	this.normalizedKeyLengths[%d] = len;\n" +
+				"	nKeyLen += len;\n" +
+				"	if (nKeyLen < 0) {\n" +
+				"		nKeyLen = Integer.MAX_VALUE;\n" +
+				"		break;\n" +
+				"	}\n" +
+				"} else {\n" +
+				"	break;\n" +
+				"}\n", i, i, i, i));
+		}
+		StringBuilder cloneMembers = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			String comparatorClass = comparators[i].getClass().getCanonicalName();
+			cloneMembers.append(String.format("f%d = (%s)toClone.f%d.duplicate();\n", i, comparatorClass, i));
+		}
+		StringBuilder flatComparators = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			if (comparators[i] instanceof CompositeTypeComparator) {
+				flatComparators.append(String.format("((CompositeTypeComparator)f%d).getFlatComparator" +
+					"(flatComparators);\n", i));
+			} else {
+				flatComparators.append(String.format("flatComparators.add(f%d);\n", i));
+			}
+		}
+		StringBuilder hashMembers = new StringBuilder();
+		for (int i = 0; i < keyFields.length; ++i) {
+			hashMembers.append(String.format(
+				"code *= TupleComparatorBase.HASH_SALT[%d & 0x1F];\n" +
+				"code += this.f%d.hash(((" + typeName + ")value)." + accessStringForField(keyFields[i]) +
+					");\n",
+				i, i));
+		}
+		StringBuilder setReference = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			setReference.append(String.format(
+				"this.f%d.setReference(((" + typeName + ")toCompare)." + accessStringForField(keyFields[i]) + ");\n",
+				i));
+		}
+		StringBuilder equalToReference = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			equalToReference.append(String.format(
+				"if (!this.f%d.equalToReference(((" + typeName + ")candidate)." +
+				accessStringForField(keyFields[i]) + ")) {\n" +
+				"	return false;\n" +
+				"}\n", i));
+		}
+		StringBuilder compareToReference = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			compareToReference.append(String.format(
+				"cmp = this.f%d.compareToReference(other.f%d);\n" +
+				"if (cmp != 0) {\n" +
+				"	return cmp;\n" +
+				"}\n", i, i));
+		}
+		StringBuilder compareFields = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			compareFields.append(String.format(
+				"cmp = f%d.compare(((" + typeName + ")first)." + accessStringForField(keyFields[i]) + "," +
+				"((" + typeName + ")second)." + accessStringForField(keyFields[i]) + ");\n" +
+				"if (cmp != 0) {\n" +
+					"return cmp;\n" +
+				"}\n", i));
+		}
+		StringBuilder putNormalizedKeys = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			putNormalizedKeys.append(String.format("if (%d >= numLeadingNormalizableKeys || numBytes <= 0) break;\n" +
+				"len = normalizedKeyLengths[%d];\n" +
+				"len = numBytes >= len ? len : numBytes;\n" +
+				"f%d.putNormalizedKey(((" + typeName + ")value)." + accessStringForField(keyFields[i]) +
+				", target, offset, len);\n" +
+				"numBytes -= len;\n" +
+				"offset += len;", i, i, i));
+		}
+		StringBuilder extractKeys = new StringBuilder();
+		for (int i = 0; i < comparators.length; ++i) {
+			extractKeys.append(String.format(
+				"localIndex += f%d.extractKeys(((" + typeName + ")record)." + accessStringForField(keyFields[i]) +
+					", target, localIndex);\n", i));
+		}
+		Map<String, Object> root = new HashMap<>();
+		root.put("packageName", packageName);
+		root.put("className", className);
+		root.put("serializerClassName", serializer.getClass().getCanonicalName());
+		root.put("members", members.toString().split("\n"));
+		root.put("initMembers", initMembers.toString().split("\n"));
+		root.put("cloneMembers", cloneMembers.toString().split("\n"));
+		root.put("flatComparators", flatComparators.toString().split("\n"));
+		root.put("hashMembers", hashMembers.toString().split("\n"));
+		root.put("normalizableKeys", normalizableKeys.toString().split("\n"));
+		root.put("setReference", setReference.toString().split("\n"));
+		root.put("equalToReference", equalToReference.toString().split("\n"));
+		root.put("compareToReference", compareToReference.toString().split("\n"));
+		root.put("compareFields", compareFields.toString().split("\n"));
+		root.put("putNormalizedKeys", putNormalizedKeys.toString().split("\n"));
+		root.put("extractKeys", extractKeys.toString().split("\n"));
+		try {
+			code = InstantiationUtil.getCodeFromTemplate("PojoComparatorTemplate.ftl", root);
+		} catch (IOException e) {
+			throw new RuntimeException("Unable to read template.", e);
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
@@ -51,8 +51,8 @@ public final class PojoSerializerGenerator<T> {
 		this.refFields = checkNotNull(reflectiveFields);
 		this.fieldSerializers = checkNotNull(fields);
 		this.config = checkNotNull(config);
-		for (int i = 0; i < this.refFields.length; i++) {
-			this.refFields[i].setAccessible(true);
+		for (Field refField : this.refFields) {
+			refField.setAccessible(true);
 		}
 	}
 
@@ -85,29 +85,25 @@ public final class PojoSerializerGenerator<T> {
 		}
 		StringBuilder createFields = new StringBuilder();
 		for (int i = 0; i < fieldSerializers.length; ++i) {
-			createFields.append(String.format("((" + typeName + ")t)." + modifyStringForField(refFields[i],
+			createFields.append(String.format("t." + modifyStringForField(refFields[i],
 				"f%d.createInstance()") + ";\n", i));
 		}
 		StringBuilder copyFields = new StringBuilder();
-		copyFields.append("Object value;\n");
 		for (int i = 0; i < fieldSerializers.length; ++i) {
 			if (refFields[i].getType().isPrimitive()) {
-				copyFields.append(String.format("((" + typeName + ")target)." + modifyStringForField(refFields[i],
+				copyFields.append(String.format("target." + modifyStringForField(refFields[i],
 					"((" + typeName + ")from)." + accessStringForField(refFields[i])) + ";\n", i));
 			} else {
 				copyFields.append(String.format(
 					"value = ((" + typeName + ")from)." + accessStringForField(refFields[i]) + ";\n" +
 					"if (value != null) {\n" +
-					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "f%d.copy(value)") + ";\n" +
+					"	target." + modifyStringForField(refFields[i], "f%d.copy(value)") + ";\n" +
 					"} else {\n" +
-					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "null") + ";\n" +
+					"	target." + modifyStringForField(refFields[i], "null") + ";\n" +
 					"}\n", i));
 			}
 		}
 		StringBuilder reuseCopyFields = new StringBuilder();
-		reuseCopyFields.append("Object value;\n");
-		reuseCopyFields.append("Object reuseValue;\n");
-		reuseCopyFields.append("Object copy;\n");
 		for (int i = 0; i < fieldSerializers.length; ++i) {
 			if (refFields[i].getType().isPrimitive()) {
 				reuseCopyFields.append(String.format("((" + typeName + ")reuse)." + modifyStringForField(refFields[i],
@@ -139,7 +135,6 @@ public final class PojoSerializerGenerator<T> {
 		}
 		memberEquals.delete(memberEquals.length() - 3, memberEquals.length());
 		StringBuilder serializeFields = new StringBuilder();
-		serializeFields.append("Object o;\n");
 		for (int i = 0; i < fieldSerializers.length; ++i) {
 			if (refFields[i].getType().isPrimitive()) {
 				serializeFields.append(String.format(
@@ -158,26 +153,22 @@ public final class PojoSerializerGenerator<T> {
 			}
 		}
 		StringBuilder deserializeFields = new StringBuilder();
-		deserializeFields.append("boolean isNull;\n");
 		for (int i = 0; i < fieldSerializers.length; ++i) {
 			if (refFields[i].getType().isPrimitive()) {
 				deserializeFields.append(String.format("source.readBoolean();\n" +
-					"((" + typeName + ")target)." + modifyStringForField(refFields[i], "f%d.deserialize(source)") +
+					"target." + modifyStringForField(refFields[i], "f%d.deserialize(source)") +
 					";\n", i));
 			} else {
 				deserializeFields.append(String.format("isNull = source.readBoolean();\n" +
 					"if (isNull) {\n" +
-					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "null") + ";\n" +
+					"	target." + modifyStringForField(refFields[i], "null") + ";\n" +
 					"} else {\n" +
-					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "f%d.deserialize(source)") +
+					"	target." + modifyStringForField(refFields[i], "f%d.deserialize(source)") +
 					";\n" +
 					"}\n", i));
 			}
 		}
 		StringBuilder reuseDeserializeFields = new StringBuilder();
-		reuseDeserializeFields.append("boolean isNull;\n");
-		reuseDeserializeFields.append("Object field;\n");
-		reuseDeserializeFields.append("Object reuseField;\n");
 		for (int i = 0; i < fieldSerializers.length; ++i) {
 			if (refFields[i].getType().isPrimitive()) {
 				reuseDeserializeFields .append(String.format("source.readBoolean();\n" +
@@ -199,7 +190,6 @@ public final class PojoSerializerGenerator<T> {
 			}
 		}
 		StringBuilder dataCopyFields = new StringBuilder();
-		dataCopyFields.append("boolean isNull;\n");
 		for (int i = 0; i < fieldSerializers.length; ++i) {
 			if (refFields[i].getType().isPrimitive()) {
 				dataCopyFields.append(String.format("source.readBoolean();\n" +

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
@@ -61,12 +61,16 @@ public final class PojoSerializerGenerator<T> {
 		final String fullClassName = packageName + "." + className;
 		code = InstantiationUtil.getCodeForCachedClass(fullClassName);
 		if (code == null) {
-			generateCode(className);
+			try {
+				generateCode(className);
+			} catch (NoSuchMethodException e) {
+				throw new RuntimeException("Unable to generate serializer: " + className, e);
+			}
 		}
 		return new GenTypeSerializerProxy<>(clazz, fullClassName, code, fieldSerializers, config);
 	}
 
-	private void generateCode(String className) {
+	private void generateCode(String className) throws NoSuchMethodException {
 		assert fieldSerializers.length > 0;
 		String typeName = clazz.getCanonicalName();
 		StringBuilder members = new StringBuilder();

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.api.java.typeutils.PojoTypeInfo.accessStringForField;
+import static org.apache.flink.api.java.typeutils.PojoTypeInfo.modifyStringForField;
+
+public final class PojoSerializerGenerator<T> {
+	private static final String packageName = "org.apache.flink.api.java.typeutils.runtime.generated";
+
+	private final Class<T> clazz;
+	private final Field[] refFields;
+	private final TypeSerializer<?>[] fieldSerializers;
+	private final ExecutionConfig config;
+	private String code;
+
+	public PojoSerializerGenerator(
+		Class<T> clazz,
+		TypeSerializer<?>[] fields,
+		Field[] reflectiveFields,
+		ExecutionConfig config) {
+		this.clazz = checkNotNull(clazz);
+		this.refFields = checkNotNull(reflectiveFields);
+		this.fieldSerializers = checkNotNull(fields);
+		this.config = checkNotNull(config);
+		for (int i = 0; i < this.refFields.length; i++) {
+			this.refFields[i].setAccessible(true);
+		}
+	}
+
+	public TypeSerializer<T> createSerializer()  {
+		final String className = clazz.getCanonicalName().replace('.', '_') + "_GeneratedSerializer";
+		final String fullClassName = packageName + "." + className;
+		code = InstantiationUtil.getCodeForCachedClass(fullClassName);
+		if (code == null) {
+			generateCode(className);
+		}
+		return new GenTypeSerializerProxy<>(clazz, fullClassName, code, fieldSerializers, config);
+	}
+
+	private void generateCode(String className) {
+		assert fieldSerializers.length > 0;
+		String typeName = clazz.getCanonicalName();
+		StringBuilder members = new StringBuilder();
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			String serializerClass = fieldSerializers[i].getClass().getCanonicalName();
+			members.append(String.format("final %s f%d;\n", serializerClass, i));
+		}
+		StringBuilder initMembers = new StringBuilder();
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			String serializerClass = fieldSerializers[i].getClass().getCanonicalName();
+			initMembers.append(String.format("f%d = (%s)serializerFields[%d];\n", i, serializerClass, i));
+		}
+		StringBuilder createFields = new StringBuilder();
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			createFields.append(String.format("((" + typeName + ")t)." + modifyStringForField(refFields[i],
+				"f%d.createInstance()") + ";\n", i));
+		}
+		StringBuilder copyFields = new StringBuilder();
+		copyFields.append("Object value;\n");
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			if (refFields[i].getType().isPrimitive()) {
+				copyFields.append(String.format("((" + typeName + ")target)." + modifyStringForField(refFields[i],
+					"((" + typeName + ")from)." + accessStringForField(refFields[i])) + ";\n", i));
+			} else {
+				copyFields.append(String.format(
+					"value = ((" + typeName + ")from)." + accessStringForField(refFields[i]) + ";\n" +
+					"if (value != null) {\n" +
+					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "f%d.copy(value)") + ";\n" +
+					"} else {\n" +
+					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "null") + ";\n" +
+					"}\n", i));
+			}
+		}
+		StringBuilder reuseCopyFields = new StringBuilder();
+		reuseCopyFields.append("Object value;\n");
+		reuseCopyFields.append("Object reuseValue;\n");
+		reuseCopyFields.append("Object copy;\n");
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			if (refFields[i].getType().isPrimitive()) {
+				reuseCopyFields.append(String.format("((" + typeName + ")reuse)." + modifyStringForField(refFields[i],
+					"((" + typeName + ")from)." + accessStringForField(refFields[i])) + ";\n", i));
+			} else {
+				reuseCopyFields.append(String.format(
+					"value = ((" + typeName + ")from)." + accessStringForField(refFields[i]) + ";\n" +
+					"if (value != null) {\n" +
+					"	reuseValue = ((" + typeName + ")reuse)." + accessStringForField(refFields[i]) + ";\n" +
+					"	if (reuseValue != null) {\n" +
+					"		copy = f%d.copy(value, reuseValue);\n" +
+					"	} else {\n" +
+					"		copy = f%d.copy(value);\n" +
+					"	}\n" +
+					"	((" + typeName + ")reuse)." + modifyStringForField(refFields[i], "copy") + ";\n" +
+					"} else {\n" +
+					"	((" + typeName + ")reuse)." + modifyStringForField(refFields[i], "null") + ";\n" +
+					"}\n", i, i));
+			}
+		}
+		StringBuilder memberHash = new StringBuilder();
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			memberHash.append(String.format(" f%d,", i));
+		}
+		memberHash.deleteCharAt(memberHash.length() - 1);
+		StringBuilder memberEquals = new StringBuilder();
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			memberEquals.append(String.format("Objects.equals(this.f%d, other.f%d) && ", i, i));
+		}
+		memberEquals.delete(memberEquals.length() - 3, memberEquals.length());
+		StringBuilder serializeFields = new StringBuilder();
+		serializeFields.append("Object o;\n");
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			if (refFields[i].getType().isPrimitive()) {
+				serializeFields.append(String.format(
+					"target.writeBoolean(false);\n" +
+					"f%d.serialize(((" + typeName + ")value)." + accessStringForField(refFields[i]) + ", target);\n",
+					i));
+			} else {
+				serializeFields.append(String.format(
+					"o = ((" + typeName + ")value)." + accessStringForField(refFields[i]) + ";\n" +
+					"if (o == null) {\n" +
+					"	target.writeBoolean(true);\n" +
+					"} else {\n" +
+					"	target.writeBoolean(false);\n" +
+					"	f%d.serialize(o, target);\n" +
+					"}\n", i));
+			}
+		}
+		StringBuilder deserializeFields = new StringBuilder();
+		deserializeFields.append("boolean isNull;\n");
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			if (refFields[i].getType().isPrimitive()) {
+				deserializeFields.append(String.format("source.readBoolean();\n" +
+					"((" + typeName + ")target)." + modifyStringForField(refFields[i], "f%d.deserialize(source)") +
+					";\n", i));
+			} else {
+				deserializeFields.append(String.format("isNull = source.readBoolean();\n" +
+					"if (isNull) {\n" +
+					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "null") + ";\n" +
+					"} else {\n" +
+					"	((" + typeName + ")target)." + modifyStringForField(refFields[i], "f%d.deserialize(source)") +
+					";\n" +
+					"}\n", i));
+			}
+		}
+		StringBuilder reuseDeserializeFields = new StringBuilder();
+		reuseDeserializeFields.append("boolean isNull;\n");
+		reuseDeserializeFields.append("Object field;\n");
+		reuseDeserializeFields.append("Object reuseField;\n");
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			if (refFields[i].getType().isPrimitive()) {
+				reuseDeserializeFields .append(String.format("source.readBoolean();\n" +
+					"((" + typeName + ")reuse)." + modifyStringForField(refFields[i], "f%d.deserialize(source)") +
+					";\n", i));
+			} else {
+				reuseDeserializeFields .append(String.format("isNull = source.readBoolean();\n" +
+					"if (isNull) {\n" +
+					"	((" + typeName + ")reuse)." + modifyStringForField(refFields[i], "null") + ";\n" +
+					"} else {\n" +
+					"	reuseField = ((" + typeName + ")reuse)." + accessStringForField(refFields[i]) + ";\n" +
+					"	if (reuseField != null) {\n" +
+					"		field = f%d.deserialize(reuseField, source);\n" +
+					"	} else {\n" +
+					"		field = f%d.deserialize(source);\n" +
+					"	}\n" +
+					"	((" + typeName + ")reuse)." + modifyStringForField(refFields[i], "field") + ";\n" +
+					"}\n", i, i, i, i, i));
+			}
+		}
+		StringBuilder dataCopyFields = new StringBuilder();
+		dataCopyFields.append("boolean isNull;\n");
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			if (refFields[i].getType().isPrimitive()) {
+				dataCopyFields.append(String.format("source.readBoolean();\n" +
+					"target.writeBoolean(false);\n" +
+					"f%d.copy(source, target);\n", i));
+			} else {
+				dataCopyFields.append(String.format("isNull = source.readBoolean();\n" +
+					"target.writeBoolean(isNull);\n" +
+					"if (!isNull) {\n" +
+					"	f%d.copy(source, target);\n" +
+					"}\n", i));
+			}
+		}
+		StringBuilder duplicateSerializers = new StringBuilder();
+		for (int i = 0; i < fieldSerializers.length; ++i) {
+			duplicateSerializers.append(String.format("duplicateFieldSerializers[%d] = f%d.duplicate();\n" +
+				"if (duplicateFieldSerializers[%d] != f%d) {\n" +
+				"	stateful = true;\n" +
+				"}\n", i, i, i, i));
+		}
+		Map<String, Object> root = new HashMap<>();
+		root.put("isFinal", Boolean.toString(Modifier.isFinal(clazz.getModifiers())));
+		root.put("alwaysNull", Boolean.toString(clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())));
+		root.put("packageName", packageName);
+		root.put("className", className);
+		root.put("typeName", typeName);
+		root.put("members", members.toString().split("\n"));
+		root.put("initMembers", initMembers.toString().split("\n"));
+		root.put("createFields", createFields.toString().split("\n"));
+		root.put("copyFields", copyFields.toString().split("\n"));
+		root.put("reuseCopyFields", reuseCopyFields.toString().split("\n"));
+		root.put("memberHash", memberHash.toString());
+		root.put("memberEquals", memberEquals.toString());
+		root.put("serializeFields", serializeFields.toString().split("\n"));
+		root.put("deserializeFields", deserializeFields.toString().split("\n"));
+		root.put("reuseDeserializeFields", reuseDeserializeFields.toString().split("\n"));
+		root.put("dataCopyFields", dataCopyFields.toString().split("\n"));
+		root.put("duplicateSerializers", duplicateSerializers.toString().split("\n"));
+		try {
+			code = InstantiationUtil.getCodeFromTemplate("PojoSerializerTemplate.ftl", root);
+		} catch (IOException e) {
+			throw new RuntimeException("Unable to read template.", e);
+		}
+	}
+}
+

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
@@ -43,7 +43,7 @@ public final class PojoSerializerGenerator {
 	private static final String packageName = "org.apache.flink.api.java.typeutils.runtime.generated";
 
 	public static <T> TypeSerializer<T> createSerializer(Class<T> clazz, TypeSerializer<?>[] fieldSerializers,
-															Field[] refFields, ExecutionConfig config)  {
+														Field[] refFields, ExecutionConfig config)  {
 		checkNotNull(clazz);
 		checkNotNull(fieldSerializers);
 		checkNotNull(refFields);

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerGenerator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -33,11 +34,16 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.api.java.typeutils.PojoTypeInfo.accessStringForField;
 import static org.apache.flink.api.java.typeutils.PojoTypeInfo.modifyStringForField;
 
+/**
+ * This class is intended to generate source code for serializing POJOs and passing it to a wrapper class.
+ * See GenTypeSerializerProxy for mor details.
+ */
+@Internal
 public final class PojoSerializerGenerator {
 	private static final String packageName = "org.apache.flink.api.java.typeutils.runtime.generated";
 
 	public static <T> TypeSerializer<T> createSerializer(Class<T> clazz, TypeSerializer<?>[] fieldSerializers,
-														 Field[] refFields, ExecutionConfig config)  {
+															Field[] refFields, ExecutionConfig config)  {
 		checkNotNull(clazz);
 		checkNotNull(fieldSerializers);
 		checkNotNull(refFields);
@@ -60,7 +66,7 @@ public final class PojoSerializerGenerator {
 	}
 
 	private static <T> String generateCode(String className, Class<T> clazz, TypeSerializer<?>[] fieldSerializers,
-										   Field[] refFields) throws NoSuchMethodException {
+											Field[] refFields) throws NoSuchMethodException {
 		assert fieldSerializers.length > 0;
 		String typeName = clazz.getCanonicalName();
 		StringBuilder members = new StringBuilder();
@@ -225,4 +231,3 @@ public final class PojoSerializerGenerator {
 		}
 	}
 }
-

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -145,7 +145,11 @@ public final class InstantiationUtil {
 				return super.resolveClass(desc);
 			} catch (ClassNotFoundException ex) {
 				// Search among generated classes.
-				return Class.forName(name, false, generatedClasses.get(name).f2);
+				Tuple3<Class, String, ClassLoader> entry = generatedClasses.get(name);
+				if (entry == null) {
+					throw ex;
+				}
+				return Class.forName(name, false, entry.f2);
 			}
 		}
 		

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -354,4 +354,22 @@ public final class StringUtils {
 
 	/** Prevent instantiation of this utility class */
 	private StringUtils() {}
+
+	/**
+	 * It takes a list of pairs and replaces every occurrence of the first member with
+	 * the second member.
+	 *
+	 * @param text The original text.
+	 * @param replacements Array of pairs. The first member will be replaced with the second for each elements.
+	 * @return The text after the replacements.
+	 */
+	public static String replaceStrings(String text, Tuple2<String, StringBuilder>[] replacements) {
+		String[] searchList = new String[replacements.length];
+		String[] replacementList = new String[replacements.length];
+		for(int i = 0; i < replacements.length; ++i) {
+			searchList[i] = replacements[i].f0;
+			replacementList[i] = replacements[i].f1.toString();
+		}
+		return org.apache.commons.lang3.StringUtils.replaceEach(text, searchList, replacementList);
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -354,22 +354,4 @@ public final class StringUtils {
 
 	/** Prevent instantiation of this utility class */
 	private StringUtils() {}
-
-	/**
-	 * It takes a list of pairs and replaces every occurrence of the first member with
-	 * the second member.
-	 *
-	 * @param text The original text.
-	 * @param replacements Array of pairs. The first member will be replaced with the second for each elements.
-	 * @return The text after the replacements.
-	 */
-	public static String replaceStrings(String text, Tuple2<String, StringBuilder>[] replacements) {
-		String[] searchList = new String[replacements.length];
-		String[] replacementList = new String[replacements.length];
-		for(int i = 0; i < replacements.length; ++i) {
-			searchList[i] = replacements[i].f0;
-			replacementList[i] = replacements[i].f1.toString();
-		}
-		return org.apache.commons.lang3.StringUtils.replaceEach(text, searchList, replacementList);
-	}
 }

--- a/flink-core/src/main/resources/PojoComparatorTemplate.ftl
+++ b/flink-core/src/main/resources/PojoComparatorTemplate.ftl
@@ -171,11 +171,9 @@ public final class ${className} extends CompositeTypeComparator implements java.
 	@Override
 	public void putNormalizedKey(Object value, MemorySegment target, int offset, int numBytes) {
 		int len;
-		do {
-			<#list putNormalizedKeys as pnk>
-			${pnk}
-			</#list>
-		} while (false);
+		<#list putNormalizedKeys as pnk>
+		${pnk}
+		</#list>
 	}
 
 	@Override

--- a/flink-core/src/main/resources/PojoComparatorTemplate.ftl
+++ b/flink-core/src/main/resources/PojoComparatorTemplate.ftl
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ${packageName};
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import org.apache.flink.api.common.typeutils.CompositeTypeComparator;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.types.NullKeyFieldException;
+import org.apache.flink.api.java.typeutils.runtime.TupleComparatorBase;
+import org.apache.flink.api.java.typeutils.runtime.GenTypeComparatorProxy;
+import org.apache.flink.util.InstantiationUtil;
+
+public final class ${className} extends CompositeTypeComparator implements java.io.Serializable {
+	private static final long serialVersionUID = 1L;
+	private final int[] normalizedKeyLengths;
+	private final int numLeadingNormalizableKeys;
+	private final int normalizableKeyPrefixLen;
+	private final int numKeyFields;
+	private final boolean invertNormKey;
+	private ${serializerClassName} serializer;
+	private final Class type;
+	<#list members as m>
+	${m}
+	</#list>
+
+	public ${className}(TypeComparator[] comparators, TypeSerializer serializer, Class type) {
+		<#list initMembers as m>
+		${m}
+		</#list>
+		this.type = type;
+		this.numKeyFields = comparators.length;
+		this.serializer = (${serializerClassName})serializer;
+		this.normalizedKeyLengths = new int[numKeyFields];
+		int nKeys = 0;
+		int nKeyLen = 0;
+		boolean inverted = f0.invertNormalizedKey();
+		do {
+			<#list normalizableKeys as n>
+			${n}
+			</#list>
+		} while (false);
+		this.numLeadingNormalizableKeys = nKeys;
+		this.normalizableKeyPrefixLen = nKeyLen;
+		this.invertNormKey = inverted;
+	}
+
+	private ${className}(${className} toClone) {
+		<#list cloneMembers as m>
+		${m}
+		</#list>
+		this.normalizedKeyLengths = toClone.normalizedKeyLengths;
+		this.numKeyFields = toClone.numKeyFields;
+		this.numLeadingNormalizableKeys = toClone.numLeadingNormalizableKeys;
+		this.normalizableKeyPrefixLen = toClone.normalizableKeyPrefixLen;
+		this.invertNormKey = toClone.invertNormKey;
+		this.type = toClone.type;
+		try {
+			this.serializer = (${serializerClassName}) InstantiationUtil.deserializeObject(
+				InstantiationUtil.serializeObject(toClone.serializer), Thread.currentThread().getContextClassLoader());
+		} catch (IOException e) {
+			throw new RuntimeException("Cannot copy serializer", e);
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Cannot copy serializer", e);
+		}
+	}
+
+	@Override
+	public void getFlatComparator(List flatComparators) {
+		<#list flatComparators as fc>
+		${fc}
+		</#list>
+	}
+
+	@Override
+	public int hash(Object value) {
+		int i = 0;
+		int code = 0;
+		<#list hashMembers as hm>
+		${hm}
+		</#list>
+		return code;
+	}
+
+	@Override
+	public void setReference(Object toCompare) {
+		<#list setReference as sr>
+		${sr}
+		</#list>
+	}
+
+	@Override
+	public boolean equalToReference(Object candidate) {
+		<#list equalToReference as er>
+		${er}
+		</#list>
+		return true;
+	}
+
+	@Override
+	public int compareToReference(TypeComparator referencedComparator) {
+		${className} other = null;
+		if (referencedComparator instanceof GenTypeComparatorProxy) {
+			other = (${className})((GenTypeComparatorProxy)referencedComparator).getImpl();
+		} else{
+			other = (${className})referencedComparator;
+		}
+		int cmp;
+		<#list compareToReference as cr>
+		${cr}
+		</#list>
+		return 0;
+	}
+
+	@Override
+	public int compare(Object first, Object second) {
+		int cmp;
+		<#list compareFields as cf>
+		${cf}
+		</#list>
+		return 0;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		Object first = this.serializer.createInstance();
+		Object second = this.serializer.createInstance();
+		first = this.serializer.deserialize(first, firstSource);
+		second = this.serializer.deserialize(second, secondSource);
+		return this.compare(first, second);
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return this.numLeadingNormalizableKeys > 0;
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return this.normalizableKeyPrefixLen;
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		return this.numLeadingNormalizableKeys < this.numKeyFields ||
+			this.normalizableKeyPrefixLen == Integer.MAX_VALUE ||
+			this.normalizableKeyPrefixLen > keyBytes;
+	}
+
+	@Override
+	public void putNormalizedKey(Object value, MemorySegment target, int offset, int numBytes) {
+		int len;
+		do {
+			<#list putNormalizedKeys as pnk>
+			${pnk}
+			</#list>
+		} while (false);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return this.invertNormKey;
+	}
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(Object record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object readWithKeyDenormalization(Object reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ${className} duplicate() {
+		return new ${className}(this);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		int localIndex = index;
+		<#list extractKeys as ek>
+		${ek}
+		</#list>
+		return localIndex - index;
+	}
+}

--- a/flink-core/src/main/resources/PojoSerializerTemplate.ftl
+++ b/flink-core/src/main/resources/PojoSerializerTemplate.ftl
@@ -139,6 +139,7 @@ public final class ${className} extends TypeSerializer {
 		<#if alwaysNull != "true">
 		${typeName} target = new ${typeName}();
 		</#if>
+		Object value;
 		<#list copyFields as cf>
 		${cf}
 		</#list>
@@ -151,6 +152,9 @@ public final class ${className} extends TypeSerializer {
 		if (reuse == null) {
 			return copy(from);
 		}
+		Object value;
+		Object reuseValue;
+		Object copy;
 		<#list reuseCopyFields as rcf>
 		${rcf}
 		</#list>
@@ -164,6 +168,7 @@ public final class ${className} extends TypeSerializer {
 			return;
 		}
 		target.writeByte(NO_SUBCLASS);
+		Object o;
 		<#list serializeFields as sf>
 		${sf}
 		</#list>
@@ -175,8 +180,8 @@ public final class ${className} extends TypeSerializer {
 		if((flags & IS_NULL) != 0) {
 			return null;
 		}
-		${typeName} target = null;
-		target = createInstance();
+		${typeName} target = createInstance();
+		boolean isNull;
 		<#list deserializeFields as dsf>
 		${dsf}
 		</#list>
@@ -192,6 +197,9 @@ public final class ${className} extends TypeSerializer {
 		if (reuse == null) {
 			reuse = createInstance();
 		}
+		boolean isNull;
+		Object field;
+		Object reuseField;
 		<#list reuseDeserializeFields as rdsf>
 		${rdsf}
 		</#list>
@@ -205,6 +213,7 @@ public final class ${className} extends TypeSerializer {
 		if ((flags & IS_NULL) != 0) {
 			return;
 		}
+		boolean isNull;
 		<#list dataCopyFields as dcf>
 		${dcf}
 		</#list>
@@ -223,6 +232,7 @@ public final class ${className} extends TypeSerializer {
 			<#if alwaysNull != "true">
 			target = new ${typeName}();
 			</#if>
+			Object value;
 			<#list copyFields as cf>
 			${cf}
 			</#list>
@@ -241,6 +251,9 @@ public final class ${className} extends TypeSerializer {
 			if (reuse == null || actualType != reuse.getClass()) {
 				return copy(from);
 			}
+			Object value;
+			Object reuseValue;
+			Object copy;
 			<#list reuseCopyFields as rcf>
 			${rcf}
 			</#list>
@@ -281,6 +294,7 @@ public final class ${className} extends TypeSerializer {
 			target.writeByte(subclassTag);
 		}
 		if ((flags & NO_SUBCLASS) != 0) {
+			Object o;
 			<#list serializeFields as sf>
 			${sf}
 			</#list>
@@ -318,6 +332,7 @@ public final class ${className} extends TypeSerializer {
 			target = createInstance();
 		}
 		if ((flags & NO_SUBCLASS) != 0) {
+			boolean isNull;
 			<#list deserializeFields as dsf>
 			${dsf}
 			</#list>
@@ -361,6 +376,9 @@ public final class ${className} extends TypeSerializer {
 			}
 		}
 		if ((flags & NO_SUBCLASS) != 0) {
+			boolean isNull;
+			Object field;
+			Object reuseField;
 			<#list reuseDeserializeFields as rdsf>
 			${rdsf}
 			</#list>
@@ -394,6 +412,7 @@ public final class ${className} extends TypeSerializer {
 			subclassSerializer = registeredSerializers[subclassTag];
 		}
 		if ((flags & NO_SUBCLASS) != 0) {
+			boolean isNull;
 			<#list dataCopyFields as dcf>
 			${dcf}
 			</#list>

--- a/flink-core/src/main/resources/PojoSerializerTemplate.ftl
+++ b/flink-core/src/main/resources/PojoSerializerTemplate.ftl
@@ -1,0 +1,426 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ${packageName};
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+public final class ${className} extends TypeSerializer {
+	private static byte IS_NULL = 1;
+	private static byte NO_SUBCLASS = 2;
+	private static byte IS_SUBCLASS = 4;
+	private static byte IS_TAGGED_SUBCLASS = 8;
+	private int numFields;
+	private ExecutionConfig executionConfig;
+	private Map<Class, TypeSerializer> subclassSerializerCache;
+	private final Map<Class, Integer> registeredClasses;
+	private final TypeSerializer[] registeredSerializers;
+	Class clazz;
+	<#list members as m>
+	${m}
+	</#list>
+
+	public ${className}(Class clazz, TypeSerializer[] serializerFields, ExecutionConfig e) {
+		this.clazz = clazz;
+		executionConfig = e;
+		this.numFields = serializerFields.length;
+		LinkedHashSet<Class> registeredPojoTypes = executionConfig.getRegisteredPojoTypes();
+		subclassSerializerCache = new HashMap<Class, TypeSerializer>();
+		List<Class> cleanedTaggedClasses = new ArrayList<Class>(registeredPojoTypes.size());
+		for (Class registeredClass: registeredPojoTypes) {
+			if (registeredClass.equals(clazz)) {
+				continue;
+			}
+			if (!clazz.isAssignableFrom(registeredClass)) {
+				continue;
+			}
+			cleanedTaggedClasses.add(registeredClass);
+		}
+		this.registeredClasses = new LinkedHashMap<Class, Integer>(cleanedTaggedClasses.size());
+		registeredSerializers = new TypeSerializer[cleanedTaggedClasses.size()];
+		int id = 0;
+		for (Class registeredClass: cleanedTaggedClasses) {
+			this.registeredClasses.put(registeredClass, id);
+			TypeInformation typeInfo = TypeExtractor.createTypeInfo(registeredClass);
+			registeredSerializers[id] = typeInfo.createSerializer(executionConfig);
+			id++;
+		}
+		<#list initMembers as m>
+		${m}
+		</#list>
+	}
+
+	private TypeSerializer getSubclassSerializer(Class subclass) {
+		TypeSerializer result = (TypeSerializer)subclassSerializerCache.get(subclass);
+		if (result == null) {
+			TypeInformation typeInfo = TypeExtractor.createTypeInfo(subclass);
+			result = typeInfo.createSerializer(executionConfig);
+			subclassSerializerCache.put(subclass, result);
+		}
+		return result;
+	}
+
+	@Override
+	public boolean isImmutableType() { return false; }
+
+	@Override
+	public ${className} duplicate() {
+		boolean stateful = false;
+		TypeSerializer[] duplicateFieldSerializers = new TypeSerializer[numFields];
+		<#list duplicateSerializers as ds>
+		${ds}
+		</#list>
+		if (stateful) {
+			return new ${className}(clazz, duplicateFieldSerializers, executionConfig);
+		} else {
+			return this;
+		}
+	}
+
+	@Override
+	public ${typeName} createInstance() {
+		<#if alwaysNull == "true">
+		return null;
+		</#if>
+		<#if alwaysNull != "true">
+		${typeName} t = new ${typeName}();
+		initializeFields(t);
+		return t;
+		</#if>
+	}
+
+	protected void initializeFields(${typeName} t) {
+		<#list createFields as cf>
+		${cf}
+		</#list>
+	}
+
+	@Override
+	public int getLength() {  return -1; } // TODO: make it smarter based on annotations?
+
+	<#if isFinal == "true">
+	@Override
+	public ${typeName} copy(Object from) {
+		if (from == null) return null;
+		<#if alwaysNull == "true">
+		${typeName} target = null;
+		</#if>
+		<#if alwaysNull != "true">
+		${typeName} target = new ${typeName}();
+		</#if>
+		<#list copyFields as cf>
+		${cf}
+		</#list>
+		return target;
+	}
+
+	@Override
+	public ${typeName} copy(Object from, Object reuse) {
+		if (from == null) return null;
+		if (reuse == null) {
+			return copy(from);
+		}
+		<#list reuseCopyFields as rcf>
+		${rcf}
+		</#list>
+		return (${typeName})reuse;
+	}
+
+	@Override
+	public void serialize(Object value, DataOutputView target) throws IOException {
+		if (value == null) {
+			target.writeByte(IS_NULL);
+			return;
+		}
+		target.writeByte(NO_SUBCLASS);
+		<#list serializeFields as sf>
+		${sf}
+		</#list>
+	}
+
+	@Override
+	public ${typeName} deserialize(DataInputView source) throws IOException {
+		int flags = source.readByte();
+		if((flags & IS_NULL) != 0) {
+			return null;
+		}
+		${typeName} target = null;
+		target = createInstance();
+		<#list deserializeFields as dsf>
+		${dsf}
+		</#list>
+		return target;
+	}
+
+	@Override
+	public ${typeName} deserialize(Object reuse, DataInputView source) throws IOException {
+		int flags = source.readByte();
+		if((flags & IS_NULL) != 0) {
+			return null;
+		}
+		if (reuse == null) {
+			reuse = createInstance();
+		}
+		<#list reuseDeserializeFields as rdsf>
+		${rdsf}
+		</#list>
+		return (${typeName})reuse;
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		int flags = source.readByte();
+		target.writeByte(flags);
+		if ((flags & IS_NULL) != 0) {
+			return;
+		}
+		<#list dataCopyFields as dcf>
+		${dcf}
+		</#list>
+	}
+	</#if>
+	<#if isFinal != "true">
+	@Override
+	public ${typeName} copy(Object from) {
+		if (from == null) return null;
+		Class<?> actualType = from.getClass();
+		${typeName} target;
+		if (actualType == clazz) {
+			<#if alwaysNull == "true">
+			target = null;
+			</#if>
+			<#if alwaysNull != "true">
+			target = new ${typeName}();
+			</#if>
+			<#list copyFields as cf>
+			${cf}
+			</#list>
+			return target;
+		} else {
+			TypeSerializer subclassSerializer = getSubclassSerializer(actualType);
+			return (${typeName})subclassSerializer.copy(from);
+		}
+	}
+
+	@Override
+	public ${typeName} copy(Object from, Object reuse) {
+		if (from == null) return null;
+		Class actualType = from.getClass();
+		if (actualType == clazz) {
+			if (reuse == null || actualType != reuse.getClass()) {
+				return copy(from);
+			}
+			<#list reuseCopyFields as rcf>
+			${rcf}
+			</#list>
+			return (${typeName})reuse;
+		} else {
+			TypeSerializer subclassSerializer = getSubclassSerializer(actualType);
+			return (${typeName})subclassSerializer.copy(from, reuse);
+		}
+	}
+
+	@Override
+	public void serialize(Object value, DataOutputView target) throws IOException {
+		int flags = 0;
+		if (value == null) {
+			flags |= IS_NULL;
+			target.writeByte(flags);
+			return;
+		}
+		Integer subclassTag = -1;
+		Class actualClass = value.getClass();
+		TypeSerializer subclassSerializer = null;
+		if (clazz != actualClass) {
+			subclassTag = (Integer)registeredClasses.get(actualClass);
+			if (subclassTag != null) {
+				flags |= IS_TAGGED_SUBCLASS;
+				subclassSerializer = registeredSerializers[subclassTag.intValue()];
+			} else {
+				flags |= IS_SUBCLASS;
+				subclassSerializer = getSubclassSerializer(actualClass);
+			}
+		} else {
+			flags |= NO_SUBCLASS;
+		}
+		target.writeByte(flags);
+		if ((flags & IS_SUBCLASS) != 0) {
+			target.writeUTF(actualClass.getName());
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			target.writeByte(subclassTag);
+		}
+		if ((flags & NO_SUBCLASS) != 0) {
+			<#list serializeFields as sf>
+			${sf}
+			</#list>
+		} else {
+			subclassSerializer.serialize(value, target);
+		}
+	}
+
+	@Override
+	public ${typeName} deserialize(DataInputView source) throws IOException {
+		int flags = source.readByte();
+		if((flags & IS_NULL) != 0) {
+			return null;
+		}
+		Class actualSubclass = null;
+		TypeSerializer subclassSerializer = null;
+		${typeName} target = null;
+		if ((flags & IS_SUBCLASS) != 0) {
+			String subclassName = source.readUTF();
+			try {
+				actualSubclass = Class.forName(subclassName, true,
+											Thread.currentThread().getContextClassLoader());
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Cannot instantiate class.", e);
+			}
+			subclassSerializer = getSubclassSerializer(actualSubclass);
+			target = (${typeName}) subclassSerializer.createInstance();
+			initializeFields(target);
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			int subclassTag = source.readByte();
+			subclassSerializer = registeredSerializers[subclassTag];
+			target = (${typeName}) subclassSerializer.createInstance();
+			initializeFields(target);
+		} else {
+			target = createInstance();
+		}
+		if ((flags & NO_SUBCLASS) != 0) {
+			<#list deserializeFields as dsf>
+			${dsf}
+			</#list>
+		} else {
+			target = (${typeName})subclassSerializer.deserialize(target, source);
+		}
+		return target;
+	}
+
+	@Override
+	public ${typeName} deserialize(Object reuse, DataInputView source) throws IOException {
+		int flags = source.readByte();
+		if((flags & IS_NULL) != 0) {
+			return null;
+		}
+		Class subclass = null;
+		TypeSerializer subclassSerializer = null;
+		if ((flags & IS_SUBCLASS) != 0) {
+			String subclassName = source.readUTF();
+			try {
+				subclass = Class.forName(subclassName, true,
+											Thread.currentThread().getContextClassLoader());
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Cannot instantiate class.", e);
+			}
+			subclassSerializer = getSubclassSerializer(subclass);
+			if (reuse == null || subclass != reuse.getClass()) {
+				reuse = subclassSerializer.createInstance();
+				initializeFields((${typeName})reuse);
+			}
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			int subclassTag = source.readByte();
+			subclassSerializer = registeredSerializers[subclassTag];
+			if (reuse == null /* TOOD:|| subclassSerializer.clazz != reuse.getClass()*/) {
+				reuse = subclassSerializer.createInstance();
+				initializeFields((${typeName})reuse);
+			}
+		} else {
+			if (reuse == null || clazz != reuse.getClass()) {
+				reuse = createInstance();
+			}
+		}
+		if ((flags & NO_SUBCLASS) != 0) {
+			<#list reuseDeserializeFields as rdsf>
+			${rdsf}
+			</#list>
+		} else {
+			reuse = (${typeName})subclassSerializer.deserialize(reuse, source);
+		}
+		return (${typeName})reuse;
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		int flags = source.readByte();
+		target.writeByte(flags);
+		TypeSerializer subclassSerializer = null;
+		if ((flags & IS_NULL) != 0) {
+			return;
+		}
+		if ((flags & IS_SUBCLASS) != 0) {
+			String className = source.readUTF();
+			target.writeUTF(className);
+			try {
+				Class subclass = Class.forName(className, true, Thread.currentThread()
+					.getContextClassLoader());
+				subclassSerializer = getSubclassSerializer(subclass);
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Cannot instantiate class.", e);
+			}
+		} else if ((flags & IS_TAGGED_SUBCLASS) != 0) {
+			int subclassTag = source.readByte();
+			target.writeByte(subclassTag);
+			subclassSerializer = registeredSerializers[subclassTag];
+		}
+		if ((flags & NO_SUBCLASS) != 0) {
+			<#list dataCopyFields as dcf>
+			${dcf}
+			</#list>
+		} else {
+			subclassSerializer.copy(source, target);
+		}
+	}
+	</#if>
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof ${className}) {
+			${className} other = (${className})obj;
+			return other.canEqual(this) && this.clazz == other.clazz && this.numFields == other.numFields
+					&& ${memberEquals} && Arrays.equals(registeredSerializers, other.registeredSerializers) &&
+					registeredClasses.equals(other.registeredClasses);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) { return obj instanceof ${className}; }
+
+	@Override
+	public int hashCode() {
+		return 31 * (31 * Arrays.hashCode(new TypeSerializer[]{${memberHash}}) +
+		Arrays.hashCode(registeredSerializers)) + Objects.hash(clazz, numFields, registeredClasses);
+	}
+}

--- a/flink-core/src/main/resources/PojoSerializerTemplate.ftl
+++ b/flink-core/src/main/resources/PojoSerializerTemplate.ftl
@@ -43,7 +43,7 @@ public final class ${className} extends TypeSerializer {
 	private static byte IS_TAGGED_SUBCLASS = 8;
 	private int numFields;
 	private ExecutionConfig executionConfig;
-	private Map<Class, TypeSerializer> subclassSerializerCache;
+	private transient Map<Class, TypeSerializer> subclassSerializerCache;
 	private final Map<Class, Integer> registeredClasses;
 	private final TypeSerializer[] registeredSerializers;
 	Class clazz;

--- a/flink-core/src/main/resources/PojoSerializerTemplate.ftl
+++ b/flink-core/src/main/resources/PojoSerializerTemplate.ftl
@@ -35,6 +35,9 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.ParameterlessTypeSerializerConfig;
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
 
 public final class ${className} extends TypeSerializer {
 	private static byte IS_NULL = 1;
@@ -441,5 +444,15 @@ public final class ${className} extends TypeSerializer {
 	public int hashCode() {
 		return 31 * (31 * Arrays.hashCode(new TypeSerializer[]{${memberHash}}) +
 		Arrays.hashCode(registeredSerializers)) + Objects.hash(clazz, numFields, registeredClasses);
+	}
+
+	@Override
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		return CompatibilityResult.compatible();
+	}
+
+	@Override
+	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		return new ParameterlessTypeSerializerConfig("${className}");
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -409,7 +409,7 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			TypeSerializer<T> ser1 = getSerializer();
 			TypeSerializer<T> ser2;
 			try {
-				ser2 = SerializationUtils.clone(ser1);
+				ser2 = InstantiationUtil.clone(ser1);
 			} catch (SerializationException e) {
 				fail("The serializer is not serializable: " + e);
 				return;

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestInstance.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestInstance.java
@@ -19,6 +19,8 @@
 package org.apache.flink.api.common.typeutils;
 
 
+import org.apache.flink.api.common.ExecutionConfig;
+
 public class SerializerTestInstance<T> extends SerializerTestBase<T> {
 
 	private final TypeSerializer<T> serializer;
@@ -42,7 +44,7 @@ public class SerializerTestInstance<T> extends SerializerTestBase<T> {
 	// --------------------------------------------------------------------------------------------
 	
 	@Override
-	protected TypeSerializer<T> createSerializer() {
+	protected TypeSerializer<T> createSerializer(ExecutionConfig config) {
 		return this.serializer;
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigDecSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigDecSerializerTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.math.BigDecimal;
 import java.util.Random;
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -29,7 +31,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 public class BigDecSerializerTest extends SerializerTestBase<BigDecimal> {
 
 	@Override
-	protected TypeSerializer<BigDecimal> createSerializer() {
+	protected TypeSerializer<BigDecimal> createSerializer(ExecutionConfig config) {
 		return new BigDecSerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigIntSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BigIntSerializerTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.math.BigInteger;
 import java.util.Random;
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -29,7 +31,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 public class BigIntSerializerTest extends SerializerTestBase<BigInteger> {
 
 	@Override
-	protected TypeSerializer<BigInteger> createSerializer() {
+	protected TypeSerializer<BigInteger> createSerializer(ExecutionConfig config) {
 		return new BigIntSerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
@@ -30,7 +31,7 @@ import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
 public class BooleanSerializerTest extends SerializerTestBase<Boolean> {
 	
 	@Override
-	protected TypeSerializer<Boolean> createSerializer() {
+	protected TypeSerializer<Boolean> createSerializer(ExecutionConfig config) {
 		return new BooleanSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.BooleanValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.BooleanValue;
 public class BooleanValueSerializerTest extends SerializerTestBase<BooleanValue> {
 	
 	@Override
-	protected TypeSerializer<BooleanValue> createSerializer() {
+	protected TypeSerializer<BooleanValue> createSerializer(ExecutionConfig config) {
 		return new BooleanValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.ByteSerializer;
@@ -30,7 +31,7 @@ import org.apache.flink.api.common.typeutils.base.ByteSerializer;
 public class ByteSerializerTest extends SerializerTestBase<Byte> {
 	
 	@Override
-	protected TypeSerializer<Byte> createSerializer() {
+	protected TypeSerializer<Byte> createSerializer(ExecutionConfig config) {
 		return new ByteSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.ByteValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.ByteValue;
 public class ByteValueSerializerTest extends SerializerTestBase<ByteValue> {
 	
 	@Override
-	protected TypeSerializer<ByteValue> createSerializer() {
+	protected TypeSerializer<ByteValue> createSerializer(ExecutionConfig config) {
 		return new ByteValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.CharSerializer;
@@ -30,7 +31,7 @@ import org.apache.flink.api.common.typeutils.base.CharSerializer;
 public class CharSerializerTest extends SerializerTestBase<Character> {
 	
 	@Override
-	protected TypeSerializer<Character> createSerializer() {
+	protected TypeSerializer<Character> createSerializer(ExecutionConfig config) {
 		return new CharSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/CharValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.CharValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.CharValue;
 public class CharValueSerializerTest extends SerializerTestBase<CharValue> {
 	
 	@Override
-	protected TypeSerializer<CharValue> createSerializer() {
+	protected TypeSerializer<CharValue> createSerializer(ExecutionConfig config) {
 		return new CharValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DateSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DateSerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -30,7 +31,7 @@ import java.util.Random;
 public class DateSerializerTest extends SerializerTestBase<Date> {
 	
 	@Override
-	protected TypeSerializer<Date> createSerializer() {
+	protected TypeSerializer<Date> createSerializer(ExecutionConfig config) {
 		return new DateSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleSerializerTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import java.util.Random;
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -28,7 +31,7 @@ import java.util.Random;
 public class DoubleSerializerTest extends SerializerTestBase<Double> {
 	
 	@Override
-	protected TypeSerializer<Double> createSerializer() {
+	protected TypeSerializer<Double> createSerializer(ExecutionConfig config) {
 		return new DoubleSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.DoubleValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.DoubleValue;
 public class DoubleValueSerializerTest extends SerializerTestBase<DoubleValue> {
 	
 	@Override
-	protected TypeSerializer<DoubleValue> createSerializer() {
+	protected TypeSerializer<DoubleValue> createSerializer(ExecutionConfig config) {
 		return new DoubleValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.FloatSerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.FloatSerializer;
 public class FloatSerializerTest extends SerializerTestBase<Float> {
 	
 	@Override
-	protected TypeSerializer<Float> createSerializer() {
+	protected TypeSerializer<Float> createSerializer(ExecutionConfig config) {
 		return new FloatSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.FloatValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.FloatValue;
 public class FloatValueSerializerTest extends SerializerTestBase<FloatValue> {
 	
 	@Override
-	protected TypeSerializer<FloatValue> createSerializer() {
+	protected TypeSerializer<FloatValue> createSerializer(ExecutionConfig config) {
 		return new FloatValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 public class IntSerializerTest extends SerializerTestBase<Integer> {
 	
 	@Override
-	protected TypeSerializer<Integer> createSerializer() {
+	protected TypeSerializer<Integer> createSerializer(ExecutionConfig config) {
 		return new IntSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/IntValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.IntValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.IntValue;
 public class IntValueSerializerTest extends SerializerTestBase<IntValue> {
 	
 	@Override
-	protected TypeSerializer<IntValue> createSerializer() {
+	protected TypeSerializer<IntValue> createSerializer(ExecutionConfig config) {
 		return new IntValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -33,7 +34,7 @@ import java.util.Random;
 public class ListSerializerTest extends SerializerTestBase<List<Long>> {
 
 	@Override
-	protected TypeSerializer<List<Long>> createSerializer() {
+	protected TypeSerializer<List<Long>> createSerializer(ExecutionConfig executionConfig) {
 		return new ListSerializer<>(LongSerializer.INSTANCE);
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 public class LongSerializerTest extends SerializerTestBase<Long> {
 	
 	@Override
-	protected TypeSerializer<Long> createSerializer() {
+	protected TypeSerializer<Long> createSerializer(ExecutionConfig config) {
 		return new LongSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/LongValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.LongValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.LongValue;
 public class LongValueSerializerTest extends SerializerTestBase<LongValue> {
 	
 	@Override
-	protected TypeSerializer<LongValue> createSerializer() {
+	protected TypeSerializer<LongValue> createSerializer(ExecutionConfig config) {
 		return new LongValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/MapSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/MapSerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -33,7 +34,7 @@ import java.util.TreeMap;
 public class MapSerializerTest extends SerializerTestBase<Map<Long, String>> {
 
 	@Override
-	protected TypeSerializer<Map<Long, String>> createSerializer() {
+	protected TypeSerializer<Map<Long, String>> createSerializer(ExecutionConfig executionConfig) {
 		return new MapSerializer<>(LongSerializer.INSTANCE, StringSerializer.INSTANCE);
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.ShortSerializer;
@@ -31,7 +32,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 public class ShortSerializerTest extends SerializerTestBase<Short> {
 	
 	@Override
-	protected TypeSerializer<Short> createSerializer() {
+	protected TypeSerializer<Short> createSerializer(ExecutionConfig config) {
 		return new ShortSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.ShortValue;
@@ -30,7 +31,7 @@ import org.apache.flink.types.ShortValue;
 public class ShortValueSerializerTest extends SerializerTestBase<ShortValue> {
 	
 	@Override
-	protected TypeSerializer<ShortValue> createSerializer() {
+	protected TypeSerializer<ShortValue> createSerializer(ExecutionConfig config) {
 		return new ShortValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlDateSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlDateSerializerTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.api.common.typeutils.base;
 
 import java.sql.Date;
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -28,7 +30,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 public class SqlDateSerializerTest extends SerializerTestBase<Date> {
 
 	@Override
-	protected TypeSerializer<Date> createSerializer() {
+	protected TypeSerializer<Date> createSerializer(ExecutionConfig config) {
 		return new SqlDateSerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimeSerializerTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.api.common.typeutils.base;
 
 import java.sql.Time;
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -28,7 +30,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 public class SqlTimeSerializerTest extends SerializerTestBase<Time> {
 
 	@Override
-	protected TypeSerializer<Time> createSerializer() {
+	protected TypeSerializer<Time> createSerializer(ExecutionConfig config) {
 		return new SqlTimeSerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampSerializerTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.api.common.typeutils.base;
 
 import java.sql.Timestamp;
+
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -28,7 +30,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 public class SqlTimestampSerializerTest extends SerializerTestBase<Timestamp> {
 
 	@Override
-	protected TypeSerializer<Timestamp> createSerializer() {
+	protected TypeSerializer<Timestamp> createSerializer(ExecutionConfig config) {
 		return new SqlTimestampSerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringSerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
@@ -28,7 +29,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 public class StringSerializerTest extends SerializerTestBase<String> {
 	
 	@Override
-	protected TypeSerializer<String> createSerializer() {
+	protected TypeSerializer<String> createSerializer(ExecutionConfig config) {
 		return new StringSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringValueSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/StringValueSerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.StringValue;
@@ -28,7 +29,7 @@ import org.apache.flink.types.StringValue;
 public class StringValueSerializerTest extends SerializerTestBase<StringValue> {
 	
 	@Override
-	protected TypeSerializer<StringValue> createSerializer() {
+	protected TypeSerializer<StringValue> createSerializer(ExecutionConfig config) {
 		return new StringValueSerializer();
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BooleanPrimitiveArraySerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerial
 public class BooleanPrimitiveArraySerializerTest extends SerializerTestBase<boolean[]> {
 
 	@Override
-	protected TypeSerializer<boolean[]> createSerializer() {
+	protected TypeSerializer<boolean[]> createSerializer(ExecutionConfig config) {
 		return new BooleanPrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
@@ -33,7 +34,7 @@ public class BytePrimitiveArraySerializerTest extends SerializerTestBase<byte[]>
 	private final Random rnd = new Random(346283764872L);
 	
 	@Override
-	protected TypeSerializer<byte[]> createSerializer() {
+	protected TypeSerializer<byte[]> createSerializer(ExecutionConfig config) {
 		return new BytePrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -27,7 +28,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 public class CharPrimitiveArraySerializerTest extends SerializerTestBase<char[]> {
 
 	@Override
-	protected TypeSerializer<char[]> createSerializer() {
+	protected TypeSerializer<char[]> createSerializer(ExecutionConfig config) {
 		return new CharPrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.DoublePrimitiveArraySerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerial
 public class DoublePrimitiveArraySerializerTest extends SerializerTestBase<double[]> {
 
 	@Override
-	protected TypeSerializer<double[]> createSerializer() {
+	protected TypeSerializer<double[]> createSerializer(ExecutionConfig config) {
 		return new DoublePrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.FloatPrimitiveArraySerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerial
 public class FloatPrimitiveArraySerializerTest extends SerializerTestBase<float[]> {
 
 	@Override
-	protected TypeSerializer<float[]> createSerializer() {
+	protected TypeSerializer<float[]> createSerializer(ExecutionConfig config) {
 		return new FloatPrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.IntPrimitiveArraySerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerial
 public class IntPrimitiveArraySerializerTest extends SerializerTestBase<int[]> {
 
 	@Override
-	protected TypeSerializer<int[]> createSerializer() {
+	protected TypeSerializer<int[]> createSerializer(ExecutionConfig config) {
 		return new IntPrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
@@ -28,7 +29,7 @@ import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerial
 public class LongPrimitiveArraySerializerTest extends SerializerTestBase<long[]> {
 
 	@Override
-	protected TypeSerializer<long[]> createSerializer() {
+	protected TypeSerializer<long[]> createSerializer(ExecutionConfig config) {
 		return new LongPrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
@@ -29,7 +30,7 @@ import org.apache.flink.api.common.typeutils.base.array.ShortPrimitiveArraySeria
 public class ShortPrimitiveArraySerializerTest extends SerializerTestBase<short[]> {
 
 	@Override
-	protected TypeSerializer<short[]> createSerializer() {
+	protected TypeSerializer<short[]> createSerializer(ExecutionConfig config) {
 		return new ShortPrimitiveArraySerializer();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base.array;
 
 import java.util.Random;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.StringArraySerializer;
@@ -35,7 +36,7 @@ import static org.junit.Assert.assertFalse;
 public class StringArraySerializerTest extends SerializerTestBase<String[]> {
 
 	@Override
-	protected TypeSerializer<String[]> createSerializer() {
+	protected TypeSerializer<String[]> createSerializer(ExecutionConfig config) {
 		return new StringArraySerializer();
 	}
 
@@ -76,7 +77,7 @@ public class StringArraySerializerTest extends SerializerTestBase<String[]> {
 
 	@Test
 	public void arrayTypeIsMutable() {
-		StringArraySerializer serializer = (StringArraySerializer) createSerializer();
+		StringArraySerializer serializer = (StringArraySerializer) createSerializer(new ExecutionConfig());
 		assertFalse(serializer.isImmutableType());
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
@@ -55,12 +55,12 @@ public class EitherSerializerTest {
 			Right(Double.MIN_VALUE),
 			Right(Double.MAX_VALUE)};
 
-	EitherTypeInfo<String, Double> eitherTypeInfo = (EitherTypeInfo<String, Double>) new EitherTypeInfo<String, Double>(
+	EitherTypeInfo<String, Double> eitherTypeInfo = new EitherTypeInfo<>(
 			BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.DOUBLE_TYPE_INFO);
 	EitherSerializer<String, Double> eitherSerializer =
 			(EitherSerializer<String, Double>) eitherTypeInfo.createSerializer(new ExecutionConfig());
 	SerializerTestInstance<Either<String, Double>> testInstance =
-			new EitherSerializerTestInstance<Either<String, Double>>(eitherSerializer, eitherTypeInfo.getTypeClass(), -1, testData);
+			new EitherSerializerTestInstance<>(eitherSerializer, eitherTypeInfo.getTypeClass(), -1, testData);
 	testInstance.testAll();
 	}
 
@@ -95,14 +95,14 @@ public class EitherSerializerTest {
 			Right(Double.MIN_VALUE),
 			Right(Double.MAX_VALUE)};
 
-	EitherTypeInfo<Tuple2<Long, Long>, Double> eitherTypeInfo = (EitherTypeInfo<Tuple2<Long, Long>, Double>)
-			new EitherTypeInfo<Tuple2<Long, Long>, Double>(
+	EitherTypeInfo<Tuple2<Long, Long>, Double> eitherTypeInfo =
+			new EitherTypeInfo<>(
 			new TupleTypeInfo<Tuple2<Long, Long>>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO),
 			BasicTypeInfo.DOUBLE_TYPE_INFO);
 	EitherSerializer<Tuple2<Long, Long>, Double> eitherSerializer =
 			(EitherSerializer<Tuple2<Long, Long>, Double>) eitherTypeInfo.createSerializer(new ExecutionConfig());
 	SerializerTestInstance<Either<Tuple2<Long, Long>, Double>> testInstance =
-			new EitherSerializerTestInstance<Either<Tuple2<Long, Long>, Double>>(
+			new EitherSerializerTestInstance<>(
 					eitherSerializer, eitherTypeInfo.getTypeClass(), -1, testData);
 	testInstance.testAll();
 	}
@@ -207,13 +207,14 @@ public class EitherSerializerTest {
 		@Test
 		public void testInstantiate() {
 			try {
-				TypeSerializer<T> serializer = getSerializer();
+				TypeSerializer<T>[] serializers = getSerializers();
+				for (TypeSerializer<T> serializer : serializers) {
+					T instance = serializer.createInstance();
+					assertNotNull("The created instance must not be null.", instance);
 
-				T instance = serializer.createInstance();
-				assertNotNull("The created instance must not be null.", instance);
-
-				Class<T> type = getTypeClass();
-				assertNotNull("The test is corrupt: type class is null.", type);
+					Class<T> type = getTypeClass();
+					assertNotNull("The test is corrupt: type class is null.", type);
+				}
 			}
 			catch (Exception e) {
 				System.err.println(e.getMessage());

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -62,8 +62,8 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 	private TypeInformation<TestUserClass> type = TypeExtractor.getForClass(TestUserClass.class);
 
 	@Override
-	protected TypeSerializer<TestUserClass> createSerializer() {
-		TypeSerializer<TestUserClass> serializer = type.createSerializer(new ExecutionConfig());
+	protected TypeSerializer<TestUserClass> createSerializer(ExecutionConfig config) {
+		TypeSerializer<TestUserClass> serializer = type.createSerializer(config);
 		return serializer;
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -64,7 +64,6 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 	@Override
 	protected TypeSerializer<TestUserClass> createSerializer() {
 		TypeSerializer<TestUserClass> serializer = type.createSerializer(new ExecutionConfig());
-		assert(serializer instanceof PojoSerializer);
 		return serializer;
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
@@ -41,7 +41,6 @@ public class PojoSubclassSerializerTest extends SerializerTestBase<PojoSubclassS
 		ExecutionConfig conf = new ExecutionConfig();
 		conf.registerPojoType(TestUserClass1.class);
 		TypeSerializer<TestUserClassBase> serializer = type.createSerializer(conf);
-		assert(serializer instanceof PojoSerializer);
 		return serializer;
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSubclassSerializerTest.java
@@ -36,11 +36,10 @@ public class PojoSubclassSerializerTest extends SerializerTestBase<PojoSubclassS
 	private TypeInformation<TestUserClassBase> type = TypeExtractor.getForClass(TestUserClassBase.class);
 
 	@Override
-	protected TypeSerializer<TestUserClassBase> createSerializer() {
+	protected TypeSerializer<TestUserClassBase> createSerializer(ExecutionConfig config) {
 		// only register one of the three child classes, the third child class is NO POJO
-		ExecutionConfig conf = new ExecutionConfig();
-		conf.registerPojoType(TestUserClass1.class);
-		TypeSerializer<TestUserClassBase> serializer = type.createSerializer(conf);
+		config.registerPojoType(TestUserClass1.class);
+		TypeSerializer<TestUserClassBase> serializer = type.createSerializer(config);
 		return serializer;
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/SubclassFromInterfaceSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/SubclassFromInterfaceSerializerTest.java
@@ -37,11 +37,10 @@ public class SubclassFromInterfaceSerializerTest extends SerializerTestBase<Subc
 	private TypeInformation<TestUserInterface> type = TypeExtractor.getForClass(TestUserInterface.class);
 
 	@Override
-	protected TypeSerializer<TestUserInterface> createSerializer() {
+	protected TypeSerializer<TestUserInterface> createSerializer(ExecutionConfig config) {
 		// only register one of the two child classes
-		ExecutionConfig conf = new ExecutionConfig();
-		conf.registerPojoType(TestUserClass2.class);
-		TypeSerializer<TestUserInterface> serializer = type.createSerializer(conf);
+		config.registerPojoType(TestUserClass2.class);
+		TypeSerializer<TestUserInterface> serializer = type.createSerializer(config);
 		assert(serializer instanceof KryoSerializer);
 		return serializer;
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerTest.java
@@ -203,13 +203,13 @@ public class TupleSerializerTest {
 		
 		@SuppressWarnings("unchecked")
 		Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>[] testTuples = new Tuple5[] {
-				new Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>(a, b1, o1, ba1, co1),
-				new Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>(b, b2, o2, ba2, co2),
-				new Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>(c, b3, o3, ba1, co3),
-				new Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>(d, b2, o4, ba1, co4),
-				new Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>(e, b4, o5, ba2, co4),
-				new Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>(f, b5, o1, ba2, co4),
-				new Tuple5<SimpleTypes, Book, ComplexNestedObject1, BookAuthor, ComplexNestedObject2>(g, b6, o4, ba1, co2)
+				Tuple5.of(a, b1, o1, ba1, co1),
+				Tuple5.of(b, b2, o2, ba2, co2),
+				Tuple5.of(c, b3, o3, ba1, co3),
+				Tuple5.of(d, b2, o4, ba1, co4),
+				Tuple5.of(e, b4, o5, ba2, co4),
+				Tuple5.of(f, b5, o1, ba2, co4),
+				Tuple5.of(g, b6, o4, ba1, co2)
 		};
 		
 		runTests(-1, testTuples);

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUUIDTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUUIDTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -25,7 +26,7 @@ import java.util.UUID;
 
 public class ValueSerializerUUIDTest extends SerializerTestBase<ValueID> {
 	@Override
-	protected TypeSerializer<ValueID> createSerializer() {
+	protected TypeSerializer<ValueID> createSerializer(ExecutionConfig config) {
 		return new ValueSerializer<>(ValueID.class);
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerClassLoadingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerClassLoadingTest.java
@@ -78,8 +78,8 @@ public class KryoSerializerClassLoadingTest extends SerializerTestBase<Object> {
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected TypeSerializer<Object> createSerializer() {
-		return new KryoSerializer<>(Object.class, new ExecutionConfig());
+	protected TypeSerializer<Object> createSerializer(ExecutionConfig executionConfig) {
+		return new KryoSerializer<>(Object.class, executionConfig);
 	}
 
 	@Override

--- a/flink-examples/flink-examples-batch/pom.xml
+++ b/flink-examples/flink-examples-batch/pom.xml
@@ -325,6 +325,30 @@ under the License.
 						</configuration>
 					</execution>
 
+					<!-- WordCountPojo -->
+					<execution>
+						<id>WordCountPojo</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>WordCountPojo</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.examples.java.wordcount.WordCountPojo</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>**/java/wordcount/WordCountPojo.class</include>
+								<include>**/java/wordcount/WordCountPojo$*.class</include>
+								<include>**/java/wordcount/util/WordCountData.class</include>
+							</includes>
+						</configuration>
+					</execution>
+
 					<!-- Distributed Copy -->
 					<execution>
 						<id>DistCp</id>
@@ -370,6 +394,7 @@ under the License.
 								<copy file="${project.basedir}/target/flink-examples-batch_${scala.binary.version}-${project.version}-TransitiveClosure.jar" tofile="${project.basedir}/target/TransitiveClosure.jar" />
 								<copy file="${project.basedir}/target/flink-examples-batch_${scala.binary.version}-${project.version}-WebLogAnalysis.jar" tofile="${project.basedir}/target/WebLogAnalysis.jar" />
 								<copy file="${project.basedir}/target/flink-examples-batch_${scala.binary.version}-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
+								<copy file="${project.basedir}/target/flink-examples-batch_${scala.binary.version}-${project.version}-WordCountPojo.jar" tofile="${project.basedir}/target/WordCountPojo.jar" />
 								<copy file="${project.basedir}/target/flink-examples-batch_${scala.binary.version}-${project.version}-DistCp.jar" tofile="${project.basedir}/target/DistCp.jar" />
 							</target>
 						</configuration>

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -84,6 +84,11 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_2.10</artifactId>
+			<version>1.1-SNAPSHOT</version>
+		</dependency>
 
 	</dependencies>
 

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -84,11 +84,6 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils_2.10</artifactId>
-			<version>1.1-SNAPSHOT</version>
-		</dependency>
 
 	</dependencies>
 

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/PojoClusterExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/PojoClusterExample.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.examples.wordcount;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.examples.java.wordcount.util.WordCountData;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.ForkableFlinkMiniCluster;
+import org.apache.flink.util.Collector;
+
+/**
+ * This example shows an implementation of WordCount without using the Tuple2
+ * type, but a custom class.
+ *
+ * <p>
+ * Usage: <code>WordCount --input &lt;path&gt; --output &lt;path&gt;</code><br>
+ * If no parameters are provided, the program is run with default data from
+ * {@link WordCountData}.
+ *
+ * <p>
+ * This example shows how to:
+ * <ul>
+ * <li>use POJO data types,
+ * <li>write a simple Flink program,
+ * <li>write and use user-defined functions.
+ * </ul>
+ */
+public class PojoClusterExample {
+
+	// *************************************************************************
+	// PROGRAM
+	// *************************************************************************
+
+	public static void main(String[] args) throws Exception {
+
+		Configuration config = new Configuration();
+		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 4);
+		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 3);
+		config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 12);
+
+		ForkableFlinkMiniCluster cluster = new ForkableFlinkMiniCluster(config, false);
+		cluster.start();
+
+		// Checking input parameters
+		final ParameterTool params = ParameterTool.fromArgs(args);
+
+		// set up the execution environment
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost",
+			cluster.getLeaderRPCPort());
+		env.setParallelism(4);
+
+		// make parameters available in the web interface
+		env.getConfig().setGlobalJobParameters(params);
+
+		// get input data
+		DataStream<String> text;
+		if (params.has("input")) {
+			System.out.println("Executing WordCountPojo example with default input data set.");
+			System.out.println("Use --input to specify file input.");
+			// read the text file from given input path
+			text = env.readTextFile(params.get("input"));
+		} else {
+			// get default test text data
+			text = env.fromElements(WordCountData.WORDS);
+		}
+
+		DataStream<Word> counts =
+		// split up the lines into Word objects
+		text.flatMap(new Tokenizer())
+		// group by the field word and sum up the frequency
+				.keyBy("word").sum("frequency");
+
+		if (params.has("output")) {
+			counts.writeAsText(params.get("output"));
+		} else {
+			System.out.println("Printing result to stdout. Use --output to specify output path.");
+			counts.print();
+		}
+
+		// execute program
+		env.execute("WordCount Pojo Example");
+		cluster.stop();
+	}
+
+	// *************************************************************************
+	// DATA TYPES
+	// *************************************************************************
+
+	/**
+	 * This is the POJO (Plain Old Java Object) that is being used for all the
+	 * operations. As long as all fields are public or have a getter/setter, the
+	 * system can handle them
+	 */
+	public static class Word {
+
+		private String word;
+		private Integer frequency;
+
+		public Word() {
+		}
+
+		public Word(String word, int i) {
+			this.word = word;
+			this.frequency = i;
+		}
+
+		public String getWord() {
+			return word;
+		}
+
+		public void setWord(String word) {
+			this.word = word;
+		}
+
+		public Integer getFrequency() {
+			return frequency;
+		}
+
+		public void setFrequency(Integer frequency) {
+			this.frequency = frequency;
+		}
+
+		@Override
+		public String toString() {
+			return "(" + word + "," + frequency + ")";
+		}
+	}
+
+	// *************************************************************************
+	// USER FUNCTIONS
+	// *************************************************************************
+
+	/**
+	 * Implements the string tokenizer that splits sentences into words as a
+	 * user-defined FlatMapFunction. The function takes a line (String) and
+	 * splits it into multiple pairs in the form of "(word,1)" ({@code Tuple2<String,
+	 * Integer>}).
+	 */
+	public static final class Tokenizer implements FlatMapFunction<String, Word> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void flatMap(String value, Collector<Word> out) {
+			// normalize and split the line
+			String[] tokens = value.toLowerCase().split("\\W+");
+
+			// emit the pairs
+			for (String token : tokens) {
+				if (token.length() > 0) {
+					out.collect(new Word(token, 1));
+				}
+			}
+		}
+	}
+
+}

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/PojoClusterExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/PojoClusterExample.java
@@ -23,9 +23,9 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.examples.java.wordcount.util.WordCountData;
+import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.test.util.ForkableFlinkMiniCluster;
 import org.apache.flink.util.Collector;
 
 /**
@@ -58,7 +58,7 @@ public class PojoClusterExample {
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 3);
 		config.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 12);
 
-		ForkableFlinkMiniCluster cluster = new ForkableFlinkMiniCluster(config, false);
+		LocalFlinkMiniCluster cluster = new LocalFlinkMiniCluster(config, false);
 		cluster.start();
 
 		// Checking input parameters

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/IntValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/IntValueArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.graph.types.valuearray;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.IntValue;
@@ -30,7 +31,7 @@ import java.util.Random;
 public class IntValueArraySerializerTest extends SerializerTestBase<IntValueArray> {
 
 	@Override
-	protected TypeSerializer<IntValueArray> createSerializer() {
+	protected TypeSerializer<IntValueArray> createSerializer(ExecutionConfig executionConfig) {
 		return new IntValueArraySerializer();
 	}
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/LongValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/LongValueArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.graph.types.valuearray;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.LongValue;
@@ -30,7 +31,7 @@ import java.util.Random;
 public class LongValueArraySerializerTest extends SerializerTestBase<LongValueArray> {
 
 	@Override
-	protected TypeSerializer<LongValueArray> createSerializer() {
+	protected TypeSerializer<LongValueArray> createSerializer(ExecutionConfig executionConfig) {
 		return new LongValueArraySerializer();
 	}
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/NullValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/NullValueArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.graph.types.valuearray;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.NullValue;
@@ -28,7 +29,7 @@ import org.apache.flink.types.NullValue;
 public class NullValueArraySerializerTest extends SerializerTestBase<NullValueArray> {
 
 	@Override
-	protected TypeSerializer<NullValueArray> createSerializer() {
+	protected TypeSerializer<NullValueArray> createSerializer(ExecutionConfig executionConfig) {
 		return new NullValueArraySerializer();
 	}
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/StringValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/StringValueArraySerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.graph.types.valuearray;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.StringValue;
@@ -30,7 +31,7 @@ import java.util.Random;
 public class StringValueArraySerializerTest extends SerializerTestBase<StringValueArray> {
 
 	@Override
-	protected TypeSerializer<StringValueArray> createSerializer() {
+	protected TypeSerializer<StringValueArray> createSerializer(ExecutionConfig executionConfig) {
 		return new StringValueArraySerializer();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -70,6 +70,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TaskStateHandles;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.SerializedValue;
 
 import org.apache.flink.util.WrappingRuntimeException;
@@ -867,6 +868,7 @@ public class Task implements Runnable, TaskActions {
 		if (userCodeClassLoader == null) {
 			throw new Exception("No user code classloader available.");
 		}
+		InstantiationUtil.invalidateGeneratedClassesCache();
 		return userCodeClassLoader;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple1;
@@ -78,7 +79,7 @@ public class JavaSerializerTest extends SerializerTestBase<Serializable> {
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected TypeSerializer<Serializable> createSerializer() {
+	protected TypeSerializer<Serializable> createSerializer(ExecutionConfig executionConfig) {
 		Thread.currentThread().setContextClassLoader(CLASS_LOADER);
 		return new JavaSerializer<>();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TypeInformationSerializationSchemaTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TypeInformationSerializationSchemaTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.streaming.util.serialization.TypeInformationSerializationSchema;
 
+import org.apache.flink.util.InstantiationUtil;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -70,7 +71,7 @@ public class TypeInformationSerializationSchemaTest {
 					new TypeInformationSerializationSchema<MyPOJO>(info, new ExecutionConfig());
 
 			// this needs to succeed
-			CommonTestUtils.createCopySerializable(schema);
+			InstantiationUtil.clone(schema);
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/PojoClusterExample.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/PojoClusterExample.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.examples.wordcount;
+package org.apache.flink.test.manual;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -30,7 +30,7 @@ import org.apache.flink.util.Collector;
 
 /**
  * This example shows an implementation of WordCount without using the Tuple2
- * type, but a custom class.
+ * type, but a custom class. This test also enables code generation for the custom class.
  *
  * <p>
  * Usage: <code>WordCount --input &lt;path&gt; --output &lt;path&gt;</code><br>
@@ -71,6 +71,7 @@ public class PojoClusterExample {
 
 		// make parameters available in the web interface
 		env.getConfig().setGlobalJobParameters(params);
+		env.getConfig().enableCodeGeneration();
 
 		// get input data
 		DataStream<String> text;

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/PojoSerializationPerformanceTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/PojoSerializationPerformanceTest.java
@@ -1,0 +1,261 @@
+package org.apache.flink.test.manual;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.disk.RandomAccessInputView;
+import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
+import org.apache.flink.runtime.memory.ListMemorySegmentSource;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+
+
+public class PojoSerializationPerformanceTest {
+	public static final class TestPojo {
+		public int key;
+		public long value;
+	}
+
+	private static final int SEGMENT_SIZE = 1024*1024;
+
+
+	public static class TestDataOutputView implements DataOutputView {
+		private byte[] buffer;
+
+		public TestDataOutputView(int size) {
+			buffer = new byte[1];
+		}
+
+		public void clear() {
+		}
+
+		public byte[] getBuffer() {
+			return buffer;
+		}
+
+		public void checkSize(int numBytes) throws EOFException {
+		}
+
+		@Override
+		public void skipBytesToWrite(int numBytes) throws IOException {
+			checkSize(numBytes);
+		}
+
+		@Override
+		public void write(DataInputView source, int numBytes) throws IOException {
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+		}
+
+		@Override
+		public void write(byte[] b) throws IOException {
+		}
+
+		@Override
+		public void write(byte[] b, int off, int len) throws IOException {
+		}
+
+		@Override
+		public void writeBoolean(boolean v) throws IOException {
+		}
+
+		@Override
+		public void writeByte(int v) throws IOException {
+		}
+
+		@Override
+		public void writeShort(int v) throws IOException {
+		}
+
+		@Override
+		public void writeChar(int v) throws IOException {
+		}
+
+		@Override
+		public void writeInt(int v) throws IOException {
+		}
+
+		@Override
+		public void writeLong(long v) throws IOException {
+		}
+
+		@Override
+		public void writeFloat(float v) throws IOException {
+		}
+
+		@Override
+		public void writeDouble(double v) throws IOException {
+		}
+
+		@Override
+		public void writeBytes(String s) throws IOException {
+		}
+
+		@Override
+		public void writeChars(String s) throws IOException {
+		}
+
+		@Override
+		public void writeUTF(String s) throws IOException {
+		}
+	}
+
+	public static class TestDataInputView implements DataInputView {
+
+		public TestDataInputView() {
+		}
+
+		@Override
+		public boolean readBoolean() throws IOException {
+			return true;
+		}
+
+		@Override
+		public byte readByte() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public char readChar() throws IOException {
+			return 'c';
+		}
+
+		@Override
+		public double readDouble() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public float readFloat() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public void readFully(byte[] b) throws IOException {
+			readFully(b, 0, b.length);
+		}
+
+		@Override
+		public void readFully(byte[] b, int off, int len) throws IOException {
+			for(int j = off; j < len; ++j) {
+				b[j] = 0;
+			}
+		}
+
+		@Override
+		public int readInt() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public String readLine() throws IOException {
+			return "";
+		}
+
+		@Override
+		public long readLong() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public short readShort() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public String readUTF() throws IOException {
+			return "";
+		}
+
+		@Override
+		public int readUnsignedByte() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public int readUnsignedShort() throws IOException {
+			return 0;
+		}
+
+		@Override
+		public int skipBytes(int n) throws IOException {
+			return n;
+		}
+
+		@Override
+		public void skipBytesToRead(int numBytes) throws IOException {
+		}
+
+		@Override
+		public int read(byte[] b, int off, int len) throws IOException {
+			for(int j = off; j < len; ++j) {
+				b[j] = 0;
+			}
+			return len - off;
+		}
+
+		@Override
+		public int read(byte[] b) throws IOException {
+			return read(b, 0, b.length);
+		}
+	}
+
+	private static ArrayList<MemorySegment> getMemory(int numSegments, int segmentSize) {
+		ArrayList<MemorySegment> list = new ArrayList<MemorySegment>(numSegments);
+		for (int i = 0; i < numSegments; i++) {
+			list.add(MemorySegmentFactory.allocateUnpooledSegment(segmentSize));
+		}
+		return list;
+	}
+
+	public static void main(String[] args) throws Exception {
+		TypeInformation<TestPojo> testPojoTypeInfo = TypeInformation.of(TestPojo.class);
+		ExecutionConfig config = new ExecutionConfig();
+		config.disableCodeGeneration();
+		TypeSerializer<TestPojo> originalSerializer = testPojoTypeInfo.createSerializer(config);
+		System.out.println(originalSerializer.getClass().getCanonicalName());
+		config.enableCodeGeneration();
+		TypeSerializer<TestPojo> generatedSerializer = testPojoTypeInfo.createSerializer(config);
+		System.out.println(generatedSerializer.getClass().getCanonicalName());
+
+		ArrayList<MemorySegment> segments = getMemory(2500, SEGMENT_SIZE);
+		ListMemorySegmentSource segmentSource = new ListMemorySegmentSource(segments);
+		SimpleCollectingOutputView outputView = new SimpleCollectingOutputView(segments, segmentSource, SEGMENT_SIZE);
+		RandomAccessInputView inputView = new RandomAccessInputView(segments, SEGMENT_SIZE);
+		TestDataInputView mockedInput = new TestDataInputView();
+		TestDataOutputView mockedOutput = new TestDataOutputView(5);
+		TestPojo obj = new TestPojo();
+		TestPojo reuse = new TestPojo();
+		for (int j = 0; j < 10000; ++j) {
+			obj.key = 0;
+			obj.value = obj.key*2;
+			testPerformance(obj, reuse, mockedOutput, mockedInput, originalSerializer, 100);
+		}
+		long start = System.currentTimeMillis();
+		for (int j = 0; j < 100; ++j) {
+			obj.key = 0;
+			obj.value = obj.key*2;
+			testPerformance(obj, reuse, mockedOutput, mockedInput, originalSerializer, 1000000);
+		}
+		long end = System.currentTimeMillis();
+		System.out.println("### Total time: " + (end - start) + "");
+	}
+
+	static void testPerformance(TestPojo obj, TestPojo reuse, DataOutputView outputView, DataInputView inputView,
+	                     TypeSerializer<TestPojo> serializer, int num) throws IOException {
+		for (int i = 0; i < num; ++i) {
+			serializer.serialize(obj, outputView);
+			obj = serializer.deserialize(inputView);
+			obj.key++;
+			obj.value = obj.key*2;
+		}
+	}
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
@@ -153,17 +153,19 @@ class ScalaSpecialTypesSerializerTestInstance[T](
   @Test
   override def testInstantiate(): Unit = {
     try {
-      val serializer: TypeSerializer[T] = getSerializer
-      if (!serializer.isInstanceOf[KryoSerializer[_]]) {
-        // kryo serializer does return null, so only test for non-kryo-serializers
-        val instance: T = serializer.createInstance
-        assertNotNull("The created instance must not be null.", instance)
+      val serializers: Array[TypeSerializer[T]] = getSerializers
+      for (serializer <- serializers) {
+        if (!serializer.isInstanceOf[KryoSerializer[_]]) {
+          // kryo serializer does return null, so only test for non-kryo-serializers
+          val instance: T = serializer.createInstance
+          assertNotNull("The created instance must not be null.", instance)
+        }
+        val tpe: Class[T] = getTypeClass
+        assertNotNull("The test is corrupt: type class is null.", tpe)
+        // We cannot check this because Collection Instances are not always of the type
+        // that the user writes, they might have generated names.
+        // assertEquals("Type of the instantiated object is wrong.", tpe, instance.getClass)
       }
-      val tpe: Class[T] = getTypeClass
-      assertNotNull("The test is corrupt: type class is null.", tpe)
-      // We cannot check this because Collection Instances are not always of the type
-      // that the user writes, they might have generated names.
-      // assertEquals("Type of the instantiated object is wrong.", tpe, instance.getClass)
     }
     catch {
       case e: Exception => {

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTestInstance.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTestInstance.scala
@@ -34,14 +34,16 @@ class TupleSerializerTestInstance[T <: Product] (
   @Test
   override def testInstantiate(): Unit = {
     try {
-      val serializer: TypeSerializer[T] = getSerializer
-      val instance: T = serializer.createInstance
-      assertNotNull("The created instance must not be null.", instance)
-      val tpe: Class[T] = getTypeClass
-      assertNotNull("The test is corrupt: type class is null.", tpe)
-      // We cannot check this because Tuple1 instances are not actually of type Tuple1
-      // but something like Tuple1$mcI$sp
-//      assertEquals("Type of the instantiated object is wrong.", tpe, instance.getClass)
+      val serializers: Array[TypeSerializer[T]] = getSerializers
+      for (serializer <- serializers) {
+        val instance: T = serializer.createInstance
+        assertNotNull("The created instance must not be null.", instance)
+        val tpe: Class[T] = getTypeClass
+        assertNotNull("The test is corrupt: type class is null.", tpe)
+        // We cannot check this because Tuple1 instances are not actually of type Tuple1
+        // but something like Tuple1$mcI$sp
+        //      assertEquals("Type of the instantiated object is wrong.", tpe, instance.getClass)
+      }
     }
     catch {
       case e: Exception => {


### PR DESCRIPTION
The current implementation of the serializers can be a
performance bottleneck in some scenarios. These performance problems were
also reported on the mailing list recently [1].

E.g. the PojoSerializer uses reflection for accessing the fields, which is slow [2].

For the complete proposal see [3].

This pull request implements code generation support for PojoComparators and PojoSerializers. On my machine I could measure about 10% performance improvements for the WordCountPojo example. This pull request does not implement distribution of the generated code to the task managers yet.

[1] http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/Tuple-performance-and-the-curious-JIT-compiler-td10666.html

[2] https://github.com/apache/flink/blob/master/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java#L369

[3] https://docs.google.com/document/d/1VC8lCeErx9kI5lCMPiUn625PO0rxR-iKlVqtt3hkVnk
