### PR TITLE
[FLINK-4171] [metrics] Replace : chars in StatsD metric names

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
@@ -43,7 +43,7 @@ public abstract class AbstractReporter implements MetricReporter {
 
 	@Override
 	public void notifyOfAddedMetric(Metric metric, String metricName, AbstractMetricGroup group) {
-		final String name = group.getScopeString() + '.' + metricName;
+		final String name = replaceInvalidChars(group.getScopeString() + '.' + metricName);
 
 		synchronized (this) {
 			if (metric instanceof Counter) {
@@ -73,5 +73,15 @@ public abstract class AbstractReporter implements MetricReporter {
 					"does not support this metric type.", metric.getClass().getName());
 			}
 		}
+	}
+
+	/**
+	 * Can be overridden by sub-classes to replace invalid characters in metric name.
+	 *
+	 * @param metricName Name of the metric
+	 * @return The metric name to register the metric under
+	 */
+	protected String replaceInvalidChars(String metricName) {
+		return metricName;
 	}
 }

--- a/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
+++ b/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
@@ -71,6 +71,8 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 
 		this.address = new InetSocketAddress(host, port);
 
+		LOG.info("Starting StatsDReporter to send metric reports to " + address);
+
 //		String conversionRate = config.getString(ARG_CONVERSION_RATE, "SECONDS");
 //		String conversionDuration = config.getString(ARG_CONVERSION_DURATION, "MILLISECONDS");
 //		this.rateFactor = TimeUnit.valueOf(conversionRate).toSeconds(1);
@@ -121,6 +123,33 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 			// ignore - may happen when metrics are concurrently added or removed
 			// report next time
 		}
+	}
+
+	@Override
+	protected String replaceInvalidChars(String metricName) {
+		char[] chars = null;
+		final int strLen = metricName.length();
+		int pos = 0;
+
+		for (int i = 0; i < strLen; i++) {
+			final char c = metricName.charAt(i);
+			switch (c) {
+				case ':':
+					if (chars == null) {
+						chars = metricName.toCharArray();
+					}
+					chars[pos++] = '-';
+					break;
+
+				default:
+					if (chars != null) {
+						chars[pos] = c;
+					}
+					pos++;
+			}
+		}
+
+		return chars == null ? metricName : new String(chars, 0, pos);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -27,6 +27,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
@@ -38,6 +40,19 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.assertEquals;
 
 public class StatsDReporterTest extends TestLogger {
+
+	@Test
+	public void testReplaceInvalidChars() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		StatsDReporter reporter = new StatsDReporter();
+
+		Class<? extends StatsDReporter> clazz = reporter.getClass();
+
+		Method m = clazz.getDeclaredMethod("replaceInvalidChars", String.class);
+
+		assertEquals("", m.invoke(reporter, ""));
+		assertEquals("abc", m.invoke(reporter, "abc"));
+		assertEquals("a-b--", m.invoke(reporter, "a:b::"));
+	}
 
 	/**
 	 * Tests that histograms are properly reported via the StatsD reporter


### PR DESCRIPTION
The StatsD server rejects metrics whose names contain the : character. Therefore,
metric names which contain : chars will be altered so that : is replaced by -.

R @zentol 