### PR TITLE
[FLINK-4176][kinesis-connector] Remove Java8-specific 'Long.hashCode()' method from Kinesis connector

### DIFF
--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/SequenceNumber.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/model/SequenceNumber.java
@@ -57,7 +57,7 @@ public class SequenceNumber implements Serializable {
 		this.sequenceNumber = checkNotNull(sequenceNumber);
 		this.subSequenceNumber = subSequenceNumber;
 
-		this.cachedHash = 37 * (sequenceNumber.hashCode() + Long.hashCode(subSequenceNumber));
+		this.cachedHash = 37 * (sequenceNumber.hashCode() + Long.valueOf(subSequenceNumber).hashCode());
 	}
 
 	public boolean isAggregated() {


### PR DESCRIPTION
Causing the Travis builds with JDK: openjdk7 to fail. Changed to non Java8 specific usage.