### PR TITLE
[FLINK-4143][metrics] Configurable delimiter

### DIFF
--- a/docs/apis/metrics.md
+++ b/docs/apis/metrics.md
@@ -162,6 +162,8 @@ public class MyMapper extends RichMapFunction<Long, Integer> {
 Every metric is assigned an identifier under which it will be reported that is based on 3 components: the user-provided name when registering the metric, an optional user-defined scope and a system-provided scope.
 For example, if `A.B` is the sytem scope, `C.D` the user scope and `E` the name, then the identifier for the metric will be `A.B.C.D.E`.
 
+You can configure which delimiter to use for the identifier (default: `.`) by setting the `metrics.scope.delimiter` key in `conf/flink-conf.yaml`.
+
 ### User Scope
 
 You can define a user scope by calling either `MetricGroup#addGroup(String name)` or `MetricGroup#addGroup(int name)`.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -639,6 +639,9 @@ public final class ConfigConstants {
 	/** The interval between reports. */
 	public static final String METRICS_REPORTER_INTERVAL = "metrics.reporter.interval";
 
+	/** The delimiter used to assemble the metric identifier. */
+	public static final String METRICS_SCOPE_DELIMITER = "metrics.scope.delimiter";
+
 	/** The scope format string that is applied to all metrics scoped to a JobManager. */
 	public static final String METRICS_SCOPE_NAMING_JM = "metrics.scope.jm";
 

--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
@@ -49,6 +49,8 @@ public class MetricRegistry {
 
 	private final ScopeFormats scopeFormats;
 
+	private final char delimiter;
+
 	/**
 	 * Creates a new MetricRegistry and starts the configured reporter.
 	 */
@@ -63,6 +65,15 @@ public class MetricRegistry {
 			scopeFormats = new ScopeFormats();
 		}
 		this.scopeFormats = scopeFormats;
+
+		char delim;
+		try {
+			delim = config.getString(ConfigConstants.METRICS_SCOPE_DELIMITER, ".").charAt(0);
+		} catch (Exception e) {
+			LOG.warn("Failed to parse delimiter, using default delimiter.", e);
+			delim = '.';
+		}
+		this.delimiter = delim;
 
 		// second, instantiate any custom configured reporters
 		
@@ -116,6 +127,10 @@ public class MetricRegistry {
 			this.reporter = reporter;
 			this.executor = executor;
 		}
+	}
+
+	public char getDelimiter() {
+		return this.delimiter;
 	}
 
 	private static JMXReporter startJmxReporter(Configuration config) {

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
@@ -87,24 +87,23 @@ public abstract class AbstractMetricGroup implements MetricGroup {
 	/**
 	 * Gets the scope as an array of the scope components, for example
 	 * {@code ["host-7", "taskmanager-2", "window_word_count", "my-mapper"]}
-	 * 
-	 * @see #getScopeString() 
 	 */
 	public String[] getScopeComponents() {
 		return scopeComponents;
 	}
 
 	/**
-	 * Gets the scope as a single delimited string, for example
-	 * {@code "host-7.taskmanager-2.window_word_count.my-mapper"}
-	 *
-	 * @see #getScopeComponents()
-	 */
-	public String getScopeString() {
+	 * Returns the fully qualified metric name, for example
+	 * {@code "host-7.taskmanager-2.window_word_count.my-mapper.metricName"}
+	 * 
+	 * @param metricName metric name
+	 * @return fully qualified metric name
+     */
+	public String getMetricIdentifier(String metricName) {
 		if (scopeString == null) {
-			scopeString = ScopeFormat.concat(scopeComponents);
+			scopeString = ScopeFormat.concat(registry.getDelimiter(), scopeComponents);
 		}
-		return scopeString;
+		return scopeString + registry.getDelimiter() + metricName;
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/scope/ScopeFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/scope/ScopeFormat.java
@@ -428,10 +428,14 @@ public abstract class ScopeFormat {
 	}
 
 	public static String concat(String... components) {
+		return concat('.', components);
+	}
+
+	public static String concat(Character delimiter, String... components) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(components[0]);
 		for (int x = 1; x < components.length; x++) {
-			sb.append(SCOPE_SEPARATOR);
+			sb.append(delimiter);
 			sb.append(components[x]);
 		}
 		return sb.toString();

--- a/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
@@ -43,7 +43,7 @@ public abstract class AbstractReporter implements MetricReporter {
 
 	@Override
 	public void notifyOfAddedMetric(Metric metric, String metricName, AbstractMetricGroup group) {
-		final String name = replaceInvalidChars(group.getScopeString() + '.' + metricName);
+		final String name = replaceInvalidChars(group.getMetricIdentifier(metricName));
 
 		synchronized (this) {
 			if (metric instanceof Counter) {

--- a/flink-core/src/test/java/org/apache/flink/metrics/MetricRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/MetricRegistryTest.java
@@ -30,7 +30,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MetricRegistryTest extends TestLogger {
 	
@@ -175,5 +176,19 @@ public class MetricRegistryTest extends TestLogger {
 		assertEquals("B", scopeConfig.getTaskManagerJobFormat().format());
 		assertEquals("C", scopeConfig.getTaskFormat().format());
 		assertEquals("D", scopeConfig.getOperatorFormat().format());
+	}
+
+	@Test
+	public void testConfigurableDelimiter() {
+		Configuration config = new Configuration();
+		config.setString(ConfigConstants.METRICS_SCOPE_DELIMITER, "_");
+		config.setString(ConfigConstants.METRICS_SCOPE_NAMING_TM, "A.B.C.D.E");
+
+		MetricRegistry registry = new MetricRegistry(config);
+
+		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "host", "id");
+		assertEquals("A_B_C_D_E_name", tmGroup.getMetricIdentifier("name"));
+
+		registry.shutdown();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/JobManagerGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/JobManagerGroupTest.java
@@ -93,7 +93,7 @@ public class JobManagerGroupTest {
 		JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
 
 		assertArrayEquals(new String[]{"localhost", "jobmanager"}, group.getScopeComponents());
-		assertEquals("localhost.jobmanager", group.getScopeString());
+		assertEquals("localhost.jobmanager.name", group.getMetricIdentifier("name"));
 	}
 
 	@Test
@@ -103,6 +103,6 @@ public class JobManagerGroupTest {
 		JobManagerMetricGroup group = new JobManagerMetricGroup(registry, format, "host");
 
 		assertArrayEquals(new String[]{"constant", "host", "foo", "host"}, group.getScopeComponents());
-		assertEquals("constant.host.foo.host", group.getScopeString());
+		assertEquals("constant.host.foo.host.name", group.getMetricIdentifier("name"));
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/JobManagerJobGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/JobManagerJobGroupTest.java
@@ -42,8 +42,8 @@ public class JobManagerJobGroupTest {
 				jmGroup.getScopeComponents());
 
 		assertEquals(
-				"theHostName.jobmanager.myJobName",
-				jmGroup.getScopeString());
+				"theHostName.jobmanager.myJobName.name",
+				jmGroup.getMetricIdentifier("name"));
 	}
 
 	@Test
@@ -63,8 +63,8 @@ public class JobManagerJobGroupTest {
 				jmGroup.getScopeComponents());
 
 		assertEquals(
-				"some-constant.myJobName",
-				jmGroup.getScopeString());
+				"some-constant.myJobName.name",
+				jmGroup.getMetricIdentifier("name"));
 	}
 
 	@Test
@@ -84,7 +84,7 @@ public class JobManagerJobGroupTest {
 				jmGroup.getScopeComponents());
 
 		assertEquals(
-				"peter.some-constant." + jid,
-				jmGroup.getScopeString());
+				"peter.some-constant." + jid + ".name",
+				jmGroup.getMetricIdentifier("name"));
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/OperatorGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/OperatorGroupTest.java
@@ -45,8 +45,8 @@ public class OperatorGroupTest {
 				opGroup.getScopeComponents());
 
 		assertEquals(
-				"theHostName.taskmanager.test-tm-id.myJobName.myOpName.11",
-				opGroup.getScopeString());
+				"theHostName.taskmanager.test-tm-id.myJobName.myOpName.11.name",
+				opGroup.getMetricIdentifier("name"));
 
 		registry.shutdown();
 	}

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskGroupTest.java
@@ -68,8 +68,8 @@ public class TaskGroupTest {
 				taskGroup.getScopeComponents());
 
 		assertEquals(
-				"theHostName.taskmanager.test-tm-id.myJobName.aTaskName.13",
-				taskGroup.getScopeString());
+				"theHostName.taskmanager.test-tm-id.myJobName.aTaskName.13.name",
+				taskGroup.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 
@@ -95,8 +95,8 @@ public class TaskGroupTest {
 				taskGroup.getScopeComponents());
 
 		assertEquals(
-				String.format("test-tm-id.%s.%s.%s", jid, vertexId, executionId),
-				taskGroup.getScopeString());
+				String.format("test-tm-id.%s.%s.%s.name", jid, vertexId, executionId),
+				taskGroup.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 
@@ -124,8 +124,8 @@ public class TaskGroupTest {
 				taskGroup.getScopeComponents());
 
 		assertEquals(
-				"theHostName.taskmanager.test-tm-id.myJobName." + executionId + ".13",
-				taskGroup.getScopeString());
+				"theHostName.taskmanager.test-tm-id.myJobName." + executionId + ".13.name",
+				taskGroup.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskManagerGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskManagerGroupTest.java
@@ -137,7 +137,7 @@ public class TaskManagerGroupTest {
 		TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, "localhost", "id");
 
 		assertArrayEquals(new String[] { "localhost", "taskmanager", "id" }, group.getScopeComponents());
-		assertEquals("localhost.taskmanager.id", group.getScopeString());
+		assertEquals("localhost.taskmanager.id.name", group.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 
@@ -148,7 +148,7 @@ public class TaskManagerGroupTest {
 		TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, format, "host", "id");
 
 		assertArrayEquals(new String[] { "constant", "host", "foo", "host" }, group.getScopeComponents());
-		assertEquals("constant.host.foo.host", group.getScopeString());
+		assertEquals("constant.host.foo.host.name", group.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskManagerJobGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/groups/TaskManagerJobGroupTest.java
@@ -43,8 +43,8 @@ public class TaskManagerJobGroupTest {
 				jmGroup.getScopeComponents());
 
 		assertEquals(
-				"theHostName.taskmanager.test-tm-id.myJobName",
-				jmGroup.getScopeString());
+				"theHostName.taskmanager.test-tm-id.myJobName.name",
+				jmGroup.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 
@@ -65,8 +65,8 @@ public class TaskManagerJobGroupTest {
 				jmGroup.getScopeComponents());
 
 		assertEquals(
-				"some-constant.myJobName",
-				jmGroup.getScopeString());
+				"some-constant.myJobName.name",
+				jmGroup.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 
@@ -87,8 +87,8 @@ public class TaskManagerJobGroupTest {
 				jmGroup.getScopeComponents());
 
 		assertEquals(
-				"peter.test-tm-id.some-constant." + jid,
-				jmGroup.getScopeString());
+				"peter.test-tm-id.some-constant." + jid + ".name",
+				jmGroup.getMetricIdentifier("name"));
 		registry.shutdown();
 	}
 }

--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -93,7 +93,7 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 
 	@Override
 	public void notifyOfAddedMetric(Metric metric, String metricName, AbstractMetricGroup group) {
-		final String fullName = group.getScopeString() + '.' + metricName;
+		final String fullName = group.getMetricIdentifier(metricName);
 
 		synchronized (this) {
 			if (metric instanceof Counter) {

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
@@ -109,7 +109,7 @@ public class DropwizardFlinkHistogramWrapperTest extends TestLogger {
 
 			metricGroup.histogram(histogramMetricName, histogramWrapper);
 
-			String fullMetricName = metricGroup.getScopeString() + "." + histogramMetricName;
+			String fullMetricName = metricGroup.getMetricIdentifier(histogramMetricName);
 
 			Field f = registry.getClass().getDeclaredField("reporter");
 			f.setAccessible(true);

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -94,7 +94,7 @@ public class StatsDReporterTest extends TestLogger {
 
 			Set<String> lines = receiver.getLines();
 
-			String prefix = metricGroup.getScopeString() + "." + histogramName;
+			String prefix = metricGroup.getMetricIdentifier(histogramName);
 
 			Set<String> expectedLines = new HashSet<>();
 


### PR DESCRIPTION
This PR makes the scope identifier delimiter configurable.

* A new config Key "metrics.scope.delimiter" was added that is extracted in the MetricRegistry. 
* A new method `getDelimiter()` was added to the MetricRegistry so that groups can access it.
* The static concat() method now takes a delimiter argument.
* ~~The String returned by getScopeString() now always ends in the delimiter. (so that Reporters don't require access to the delimiter)~~