### PR TITLE
[FLINK-4184] [metrics] Replace invalid characters in ScheduledDropwizardReporter

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/metrics/CharacterFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/CharacterFilter.java
@@ -16,29 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.metrics.util;
+package org.apache.flink.metrics;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.metrics.Metric;
-import org.apache.flink.metrics.groups.AbstractMetricGroup;
-import org.apache.flink.metrics.reporter.AbstractReporter;
+/**
+ * Interface for a character filter function. The filter function is given a string which the filter
+ * can transform. The returned string is the transformation result.
+ */
+public interface CharacterFilter {
 
-public class TestReporter extends AbstractReporter {
-
-	@Override
-	public void open(Configuration config) {}
-
-	@Override
-	public void close() {}
-
-	@Override
-	public void notifyOfAddedMetric(Metric metric, String metricName, AbstractMetricGroup group) {}
-
-	@Override
-	public void notifyOfRemovedMetric(Metric metric, String metricName, AbstractMetricGroup group) {}
-
-	@Override
-	public String filterCharacters(String input) {
-		return input;
-	}
+	/**
+	 * Filter the given string and generate a resulting string from it.
+	 *
+	 * For example, one implementation could filter out invalid characters from the input string.
+	 *
+	 * @param input Input string
+	 * @return Filtered result string
+	 */
+	String filterCharacters(String input);
 }

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
@@ -109,12 +109,14 @@ public abstract class AbstractMetricGroup implements MetricGroup {
 	 * {@code "host-7.taskmanager-2.window_word_count.my-mapper.metricName"}
 	 *
 	 * @param metricName metric name
-	 * @param filter character filter which is applied to the fully qualified metric name
+	 * @param filter character filter which is applied to the scope components if not null.
 	 * @return fully qualified metric name
 	 */
 	public String getMetricIdentifier(String metricName, CharacterFilter filter) {
 		if (scopeString == null) {
 			if (filter != null) {
+				scopeString = ScopeFormat.concat(filter, registry.getDelimiter(), scopeComponents);
+			} else {
 				scopeString = ScopeFormat.concat(registry.getDelimiter(), scopeComponents);
 			}
 		}

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/AbstractMetricGroup.java
@@ -19,6 +19,7 @@
 package org.apache.flink.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
@@ -100,10 +101,29 @@ public abstract class AbstractMetricGroup implements MetricGroup {
 	 * @return fully qualified metric name
      */
 	public String getMetricIdentifier(String metricName) {
+		return getMetricIdentifier(metricName, null);
+	}
+
+	/**
+	 * Returns the fully qualified metric name, for example
+	 * {@code "host-7.taskmanager-2.window_word_count.my-mapper.metricName"}
+	 *
+	 * @param metricName metric name
+	 * @param filter character filter which is applied to the fully qualified metric name
+	 * @return fully qualified metric name
+	 */
+	public String getMetricIdentifier(String metricName, CharacterFilter filter) {
 		if (scopeString == null) {
-			scopeString = ScopeFormat.concat(registry.getDelimiter(), scopeComponents);
+			if (filter != null) {
+				scopeString = ScopeFormat.concat(registry.getDelimiter(), scopeComponents);
+			}
 		}
-		return scopeString + registry.getDelimiter() + metricName;
+
+		if (filter != null) {
+			return scopeString + registry.getDelimiter() + filter.filterCharacters(metricName);
+		} else {
+			return scopeString + registry.getDelimiter() + metricName;
+		}
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/scope/ScopeFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/scope/ScopeFormat.java
@@ -436,27 +436,27 @@ public abstract class ScopeFormat {
 	}
 
 	public static String concat(String... components) {
-		return concat('.', defaultFilter, components);
+		return concat(defaultFilter, '.', components);
 	}
 
 	public static String concat(CharacterFilter filter, String... components) {
-		return concat('.', filter, components);
+		return concat(filter, '.', components);
 	}
 
 	public static String concat(Character delimiter, String... components) {
-		return concat(delimiter, defaultFilter, components);
+		return concat(defaultFilter, delimiter, components);
 	}
 
 	/**
 	 * Concatenates the given component names separated by the delimiter character. Additionally
 	 * the character filter is applied to all component names.
 	 *
-	 * @param delimiter Delimiter to separate component names
 	 * @param filter Character filter to be applied to the component names
+	 * @param delimiter Delimiter to separate component names
 	 * @param components Array of component names
 	 * @return The concatenated component name
 	 */
-	public static String concat(Character delimiter, CharacterFilter filter, String... components) {
+	public static String concat(CharacterFilter filter, Character delimiter, String... components) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(filter.filterCharacters(components[0]));
 		for (int x = 1; x < components.length; x++) {

--- a/flink-core/src/main/java/org/apache/flink/metrics/groups/scope/ScopeFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/groups/scope/ScopeFormat.java
@@ -19,6 +19,7 @@
 package org.apache.flink.metrics.groups.scope;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.metrics.groups.JobMetricGroup;
 import org.apache.flink.metrics.groups.TaskManagerJobMetricGroup;
@@ -44,6 +45,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * exclude it (continuity of the namespace across failure and recovery).
  */
 public abstract class ScopeFormat {
+
+	private static CharacterFilter defaultFilter = new CharacterFilter() {
+		@Override
+		public String filterCharacters(String input) {
+			return input;
+		}
+	};
 
 	// ------------------------------------------------------------------------
 	//  Scope Format Special Characters
@@ -428,15 +436,32 @@ public abstract class ScopeFormat {
 	}
 
 	public static String concat(String... components) {
-		return concat('.', components);
+		return concat('.', defaultFilter, components);
+	}
+
+	public static String concat(CharacterFilter filter, String... components) {
+		return concat('.', filter, components);
 	}
 
 	public static String concat(Character delimiter, String... components) {
+		return concat(delimiter, defaultFilter, components);
+	}
+
+	/**
+	 * Concatenates the given component names separated by the delimiter character. Additionally
+	 * the character filter is applied to all component names.
+	 *
+	 * @param delimiter Delimiter to separate component names
+	 * @param filter Character filter to be applied to the component names
+	 * @param components Array of component names
+	 * @return The concatenated component name
+	 */
+	public static String concat(Character delimiter, CharacterFilter filter, String... components) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(components[0]);
+		sb.append(filter.filterCharacters(components[0]));
 		for (int x = 1; x < components.length; x++) {
 			sb.append(delimiter);
-			sb.append(components[x]);
+			sb.append(filter.filterCharacters(components[x]));
 		}
 		return sb.toString();
 	}

--- a/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.metrics.reporter;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
@@ -34,7 +35,7 @@ import java.util.Map;
  * Base interface for custom metric reporters.
  */
 @PublicEvolving
-public abstract class AbstractReporter implements MetricReporter {
+public abstract class AbstractReporter implements MetricReporter, CharacterFilter {
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	protected final Map<Gauge<?>, String> gauges = new HashMap<>();
@@ -43,7 +44,7 @@ public abstract class AbstractReporter implements MetricReporter {
 
 	@Override
 	public void notifyOfAddedMetric(Metric metric, String metricName, AbstractMetricGroup group) {
-		final String name = replaceInvalidChars(group.getMetricIdentifier(metricName));
+		final String name = group.getMetricIdentifier(metricName, this);
 
 		synchronized (this) {
 			if (metric instanceof Counter) {
@@ -73,35 +74,5 @@ public abstract class AbstractReporter implements MetricReporter {
 					"does not support this metric type.", metric.getClass().getName());
 			}
 		}
-	}
-
-	/**
-	 * Can be overridden by sub-classes to replace invalid characters in metric name.
-	 *
-	 * @param metricName Name of the metric
-	 * @return The metric name to register the metric under
-	 */
-	protected String replaceInvalidChars(String metricName) {
-		return metricName;
-	}
-
-	/**
-	 * Method which constructs the fully qualified metric name from the metric group and the metric
-	 * name.
-	 *
-	 * @param metricName Name of the metric
-	 * @param group Associated metric group
-	 * @return Fully qualified metric name
-	 */
-	private String constructMetricName(String metricName, AbstractMetricGroup group) {
-		StringBuilder builder = new StringBuilder();
-
-		for (String componentName : group.getScopeComponents()) {
-			builder.append(replaceInvalidChars(componentName)).append(".");
-		}
-
-		builder.append(replaceInvalidChars(metricName));
-
-		return builder.toString();
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/reporter/AbstractReporter.java
@@ -84,4 +84,24 @@ public abstract class AbstractReporter implements MetricReporter {
 	protected String replaceInvalidChars(String metricName) {
 		return metricName;
 	}
+
+	/**
+	 * Method which constructs the fully qualified metric name from the metric group and the metric
+	 * name.
+	 *
+	 * @param metricName Name of the metric
+	 * @param group Associated metric group
+	 * @return Fully qualified metric name
+	 */
+	private String constructMetricName(String metricName, AbstractMetricGroup group) {
+		StringBuilder builder = new StringBuilder();
+
+		for (String componentName : group.getScopeComponents()) {
+			builder.append(replaceInvalidChars(componentName)).append(".");
+		}
+
+		builder.append(replaceInvalidChars(metricName));
+
+		return builder.toString();
+	}
 }

--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -75,6 +75,15 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 	}
 
 	// ------------------------------------------------------------------------
+	//  Getters
+	// ------------------------------------------------------------------------
+
+	// used for testing purposes
+	Map<Counter, String> getCounters() {
+		return counters;
+	}
+
+	// ------------------------------------------------------------------------
 	//  life cycle
 	// ------------------------------------------------------------------------
 

--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -140,6 +140,63 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 		}
 	}
 
+	/**
+	 * Can be overridden by sub-classes to replace invalid characters in metric name.
+	 *
+	 * @param metricName Name of the metric
+	 * @return The metric name to register the metric under
+	 */
+	protected String replaceInvalidChars(String metricName) {
+		char[] chars = null;
+		final int strLen = metricName.length();
+		int pos = 0;
+
+		for (int i = 0; i < strLen; i++) {
+			final char c = metricName.charAt(i);
+			switch (c) {
+				case '.':
+					if (chars == null) {
+						chars = metricName.toCharArray();
+					}
+					chars[pos++] = '-';
+					break;
+				case '"':
+					if (chars == null) {
+						chars = metricName.toCharArray();
+					}
+					break;
+
+				default:
+					if (chars != null) {
+						chars[pos] = c;
+					}
+					pos++;
+			}
+		}
+
+		return chars == null ? metricName : new String(chars, 0, pos);
+	}
+
+	/**
+	 * Method which constructs the fully qualified metric name from the metric group and the metric
+	 * name.
+	 *
+	 * @param metricName Name of the metric
+	 * @param group Associated metric group
+	 * @return Fully qualified metric name
+	 */
+	private String constructMetricName(String metricName, AbstractMetricGroup group) {
+		StringBuilder builder = new StringBuilder();
+
+		for (String componentName : group.getScopeComponents()) {
+			builder.append(replaceInvalidChars(componentName)).append(".");
+		}
+
+		builder.append(replaceInvalidChars(metricName));
+
+		return builder.toString();
+	}
+
 	// ------------------------------------------------------------------------
 	//  scheduled reporting
 	// ------------------------------------------------------------------------

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -19,12 +19,25 @@
 package org.apache.flink.dropwizard;
 
 import com.codahale.metrics.ScheduledReporter;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricRegistry;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.TaskManagerJobMetricGroup;
+import org.apache.flink.metrics.groups.TaskManagerMetricGroup;
+import org.apache.flink.metrics.groups.TaskMetricGroup;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.util.AbstractID;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ScheduledDropwizardReporterTest {
 
@@ -40,5 +53,72 @@ public class ScheduledDropwizardReporterTest {
 		assertEquals("abc", reporter.filterCharacters("abc"));
 		assertEquals("a--b-c-", reporter.filterCharacters("a..b.c."));
 		assertEquals("ab-c", reporter.filterCharacters("a\"b.c"));
+	}
+
+	/**
+	 * Tests that the registered metrics' names don't contain invalid characters.
+	 */
+	@Test
+	public void testAddingMetrics() throws NoSuchFieldException, IllegalAccessException {
+		Configuration configuration = new Configuration();
+		String taskName = "test\"Ta\"..sk";
+		String jobName = "testJ\"ob:-!ax..?";
+		String hostname = "loc<>al\"::host\".:";
+		String taskManagerId = "tas:kMana::ger";
+		String counterName = "testCounter";
+
+		configuration.setString(ConfigConstants.METRICS_REPORTER_CLASS, "org.apache.flink.dropwizard.ScheduledDropwizardReporterTest$TestingScheduledDropwizardReporter");
+		configuration.setString(ConfigConstants.METRICS_SCOPE_NAMING_TASK, "<host>.<tm_id>.<job_name>");
+		configuration.setString(ConfigConstants.METRICS_SCOPE_DELIMITER, "_");
+
+		MetricRegistry metricRegistry = new MetricRegistry(configuration);
+
+		char delimiter = metricRegistry.getDelimiter();
+
+		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(metricRegistry, hostname, taskManagerId);
+		TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(metricRegistry, tmMetricGroup, new JobID(), jobName);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new AbstractID(), new AbstractID(), taskName, 0, 0);
+
+		SimpleCounter myCounter = new SimpleCounter();
+
+		taskMetricGroup.counter(counterName, myCounter);
+
+		Field reporterField = MetricRegistry.class.getDeclaredField("reporter");
+		reporterField.setAccessible(true);
+
+		MetricReporter metricReporter = (MetricReporter) reporterField.get(metricRegistry);
+
+		assertTrue("Reporter should be of type ScheduledDropwizardReporter", metricReporter instanceof ScheduledDropwizardReporter);
+
+		TestingScheduledDropwizardReporter reporter = (TestingScheduledDropwizardReporter) metricReporter;
+
+		Map<Counter, String> counters = reporter.getCounters();
+
+		assertTrue(counters.containsKey(myCounter));
+
+		String expectedCounterName = reporter.filterCharacters(hostname)
+			+ delimiter
+			+ reporter.filterCharacters(taskManagerId)
+			+ delimiter
+			+ reporter.filterCharacters(jobName)
+			+ delimiter
+			+ reporter.filterCharacters(counterName);
+
+		assertEquals(expectedCounterName, counters.get(myCounter));
+
+		metricRegistry.shutdown();
+	}
+
+	public static class TestingScheduledDropwizardReporter extends ScheduledDropwizardReporter {
+
+		@Override
+		public ScheduledReporter getReporter(Configuration config) {
+			return null;
+		}
+
+		@Override
+		public void close() {
+			// don't do anything
+		}
 	}
 }

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import static org.junit.Assert.assertEquals;
 
@@ -38,12 +37,8 @@ public class ScheduledDropwizardReporterTest {
 			}
 		};
 
-		Class<? extends ScheduledDropwizardReporter> clazz = reporter.getClass();
-
-		Method method = clazz.getSuperclass().getDeclaredMethod("replaceInvalidChars", String.class);
-
-		assertEquals("abc", method.invoke(reporter, "abc"));
-		assertEquals("a--b-c-", method.invoke(reporter, "a..b.c."));
-		assertEquals("ab-c", method.invoke(reporter, "a\"b.c"));
+		assertEquals("abc", reporter.filterCharacters("abc"));
+		assertEquals("a--b-c-", reporter.filterCharacters("a..b.c."));
+		assertEquals("ab-c", reporter.filterCharacters("a\"b.c"));
 	}
 }

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.dropwizard;
+
+import com.codahale.metrics.ScheduledReporter;
+import org.apache.flink.configuration.Configuration;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScheduledDropwizardReporterTest {
+
+	@Test
+	public void testInvalidCharacterReplacement() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		ScheduledDropwizardReporter reporter = new ScheduledDropwizardReporter() {
+			@Override
+			public ScheduledReporter getReporter(Configuration config) {
+				return null;
+			}
+		};
+
+		Class<? extends ScheduledDropwizardReporter> clazz = reporter.getClass();
+
+		Method method = clazz.getSuperclass().getDeclaredMethod("replaceInvalidChars", String.class);
+
+		assertEquals("abc", method.invoke(reporter, "abc"));
+		assertEquals("a--b-c-", method.invoke(reporter, "a..b.c."));
+		assertEquals("ab-c", method.invoke(reporter, "a\"b.c"));
+	}
+}

--- a/flink-metrics/flink-metrics-ganglia/src/main/java/org/apache/flink/metrics/ganglia/GangliaReporter.java
+++ b/flink-metrics/flink-metrics-ganglia/src/main/java/org/apache/flink/metrics/ganglia/GangliaReporter.java
@@ -47,7 +47,7 @@ public class GangliaReporter extends ScheduledDropwizardReporter {
 				throw new IllegalArgumentException("Invalid host/port configuration. Host: " + host + " Port: " + port);
 			}
 			String addressingMode = config.getString(ARG_MODE_ADDRESSING, "MULTICAST");
-			int ttl = config.getInteger(ARG_TTL, -1);
+			int ttl = config.getInteger(ARG_TTL, 1);
 			GMetric gMetric = new GMetric(host, port, GMetric.UDPAddressingMode.valueOf(addressingMode), ttl);
 
 			String prefix = config.getString(ARG_PREFIX, null);

--- a/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
+++ b/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
@@ -125,33 +125,6 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 		}
 	}
 
-	@Override
-	protected String replaceInvalidChars(String metricName) {
-		char[] chars = null;
-		final int strLen = metricName.length();
-		int pos = 0;
-
-		for (int i = 0; i < strLen; i++) {
-			final char c = metricName.charAt(i);
-			switch (c) {
-				case ':':
-					if (chars == null) {
-						chars = metricName.toCharArray();
-					}
-					chars[pos++] = '-';
-					break;
-
-				default:
-					if (chars != null) {
-						chars[pos] = c;
-					}
-					pos++;
-			}
-		}
-
-		return chars == null ? metricName : new String(chars, 0, pos);
-	}
-
 	// ------------------------------------------------------------------------
 	
 	private void reportCounter(final String name, final Counter counter) {
@@ -209,5 +182,32 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 		catch (IOException e) {
 			LOG.error("unable to send packet to statsd at '{}:{}'", address.getHostName(), address.getPort());
 		}
+	}
+
+	@Override
+	public String filterCharacters(String input) {
+		char[] chars = null;
+		final int strLen = input.length();
+		int pos = 0;
+
+		for (int i = 0; i < strLen; i++) {
+			final char c = input.charAt(i);
+			switch (c) {
+				case ':':
+					if (chars == null) {
+						chars = input.toCharArray();
+					}
+					chars[pos++] = '-';
+					break;
+
+				default:
+					if (chars != null) {
+						chars[pos] = c;
+					}
+					pos++;
+			}
+		}
+
+		return chars == null ? input : new String(chars, 0, pos);
 	}
 }

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
@@ -46,13 +45,10 @@ public class StatsDReporterTest extends TestLogger {
 	public void testReplaceInvalidChars() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 		StatsDReporter reporter = new StatsDReporter();
 
-		Class<? extends StatsDReporter> clazz = reporter.getClass();
 
-		Method m = clazz.getDeclaredMethod("replaceInvalidChars", String.class);
-
-		assertEquals("", m.invoke(reporter, ""));
-		assertEquals("abc", m.invoke(reporter, "abc"));
-		assertEquals("a-b--", m.invoke(reporter, "a:b::"));
+		assertEquals("", reporter.filterCharacters(""));
+		assertEquals("abc", reporter.filterCharacters("abc"));
+		assertEquals("a-b--", reporter.filterCharacters("a:b::"));
 	}
 
 	/**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1812,7 +1812,7 @@ class JobManager(
     val garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans
 
     for (garbageCollector <- garbageCollectors.asScala) {
-      val gcGroup = metrics.addGroup("\"" + garbageCollector.getName + "\"")
+      val gcGroup = metrics.addGroup(garbageCollector.getName)
       gcGroup.gauge[Long, Gauge[Long]]("Count", new Gauge[Long] {
         override def getValue: Long = garbageCollector.getCollectionCount
       })

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -2305,7 +2305,7 @@ object TaskManager {
     val garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans
 
     for (garbageCollector <- garbageCollectors.asScala) {
-      val gcGroup = metrics.addGroup("\"" + garbageCollector.getName + "\"")
+      val gcGroup = metrics.addGroup(garbageCollector.getName)
       gcGroup.gauge[Long, FlinkGauge[Long]]("Count", new FlinkGauge[Long] {
         override def getValue: Long = garbageCollector.getCollectionCount
       })


### PR DESCRIPTION
The GraphiteReporter and GangliaReporter report metric names which can contain invalid
characters. These characters include quotes and dots. In order to properly report metrics
to these systems, the afore-mentioned characters have to be replaced in metric names.

The PR also removes quotes from the garbage collector metric name.

The PR sets the default value for TTL in the GangliaReporter to 1, because -1 causes the
reporter to fail.

R @zentol.