### PR TITLE
[FLINK-4154] [core] Correction of murmur hash breaks backwards compatibility

### DIFF
--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
@@ -49,9 +49,9 @@ public class StormFieldsGroupingITCase extends StreamingProgramTestBase {
 
 	@Override
 	protected void postSubmit() throws Exception {
-		compareResultsByLinesInMemory("4> -1155484576\n" + "3> 1033096058\n" + "3> -1930858313\n" +
-			"4> 1431162155\n" + "3> -1557280266\n" + "4> -1728529858\n" + "3> 1654374947\n" +
-			"3> -65105105\n" + "3> -518907128\n" + "4> -252332814\n", this.resultPath);
+		compareResultsByLinesInMemory("3> -1155484576\n" + "3> 1033096058\n" + "3> -1930858313\n" +
+			"3> 1431162155\n" + "4> -1557280266\n" + "4> -1728529858\n" + "4> 1654374947\n" +
+			"4> -65105105\n" + "4> -518907128\n" + "4> -252332814\n", this.resultPath);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
@@ -135,7 +135,10 @@ public final class MathUtils {
 		code *= 0x1b873593;
 
 		code = Integer.rotateLeft(code, 13);
-		code = code * 5 + 0xe6546b64;
+		// By the MurmurHash algorithm the following should be "code = code * 5 + 0xe6546b64;" (see FLINK-3623)
+		// but correcting the algorithm is a breaking change (see FLINK-4154). The effect of the resulting skew
+		// increases with increased parallelism (see FLINK-4154).
+		code *= 0xe6546b64;
 
 		code ^= 4;
 		code ^= code >>> 16;

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
@@ -74,8 +74,7 @@ class StreamingOperatorsITCase extends ScalaStreamingMultipleProgramsTestBase {
 
       override def run(ctx: SourceContext[(Int, Int)]): Unit = {
         0 until numElements foreach {
-          // keys '1' and '2' hash to different buckets
-          i => ctx.collect((1 + (MathUtils.murmurHash(i)) % numKeys, i))
+          i => ctx.collect((MathUtils.murmurHash(i) % numKeys, i))
         }
       }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/StreamingOperatorsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/StreamingOperatorsITCase.java
@@ -223,8 +223,7 @@ public class StreamingOperatorsITCase extends StreamingMultipleProgramsTestBase 
 		@Override
 		public void run(SourceContext<Tuple2<Integer, Integer>> ctx) throws Exception {
 			for (int i = 0; i < numElements; i++) {
-				// keys '1' and '2' hash to different buckets
-				Tuple2<Integer, Integer> result = new Tuple2<>(1 + (MathUtils.murmurHash(i) % numKeys), i);
+				Tuple2<Integer, Integer> result = new Tuple2<>(MathUtils.murmurHash(i) % numKeys, i);
 				ctx.collect(result);
 			}
 		}


### PR DESCRIPTION
Revert "[FLINK-3623] [runtime] Adjust MurmurHash Algorithm"

This reverts commit 641a0d436c9b7a34ff33ceb370cf29962cac4dee.