### PR TITLE
[FLINK-4197] Allow Kinesis endpoint to be overridden via config

### DIFF
--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -299,3 +299,41 @@ Otherwise, the returned stream name is used.
 Other optional configuration keys can be found in `KinesisConfigConstants`.
 		
 		
+### Using non-AWS Kinesis Endpoints
+
+It is sometimes desirable to have Flink operate as a consumer or producer against a non-AWS Kinesis endpoint such as kinesalite; this is especially useful when performing functional testing of a Flink application. The AWS endpoint that would normally be inferred by the AWS region set in the Flink configuration must be overriden via a configuration property.
+
+To override the AWS endpoint, set the `CONFIG_AWS_ENDPOINT` property in the Flink configuration, in addition to the `CONFIG_AWS_REGION` required by Flink. Although the region is required, it will not be used to determine the AWS endpoint URL.
+
+The following example shows how one might supply the `CONFIG_AWS_ENDPOINT` configuration property:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+Properties kinesisProducerConfig = new Properties();
+kinesisProducerConfig.put(KinesisConfigConstants.CONFIG_AWS_REGION, "us-east-1");
+kinesisProducerConfig.put(
+    KinesisConfigConstants.CONFIG_AWS_CREDENTIALS_PROVIDER_BASIC_ACCESSKEYID,
+    "aws_access_key_id_here");
+kinesisProducerConfig.put(
+    KinesisConfigConstants.CONFIG_AWS_CREDENTIALS_PROVIDER_BASIC_SECRETKEY,
+    "aws_secret_key_here");
+kinesisProducerConfig.put(
+    KinesisConfigConstants.CONFIG_AWS_ENDPOINT,
+    "http://localhost:4567");
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val kinesisProducerConfig = new Properties();
+kinesisProducerConfig.put(KinesisConfigConstants.CONFIG_AWS_REGION, "us-east-1");
+kinesisProducerConfig.put(
+    KinesisConfigConstants.CONFIG_AWS_CREDENTIALS_PROVIDER_BASIC_ACCESSKEYID,
+    "aws_access_key_id_here");
+kinesisProducerConfig.put(
+    KinesisConfigConstants.CONFIG_AWS_CREDENTIALS_PROVIDER_BASIC_SECRETKEY,
+    "aws_secret_key_here");
+kinesisProducerConfig.put(KinesisConfigConstants.CONFIG_AWS_ENDPOINT, "http://localhost:4567");
+{% endhighlight %}
+</div>
+</div>

--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -333,7 +333,9 @@ kinesisProducerConfig.put(
 kinesisProducerConfig.put(
     KinesisConfigConstants.CONFIG_AWS_CREDENTIALS_PROVIDER_BASIC_SECRETKEY,
     "aws_secret_key_here");
-kinesisProducerConfig.put(KinesisConfigConstants.CONFIG_AWS_ENDPOINT, "http://localhost:4567");
+kinesisProducerConfig.put(
+    KinesisConfigConstants.CONFIG_AWS_ENDPOINT,
+    "http://localhost:4567");
 {% endhighlight %}
 </div>
 </div>

--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -303,9 +303,9 @@ Other optional configuration keys can be found in `KinesisConfigConstants`.
 
 It is sometimes desirable to have Flink operate as a consumer or producer against a non-AWS Kinesis endpoint such as kinesalite; this is especially useful when performing functional testing of a Flink application. The AWS endpoint that would normally be inferred by the AWS region set in the Flink configuration must be overriden via a configuration property.
 
-To override the AWS endpoint, set the `CONFIG_AWS_ENDPOINT` property in the Flink configuration, in addition to the `CONFIG_AWS_REGION` required by Flink. Although the region is required, it will not be used to determine the AWS endpoint URL.
+To override the AWS endpoint, set the `KinesisConfigConstants.CONFIG_AWS_ENDPOINT` property in the Flink configuration, in addition to the `KinesisConfigConstants.CONFIG_AWS_REGION` required by Flink. Although the region is required, it will not be used to determine the AWS endpoint URL.
 
-The following example shows how one might supply the `CONFIG_AWS_ENDPOINT` configuration property:
+The following example shows how one might supply the `KinesisConfigConstants.CONFIG_AWS_ENDPOINT` configuration property:
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">

--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -299,7 +299,7 @@ Otherwise, the returned stream name is used.
 Other optional configuration keys can be found in `KinesisConfigConstants`.
 		
 		
-### Using non-AWS Kinesis Endpoints
+### Using Non-AWS Kinesis Endpoints for Testing
 
 It is sometimes desirable to have Flink operate as a consumer or producer against a non-AWS Kinesis endpoint such as kinesalite; this is especially useful when performing functional testing of a Flink application. The AWS endpoint that would normally be inferred by the AWS region set in the Flink configuration must be overriden via a configuration property.
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/KinesisConfigConstants.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/KinesisConfigConstants.java
@@ -86,6 +86,9 @@ public class KinesisConfigConstants {
 	/** The AWS region of the Kinesis streams to be pulled ("us-east-1" is used if not set) */
 	public static final String CONFIG_AWS_REGION = "aws.region";
 
+	/** The AWS endpoint for Kinesis (derived from the AWS region setting if not set) */
+	public static final String CONFIG_AWS_ENDPOINT = "aws.endpoint";
+
 	/** Maximum number of items to pack into an PutRecords request. **/
 	public static final String CONFIG_PRODUCER_COLLECTION_MAX_COUNT = "aws.producer.collectionMaxCount";
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -53,6 +53,9 @@ public class AWSUtil {
 		AmazonKinesisClient client =
 			new AmazonKinesisClient(AWSUtil.getCredentialsProvider(configProps).getCredentials(), awsClientConfig);
 		client.setRegion(Region.getRegion(Regions.fromName(configProps.getProperty(KinesisConfigConstants.CONFIG_AWS_REGION))));
+		if (configProps.containsKey(KinesisConfigConstants.CONFIG_AWS_ENDPOINT)) {
+			client.setEndpoint(configProps.getProperty(KinesisConfigConstants.CONFIG_AWS_ENDPOINT));
+		}
 		return client;
 	}
 


### PR DESCRIPTION
I perform local testing of my application stack with Flink configured as a consumer on a Kinesis stream provided by Kinesalite, an implementation of Kinesis built on LevelDB. This requires me to override the AWS endpoint to refer to my local Kinesalite server rather than reference the real AWS endpoint. I'd like to add a configuration property to the Kinesis streaming connector that allows the AWS endpoint to be specified explicitly.

This should be a fairly small change and provide a lot of flexibility to people looking to integrate Flink with Kinesis in a non-production setup.