### PR TITLE
[hotfix][kinesis-connector] Remove duplicate info in KinesisDeserializationSchema

### DIFF
--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -209,12 +209,9 @@ public class ShardConsumer<T> implements Runnable {
 		byte[] dataBytes = new byte[recordData.remaining()];
 		recordData.get(dataBytes);
 
-		byte[] keyBytes = record.getPartitionKey().getBytes();
-
 		final long approxArrivalTimestamp = record.getApproximateArrivalTimestamp().getTime();
 
 		final T value = deserializer.deserialize(
-			keyBytes,
 			dataBytes,
 			record.getPartitionKey(),
 			record.getSequenceNumber(),

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchema.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchema.java
@@ -35,7 +35,6 @@ public interface KinesisDeserializationSchema<T> extends Serializable, ResultTyp
 	/**
 	 * Deserializes a Kinesis record's bytes
 	 *
-	 * @param recordKey the records's key as a byte array (null if no key has been set for the record)
 	 * @param recordValue the record's value as a byte array
 	 * @param partitionKey the record's partition key at the time of writing
 	 * @param seqNum the sequence number of this record in the Kinesis shard
@@ -45,7 +44,7 @@ public interface KinesisDeserializationSchema<T> extends Serializable, ResultTyp
 	 * @return the deserialized message as an Java object
 	 * @throws IOException
 	 */
-	T deserialize(byte[] recordKey, byte[] recordValue, String partitionKey, String seqNum, long approxArrivalTimestamp, String stream, String shardId) throws IOException;
+	T deserialize(byte[] recordValue, String partitionKey, String seqNum, long approxArrivalTimestamp, String stream, String shardId) throws IOException;
 
 	/**
 	 * Method to decide whether the element signals the end of the stream. If

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchemaWrapper.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchemaWrapper.java
@@ -37,7 +37,7 @@ public class KinesisDeserializationSchemaWrapper<T> implements KinesisDeserializ
 	}
 
 	@Override
-	public T deserialize(byte[] recordKey, byte[] recordValue, String partitionKey, String seqNum, long approxArrivalTimestamp, String stream, String shardId)
+	public T deserialize(byte[] recordValue, String partitionKey, String seqNum, long approxArrivalTimestamp, String stream, String shardId)
 		throws IOException {
 		return deserializationSchema.deserialize(recordValue);
 	}


### PR DESCRIPTION
The duplicate was added in https://github.com/apache/flink/pull/2225.
`byte[] recordKey` and `String partitionKey` are actually the same only in different form, so now we have duplicate info in the deser schema. I think we can keep the `String` one, since it's the type we get from the AWS API for the key.