### PR TITLE
[hotfix] Fix Redis Sink to fail at opening if Redis is not initialized.

### DIFF
--- a/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
@@ -166,7 +166,13 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
      */
 	@Override
 	public void open(Configuration parameters) throws Exception {
-		this.redisCommandsContainer = RedisCommandsContainerBuilder.build(this.flinkJedisConfigBase);
+		try {
+			this.redisCommandsContainer = RedisCommandsContainerBuilder.build(this.flinkJedisConfigBase);
+			this.redisCommandsContainer.open();
+		} catch (Exception e) {
+			LOG.error("Redis has not been properly initialized.");
+			throw e;
+		}
 	}
 
 	/**

--- a/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
@@ -170,7 +170,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
 			this.redisCommandsContainer = RedisCommandsContainerBuilder.build(this.flinkJedisConfigBase);
 			this.redisCommandsContainer.open();
 		} catch (Exception e) {
-			LOG.error("Redis has not been properly initialized.");
+			LOG.error("Redis has not been properly initialized: ", e);
 			throw e;
 		}
 	}

--- a/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -47,6 +47,11 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
 	}
 
 	@Override
+	public void open() throws Exception {
+		jedisCluster.echo("Test");
+	}
+
+	@Override
 	public void hset(final String key, final String hashField, final String value) {
 		try {
 			jedisCluster.hset(key, hashField, value);

--- a/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -33,7 +33,7 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
 
 	private static final Logger LOG = LoggerFactory.getLogger(RedisClusterContainer.class);
 
-	private JedisCluster jedisCluster;
+	private transient JedisCluster jedisCluster;
 
 	/**
 	 * Initialize Redis command container for Redis cluster.
@@ -48,6 +48,11 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
 
 	@Override
 	public void open() throws Exception {
+
+		// echo() tries to open a connection and echos back the
+		// message passed as argument. Here we use it to monitor
+		// if we can communicate with the cluster.
+
 		jedisCluster.echo("Test");
 	}
 

--- a/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
@@ -25,6 +25,13 @@ import java.io.Serializable;
 public interface RedisCommandsContainer extends Serializable {
 
 	/**
+	 * Open the Jedis container.
+	 *
+	 * @throws Exception if the instance can not be opened properly
+	 */
+	void open() throws Exception;
+
+	/**
 	 * Sets field in the hash stored at key to value.
 	 * If key does not exist, a new key holding a hash is created.
 	 * If field already exists in the hash, it is overwritten.

--- a/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * Redis command container if we want to connect to a single Redis server or to Redis sentinels
  * If want to connect to a single Redis server, please use the first constructor {@link #RedisContainer(JedisPool)}.
- * If want to connect to a Redis sentinels, Please use the second constructor {@link #RedisContainer(JedisSentinelPool)}
+ * If want to connect to a Redis sentinels, please use the second constructor {@link #RedisContainer(JedisSentinelPool)}
  */
 public class RedisContainer implements RedisCommandsContainer, Closeable {
 
@@ -37,9 +37,8 @@ public class RedisContainer implements RedisCommandsContainer, Closeable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RedisContainer.class);
 
-	private final JedisPool jedisPool;
-	private final JedisSentinelPool jedisSentinelPool;
-
+	private transient JedisPool jedisPool;
+	private transient JedisSentinelPool jedisSentinelPool;
 
 	/**
 	 * Use this constructor if to connect with single Redis server.
@@ -68,11 +67,21 @@ public class RedisContainer implements RedisCommandsContainer, Closeable {
 	 */
 	@Override
 	public void close() throws IOException {
-		getInstance().close();
+		if (this.jedisPool != null) {
+			this.jedisPool.close();
+		}
+		if (this.jedisSentinelPool != null) {
+			this.jedisSentinelPool.close();
+		}
 	}
 
 	@Override
 	public void open() throws Exception {
+
+		// echo() tries to open a connection and echos back the
+		// message passed as argument. Here we use it to monitor
+		// if we can communicate with the cluster.
+
 		getInstance().echo("Test");
 	}
 

--- a/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
@@ -68,12 +68,12 @@ public class RedisContainer implements RedisCommandsContainer, Closeable {
 	 */
 	@Override
 	public void close() throws IOException {
-		if (this.jedisPool != null) {
-			this.jedisPool.close();
-		}
-		if (this.jedisSentinelPool != null) {
-			this.jedisSentinelPool.close();
-		}
+		getInstance().close();
+	}
+
+	@Override
+	public void open() throws Exception {
+		getInstance().echo("Test");
 	}
 
 	@Override

--- a/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkITCase.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkITCase.java
@@ -20,7 +20,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisClusterConfig;
 import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisPoolConfig;
 import org.apache.flink.streaming.connectors.redis.common.mapper.RedisCommand;
 import org.apache.flink.streaming.connectors.redis.common.mapper.RedisCommandDescription;
@@ -31,7 +30,6 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class RedisSinkITCase extends RedisITCaseBase {
 

--- a/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkTest.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkTest.java
@@ -33,6 +33,8 @@ import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.Assert.fail;
+
 public class RedisSinkTest extends TestLogger {
 
 	@Test(expected=NullPointerException.class)
@@ -103,15 +105,17 @@ public class RedisSinkTest extends TestLogger {
 		try {
 			redisSink.open(new Configuration());
 		} catch (Throwable e) {
+			Throwable init = e;
 
-			// search for nested ConnectionExceptions
+			// search for nested JedisConnectionExceptions
 			// because this is the expected behavior
 
 			int depth = 0;
 			while (!(e instanceof JedisConnectionException)) {
-				Throwable cause = e.getCause();
-				if (cause == null || depth++ == 20) {
-					throw e;
+				e = e.getCause();
+				if (e == null || depth++ == 20) {
+					init.printStackTrace();
+					fail("Test Failed: " + init.getMessage());
 				}
 			}
 		}

--- a/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkTest.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkTest.java
@@ -104,14 +104,18 @@ public class RedisSinkTest extends TestLogger {
 
 		try {
 			redisSink.open(new Configuration());
-		} catch (Throwable e) {
+		} catch (Exception e) {
 
-			// search for the JedisConnectionExceptions
+			// search for nested JedisConnectionExceptions
 			// because this is the expected behavior
-			
-			if (!(e instanceof JedisConnectionException)) {
-				e.printStackTrace();
-				fail("Test Failed: " + e.getMessage());
+
+			Throwable t = e;
+			int depth = 0;
+			while (!(t instanceof JedisConnectionException)) {
+				t = t.getCause();
+				if (t == null || depth++ == 20) {
+					throw e;
+				}
 			}
 		}
 	}

--- a/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkTest.java
+++ b/flink-streaming-connectors/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkTest.java
@@ -105,18 +105,13 @@ public class RedisSinkTest extends TestLogger {
 		try {
 			redisSink.open(new Configuration());
 		} catch (Throwable e) {
-			Throwable init = e;
 
-			// search for nested JedisConnectionExceptions
+			// search for the JedisConnectionExceptions
 			// because this is the expected behavior
-
-			int depth = 0;
-			while (!(e instanceof JedisConnectionException)) {
-				e = e.getCause();
-				if (e == null || depth++ == 20) {
-					init.printStackTrace();
-					fail("Test Failed: " + init.getMessage());
-				}
+			
+			if (!(e instanceof JedisConnectionException)) {
+				e.printStackTrace();
+				fail("Test Failed: " + e.getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
Before if Redis was not initialized, the job would start and would wait until the first element arrives in order to realize that Redis is not running. This fixes that by checking the connection to redis during the opening phase.