### PR TITLE
[FLINK-4166] [CLI] Generate different namespaces for Zookeeper

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -286,7 +286,9 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 - `recovery.zookeeper.quorum`: Defines the ZooKeeper quorum URL which is used to connet to the ZooKeeper cluster when the 'zookeeper' recovery mode is selected
 
-- `recovery.zookeeper.path.root`: (Default '/flink') Defines the root dir under which the ZooKeeper recovery mode will create znodes.
+- `recovery.zookeeper.path.root`: (Default '/flink') Defines the root dir under which the ZooKeeper recovery mode will create namespace directories.
+
+- `recovery.zookeeper.path.namespace`: (Default '/default_ns' in standalone mode, or the <yarn-application-id> under Yarn) Defines the subdirectory under the root dir where the ZooKeeper recovery mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. 
 
 - `recovery.zookeeper.path.latch`: (Default '/leaderlatch') Defines the znode of the leader latch which is used to elect the leader.
 

--- a/docs/setup/jobmanager_high_availability.md
+++ b/docs/setup/jobmanager_high_availability.md
@@ -82,7 +82,7 @@ In order to start an HA-cluster add the following configuration keys to `conf/fl
 
   <pre>recovery.zookeeper.path.namespace: /default_ns # important: customize per cluster</pre> 
 
-  **Important**: if you are running multiple Flink HA clusters, you have to manually configure separate namespaces for each cluster. By default, Yarn cluster and Yarn session automatically generate namespaces based on Yarn application id. A manual configuration overrides this behaviour in Yarn. Specifying a namespace with the -z CLI option, in turn, overrides manual configuration. 
+  **Important**: if you are running multiple Flink HA clusters, you have to manually configure separate namespaces for each cluster. By default, the Yarn cluster and the Yarn session automatically generate namespaces based on Yarn application id. A manual configuration overrides this behaviour in Yarn. Specifying a namespace with the -z CLI option, in turn, overrides manual configuration. 
 
 - **State backend and storage directory** (required): JobManager meta data is persisted in the *state backend* and only a pointer to this state is stored in ZooKeeper. Currently, only the file system state backend is supported in HA mode.
 

--- a/docs/setup/jobmanager_high_availability.md
+++ b/docs/setup/jobmanager_high_availability.md
@@ -74,11 +74,15 @@ In order to start an HA-cluster add the following configuration keys to `conf/fl
 
   Each *addressX:port* refers to a ZooKeeper server, which is reachable by Flink at the given address and port.
 
-- **ZooKeeper root** (recommended): The *root ZooKeeper node*, under which all required coordination data is placed.
+- **ZooKeeper root** (recommended): The *root ZooKeeper node*, under which all cluster namespace nodes are placed.
 
-  <pre>recovery.zookeeper.path.root: /flink # important: customize per cluster</pre>
+  <pre>recovery.zookeeper.path.root: /flink
 
-  **Important**: if you are running multiple Flink HA clusters, you have to manually configure separate root nodes for each cluster.
+- **ZooKeeper namespace** (recommended): The *namespace ZooKeeper node*, under which all required coordination data for a cluster is placed.
+
+  <pre>recovery.zookeeper.path.namespace: /default_ns # important: customize per cluster</pre> 
+
+  **Important**: if you are running multiple Flink HA clusters, you have to manually configure separate namespaces for each cluster. By default, Yarn cluster and Yarn session automatically generate namespaces based on Yarn application id. A manual configuration overrides this behaviour in Yarn. Specifying a namespace with the -z CLI option, in turn, overrides manual configuration. 
 
 - **State backend and storage directory** (required): JobManager meta data is persisted in the *state backend* and only a pointer to this state is stored in ZooKeeper. Currently, only the file system state backend is supported in HA mode.
 
@@ -98,7 +102,8 @@ After configuring the masters and the ZooKeeper quorum, you can use the provided
    <pre>
 recovery.mode: zookeeper
 recovery.zookeeper.quorum: localhost:2181
-recovery.zookeeper.path.root: /flink # important: customize per cluster
+recovery.zookeeper.path.root: /flink
+recovery.zookeeper.path.namespace: /cluster_one # important: customize per cluster
 state.backend: filesystem
 state.backend.fs.checkpointdir: hdfs:///flink/checkpoints
 recovery.zookeeper.storageDir: hdfs:///flink/recovery</pre>
@@ -183,7 +188,8 @@ This means that the application can be restarted 10 times before YARN fails the 
    <pre>
 recovery.mode: zookeeper
 recovery.zookeeper.quorum: localhost:2181
-recovery.zookeeper.path.root: /flink # important: customize per cluster
+recovery.zookeeper.path.root: /flink
+recovery.zookeeper.path.namespace: /cluster_one # important: customize per cluster
 state.backend: filesystem
 state.backend.fs.checkpointdir: hdfs:///flink/checkpoints
 recovery.zookeeper.storageDir: hdfs:///flink/recovery

--- a/docs/setup/yarn_setup.md
+++ b/docs/setup/yarn_setup.md
@@ -107,6 +107,7 @@ Usage:
      -qu,--queue <arg>               Specify YARN queue.
      -s,--slots <arg>                Number of slots per TaskManager
      -tm,--taskManagerMemory <arg>   Memory per TaskManager Container [in MB]
+     -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths for HA mode
 ~~~
 
 Please note that the Client requires the `YARN_CONF_DIR` or `HADOOP_CONF_DIR` environment variable to be set to read the YARN and HDFS configuration.

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -57,7 +57,7 @@ public class CliFrontendParser {
 			"specified in the configuration.");
 
 	static final Option LOGGING_OPTION = new Option("q", "sysoutLogging", false, "If present, " +
-			"supress logging output to standard out.");
+			"suppress logging output to standard out.");
 
 	public static final Option DETACHED_OPTION = new Option("d", "detached", false, "If present, runs " +
 			"the job in detached mode");
@@ -81,6 +81,9 @@ public class CliFrontendParser {
 
 	static final Option SCHEDULED_OPTION = new Option("s", "scheduled", false,
 			"Show only scheduled programs and their JobIDs");
+
+	static final Option ZOOKEEPER_NAMESPACE_OPTION = new Option("z", "zookeeperNamespace", true,
+			"Namespace to create the Zookeeper sub-paths for high availability mode");
 
 	static {
 		HELP_OPTION.setRequired(false);
@@ -112,6 +115,9 @@ public class CliFrontendParser {
 
 		SAVEPOINT_PATH_OPTION.setRequired(false);
 		SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
+
+		ZOOKEEPER_NAMESPACE_OPTION.setRequired(false);
+		ZOOKEEPER_NAMESPACE_OPTION.setArgName("zookeeperNamespace");
 	}
 
 	private static final Options RUN_OPTIONS = getRunOptions(buildGeneralOptions(new Options()));
@@ -141,6 +147,7 @@ public class CliFrontendParser {
 		options.addOption(LOGGING_OPTION);
 		options.addOption(DETACHED_OPTION);
 		options.addOption(SAVEPOINT_PATH_OPTION);
+		options.addOption(ZOOKEEPER_NAMESPACE_OPTION);
 		return options;
 	}
 
@@ -151,6 +158,7 @@ public class CliFrontendParser {
 		options.addOption(LOGGING_OPTION);
 		options.addOption(DETACHED_OPTION);
 		options.addOption(SAVEPOINT_PATH_OPTION);
+		options.addOption(ZOOKEEPER_NAMESPACE_OPTION);
 		return options;
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -22,6 +22,7 @@ import org.apache.commons.cli.Options;
 import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
 import org.apache.flink.client.program.StandaloneClusterClient;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 
 import java.net.InetSocketAddress;
@@ -59,6 +60,11 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 			String addressWithPort = commandLine.getOptionValue(CliFrontendParser.ADDRESS_OPTION.getOpt());
 			InetSocketAddress jobManagerAddress = ClientUtils.parseHostPortAddress(addressWithPort);
 			setJobManagerAddressInConfig(config, jobManagerAddress);
+		}
+
+		if (commandLine.hasOption(CliFrontendParser.ZOOKEEPER_NAMESPACE_OPTION.getOpt())) {
+			String zkNamespace = commandLine.getOptionValue(CliFrontendParser.ZOOKEEPER_NAMESPACE_OPTION.getOpt());
+			config.setString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, zkNamespace);
 		}
 
 		StandaloneClusterDescriptor descriptor = new StandaloneClusterDescriptor(config);

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -974,7 +974,7 @@ public final class ConfigConstants {
 
 	public static final String DEFAULT_ZOOKEEPER_DIR_KEY = "/flink";
 
-	public static final String DEFAULT_ZOOKEEPER_NAMESPACE_KEY = "/default_ns";
+	public static final String DEFAULT_ZOOKEEPER_NAMESPACE_KEY = "/default";
 
 	public static final String DEFAULT_ZOOKEEPER_LATCH_PATH = "/leaderlatch";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -626,6 +626,8 @@ public final class ConfigConstants {
 	/** ZooKeeper root path. */
 	public static final String ZOOKEEPER_DIR_KEY = "recovery.zookeeper.path.root";
 
+	public static final String ZOOKEEPER_NAMESPACE_KEY = "recovery.zookeeper.path.namespace";
+
 	public static final String ZOOKEEPER_LATCH_PATH = "recovery.zookeeper.path.latch";
 
 	public static final String ZOOKEEPER_LEADER_PATH = "recovery.zookeeper.path.leader";
@@ -971,6 +973,8 @@ public final class ConfigConstants {
 	// --------------------------- ZooKeeper ----------------------------------
 
 	public static final String DEFAULT_ZOOKEEPER_DIR_KEY = "/flink";
+
+	public static final String DEFAULT_ZOOKEEPER_NAMESPACE_KEY = "/default_ns";
 
 	public static final String DEFAULT_ZOOKEEPER_LATCH_PATH = "/leaderlatch";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -25,8 +25,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCompletedCheckpointStore;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
@@ -169,7 +169,6 @@ public class ZooKeeperUtils {
 	 * @param client        The {@link CuratorFramework} ZooKeeper client to use
 	 * @param configuration {@link Configuration} object containing the configuration values
 	 * @return {@link ZooKeeperLeaderElectionService} instance.
-	 * @return {@link ZooKeeperLeaderElectionService} instance.
 	 * @throws Exception
 	 */
 	public static ZooKeeperLeaderElectionService createLeaderElectionService(
@@ -292,11 +291,11 @@ public class ZooKeeperUtils {
 	}
 
 	private static String generateZookeeperPath(String root, String namespace) {
-		if(!namespace.startsWith("/")) {
+		if (!namespace.startsWith("/")) {
 			namespace = "/" + namespace;
 		}
 
-		if(namespace.endsWith("/")) {
+		if (namespace.endsWith("/")) {
 			namespace = namespace.substring(0, namespace.length() - 1);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -83,7 +83,12 @@ public class ZooKeeperUtils {
 		String root = configuration.getString(ConfigConstants.ZOOKEEPER_DIR_KEY,
 				ConfigConstants.DEFAULT_ZOOKEEPER_DIR_KEY);
 
-		LOG.info("Using '{}' as root namespace.", root);
+		String namespace = configuration.getString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY,
+				ConfigConstants.DEFAULT_ZOOKEEPER_NAMESPACE_KEY);
+
+		String rootWithNamespace = generateZookeeperPath(root, namespace);
+
+		LOG.info("Using '{}' as zookeeper namespace.", rootWithNamespace);
 
 		CuratorFramework cf = CuratorFrameworkFactory.builder()
 				.connectString(zkQuorum)
@@ -92,7 +97,7 @@ public class ZooKeeperUtils {
 				.retryPolicy(new ExponentialBackoffRetry(retryWait, maxRetryAttempts))
 				// Curator prepends a '/' manually and throws an Exception if the
 				// namespace starts with a '/'.
-				.namespace(root.startsWith("/") ? root.substring(1) : root)
+				.namespace(rootWithNamespace.startsWith("/") ? rootWithNamespace.substring(1) : rootWithNamespace)
 				.build();
 
 		cf.start();
@@ -163,6 +168,7 @@ public class ZooKeeperUtils {
 	 *
 	 * @param client        The {@link CuratorFramework} ZooKeeper client to use
 	 * @param configuration {@link Configuration} object containing the configuration values
+	 * @return {@link ZooKeeperLeaderElectionService} instance.
 	 * @return {@link ZooKeeperLeaderElectionService} instance.
 	 * @throws Exception
 	 */
@@ -283,6 +289,18 @@ public class ZooKeeperUtils {
 		} else {
 			return new FileSystemStateStorageHelper<T>(rootPath, prefix);
 		}
+	}
+
+	private static String generateZookeeperPath(String root, String namespace) {
+		if(!namespace.startsWith("/")) {
+			namespace = "/" + namespace;
+		}
+
+		if(namespace.endsWith("/")) {
+			namespace = namespace.substring(0, namespace.length() - 1);
+		}
+
+		return root + namespace;
 	}
 
 	/**

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.impl.YarnClientImpl;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -197,6 +198,34 @@ public class CliFrontendYarnAddressConfigurationTest {
 			frontend.getConfiguration(),
 			TEST_YARN_JOB_MANAGER_ADDRESS,
 			TEST_YARN_JOB_MANAGER_PORT);
+	}
+
+	@Test
+	public void testResumeFromYarnIDZookeeperNamespace() throws Exception {
+		File directoryPath = writeYarnPropertiesFile(validPropertiesFile);
+		// start CLI Frontend
+		TestCLI frontend = new CustomYarnTestCLI(directoryPath.getAbsolutePath());
+
+		RunOptions options =
+				CliFrontendParser.parseRunCommand(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString()});
+
+		frontend.retrieveClient(options);
+		String zkNs = frontend.getConfiguration().getString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, "error");
+		Assert.assertTrue(zkNs.matches("application_\\d+_0042"));
+	}
+
+	@Test
+	public void testResumeFromYarnIDZookeeperNamespaceOverride() throws Exception {
+		File directoryPath = writeYarnPropertiesFile(validPropertiesFile);
+		// start CLI Frontend
+		TestCLI frontend = new CustomYarnTestCLI(directoryPath.getAbsolutePath());
+		String overrideZkNamespace = "my_cluster";
+		RunOptions options =
+				CliFrontendParser.parseRunCommand(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString(), "-yz", overrideZkNamespace});
+
+		frontend.retrieveClient(options);
+		String zkNs = frontend.getConfiguration().getString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, "error");
+		Assert.assertEquals(overrideZkNamespace, zkNs);
 	}
 
 	@Test(expected = IllegalConfigurationException.class)

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -134,6 +134,25 @@ public class FlinkYarnSessionCliTest {
 		Assert.assertEquals(6, client.getMaxSlots());
 	}
 
+	@Test
+	public void testZookeeperNamespaceProperty() throws Exception {
+
+		File confFile = tmp.newFile("flink-conf.yaml");
+		File jarFile = tmp.newFile("test.jar");
+		new CliFrontend(tmp.getRoot().getAbsolutePath());
+
+		String zkNamespaceCliInput = "flink_test_namespace";
+
+		String[] params =
+				new String[] {"-yn", "2", "-yz", zkNamespaceCliInput, jarFile.getAbsolutePath()};
+
+		RunOptions runOptions = CliFrontendParser.parseRunCommand(params);
+
+		FlinkYarnSessionCli yarnCLI = new TestCLI("y", "yarn");
+		AbstractYarnClusterDescriptor descriptor = yarnCLI.createDescriptor("", runOptions.getCommandLine());
+		System.out.println(descriptor.getZookeeperNamespace());
+		Assert.assertEquals(zkNamespaceCliInput, descriptor.getZookeeperNamespace());
+	}
 
 	private static class TestCLI extends FlinkYarnSessionCli {
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -129,6 +129,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 	private String customName;
 
+	private String zookeeperNamespace;
 
 	public AbstractYarnClusterDescriptor() {
 		// for unit tests only
@@ -289,6 +290,13 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		return detached;
 	}
 
+	public String getZookeeperNamespace() {
+		return zookeeperNamespace;
+	}
+
+	public void setZookeeperNamespace(String zookeeperNamespace) {
+		this.zookeeperNamespace = zookeeperNamespace;
+	}
 
 	/**
 	 * Gets a Hadoop Yarn client
@@ -369,7 +377,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	 */
 	protected YarnClusterClient deployInternal() throws Exception {
 		isReadyForDeployment();
-
 		LOG.info("Using values:");
 		LOG.info("\tTaskManager count = {}", taskManagerCount);
 		LOG.info("\tJobManager memory = {}", jobManagerMemoryMb);
@@ -409,7 +416,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		}
 
 		// ------------------ Add dynamic properties to local flinkConfiguraton ------
-
 		Map<String, String> dynProperties = getDynamicProperties(dynamicPropertiesEncoded);
 		for (Map.Entry<String, String> dynProperty : dynProperties.entrySet()) {
 			flinkConfiguration.setString(dynProperty.getKey(), dynProperty.getValue());
@@ -545,6 +551,19 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// Set-up ApplicationSubmissionContext for the application
 		ApplicationSubmissionContext appContext = yarnApplication.getApplicationSubmissionContext();
 
+		final ApplicationId appId = appContext.getApplicationId();
+
+		// ------------------ Add Zookeeper namespace to local flinkConfiguraton ------
+		String zkNamespace = getZookeeperNamespace();
+		// no user specified cli argument for namespace?
+		if(zkNamespace == null || zkNamespace.isEmpty()) {
+			// namespace defined in config? else use applicationId as default.
+			zkNamespace = flinkConfiguration.getString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, String.valueOf(appId));
+			setZookeeperNamespace(zkNamespace);
+		}
+
+		flinkConfiguration.setString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, zkNamespace);
+
 		if (RecoveryMode.isHighAvailabilityModeActivated(flinkConfiguration)) {
 			// activate re-execution of failed applications
 			appContext.setMaxAppAttempts(
@@ -560,8 +579,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 					ConfigConstants.YARN_APPLICATION_ATTEMPTS,
 					1));
 		}
-
-		final ApplicationId appId = appContext.getApplicationId();
 
 		// local resource map for Yarn
 		final Map<String, LocalResource> localResources = new HashMap<>(2 + effectiveShipFiles.size());
@@ -637,6 +654,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_USERNAME, UserGroupInformation.getCurrentUser().getShortUserName());
 		appMasterEnv.put(YarnConfigKeys.ENV_SLOTS, String.valueOf(slots));
 		appMasterEnv.put(YarnConfigKeys.ENV_DETACHED, String.valueOf(detached));
+		appMasterEnv.put(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE, getZookeeperNamespace());
 
 		if(dynamicPropertiesEncoded != null) {
 			appMasterEnv.put(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES, dynamicPropertiesEncoded);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -20,11 +20,10 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.client.CliFrontend;
 import org.apache.flink.client.deployment.ClusterDescriptor;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -51,7 +50,6 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -556,7 +554,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// ------------------ Add Zookeeper namespace to local flinkConfiguraton ------
 		String zkNamespace = getZookeeperNamespace();
 		// no user specified cli argument for namespace?
-		if(zkNamespace == null || zkNamespace.isEmpty()) {
+		if (zkNamespace == null || zkNamespace.isEmpty()) {
 			// namespace defined in config? else use applicationId as default.
 			zkNamespace = flinkConfiguration.getString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, String.valueOf(appId));
 			setZookeeperNamespace(zkNamespace);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
+
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -36,6 +37,7 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitor;
+
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -48,8 +50,10 @@ import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.Records;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.File;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -21,7 +21,6 @@ package org.apache.flink.yarn;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
-
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -37,7 +36,6 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitor;
-
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -50,10 +48,8 @@ import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.Records;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.File;
@@ -167,8 +163,8 @@ public class YarnApplicationMasterRunner {
 
 	/**
 	 * The main work method, must run as a privileged action.
-	 * 
-	 * @return The return code for the Java process. 
+	 *
+	 * @return The return code for the Java process.
 	 */
 	protected int runApplicationMaster() {
 		ActorSystem actorSystem = null;
@@ -426,6 +422,12 @@ public class YarnApplicationMasterRunner {
 		// add dynamic properties to JobManager configuration.
 		for (Map.Entry<String, String> property : additional.entrySet()) {
 			configuration.setString(property.getKey(), property.getValue());
+		}
+
+		// override zookeeper namespace with user cli argument (if provided)
+		String cliZKNamespace = ENV.get(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE);
+		if(cliZKNamespace != null && !cliZKNamespace.isEmpty()) {
+			configuration.setString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, cliZKNamespace);
 		}
 
 		// if a web monitor shall be started, set the port to random binding

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -426,7 +426,7 @@ public class YarnApplicationMasterRunner {
 
 		// override zookeeper namespace with user cli argument (if provided)
 		String cliZKNamespace = ENV.get(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE);
-		if(cliZKNamespace != null && !cliZKNamespace.isEmpty()) {
+		if (cliZKNamespace != null && !cliZKNamespace.isEmpty()) {
 			configuration.setString(ConfigConstants.ZOOKEEPER_NAMESPACE_KEY, cliZKNamespace);
 		}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -41,6 +41,8 @@ public class YarnConfigKeys {
 
 	public final static String FLINK_JAR_PATH = "_FLINK_JAR_PATH"; // the Flink jar resource location (in HDFS).
 
+	public static final String ENV_ZOOKEEPER_NAMESPACE = "_ZOOKEEPER_NAMESPACE";
+
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request addresses the issue [FLINK-4166] : Generate automatic different namespaces in Zookeeper for Flink applications.

The approach introduces a dedicated property for zookeeper namespaces. For standalone, there is a fixed default value. For Yarn, the default value is the application id. An entry in the config file overrides the defaults to a fixed value specified by the user. Command line parameter (-z), in turn, overrides the config file value. 
