### PR TITLE
[FLINK-4219] [scripts] Quote PDSH opts in start-cluster.sh

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -58,6 +58,6 @@ if [[ $? -ne 0 ]]; then
         ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" start &"
     done
 else
-    PDSH_SSH_ARGS="" PDSH_SSH_ARGS_APPEND=$FLINK_SSH_OPTS pdsh -w $(IFS=, ; echo "${SLAVES[*]}") \
+    PDSH_SSH_ARGS="" PDSH_SSH_ARGS_APPEND="${FLINK_SSH_OPTS}" pdsh -w $(IFS=, ; echo "${SLAVES[*]}") \
         "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" start"
 fi


### PR DESCRIPTION
This prevents word splitting if the user configures multiple SSH options.