### PR TITLE
[FLINK-4150] [runtime] Don't clean up BlobStore on BlobServer shut down

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -301,9 +301,6 @@ public class BlobServer extends Thread implements BlobService {
 				LOG.error("BLOB server failed to properly clean up its storage directory.");
 			}
 
-			// Clean up the recovery directory
-			blobStore.cleanUp();
-
 			// Remove shutdown hook to prevent resource leaks, unless this is invoked by the
 			// shutdown hook itself
 			if (shutdownHook != null && shutdownHook != Thread.currentThread()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -143,7 +143,17 @@ class FileSystemBlobStore implements BlobStore {
 		try {
 			LOG.debug("Deleting {}.", blobPath);
 
-			FileSystem.get(new URI(blobPath)).delete(new Path(blobPath), true);
+			FileSystem fs = FileSystem.get(new URI(blobPath));
+			Path path = new Path(blobPath);
+
+			fs.delete(path, true);
+
+			// send a call to delete the directory containing the file. This will
+			// fail (and be ignored) when some files still exist.
+			try {
+				fs.delete(path.getParent(), false);
+				fs.delete(new Path(basePath), false);
+			} catch (IOException ignored) {}
 		}
 		catch (Exception e) {
 			LOG.warn("Failed to delete blob at " + blobPath);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -77,7 +77,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 
 		// Initializing the clean up task
 		this.cleanupTimer = new Timer(true);
-		this.cleanupTimer.schedule(this, cleanupInterval);
+		this.cleanupTimer.schedule(this, cleanupInterval, cleanupInterval);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -200,6 +200,12 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 
 	@Override
 	public void shutdown() throws IOException{
+		try {
+			run();
+		} catch (Throwable t) {
+			LOG.warn("Failed to run clean up task before shutdown", t);
+		}
+
 		blobService.shutdown();
 		cleanupTimer.cancel();
 	}
@@ -210,7 +216,6 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	@Override
 	public void run() {
 		synchronized (lockObject) {
-			
 			Iterator<Map.Entry<BlobKey, Integer>> entryIter = blobKeyReferenceCounters.entrySet().iterator();
 			
 			while (entryIter.hasNext()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -139,6 +139,12 @@ public class BlobRecoveryITCase {
 					assertEquals(expected[i], actual[j]);
 				}
 			}
+
+			// Remove again
+			client.delete(keys[0]);
+			client.delete(keys[1]);
+			client.delete(jobId[0], testKey[0]);
+			client.delete(jobId[1], testKey[1]);
 		}
 		finally {
 			for (BlobServer s : server) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -136,6 +136,12 @@ public class BlobLibraryCacheRecoveryITCase {
 
 				assertEquals(0, fis.available());
 			}
+
+			// Remove blobs again
+			try (BlobClient client = new BlobClient(serverAddress[1])) {
+				client.delete(keys.get(0));
+				client.delete(keys.get(1));
+			}
 		}
 		finally {
 			for (BlobServer s : server) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -22,16 +22,19 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
+import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.HeapStateStore;
 import org.apache.flink.runtime.checkpoint.SavepointStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
@@ -43,6 +46,7 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -54,6 +58,7 @@ import org.apache.flink.runtime.testingUtils.TestingMessages;
 import org.apache.flink.runtime.testingUtils.TestingTaskManager;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.Preconditions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -66,13 +71,21 @@ import scala.concurrent.Future;
 import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -241,6 +254,268 @@ public class JobManagerHARecoveryTest {
 				taskManager.tell(PoisonPill.getInstance(), ActorRef.noSender());
 			}
 		}
+	}
+
+	/**
+	 * Tests that the persisted job is not removed from the job graph store
+	 * after the postStop method of the JobManager. Furthermore, it checks
+	 * that BLOBs of the JobGraph are recovered properly and cleaned up after
+	 * the job finishes.
+	 */
+	@Test
+	public void testBlobRecoveryAfterLostJobManager() throws Exception {
+		FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
+		FiniteDuration jobRecoveryTimeout = new FiniteDuration(3, TimeUnit.SECONDS);
+		Deadline deadline = new FiniteDuration(2, TimeUnit.MINUTES).fromNow();
+		Configuration flinkConfiguration = new Configuration();
+		UUID leaderSessionID = UUID.randomUUID();
+		UUID newLeaderSessionID = UUID.randomUUID();
+		int slots = 2;
+		ActorRef archiveRef = null;
+		ActorRef jobManagerRef = null;
+		ActorRef taskManagerRef = null;
+
+		String haStoragePath = temporaryFolder.newFolder().toString();
+
+		flinkConfiguration.setString(ConfigConstants.RECOVERY_MODE, "zookeeper");
+		flinkConfiguration.setString(ConfigConstants.ZOOKEEPER_RECOVERY_PATH, haStoragePath);
+		flinkConfiguration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, slots);
+
+		try {
+			MySubmittedJobGraphStore mySubmittedJobGraphStore = new MySubmittedJobGraphStore();
+			TestingLeaderElectionService myLeaderElectionService = new TestingLeaderElectionService();
+			TestingLeaderRetrievalService myLeaderRetrievalService = new TestingLeaderRetrievalService();
+
+			archiveRef = system.actorOf(Props.create(
+					MemoryArchivist.class,
+					10), "archive");
+
+			jobManagerRef = createJobManagerActor(
+					"jobmanager-0",
+					flinkConfiguration,
+					myLeaderElectionService,
+					mySubmittedJobGraphStore,
+					3600000,
+					timeout,
+					jobRecoveryTimeout, archiveRef);
+
+			ActorGateway jobManager = new AkkaActorGateway(jobManagerRef, leaderSessionID);
+
+			taskManagerRef = TaskManager.startTaskManagerComponentsAndActor(
+					flinkConfiguration,
+					ResourceID.generate(),
+					system,
+					"localhost",
+					Option.apply("taskmanager"),
+					Option.apply((LeaderRetrievalService) myLeaderRetrievalService),
+					true,
+					TestingTaskManager.class);
+
+			ActorGateway tmGateway = new AkkaActorGateway(taskManagerRef, leaderSessionID);
+
+			Future<Object> tmAlive = tmGateway.ask(TestingMessages.getAlive(), deadline.timeLeft());
+
+			Await.ready(tmAlive, deadline.timeLeft());
+
+			JobVertex sourceJobVertex = new JobVertex("Source");
+			sourceJobVertex.setInvokableClass(BlockingInvokable.class);
+			sourceJobVertex.setParallelism(slots);
+
+			JobGraph jobGraph = new JobGraph("TestingJob", sourceJobVertex);
+
+			// Upload fake JAR file to first JobManager
+			File jarFile = temporaryFolder.newFile();
+			ZipOutputStream out = new ZipOutputStream(new FileOutputStream(jarFile));
+			out.close();
+
+			jobGraph.addJar(new Path(jarFile.toURI()));
+			JobClient.uploadJarFiles(jobGraph, jobManager, deadline.timeLeft());
+
+			Future<Object> isLeader = jobManager.ask(
+					TestingJobManagerMessages.getNotifyWhenLeader(),
+					deadline.timeLeft());
+
+			Future<Object> isConnectedToJobManager = tmGateway.ask(
+					new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManagerRef),
+					deadline.timeLeft());
+
+			// tell jobManager that he's the leader
+			myLeaderElectionService.isLeader(leaderSessionID);
+			// tell taskManager who's the leader
+			myLeaderRetrievalService.notifyListener(jobManager.path(), leaderSessionID);
+
+			Await.ready(isLeader, deadline.timeLeft());
+			Await.ready(isConnectedToJobManager, deadline.timeLeft());
+
+			// submit blocking job
+			Future<Object> jobSubmitted = jobManager.ask(
+					new JobManagerMessages.SubmitJob(jobGraph, ListeningBehaviour.DETACHED),
+					deadline.timeLeft());
+
+			Await.ready(jobSubmitted, deadline.timeLeft());
+
+			// Wait for running
+			Future<Object> jobRunning = jobManager.ask(
+					new TestingJobManagerMessages.NotifyWhenJobStatus(jobGraph.getJobID(), JobStatus.RUNNING),
+					deadline.timeLeft());
+
+			Await.ready(jobRunning, deadline.timeLeft());
+
+			// terminate the job manager
+			jobManagerRef.tell(PoisonPill.getInstance(), ActorRef.noSender());
+
+			Future<Boolean> terminatedFuture = Patterns.gracefulStop(jobManagerRef, deadline.timeLeft());
+			Boolean terminated = Await.result(terminatedFuture, deadline.timeLeft());
+			assertTrue("Failed to stop job manager", terminated);
+
+			// job stays in the submitted job graph store
+			assertTrue(mySubmittedJobGraphStore.contains(jobGraph.getJobID()));
+
+			// start new job manager
+			myLeaderElectionService.reset();
+
+			jobManagerRef = createJobManagerActor(
+					"jobmanager-1",
+					flinkConfiguration,
+					myLeaderElectionService,
+					mySubmittedJobGraphStore,
+					500,
+					timeout,
+					jobRecoveryTimeout,
+					archiveRef);
+
+			jobManager = new AkkaActorGateway(jobManagerRef, newLeaderSessionID);
+
+			Future<Object> isAlive = jobManager.ask(TestingMessages.getAlive(), deadline.timeLeft());
+
+			isLeader = jobManager.ask(
+					TestingJobManagerMessages.getNotifyWhenLeader(),
+					deadline.timeLeft());
+
+			isConnectedToJobManager = tmGateway.ask(
+					new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManagerRef),
+					deadline.timeLeft());
+
+			Await.ready(isAlive, deadline.timeLeft());
+
+			// tell new jobManager that he's the leader
+			myLeaderElectionService.isLeader(newLeaderSessionID);
+			// tell taskManager who's the leader
+			myLeaderRetrievalService.notifyListener(jobManager.path(), newLeaderSessionID);
+
+			Await.ready(isLeader, deadline.timeLeft());
+			Await.ready(isConnectedToJobManager, deadline.timeLeft());
+
+			jobRunning = jobManager.ask(
+					new TestingJobManagerMessages.NotifyWhenJobStatus(jobGraph.getJobID(), JobStatus.RUNNING),
+					deadline.timeLeft());
+
+			// wait that the job is recovered and reaches state RUNNING
+			Await.ready(jobRunning, deadline.timeLeft());
+
+			Future<Object> jobFinished = jobManager.ask(
+					new TestingJobManagerMessages.NotifyWhenJobRemoved(jobGraph.getJobID()),
+					deadline.timeLeft());
+
+			BlockingInvokable.unblock();
+
+			// wait til the job has finished
+			Await.ready(jobFinished, deadline.timeLeft());
+
+			// check that the job has been removed from the submitted job graph store
+			assertFalse(mySubmittedJobGraphStore.contains(jobGraph.getJobID()));
+
+			// Check that the BLOB store files are removed
+			File rootPath = new File(haStoragePath);
+
+			boolean cleanedUpFiles = false;
+			while (deadline.hasTimeLeft()) {
+				if (listFiles(rootPath).isEmpty()) {
+					cleanedUpFiles = true;
+					break;
+				} else {
+					Thread.sleep(100);
+				}
+			}
+
+			assertTrue("BlobStore files not cleaned up", cleanedUpFiles);
+		} finally {
+			if (archiveRef != null) {
+				archiveRef.tell(PoisonPill.getInstance(), ActorRef.noSender());
+			}
+
+			if (jobManagerRef != null) {
+				jobManagerRef.tell(PoisonPill.getInstance(), ActorRef.noSender());
+			}
+
+			if (taskManagerRef != null) {
+				taskManagerRef.tell(PoisonPill.getInstance(), ActorRef.noSender());
+			}
+		}
+	}
+
+	/**
+	 * Recursively lists all files under the given base path.
+	 *
+	 * @param basePath Base path to start listing files from.
+	 * @return Collection of all files found under the base path.
+	 * @throws IOException If base path not found.
+	 */
+	private static Collection<File> listFiles(File basePath) throws IOException {
+		Preconditions.checkNotNull(basePath);
+
+		Set<File> files = new HashSet<>();
+
+		File[] listed = basePath.listFiles();
+		if (listed == null) {
+			throw new IOException(basePath + " not found");
+		} else {
+			for (File file : listed) {
+				if (file.isFile()) {
+					files.add(file);
+				} else {
+					files.addAll(listFiles(file));
+				}
+			}
+			return files;
+		}
+	}
+
+	/**
+	 * Creates a new JobManager actor.
+	 */
+	private ActorRef createJobManagerActor(
+			String name,
+			Configuration flinkConfiguration,
+			LeaderElectionService leaderElectionService,
+			SubmittedJobGraphStore submittedJobGraphs,
+			int blobCleanupInterval,
+			FiniteDuration timeout,
+			FiniteDuration jobRecoveryTimeout,
+			ActorRef archive) throws IOException {
+
+		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
+		InstanceManager instanceManager = new InstanceManager();
+		instanceManager.addInstanceListener(scheduler);
+
+		Props jobManagerProps = Props.create(
+				TestingJobManager.class,
+				flinkConfiguration,
+				new ForkJoinPool(),
+				instanceManager,
+				scheduler,
+				new BlobLibraryCacheManager(new BlobServer(flinkConfiguration), blobCleanupInterval),
+				archive,
+				new FixedDelayRestartStrategy.FixedDelayRestartStrategyFactory(Int.MaxValue(), 100),
+				timeout,
+				leaderElectionService,
+				submittedJobGraphs,
+				new StandaloneCheckpointRecoveryFactory(),
+				new SavepointStore(new HeapStateStore()),
+				jobRecoveryTimeout,
+				Option.apply(null));
+
+		return system.actorOf(jobManagerProps, name);
 	}
 
 	static class MySubmittedJobGraphStore implements SubmittedJobGraphStore {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.HeapStateStore;
 import org.apache.flink.runtime.checkpoint.SavepointStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
-import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
@@ -327,7 +326,8 @@ public class JobManagerHARecoveryTest {
 			out.close();
 
 			jobGraph.addJar(new Path(jarFile.toURI()));
-			JobClient.uploadJarFiles(jobGraph, jobManager, deadline.timeLeft());
+
+			jobGraph.uploadUserJars(jobManager, deadline.timeLeft());
 
 			Future<Object> isLeader = jobManager.ask(
 					TestingJobManagerMessages.getNotifyWhenLeader(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -430,7 +430,8 @@ public class JobManagerHARecoveryTest {
 
 			boolean cleanedUpFiles = false;
 			while (deadline.hasTimeLeft()) {
-				if (listFiles(rootPath).isEmpty()) {
+				File[] files = rootPath.listFiles();
+				if (files != null && files.length == 0) {
 					cleanedUpFiles = true;
 					break;
 				} else {
@@ -451,33 +452,6 @@ public class JobManagerHARecoveryTest {
 			if (taskManagerRef != null) {
 				taskManagerRef.tell(PoisonPill.getInstance(), ActorRef.noSender());
 			}
-		}
-	}
-
-	/**
-	 * Recursively lists all files under the given base path.
-	 *
-	 * @param basePath Base path to start listing files from.
-	 * @return Collection of all files found under the base path.
-	 * @throws IOException If base path not found.
-	 */
-	private static Collection<File> listFiles(File basePath) throws IOException {
-		Preconditions.checkNotNull(basePath);
-
-		Set<File> files = new HashSet<>();
-
-		File[] listed = basePath.listFiles();
-		if (listed == null) {
-			throw new IOException(basePath + " not found");
-		} else {
-			for (File file : listed) {
-				if (file.isFile()) {
-					files.add(file);
-				} else {
-					files.addAll(listFiles(file));
-				}
-			}
-			return files;
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -288,7 +288,7 @@ public class JobManagerHARecoveryTest {
 
 			archiveRef = system.actorOf(Props.create(
 					MemoryArchivist.class,
-					10), "archive");
+					10), "archive-0");
 
 			jobManagerRef = createJobManagerActor(
 					"jobmanager-0",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -386,6 +386,8 @@ public class JobManagerHARecoveryTest {
 
 			Future<Object> isAlive = jobManager.ask(TestingMessages.getAlive(), deadline.timeLeft());
 
+			Await.ready(isAlive, deadline.timeLeft());
+
 			isLeader = jobManager.ask(
 					TestingJobManagerMessages.getNotifyWhenLeader(),
 					deadline.timeLeft());
@@ -393,8 +395,6 @@ public class JobManagerHARecoveryTest {
 			isConnectedToJobManager = tmGateway.ask(
 					new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManagerRef),
 					deadline.timeLeft());
-
-			Await.ready(isAlive, deadline.timeLeft());
 
 			// tell new jobManager that he's the leader
 			myLeaderElectionService.isLeader(newLeaderSessionID);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -58,4 +58,9 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 		hasLeadership = false;
 		contender.revokeLeadership();
 	}
+
+	public void reset() {
+		contender = null;
+		hasLeadership  = false;
+	}
 }


### PR DESCRIPTION
The `BlobServer` acts as a local cache for uploaded BLOBs. The life-cycle of each BLOB is bound to the life-cycle of the `BlobServer`. If the BlobServer shuts down (on JobManager shut down), all local files will be removed.

With HA, BLOBs are persisted to another file system (e.g. HDFS) via the `BlobStore` in order to have BLOBs available after a JobManager failure (or shut down). These BLOBs are only allowed to be removed when the job that requires them enters a globally terminal state (`FINISHED`, `CANCELLED`, `FAILED`).

This commit removes the `BlobStore` clean up call from the `BlobServer` shutdown. The `BlobStore` files will only be cleaned up via the `BlobLibraryCacheManager`'s' clean up task (periodically or on BlobLibraryCacheManager shutdown). This means that there is a chance that BLOBs will linger around after the job has terminated, if the job manager fails before the clean up.