### PR TITLE
[FLINK-4222] Allow Kinesis configuration to get credentials from AWS Metadata	

### DIFF
--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -26,7 +26,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The Kinesis connector provides access to [Amazon AWS Kinesis Streams](http://aws.amazon.com/kinesis/streams/).
+The Kinesis connector provides access to [Amazon AWS Kinesis Streams](http://aws.amazon.com/kinesis/streams/). 
 
 To use the connector, add the following Maven dependency to your project:
 
@@ -50,7 +50,7 @@ mvn clean install -Pinclude-kinesis -DskipTests
 {% endhighlight %}
 
 
-The streaming connectors are not part of the binary distribution. See how to link with them for cluster
+The streaming connectors are not part of the binary distribution. See how to link with them for cluster 
 execution [here]({{site.baseurl}}/apis/cluster_execution.html#linking-with-modules-not-contained-in-the-binary-distribution).
 
 ### Using the Amazon Kinesis Streams Service
@@ -231,8 +231,8 @@ consumer when calling this API can also be modified by using the other keys pref
 ### Kinesis Producer
 
 The `FlinkKinesisProducer` is used for putting data from a Flink stream into a Kinesis stream. Note that the producer is not participating in
-Flink's checkpointing and doesn't provide exactly-once processing guarantees.
-Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details).
+Flink's checkpointing and doesn't provide exactly-once processing guarantees. 
+Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details). 
 
 In case of a failure or a resharding, data will be written again to Kinesis, leading to duplicates. This behavior is usually called "at-least-once" semantics.
 
@@ -278,13 +278,13 @@ simpleStringStream.addSink(kinesis);
 The above is a simple example of using the producer. Configuration for the producer with the mandatory configuration values is supplied with a `java.util.Properties`
 instance as described above for the consumer. The example demonstrates producing a single Kinesis stream in the AWS region "us-east-1".
 
-Instead of a `SerializationSchema`, it also supports a `KinesisSerializationSchema`. The `KinesisSerializationSchema` allows to send the data to multiple streams. This is
+Instead of a `SerializationSchema`, it also supports a `KinesisSerializationSchema`. The `KinesisSerializationSchema` allows to send the data to multiple streams. This is 
 done using the `KinesisSerializationSchema.getTargetStream(T element)` method. Returning `null` there will instruct the producer to write the element to the default stream.
 Otherwise, the returned stream name is used.
 
 Other optional configuration keys for the producer can be found in `ProducerConfigConstants`.
-
-
+		
+		
 ### Using Non-AWS Kinesis Endpoints for Testing
 
 It is sometimes desirable to have Flink operate as a consumer or producer against a non-AWS Kinesis endpoint such as

--- a/docs/apis/streaming/connectors/kinesis.md
+++ b/docs/apis/streaming/connectors/kinesis.md
@@ -26,7 +26,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The Kinesis connector provides access to [Amazon AWS Kinesis Streams](http://aws.amazon.com/kinesis/streams/). 
+The Kinesis connector provides access to [Amazon AWS Kinesis Streams](http://aws.amazon.com/kinesis/streams/).
 
 To use the connector, add the following Maven dependency to your project:
 
@@ -50,7 +50,7 @@ mvn clean install -Pinclude-kinesis -DskipTests
 {% endhighlight %}
 
 
-The streaming connectors are not part of the binary distribution. See how to link with them for cluster 
+The streaming connectors are not part of the binary distribution. See how to link with them for cluster
 execution [here]({{site.baseurl}}/apis/cluster_execution.html#linking-with-modules-not-contained-in-the-binary-distribution).
 
 ### Using the Amazon Kinesis Streams Service
@@ -101,7 +101,7 @@ The above is a simple example of using the consumer. Configuration for the consu
 instance, the configuration keys for which can be found in `ConsumerConfigConstants`. The example
 demonstrates consuming a single Kinesis stream in the AWS region "us-east-1". The AWS credentials are supplied using the basic method in which
 the AWS access key ID and secret access key are directly supplied in the configuration (other options are setting
-`ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER` to `ENV_VAR`, `SYS_PROP`, and `PROFILE`). Also, data is being consumed
+`ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER` to `ENV_VAR`, `SYS_PROP`, `PROFILE`, and `AUTO`). Also, data is being consumed
 from the newest position in the Kinesis stream (the other option will be setting `ConsumerConfigConstants.STREAM_INITIAL_POSITION`
 to `TRIM_HORIZON`, which lets the consumer start reading the Kinesis stream from the earliest record possible).
 
@@ -231,8 +231,8 @@ consumer when calling this API can also be modified by using the other keys pref
 ### Kinesis Producer
 
 The `FlinkKinesisProducer` is used for putting data from a Flink stream into a Kinesis stream. Note that the producer is not participating in
-Flink's checkpointing and doesn't provide exactly-once processing guarantees. 
-Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details). 
+Flink's checkpointing and doesn't provide exactly-once processing guarantees.
+Also, the Kinesis producer does not guarantee that records are written in order to the shards (See [here](https://github.com/awslabs/amazon-kinesis-producer/issues/23) and [here](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) for more details).
 
 In case of a failure or a resharding, data will be written again to Kinesis, leading to duplicates. This behavior is usually called "at-least-once" semantics.
 
@@ -278,13 +278,13 @@ simpleStringStream.addSink(kinesis);
 The above is a simple example of using the producer. Configuration for the producer with the mandatory configuration values is supplied with a `java.util.Properties`
 instance as described above for the consumer. The example demonstrates producing a single Kinesis stream in the AWS region "us-east-1".
 
-Instead of a `SerializationSchema`, it also supports a `KinesisSerializationSchema`. The `KinesisSerializationSchema` allows to send the data to multiple streams. This is 
+Instead of a `SerializationSchema`, it also supports a `KinesisSerializationSchema`. The `KinesisSerializationSchema` allows to send the data to multiple streams. This is
 done using the `KinesisSerializationSchema.getTargetStream(T element)` method. Returning `null` there will instruct the producer to write the element to the default stream.
 Otherwise, the returned stream name is used.
 
 Other optional configuration keys for the producer can be found in `ProducerConfigConstants`.
-		
-		
+
+
 ### Using Non-AWS Kinesis Endpoints for Testing
 
 It is sometimes desirable to have Flink operate as a consumer or producer against a non-AWS Kinesis endpoint such as

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
@@ -40,7 +40,10 @@ public class AWSConfigConstants {
 		PROFILE,
 
 		/** Simply create AWS credentials by supplying the AWS access key ID and AWS secret key in the configuration properties */
-		BASIC
+		BASIC,
+
+		/** Don't supply AWS credentials and rely on the AWS library auto-detecting, which supports ENV vars and AWS MetaData **/
+		AUTO,
 	}
 
 	/** The AWS region of the Kinesis streams to be pulled ("us-east-1" is used if not set) */

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
@@ -42,7 +42,7 @@ public class AWSConfigConstants {
 		/** Simply create AWS credentials by supplying the AWS access key ID and AWS secret key in the configuration properties */
 		BASIC,
 
-		/** Don't supply AWS credentials and rely on the AWS library auto-detecting, which supports ENV vars and AWS MetaData **/
+		/** A credentials provider chain will be used that searches for credentials in this order: ENV_VARS, SYS_PROPS, PROFILE in the AWS instance metadata **/
 		AUTO,
 	}
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -50,13 +50,12 @@ public class AWSUtil {
 		awsClientConfig.setUserAgent("Apache Flink " + EnvironmentInformation.getVersion() +
 			" (" + EnvironmentInformation.getRevisionInformation().commitId + ") Kinesis Connector");
 
-		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(configProps);
 		AmazonKinesisClient client;
-		if (credentialsProvider != null) {
-			AmazonKinesisClient client =
-				new AmazonKinesisClient(credentialsProvider.getCredentials(), awsClientConfig);
+		if (AWSUtil.getCredentialsProvider(configProps) != null) {
+			client = new AmazonKinesisClient(
+				AWSUtil.getCredentialsProvider(configProps).getCredentials(), awsClientConfig);
 		} else {
-			AmazonKinesisClient client = new AmazonKinesisClient(awsClientConfig);
+			client = new AmazonKinesisClient(awsClientConfig);
 		}
 
 		client.setRegion(Region.getRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION))));

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -50,8 +50,14 @@ public class AWSUtil {
 		awsClientConfig.setUserAgent("Apache Flink " + EnvironmentInformation.getVersion() +
 			" (" + EnvironmentInformation.getRevisionInformation().commitId + ") Kinesis Connector");
 
-		AmazonKinesisClient client =
-			new AmazonKinesisClient(AWSUtil.getCredentialsProvider(configProps).getCredentials(), awsClientConfig);
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(configProps);
+
+		if (credentialsProvider != null) {
+			AmazonKinesisClient client =
+				new AmazonKinesisClient(credentialsProvider.getCredentials(), awsClientConfig);
+		} else {
+			AmazonKinesisClient client = new AmazonKinesisClient(awsClientConfig);
+		}
 		client.setRegion(Region.getRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION))));
 		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
 			client.setEndpoint(configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT));
@@ -87,6 +93,8 @@ public class AWSUtil {
 					? new ProfileCredentialsProvider(profileName)
 					: new ProfileCredentialsProvider(profileConfigPath, profileName);
 				break;
+			case AUTO:
+				credentialsProvider = null;
 			default:
 			case BASIC:
 				credentialsProvider = new AWSCredentialsProvider() {

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -51,13 +51,14 @@ public class AWSUtil {
 			" (" + EnvironmentInformation.getRevisionInformation().commitId + ") Kinesis Connector");
 
 		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(configProps);
-
+		AmazonKinesisClient client;
 		if (credentialsProvider != null) {
 			AmazonKinesisClient client =
 				new AmazonKinesisClient(credentialsProvider.getCredentials(), awsClientConfig);
 		} else {
 			AmazonKinesisClient client = new AmazonKinesisClient(awsClientConfig);
 		}
+
 		client.setRegion(Region.getRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION))));
 		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
 			client.setEndpoint(configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT));


### PR DESCRIPTION
When called without credentials, the AmazonKinesisClient tries to configure itself automatically, searching for credentials from environment variables, java system properties, and finally from instance profile credentials delivered through the Amazon EC2 metadata service.

Add the AWSConfigConstant "AUTO", which supports creating an AmazonKinesisClient without any AWSCredentials, which allows for this auto-discovery mechanism to take place and supports getting kinesis credentials from the AWS EC2 metadata service.