### PR TITLE
[FLINK-4199] Fix misleading CLI messages and return execution result for interactive blocking execution

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -884,7 +884,7 @@ public class CliFrontend {
 		ClusterClient client;
 		try {
 			client = activeCommandLine.retrieveCluster(options.getCommandLine(), config);
-			logAndSysout("Cluster retrieved: " + client.getClusterIdentifier());
+			logAndSysout("Cluster configuration: " + client.getClusterIdentifier());
 		} catch (UnsupportedOperationException e) {
 			try {
 				String applicationName = "Flink Application: " + programName;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -97,11 +97,11 @@ public abstract class ClusterClient {
 	private boolean printStatusDuringExecution = true;
 
 	/**
-	 * For interactive invocations, the Job ID is only available after the ContextEnvironment has
+	 * For interactive invocations, the job results are only available after the ContextEnvironment has
 	 * been run inside the user JAR. We pass the Client to every instance of the ContextEnvironment
-	 * which lets us access the last JobID here.
+	 * which lets us access the execution result here.
 	 */
-	private JobID lastJobID;
+	private JobExecutionResult lastJobExecutionResult;
 
 	/** Switch for blocking/detached job submission of the client */
 	private boolean detachedJobSubmission = false;
@@ -335,7 +335,7 @@ public abstract class ClusterClient {
 				}
 				else {
 					// in blocking mode, we execute all Flink jobs contained in the user code and then return here
-					return new JobSubmissionResult(lastJobID);
+					return this.lastJobExecutionResult;
 				}
 			}
 			finally {
@@ -406,9 +406,9 @@ public abstract class ClusterClient {
 
 		try {
 			logAndSysout("Submitting job with JobID: " + jobGraph.getJobID() + ". Waiting for job completion.");
-			this.lastJobID = jobGraph.getJobID();
-			return JobClient.submitJobAndWait(actorSystemLoader.get(),
+			this.lastJobExecutionResult = JobClient.submitJobAndWait(actorSystemLoader.get(),
 				leaderRetrievalService, jobGraph, timeout, printStatusDuringExecution, classLoader);
+			return this.lastJobExecutionResult;
 		} catch (JobExecutionException e) {
 			throw new ProgramInvocationException("The program execution failed: " + e.getMessage(), e);
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.SerializedValue;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -114,8 +115,18 @@ public class AccumulatorHelper {
 	public static String getResultsFormated(Map<String, Object> map) {
 		StringBuilder builder = new StringBuilder();
 		for (Map.Entry<String, Object> entry : map.entrySet()) {
-			builder.append("- ").append(entry.getKey()).append(" (").append(entry.getValue().getClass().getName());
-			builder.append(")").append(": ").append(entry.getValue().toString()).append("\n");
+			// format all accumulators but ignore the ones that print eagerly
+			builder
+				.append("- ")
+				.append(entry.getKey())
+				.append(" (")
+				.append(entry.getValue().getClass().getName())
+				.append(")");
+			if (entry.getValue() instanceof Collection) {
+				builder.append(" [").append(((Collection) entry.getValue()).size()).append(" elements]");
+			} else {
+				builder.append(": ").append(entry.getValue().toString()).append(System.lineSeparator());
+			}
 		}
 		return builder.toString();
 	}


### PR DESCRIPTION
**OLD**
```
Cluster retrieved: Standalone cluster with JobManager at localhost/127.0.0.1:6123
Using address localhost:6123 to connect to JobManager.
JobManager web interface address http://localhost:8081
Starting execution of program
Submitting job with JobID: 9c7120e5cc55b2a9157a7e2bc5a12c9d. Waiting for job completion.
org.apache.flink.client.program.ProgramInvocationException: The program execution failed: Communication with JobManager failed: Lost connection to the JobManager.
Job has been submitted with JobID 9c7120e5cc55b2a9157a7e2bc5a12c9d
```
**NEW**
```
Cluster configuration: Standalone cluster with JobManager at localhost/127.0.0.1:6123
Using address localhost:6123 to connect to JobManager.
JobManager web interface address http://localhost:8081
Starting execution of program
Executing WordCount example with default input data set.
Use --input to specify file input.
Printing result to stdout. Use --output to specify output path.
Submitting job with JobID: 20d070cf6a4289df4e5045c9c52cc47b. Waiting for job completion.

------------------------------------------------------------
 The program finished with the following exception:

org.apache.flink.client.program.ProgramInvocationException: The program execution failed: Communication with JobManager failed: Lost connection to the JobManager.
```

---

**OLD**

```
Cluster retrieved: Standalone cluster with JobManager at localhost/127.0.0.1:6123
Using address localhost:6123 to connect to JobManager.
JobManager web interface address http://localhost:8081
Starting execution of program
Submitting job with JobID: 477429b836247909dd428a6cba5b923b. Waiting for job completion.
07/12/2016 16:18:52	Job execution switched to status RUNNING.
07/12/2016 16:18:52	Source: Socket Stream -> Sink: Unnamed(1/1) switched to SCHEDULED
07/12/2016 16:18:52	Source: Socket Stream -> Sink: Unnamed(1/1) switched to DEPLOYING
07/12/2016 16:18:52	Source: Socket Stream -> Sink: Unnamed(1/1) switched to RUNNING
07/12/2016 16:18:58	Source: Socket Stream -> Sink: Unnamed(1/1) switched to FINISHED
07/12/2016 16:18:58	Job execution switched to status FINISHED.
Job has been submitted with JobID 477429b836247909dd428a6cba5b923b
```

**NEW**

```
Cluster configuration: Standalone cluster with JobManager at localhost/127.0.0.1:6123
Using address localhost:6123 to connect to JobManager.
JobManager web interface address http://localhost:8081
Starting execution of program
Executing WordCount example with default input data set.
Use --input to specify file input.
Printing result to stdout. Use --output to specify output path.
Submitting job with JobID: a56b184080d9755d3f2d40c7d9092b31. Waiting for job completion.
07/18/2016 16:42:23	Job execution switched to status RUNNING.
07/18/2016 16:42:23	Source: Collection Source -> Flat Map(1/1) switched to SCHEDULED 
07/18/2016 16:42:23	Source: Collection Source -> Flat Map(1/1) switched to DEPLOYING 
07/18/2016 16:42:23	Keyed Aggregation -> Sink: Unnamed(1/1) switched to SCHEDULED 
07/18/2016 16:42:23	Keyed Aggregation -> Sink: Unnamed(1/1) switched to DEPLOYING 
07/18/2016 16:42:23	Keyed Aggregation -> Sink: Unnamed(1/1) switched to RUNNING 
07/18/2016 16:42:23	Source: Collection Source -> Flat Map(1/1) switched to RUNNING 
07/18/2016 16:42:23	Source: Collection Source -> Flat Map(1/1) switched to FINISHED 
07/18/2016 16:42:23	Keyed Aggregation -> Sink: Unnamed(1/1) switched to FINISHED 
07/18/2016 16:42:23	Job execution switched to status FINISHED.
Program execution finished
Job with JobID a56b184080d9755d3f2d40c7d9092b31 has finished.
Job Runtime: 25 ms
```
---