### PR TITLE
[FLINK-4229] Do not start any Metrics Reporter by default

### DIFF
--- a/docs/apis/metrics.md
+++ b/docs/apis/metrics.md
@@ -239,12 +239,12 @@ Metrics can be exposed to an external system by configuring a reporter in `conf/
 You can write your own `Reporter` by implementing the `org.apache.flink.metrics.reporter.MetricReporter` interface.
 If the Reporter should send out reports regularly you have to implement the `Scheduled` interface as well.
 
-By default Flink uses JMX to expose metrics.
-All non-JMXReporters are not part of the distribution. To use them you have to copy the respective fat jar to the `/lib` folder.
-
 The following sections list the supported reporters.
 
-### JMX
+### JMX (org.apache.flink.metrics.reporter.JMXReporter)
+
+You don't have to include an additional dependency since the JMX reporter is available by default
+but not activated.
 
 The port for JMX can be configured by setting the `metrics.jmx.port` key. This parameter expects either a single port
 or a port range, with the default being 9010-9025. The used port is shown in the relevant job or task manager log.
@@ -262,7 +262,7 @@ Dependency:
 Parameters:
 
 - `host` - the gmond host address configured under `udp_recv_channel.bind` in `gmond.conf`
-- `port` - the gmond port configured under `udp_recv_channel.port` in `gmond.conf` 
+- `port` - the gmond port configured under `udp_recv_channel.port` in `gmond.conf`
 - `tmax` - soft limit for how long an old metric should be retained
 - `dmax` - hard limit for how long an old metric should be retained
 - `ttl` - time-to-live for transmitted UDP packets

--- a/docs/apis/metrics.md
+++ b/docs/apis/metrics.md
@@ -246,8 +246,11 @@ The following sections list the supported reporters.
 You don't have to include an additional dependency since the JMX reporter is available by default
 but not activated.
 
-The port for JMX can be configured by setting the `metrics.jmx.port` key. This parameter expects either a single port
-or a port range, with the default being 9010-9025. The used port is shown in the relevant job or task manager log.
+Parameters:
+
+- `port` - the port on which JMX listens for connections. This can also be a port range. When a
+range is specified the actual port is shown in the relevant job or task manager log. Default:
+`9010-9025`.
 
 ### Ganglia (org.apache.flink.metrics.ganglia.GangliaReporter)
 Dependency:

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -649,9 +649,6 @@ public final class ConfigConstants {
 
 	// ---------------------------- Metrics -----------------------------------
 
-	/** The port range from which JMX will pick one to listen for incoming connections. */
-	public static final String METRICS_JMX_PORT = "metrics.jmx.port";
-	
 	/** The class of the reporter to use. */
 	public static final String METRICS_REPORTER_CLASS = "metrics.reporter.class";
 	

--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.metrics.groups.scope.ScopeFormat;
 import org.apache.flink.metrics.groups.scope.ScopeFormats;
-import org.apache.flink.metrics.reporter.JMXReporter;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 

--- a/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/MetricRegistry.java
@@ -79,9 +79,9 @@ public class MetricRegistry {
 		
 		final String className = config.getString(ConfigConstants.METRICS_REPORTER_CLASS, null);
 		if (className == null) {
-			// by default, create JMX metrics
-			LOG.info("No metrics reporter configured, exposing metrics via JMX");
-			this.reporter = startJmxReporter(config);
+			// by default, don't report anything
+			LOG.info("No metrics reporter configured, no metrics will be exposed/reported.");
+			this.reporter = null;
 			this.executor = null;
 		}
 		else {
@@ -120,8 +120,8 @@ public class MetricRegistry {
 			}
 			catch (Throwable t) {
 				shutdownExecutor();
-				LOG.error("Could not instantiate custom metrics reporter. Defaulting to JMX metrics export.", t);
-				reporter = startJmxReporter(config);
+				LOG.error("Could not instantiate metrics reporter. No metrics will be exposed/reported.", t);
+				reporter = null;
 			}
 
 			this.reporter = reporter;
@@ -131,23 +131,6 @@ public class MetricRegistry {
 
 	public char getDelimiter() {
 		return this.delimiter;
-	}
-
-	private static JMXReporter startJmxReporter(Configuration config) {
-		JMXReporter reporter = null;
-		try {
-			Configuration reporterConfig = new Configuration();
-			String portRange = config.getString(ConfigConstants.METRICS_JMX_PORT, null);
-			if (portRange != null) {
-				reporterConfig.setString(ConfigConstants.METRICS_JMX_PORT, portRange);
-			}
-			reporter = new JMXReporter();
-			reporter.open(reporterConfig);
-		} catch (Exception e) {
-			LOG.error("Failed to instantiate JMX reporter.", e);
-		} finally {
-			return reporter;
-		}
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/metrics/reporter/JMXReporter.java
+++ b/flink-core/src/main/java/org/apache/flink/metrics/reporter/JMXReporter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.metrics.reporter;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -62,6 +61,8 @@ public class JMXReporter implements MetricReporter {
 	private static final String PREFIX = "org.apache.flink.metrics:";
 	private static final String KEY_PREFIX = "key";
 
+	public static final String ARG_PORT = "port";
+
 	private static final Logger LOG = LoggerFactory.getLogger(JMXReporter.class);
 
 	// ------------------------------------------------------------------------
@@ -93,7 +94,9 @@ public class JMXReporter implements MetricReporter {
 	}
 
 	private static JMXServer startJmxServer(Configuration config) {
-		Iterator<Integer> ports = NetUtils.getPortRangeFromString(config.getString(ConfigConstants.METRICS_JMX_PORT, "9010-9025"));
+		String portsConfig = config.getString(ARG_PORT, "9010-9025");
+
+		Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
 
 		JMXServer server = new JMXServer();
 		while (ports.hasNext()) {

--- a/flink-core/src/test/java/org/apache/flink/metrics/reporter/JMXReporterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/reporter/JMXReporterTest.java
@@ -88,7 +88,7 @@ public class JMXReporterTest extends TestLogger {
 		JMXReporter rep2 = new JMXReporter();
 
 		Configuration cfg1 = new Configuration();
-		cfg1.setString(ConfigConstants.METRICS_JMX_PORT, "9020-9035");
+		cfg1.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "-port 9020-9035");
 
 		rep1.open(cfg1);
 		rep2.open(cfg1);
@@ -137,7 +137,7 @@ public class JMXReporterTest extends TestLogger {
 		JMXReporter rep2 = new JMXReporter();
 
 		Configuration cfg1 = new Configuration();
-		cfg1.setString(ConfigConstants.METRICS_JMX_PORT, "9040-9055");
+		cfg1.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "-port 9040-9055");
 		rep1.open(cfg1);
 		rep2.open(cfg1);
 
@@ -197,6 +197,7 @@ public class JMXReporterTest extends TestLogger {
 
 		try {
 			Configuration config = new Configuration();
+			config.setString(ConfigConstants.METRICS_REPORTER_CLASS, "org.apache.flink.metrics.reporter.JMXReporter");
 
 			registry = new MetricRegistry(config);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerMetricTest.java
@@ -50,9 +50,10 @@ public class JobManagerMetricTest {
 	public void testJobManagerMetricAccess() throws Exception {
 		Deadline deadline = new FiniteDuration(2, TimeUnit.MINUTES).fromNow();
 		Configuration flinkConfiguration = new Configuration();
-		
+
+		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_CLASS, "org.apache.flink.metrics.reporter.JMXReporter");
 		flinkConfiguration.setString(ConfigConstants.METRICS_SCOPE_NAMING_JM_JOB, "jobmanager.<job_name>");
-		flinkConfiguration.setString(ConfigConstants.METRICS_JMX_PORT, "9060-9075");
+		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "-port 9060-9075");
 
 		TestingCluster flink = new TestingCluster(flinkConfiguration);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerMetricTest.java
@@ -53,7 +53,7 @@ public class JobManagerMetricTest {
 
 		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_CLASS, "org.apache.flink.metrics.reporter.JMXReporter");
 		flinkConfiguration.setString(ConfigConstants.METRICS_SCOPE_NAMING_JM_JOB, "jobmanager.<job_name>");
-		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "-port 9060-9075");
+		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "--port 9060-9075");
 
 		TestingCluster flink = new TestingCluster(flinkConfiguration);
 

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -101,6 +101,7 @@ public abstract class KafkaTestBase extends TestLogger {
 		flinkConfig.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 8);
 		flinkConfig.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 16);
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
+		flinkConfig.setString(ConfigConstants.METRICS_REPORTER_CLASS, "org.apache.flink.metrics.reporter.JMXReporter");
 
 		flink = new ForkableFlinkMiniCluster(flinkConfig, false);
 		flink.start();


### PR DESCRIPTION
@rmetzger Is this what you had in mind when you mentioned that the JMXReporter should not be active by default because it starts a lot of RMI threads?

R: @zentol for review