### PR TITLE
[FLINK-3956] Make FileInputFormats independent from Configuration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
@@ -86,14 +86,27 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
 	public void configure(Configuration parameters) {
 		super.configure(parameters);
 
-		// read own parameters
-		this.blockSize = parameters.getLong(BLOCK_SIZE_PARAMETER_KEY, NATIVE_BLOCK_SIZE);
-		if (this.blockSize < 1 && this.blockSize != NATIVE_BLOCK_SIZE) {
+		// the if is to prevent the configure() method from
+		// overwriting the value set by the setter
+
+		if (this.blockSize == NATIVE_BLOCK_SIZE) {
+			long blockSize = parameters.getLong(BLOCK_SIZE_PARAMETER_KEY, NATIVE_BLOCK_SIZE);
+			setBlockSize(blockSize);
+		}
+	}
+
+	public void setBlockSize(long blockSize) {
+		if (blockSize < 1 && blockSize != NATIVE_BLOCK_SIZE) {
 			throw new IllegalArgumentException("The block size parameter must be set and larger than 0.");
 		}
-		if (this.blockSize > Integer.MAX_VALUE) {
-			throw new UnsupportedOperationException("Currently only block size up to Integer.MAX_VALUE are supported");
+		if (blockSize > Integer.MAX_VALUE) {
+			throw new UnsupportedOperationException("Currently only block sizes up to Integer.MAX_VALUE are supported");
 		}
+		this.blockSize = blockSize;
+	}
+
+	public long getBlockSize() {
+		return this.blockSize;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -35,6 +35,7 @@ import org.apache.flink.core.fs.Path;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Base implementation for input formats that split the input at a delimiter into records.
@@ -181,7 +182,6 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 		if (delimiter == null) {
 			throw new IllegalArgumentException("Delimiter must not be null");
 		}
-		
 		this.delimiter = delimiter;
 	}
 
@@ -190,6 +190,9 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	}
 	
 	public void setDelimiter(String delimiter) {
+		if (delimiter == null) {
+			throw new IllegalArgumentException("Delimiter must not be null");
+		}
 		this.delimiter = delimiter.getBytes(UTF_8_CHARSET);
 	}
 	
@@ -225,7 +228,6 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 		if (numLineSamples < 0) {
 			throw new IllegalArgumentException("Number of line samples must not be negative.");
 		}
-		
 		this.numLineSamples = numLineSamples;
 	}
 
@@ -260,23 +262,29 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	@Override
 	public void configure(Configuration parameters) {
 		super.configure(parameters);
-		
-		String delimString = parameters.getString(RECORD_DELIMITER, null);
-		if (delimString != null) {
-			setDelimiter(delimString);
+
+		// the if() clauses are to prevent the configure() method from
+		// overwriting the values set by the setters
+
+		if (Arrays.equals(delimiter, new byte[] {'\n'})) {
+			String delimString = parameters.getString(RECORD_DELIMITER, null);
+			if (delimString != null) {
+				setDelimiter(delimString);
+			}
 		}
 		
 		// set the number of samples
-		String samplesString = parameters.getString(NUM_STATISTICS_SAMPLES, null);
-		if (samplesString != null) {
-			try {
-				setNumLineSamples(Integer.parseInt(samplesString));
-			}
-			catch (NumberFormatException e) {
-				if (LOG.isWarnEnabled()) {
-					LOG.warn("Invalid value for number of samples to take: " + samplesString + ". Skipping sampling.");
+		if (numLineSamples == NUM_SAMPLES_UNDEFINED) {
+			String samplesString = parameters.getString(NUM_STATISTICS_SAMPLES, null);
+			if (samplesString != null) {
+				try {
+					setNumLineSamples(Integer.parseInt(samplesString));
+				} catch (NumberFormatException e) {
+					if (LOG.isWarnEnabled()) {
+						LOG.warn("Invalid value for number of samples to take: " + samplesString + ". Skipping sampling.");
+					}
+					setNumLineSamples(0);
 				}
-				setNumLineSamples(0);
 			}
 		}
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/BinaryInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/BinaryInputFormatTest.java
@@ -57,10 +57,11 @@ public class BinaryInputFormatTest {
 		fileOutputStream.close();
 
 		final Configuration config = new Configuration();
-		config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
-		
+		config.setLong("input.block_size", blockSize + 10);
+
 		final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
 		inputFormat.setFilePath(tempFile.toURI().toString());
+		inputFormat.setBlockSize(blockSize);
 		
 		inputFormat.configure(config);
 		

--- a/flink-java/src/test/java/org/apache/flink/api/common/io/SerializedFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/io/SerializedFormatTest.java
@@ -49,10 +49,10 @@ public class SerializedFormatTest extends SequentialFormatTestBase<Record> {
 	@Override
 	protected BinaryInputFormat<Record> createInputFormat() {
 		Configuration configuration = new Configuration();
-		configuration.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, this.blockSize);
 
 		final SerializedInputFormat<Record> inputFormat = new SerializedInputFormat<Record>();
 		inputFormat.setFilePath(this.tempFile.toURI().toString());
+		inputFormat.setBlockSize(this.blockSize);
 
 		inputFormat.configure(configuration);
 		return inputFormat;

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TypeSerializerFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TypeSerializerFormatTest.java
@@ -63,11 +63,11 @@ public class TypeSerializerFormatTest extends SequentialFormatTestBase<Tuple2<In
 	@Override
 	protected BinaryInputFormat<Tuple2<Integer, String>> createInputFormat() {
 		Configuration configuration = new Configuration();
-		configuration.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, this.blockSize);
 
 		final TypeSerializerInputFormat<Tuple2<Integer, String>> inputFormat = new
 				TypeSerializerInputFormat<Tuple2<Integer, String>>(resultType);
 		inputFormat.setFilePath(this.tempFile.toURI().toString());
+		inputFormat.setBlockSize(this.blockSize);
 
 		inputFormat.configure(configuration);
 		return inputFormat;


### PR DESCRIPTION
This PR makes all the parameters from the input formats accessible through setters.
Before, some could only be set through a configuration object that was passed in the 
`configure()` method. This was problematic because in streaming, this configuration 
object is overwritten by a new configuration object with the default values, as it travels 
from the client to the task managers, leading to parameters like the 
`enumerateNestedFiles` flag in the `FileInputFormat` not being able to be set to a 
non-default value.

NOTE: Now, values set by the setters overwrite the ones in the configuration.