### PR TITLE
[FLINK-4201] [runtime] Forward suspend to checkpoint coordinator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointIDCounter.java
@@ -29,9 +29,18 @@ public interface CheckpointIDCounter {
 	void start() throws Exception;
 
 	/**
-	 * Stops the {@link CheckpointIDCounter} service.
+	 * Shuts the {@link CheckpointIDCounter} service down and frees all created
+	 * resources.
 	 */
-	void stop() throws Exception;
+	void shutdown() throws Exception;
+
+	/**
+	 * Suspends the counter.
+	 *
+	 * <p>If the implementation allows recovery, the counter state needs to be
+	 * kept. Otherwise, this acts as shutdown.
+	 */
+	void suspend() throws Exception;
 
 	/**
 	 * Atomically increments the current checkpoint ID.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -49,10 +49,17 @@ public interface CompletedCheckpointStore {
 	CompletedCheckpoint getLatestCheckpoint() throws Exception;
 
 	/**
-	 * Discards all added {@link CompletedCheckpoint} instances via {@link
-	 * CompletedCheckpoint#discard(ClassLoader)}.
+	 * Shuts down the store and discards all checkpoint instances.
 	 */
-	void discardAllCheckpoints() throws Exception;
+	void shutdown() throws Exception;
+
+	/**
+	 * Suspends the store.
+	 *
+	 * <p>If the implementation allows recovery, checkpoint state needs to be
+	 * kept around. Otherwise, this should act like shutdown.
+	 */
+	void suspend() throws Exception;
 
 	/**
 	 * Returns all {@link CompletedCheckpoint} instances.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SavepointCoordinator.java
@@ -362,7 +362,11 @@ public class SavepointCoordinator extends CheckpointCoordinator {
 		}
 
 		@Override
-		public void discardAllCheckpoints() throws Exception {
+		public void shutdown() throws Exception {
+		}
+
+		@Override
+		public void suspend() throws Exception {
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointIDCounter.java
@@ -33,12 +33,13 @@ public class StandaloneCheckpointIDCounter implements CheckpointIDCounter {
 	private final AtomicLong checkpointIdCounter = new AtomicLong(1);
 
 	@Override
-	public void start() throws Exception {
-	}
+	public void start() throws Exception {}
 
 	@Override
-	public void stop() throws Exception {
-	}
+	public void shutdown() throws Exception {}
+
+	@Override
+	public void suspend() throws Exception {}
 
 	@Override
 	public long getAndIncrement() throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -90,11 +90,17 @@ class StandaloneCompletedCheckpointStore implements CompletedCheckpointStore {
 	}
 
 	@Override
-	public void discardAllCheckpoints() throws Exception {
+	public void shutdown() throws Exception {
 		for (CompletedCheckpoint checkpoint : checkpoints) {
 			checkpoint.discard(userClassLoader);
 		}
 
 		checkpoints.clear();
+	}
+
+	@Override
+	public void suspend() throws Exception {
+		// Do a regular shutdown, because we can't recovery anything
+		shutdown();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
@@ -91,14 +91,30 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 	}
 
 	@Override
-	public void stop() throws Exception {
+	public void shutdown() throws Exception {
 		synchronized (startStopLock) {
 			if (isStarted) {
+				LOG.info("Shutting down.");
 				sharedCount.close();
 				client.getConnectionStateListenable().removeListener(connStateListener);
 
 				LOG.info("Removing {} from ZooKeeper", counterPath);
 				client.delete().deletingChildrenIfNeeded().inBackground().forPath(counterPath);
+
+				isStarted = false;
+			}
+		}
+	}
+
+	@Override
+	public void suspend() throws Exception {
+		synchronized (startStopLock) {
+			if (isStarted) {
+				LOG.info("Suspending.");
+				sharedCount.close();
+				client.getConnectionStateListenable().removeListener(connStateListener);
+
+				// Don't remove any state
 
 				isStarted = false;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -232,7 +232,9 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	}
 
 	@Override
-	public void discardAllCheckpoints() throws Exception {
+	public void shutdown() throws Exception {
+		LOG.info("Shutting down");
+
 		for (Tuple2<StateHandle<CompletedCheckpoint>, String> checkpoint : checkpointStateHandles) {
 			try {
 				removeFromZooKeeperAndDiscardCheckpoint(checkpoint);
@@ -248,6 +250,14 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 		LOG.info("Removing {} from ZooKeeper", path);
 		ZKPaths.deleteChildren(client.getZookeeperClient().getZooKeeper(), path, true);
+	}
+
+	@Override
+	public void suspend() throws Exception {
+		LOG.info("Suspending");
+
+		// Clear the local handles, but don't remove any state
+		checkpointStateHandles.clear();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1110,7 +1110,11 @@ public class ExecutionGraph implements Serializable {
 			CheckpointCoordinator coord = this.checkpointCoordinator;
 			this.checkpointCoordinator = null;
 			if (coord != null) {
-				coord.shutdown();
+				if (state.isGloballyTerminalState()) {
+					coord.shutdown();
+				} else {
+					coord.suspend();
+				}
 			}
 
 			// We don't clean the checkpoint stats tracker, because we want
@@ -1122,8 +1126,13 @@ public class ExecutionGraph implements Serializable {
 		try {
 			CheckpointCoordinator coord = this.savepointCoordinator;
 			this.savepointCoordinator = null;
+
 			if (coord != null) {
-				coord.shutdown();
+				if (state.isGloballyTerminalState()) {
+					coord.shutdown();
+				} else {
+					coord.suspend();
+				}
 			}
 		} catch (Exception e) {
 			LOG.error("Error while cleaning up after execution", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
-import org.apache.curator.framework.api.Pathable;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.StateHandle;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -171,7 +171,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 			checkpoints.addCheckpoint(checkpoint);
 		}
 
-		checkpoints.discardAllCheckpoints();
+		checkpoints.shutdown();
 
 		// Empty state
 		assertNull(checkpoints.getLatestCheckpoint());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import akka.actor.ActorSystem;
-
+import akka.testkit.JavaTestKit;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
@@ -29,14 +29,15 @@ import org.apache.flink.runtime.checkpoint.stats.DisabledCheckpointStatsTracker;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
-
+import org.junit.AfterClass;
 import org.junit.Test;
-
 import scala.concurrent.duration.FiniteDuration;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Collections;
@@ -44,63 +45,114 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ExecutionGraphCheckpointCoordinatorTest {
+
+	private static ActorSystem system = AkkaUtils.createLocalActorSystem(new Configuration());
+
+	@AfterClass
+	public static void teardown() {
+		JavaTestKit.shutdownActorSystem(system);
+	}
 	
 	@Test
 	public void testCheckpointAndSavepointCoordinatorShareCheckpointIDCounter() throws Exception {
+		ExecutionGraph executionGraph = createExecutionGraphAndEnableCheckpointing(
+				new StandaloneCheckpointIDCounter(),
+				new StandaloneCompletedCheckpointStore(1, ClassLoader.getSystemClassLoader()));
+
+		CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
+		SavepointCoordinator savepointCoordinator = executionGraph.getSavepointCoordinator();
+
+		// Both the checkpoint and savepoint coordinator need to operate
+		// with the same checkpoint ID counter.
+		Field counterField = CheckpointCoordinator.class.getDeclaredField("checkpointIdCounter");
+
+		CheckpointIDCounter counterCheckpointCoordinator = (CheckpointIDCounter) counterField
+				.get(checkpointCoordinator);
+
+		CheckpointIDCounter counterSavepointCoordinator = (CheckpointIDCounter) counterField
+				.get(savepointCoordinator);
+
+		assertEquals(counterCheckpointCoordinator, counterSavepointCoordinator);
+	}
+
+	/**
+	 * Tests that a shut down checkpoint coordinator calls shutdown on
+	 * the store and counter.
+	 */
+	@Test
+	public void testShutdownCheckpointCoordinator() throws Exception {
+		CheckpointIDCounter counter = mock(CheckpointIDCounter.class);
+		CompletedCheckpointStore store = mock(CompletedCheckpointStore.class);
+
+		ExecutionGraph graph = createExecutionGraphAndEnableCheckpointing(counter, store);
+		graph.fail(new Exception("Test Exception"));
+
+		// Two times, because shared with savepoint coordinator
+		verify(counter, times(2)).shutdown();
+		verify(store, times(1)).shutdown();
+	}
+
+	/**
+	 * Tests that a suspended checkpoint coordinator calls suspend on
+	 * the store and counter.
+	 */
+	@Test
+	public void testSuspendCheckpointCoordinator() throws Exception {
+		CheckpointIDCounter counter = mock(CheckpointIDCounter.class);
+		CompletedCheckpointStore store = mock(CompletedCheckpointStore.class);
+
+		ExecutionGraph graph = createExecutionGraphAndEnableCheckpointing(counter, store);
+		graph.suspend(new Exception("Test Exception"));
+
+		// No shutdown
+		verify(counter, times(0)).shutdown();
+		verify(store, times(0)).shutdown();
+
+		// Two times, because shared with savepoint coordinator
+		verify(counter, times(2)).suspend();
+		verify(store, times(1)).suspend();
+	}
+
+	private ExecutionGraph createExecutionGraphAndEnableCheckpointing(
+			CheckpointIDCounter counter,
+			CompletedCheckpointStore store) throws Exception {
 		ExecutionGraph executionGraph = new ExecutionGraph(
-			TestingUtils.defaultExecutionContext(),
-			new JobID(),
-			"test",
-			new Configuration(),
-			new SerializedValue<>(new ExecutionConfig()),
-			new FiniteDuration(1, TimeUnit.DAYS),
-			new NoRestartStrategy(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList(),
-			ClassLoader.getSystemClassLoader());
+				TestingUtils.defaultExecutionContext(),
+				new JobID(),
+				"test",
+				new Configuration(),
+				new SerializedValue<>(new ExecutionConfig()),
+				new FiniteDuration(1, TimeUnit.DAYS),
+				new NoRestartStrategy(),
+				Collections.<BlobKey>emptyList(),
+				Collections.<URL>emptyList(),
+				ClassLoader.getSystemClassLoader());
 
-		ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
+		executionGraph.enableSnapshotCheckpointing(
+				100,
+				100,
+				100,
+				1,
+				42,
+				Collections.<ExecutionJobVertex>emptyList(),
+				Collections.<ExecutionJobVertex>emptyList(),
+				Collections.<ExecutionJobVertex>emptyList(),
+				system,
+				UUID.randomUUID(),
+				counter,
+				store,
+				RecoveryMode.STANDALONE,
+				new HeapStateStore<CompletedCheckpoint>(),
+				new DisabledCheckpointStatsTracker());
 
-		try {
-			executionGraph.enableSnapshotCheckpointing(
-					100,
-					100,
-					100,
-					1,
-					42,
-					Collections.<ExecutionJobVertex>emptyList(),
-					Collections.<ExecutionJobVertex>emptyList(),
-					Collections.<ExecutionJobVertex>emptyList(),
-					actorSystem,
-					UUID.randomUUID(),
-					new StandaloneCheckpointIDCounter(),
-					new StandaloneCompletedCheckpointStore(1, ClassLoader.getSystemClassLoader()),
-					RecoveryMode.STANDALONE,
-					new HeapStateStore<CompletedCheckpoint>(),
-					new DisabledCheckpointStatsTracker());
+		JobVertex jobVertex = new JobVertex("MockVertex");
+		executionGraph.attachJobGraph(Collections.singletonList(jobVertex));
 
-			CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
-			SavepointCoordinator savepointCoordinator = executionGraph.getSavepointCoordinator();
-
-			// Both the checkpoint and savepoint coordinator need to operate\
-			// with the same checkpoint ID counter.
-			Field counterField = CheckpointCoordinator.class.getDeclaredField("checkpointIdCounter");
-
-			CheckpointIDCounter counterCheckpointCoordinator = (CheckpointIDCounter) counterField
-					.get(checkpointCoordinator);
-
-			CheckpointIDCounter counterSavepointCoordinator = (CheckpointIDCounter) counterField
-					.get(savepointCoordinator);
-
-			assertEquals(counterCheckpointCoordinator, counterSavepointCoordinator);
-		}
-		finally {
-			if (actorSystem != null) {
-				actorSystem.shutdown();
-			}
-		}
-
+		return executionGraph;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SavepointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SavepointCoordinatorTest.java
@@ -1109,7 +1109,12 @@ public class SavepointCoordinatorTest extends TestLogger {
 		}
 
 		@Override
-		public void stop() throws Exception {
+		public void shutdown() throws Exception {
+			started = false;
+		}
+
+		@Override
+		public void suspend() throws Exception {
 			started = false;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -29,9 +29,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.HeapStateStore;
 import org.apache.flink.runtime.checkpoint.SavepointStore;
-import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
@@ -41,12 +45,17 @@ import org.apache.flink.runtime.instance.InstanceManager;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
+import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.state.LocalStateHandle;
+import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.apache.flink.runtime.testingUtils.TestingJobManager;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
@@ -66,11 +75,14 @@ import scala.concurrent.Future;
 import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
@@ -97,13 +109,10 @@ public class JobManagerHARecoveryTest {
 	/**
 	 * Tests that the persisted job is not removed from the SubmittedJobGraphStore if the JobManager
 	 * loses its leadership. Furthermore, it tests that the job manager can recover the job from
-	 * the SubmittedJobGraphStore.
-	 *
-	 * @throws Exception
+	 * the SubmittedJobGraphStore and checkpoint state is recovered as well.
 	 */
 	@Test
 	public void testJobRecoveryWhenLosingLeadership() throws Exception {
-
 		FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
 		FiniteDuration jobRecoveryTimeout = new FiniteDuration(3, TimeUnit.SECONDS);
 		Deadline deadline = new FiniteDuration(2, TimeUnit.MINUTES).fromNow();
@@ -120,10 +129,12 @@ public class JobManagerHARecoveryTest {
 		flinkConfiguration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, slots);
 
 		try {
-
 			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 
 			MySubmittedJobGraphStore mySubmittedJobGraphStore = new MySubmittedJobGraphStore();
+			MyCheckpointStore checkpointStore = new MyCheckpointStore();
+			CheckpointIDCounter checkpointCounter = new StandaloneCheckpointIDCounter();
+			CheckpointRecoveryFactory checkpointStateFactory = new MyCheckpointRecoveryFactory(checkpointStore, checkpointCounter);
 			TestingLeaderElectionService myLeaderElectionService = new TestingLeaderElectionService();
 			TestingLeaderRetrievalService myLeaderRetrievalService = new TestingLeaderRetrievalService();
 
@@ -146,7 +157,7 @@ public class JobManagerHARecoveryTest {
 				timeout,
 				myLeaderElectionService,
 				mySubmittedJobGraphStore,
-				new StandaloneCheckpointRecoveryFactory(),
+				checkpointStateFactory,
 				new SavepointStore(new HeapStateStore()),
 				jobRecoveryTimeout,
 				Option.apply(null));
@@ -171,10 +182,22 @@ public class JobManagerHARecoveryTest {
 			Await.ready(tmAlive, deadline.timeLeft());
 
 			JobVertex sourceJobVertex = new JobVertex("Source");
-			sourceJobVertex.setInvokableClass(BlockingInvokable.class);
+			sourceJobVertex.setInvokableClass(BlockingStatefulInvokable.class);
 			sourceJobVertex.setParallelism(slots);
 
 			JobGraph jobGraph = new JobGraph("TestingJob", sourceJobVertex);
+
+			List<JobVertexID> vertexId = Collections.singletonList(sourceJobVertex.getID());
+			jobGraph.setSnapshotSettings(new JobSnapshottingSettings(
+					vertexId,
+					vertexId,
+					vertexId,
+					100,
+					10 * 60 * 1000,
+					0,
+					1));
+
+			BlockingStatefulInvokable.initializeStaticHelpers(slots);
 
 			Future<Object> isLeader = gateway.ask(
 				TestingJobManagerMessages.getNotifyWhenLeader(),
@@ -198,6 +221,9 @@ public class JobManagerHARecoveryTest {
 				deadline.timeLeft());
 
 			Await.ready(jobSubmitted, deadline.timeLeft());
+
+			// Wait for some checkpoints to complete
+			BlockingStatefulInvokable.awaitCompletedCheckpoints();
 
 			Future<Object> jobRemoved = gateway.ask(new TestingJobManagerMessages.NotifyWhenJobRemoved(jobGraph.getJobID()), deadline.timeLeft());
 
@@ -228,6 +254,15 @@ public class JobManagerHARecoveryTest {
 
 			// check that the job has been removed from the submitted job graph store
 			assertFalse(mySubmittedJobGraphStore.contains(jobGraph.getJobID()));
+
+			// Check that state has been recovered
+			long[] recoveredStates = BlockingStatefulInvokable.getRecoveredStates();
+			for (long state : recoveredStates) {
+				boolean isExpected = state >= BlockingStatefulInvokable.NUM_CHECKPOINTS_TO_COMPLETE;
+				assertTrue("Did not recover checkpoint state correctly, expecting >= " +
+						BlockingStatefulInvokable.NUM_CHECKPOINTS_TO_COMPLETE +
+						", but state was " + state, isExpected);
+			}
 		} finally {
 			if (archive != null) {
 				archive.tell(PoisonPill.getInstance(), ActorRef.noSender());
@@ -243,7 +278,89 @@ public class JobManagerHARecoveryTest {
 		}
 	}
 
+	/**
+	 * A checkpoint store, which supports shutdown and suspend. You can use this to test HA
+	 * as long as the factory always returns the same store instance.
+	 */
+	static class MyCheckpointStore implements CompletedCheckpointStore {
+
+
+		private final ArrayDeque<CompletedCheckpoint> checkpoints = new ArrayDeque<>(2);
+
+		private final ArrayDeque<CompletedCheckpoint> suspended = new ArrayDeque<>(2);
+
+		@Override
+		public void recover() throws Exception {
+			checkpoints.addAll(suspended);
+			suspended.clear();
+		}
+
+		@Override
+		public void addCheckpoint(CompletedCheckpoint checkpoint) throws Exception {
+			checkpoints.addLast(checkpoint);
+			if (checkpoints.size() > 1) {
+				checkpoints.removeFirst().discard(ClassLoader.getSystemClassLoader());
+			}
+		}
+
+		@Override
+		public CompletedCheckpoint getLatestCheckpoint() throws Exception {
+			return checkpoints.isEmpty() ? null : checkpoints.getLast();
+		}
+
+		@Override
+		public void shutdown() throws Exception {
+			checkpoints.clear();
+			suspended.clear();
+		}
+
+		@Override
+		public void suspend() throws Exception {
+			suspended.addAll(checkpoints);
+			checkpoints.clear();
+		}
+
+		@Override
+		public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
+			return new ArrayList<>(checkpoints);
+		}
+
+		@Override
+		public int getNumberOfRetainedCheckpoints() {
+			return checkpoints.size();
+		}
+
+	}
+
+	static class MyCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
+
+		private final CompletedCheckpointStore store;
+		private final CheckpointIDCounter counter;
+
+		public MyCheckpointRecoveryFactory(CompletedCheckpointStore store, CheckpointIDCounter counter) {
+			this.store = store;
+			this.counter = counter;
+		}
+
+		@Override
+		public void start() {}
+
+		@Override
+		public void stop() {}
+
+		@Override
+		public CompletedCheckpointStore createCompletedCheckpoints(JobID jobId, ClassLoader userClassLoader) throws Exception {
+			return store;
+		}
+
+		@Override
+		public CheckpointIDCounter createCheckpointIDCounter(JobID jobId) throws Exception {
+			return counter;
+		}
+	}
+
 	static class MySubmittedJobGraphStore implements SubmittedJobGraphStore {
+
 		Map<JobID, SubmittedJobGraph> storedJobs = new HashMap<>();
 
 		@Override
@@ -305,6 +422,52 @@ public class JobManagerHARecoveryTest {
 			synchronized (lock) {
 				lock.notifyAll();
 			}
+		}
+	}
+
+	public static class BlockingStatefulInvokable extends BlockingInvokable implements StatefulTask<StateHandle<Long>> {
+
+		private static final int NUM_CHECKPOINTS_TO_COMPLETE = 5;
+
+		private static volatile CountDownLatch completedCheckpointsLatch = new CountDownLatch(1);
+
+		private static volatile long[] recoveredStates = new long[0];
+
+		private int completedCheckpoints = 0;
+
+		@Override
+		public void setInitialState(StateHandle<Long> stateHandle) throws Exception {
+			int subtaskIndex = getIndexInSubtaskGroup();
+			if (subtaskIndex < recoveredStates.length) {
+				recoveredStates[subtaskIndex] = stateHandle.getState(getUserCodeClassLoader());
+			}
+		}
+
+		@Override
+		public boolean triggerCheckpoint(long checkpointId, long timestamp) {
+			StateHandle<Long> state = new LocalStateHandle<>(checkpointId);
+			getEnvironment().acknowledgeCheckpoint(checkpointId, state);
+			return true;
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			if (completedCheckpoints++ > NUM_CHECKPOINTS_TO_COMPLETE) {
+				completedCheckpointsLatch.countDown();
+			}
+		}
+
+		public static void initializeStaticHelpers(int numSubtasks) {
+			completedCheckpointsLatch = new CountDownLatch(numSubtasks);
+			recoveredStates = new long[numSubtasks];
+		}
+
+		public static void awaitCompletedCheckpoints() throws InterruptedException {
+			completedCheckpointsLatch.await();
+		}
+
+		public static long[] getRecoveredStates() {
+			return recoveredStates;
 		}
 	}
 


### PR DESCRIPTION
Suspended jobs were leading to shutdown of the checkpoint coordinator and hence removal of checkpoint state. For standalone recovery mode this is OK as no state can be recovered anyways (unchanged in this PR). For HA though this lead to removal of checkpoint state, which we
actually want to keep for recovery.

We have the following behaviour now:


JobState | Standalone | High Availability
-----------|------------|-------------------
 SUSPENDED |  Discard   |       Keep
 FINISHED/FAILED/CANCELED |  Discard   |     Discard