### PR TITLE
[FLINK-4229] Only start JMX server when port is specified

### DIFF
--- a/docs/apis/metrics.md
+++ b/docs/apis/metrics.md
@@ -249,8 +249,9 @@ but not activated.
 Parameters:
 
 - `port` - the port on which JMX listens for connections. This can also be a port range. When a
-range is specified the actual port is shown in the relevant job or task manager log. Default:
-`9010-9025`.
+range is specified the actual port is shown in the relevant job or task manager log. If you don't
+specify a port no extra JMX server will be started. Metrics are still available on the default
+local JMX interface.
 
 ### Ganglia (org.apache.flink.metrics.ganglia.GangliaReporter)
 Dependency:

--- a/flink-core/src/test/java/org/apache/flink/metrics/reporter/JMXReporterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/metrics/reporter/JMXReporterTest.java
@@ -88,7 +88,7 @@ public class JMXReporterTest extends TestLogger {
 		JMXReporter rep2 = new JMXReporter();
 
 		Configuration cfg1 = new Configuration();
-		cfg1.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "-port 9020-9035");
+		cfg1.setString("port", "9020-9035");
 
 		rep1.open(cfg1);
 		rep2.open(cfg1);
@@ -137,7 +137,7 @@ public class JMXReporterTest extends TestLogger {
 		JMXReporter rep2 = new JMXReporter();
 
 		Configuration cfg1 = new Configuration();
-		cfg1.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "-port 9040-9055");
+		cfg1.setString("port", "9040-9055");
 		rep1.open(cfg1);
 		rep2.open(cfg1);
 


### PR DESCRIPTION
The JMX reporter now only starts an extra server if a port (or port range) was specified. Otherwise, it will just have the default local JMX capabilities.

R: @StephanEwen 
R: @zentol 