### PR TITLE
RMQ Sink: Possibility to customize queue config [FLINK-4251]

### DIFF
--- a/flink-streaming-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-streaming-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -39,7 +39,7 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RMQSink.class);
 
-	private String queueName;
+	protected String queueName;
 	private RMQConnectionConfig rmqConnectionConfig;
 	private transient Connection connection;
 	private transient Channel channel;
@@ -55,6 +55,15 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 		this.rmqConnectionConfig = rmqConnectionConfig;
 		this.queueName = queueName;
 		this.schema = schema;
+	}
+
+	/**
+	 * Sets up the queue. The default implementation just declares the queue. The user may override
+	 * this method to have a custom setup for the queue (i.e. binding the queue to an exchange or
+	 * defining custom queue parameters)
+	 */
+	protected void setupQueue() throws IOException {
+		channel.queueDeclare(queueName, false, false, false, null);
 	}
 
 	/**
@@ -79,7 +88,7 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 			if (channel == null) {
 				throw new RuntimeException("None of RabbitMQ channels are available");
 			}
-			channel.queueDeclare(queueName, false, false, false, null);
+			setupQueue();
 		} catch (IOException e) {
 			throw new RuntimeException("Error while creating the channel", e);
 		}

--- a/flink-streaming-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-streaming-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -39,11 +39,11 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RMQSink.class);
 
-	protected String queueName;
-	private RMQConnectionConfig rmqConnectionConfig;
-	private transient Connection connection;
-	private transient Channel channel;
-	private SerializationSchema<IN> schema;
+	protected final String queueName;
+	private final RMQConnectionConfig rmqConnectionConfig;
+	protected transient Connection connection;
+	protected transient Channel channel;
+	protected SerializationSchema<IN> schema;
 	private boolean logFailuresOnly = false;
 
 	/**


### PR DESCRIPTION
This patch adds the possibilty for the user of the RabbitMQ
Streaming Sink to customize the queue which is used. 
This adopts the behavior of [FLINK-4025] for the sink.
The commit doesn't change the actual behaviour but makes it possible for users to override the `setupQueue` method and customize their implementation. This was only possible for the RMQSource before. The Sink and the Source offer now both the same functionality, so this should increase usability. 

[FLINK-4025] = https://issues.apache.org/jira/browse/FLINK-4251

Best,
Philipp