### PR TITLE
[FLINK-4246] Allow Specifying Multiple Metrics Reporters

### DIFF
--- a/docs/apis/metrics.md
+++ b/docs/apis/metrics.md
@@ -227,14 +227,29 @@ or by assigning unique names to jobs and operators.
 
 ## Reporter
 
-Metrics can be exposed to an external system by configuring a reporter in `conf/flink-conf.yaml`.
+Metrics can be exposed to an external system by configuring one or several reporters in `conf/flink-conf.yaml`.
 
-- `metrics.reporter.class`: The class of the reporter to use.
-  - Example: org.apache.flink.metrics.jmx.JMXReporter
-- `metrics.reporter.arguments`: A list of named parameters that are passed to the reporter.
-  - Example: --host localhost --port 9010
-- `metrics.reporter.interval`: The interval between reports.
-  - Example: 10 SECONDS
+- `metrics.reporters`: The list of named reporters.
+- `metrics.reporter.<name>.<config>`: Generic setting `<config>` for the reporter named `<name>`.
+- `metrics.reporter.<name>.class`: The reporter class to use for the reporter named `<name>`.
+- `metrics.reporter.<name>.interval`: The reporter interval to use for the reporter named `<name>`.
+
+All reporters must at least have the `class` property, some allow specifying a reporting `interval`. Below,
+we will list more settings specific to each reporter.
+
+Example reporter configuration that specifies multiple reporters:
+
+```
+metrics.reporters: my_jmx_reporter,my_other_reporter
+
+metrics.reporter.my_jmx_reporter.class: org.apache.flink.metrics.jmx.JMXReporter
+metrics.reporter.my_jmx_reporter.port: 9020-9040
+
+metrics.reporter.my_other_reporter.class: org.apache.flink.metrics.graphite.GraphiteReporter
+metrics.reporter.my_other_reporter.host: 192.168.1.1
+metrics.reporter.my_other_reporter.port: 10000
+
+```
 
 You can write your own `Reporter` by implementing the `org.apache.flink.metrics.reporter.MetricReporter` interface.
 If the Reporter should send out reports regularly you have to implement the `Scheduled` interface as well.

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -150,7 +150,7 @@ Default value is 1.
 - `restart-strategy.fixed-delay.delay`: Delay between restart attempts, used if the default restart strategy is set to "fixed-delay".
 Default value is the `akka.ask.timeout`.
 
-- `restart-strategy.failure-rate.max-failures-per-interval`: Maximum number of restarts in given time interval before failing a job in "failure-rate" strategy. 
+- `restart-strategy.failure-rate.max-failures-per-interval`: Maximum number of restarts in given time interval before failing a job in "failure-rate" strategy.
 Default value is 1.
 
 - `restart-strategy.failure-rate.failure-rate-interval`: Time interval for measuring failure rate in "failure-rate" strategy.
@@ -288,7 +288,7 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 - `recovery.zookeeper.path.root`: (Default '/flink') Defines the root dir under which the ZooKeeper recovery mode will create namespace directories.
 
-- `recovery.zookeeper.path.namespace`: (Default '/default_ns' in standalone mode, or the <yarn-application-id> under Yarn) Defines the subdirectory under the root dir where the ZooKeeper recovery mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. 
+- `recovery.zookeeper.path.namespace`: (Default '/default_ns' in standalone mode, or the <yarn-application-id> under Yarn) Defines the subdirectory under the root dir where the ZooKeeper recovery mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper.
 
 - `recovery.zookeeper.path.latch`: (Default '/leaderlatch') Defines the znode of the leader latch which is used to elect the leader.
 
@@ -312,7 +312,13 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 ## Metrics
 
-- `metrics.jmx.port`: (Default: 9010-9025) Defines the port used by JMX.
+- `metrics.reporters`: The list of named reporters, i.e. "foo,bar".
+
+- `metrics.reporter.<name>.<config>`: Generic setting `<config>` for the reporter named `<name>`.
+
+- `metrics.reporter.<name>.class`: The reporter class to use for the reporter named `<name>`.
+
+- `metrics.reporter.<name>.interval`: The reporter interval to use for the reporter named `<name>`.
 
 - `metrics.scope.jm`: (Default: &lt;host&gt;.jobmanager) Defines the scope format string that is applied to all metrics scoped to a JobManager.
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -651,14 +651,34 @@ public final class ConfigConstants {
 
 	// ---------------------------- Metrics -----------------------------------
 
-	/** The class of the reporter to use. */
-	public static final String METRICS_REPORTER_CLASS = "metrics.reporter.class";
+	/**
+	 * The list of named reporters. Names are defined here and per-reporter configs
+	 * are given with the reporter config prefix and the reporter name.
+	 *
+	 * Example:
+	 * <pre>{@code
+	 * metrics.reporters = foo, bar
+	 *
+	 * metrics.reporter.foo.class = org.apache.flink.metrics.reporter.JMXReporter
+	 * metrics.reporter.foo.interval = 10
+	 *
+	 * metrics.reporter.bar.class = org.apache.flink.metrics.graphite.GraphiteReporter
+	 * metrics.reporter.bar.port = 1337
+	 * }</pre>
+	 */
+	public static final String METRICS_REPORTERS_LIST = "metrics.reporters";
+
+	/**
+	 * The prefix for per-reporter configs. Has to be combined with a reporter name and
+	 * the configs mentioned below.
+	 */
+	public static final String METRICS_REPORTER_PREFIX = "metrics.reporter.";
+
+	/** The class of the reporter to use. This is used as a suffix in an actual reporter config */
+	public static final String METRICS_REPORTER_CLASS_SUFFIX = "class";
 	
-	/** A list of named parameters that are passed to the reporter. */
-	public static final String METRICS_REPORTER_ARGUMENTS = "metrics.reporter.arguments";
-	
-	/** The interval between reports. */
-	public static final String METRICS_REPORTER_INTERVAL = "metrics.reporter.interval";
+	/** The interval between reports. This is used as a suffix in an actual reporter config */
+	public static final String METRICS_REPORTER_INTERVAL_SUFFIX = "interval";
 
 	/** The delimiter used to assemble the metric identifier. */
 	public static final String METRICS_SCOPE_DELIMITER = "metrics.scope.delimiter";

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.flink.annotation.Public;
@@ -56,7 +57,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	
 
 	/** Stores the concrete key/value pairs of this configuration object. */
-	private final HashMap<String, Object> confData;
+	final HashMap<String, Object> confData;
 	
 	// --------------------------------------------------------------------------------------------
 
@@ -417,6 +418,17 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	public Set<String> keySet() {
 		synchronized (this.confData) {
 			return new HashSet<String>(this.confData.keySet());
+		}
+	}
+
+	/**
+	 * Adds all entries in this {@code Configuration} to the given {@link Properties}.
+	 */
+	public void addAllToProperties(Properties props) {
+		synchronized (this.confData) {
+			for (Map.Entry<String, Object> entry : this.confData.entrySet()) {
+				props.put(entry.getKey(), entry.getValue());
+			}
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.configuration;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * A configuration that manages a subset of keys with a common prefix from a given configuration.
+ */
+public final class DelegatingConfiguration extends Configuration {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Configuration backingConfig;		// the configuration actually storing the data
+
+	private String prefix;							// the prefix key by which keys for this config are marked
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Default constructor for serialization. Creates an empty delegating configuration.
+	 */
+	public DelegatingConfiguration() {
+		this.backingConfig = new Configuration();
+		this.prefix = "";
+	}
+
+	/**
+	 * Creates a new delegating configuration which stores its key/value pairs in the given
+	 * configuration using the specifies key prefix.
+	 *
+	 * @param backingConfig The configuration holding the actual config data.
+	 * @param prefix The prefix prepended to all config keys.
+	 */
+	public DelegatingConfiguration(Configuration backingConfig, String prefix)
+	{
+		this.backingConfig = backingConfig;
+		this.prefix = prefix;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public String getString(String key, String defaultValue) {
+		return this.backingConfig.getString(this.prefix + key, defaultValue);
+	}
+
+	@Override
+	public void setString(String key, String value) {
+		this.backingConfig.setString(this.prefix + key, value);
+	}
+
+	@Override
+	public <T> Class<T> getClass(String key, Class<? extends T> defaultValue, ClassLoader classLoader) throws ClassNotFoundException {
+		return this.backingConfig.getClass(this.prefix + key, defaultValue, classLoader);
+	}
+
+	@Override
+	public void setClass(String key, Class<?> klazz) {
+		this.backingConfig.setClass(this.prefix + key, klazz);
+	}
+
+	@Override
+	public int getInteger(String key, int defaultValue) {
+		return this.backingConfig.getInteger(this.prefix + key, defaultValue);
+	}
+
+	@Override
+	public void setInteger(String key, int value) {
+		this.backingConfig.setInteger(this.prefix + key, value);
+	}
+
+	@Override
+	public long getLong(String key, long defaultValue) {
+		return this.backingConfig.getLong(this.prefix + key, defaultValue);
+	}
+
+	@Override
+	public void setLong(String key, long value) {
+		this.backingConfig.setLong(this.prefix + key, value);
+	}
+
+	@Override
+	public boolean getBoolean(String key, boolean defaultValue) {
+		return this.backingConfig.getBoolean(this.prefix + key, defaultValue);
+	}
+
+	@Override
+	public void setBoolean(String key, boolean value) {
+		this.backingConfig.setBoolean(this.prefix + key, value);
+	}
+
+	@Override
+	public float getFloat(String key, float defaultValue) {
+		return this.backingConfig.getFloat(this.prefix + key, defaultValue);
+	}
+
+	@Override
+	public void setFloat(String key, float value) {
+		this.backingConfig.setFloat(this.prefix + key, value);
+	}
+
+	@Override
+	public double getDouble(String key, double defaultValue) {
+		return this.backingConfig.getDouble(this.prefix + key, defaultValue);
+	}
+
+	@Override
+	public void setDouble(String key, double value) {
+		this.backingConfig.setDouble(this.prefix + key, value);
+	}
+
+	@Override
+	public byte[] getBytes(final String key, final byte[] defaultValue) {
+		return this.backingConfig.getBytes(this.prefix + key, defaultValue);
+	}
+
+	@Override
+	public void setBytes(final String key, final byte[] bytes) {
+		this.backingConfig.setBytes(this.prefix + key, bytes);
+	}
+
+	@Override
+	public void addAllToProperties(Properties props) {
+		// only add keys with our prefix
+		synchronized (backingConfig.confData) {
+			for (Map.Entry<String, Object> entry : this.confData.entrySet()) {
+				if (entry.getKey().startsWith(prefix)) {
+					String keyWithoutPrefix =
+							entry.getKey().substring(prefix.length(),
+									entry.getKey().length());
+
+					props.put(keyWithoutPrefix, entry.getValue());
+				} else {
+					// don't add stuff that doesn't have our prefix
+				}
+			}
+		}
+
+	}
+
+	@Override
+	public void addAll(Configuration other) {
+		this.addAll(other, "");
+	}
+
+	@Override
+	public void addAll(Configuration other, String prefix) {
+		this.backingConfig.addAll(other, this.prefix + prefix);
+	}
+
+	@Override
+	public String toString() {
+		return backingConfig.toString();
+	}
+
+	@Override
+	public Set<String> keySet() {
+		final HashSet<String> set = new HashSet<String>();
+		final int prefixLen = this.prefix == null ? 0 : this.prefix.length();
+
+		for (String key : this.backingConfig.keySet()) {
+			if (key.startsWith(this.prefix)) {
+				set.add(key.substring(prefixLen));
+			}
+		}
+		return set;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		this.prefix = in.readUTF();
+		this.backingConfig.read(in);
+	}
+
+	@Override
+	public void write(DataOutputView out) throws IOException {
+		out.writeUTF(this.prefix);
+		this.backingConfig.write(out);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		return this.prefix.hashCode() ^ this.backingConfig.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof DelegatingConfiguration) {
+			DelegatingConfiguration other = (DelegatingConfiguration) obj;
+			return this.prefix.equals(other.prefix) && this.backingConfig.equals(other.backingConfig);
+		} else {
+			return false;
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
@@ -20,6 +20,8 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.Public;
 
+import java.util.Properties;
+
 /**
  * Unmodifiable version of the Configuration class.
  */
@@ -41,6 +43,13 @@ public class UnmodifiableConfiguration extends Configuration {
 	// --------------------------------------------------------------------------------------------
 	//  All mutating methods must fail
 	// --------------------------------------------------------------------------------------------
+
+
+	@Override
+	public void addAllToProperties(Properties props) {
+		// override to make the UnmodifiableConfigurationTest happy
+		super.addAllToProperties(props);
+	}
 
 	@Override
 	public final void addAll(Configuration other) {

--- a/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
@@ -17,9 +17,9 @@
  */
 
 
-package org.apache.flink.runtime.util;
+package org.apache.flink.configuration;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -27,9 +27,7 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.operators.util.TaskConfig.DelegatingConfiguration;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 
 public class DelegatingConfigurationTest {

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
@@ -96,8 +96,9 @@ public class DropwizardFlinkHistogramWrapperTest extends TestLogger {
 		int size = 10;
 		String histogramMetricName = "histogram";
 		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_CLASS, TestingReporter.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_INTERVAL, reportingInterval + " MILLISECONDS");
+		config.setString(ConfigConstants.METRICS_REPORTERS_LIST, "my_reporter");
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestingReporter.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, reportingInterval + " MILLISECONDS");
 
 		MetricRegistry registry = null;
 
@@ -112,10 +113,9 @@ public class DropwizardFlinkHistogramWrapperTest extends TestLogger {
 
 			String fullMetricName = metricGroup.getMetricIdentifier(histogramMetricName);
 
-			Field f = registry.getClass().getDeclaredField("reporter");
-			f.setAccessible(true);
+			assertTrue(registry.getReporters().size() == 1);
 
-			MetricReporter reporter = (MetricReporter) f.get(registry);
+			MetricReporter reporter = registry.getReporters().get(0);
 
 			assertTrue(reporter instanceof TestingReporter);
 

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -19,12 +19,12 @@ package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.jmx.JMXReporter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
-import org.apache.flink.metrics.jmx.JMXReporter;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
 import org.junit.Test;
@@ -52,9 +52,11 @@ public class JMXJobManagerMetricTest {
 		Deadline deadline = new FiniteDuration(2, TimeUnit.MINUTES).fromNow();
 		Configuration flinkConfiguration = new Configuration();
 
-		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_CLASS, JMXReporter.class.getName());
+		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTERS_LIST, "test");
+		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
+		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.port", "9060-9075");
+
 		flinkConfiguration.setString(ConfigConstants.METRICS_SCOPE_NAMING_JM_JOB, "jobmanager.<job_name>");
-		flinkConfiguration.setString(ConfigConstants.METRICS_REPORTER_ARGUMENTS, "--port 9060-9075");
 
 		TestingCluster flink = new TestingCluster(flinkConfiguration);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
@@ -85,7 +85,8 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 		JobGraph jobGraph = new JobGraph("Test Job", jobVertex);
 
 		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_CLASS, TestingReporter.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTERS_LIST, "test");
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestingReporter.class.getName());
 
 		Configuration jobConfig = new Configuration();
 
@@ -93,7 +94,9 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 
 		MetricRegistry metricRegistry = new MetricRegistry(config);
 
-		MetricReporter reporter = metricRegistry.getReporter();
+		assertTrue(metricRegistry.getReporters().size() == 1);
+
+		MetricReporter reporter = metricRegistry.getReporters().get(0);
 
 		assertTrue(reporter instanceof TestingReporter);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
@@ -40,7 +40,8 @@ public class MetricGroupRegistrationTest {
 	@Test
 	public void testMetricInstantiation() {
 		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_CLASS, TestReporter1.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTERS_LIST, "test");
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
 
 		MetricRegistry registry = new MetricRegistry(config);
 

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -102,7 +102,8 @@ public abstract class KafkaTestBase extends TestLogger {
 		flinkConfig.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 8);
 		flinkConfig.setInteger(ConfigConstants.TASK_MANAGER_MEMORY_SIZE_KEY, 16);
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
-		flinkConfig.setString(ConfigConstants.METRICS_REPORTER_CLASS, JMXReporter.class.getName());
+		flinkConfig.setString(ConfigConstants.METRICS_REPORTERS_LIST, "my_reporter");
+		flinkConfig.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
 
 		flink = new ForkableFlinkMiniCluster(flinkConfig, false);
 		flink.start();


### PR DESCRIPTION
This also updates documentation and tests.

Reporters can now be specified like this:

metrics.reporters: foo,bar

metrics.reporter.foo.class: JMXReporter.class
metrics.reporter.foo.port: 10

metrics.reporter.bar.class: GangliaReporter.class
metrics.reporter.bar.port: 11
metrics.reporter.bar.interval: 10 SECONDS
metrics.reporter.bar.something: 42

R: @StephanEwen and @zentol for review