### PR TITLE
[hotfix] Prevent CheckpointCommitter from failing job

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
@@ -219,7 +219,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 		verifyResultsDataDiscardingUponRestore(testHarness, task, (S) task.getOperator());
 	}
 
-	private StreamTaskState copyTaskState(StreamTaskState toCopy) throws IOException, ClassNotFoundException {
+	protected StreamTaskState copyTaskState(StreamTaskState toCopy) throws IOException, ClassNotFoundException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		ObjectOutputStream oos = new ObjectOutputStream(baos);
 		oos.writeObject(toCopy);


### PR DESCRIPTION
This PR fixes an issue in the `GenericWriteAheadSink` that @aljoscha stumbled upon.

If the sink fails while writing the data into the external storage the sink retries again on the next notify; it will never fail the job. However, the CheckpointCommitter does not behave that way; if the storage cannot be queried it will throw an exception that is not catched by the sink.

The exceptions are now catched and logged by the sink.

@aljoscha Could you try out whether this fixes the issue?