### PR TITLE
[FLINK-4226] Typo: Define Keys using Field Expressions example should use window and not reduce

### DIFF
--- a/docs/apis/common/index.md
+++ b/docs/apis/common/index.md
@@ -528,7 +528,7 @@ val wordCounts = words.keyBy("word").window(/*window specification*/)
 // or, as a case class, which is less typing
 case class WC(word: String, count: Int)
 val words: DataStream[WC] = // [...]
-val wordCounts = words.keyBy("word").reduce(/*window specification*/)
+val wordCounts = words.keyBy("word").window(/*window specification*/)
 {% endhighlight %}
 
 **Field Expression Syntax**:


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/FLINK-4226
Description:
val wordCounts = words.keyBy("word").reduce(/*window specification*/)
Should be: 
val wordCounts = words.keyBy("word").reduce window(/window specification/)

File:
/flink/docs/apis/common/index.md

Requesting Review.