### PR TITLE
[FLINK-4259]: Unclosed FSDataOutputStream in FileCache#copy(): Added a …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -259,6 +259,8 @@ public class FileCache {
 					IOUtils.copyBytes(fsInput, lfsOutput);
 					//noinspection ResultOfMethodCallIgnored
 					new File(targetPath.toString()).setExecutable(executable);
+					// closing the FSDataOutputStream
+					lfsOutput.close();
 				}
 				catch (IOException ioe) {
 					LOG.error("could not copy file to local file cache.", ioe);


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

Description of Changes:
Add a close statement for closing the FSDataOutputStream.
Requesting review.

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-4259] Unclosed FSDataOutputStream in FileCache#copy()")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

…close statement to close the FSDataOutputStream object