### PR TITLE
[FLINK-4245] [metrics] Expose all defined variables

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.metrics;
 
+import java.util.Map;
+
 /**
  * A MetricGroup is a named container for {@link Metric Metrics} and further metric subgroups.
  * 
@@ -140,6 +142,14 @@ public interface MetricGroup {
 	 * @see #getMetricIdentifier(String, CharacterFilter)
 	 */
 	String[] getScopeComponents();
+
+	/**
+	 * Returns a map of all variables and their associated value, for example
+	 * {@code {"<host>"="host-7", "<tm_id>"="taskmanager-2"}}
+	 * 
+	 * @return map of all variables and their associated value
+     */
+	Map<String, String> getAllVariables();
 
 	/**
 	 * Returns the fully qualified metric name, for example

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
@@ -25,6 +25,9 @@ import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * A special {@link MetricGroup} that does not register any metrics at the metrics registry
  * and any reporters.
@@ -84,6 +87,11 @@ public class UnregisteredMetricsGroup implements MetricGroup {
 	@Override
 	public String[] getScopeComponents() {
 		return new String[0];
+	}
+
+	@Override
+	public Map<String, String> getAllVariables() {
+		return new HashMap<>();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ComponentMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ComponentMetricGroup.java
@@ -20,6 +20,9 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.runtime.metrics.MetricRegistry;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Abstract {@link org.apache.flink.metrics.MetricGroup} for system components (e.g., 
  * TaskManager, Job, Task, Operator).
@@ -33,7 +36,7 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
  * group could for example include the task attempt number (more fine grained identification), or
  * exclude it (for continuity of the namespace across failure and recovery).
  */
-public abstract class ComponentMetricGroup extends AbstractMetricGroup {
+public abstract class ComponentMetricGroup<P extends AbstractMetricGroup> extends AbstractMetricGroup<P> {
 
 	/**
 	 * Creates a new ComponentMetricGroup.
@@ -41,9 +44,32 @@ public abstract class ComponentMetricGroup extends AbstractMetricGroup {
 	 * @param registry     registry to register new metrics with
 	 * @param scope        the scope of the group
 	 */
-	public ComponentMetricGroup(MetricRegistry registry, String[] scope) {
-		super(registry, scope);
+	public ComponentMetricGroup(MetricRegistry registry, String[] scope, P parent) {
+		super(registry, scope, parent);
 	}
+
+	@Override
+	public Map<String, String> getAllVariables() {
+		if (variables == null) { // avoid synchronization for common case
+			synchronized (this) {
+				if (variables == null) {
+					variables = new HashMap<>();
+					putVariables(variables);
+					if (parent != null) { // not true for Job-/TaskManagerMetricGroup
+						variables.putAll(parent.getAllVariables());
+					}
+				}
+			}
+		}
+		return variables;
+	}
+
+	/**
+	 * Enters all variables specific to this ComponentMetricGroup and their associated values into the map.
+	 *
+	 * @param variables map to enter variables and their values into
+     */
+	protected abstract void putVariables(Map<String, String> variables);
 
 	/**
 	 * Closes the component group by removing and closing all metrics and subgroups

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
@@ -29,19 +29,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Special {@link org.apache.flink.metrics.MetricGroup} representing everything belonging to
  * a specific job, running on the JobManager.
  */
-public class JobManagerJobMetricGroup extends JobMetricGroup {
-
-	/** The metrics group that contains this group */
-	private final JobManagerMetricGroup parent;
-
+public class JobManagerJobMetricGroup extends JobMetricGroup<JobManagerMetricGroup> {
 	public JobManagerJobMetricGroup(
 			MetricRegistry registry,
 			JobManagerMetricGroup parent,
 			JobID jobId,
 			@Nullable String jobName) {
-		super(registry, jobId, jobName, registry.getScopeFormats().getJobManagerJobFormat().formatScope(checkNotNull(parent), jobId, jobName));
-
-		this.parent = parent;
+		super(registry, checkNotNull(parent), jobId, jobName, registry.getScopeFormats().getJobManagerJobFormat().formatScope(checkNotNull(parent), jobId, jobName));
 	}
 
 	public final JobManagerMetricGroup parent() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,14 +31,14 @@ import java.util.Map;
  * <p>Contains extra logic for adding jobs with tasks, and removing jobs when they do
  * not contain tasks any more
  */
-public class JobManagerMetricGroup extends ComponentMetricGroup {
+public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetricGroup> {
 
 	private final Map<JobID, JobManagerJobMetricGroup> jobs = new HashMap<>();
 
 	private final String hostname;
 
 	public JobManagerMetricGroup(MetricRegistry registry, String hostname) {
-		super(registry, registry.getScopeFormats().getJobManagerFormat().formatScope(hostname));
+		super(registry, registry.getScopeFormats().getJobManagerFormat().formatScope(hostname), null);
 		this.hostname = hostname;
 	}
 
@@ -84,6 +85,15 @@ public class JobManagerMetricGroup extends ComponentMetricGroup {
 
 	public int numRegisteredJobMetricGroups() {
 		return jobs.size();
+	}
+
+	// ------------------------------------------------------------------------
+	//  Component Metric Group Specifics
+	// ------------------------------------------------------------------------
+
+	@Override
+	protected void putVariables(Map<String, String> variables) {
+		variables.put(ScopeFormat.SCOPE_ACTOR_HOST, hostname);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -93,7 +93,7 @@ public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetric
 
 	@Override
 	protected void putVariables(Map<String, String> variables) {
-		variables.put(ScopeFormat.SCOPE_ACTOR_HOST, hostname);
+		variables.put(ScopeFormat.SCOPE_HOST, hostname);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobMetricGroup.java
@@ -21,15 +21,17 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 
 /**
  * Special abstract {@link org.apache.flink.metrics.MetricGroup} representing everything belonging to
  * a specific job.
  */
 @Internal
-public abstract class JobMetricGroup extends ComponentMetricGroup {
+public abstract class JobMetricGroup<C extends ComponentMetricGroup<C>> extends ComponentMetricGroup<C> {
 
 	/** The ID of the job represented by this metrics group */
 	protected final JobID jobId;
@@ -42,10 +44,11 @@ public abstract class JobMetricGroup extends ComponentMetricGroup {
 
 	protected JobMetricGroup(
 			MetricRegistry registry,
+			C parent,
 			JobID jobId,
 			@Nullable String jobName,
 			String[] scope) {
-		super(registry, scope);
+		super(registry, scope, parent);
 		
 		this.jobId = jobId;
 		this.jobName = jobName;
@@ -58,5 +61,15 @@ public abstract class JobMetricGroup extends ComponentMetricGroup {
 	@Nullable
 	public String jobName() {
 		return jobName;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Component Metric Group Specifics
+	// ------------------------------------------------------------------------
+
+	@Override
+	protected void putVariables(Map<String, String> variables) {
+		variables.put(ScopeFormat.SCOPE_JOB_ID, jobId.toString());
+		variables.put(ScopeFormat.SCOPE_JOB_NAME, jobName);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
@@ -19,22 +19,22 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Special {@link org.apache.flink.metrics.MetricGroup} representing an Operator.
  */
-public class OperatorMetricGroup extends ComponentMetricGroup {
-
-	/** The task metric group that contains this operator metric groups */
-	private final TaskMetricGroup parent;
+public class OperatorMetricGroup extends ComponentMetricGroup<TaskMetricGroup> {
+	private final String operatorName;
 
 	public OperatorMetricGroup(MetricRegistry registry, TaskMetricGroup parent, String operatorName) {
-		super(registry, registry.getScopeFormats().getOperatorFormat().formatScope(checkNotNull(parent), operatorName));
-		this.parent = parent;
+		super(registry, registry.getScopeFormats().getOperatorFormat().formatScope(checkNotNull(parent), operatorName), parent);
+		this.operatorName = operatorName;
 	}
 
 	// ------------------------------------------------------------------------
@@ -46,6 +46,12 @@ public class OperatorMetricGroup extends ComponentMetricGroup {
 	// ------------------------------------------------------------------------
 	//  Component Metric Group Specifics
 	// ------------------------------------------------------------------------
+
+	@Override
+	protected void putVariables(Map<String, String> variables) {
+		variables.put(ScopeFormat.SCOPE_OPERATOR_NAME, operatorName);
+		// we don't enter the subtask_index as the task group does that already
+	}
 
 	@Override
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ProxyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ProxyMetricGroup.java
@@ -24,6 +24,8 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 
+import java.util.Map;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -92,6 +94,11 @@ public class ProxyMetricGroup<P extends MetricGroup> implements MetricGroup {
 	@Override
 	public String[] getScopeComponents() {
 		return parentMetricGroup.getScopeComponents();
+	}
+
+	@Override
+	public Map<String, String> getAllVariables() {
+		return parentMetricGroup.getAllVariables();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -34,10 +34,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>Contains extra logic for adding Tasks ({@link TaskMetricGroup}).
  */
-public class TaskManagerJobMetricGroup extends JobMetricGroup {
-
-	/** The metrics group that contains this group */
-	private final TaskManagerMetricGroup parent;
+public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricGroup> {
 
 	/** Map from execution attempt ID (task identifier) to task metrics */
 	private final Map<AbstractID, TaskMetricGroup> tasks = new HashMap<>();
@@ -49,8 +46,7 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup {
 			TaskManagerMetricGroup parent,
 			JobID jobId,
 			@Nullable String jobName) {
-		super(registry, jobId, jobName, registry.getScopeFormats().getTaskManagerJobFormat().formatScope(checkNotNull(parent), jobId, jobName));
-		this.parent = parent;
+		super(registry, parent, jobId, jobName, registry.getScopeFormats().getTaskManagerJobFormat().formatScope(checkNotNull(parent), jobId, jobName));
 	}
 
 	public final TaskManagerMetricGroup parent() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +32,7 @@ import java.util.Map;
  * <p>Contains extra logic for adding jobs with tasks, and removing jobs when they do
  * not contain tasks any more
  */
-public class TaskManagerMetricGroup extends ComponentMetricGroup {
+public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetricGroup> {
 
 	private final Map<JobID, TaskManagerJobMetricGroup> jobs = new HashMap<>();
 
@@ -41,7 +42,7 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup {
 
 
 	public TaskManagerMetricGroup(MetricRegistry registry, String hostname, String taskManagerId) {
-		super(registry, registry.getScopeFormats().getTaskManagerFormat().formatScope(hostname, taskManagerId));
+		super(registry, registry.getScopeFormats().getTaskManagerFormat().formatScope(hostname, taskManagerId), null);
 		this.hostname = hostname;
 		this.taskManagerId = taskManagerId;
 	}
@@ -114,6 +115,12 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup {
 	// ------------------------------------------------------------------------
 	//  Component Metric Group Specifics
 	// ------------------------------------------------------------------------
+
+	@Override
+	protected void putVariables(Map<String, String> variables) {
+		variables.put(ScopeFormat.SCOPE_ACTOR_HOST, hostname);
+		variables.put(ScopeFormat.SCOPE_TASKMANAGER_ID, taskManagerId);
+	}
 
 	@Override
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -118,7 +118,7 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetr
 
 	@Override
 	protected void putVariables(Map<String, String> variables) {
-		variables.put(ScopeFormat.SCOPE_ACTOR_HOST, hostname);
+		variables.put(ScopeFormat.SCOPE_HOST, hostname);
 		variables.put(ScopeFormat.SCOPE_TASKMANAGER_ID, taskManagerId);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/JobManagerJobScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/JobManagerJobScopeFormat.java
@@ -28,7 +28,7 @@ public class JobManagerJobScopeFormat extends ScopeFormat {
 
 	public JobManagerJobScopeFormat(String format, JobManagerScopeFormat parentFormat) {
 		super(format, parentFormat, new String[] {
-				SCOPE_ACTOR_HOST,
+				SCOPE_HOST,
 				SCOPE_JOB_ID,
 				SCOPE_JOB_NAME
 		});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/JobManagerScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/JobManagerScopeFormat.java
@@ -25,7 +25,7 @@ public class JobManagerScopeFormat extends ScopeFormat {
 
 	public JobManagerScopeFormat(String format) {
 		super(format, null, new String[] {
-			SCOPE_ACTOR_HOST
+			SCOPE_HOST
 		});
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/OperatorScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/OperatorScopeFormat.java
@@ -27,7 +27,7 @@ public class OperatorScopeFormat extends ScopeFormat {
 
 	public OperatorScopeFormat(String format, TaskScopeFormat parentFormat) {
 		super(format, parentFormat, new String[] {
-				SCOPE_ACTOR_HOST,
+				SCOPE_HOST,
 				SCOPE_TASKMANAGER_ID,
 				SCOPE_JOB_ID,
 				SCOPE_JOB_NAME,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
@@ -68,13 +68,13 @@ public abstract class ScopeFormat {
 	//  Scope Variables
 	// ------------------------------------------------------------------------
 
-	public static final String SCOPE_ACTOR_HOST = asVariable("host");
+	public static final String SCOPE_HOST = asVariable("host");
 
 	// ----- Job Manager ----
 
 	/** The default scope format of the JobManager component: {@code "<host>.jobmanager"} */
 	public static final String DEFAULT_SCOPE_JOBMANAGER_COMPONENT =
-		concat(SCOPE_ACTOR_HOST, "jobmanager");
+		concat(SCOPE_HOST, "jobmanager");
 
 	/** The default scope format of JobManager metrics: {@code "<host>.jobmanager"} */
 	public static final String DEFAULT_SCOPE_JOBMANAGER_GROUP = DEFAULT_SCOPE_JOBMANAGER_COMPONENT;
@@ -85,7 +85,7 @@ public abstract class ScopeFormat {
 
 	/** The default scope format of the TaskManager component: {@code "<host>.taskmanager.<tm_id>"} */
 	public static final String DEFAULT_SCOPE_TASKMANAGER_COMPONENT =
-			concat(SCOPE_ACTOR_HOST, "taskmanager", SCOPE_TASKMANAGER_ID);
+			concat(SCOPE_HOST, "taskmanager", SCOPE_TASKMANAGER_ID);
 
 	/** The default scope format of TaskManager metrics: {@code "<host>.taskmanager.<tm_id>"} */
 	public static final String DEFAULT_SCOPE_TASKMANAGER_GROUP = DEFAULT_SCOPE_TASKMANAGER_COMPONENT;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskManagerJobScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskManagerJobScopeFormat.java
@@ -28,7 +28,7 @@ public class TaskManagerJobScopeFormat extends ScopeFormat {
 
 	public TaskManagerJobScopeFormat(String format, TaskManagerScopeFormat parentFormat) {
 		super(format, parentFormat, new String[] {
-				SCOPE_ACTOR_HOST,
+				SCOPE_HOST,
 				SCOPE_TASKMANAGER_ID,
 				SCOPE_JOB_ID,
 				SCOPE_JOB_NAME

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskManagerScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskManagerScopeFormat.java
@@ -25,7 +25,7 @@ public class TaskManagerScopeFormat extends ScopeFormat {
 
 	public TaskManagerScopeFormat(String format) {
 		super(format, null, new String[] {
-				SCOPE_ACTOR_HOST,
+				SCOPE_HOST,
 				SCOPE_TASKMANAGER_ID
 		});
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskScopeFormat.java
@@ -28,7 +28,7 @@ public class TaskScopeFormat extends ScopeFormat {
 
 	public TaskScopeFormat(String format, TaskManagerJobScopeFormat parentFormat) {
 		super(format, parentFormat, new String[] {
-				SCOPE_ACTOR_HOST,
+				SCOPE_HOST,
 				SCOPE_TASKMANAGER_ID,
 				SCOPE_JOB_ID,
 				SCOPE_JOB_NAME,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -15,33 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.runtime.metrics.groups;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.junit.Test;
 
-/**
- * A simple named {@link org.apache.flink.metrics.MetricGroup} that is used to hold
- * subgroups of metrics.
- */
-public class GenericMetricGroup extends AbstractMetricGroup<AbstractMetricGroup> {
+import static org.junit.Assert.assertTrue;
 
-	public GenericMetricGroup(MetricRegistry registry, AbstractMetricGroup parent, String name) {
-		super(registry, makeScopeComponents(parent, name), parent);
-	}
+public class AbstractMetricGroupTest {
+	/**
+	 * Verifies that no {@link NullPointerException} is thrown when {@link AbstractMetricGroup#getAllVariables()} is
+	 * called and the parent is null.
+	 */
+	@Test
+	public void testGetAllVariables() {
+		MetricRegistry registry = new MetricRegistry(new Configuration());
 
-	// ------------------------------------------------------------------------
-
-	private static String[] makeScopeComponents(AbstractMetricGroup parent, String name) {
-		if (parent != null) {
-			String[] parentComponents = parent.getScopeComponents();
-			if (parentComponents != null && parentComponents.length > 0) {
-				String[] parts = new String[parentComponents.length + 1];
-				System.arraycopy(parentComponents, 0, parts, 0, parentComponents.length);
-				parts[parts.length - 1] = name;
-				return parts;
-			}
-		}
-		return new String[] { name };
+		AbstractMetricGroup group = new AbstractMetricGroup<AbstractMetricGroup>(registry, new String[0], null) {
+		};
+		assertTrue(group.getAllVariables().isEmpty());
+		
+		registry.shutdown();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -135,7 +135,7 @@ public class MetricGroupTest {
 	private static class DummyAbstractMetricGroup extends AbstractMetricGroup {
 
 		public DummyAbstractMetricGroup(MetricRegistry registry) {
-			super(registry, new String[0]);
+			super(registry, new String[0], null);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -72,7 +72,7 @@ public class OperatorGroupTest {
 
 		Map<String, String> variables = opGroup.getAllVariables();
 
-		testVariable(variables, ScopeFormat.SCOPE_ACTOR_HOST, "theHostName");
+		testVariable(variables, ScopeFormat.SCOPE_HOST, "theHostName");
 		testVariable(variables, ScopeFormat.SCOPE_TASKMANAGER_ID, "test-tm-id");
 		testVariable(variables, ScopeFormat.SCOPE_JOB_ID, jid.toString());
 		testVariable(variables, ScopeFormat.SCOPE_JOB_NAME, "myJobName");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -21,12 +21,17 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.util.AbstractID;
 
 import org.junit.Test;
 
+import java.util.Map;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class OperatorGroupTest {
 
@@ -49,5 +54,41 @@ public class OperatorGroupTest {
 				opGroup.getMetricIdentifier("name"));
 
 		registry.shutdown();
+	}
+
+	@Test
+	public void testVariables() {
+		MetricRegistry registry = new MetricRegistry(new Configuration());
+
+		JobID jid = new JobID();
+		AbstractID tid = new AbstractID();
+		AbstractID eid = new AbstractID();
+		
+		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
+		TaskMetricGroup taskGroup = new TaskMetricGroup(
+			registry, jmGroup,  tid,  eid, "aTaskName", 11, 0);
+		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, "myOpName");
+
+		Map<String, String> variables = opGroup.getAllVariables();
+
+		testVariable(variables, ScopeFormat.SCOPE_ACTOR_HOST, "theHostName");
+		testVariable(variables, ScopeFormat.SCOPE_TASKMANAGER_ID, "test-tm-id");
+		testVariable(variables, ScopeFormat.SCOPE_JOB_ID, jid.toString());
+		testVariable(variables, ScopeFormat.SCOPE_JOB_NAME, "myJobName");
+		testVariable(variables, ScopeFormat.SCOPE_TASK_VERTEX_ID, tid.toString());
+		testVariable(variables, ScopeFormat.SCOPE_TASK_NAME, "aTaskName");
+		testVariable(variables, ScopeFormat.SCOPE_TASK_ATTEMPT_ID, eid.toString());
+		testVariable(variables, ScopeFormat.SCOPE_TASK_SUBTASK_INDEX, "11");
+		testVariable(variables, ScopeFormat.SCOPE_TASK_ATTEMPT_NUM, "0");
+		testVariable(variables, ScopeFormat.SCOPE_OPERATOR_NAME, "myOpName");
+
+		registry.shutdown();
+	}
+
+	private static void testVariable(Map<String, String> variables, String key, String expectedValue) {
+		String actualValue = variables.get(key);
+		assertNotNull(actualValue);
+		assertEquals(expectedValue, actualValue);
 	}
 }


### PR DESCRIPTION
This PR allows users and reporters to access a `Map<String, String>` of all defined variables and their associated values via `MetricGroup#getAllVariables()`.

The following changes were made:
* Every `AbstractMetricGroup` now has a parent field (previously, each `ComponentMetricGroup` had it's own field). For proper typing, both of these now have a generic type argument, denoting the type of the parent. 
 * For example: `TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGroup>`
 * most super() calls had to be adjusted to pass the parent as well
* The method `Map<String, String> getAllVariables()` was added to the `MetricGroup` interface
 * Non-`ComponentMetricGroup` implementations always forward the call to the parent or return an empty map.
 * A `ComponentMetricGroup` creates a new `HashMap` (if it wasn't created before), enters it's own variables (see next item), and adds the values returned by `parent.getAllVariables()`
* The method `protected void putVariables(Map<String, String> variables)` was added to the `ComponentMetricGroup` class.
 * In this method the group adds it's varaibles and values into the map
* The map is lazily computed.