### PR TITLE
[hotfix] [metrics] Refactor constructors and tests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.JobManagerJobScopeFormat;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -36,22 +35,11 @@ public class JobManagerJobMetricGroup extends JobMetricGroup {
 	private final JobManagerMetricGroup parent;
 
 	public JobManagerJobMetricGroup(
-		MetricRegistry registry,
-		JobManagerMetricGroup parent,
-		JobID jobId,
-		@Nullable String jobName) {
-
-		this(registry, checkNotNull(parent), registry.getScopeFormats().getJobManagerJobFormat(), jobId, jobName);
-	}
-
-	public JobManagerJobMetricGroup(
-		MetricRegistry registry,
-		JobManagerMetricGroup parent,
-		JobManagerJobScopeFormat scopeFormat,
-		JobID jobId,
-		@Nullable String jobName) {
-
-		super(registry, jobId, jobName, scopeFormat.formatScope(parent, jobId, jobName));
+			MetricRegistry registry,
+			JobManagerMetricGroup parent,
+			JobID jobId,
+			@Nullable String jobName) {
+		super(registry, jobId, jobName, registry.getScopeFormats().getJobManagerJobFormat().formatScope(parent, jobId, jobName));
 
 		this.parent = checkNotNull(parent);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
@@ -39,9 +39,9 @@ public class JobManagerJobMetricGroup extends JobMetricGroup {
 			JobManagerMetricGroup parent,
 			JobID jobId,
 			@Nullable String jobName) {
-		super(registry, jobId, jobName, registry.getScopeFormats().getJobManagerJobFormat().formatScope(parent, jobId, jobName));
+		super(registry, jobId, jobName, registry.getScopeFormats().getJobManagerJobFormat().formatScope(checkNotNull(parent), jobId, jobName));
 
-		this.parent = checkNotNull(parent);
+		this.parent = parent;
 	}
 
 	public final JobManagerMetricGroup parent() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.JobManagerScopeFormat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,15 +37,7 @@ public class JobManagerMetricGroup extends ComponentMetricGroup {
 	private final String hostname;
 
 	public JobManagerMetricGroup(MetricRegistry registry, String hostname) {
-		this(registry, registry.getScopeFormats().getJobManagerFormat(), hostname);
-	}
-
-	public JobManagerMetricGroup(
-		MetricRegistry registry,
-		JobManagerScopeFormat scopeFormat,
-		String hostname) {
-
-		super(registry, scopeFormat.formatScope(hostname));
+		super(registry, registry.getScopeFormats().getJobManagerFormat().formatScope(hostname));
 		this.hostname = hostname;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.OperatorScopeFormat;
 
 import java.util.Collections;
 
@@ -34,16 +33,7 @@ public class OperatorMetricGroup extends ComponentMetricGroup {
 	private final TaskMetricGroup parent;
 
 	public OperatorMetricGroup(MetricRegistry registry, TaskMetricGroup parent, String operatorName) {
-		this(registry, parent, registry.getScopeFormats().getOperatorFormat(), operatorName);
-	}
-
-	public OperatorMetricGroup(
-			MetricRegistry registry,
-			TaskMetricGroup parent,
-			OperatorScopeFormat scopeFormat,
-			String operatorName) {
-
-		super(registry, scopeFormat.formatScope(parent, operatorName));
+		super(registry, registry.getScopeFormats().getOperatorFormat().formatScope(parent, operatorName));
 		this.parent = checkNotNull(parent);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
@@ -33,8 +33,8 @@ public class OperatorMetricGroup extends ComponentMetricGroup {
 	private final TaskMetricGroup parent;
 
 	public OperatorMetricGroup(MetricRegistry registry, TaskMetricGroup parent, String operatorName) {
-		super(registry, registry.getScopeFormats().getOperatorFormat().formatScope(parent, operatorName));
-		this.parent = checkNotNull(parent);
+		super(registry, registry.getScopeFormats().getOperatorFormat().formatScope(checkNotNull(parent), operatorName));
+		this.parent = parent;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.TaskManagerJobScopeFormat;
 import org.apache.flink.util.AbstractID;
 
 import javax.annotation.Nullable;
@@ -50,20 +49,8 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup {
 			TaskManagerMetricGroup parent,
 			JobID jobId,
 			@Nullable String jobName) {
-
-		this(registry, checkNotNull(parent), registry.getScopeFormats().getTaskManagerJobFormat(), jobId, jobName);
-	}
-
-	public TaskManagerJobMetricGroup(
-			MetricRegistry registry,
-			TaskManagerMetricGroup parent,
-			TaskManagerJobScopeFormat scopeFormat,
-			JobID jobId,
-			@Nullable String jobName) {
-
-		super(registry, jobId, jobName, scopeFormat.formatScope(parent, jobId, jobName));
-
-		this.parent = checkNotNull(parent);
+		super(registry, jobId, jobName, registry.getScopeFormats().getTaskManagerJobFormat().formatScope(checkNotNull(parent), jobId, jobName));
+		this.parent = parent;
 	}
 
 	public final TaskManagerMetricGroup parent() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.TaskManagerScopeFormat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,15 +41,7 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup {
 
 
 	public TaskManagerMetricGroup(MetricRegistry registry, String hostname, String taskManagerId) {
-		this(registry, registry.getScopeFormats().getTaskManagerFormat(), hostname, taskManagerId);
-	}
-
-	public TaskManagerMetricGroup(
-			MetricRegistry registry,
-			TaskManagerScopeFormat scopeFormat,
-			String hostname, String taskManagerId) {
-
-		super(registry, scopeFormat.formatScope(hostname, taskManagerId));
+		super(registry, registry.getScopeFormats().getTaskManagerFormat().formatScope(hostname, taskManagerId));
 		this.hostname = hostname;
 		this.taskManagerId = taskManagerId;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.TaskScopeFormat;
 import org.apache.flink.util.AbstractID;
 
 import javax.annotation.Nullable;
@@ -65,23 +64,8 @@ public class TaskMetricGroup extends ComponentMetricGroup {
 			@Nullable String taskName,
 			int subtaskIndex,
 			int attemptNumber) {
-		
-		this(registry, parent, registry.getScopeFormats().getTaskFormat(),
-				vertexId, executionId, taskName, subtaskIndex, attemptNumber);
-	}
-
-	public TaskMetricGroup(
-			MetricRegistry registry,
-			TaskManagerJobMetricGroup parent,
-			TaskScopeFormat scopeFormat, 
-			@Nullable AbstractID vertexId,
-			AbstractID executionId,
-			@Nullable String taskName,
-			int subtaskIndex,
-			int attemptNumber) {
-
-		super(registry, scopeFormat.formatScope(
-				parent, vertexId, executionId, taskName, subtaskIndex, attemptNumber));
+		super(registry, registry.getScopeFormats().getTaskFormat().formatScope(
+			parent, vertexId, executionId, taskName, subtaskIndex, attemptNumber));
 
 		this.parent = checkNotNull(parent);
 		this.executionId = checkNotNull(executionId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -65,10 +65,10 @@ public class TaskMetricGroup extends ComponentMetricGroup {
 			int subtaskIndex,
 			int attemptNumber) {
 		super(registry, registry.getScopeFormats().getTaskFormat().formatScope(
-			parent, vertexId, executionId, taskName, subtaskIndex, attemptNumber));
+			checkNotNull(parent), vertexId, checkNotNull(executionId), taskName, subtaskIndex, attemptNumber));
 
-		this.parent = checkNotNull(parent);
-		this.executionId = checkNotNull(executionId);
+		this.parent = parent;
+		this.executionId = executionId;
 		this.vertexId = vertexId;
 		this.taskName = taskName;
 		this.subtaskIndex = subtaskIndex;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
@@ -53,6 +53,8 @@ public class MetricRegistryTest extends TestLogger {
 		assertTrue(metricRegistry.getReporters().size() == 1);
 
 		Assert.assertTrue(TestReporter1.wasOpened);
+
+		metricRegistry.shutdown();
 	}
 
 	protected static class TestReporter1 extends TestReporter {
@@ -83,6 +85,8 @@ public class MetricRegistryTest extends TestLogger {
 		Assert.assertTrue(TestReporter11.wasOpened);
 		Assert.assertTrue(TestReporter12.wasOpened);
 		Assert.assertTrue(TestReporter13.wasOpened);
+
+		metricRegistry.shutdown();
 	}
 
 	protected static class TestReporter11 extends TestReporter {
@@ -124,7 +128,7 @@ public class MetricRegistryTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.arg1", "hello");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.arg2", "world");
 
-		new MetricRegistry(config);
+		new MetricRegistry(config).shutdown();
 	}
 
 	protected static class TestReporter2 extends TestReporter {
@@ -149,7 +153,7 @@ public class MetricRegistryTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.arg1", "hello");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, "50 MILLISECONDS");
 
-		new MetricRegistry(config);
+		MetricRegistry registry = new MetricRegistry(config);
 
 		long start = System.currentTimeMillis();
 		for (int x = 0; x < 10; x++) {
@@ -168,6 +172,8 @@ public class MetricRegistryTest extends TestLogger {
 			Assert.assertTrue("Too many report were triggered.", maxAllowedReports >= reportCount);
 		}
 		Assert.assertTrue("No report was triggered.", TestReporter3.reportCount > 0);
+
+		registry.shutdown();
 	}
 
 	protected static class TestReporter3 extends TestReporter implements Scheduled {
@@ -199,6 +205,8 @@ public class MetricRegistryTest extends TestLogger {
 		assertTrue(TestReporter6.removeCalled);
 		assertTrue(TestReporter7.addCalled);
 		assertTrue(TestReporter7.removeCalled);
+
+		registry.shutdown();
 	}
 
 	protected static class TestReporter6 extends TestReporter {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
@@ -111,5 +111,6 @@ public class MetricGroupRegistrationTest {
 		MetricGroup group3 = root.addGroup("group");
 		Assert.assertTrue(group1 == group2 && group2 == group3);
 
+		registry.shutdown();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -28,7 +29,6 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.TaskManagerScopeFormat;
 import org.apache.flink.util.AbstractID;
 
 import org.apache.flink.util.SerializedValue;
@@ -260,9 +260,10 @@ public class TaskManagerGroupTest {
 
 	@Test
 	public void testGenerateScopeCustom() {
-		MetricRegistry registry = new MetricRegistry(new Configuration());
-		TaskManagerScopeFormat format = new TaskManagerScopeFormat("constant.<host>.foo.<host>");
-		TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, format, "host", "id");
+		Configuration cfg = new Configuration();
+		cfg.setString(ConfigConstants.METRICS_SCOPE_NAMING_TM, "constant.<host>.foo.<host>");
+		MetricRegistry registry = new MetricRegistry(cfg);
+		TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, "host", "id");
 
 		assertArrayEquals(new String[] { "constant", "host", "foo", "host" }, group.getScopeComponents());
 		assertEquals("constant.host.foo.host.name", group.getMetricIdentifier("name"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
@@ -19,10 +19,9 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.scope.TaskManagerJobScopeFormat;
-import org.apache.flink.runtime.metrics.scope.TaskManagerScopeFormat;
 
 import org.junit.Test;
 
@@ -50,15 +49,15 @@ public class TaskManagerJobGroupTest {
 
 	@Test
 	public void testGenerateScopeCustom() {
-		MetricRegistry registry = new MetricRegistry(new Configuration());
-
-		TaskManagerScopeFormat tmFormat = new TaskManagerScopeFormat("abc");
-		TaskManagerJobScopeFormat jmFormat = new TaskManagerJobScopeFormat("some-constant.<job_name>", tmFormat);
+		Configuration cfg = new Configuration();
+		cfg.setString(ConfigConstants.METRICS_SCOPE_NAMING_TM, "abc");
+		cfg.setString(ConfigConstants.METRICS_SCOPE_NAMING_TM_JOB, "some-constant.<job_name>");
+		MetricRegistry registry = new MetricRegistry(cfg);
 
 		JobID jid = new JobID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
-		JobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jmFormat, jid, "myJobName");
+		JobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
 
 		assertArrayEquals(
 				new String[] { "some-constant", "myJobName" },
@@ -72,15 +71,15 @@ public class TaskManagerJobGroupTest {
 
 	@Test
 	public void testGenerateScopeCustomWildcard() {
-		MetricRegistry registry = new MetricRegistry(new Configuration());
-
-		TaskManagerScopeFormat tmFormat = new TaskManagerScopeFormat("peter.<tm_id>");
-		TaskManagerJobScopeFormat jmFormat = new TaskManagerJobScopeFormat("*.some-constant.<job_id>", tmFormat);
+		Configuration cfg = new Configuration();
+		cfg.setString(ConfigConstants.METRICS_SCOPE_NAMING_TM, "peter.<tm_id>");
+		cfg.setString(ConfigConstants.METRICS_SCOPE_NAMING_TM_JOB, "*.some-constant.<job_id>");
+		MetricRegistry registry = new MetricRegistry(cfg);
 
 		JobID jid = new JobID();
 
-		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, tmFormat, "theHostName", "test-tm-id");
-		JobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jmFormat, jid, "myJobName");
+		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+		JobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
 
 		assertArrayEquals(
 				new String[] { "peter", "test-tm-id", "some-constant", jid.toString() },


### PR DESCRIPTION
Several `ComponentMetricGroup` classes had an additional constructor which took a `ScopeFormat` argument. This contructor was only used by tests. In this PR i removed them, as they did not made it any easier to test specific formats. By not going through the common channel (via the configuration) they in fact become more obscure imo.

The following changes were made:
- removed constructors taking a specific ScopeFormat as argument
- refactored tests accordingly
- made sure that the registry is shutdown in every test