### PR TITLE
[FLINK-4248] [core] [table] CsvTableSource does not support reading SqlTimeTypeInfo types

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/parser/BigDecParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/BigDecParser.java
@@ -35,29 +35,13 @@ public class BigDecParser extends FieldParser<BigDecimal> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, BigDecimal reusable) {
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
 		try {
-			final int length = i - startPos;
+			final int length = endPos - startPos;
 			if (reuse == null || reuse.length < length) {
 				reuse = new char[length];
 			}
@@ -70,7 +54,7 @@ public class BigDecParser extends FieldParser<BigDecimal> {
 			}
 
 			this.result = new BigDecimal(reuse, 0, length);
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		} catch (NumberFormatException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
 			return -1;

--- a/flink-core/src/main/java/org/apache/flink/types/parser/BigDecParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/BigDecParser.java
@@ -35,7 +35,7 @@ public class BigDecParser extends FieldParser<BigDecimal> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, BigDecimal reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/BigDecParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/BigDecParser.java
@@ -35,7 +35,7 @@ public class BigDecParser extends FieldParser<BigDecimal> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, BigDecimal reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -48,7 +48,8 @@ public class BigDecParser extends FieldParser<BigDecimal> {
 			for (int j = 0; j < length; j++) {
 				final byte b = bytes[startPos + j];
 				if ((b < '0' || b > '9') && b != '-' && b != '+' && b != '.' && b != 'E' && b != 'e') {
-					throw new NumberFormatException();
+					setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+					return -1;
 				}
 				reuse[j] = (char) bytes[startPos + j];
 			}
@@ -80,7 +81,7 @@ public class BigDecParser extends FieldParser<BigDecimal> {
 	 * @param startPos The offset to start the parsing.
 	 * @param length   The length of the byte sequence (counting from the offset).
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final BigDecimal parseField(byte[] bytes, int startPos, int length) {
@@ -97,7 +98,7 @@ public class BigDecParser extends FieldParser<BigDecimal> {
 	 * @param length    The length of the byte sequence (counting from the offset).
 	 * @param delimiter The delimiter that terminates the field.
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final BigDecimal parseField(byte[] bytes, int startPos, int length, char delimiter) {

--- a/flink-core/src/main/java/org/apache/flink/types/parser/BigIntParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/BigIntParser.java
@@ -34,31 +34,15 @@ public class BigIntParser extends FieldParser<BigInteger> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, BigInteger reusable) {
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
-		String str = new String(bytes, startPos, i - startPos);
+		String str = new String(bytes, startPos, endPos - startPos);
 		try {
 			this.result = new BigInteger(str);
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		} catch (NumberFormatException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
 			return -1;
@@ -105,22 +89,7 @@ public class BigIntParser extends FieldParser<BigInteger> {
 	 * represents not a correct number.
 	 */
 	public static final BigInteger parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		if (length <= 0) {
-			throw new NumberFormatException("Invalid input: Empty string");
-		}
-		int i = 0;
-		final byte delByte = (byte) delimiter;
-
-		while (i < length && bytes[startPos + i] != delByte) {
-			i++;
-		}
-
-		if (i > 0 &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
-			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
-		}
-
-		String str = new String(bytes, startPos, i);
+		final String str = formattedString(bytes, startPos, length, delimiter);
 		return new BigInteger(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/BigIntParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/BigIntParser.java
@@ -34,8 +34,14 @@ public class BigIntParser extends FieldParser<BigInteger> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, BigInteger reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
+			return -1;
+		}
+
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 
@@ -68,7 +74,7 @@ public class BigIntParser extends FieldParser<BigInteger> {
 	 * @param startPos The offset to start the parsing.
 	 * @param length   The length of the byte sequence (counting from the offset).
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final BigInteger parseField(byte[] bytes, int startPos, int length) {
@@ -85,11 +91,18 @@ public class BigIntParser extends FieldParser<BigInteger> {
 	 * @param length    The length of the byte sequence (counting from the offset).
 	 * @param delimiter The delimiter that terminates the field.
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final BigInteger parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = nextNumericString(bytes, startPos, length, delimiter);
+		final int limitedLen = nextStringLength(bytes, startPos, length, delimiter);
+
+		if (limitedLen > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + limitedLen - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
+		}
+
+		final String str = new String(bytes, startPos, limitedLen);
 		return new BigInteger(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/BigIntParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/BigIntParser.java
@@ -34,7 +34,7 @@ public class BigIntParser extends FieldParser<BigInteger> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, BigInteger reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -89,7 +89,7 @@ public class BigIntParser extends FieldParser<BigInteger> {
 	 * represents not a correct number.
 	 */
 	public static final BigInteger parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = formattedString(bytes, startPos, length, delimiter);
+		final String str = nextNumericString(bytes, startPos, length, delimiter);
 		return new BigInteger(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/DoubleParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/DoubleParser.java
@@ -33,31 +33,15 @@ public class DoubleParser extends FieldParser<Double> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Double reusable) {
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
-		String str = new String(bytes, startPos, i - startPos);
+		String str = new String(bytes, startPos, endPos - startPos);
 		try {
 			this.result = Double.parseDouble(str);
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		} catch (NumberFormatException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
 			return -1;
@@ -104,22 +88,7 @@ public class DoubleParser extends FieldParser<Double> {
 	 * represents not a correct number.
 	 */
 	public static final double parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		if (length <= 0) {
-			throw new NumberFormatException("Invalid input: Empty string");
-		}
-		int i = 0;
-		final byte delByte = (byte) delimiter;
-
-		while (i < length && bytes[startPos + i] != delByte) {
-			i++;
-		}
-
-		if (i > 0 &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
-			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
-		}
-
-		String str = new String(bytes, startPos, i);
+		final String str = formattedString(bytes, startPos, length, delimiter);
 		return Double.parseDouble(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/DoubleParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/DoubleParser.java
@@ -33,7 +33,7 @@ public class DoubleParser extends FieldParser<Double> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Double reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -88,7 +88,7 @@ public class DoubleParser extends FieldParser<Double> {
 	 * represents not a correct number.
 	 */
 	public static final double parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = formattedString(bytes, startPos, length, delimiter);
+		final String str = nextNumericString(bytes, startPos, length, delimiter);
 		return Double.parseDouble(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/DoubleParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/DoubleParser.java
@@ -33,8 +33,14 @@ public class DoubleParser extends FieldParser<Double> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Double reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
+			return -1;
+		}
+
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 
@@ -67,7 +73,7 @@ public class DoubleParser extends FieldParser<Double> {
 	 * @param startPos The offset to start the parsing.
 	 * @param length   The length of the byte sequence (counting from the offset).
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final double parseField(byte[] bytes, int startPos, int length) {
@@ -84,11 +90,18 @@ public class DoubleParser extends FieldParser<Double> {
 	 * @param length    The length of the byte sequence (counting from the offset).
 	 * @param delimiter The delimiter that terminates the field.
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final double parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = nextNumericString(bytes, startPos, length, delimiter);
+		final int limitedLen = nextStringLength(bytes, startPos, length, delimiter);
+
+		if (limitedLen > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + limitedLen - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
+		}
+
+		final String str = new String(bytes, startPos, limitedLen);
 		return Double.parseDouble(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/DoubleValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/DoubleValueParser.java
@@ -32,34 +32,17 @@ public class DoubleValueParser extends FieldParser<DoubleValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, DoubleValue reusable) {
-		
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-		
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[i - 1]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
-		String str = new String(bytes, startPos, i - startPos);
+		String str = new String(bytes, startPos, endPos - startPos);
 		try {
 			double value = Double.parseDouble(str);
 			reusable.setValue(value);
 			this.result = reusable;
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		}
 		catch (NumberFormatException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);

--- a/flink-core/src/main/java/org/apache/flink/types/parser/DoubleValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/DoubleValueParser.java
@@ -32,8 +32,14 @@ public class DoubleValueParser extends FieldParser<DoubleValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, DoubleValue reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
+			return -1;
+		}
+
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/DoubleValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/DoubleValueParser.java
@@ -32,7 +32,7 @@ public class DoubleValueParser extends FieldParser<DoubleValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, DoubleValue reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -222,5 +222,10 @@ public abstract class FieldParser<T> {
 		PARSERS.put(FloatValue.class, FloatValueParser.class);
 		PARSERS.put(DoubleValue.class, DoubleValueParser.class);
 		PARSERS.put(BooleanValue.class, BooleanValueParser.class);
+
+		// SQL date/time types
+		PARSERS.put(java.sql.Time.class, SqlTimeParser.class);
+		PARSERS.put(java.sql.Date.class, SqlDateParser.class);
+		PARSERS.put(java.sql.Timestamp.class, SqlTimestampParser.class);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -176,43 +176,43 @@ public abstract class FieldParser<T> {
 	}
 
 	/**
-	 * Returns the end position of a string with a numeric format (like XXXX-XX-XX). Sets the error state if the
-	 * string contains leading/trailing whitespaces or if the column is empty.
+	 * Returns the end position of a numeric string. A numeric string does not start or end with whitespaces.
+	 * Sets the error state if the string contains leading/trailing whitespaces or if the column is empty.
 	 *
 	 * @return the end position of the string or -1 if an error occurred
 	 */
-	public final int formattedStringEndPos(byte[] bytes, int startPos, int limit, byte[] delimiter) {
-		int len = startPos;
+	protected final int nextNumericStringEndPos(byte[] bytes, int startPos, int limit, byte[] delimiter) {
+		int endPos = startPos;
 
 		final int delimLimit = limit - delimiter.length + 1;
 
-		while (len < limit) {
-			if (len < delimLimit && delimiterNext(bytes, len, delimiter)) {
-				if (len == startPos) {
+		while (endPos < limit) {
+			if (endPos < delimLimit && delimiterNext(bytes, endPos, delimiter)) {
+				if (endPos == startPos) {
 					setErrorState(ParseErrorState.EMPTY_COLUMN);
 					return -1;
 				}
 				break;
 			}
-			len++;
+			endPos++;
 		}
 
-		if (len > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(len - 1)]))) {
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 
-		return len;
+		return endPos;
 	}
 
 	/**
-	 * Returns a string with a numeric format (like XXXX-XX-XX). Throws an exception if the
-	 * string contains leading/trailing whitespaces or if the column is empty.
+	 * Returns a numeric string. A numeric string does not start or end with whitespaces. Throws an
+	 * exception if the string contains leading/trailing whitespaces or if the column is empty.
 	 *
 	 * @return the parsed string
 	 */
-	public static final String formattedString(byte[] bytes, int startPos, int length, char delimiter) {
+	protected static final String nextNumericString(byte[] bytes, int startPos, int length, char delimiter) {
 		if (length <= 0) {
 			throw new NumberFormatException("Invalid input: Empty string");
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -176,12 +176,11 @@ public abstract class FieldParser<T> {
 	}
 
 	/**
-	 * Returns the end position of a numeric string. A numeric string does not start or end with whitespaces.
-	 * Sets the error state if the string contains leading/trailing whitespaces or if the column is empty.
+	 * Returns the end position of a string. Sets the error state if the column is empty.
 	 *
 	 * @return the end position of the string or -1 if an error occurred
 	 */
-	protected final int nextNumericStringEndPos(byte[] bytes, int startPos, int limit, byte[] delimiter) {
+	protected final int nextStringEndPos(byte[] bytes, int startPos, int limit, byte[] delimiter) {
 		int endPos = startPos;
 
 		final int delimLimit = limit - delimiter.length + 1;
@@ -197,38 +196,26 @@ public abstract class FieldParser<T> {
 			endPos++;
 		}
 
-		if (endPos > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
-			return -1;
-		}
-
 		return endPos;
 	}
 
 	/**
-	 * Returns a numeric string. A numeric string does not start or end with whitespaces. Throws an
-	 * exception if the string contains leading/trailing whitespaces or if the column is empty.
+	 * Returns the length of a string. Throws an exception if the column is empty.
 	 *
-	 * @return the parsed string
+	 * @return the length of the string
 	 */
-	protected static final String nextNumericString(byte[] bytes, int startPos, int length, char delimiter) {
+	protected static final int nextStringLength(byte[] bytes, int startPos, int length, char delimiter) {
 		if (length <= 0) {
-			throw new NumberFormatException("Invalid input: Empty string");
+			throw new IllegalArgumentException("Invalid input: Empty string");
 		}
-		int i = 0;
+		int limitedLength = 0;
 		final byte delByte = (byte) delimiter;
 
-		while (i < length && bytes[startPos + i] != delByte) {
-			i++;
+		while (limitedLength < length && bytes[startPos + limitedLength] != delByte) {
+			limitedLength++;
 		}
 
-		if (i > 0 &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
-			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
-		}
-
-		return new String(bytes, startPos, i);
+		return limitedLength;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FloatParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FloatParser.java
@@ -30,34 +30,16 @@ public class FloatParser extends FieldParser<Float> {
 	private float result;
 	
 	@Override
-	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Float 
-		reusable) {
-
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[i - 1]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Float reusable) {
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
-		String str = new String(bytes, startPos, i - startPos);
+		String str = new String(bytes, startPos, endPos - startPos);
 		try {
 			this.result = Float.parseFloat(str);
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		} catch (NumberFormatException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
 			return -1;
@@ -104,22 +86,7 @@ public class FloatParser extends FieldParser<Float> {
 	 * represents not a correct number.
 	 */
 	public static final float parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		if (length <= 0) {
-			throw new NumberFormatException("Invalid input: Empty string");
-		}
-		int i = 0;
-		final byte delByte = (byte) delimiter;
-
-		while (i < length && bytes[startPos + i] != delByte) {
-			i++;
-		}
-
-		if (i > 0 &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
-			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
-		}
-
-		String str = new String(bytes, startPos, i);
+		final String str = formattedString(bytes, startPos, length, delimiter);
 		return Float.parseFloat(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FloatParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FloatParser.java
@@ -31,8 +31,14 @@ public class FloatParser extends FieldParser<Float> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Float reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
+			return -1;
+		}
+
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 
@@ -65,7 +71,7 @@ public class FloatParser extends FieldParser<Float> {
 	 * @param startPos The offset to start the parsing.
 	 * @param length   The length of the byte sequence (counting from the offset).
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final float parseField(byte[] bytes, int startPos, int length) {
@@ -82,11 +88,18 @@ public class FloatParser extends FieldParser<Float> {
 	 * @param length    The length of the byte sequence (counting from the offset).
 	 * @param delimiter The delimiter that terminates the field.
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final float parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = nextNumericString(bytes, startPos, length, delimiter);
+		final int limitedLen = nextStringLength(bytes, startPos, length, delimiter);
+
+		if (limitedLen > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + limitedLen - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
+		}
+
+		final String str = new String(bytes, startPos, limitedLen);
 		return Float.parseFloat(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FloatParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FloatParser.java
@@ -31,7 +31,7 @@ public class FloatParser extends FieldParser<Float> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Float reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -86,7 +86,7 @@ public class FloatParser extends FieldParser<Float> {
 	 * represents not a correct number.
 	 */
 	public static final float parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = formattedString(bytes, startPos, length, delimiter);
+		final String str = nextNumericString(bytes, startPos, length, delimiter);
 		return Float.parseFloat(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FloatValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FloatValueParser.java
@@ -32,34 +32,17 @@ public class FloatValueParser extends FieldParser<FloatValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, FloatValue reusable) {
-		
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_COLUMN);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-		
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[i - 1]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
-		String str = new String(bytes, startPos, i - startPos);
+		String str = new String(bytes, startPos, endPos - startPos);
 		try {
 			float value = Float.parseFloat(str);
 			reusable.setValue(value);
 			this.result = reusable;
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		}
 		catch (NumberFormatException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FloatValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FloatValueParser.java
@@ -32,8 +32,14 @@ public class FloatValueParser extends FieldParser<FloatValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, FloatValue reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
+			return -1;
+		}
+
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FloatValueParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FloatValueParser.java
@@ -32,7 +32,7 @@ public class FloatValueParser extends FieldParser<FloatValue> {
 	
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, FloatValue reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
@@ -34,31 +34,15 @@ public class SqlDateParser extends FieldParser<Date> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Date reusable) {
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_STRING);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
-		String str = new String(bytes, startPos, i - startPos);
+		String str = new String(bytes, startPos, endPos - startPos);
 		try {
 			this.result = Date.valueOf(str);
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		} catch (IllegalArgumentException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
 			return -1;
@@ -105,22 +89,7 @@ public class SqlDateParser extends FieldParser<Date> {
 	 * represents not a correct number.
 	 */
 	public static final Date parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		if (length <= 0) {
-			throw new NumberFormatException("Invalid input: Empty string");
-		}
-		int i = 0;
-		final byte delByte = (byte) delimiter;
-
-		while (i < length && bytes[startPos + i] != delByte) {
-			i++;
-		}
-
-		if (i > 0 &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
-			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
-		}
-
-		String str = new String(bytes, startPos, i);
+		final String str = formattedString(bytes, startPos, length, delimiter);
 		try {
 			return Date.valueOf(str);
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.types.parser;
+
+import java.sql.Date;
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Parses a text field into a {@link java.sql.Date}.
+ */
+@PublicEvolving
+public class SqlDateParser extends FieldParser<Date> {
+
+	private static final Date DATE_INSTANCE = new Date(0L);
+
+	private Date result;
+
+	@Override
+	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Date reusable) {
+		int i = startPos;
+
+		final int delimLimit = limit - delimiter.length + 1;
+
+		while (i < limit) {
+			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
+				if (i == startPos) {
+					setErrorState(ParseErrorState.EMPTY_STRING);
+					return -1;
+				}
+				break;
+			}
+			i++;
+		}
+
+		if (i > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+			return -1;
+		}
+
+		String str = new String(bytes, startPos, i - startPos);
+		try {
+			this.result = Date.valueOf(str);
+			return (i == limit) ? limit : i + delimiter.length;
+		} catch (IllegalArgumentException e) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
+			return -1;
+		}
+	}
+
+	@Override
+	public Date createValue() {
+		return DATE_INSTANCE;
+	}
+
+	@Override
+	public Date getLastResult() {
+		return this.result;
+	}
+
+	/**
+	 * Static utility to parse a field of type Date from a byte sequence that represents text
+	 * characters
+	 * (such as when read from a file stream).
+	 *
+	 * @param bytes    The bytes containing the text data that should be parsed.
+	 * @param startPos The offset to start the parsing.
+	 * @param length   The length of the byte sequence (counting from the offset).
+	 * @return The parsed value.
+	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * represents not a correct number.
+	 */
+	public static final Date parseField(byte[] bytes, int startPos, int length) {
+		return parseField(bytes, startPos, length, (char) 0xffff);
+	}
+
+	/**
+	 * Static utility to parse a field of type Date from a byte sequence that represents text
+	 * characters
+	 * (such as when read from a file stream).
+	 *
+	 * @param bytes     The bytes containing the text data that should be parsed.
+	 * @param startPos  The offset to start the parsing.
+	 * @param length    The length of the byte sequence (counting from the offset).
+	 * @param delimiter The delimiter that terminates the field.
+	 * @return The parsed value.
+	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * represents not a correct number.
+	 */
+	public static final Date parseField(byte[] bytes, int startPos, int length, char delimiter) {
+		if (length <= 0) {
+			throw new NumberFormatException("Invalid input: Empty string");
+		}
+		int i = 0;
+		final byte delByte = (byte) delimiter;
+
+		while (i < length && bytes[startPos + i] != delByte) {
+			i++;
+		}
+
+		if (i > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
+		}
+
+		String str = new String(bytes, startPos, i);
+		try {
+			return Date.valueOf(str);
+		}
+		catch (NumberFormatException e) {
+			throw e;
+		}
+		catch (IllegalArgumentException e) {
+			throw new NumberFormatException(); // needed for consistent behavior of other parsers
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
@@ -34,8 +34,14 @@ public class SqlDateParser extends FieldParser<Date> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Date reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
+			return -1;
+		}
+
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 
@@ -68,7 +74,7 @@ public class SqlDateParser extends FieldParser<Date> {
 	 * @param startPos The offset to start the parsing.
 	 * @param length   The length of the byte sequence (counting from the offset).
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final Date parseField(byte[] bytes, int startPos, int length) {
@@ -85,19 +91,18 @@ public class SqlDateParser extends FieldParser<Date> {
 	 * @param length    The length of the byte sequence (counting from the offset).
 	 * @param delimiter The delimiter that terminates the field.
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final Date parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = nextNumericString(bytes, startPos, length, delimiter);
-		try {
-			return Date.valueOf(str);
+		final int limitedLen = nextStringLength(bytes, startPos, length, delimiter);
+
+		if (limitedLen > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + limitedLen - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
 		}
-		catch (NumberFormatException e) {
-			throw e;
-		}
-		catch (IllegalArgumentException e) {
-			throw new NumberFormatException(); // needed for consistent behavior of other parsers
-		}
+
+		final String str = new String(bytes, startPos, limitedLen);
+		return Date.valueOf(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlDateParser.java
@@ -34,7 +34,7 @@ public class SqlDateParser extends FieldParser<Date> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Date reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -89,7 +89,7 @@ public class SqlDateParser extends FieldParser<Date> {
 	 * represents not a correct number.
 	 */
 	public static final Date parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = formattedString(bytes, startPos, length, delimiter);
+		final String str = nextNumericString(bytes, startPos, length, delimiter);
 		try {
 			return Date.valueOf(str);
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.types.parser;
+
+import java.sql.Time;
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Parses a text field into a {@link Time}.
+ */
+@PublicEvolving
+public class SqlTimeParser extends FieldParser<Time> {
+
+	private static final Time TIME_INSTANCE = new Time(0L);
+
+	private Time result;
+
+	@Override
+	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Time reusable) {
+		int i = startPos;
+
+		final int delimLimit = limit - delimiter.length + 1;
+
+		while (i < limit) {
+			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
+				if (i == startPos) {
+					setErrorState(ParseErrorState.EMPTY_STRING);
+					return -1;
+				}
+				break;
+			}
+			i++;
+		}
+
+		if (i > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+			return -1;
+		}
+
+		String str = new String(bytes, startPos, i - startPos);
+		try {
+			this.result = Time.valueOf(str);
+			return (i == limit) ? limit : i + delimiter.length;
+		} catch (IllegalArgumentException e) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
+			return -1;
+		}
+	}
+
+	@Override
+	public Time createValue() {
+		return TIME_INSTANCE;
+	}
+
+	@Override
+	public Time getLastResult() {
+		return this.result;
+	}
+
+	/**
+	 * Static utility to parse a field of type Time from a byte sequence that represents text
+	 * characters
+	 * (such as when read from a file stream).
+	 *
+	 * @param bytes    The bytes containing the text data that should be parsed.
+	 * @param startPos The offset to start the parsing.
+	 * @param length   The length of the byte sequence (counting from the offset).
+	 * @return The parsed value.
+	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * represents not a correct number.
+	 */
+	public static final Time parseField(byte[] bytes, int startPos, int length) {
+		return parseField(bytes, startPos, length, (char) 0xffff);
+	}
+
+	/**
+	 * Static utility to parse a field of type Time from a byte sequence that represents text
+	 * characters
+	 * (such as when read from a file stream).
+	 *
+	 * @param bytes     The bytes containing the text data that should be parsed.
+	 * @param startPos  The offset to start the parsing.
+	 * @param length    The length of the byte sequence (counting from the offset).
+	 * @param delimiter The delimiter that terminates the field.
+	 * @return The parsed value.
+	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * represents not a correct number.
+	 */
+	public static final Time parseField(byte[] bytes, int startPos, int length, char delimiter) {
+		if (length <= 0) {
+			throw new NumberFormatException("Invalid input: Empty string");
+		}
+		int i = 0;
+		final byte delByte = (byte) delimiter;
+
+		while (i < length && bytes[startPos + i] != delByte) {
+			i++;
+		}
+
+		if (i > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
+		}
+
+		String str = new String(bytes, startPos, i);
+		try {
+			return Time.valueOf(str);
+		}
+		catch (NumberFormatException e) {
+			throw e;
+		}
+		catch (IllegalArgumentException e) {
+			throw new NumberFormatException(); // needed for consistent behavior of other parsers
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
@@ -34,31 +34,15 @@ public class SqlTimeParser extends FieldParser<Time> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Time reusable) {
-		int i = startPos;
-
-		final int delimLimit = limit - delimiter.length + 1;
-
-		while (i < limit) {
-			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
-				if (i == startPos) {
-					setErrorState(ParseErrorState.EMPTY_STRING);
-					return -1;
-				}
-				break;
-			}
-			i++;
-		}
-
-		if (i > startPos &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
-			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		if (endPos < 0) {
 			return -1;
 		}
 
-		String str = new String(bytes, startPos, i - startPos);
+		String str = new String(bytes, startPos, endPos - startPos);
 		try {
 			this.result = Time.valueOf(str);
-			return (i == limit) ? limit : i + delimiter.length;
+			return (endPos == limit) ? limit : endPos + delimiter.length;
 		} catch (IllegalArgumentException e) {
 			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
 			return -1;
@@ -105,22 +89,7 @@ public class SqlTimeParser extends FieldParser<Time> {
 	 * represents not a correct number.
 	 */
 	public static final Time parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		if (length <= 0) {
-			throw new NumberFormatException("Invalid input: Empty string");
-		}
-		int i = 0;
-		final byte delByte = (byte) delimiter;
-
-		while (i < length && bytes[startPos + i] != delByte) {
-			i++;
-		}
-
-		if (i > 0 &&
-				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
-			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
-		}
-
-		String str = new String(bytes, startPos, i);
+		final String str = formattedString(bytes, startPos, length, delimiter);
 		try {
 			return Time.valueOf(str);
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
@@ -34,7 +34,7 @@ public class SqlTimeParser extends FieldParser<Time> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Time reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -89,7 +89,7 @@ public class SqlTimeParser extends FieldParser<Time> {
 	 * represents not a correct number.
 	 */
 	public static final Time parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = formattedString(bytes, startPos, length, delimiter);
+		final String str = nextNumericString(bytes, startPos, length, delimiter);
 		try {
 			return Time.valueOf(str);
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimeParser.java
@@ -34,7 +34,7 @@ public class SqlTimeParser extends FieldParser<Time> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Time reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -68,7 +68,7 @@ public class SqlTimeParser extends FieldParser<Time> {
 	 * @param startPos The offset to start the parsing.
 	 * @param length   The length of the byte sequence (counting from the offset).
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final Time parseField(byte[] bytes, int startPos, int length) {
@@ -85,19 +85,18 @@ public class SqlTimeParser extends FieldParser<Time> {
 	 * @param length    The length of the byte sequence (counting from the offset).
 	 * @param delimiter The delimiter that terminates the field.
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final Time parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = nextNumericString(bytes, startPos, length, delimiter);
-		try {
-			return Time.valueOf(str);
+		final int limitedLen = nextStringLength(bytes, startPos, length, delimiter);
+
+		if (limitedLen > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + limitedLen - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
 		}
-		catch (NumberFormatException e) {
-			throw e;
-		}
-		catch (IllegalArgumentException e) {
-			throw new NumberFormatException(); // needed for consistent behavior of other parsers
-		}
+
+		final String str = new String(bytes, startPos, limitedLen);
+		return Time.valueOf(str);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimestampParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimestampParser.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.types.parser;
+
+import java.sql.Timestamp;
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Parses a text field into a {@link Timestamp}.
+ */
+@PublicEvolving
+public class SqlTimestampParser extends FieldParser<Timestamp> {
+
+	private static final Timestamp TIMESTAMP_INSTANCE = new Timestamp(0L);
+
+	private Timestamp result;
+
+	@Override
+	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Timestamp reusable) {
+		int i = startPos;
+
+		final int delimLimit = limit - delimiter.length + 1;
+
+		while (i < limit) {
+			if (i < delimLimit && delimiterNext(bytes, i, delimiter)) {
+				if (i == startPos) {
+					setErrorState(ParseErrorState.EMPTY_STRING);
+					return -1;
+				}
+				break;
+			}
+			i++;
+		}
+
+		if (i > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(i - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
+			return -1;
+		}
+
+		String str = new String(bytes, startPos, i - startPos);
+		try {
+			this.result = Timestamp.valueOf(str);
+			return (i == limit) ? limit : i + delimiter.length;
+		} catch (IllegalArgumentException e) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_FORMAT_ERROR);
+			return -1;
+		}
+	}
+
+	@Override
+	public Timestamp createValue() {
+		return TIMESTAMP_INSTANCE;
+	}
+
+	@Override
+	public Timestamp getLastResult() {
+		return this.result;
+	}
+
+	/**
+	 * Static utility to parse a field of type Timestamp from a byte sequence that represents text
+	 * characters
+	 * (such as when read from a file stream).
+	 *
+	 * @param bytes    The bytes containing the text data that should be parsed.
+	 * @param startPos The offset to start the parsing.
+	 * @param length   The length of the byte sequence (counting from the offset).
+	 * @return The parsed value.
+	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * represents not a correct number.
+	 */
+	public static final Timestamp parseField(byte[] bytes, int startPos, int length) {
+		return parseField(bytes, startPos, length, (char) 0xffff);
+	}
+
+	/**
+	 * Static utility to parse a field of type Timestamp from a byte sequence that represents text
+	 * characters
+	 * (such as when read from a file stream).
+	 *
+	 * @param bytes     The bytes containing the text data that should be parsed.
+	 * @param startPos  The offset to start the parsing.
+	 * @param length    The length of the byte sequence (counting from the offset).
+	 * @param delimiter The delimiter that terminates the field.
+	 * @return The parsed value.
+	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * represents not a correct number.
+	 */
+	public static final Timestamp parseField(byte[] bytes, int startPos, int length, char delimiter) {
+		if (length <= 0) {
+			throw new NumberFormatException("Invalid input: Empty string");
+		}
+		int i = 0;
+		final byte delByte = (byte) delimiter;
+
+		while (i < length && bytes[startPos + i] != delByte) {
+			i++;
+		}
+
+		if (i > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + i - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
+		}
+
+		String str = new String(bytes, startPos, i);
+		try {
+			return Timestamp.valueOf(str);
+		}
+		catch (NumberFormatException e) {
+			throw e;
+		}
+		catch (IllegalArgumentException e) {
+			throw new NumberFormatException(); // needed for consistent behavior of other parsers
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimestampParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimestampParser.java
@@ -34,7 +34,7 @@ public class SqlTimestampParser extends FieldParser<Timestamp> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Timestamp reusable) {
-		final int endPos = formattedStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
 			return -1;
 		}
@@ -89,7 +89,7 @@ public class SqlTimestampParser extends FieldParser<Timestamp> {
 	 * represents not a correct number.
 	 */
 	public static final Timestamp parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = formattedString(bytes, startPos, length, delimiter);
+		final String str = nextNumericString(bytes, startPos, length, delimiter);
 		try {
 			return Timestamp.valueOf(str);
 		}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimestampParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/SqlTimestampParser.java
@@ -34,8 +34,14 @@ public class SqlTimestampParser extends FieldParser<Timestamp> {
 
 	@Override
 	public int parseField(byte[] bytes, int startPos, int limit, byte[] delimiter, Timestamp reusable) {
-		final int endPos = nextNumericStringEndPos(bytes, startPos, limit, delimiter);
+		final int endPos = nextStringEndPos(bytes, startPos, limit, delimiter);
 		if (endPos < 0) {
+			return -1;
+		}
+
+		if (endPos > startPos &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[(endPos - 1)]))) {
+			setErrorState(ParseErrorState.NUMERIC_VALUE_ILLEGAL_CHARACTER);
 			return -1;
 		}
 
@@ -68,7 +74,7 @@ public class SqlTimestampParser extends FieldParser<Timestamp> {
 	 * @param startPos The offset to start the parsing.
 	 * @param length   The length of the byte sequence (counting from the offset).
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final Timestamp parseField(byte[] bytes, int startPos, int length) {
@@ -85,19 +91,18 @@ public class SqlTimestampParser extends FieldParser<Timestamp> {
 	 * @param length    The length of the byte sequence (counting from the offset).
 	 * @param delimiter The delimiter that terminates the field.
 	 * @return The parsed value.
-	 * @throws NumberFormatException Thrown when the value cannot be parsed because the text 
+	 * @throws IllegalArgumentException Thrown when the value cannot be parsed because the text
 	 * represents not a correct number.
 	 */
 	public static final Timestamp parseField(byte[] bytes, int startPos, int length, char delimiter) {
-		final String str = nextNumericString(bytes, startPos, length, delimiter);
-		try {
-			return Timestamp.valueOf(str);
+		final int limitedLen = nextStringLength(bytes, startPos, length, delimiter);
+
+		if (limitedLen > 0 &&
+				(Character.isWhitespace(bytes[startPos]) || Character.isWhitespace(bytes[startPos + limitedLen - 1]))) {
+			throw new NumberFormatException("There is leading or trailing whitespace in the numeric field.");
 		}
-		catch (NumberFormatException e) {
-			throw e;
-		}
-		catch (IllegalArgumentException e) {
-			throw new NumberFormatException(); // needed for consistent behavior of other parsers
-		}
+
+		final String str = new String(bytes, startPos, limitedLen);
+		return Timestamp.valueOf(str);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimeSerializerTest.java
@@ -47,7 +47,7 @@ public class SqlTimeSerializerTest extends SerializerTestBase<Time> {
 		return new Time[] {
 			new Time(0L),
 			Time.valueOf("00:00:00"),
-			Time.valueOf("02:42:85"),
+			Time.valueOf("02:42:25"),
 			Time.valueOf("14:15:59"),
 			Time.valueOf("18:00:45")
 		};

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampComparatorTest.java
@@ -40,9 +40,9 @@ public class SqlTimestampComparatorTest extends ComparatorTestBase<Timestamp> {
 	protected Timestamp[] getSortedTestData() {
 		return new Timestamp[] {
 			Timestamp.valueOf("1970-01-01 00:00:00.000"),
-			Timestamp.valueOf("1990-10-14 02:42:85.123"),
-			Timestamp.valueOf("1990-10-14 02:42:85.123000001"),
-			Timestamp.valueOf("1990-10-14 02:42:85.123000002"),
+			Timestamp.valueOf("1990-10-14 02:42:25.123"),
+			Timestamp.valueOf("1990-10-14 02:42:25.123000001"),
+			Timestamp.valueOf("1990-10-14 02:42:25.123000002"),
 			Timestamp.valueOf("2013-08-12 14:15:59.478"),
 			Timestamp.valueOf("2013-08-12 14:15:59.479"),
 			Timestamp.valueOf("2040-05-12 18:00:45.999")

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/SqlTimestampSerializerTest.java
@@ -47,9 +47,9 @@ public class SqlTimestampSerializerTest extends SerializerTestBase<Timestamp> {
 		return new Timestamp[] {
 			new Timestamp(0L),
 			Timestamp.valueOf("1970-01-01 00:00:00.000"),
-			Timestamp.valueOf("1990-10-14 02:42:85.123"),
-			Timestamp.valueOf("1990-10-14 02:42:85.123000001"),
-			Timestamp.valueOf("1990-10-14 02:42:85.123000002"),
+			Timestamp.valueOf("1990-10-14 02:42:25.123"),
+			Timestamp.valueOf("1990-10-14 02:42:25.123000001"),
+			Timestamp.valueOf("1990-10-14 02:42:25.123000002"),
 			Timestamp.valueOf("2013-08-12 14:15:59.478"),
 			Timestamp.valueOf("2013-08-12 14:15:59.479"),
 			Timestamp.valueOf("2040-05-12 18:00:45.999")

--- a/flink-core/src/test/java/org/apache/flink/types/parser/SqlDateParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/SqlDateParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.types.parser;
+
+
+import java.sql.Date;
+
+public class SqlDateParserTest extends ParserTestBase<Date> {
+
+	@Override
+	public String[] getValidTestValues() {
+		return new String[] {
+			"1970-01-01", "1990-10-14", "2013-08-12", "2040-05-12", "2040-5-12", "1970-1-1",
+		};
+	}
+
+	@Override
+	public Date[] getValidTestResults() {
+		return new Date[] {
+			Date.valueOf("1970-01-01"), Date.valueOf("1990-10-14"), Date.valueOf("2013-08-12"),
+			Date.valueOf("2040-05-12"), Date.valueOf("2040-05-12"), Date.valueOf("1970-01-01")
+		};
+	}
+
+	@Override
+	public String[] getInvalidTestValues() {
+		return new String[] {
+			" 2013-08-12", "2013-08-12 ", "2013-08--12", "13-08-12", "2013/08/12", " ", "\t",
+			"2013-XX-XX"
+		};
+	}
+
+	@Override
+	public boolean allowsEmptyField() {
+		return false;
+	}
+
+	@Override
+	public FieldParser<Date> getParser() {
+		return new SqlDateParser();
+	}
+
+	@Override
+	public Class<Date> getTypeClass() {
+		return Date.class;
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/types/parser/SqlDateParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/SqlDateParserTest.java
@@ -43,7 +43,7 @@ public class SqlDateParserTest extends ParserTestBase<Date> {
 	public String[] getInvalidTestValues() {
 		return new String[] {
 			" 2013-08-12", "2013-08-12 ", "2013-08--12", "13-08-12", "2013/08/12", " ", "\t",
-			"2013-XX-XX"
+			"2013-XX-XX", "2000-02-35"
 		};
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/types/parser/SqlTimeParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/SqlTimeParserTest.java
@@ -16,33 +16,48 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.common.typeutils.base;
+
+package org.apache.flink.types.parser;
+
 
 import java.sql.Time;
-import org.apache.flink.api.common.typeutils.ComparatorTestBase;
-import org.apache.flink.api.common.typeutils.TypeComparator;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 
-public class SqlTimeComparatorTest extends ComparatorTestBase<Time> {
-
-	@SuppressWarnings("unchecked")
-	@Override
-	protected TypeComparator<Time> createComparator(boolean ascending) {
-		return (TypeComparator) new DateComparator(ascending);
-	}
+public class SqlTimeParserTest extends ParserTestBase<Time> {
 
 	@Override
-	protected TypeSerializer<Time> createSerializer() {
-		return new SqlTimeSerializer();
-	}
-
-	@Override
-	protected Time[] getSortedTestData() {
-		return new Time[] {
-			Time.valueOf("00:00:00"),
-			Time.valueOf("02:42:25"),
-			Time.valueOf("14:15:59"),
-			Time.valueOf("18:00:45")
+	public String[] getValidTestValues() {
+		return new String[] {
+			"00:00:00", "02:42:25", "14:15:51", "18:00:45", "23:59:58", "0:0:0"
 		};
+	}
+
+	@Override
+	public Time[] getValidTestResults() {
+		return new Time[] {
+			Time.valueOf("00:00:00"), Time.valueOf("02:42:25"), Time.valueOf("14:15:51"),
+			Time.valueOf("18:00:45"), Time.valueOf("23:59:58"), Time.valueOf("0:0:0")
+		};
+	}
+
+	@Override
+	public String[] getInvalidTestValues() {
+		return new String[] {
+			" 00:00:00", "00:00:00 ", "00:00::00", "00x00:00", "2013/08/12", " ", "\t"
+		};
+	}
+
+	@Override
+	public boolean allowsEmptyField() {
+		return false;
+	}
+
+	@Override
+	public FieldParser<Time> getParser() {
+		return new SqlTimeParser();
+	}
+
+	@Override
+	public Class<Time> getTypeClass() {
+		return Time.class;
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/types/parser/SqlTimestampParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/SqlTimestampParserTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.types.parser;
+
+
+import java.sql.Timestamp;
+
+public class SqlTimestampParserTest extends ParserTestBase<Timestamp> {
+
+	@Override
+	public String[] getValidTestValues() {
+		return new String[] {
+			"1970-01-01 00:00:00.000", "1990-10-14 02:42:25.123", "1990-10-14 02:42:25.123000001",
+			"1990-10-14 02:42:25.123000002", "2013-08-12 14:15:59.478", "2013-08-12 14:15:59.47",
+			"0000-01-01 00:00:00.000",
+		};
+	}
+
+	@Override
+	public Timestamp[] getValidTestResults() {
+		return new Timestamp[] {
+			Timestamp.valueOf("1970-01-01 00:00:00.000"), Timestamp.valueOf("1990-10-14 02:42:25.123"),
+			Timestamp.valueOf("1990-10-14 02:42:25.123000001"), Timestamp.valueOf("1990-10-14 02:42:25.123000002"),
+			Timestamp.valueOf("2013-08-12 14:15:59.478"), Timestamp.valueOf("2013-08-12 14:15:59.47"),
+			Timestamp.valueOf("0000-01-01 00:00:00.000")
+		};
+	}
+
+	@Override
+	public String[] getInvalidTestValues() {
+		return new String[] {
+			" 2013-08-12 14:15:59.479", "2013-08-12 14:15:59.479 ", "1970-01-01 00:00::00",
+			"00x00:00", "2013/08/12", "0000-01-01 00:00:00.f00", "2013-08-12 14:15:59.4788888888888888",
+			" ", "\t"
+		};
+	}
+
+	@Override
+	public boolean allowsEmptyField() {
+		return false;
+	}
+
+	@Override
+	public FieldParser<Timestamp> getParser() {
+		return new SqlTimestampParser();
+	}
+
+	@Override
+	public Class<Timestamp> getTypeClass() {
+		return Timestamp.class;
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/types/parser/SqlTimestampParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/SqlTimestampParserTest.java
@@ -27,7 +27,7 @@ public class SqlTimestampParserTest extends ParserTestBase<Timestamp> {
 	@Override
 	public String[] getValidTestValues() {
 		return new String[] {
-			"1970-01-01 00:00:00.000", "1990-10-14 02:42:25.123", "1990-10-14 02:42:25.123000001",
+			"1970-01-01 00:00:00.000", "1990-10-14 02:42:25", "1990-10-14 02:42:25.123", "1990-10-14 02:42:25.123000001",
 			"1990-10-14 02:42:25.123000002", "2013-08-12 14:15:59.478", "2013-08-12 14:15:59.47",
 			"0000-01-01 00:00:00.000",
 		};
@@ -36,7 +36,7 @@ public class SqlTimestampParserTest extends ParserTestBase<Timestamp> {
 	@Override
 	public Timestamp[] getValidTestResults() {
 		return new Timestamp[] {
-			Timestamp.valueOf("1970-01-01 00:00:00.000"), Timestamp.valueOf("1990-10-14 02:42:25.123"),
+			Timestamp.valueOf("1970-01-01 00:00:00.000"), Timestamp.valueOf("1990-10-14 02:42:25"), Timestamp.valueOf("1990-10-14 02:42:25.123"),
 			Timestamp.valueOf("1990-10-14 02:42:25.123000001"), Timestamp.valueOf("1990-10-14 02:42:25.123000002"),
 			Timestamp.valueOf("2013-08-12 14:15:59.478"), Timestamp.valueOf("2013-08-12 14:15:59.47"),
 			Timestamp.valueOf("0000-01-01 00:00:00.000")


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR implements parsers for SQL Date/Time/Timestamp and tests. It also tests if the new parsers can be used in the RowCsvInputFormat.