### PR TITLE
[FLINK-4271] [DataStreamAPI] Enable CoGroupedStreams and JoinedStreams to set parallellism

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -245,13 +245,13 @@ public class CoGroupedStreams<T1, T2> {
 		 * for windowed groups.
 		 *
 		 * <p>
-		 *     Note: This is a temporary workaround for setting parallelism after co-group operator.
-		 *     This method only calls {@link #apply(CoGroupFunction)}, and
-		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 *     Note: This is a temporary workaround while the {@link #apply(CoGroupFunction)} method has the wrong return type.
 		 * </p>
 		 * @deprecated This method will be replaced by {@link #apply(CoGroupFunction)} in Flink 2.0.
 		 * So use the {@link #apply(CoGroupFunction)} in the future.
          */
+		@PublicEvolving
+		@Deprecated
 		public <T> SingleOutputStreamOperator<T> with(CoGroupFunction<T1, T2, T> function) {
 			return (SingleOutputStreamOperator<T>) apply(function);
 		}
@@ -298,13 +298,13 @@ public class CoGroupedStreams<T1, T2> {
 		 * for windowed groups.
 		 *
 		 * <p>
-		 *     Note: This is a temporary workaround for setting parallelism after co-group operator.
-		 *     This method only calls {@link #apply(CoGroupFunction, TypeInformation)}, and
-		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 *     Note: This is a temporary workaround while the {@link #apply(CoGroupFunction, TypeInformation)} method has the wrong return type.
 		 * </p>
 		 * @deprecated This method will be replaced by {@link #apply(CoGroupFunction, TypeInformation)} in Flink 2.0.
 		 * So use the {@link #apply(CoGroupFunction, TypeInformation)} in the future.
 		 */
+		@PublicEvolving
+		@Deprecated
 		public <T> SingleOutputStreamOperator<T> with(CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			return (SingleOutputStreamOperator<T>) apply(function, resultType);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -225,7 +225,7 @@ public class CoGroupedStreams<T1, T2> {
 		 * Completes the co-group operation with the user function that is executed
 		 * for windowed groups.
 		 */
-		public <T> SingleOutputStreamOperator<T> apply(CoGroupFunction<T1, T2, T> function) {
+		public <T> DataStream<T> apply(CoGroupFunction<T1, T2, T> function) {
 
 			TypeInformation<T> resultType = TypeExtractor.getBinaryOperatorReturnType(
 					function,
@@ -243,8 +243,24 @@ public class CoGroupedStreams<T1, T2> {
 		/**
 		 * Completes the co-group operation with the user function that is executed
 		 * for windowed groups.
+		 *
+		 * <p>
+		 *     Note: This is a temporary workaround for setting parallelism after co-group operator.
+		 *     This method only calls {@link #apply(CoGroupFunction)}, and
+		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 * </p>
+		 * @deprecated This method will be replaced by {@link #apply(CoGroupFunction)} in Flink 2.0.
+		 * So use the {@link #apply(CoGroupFunction)} in the future.
+         */
+		public <T> SingleOutputStreamOperator<T> with(CoGroupFunction<T1, T2, T> function) {
+			return (SingleOutputStreamOperator<T>) apply(function);
+		}
+
+		/**
+		 * Completes the co-group operation with the user function that is executed
+		 * for windowed groups.
 		 */
-		public <T> SingleOutputStreamOperator<T> apply(CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+		public <T> DataStream<T> apply(CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			//clean the closure
 			function = input1.getExecutionEnvironment().clean(function);
 
@@ -275,6 +291,22 @@ public class CoGroupedStreams<T1, T2> {
 			}
 
 			return windowOp.apply(new CoGroupWindowFunction<T1, T2, T, KEY, W>(function), resultType);
+		}
+
+		/**
+		 * Completes the co-group operation with the user function that is executed
+		 * for windowed groups.
+		 *
+		 * <p>
+		 *     Note: This is a temporary workaround for setting parallelism after co-group operator.
+		 *     This method only calls {@link #apply(CoGroupFunction, TypeInformation)}, and
+		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 * </p>
+		 * @deprecated This method will be replaced by {@link #apply(CoGroupFunction, TypeInformation)} in Flink 2.0.
+		 * So use the {@link #apply(CoGroupFunction, TypeInformation)} in the future.
+		 */
+		public <T> SingleOutputStreamOperator<T> with(CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+			return (SingleOutputStreamOperator<T>) apply(function, resultType);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -225,7 +225,7 @@ public class CoGroupedStreams<T1, T2> {
 		 * Completes the co-group operation with the user function that is executed
 		 * for windowed groups.
 		 */
-		public <T> DataStream<T> apply(CoGroupFunction<T1, T2, T> function) {
+		public <T> SingleOutputStreamOperator<T> apply(CoGroupFunction<T1, T2, T> function) {
 
 			TypeInformation<T> resultType = TypeExtractor.getBinaryOperatorReturnType(
 					function,
@@ -244,7 +244,7 @@ public class CoGroupedStreams<T1, T2> {
 		 * Completes the co-group operation with the user function that is executed
 		 * for windowed groups.
 		 */
-		public <T> DataStream<T> apply(CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+		public <T> SingleOutputStreamOperator<T> apply(CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			//clean the closure
 			function = input1.getExecutionEnvironment().clean(function);
 
@@ -253,9 +253,11 @@ public class CoGroupedStreams<T1, T2> {
 			
 			DataStream<TaggedUnion<T1, T2>> taggedInput1 = input1
 					.map(new Input1Tagger<T1, T2>())
+					.setParallelism(input1.getParallelism())
 					.returns(unionType);
 			DataStream<TaggedUnion<T1, T2>> taggedInput2 = input2
 					.map(new Input2Tagger<T1, T2>())
+					.setParallelism(input2.getParallelism())
 					.returns(unionType);
 
 			DataStream<TaggedUnion<T1, T2>> unionStream = taggedInput1.union(taggedInput2);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
@@ -220,7 +220,7 @@ public class JoinedStreams<T1, T2> {
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
 		 */
-		public <T> SingleOutputStreamOperator<T> apply(JoinFunction<T1, T2, T> function) {
+		public <T> DataStream<T> apply(JoinFunction<T1, T2, T> function) {
 			TypeInformation<T> resultType = TypeExtractor.getBinaryOperatorReturnType(
 					function,
 					JoinFunction.class,
@@ -237,8 +237,24 @@ public class JoinedStreams<T1, T2> {
 		/**
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
+		 *
+		 * <p>
+		 *     Note: This is a temporary workaround for setting parallelism after join operator.
+		 *     This method only calls {@link #apply(JoinFunction)}, and
+		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 * </p>
+		 * @deprecated This method will be replaced by {@link #apply(JoinFunction)} in Flink 2.0.
+		 * So use the {@link #apply(JoinFunction)} in the future.
 		 */
-		public <T> SingleOutputStreamOperator<T> apply(FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+		public <T> SingleOutputStreamOperator<T> with(JoinFunction<T1, T2, T> function) {
+			return (SingleOutputStreamOperator<T>) apply(function);
+		}
+
+		/**
+		 * Completes the join operation with the user function that is executed
+		 * for each combination of elements with the same key in a window.
+		 */
+		public <T> DataStream<T> apply(FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			//clean the closure
 			function = input1.getExecutionEnvironment().clean(function);
 
@@ -252,11 +268,28 @@ public class JoinedStreams<T1, T2> {
 
 		}
 
+
+		/**
+		 * Completes the join operation with the user function that is executed
+		 * for each combination of elements with the same key in a window.
+		 *
+		 * <p>
+		 *     Note: This is a temporary workaround for setting parallelism after join operator.
+		 *     This method only calls {@link #apply(FlatJoinFunction, TypeInformation)}, and
+		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 * </p>
+		 * @deprecated This method will be replaced by {@link #apply(FlatJoinFunction, TypeInformation)} in Flink 2.0.
+		 * So use the {@link #apply(FlatJoinFunction, TypeInformation)} in the future.
+		 */
+		public <T> SingleOutputStreamOperator<T> with(FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+			return (SingleOutputStreamOperator<T>) apply(function, resultType);
+		}
+
 		/**
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
 		 */
-		public <T> SingleOutputStreamOperator<T> apply(FlatJoinFunction<T1, T2, T> function) {
+		public <T> DataStream<T> apply(FlatJoinFunction<T1, T2, T> function) {
 			TypeInformation<T> resultType = TypeExtractor.getBinaryOperatorReturnType(
 					function,
 					JoinFunction.class,
@@ -273,8 +306,24 @@ public class JoinedStreams<T1, T2> {
 		/**
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
+		 *
+		 * <p>
+		 *     Note: This is a temporary workaround for setting parallelism after join operator.
+		 *     This method only calls {@link #apply(FlatJoinFunction)}, and
+		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 * </p>
+		 * @deprecated This method will be replaced by {@link #apply(FlatJoinFunction)} in Flink 2.0.
+		 * So use the {@link #apply(FlatJoinFunction)} in the future.
 		 */
-		public <T> SingleOutputStreamOperator<T> apply(JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+		public <T> SingleOutputStreamOperator<T> with(FlatJoinFunction<T1, T2, T> function) {
+			return (SingleOutputStreamOperator<T>) apply(function);
+		}
+
+		/**
+		 * Completes the join operation with the user function that is executed
+		 * for each combination of elements with the same key in a window.
+		 */
+		public <T> DataStream<T> apply(JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			//clean the closure
 			function = input1.getExecutionEnvironment().clean(function);
 
@@ -286,6 +335,22 @@ public class JoinedStreams<T1, T2> {
 					.evictor(evictor)
 					.apply(new JoinCoGroupFunction<>(function), resultType);
 
+		}
+
+		/**
+		 * Completes the join operation with the user function that is executed
+		 * for each combination of elements with the same key in a window.
+		 *
+		 * <p>
+		 *     Note: This is a temporary workaround for setting parallelism after join operator.
+		 *     This method only calls {@link #apply(JoinFunction, TypeInformation)}, and
+		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 * </p>
+		 * @deprecated This method will be replaced by {@link #apply(JoinFunction, TypeInformation)} in Flink 2.0.
+		 * So use the {@link #apply(JoinFunction, TypeInformation)} in the future.
+		 */
+		public <T> SingleOutputStreamOperator<T> with(JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+			return (SingleOutputStreamOperator<T>) apply(function, resultType);
 		}
 	}
 	

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
@@ -239,13 +239,13 @@ public class JoinedStreams<T1, T2> {
 		 * for each combination of elements with the same key in a window.
 		 *
 		 * <p>
-		 *     Note: This is a temporary workaround for setting parallelism after join operator.
-		 *     This method only calls {@link #apply(JoinFunction)}, and
-		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 *     Note: This is a temporary workaround while the {@link #apply(JoinFunction)} method has the wrong return type.
 		 * </p>
 		 * @deprecated This method will be replaced by {@link #apply(JoinFunction)} in Flink 2.0.
 		 * So use the {@link #apply(JoinFunction)} in the future.
 		 */
+		@PublicEvolving
+		@Deprecated
 		public <T> SingleOutputStreamOperator<T> with(JoinFunction<T1, T2, T> function) {
 			return (SingleOutputStreamOperator<T>) apply(function);
 		}
@@ -274,13 +274,13 @@ public class JoinedStreams<T1, T2> {
 		 * for each combination of elements with the same key in a window.
 		 *
 		 * <p>
-		 *     Note: This is a temporary workaround for setting parallelism after join operator.
-		 *     This method only calls {@link #apply(FlatJoinFunction, TypeInformation)}, and
-		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 *     Note: This is a temporary workaround while the {@link #apply(FlatJoinFunction, TypeInformation)} method has the wrong return type.
 		 * </p>
 		 * @deprecated This method will be replaced by {@link #apply(FlatJoinFunction, TypeInformation)} in Flink 2.0.
 		 * So use the {@link #apply(FlatJoinFunction, TypeInformation)} in the future.
 		 */
+		@PublicEvolving
+		@Deprecated
 		public <T> SingleOutputStreamOperator<T> with(FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			return (SingleOutputStreamOperator<T>) apply(function, resultType);
 		}
@@ -308,13 +308,13 @@ public class JoinedStreams<T1, T2> {
 		 * for each combination of elements with the same key in a window.
 		 *
 		 * <p>
-		 *     Note: This is a temporary workaround for setting parallelism after join operator.
-		 *     This method only calls {@link #apply(FlatJoinFunction)}, and
-		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 *     Note: This is a temporary workaround while the {@link #apply(FlatJoinFunction)} method has the wrong return type.
 		 * </p>
 		 * @deprecated This method will be replaced by {@link #apply(FlatJoinFunction)} in Flink 2.0.
 		 * So use the {@link #apply(FlatJoinFunction)} in the future.
 		 */
+		@PublicEvolving
+		@Deprecated
 		public <T> SingleOutputStreamOperator<T> with(FlatJoinFunction<T1, T2, T> function) {
 			return (SingleOutputStreamOperator<T>) apply(function);
 		}
@@ -342,13 +342,13 @@ public class JoinedStreams<T1, T2> {
 		 * for each combination of elements with the same key in a window.
 		 *
 		 * <p>
-		 *     Note: This is a temporary workaround for setting parallelism after join operator.
-		 *     This method only calls {@link #apply(JoinFunction, TypeInformation)}, and
-		 *     cast the returned value to {@link SingleOutputStreamOperator}.
+		 *     Note: This is a temporary workaround while the {@link #apply(JoinFunction, TypeInformation)} method has the wrong return type.
 		 * </p>
 		 * @deprecated This method will be replaced by {@link #apply(JoinFunction, TypeInformation)} in Flink 2.0.
 		 * So use the {@link #apply(JoinFunction, TypeInformation)} in the future.
 		 */
+		@PublicEvolving
+		@Deprecated
 		public <T> SingleOutputStreamOperator<T> with(JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			return (SingleOutputStreamOperator<T>) apply(function, resultType);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
@@ -220,7 +220,7 @@ public class JoinedStreams<T1, T2> {
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
 		 */
-		public <T> DataStream<T> apply(JoinFunction<T1, T2, T> function) {
+		public <T> SingleOutputStreamOperator<T> apply(JoinFunction<T1, T2, T> function) {
 			TypeInformation<T> resultType = TypeExtractor.getBinaryOperatorReturnType(
 					function,
 					JoinFunction.class,
@@ -238,7 +238,7 @@ public class JoinedStreams<T1, T2> {
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
 		 */
-		public <T> DataStream<T> apply(FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+		public <T> SingleOutputStreamOperator<T> apply(FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			//clean the closure
 			function = input1.getExecutionEnvironment().clean(function);
 
@@ -256,7 +256,7 @@ public class JoinedStreams<T1, T2> {
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
 		 */
-		public <T> DataStream<T> apply(FlatJoinFunction<T1, T2, T> function) {
+		public <T> SingleOutputStreamOperator<T> apply(FlatJoinFunction<T1, T2, T> function) {
 			TypeInformation<T> resultType = TypeExtractor.getBinaryOperatorReturnType(
 					function,
 					JoinFunction.class,
@@ -274,7 +274,7 @@ public class JoinedStreams<T1, T2> {
 		 * Completes the join operation with the user function that is executed
 		 * for each combination of elements with the same key in a window.
 		 */
-		public <T> DataStream<T> apply(JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
+		public <T> SingleOutputStreamOperator<T> apply(JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
 			//clean the closure
 			function = input1.getExecutionEnvironment().clean(function);
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

The CoGroupStream will construct the following graph. 

```
source -> MAP ---
                            |->  WindowOp -> Sink
source -> MAP ---
```

By now , the MAP and WindowOp can not set parallelism.  We can keep the MAP has same parallelism as previous operator (chaining). And we can change {{CoGroupedStreams.apply}} to return a  {{SingleOutputStreamOperator}} instead of {{DataStream}}, so that we can set WindowOp's parallelism.  The same thing has be done to {{JoinedStream}}.

So that we can do the following things:

```
DataStream<T> result = one.coGroup(two)
     .where(new MyFirstKeySelector())
     .equalTo(new MyFirstKeySelector())
     .window(TumblingEventTimeWindows.of(Time.of(5, TimeUnit.SECONDS)))
     .apply(new MyCoGroupFunction())
     .setParallelism(10)
     .name("MyCoGroupWindow");
```