### PR TITLE
[FLINK-4270] [table] fix 'as' in front of join does not work

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/operators.scala
@@ -86,10 +86,11 @@ case class Project(projectList: Seq[NamedExpression], child: LogicalNode) extend
     if (allAlias) {
       // Calcite's RelBuilder does not translate identity projects even if they rename fields.
       //   Add a projection ourselves (will be automatically removed by translation rules).
-      relBuilder.push(
-        LogicalProject.create(relBuilder.peek(),
-          projectList.map(_.toRexNode(relBuilder)).asJava,
-          projectList.map(_.name).asJava))
+      val project = LogicalProject.create(relBuilder.peek(),
+        projectList.map(_.toRexNode(relBuilder)).asJava,
+        projectList.map(_.name).asJava)
+      relBuilder.build()  // pop previous relNode
+      relBuilder.push(project)
     } else {
       relBuilder.project(projectList.map(_.toRexNode(relBuilder)): _*)
     }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/JoinITCase.scala
@@ -55,8 +55,8 @@ class JoinITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode)
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).where('b === 'e && 'b < 2).select('c, 'g)
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


The `Project` has a wrong way to construct RelNode. It pushes a new `LogicalProject` to the stack, but not pop the previous RelNode. It has problem when Join two tables. 

When join two tables (with all fields renamed), the stack will look like this before join:

```
LogicalProject1
TableScan1
LogicalProject0
TableScan0
``` 

After that, join will use  `LogicalProject1` and `TableScan1` which are the same table to create `LogicalJoin`. Then the exception throws.

The correct way to do this is make sure the previous TableScan removed from the stack before we push a new LogicalProject. 

```
LogicalProject1
LogicalProject0
``` 

