### PR TITLE
[FLINK-4279] [py] Set flink dependencies to provided

### DIFF
--- a/flink-libraries/flink-python/pom.xml
+++ b/flink-libraries/flink-python/pom.xml
@@ -59,26 +59,19 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-core</artifactId>
             <version>${project.version}</version>
+			<scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-java</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-optimizer_2.10</artifactId>
-            <version>${project.version}</version>
+			<scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-runtime_2.10</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_2.10</artifactId>
-            <version>${project.version}</version>
+			<scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
* removed unused `flink-optimizer` and `flink-clients` dependency
* set the remaining dependencies to `provided`
 * as otherwise several shaded classes were included in the jar