### PR TITLE
[FLINK-4161] Add Quickstart exclusion for flink-dist dependencies

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -110,6 +110,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-metrics-jmx</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -179,6 +179,11 @@ under the License.
 									<exclude>org.apache.flink:flink-examples-batch_2.10</exclude>
 									<exclude>org.apache.flink:flink-examples-streaming_2.10</exclude>
 									<exclude>org.apache.flink:flink-streaming-java_2.10</exclude>
+									<exclude>org.apache.flink:flink-streaming-scala_2.10</exclude>
+									<exclude>org.apache.flink:flink-scala-shell_2.10</exclude>
+									<exclude>org.apache.flink:flink-python</exclude>
+									<exclude>org.apache.flink:flink-metrics-core</exclude>
+									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
 
 									<!-- Also exclude very big transitive dependencies of Flink
 

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -183,6 +183,11 @@ under the License.
 									<exclude>org.apache.flink:flink-examples-batch_2.10</exclude>
 									<exclude>org.apache.flink:flink-examples-streaming_2.10</exclude>
 									<exclude>org.apache.flink:flink-streaming-java_2.10</exclude>
+									<exclude>org.apache.flink:flink-streaming-scala_2.10</exclude>
+									<exclude>org.apache.flink:flink-scala-shell_2.10</exclude>
+									<exclude>org.apache.flink:flink-python</exclude>
+									<exclude>org.apache.flink:flink-metrics-core</exclude>
+									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
 
 									<!-- Also exclude very big transitive dependencies of Flink
 


### PR DESCRIPTION
Updated version of #2218 which got closed as I accidentally deleted the branch.

In addition to the previous changes:
* `flink-dist` now explicitly dependends on `flink-metrics-core`
* excluded `flink-python`
* excluded `flink-metrics-core`
* excluded `flink-metrics-jmx`