### PR TITLE
[FLINK-4277] Fix TaskManagerConfigurationTest#testDefaultFsParameterLoading

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerConfigurationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.testutils.CommonTestUtils;
@@ -110,7 +111,7 @@ public class TaskManagerConfigurationTest {
 	@Test
 	public void testDefaultFsParameterLoading() {
 		final File tmpDir = getTmpDir();
-		final File confFile =  new File(tmpDir, "flink-conf.yaml");
+		final File confFile =  new File(tmpDir, GlobalConfiguration.FLINK_CONF_FILENAME);
 
 		try {
 			final URI defaultFS = new URI("otherFS", null, "localhost", 1234, null, null, null);
@@ -127,10 +128,8 @@ public class TaskManagerConfigurationTest {
 			URI scheme = (URI) f.get(null);
 
 			assertEquals("Default Filesystem Scheme not configured.", scheme, defaultFS);
-		} catch (FileNotFoundException e) {
-			fail(e.getMessage());
 		} catch (Exception e) {
-			e.printStackTrace();
+			fail(e.getMessage());
 		} finally {
 			confFile.delete();
 			tmpDir.delete();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerConfigurationTest.java
@@ -110,7 +110,7 @@ public class TaskManagerConfigurationTest {
 	@Test
 	public void testDefaultFsParameterLoading() {
 		final File tmpDir = getTmpDir();
-		final File confFile =  new File(tmpDir, UUID.randomUUID().toString() + ".yaml");
+		final File confFile =  new File(tmpDir, "flink-conf.yaml");
 
 		try {
 			final URI defaultFS = new URI("otherFS", null, "localhost", 1234, null, null, null);
@@ -119,9 +119,7 @@ public class TaskManagerConfigurationTest {
 			pw1.println("fs.default-scheme: "+ defaultFS);
 			pw1.close();
 
-			String filepath = confFile.getAbsolutePath();
-
-			String[] args = new String[]{"--configDir:"+filepath};
+			String[] args = new String[]{"--configDir:" + tmpDir};
 			TaskManager.parseArgsAndLoadConfig(args);
 
 			Field f = FileSystem.class.getDeclaredField("defaultScheme");


### PR DESCRIPTION
This PR fixes the `TaskManagerConfigurationTest#testDefaultFsParameterLoading` by creating a proper `flink-conf.yaml` file and passing the correct `--configDir` parameter.

Previously, the generated yaml had a random name (`<random UUID>.yaml`) even though it should be called `flink-conf.yaml`. In addition, the `--configDir` parameter was set to the file name, and not directory it resides in.

I don't know why this test did not fail earlier; maybe @mxm has an idea as he recently did some work on the `GlobalConfiguration`.