### PR TITLE
[FLINK-4276] Fix TextInputFormatTest#testNestedFileRead

### DIFF
--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.junit.Test;
 
@@ -103,7 +104,7 @@ public class TextInputFormatTest {
 				File tempFile = File.createTempFile("TextInputFormatTest", ".tmp", tmpDir);
 				tempFile.deleteOnExit();
 
-				expectedFiles.add("file:" + tempFile.getAbsolutePath());
+				expectedFiles.add(new Path(tempFile.getAbsolutePath()).makeQualified(FileSystem.getLocalFileSystem()).toString());
 			}
 			File parentDir = new File("tmp");
 


### PR DESCRIPTION
The problem with test was a simple formatting mismatch between the paths returned by `"file:" + File.getAbsolutePath()` and `Path#toString()`. The orientation of slashes were different, and one slash missing after `file:`.

The test was changed to make sure that the paths are formatted the same way.