### PR TITLE
[FLINK-4291] Add log entry for scheduled reporters

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
@@ -131,6 +131,8 @@ public class MetricRegistry {
 
 						executor.scheduleWithFixedDelay(
 								new ReporterTask((Scheduled) reporterInstance), period, period, timeunit);
+					} else {
+						LOG.info("Reporting metrics for reporter {} of type {}.", namedReporter, className);
 					}
 					reporters.add(reporterInstance);
 				}


### PR DESCRIPTION
simple PR that adds a log message for instantiated unscheduled reporters containing the name and class.