### PR TITLE
[FLINK-4297][yarn] decode URL encoded fat jar path

### DIFF
--- a/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
+++ b/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
@@ -48,9 +48,9 @@ constructCLIClientClassPath() {
 CC_CLASSPATH=`manglePathList $(constructCLIClientClassPath)`
 
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-yarn-session-$HOSTNAME.log
-log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-yarn-session.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback-yarn.xml"
+log_setting="-Dlog.file=\"$log\" -Dlog4j.configuration=file:\"$FLINK_CONF_DIR\"/log4j-yarn-session.properties -Dlogback.configurationFile=file:\"$FLINK_CONF_DIR\"/logback-yarn.xml"
 
 export FLINK_CONF_DIR
 
-$JAVA_RUN $JVM_ARGS -classpath $CC_CLASSPATH:$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR  $log_setting org.apache.flink.yarn.cli.FlinkYarnSessionCli -j $FLINK_LIB_DIR/flink-dist*.jar "$@"
+$JAVA_RUN $JVM_ARGS -classpath "$CC_CLASSPATH:$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR" $log_setting org.apache.flink.yarn.cli.FlinkYarnSessionCli -j "$FLINK_LIB_DIR"/flink-dist*.jar "$@"
 

--- a/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
+++ b/flink-dist/src/main/flink-bin/yarn-bin/yarn-session.sh
@@ -48,7 +48,7 @@ constructCLIClientClassPath() {
 CC_CLASSPATH=`manglePathList $(constructCLIClientClassPath)`
 
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-yarn-session-$HOSTNAME.log
-log_setting="-Dlog.file=\"$log\" -Dlog4j.configuration=file:\"$FLINK_CONF_DIR\"/log4j-yarn-session.properties -Dlogback.configurationFile=file:\"$FLINK_CONF_DIR\"/logback-yarn.xml"
+log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-yarn-session.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback-yarn.xml"
 
 export FLINK_CONF_DIR
 


### PR DESCRIPTION
This solves problems with spaces and special characters in the
automatically determined fat jar path which is returned URL encoded.