### PR TITLE
[FLINK-4296] Fixes failure reporting of consumer task scheduling when producer has already finished

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -548,7 +548,7 @@ public class Execution implements Serializable {
 									consumerVertex.getExecutionGraph().getScheduler(),
 									consumerVertex.getExecutionGraph().isQueuedSchedulingAllowed());
 						} catch (Throwable t) {
-							fail(new IllegalStateException("Could not schedule consumer " +
+							consumerVertex.fail(new IllegalStateException("Could not schedule consumer " +
 									"vertex " + consumerVertex, t));
 						}
 


### PR DESCRIPTION
This PR changes the failure behaviour such that the consumer task is failed instead of the
producer task. The latter is problematic, since a finsihed producer task will simply swallow
scheduling exception originating from scheduling the consumer task.

This PR should also be merged in the release-1.1.0 branch.

R @mxm.