### PR TITLE
[hotfix] Fix TypeExtractor.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -348,7 +348,8 @@ public class TypeExtractor {
 				
 				// parameters must be accessed from behind, since JVM can add additional parameters e.g. when using local variables inside lambda function
 				final int paramLen = m.getGenericParameterTypes().length - 1;
-				final Type input = (outputTypeArgumentIndex >= 0) ? m.getGenericParameterTypes()[paramLen - 1] : m.getGenericParameterTypes()[paramLen];
+				final Type input = (paramLen < 0) ? inType.getTypeClass() :
+					(outputTypeArgumentIndex >= 0) ? m.getGenericParameterTypes()[paramLen - 1] : m.getGenericParameterTypes()[paramLen];
 				validateInputType((inputTypeArgumentIndex >= 0) ? extractTypeArgument(input, inputTypeArgumentIndex) : input, inType);
 				if(function instanceof ResultTypeQueryable) {
 					return ((ResultTypeQueryable<OUT>) function).getProducedType();


### PR DESCRIPTION
When function is a method reference to an instance method of an arbitrary object of a particular type it hasn't any parameters and getting of input type throws exception.

For example this code

```
environment.fromElements(1, 2, 3, 4, 5).map(Object::toString).print();
```

throws exception: 

```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: -1
	at org.apache.flink.api.java.typeutils.TypeExtractor.getUnaryOperatorReturnType(TypeExtractor.java:350)
	at org.apache.flink.api.java.typeutils.TypeExtractor.getUnaryOperatorReturnType(TypeExtractor.java:304)
	at org.apache.flink.api.java.typeutils.TypeExtractor.getMapReturnTypes(TypeExtractor.java:119)
	at org.apache.flink.api.java.DataSet.map(DataSet.java:215)
	at ru.chermenin.flink.task.TestTask.main(TestTask.java:14)
```

but this is executed normally:

```
environment.fromElements(1, 2, 3, 4, 5).map(i -> i.toString()).print();
```