### PR TITLE
[FLINK-4310] [build] Selectively run API compatibility checks in API projects.

### DIFF
--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -34,15 +34,4 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/flink-batch-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-batch-connectors/flink-hadoop-compatibility/pom.xml
@@ -74,4 +74,16 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+
+	<build>
+		<plugins>
+			<!-- activate API compatibility checks -->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -108,7 +108,8 @@ under the License.
 
 	<build>
 		<plugins>
-			<!-- Exclude removed CONFIG_KEY from ccheck -->
+
+			<!-- activate API compatibility checks -->
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
@@ -119,14 +120,6 @@ under the License.
 						</excludes>
 					</parameter>
 				</configuration>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>cmp</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 			<!-- publish some test base classes -->

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -77,6 +77,13 @@ under the License.
 
 	<build>
 		<plugins>
+
+			<!-- activate API compatibility checks -->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+
 			<!-- Because flink-scala and flink-avro uses it in tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -32,4 +32,14 @@ under the License.
 	<artifactId>flink-metrics-core</artifactId>
 	<name>flink-metrics-core</name>
 
+	<build>
+		<plugins>
+			<!-- activate API compatibility checks -->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -106,6 +106,13 @@ under the License.
 
 	<build>
 		<plugins>
+
+			<!-- activate API compatibility checks -->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+
 			<!-- Scala Compiler -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>

--- a/flink-shaded-curator/pom.xml
+++ b/flink-shaded-curator/pom.xml
@@ -38,16 +38,4 @@
 
 	<packaging>pom</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -163,14 +163,6 @@ under the License.
 				</executions>
 			</plugin>
 
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-
 		</plugins>
 	</build>
 

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -95,6 +95,13 @@ under the License.
 
 	<build>
 		<plugins>
+
+			<!-- activate API compatibility checks -->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+
 			<!-- disable fork reuse for the streaming project, because of
 			incorrect declaration of tests -->
 			<plugin>
@@ -104,6 +111,7 @@ under the License.
 					<reuseForks>false</reuseForks>
 				</configuration>
 			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -215,13 +215,14 @@ under the License.
 				</configuration>
 			</plugin>
 
-			<!-- Exclude generated classes from api compatibility checks -->
+			<!-- activate API compatibility checks -->
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 				<configuration>
 					<parameter>
 						<excludes>
+							<!-- Exclude generated classes from api compatibility checks -->
 							<exclude>*\$\$anon\$*</exclude>
 						</excludes>
 					</parameter>

--- a/pom.xml
+++ b/pom.xml
@@ -766,63 +766,6 @@ under the License.
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-				<version>0.7.0</version>
-				<configuration>
-					<oldVersion>
-						<dependency>
-							<groupId>org.apache.flink</groupId>
-							<artifactId>${project.artifactId}</artifactId>
-							<version>1.0.0</version>
-							<type>${project.packaging}</type>
-						</dependency>
-					</oldVersion>
-					<newVersion>
-						<file>
-							<path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
-						</file>
-					</newVersion>
-					<parameter>
-						<onlyModified>true</onlyModified>
-						<includes>
-							<include>@org.apache.flink.annotation.Public</include>
-						</includes>
-						<excludes>
-							<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
-							<exclude>@org.apache.flink.annotation.Internal</exclude>
-						</excludes>
-						<accessModifier>public</accessModifier>
-						<breakBuildOnModifications>false</breakBuildOnModifications>
-						<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
-						<breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
-						<onlyBinaryIncompatible>false</onlyBinaryIncompatible>
-						<includeSynthetic>true</includeSynthetic>
-						<ignoreMissingClasses>false</ignoreMissingClasses>
-						<skipPomModules>true</skipPomModules>
-						<!-- Don't break build on newly added maven modules -->
-						<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
-					</parameter>
-					<skip>false</skip>
-					<dependencies>
-						<dependency>
-							<groupId>org.apache.flink</groupId>
-							<artifactId>flink-annotations</artifactId>
-							<version>${project.version}</version>
-						</dependency>
-					</dependencies>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>cmp</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
@@ -1128,20 +1071,19 @@ under the License.
 
 		</plugins>
 
-		<!--
-		Disable git-commit-id-plugin in eclipse
-		See https://github.com/stratosphere/stratosphere/pull/231#issuecomment-27896187
-		-->
+		<!-- Plugin configurations for plugins activated in sub-projects --> 
+
 		<pluginManagement>
 			<plugins>
-				<!--set maven shade plugin version-->
+
+				<!-- Pin the version of the maven shade plugin -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>2.4.1</version>
 				</plugin>
-				<!--This plugin's configuration is used to store Eclipse m2e settings
-					only. It has no influence on the Maven build itself. -->
+				
+				<!-- Disable certain plugins in Eclipse -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>
@@ -1151,15 +1093,9 @@ under the License.
 							<pluginExecutions>
 								<pluginExecution>
 									<pluginExecutionFilter>
-										<groupId>
-											pl.project13.maven
-										</groupId>
-										<artifactId>
-											git-commit-id-plugin
-										</artifactId>
-										<versionRange>
-											[2.1.5,)
-										</versionRange>
+										<groupId>pl.project13.maven</groupId>
+										<artifactId>git-commit-id-plugin</artifactId>
+										<versionRange>[2.1.5,)</versionRange>
 										<goals>
 											<goal>revision</goal>
 										</goals>
@@ -1170,15 +1106,9 @@ under the License.
 								</pluginExecution>
 								<pluginExecution>
 									<pluginExecutionFilter>
-										<groupId>
-											org.apache.maven.plugins
-										</groupId>
-										<artifactId>
-											maven-checkstyle-plugin
-										</artifactId>
-										<versionRange>
-											[2.12.1,)
-										</versionRange>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-checkstyle-plugin</artifactId>
+										<versionRange>[2.12.1,)</versionRange>
 										<goals>
 											<goal>check</goal>
 										</goals>
@@ -1248,7 +1178,67 @@ under the License.
 					<artifactId>scala-maven-plugin</artifactId>
 					<version>3.2.2</version>
 				</plugin>
+
+				<!-- Configuration for the binary compatibility checker -->
+				<plugin>
+					<groupId>com.github.siom79.japicmp</groupId>
+					<artifactId>japicmp-maven-plugin</artifactId>
+					<version>0.7.0</version>
+					<configuration>
+						<oldVersion>
+							<dependency>
+								<groupId>org.apache.flink</groupId>
+								<artifactId>${project.artifactId}</artifactId>
+								<version>1.0.0</version>
+								<type>${project.packaging}</type>
+							</dependency>
+						</oldVersion>
+						<newVersion>
+							<file>
+								<path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+							</file>
+						</newVersion>
+						<parameter>
+							<onlyModified>true</onlyModified>
+							<includes>
+								<include>@org.apache.flink.annotation.Public</include>
+							</includes>
+							<excludes>
+								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
+								<exclude>@org.apache.flink.annotation.Internal</exclude>
+							</excludes>
+							<accessModifier>public</accessModifier>
+							<breakBuildOnModifications>false</breakBuildOnModifications>
+							<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+							<breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+							<onlyBinaryIncompatible>false</onlyBinaryIncompatible>
+							<includeSynthetic>true</includeSynthetic>
+							<ignoreMissingClasses>false</ignoreMissingClasses>
+							<skipPomModules>true</skipPomModules>
+							<!-- Don't break build on newly added maven modules -->
+							<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
+						</parameter>
+						<skip>false</skip>
+						<dependencies>
+							<dependency>
+								<groupId>org.apache.flink</groupId>
+								<artifactId>flink-annotations</artifactId>
+								<version>${project.version}</version>
+							</dependency>
+						</dependencies>
+					</configuration>
+					<executions>
+						<execution>
+							<phase>verify</phase>
+							<goals>
+								<goal>cmp</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+
 			</plugins>
 		</pluginManagement>
 	</build>
+
 </project>


### PR DESCRIPTION
This moves the API compatibility checks into the API projects that use stability annotations.
Previously, every project ran the tests, regardless of whether it contained public API classes or not.

API compatibility checks are done in
  - `flink-metrics-core`
  - `flink-core`
  - `flink-java`
  - `flink-scala`
  - `flink-streaming-scala`
  - `flink-streaming-java`
  - `flink-hadoop-compatibility`

Those were the projects where I found the `@Public` annotation being used.