### PR TITLE
FLINK-4094 Off heap memory deallocation might not properly work (Ram)

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -83,7 +83,8 @@ The default fraction for managed memory can be adjusted using the `taskmanager.m
 
 - `taskmanager.memory.segment-size`: The size of memory buffers used by the memory manager and the network stack in bytes (DEFAULT: 32768 (= 32 KiBytes)).
 
-- `taskmanager.memory.preallocate`: Can be either of `true` or `false`. Specifies whether task managers should allocate all managed memory when starting up. (DEFAULT: false)
+- `taskmanager.memory.preallocate`: Can be either of `true` or `false`. Specifies whether task managers should allocate all managed memory when starting up. (DEFAULT: false). When `taskmanager.memory.off-heap` is set to `true`, then it is advised that this configuration is also set to `true`, because when set to
+`false`, cleaning up of the allocated offheap memory kicks up only when the configured JVM parameter MaxDirectMemorySize is reached by triggering a full GC.
 
 ### Memory and Performance Debugging
 

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -83,8 +83,7 @@ The default fraction for managed memory can be adjusted using the `taskmanager.m
 
 - `taskmanager.memory.segment-size`: The size of memory buffers used by the memory manager and the network stack in bytes (DEFAULT: 32768 (= 32 KiBytes)).
 
-- `taskmanager.memory.preallocate`: Can be either of `true` or `false`. Specifies whether task managers should allocate all managed memory when starting up. (DEFAULT: false). When `taskmanager.memory.off-heap` is set to `true`, then it is advised that this configuration is also set to `true`, because when set to
-`false`, cleaning up of the allocated offheap memory kicks up only when the configured JVM parameter MaxDirectMemorySize is reached by triggering a full GC.
+- `taskmanager.memory.preallocate`: Can be either of `true` or `false`. Specifies whether task managers should allocate all managed memory when starting up. (DEFAULT: false). When `taskmanager.memory.off-heap` is set to `true`, then it is advised that this configuration is also set to `true`.  If this configuration is set to `false` cleaning up of the allocated offheap memory happens only when the configured JVM parameter MaxDirectMemorySize is reached by triggering a full GC.
 
 ### Memory and Performance Debugging
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MemoryManager {
 
-	static final Logger LOG = LoggerFactory.getLogger(MemoryManager.class);
+	private static final Logger LOG = LoggerFactory.getLogger(MemoryManager.class);
 	/** The default memory page size. Currently set to 32 KiBytes. */
 	public static final int DEFAULT_PAGE_SIZE = 32 * 1024;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -34,6 +34,8 @@ import org.apache.flink.core.memory.HybridMemorySegment;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.util.MathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The memory manager governs the memory that Flink uses for sorting, hashing, and caching. Memory
@@ -53,6 +55,7 @@ import org.apache.flink.util.MathUtils;
  */
 public class MemoryManager {
 
+	static final Logger LOG = LoggerFactory.getLogger(MemoryManager.class);
 	/** The default memory page size. Currently set to 32 KiBytes. */
 	public static final int DEFAULT_PAGE_SIZE = 32 * 1024;
 
@@ -163,6 +166,10 @@ public class MemoryManager {
 				this.memoryPool = new HeapMemoryPool(memToAllocate, pageSize);
 				break;
 			case OFF_HEAP:
+				if(!preAllocateMemory) {
+					LOG.warn("It is advisable to set 'taskmanager.memory.preallocate' to true when" +
+						" the memory type 'taskmanager.memory.off-heap' is set to true.");
+				}
 				this.memoryPool = new HybridOffHeapMemoryPool(memToAllocate, pageSize);
 				break;
 			default:


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Just added a log msg warning the user about using OFFHEAP and PREALLOCATION together. Same comment is added over in the doc also. But not sure if that is enough or we need more information to be added there. But for a user it may not be relevant. Any thoughts?