### PR TITLE
[FLINK-4337] [build] Remove unnecessary Scala Suffix from Hadoop 1 shaded artifact

### DIFF
--- a/flink-shaded-hadoop/flink-shaded-hadoop1/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop1/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-shaded-hadoop1_2.10</artifactId>
+	<artifactId>flink-shaded-hadoop1</artifactId>
 	<name>flink-shaded-hadoop1</name>
 
 	<packaging>jar</packaging>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<modules>
-		<module>${shading-artifact-module.name}</module>
+		<module>${shading-artifact.name}</module>
 	</modules>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,6 @@ under the License.
 		<shading-artifact.name>error</shading-artifact.name>
 		<!-- Internal property to reduce build times on TravisCi -->
 		<flink-fast-tests-pattern>never-match-me</flink-fast-tests-pattern>
-		<!-- The shading artifact module name can be used as a module name. it does not get a scala version suffix -->
-		<shading-artifact-module.name>error</shading-artifact-module.name>
 		<hadoop-one.version>1.2.1</hadoop-one.version>
 		<hadoop-two.version>2.3.0</hadoop-two.version>
 		<!-- Need to use a user property here because the surefire
@@ -430,8 +428,7 @@ under the License.
 			</activation>
 			<properties>
 				<hadoop.version>${hadoop-one.version}</hadoop.version>
-				<shading-artifact.name>flink-shaded-hadoop1_2.10</shading-artifact.name>
-				<shading-artifact-module.name>flink-shaded-hadoop1</shading-artifact-module.name>
+				<shading-artifact.name>flink-shaded-hadoop1</shading-artifact.name>
 			</properties>
 		</profile>
 
@@ -447,7 +444,6 @@ under the License.
 			<properties>
 				<hadoop.version>${hadoop-two.version}</hadoop.version>
 				<shading-artifact.name>flink-shaded-hadoop2</shading-artifact.name>
-				<shading-artifact-module.name>flink-shaded-hadoop2</shading-artifact-module.name>
 			</properties>
 			<modules>
 				<module>flink-yarn</module>


### PR DESCRIPTION
The shaded Hadoop 1 dependency was versioned with a Scala Version Suffix, even though it does not depend on Scala.

This pull request removes that suffix and simplifies the POM files accordingly.