### PR TITLE
[hotfix][build] Remove Scala suffix from Hadoop1 shading project

### DIFF
--- a/flink-shaded-hadoop/flink-shaded-hadoop1/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop1/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-shaded-hadoop1_2.10</artifactId>
+	<artifactId>flink-shaded-hadoop1</artifactId>
 	<name>flink-shaded-hadoop1</name>
 
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@ under the License.
 			</activation>
 			<properties>
 				<hadoop.version>${hadoop-one.version}</hadoop.version>
-				<shading-artifact.name>flink-shaded-hadoop1_2.10</shading-artifact.name>
+				<shading-artifact.name>flink-shaded-hadoop1</shading-artifact.name>
 				<shading-artifact-module.name>flink-shaded-hadoop1</shading-artifact-module.name>
 			</properties>
 		</profile>


### PR DESCRIPTION
It seems that the hadoop1 shaded artifact has a scala suffix, which is not needed anymore.