### PR TITLE
[FLINK-4342] [build] Fix dependencies of flink-connector-filesystem

### DIFF
--- a/flink-streaming-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-streaming-connectors/flink-connector-filesystem/pom.xml
@@ -51,15 +51,10 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>${shading-artifact.name}</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
This fixes dependencies of the `flink-connector-filesystem` project

  - Remove unneeded Guava dependency
  - Set hadoop-shaded-artifact dependency to 'provided' as in other connectors, because the dependency should not go into the user's jar.