### PR TITLE
[FLINK-4236] fix error handling for jar files with no main method

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -94,20 +94,23 @@ public class JarListHandler implements RequestHandler {
 				} catch (IOException ignored) {
 					// we simply show no entries here
 				}
-				
+
 				// show every entry class that can be loaded later on.
-				PackagedProgram program;
 				for (String clazz : classes) {
 					clazz = clazz.trim();
+
+					PackagedProgram program = null;
 					try {
 						program = new PackagedProgram(f, clazz, new String[0]);
+					} catch (Exception ignored) {
+						// ignore jar files which throw an error upon creating a PackagedProgram
+					}
+					if (program != null) {
 						gen.writeStartObject();
 						gen.writeStringField("name", clazz);
 						String desc = program.getDescription();
 						gen.writeStringField("description", desc == null ? "No description provided" : desc);
 						gen.writeEndObject();
-					} catch (ProgramInvocationException e) {
-						//
 					}
 				}
 				gen.writeEndArray();


### PR DESCRIPTION
This change shows only entry classes with a valid main method. It
ignores classes which contain no main method.