### PR TITLE
[FLINK-4368] [distributed runtime] Eagerly initialize the RPC endpoint members

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -41,12 +41,12 @@ public interface RpcService {
 	/**
 	 * Start a rpc server which forwards the remote procedure calls to the provided rpc protocol.
 	 *
-	 * @param rpcProtocol Rpc protocl to dispath the rpcs to
+	 * @param rpcProtocol RPC endpoint to dispatch the calls to
 	 * @param <S> Type of the rpc protocol
 	 * @param <C> Type of the self rpc gateway associated with the rpc server
 	 * @return Self gateway to dispatch remote procedure calls to oneself
 	 */
-	<S extends RpcProtocol, C extends RpcGateway> C startServer(S rpcProtocol);
+	<C extends RpcGateway, S extends RpcProtocol<C>> C startServer(S rpcProtocol);
 
 	/**
 	 * Stop the underlying rpc server of the provided self gateway.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -85,7 +85,7 @@ public class AkkaRpcService implements RpcService {
 	}
 
 	@Override
-	public <S extends RpcProtocol, C extends RpcGateway> C startServer(S rpcProtocol) {
+	public <C extends RpcGateway, S extends RpcProtocol<C>> C startServer(S rpcProtocol) {
 		ActorRef ref;
 		C self;
 		if (rpcProtocol instanceof TaskExecutor) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -54,15 +54,13 @@ public class AkkaRpcServiceTest extends TestLogger {
 		ResourceManager resourceManager = new ResourceManager(akkaRpcService, executorService);
 		JobMaster jobMaster = new JobMaster(akkaRpcService2, executorService);
 
-		resourceManager.start();
-
 		ResourceManagerGateway rm = resourceManager.getSelf();
 
 		assertTrue(rm instanceof AkkaGateway);
 
 		AkkaGateway akkaClient = (AkkaGateway) rm;
 
-		jobMaster.start();
+		
 		jobMaster.registerAtResourceManager(AkkaUtils.getAkkaURL(actorSystem, akkaClient.getActorRef()));
 
 		// wait for successful registration


### PR DESCRIPTION
This eagerly initialized the RPC members like
  - self gateway
  - self reference
  - main thread executor
and makes them immutable.

This also adds structural comments to the `RpcProtocol` class.