### PR TITLE
[FLINK-4366] Enforce parallelism=1 For AllWindowedStream

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -302,7 +302,10 @@ public class AllWindowedStream<T, W extends Window> {
 					allowedLateness);
 		}
 
-		return input.transform(opName, resultType, operator).setParallelism(1);
+		SingleOutputStreamOperator<R> result = input.transform(opName, resultType, operator);
+		result.getTransformation().setAllWindow(true);
+
+		return result.setParallelism(1);
 	}
 
 	/**
@@ -390,8 +393,10 @@ public class AllWindowedStream<T, W extends Window> {
 					trigger,
 					allowedLateness);
 		}
+		SingleOutputStreamOperator<R> result = input.transform(opName, resultType, operator);
+		result.getTransformation().setAllWindow(true);
 
-		return input.transform(opName, resultType, operator).setParallelism(1);
+		return result.setParallelism(1);
 	}
 
 	/**
@@ -486,7 +491,10 @@ public class AllWindowedStream<T, W extends Window> {
 					allowedLateness);
 		}
 
-		return input.transform(opName, resultType, operator).setParallelism(1);
+		SingleOutputStreamOperator<R> result = input.transform(opName, resultType, operator);
+		result.getTransformation().setAllWindow(true);
+
+		return result.setParallelism(1);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -302,10 +302,7 @@ public class AllWindowedStream<T, W extends Window> {
 					allowedLateness);
 		}
 
-		SingleOutputStreamOperator<R> result = input.transform(opName, resultType, operator);
-		result.getTransformation().setAllWindow(true);
-
-		return result.setParallelism(1);
+		return input.transform(opName, resultType, operator).forceNonParallel();
 	}
 
 	/**
@@ -393,10 +390,8 @@ public class AllWindowedStream<T, W extends Window> {
 					trigger,
 					allowedLateness);
 		}
-		SingleOutputStreamOperator<R> result = input.transform(opName, resultType, operator);
-		result.getTransformation().setAllWindow(true);
 
-		return result.setParallelism(1);
+		return input.transform(opName, resultType, operator).forceNonParallel();
 	}
 
 	/**
@@ -491,10 +486,7 @@ public class AllWindowedStream<T, W extends Window> {
 					allowedLateness);
 		}
 
-		SingleOutputStreamOperator<R> result = input.transform(opName, resultType, operator);
-		result.getTransformation().setAllWindow(true);
-
-		return result.setParallelism(1);
+		return input.transform(opName, resultType, operator).forceNonParallel();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -94,7 +94,9 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 		if (parallelism < 1) {
 			throw new IllegalArgumentException("The parallelism of an operator must be at least 1.");
 		}
-
+		if (transformation.isAllWindow() && parallelism > 1) {
+			throw new IllegalArgumentException("The parallelism of all-windowed operator must be 1.");
+		}
 		transformation.setParallelism(parallelism);
 
 		return this;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -40,6 +40,9 @@ import static java.util.Objects.requireNonNull;
 @Public
 public class SingleOutputStreamOperator<T> extends DataStream<T> {
 
+	/** Indicate this is a non-parallel operator and cannot set a non-1 degree of parallelism. **/
+	protected boolean nonParallel = false;
+
 	protected SingleOutputStreamOperator(StreamExecutionEnvironment environment, StreamTransformation<T> transformation) {
 		super(environment, transformation);
 	}
@@ -94,11 +97,24 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 		if (parallelism < 1) {
 			throw new IllegalArgumentException("The parallelism of an operator must be at least 1.");
 		}
-		if (transformation.isAllWindow() && parallelism > 1) {
-			throw new IllegalArgumentException("The parallelism of all-windowed operator must be 1.");
+		if (nonParallel && parallelism > 1) {
+			throw new IllegalArgumentException("The parallelism of non parallel operator must be 1.");
 		}
 		transformation.setParallelism(parallelism);
 
+		return this;
+	}
+
+	/**
+	 * Sets the parallelism of this operator to one.
+	 * And mark this operator cannot set a non-1 degree of parallelism.
+	 *
+	 * @return The operator with only one parallelism.
+     */
+	@PublicEvolving
+	public SingleOutputStreamOperator<T> forceNonParallel() {
+		transformation.setParallelism(1);
+		nonParallel = true;
 		return this;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -116,9 +116,6 @@ public abstract class StreamTransformation<T> {
 
 	private int parallelism;
 
-	// This is used to avoid set a different parallelism on an all-windowed stream.
-	protected boolean isAllWindow = false;
-
 	/**
 	 * User-specified ID for this transformation. This is used to assign the
 	 * same operator ID across job restarts. There is also the automatically
@@ -308,23 +305,6 @@ public abstract class StreamTransformation<T> {
 	 * @return The list of transitive predecessors.
 	 */
 	public abstract Collection<StreamTransformation<?>> getTransitivePredecessors();
-
-	/**
-	 * Marks this transformation is an all-windowed stream.
-	 * @param allWindow true if this transformation is an all-windowed stream
-	 */
-	public void setAllWindow(boolean allWindow) {
-		isAllWindow = allWindow;
-	}
-
-	/**
-	 * Returns True if this transformation is an all-windowed stream.
-	 *
-	 * @return True if this transformation is an all-windowed stream.
-	 */
-	public boolean isAllWindow() {
-		return isAllWindow;
-	}
 
 	@Override
 	public String toString() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -116,6 +116,9 @@ public abstract class StreamTransformation<T> {
 
 	private int parallelism;
 
+	// This is used to avoid set a different parallelism on an all-windowed stream.
+	protected boolean isAllWindow = false;
+
 	/**
 	 * User-specified ID for this transformation. This is used to assign the
 	 * same operator ID across job restarts. There is also the automatically
@@ -305,6 +308,23 @@ public abstract class StreamTransformation<T> {
 	 * @return The list of transitive predecessors.
 	 */
 	public abstract Collection<StreamTransformation<?>> getTransitivePredecessors();
+
+	/**
+	 * Marks this transformation is an all-windowed stream.
+	 * @param allWindow true if this transformation is an all-windowed stream
+	 */
+	public void setAllWindow(boolean allWindow) {
+		isAllWindow = allWindow;
+	}
+
+	/**
+	 * Returns True if this transformation is an all-windowed stream.
+	 *
+	 * @return True if this transformation is an all-windowed stream.
+	 */
+	public boolean isAllWindow() {
+		return isAllWindow;
+	}
 
 	@Override
 	public String toString() {


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR avoid users try to set a parallelism on an all-windowed stream. 

I add an `isAllWindow` field to mark a transformation is  all-windowed. I'm appreciate if there is better solutions. 
