### PR TITLE
[FLINK-4385] [table] Union on Timestamp fields does not work

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetRel.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetRel.scala
@@ -62,7 +62,10 @@ trait DataSetRel extends RelNode with FlinkRel {
         case SqlTypeName.VARCHAR => s + 12
         case SqlTypeName.CHAR => s + 1
         case SqlTypeName.DECIMAL => s + 12
-        case _ => throw new TableException("Unsupported data type encountered")
+        case SqlTypeName.INTERVAL_DAY_TIME => s + 8
+        case SqlTypeName.INTERVAL_YEAR_MONTH => s + 4
+        case SqlTypeName.TIME | SqlTypeName.TIMESTAMP | SqlTypeName.DATE => s + 12
+        case _ => throw TableException(s"Unsupported data type encountered: $t")
       }
     }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/typeutils/IntervalTypeInfo.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/typeutils/IntervalTypeInfo.scala
@@ -97,7 +97,7 @@ object IntervalTypeInfo {
       ascendingOrder: java.lang.Boolean)
     : TypeComparator[X] = {
     try {
-      val constructor = comparatorClass.getConstructor(classOf[java.lang.Boolean])
+      val constructor = comparatorClass.getConstructor(java.lang.Boolean.TYPE)
       constructor.newInstance(ascendingOrder)
     } catch {
       case e: Exception =>


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR fix the problem mentioned in JIRA. The reason is that it will call `estimateRowSize` and encounter type mismatch for temporal types in batch mode.

Another fix is the IntervalTypeInfo's Comparator instantiation, the constructor of TypeComparator should be `boolean`.

