### PR TITLE
[FLINK-4383] [rpc] Eagerly serialize remote rpc invocation messages

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaGateway.java
@@ -26,5 +26,5 @@ import org.apache.flink.runtime.rpc.RpcGateway;
  */
 interface AkkaGateway extends RpcGateway {
 
-	ActorRef getRpcServer();
+	ActorRef getRpcEndpoint();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/LocalRpcInvocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/LocalRpcInvocation.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka.messages;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Local rpc invocation message containing the remote procedure name, its parameter types and the
+ * corresponding call arguments. This message will only be sent if the communication is local and,
+ * thus, the message does not have to be serialized.
+ */
+public final class LocalRpcInvocation implements RpcInvocation {
+
+	private final String methodName;
+	private final Class<?>[] parameterTypes;
+	private final Object[] args;
+
+	public LocalRpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] args) {
+		this.methodName = Preconditions.checkNotNull(methodName);
+		this.parameterTypes = Preconditions.checkNotNull(parameterTypes);
+		this.args = args;
+	}
+
+	@Override
+	public String getMethodName() {
+		return methodName;
+	}
+
+	@Override
+	public Class<?>[] getParameterTypes() {
+		return parameterTypes;
+	}
+
+	@Override
+	public Object[] getArgs() {
+		return args;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/RemoteRpcInvocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/RemoteRpcInvocation.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka.messages;
+
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedValue;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * Remote rpc invocation message which is used when the actor communication is remote and, thus, the
+ * message has to be serialized.
+ * <p>
+ * In order to fail fast and report an appropriate error message to the user, the method name, the
+ * parameter types and the arguments are eagerly serialized. In case the the invocation call
+ * contains a non-serializable object, then an {@link IOException} is thrown.
+ */
+public class RemoteRpcInvocation implements RpcInvocation, Serializable {
+	private static final long serialVersionUID = 6179354390913843809L;
+
+	// Serialized invocation data
+	private SerializedValue<RemoteRpcInvocation.MethodInvocation> serializedMethodInvocation;
+
+	// Transient field which is lazily initialized upon first access to the invocation data
+	private transient RemoteRpcInvocation.MethodInvocation methodInvocation;
+
+	public  RemoteRpcInvocation(
+		final String methodName,
+		final Class<?>[] parameterTypes,
+		final Object[] args) throws IOException {
+
+		serializedMethodInvocation = new SerializedValue<>(new RemoteRpcInvocation.MethodInvocation(methodName, parameterTypes, args));
+		methodInvocation = null;
+	}
+
+	@Override
+	public String getMethodName() throws IOException, ClassNotFoundException {
+		deserializeMethodInvocation();
+
+		return methodInvocation.getMethodName();
+	}
+
+	@Override
+	public Class<?>[] getParameterTypes() throws IOException, ClassNotFoundException {
+		deserializeMethodInvocation();
+
+		return methodInvocation.getParameterTypes();
+	}
+
+	@Override
+	public Object[] getArgs() throws IOException, ClassNotFoundException {
+		deserializeMethodInvocation();
+
+		return methodInvocation.getArgs();
+	}
+
+	/**
+	 * Size (#bytes of the serialized data) of the rpc invocation message.
+	 *
+	 * @return Size of the remote rpc invocation message
+	 */
+	public long getSize() {
+		return serializedMethodInvocation.getByteArray().length;
+	}
+
+	private void deserializeMethodInvocation() throws IOException, ClassNotFoundException {
+		if (methodInvocation == null) {
+			methodInvocation = serializedMethodInvocation.deserializeValue(ClassLoader.getSystemClassLoader());
+		}
+	}
+
+	// -------------------------------------------------------------------
+	// Serialization methods
+	// -------------------------------------------------------------------
+
+	private void writeObject(ObjectOutputStream oos) throws IOException {
+		oos.writeObject(serializedMethodInvocation);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+		serializedMethodInvocation = (SerializedValue<RemoteRpcInvocation.MethodInvocation>) ois.readObject();
+		methodInvocation = null;
+	}
+
+	// -------------------------------------------------------------------
+	// Utility classes
+	// -------------------------------------------------------------------
+
+	/**
+	 * Wrapper class for the method invocation information
+	 */
+	private static final class MethodInvocation implements Serializable {
+		private static final long serialVersionUID = 9187962608946082519L;
+
+		private String methodName;
+		private Class<?>[] parameterTypes;
+		private Object[] args;
+
+		private MethodInvocation(final String methodName, final Class<?>[] parameterTypes, final Object[] args) {
+			this.methodName = methodName;
+			this.parameterTypes = Preconditions.checkNotNull(parameterTypes);
+			this.args = args;
+		}
+
+		String getMethodName() {
+			return methodName;
+		}
+
+		Class<?>[] getParameterTypes() {
+			return parameterTypes;
+		}
+
+		Object[] getArgs() {
+			return args;
+		}
+
+		private void writeObject(ObjectOutputStream oos) throws IOException {
+			oos.writeUTF(methodName);
+
+			oos.writeInt(parameterTypes.length);
+
+			for (Class<?> parameterType : parameterTypes) {
+				oos.writeObject(parameterType);
+			}
+
+			if (args != null) {
+				oos.writeBoolean(true);
+
+				for (int i = 0; i < args.length; i++) {
+					try {
+						oos.writeObject(args[i]);
+					} catch (IOException e) {
+						throw new IOException("Could not serialize " + i + "th argument of method " +
+							methodName + ". This indicates that the argument type " +
+							args.getClass().getName() + " is not serializable. Arguments have to " +
+							"be serializable for remote rpc calls.", e);
+					}
+				}
+			} else {
+				oos.writeBoolean(false);
+			}
+		}
+
+		private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+			methodName = ois.readUTF();
+
+			int length = ois.readInt();
+
+			parameterTypes = new Class<?>[length];
+
+			for (int i = 0; i < length; i++) {
+				try {
+					parameterTypes[i] = (Class<?>) ois.readObject();
+				} catch (IOException e) {
+					throw new IOException("Could not deserialize " + i + "th parameter type of method " +
+						methodName + '.', e);
+				} catch (ClassNotFoundException e) {
+					throw new ClassNotFoundException("Could not deserialize " + i + "th " +
+						"parameter type of method " + methodName + ". This indicates that the parameter " +
+						"type is not part of the system class loader.", e);
+				}
+			}
+
+			boolean hasArgs = ois.readBoolean();
+
+			if (hasArgs) {
+				args = new Object[length];
+
+				for (int i = 0; i < length; i++) {
+					try {
+						args[i] = ois.readObject();
+					} catch (IOException e) {
+						throw new IOException("Could not deserialize " + i + "th argument of method " +
+							methodName + '.', e);
+					} catch (ClassNotFoundException e) {
+						throw new ClassNotFoundException("Could not deserialize " + i + "th " +
+							"argument of method " + methodName + ". This indicates that the argument " +
+							"type is not part of the system class loader.", e);
+					}
+				}
+			} else {
+				args = null;
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/RpcInvocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/RpcInvocation.java
@@ -18,81 +18,41 @@
 
 package org.apache.flink.runtime.rpc.akka.messages;
 
-import org.apache.flink.util.Preconditions;
-
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
 
 /**
- * Rpc invocation message containing the remote procedure name, its parameter types and the
- * corresponding call arguments.
+ * Interface for rpc invocation messages. The interface allows to request all necessary information
+ * to lookup a method and call it with the corresponding arguments.
  */
-public final class RpcInvocation implements Serializable {
-	private static final long serialVersionUID = -7058254033460536037L;
+public interface RpcInvocation {
 
-	private final String methodName;
-	private final Class<?>[] parameterTypes;
-	private transient Object[] args;
+	/**
+	 * Returns the method's name.
+	 *
+	 * @return Method name
+	 * @throws IOException if the rpc invocation message is a remote message and could not be deserialized
+	 * @throws ClassNotFoundException if the rpc invocation message is a remote message and contains
+	 * serialized classes which cannot be found on the receiving side
+	 */
+	String getMethodName() throws IOException, ClassNotFoundException;
 
-	public RpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] args) {
-		this.methodName = Preconditions.checkNotNull(methodName);
-		this.parameterTypes = Preconditions.checkNotNull(parameterTypes);
-		this.args = args;
-	}
+	/**
+	 * Returns the method's parameter types
+	 *
+	 * @return Method's parameter types
+	 * @throws IOException if the rpc invocation message is a remote message and could not be deserialized
+	 * @throws ClassNotFoundException if the rpc invocation message is a remote message and contains
+	 * serialized classes which cannot be found on the receiving side
+	 */
+	Class<?>[] getParameterTypes() throws IOException, ClassNotFoundException;
 
-	public String getMethodName() {
-		return methodName;
-	}
-
-	public Class<?>[] getParameterTypes() {
-		return parameterTypes;
-	}
-
-	public Object[] getArgs() {
-		return args;
-	}
-
-	private void writeObject(ObjectOutputStream oos) throws IOException {
-		oos.defaultWriteObject();
-
-		if (args != null) {
-			// write has args true
-			oos.writeBoolean(true);
-
-			for (int i = 0; i < args.length; i++) {
-				try {
-					oos.writeObject(args[i]);
-				} catch (IOException e) {
-					Class<?> argClass = args[i].getClass();
-
-					throw new IOException("Could not write " + i + "th argument of method " +
-						methodName + ". The argument type is " + argClass + ". " +
-						"Make sure that this type is serializable.", e);
-				}
-			}
-		} else {
-			// write has args false
-			oos.writeBoolean(false);
-		}
-	}
-
-	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-		ois.defaultReadObject();
-
-		boolean hasArgs = ois.readBoolean();
-
-		if (hasArgs) {
-			int numberArguments = parameterTypes.length;
-
-			args = new Object[numberArguments];
-
-			for (int i = 0; i < numberArguments; i++) {
-				args[i] = ois.readObject();
-			}
-		} else {
-			args = null;
-		}
-	}
+	/**
+	 * Returns the arguments of the remote procedure call
+	 *
+	 * @return Arguments of the remote procedure call
+	 * @throws IOException if the rpc invocation message is a remote message and could not be deserialized
+	 * @throws ClassNotFoundException if the rpc invocation message is a remote message and contains
+	 * serialized classes which cannot be found on the receiving side
+	 */
+	Object[] getArgs() throws IOException, ClassNotFoundException;
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -64,7 +64,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 		AkkaGateway akkaClient = (AkkaGateway) rm;
 
 		
-		jobMaster.registerAtResourceManager(AkkaUtils.getAkkaURL(actorSystem, akkaClient.getRpcServer()));
+		jobMaster.registerAtResourceManager(AkkaUtils.getAkkaURL(actorSystem, akkaClient.getRpcEndpoint()));
 
 		// wait for successful registration
 		FiniteDuration timeout = new FiniteDuration(200, TimeUnit.SECONDS);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import akka.actor.ActorSystem;
+import akka.util.Timeout;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcMethod;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.TestLogger;
+import org.hamcrest.core.Is;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.io.IOException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that akka rpc invocation messages are properly serialized and errors reported
+ */
+public class MessageSerializationTest extends TestLogger {
+	private static ActorSystem actorSystem1;
+	private static ActorSystem actorSystem2;
+	private static AkkaRpcService akkaRpcService1;
+	private static AkkaRpcService akkaRpcService2;
+
+	private static final FiniteDuration timeout = new FiniteDuration(10L, TimeUnit.SECONDS);
+	private static final int maxFrameSize = 32000;
+
+	@BeforeClass
+	public static void setup() {
+		Config akkaConfig = AkkaUtils.getDefaultAkkaConfig();
+		Config modifiedAkkaConfig = akkaConfig.withValue(AkkaRpcService.MAXIMUM_FRAME_SIZE_PATH, ConfigValueFactory.fromAnyRef(maxFrameSize + "b"));
+
+		actorSystem1 = AkkaUtils.createActorSystem(modifiedAkkaConfig);
+		actorSystem2 = AkkaUtils.createActorSystem(modifiedAkkaConfig);
+
+		akkaRpcService1 = new AkkaRpcService(actorSystem1, new Timeout(timeout));
+		akkaRpcService2 = new AkkaRpcService(actorSystem2, new Timeout(timeout));
+	}
+
+	@AfterClass
+	public static void teardown() {
+		akkaRpcService1.stopService();
+		akkaRpcService2.stopService();
+
+		actorSystem1.shutdown();
+		actorSystem2.shutdown();
+
+		actorSystem1.awaitTermination();
+		actorSystem2.awaitTermination();
+	}
+
+	/**
+	 * Tests that a local rpc call with a non serializable argument can be executed.
+	 */
+	@Test
+	public void testNonSerializableLocalMessageTransfer() throws InterruptedException, IOException {
+		LinkedBlockingQueue<Object> linkedBlockingQueue = new LinkedBlockingQueue<>();
+		TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService1, linkedBlockingQueue);
+
+		TestGateway testGateway = testEndpoint.getSelf();
+
+		NonSerializableObject expected = new NonSerializableObject(42);
+
+		testGateway.foobar(expected);
+
+		assertThat(linkedBlockingQueue.take(), Is.<Object>is(expected));
+	}
+
+	/**
+	 * Tests that a remote rpc call with a non-serializable argument fails with an
+	 * {@link IOException} (or an {@link java.lang.reflect.UndeclaredThrowableException} if the
+	 * the method declaration does not include the {@link IOException} as throwable).
+	 */
+	@Test(expected = IOException.class)
+	public void testNonSerializableRemoteMessageTransfer() throws Exception {
+		LinkedBlockingQueue<Object> linkedBlockingQueue = new LinkedBlockingQueue<>();
+
+		TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService1, linkedBlockingQueue);
+
+		String address = testEndpoint.getAddress();
+
+		Future<TestGateway> remoteGatewayFuture = akkaRpcService2.connect(address, TestGateway.class);
+
+		TestGateway remoteGateway = Await.result(remoteGatewayFuture, timeout);
+
+		remoteGateway.foobar(new Object());
+
+		fail("Should have failed because Object is not serializable.");
+	}
+
+	/**
+	 * Tests that a remote rpc call with a serializable argument can be successfully executed.
+	 */
+	@Test
+	public void testSerializableRemoteMessageTransfer() throws Exception {
+		LinkedBlockingQueue<Object> linkedBlockingQueue = new LinkedBlockingQueue<>();
+
+		TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService1, linkedBlockingQueue);
+
+		String address = testEndpoint.getAddress();
+
+		Future<TestGateway> remoteGatewayFuture = akkaRpcService2.connect(address, TestGateway.class);
+
+		TestGateway remoteGateway = Await.result(remoteGatewayFuture, timeout);
+
+		int expected = 42;
+
+		remoteGateway.foobar(expected);
+
+		assertThat(linkedBlockingQueue.take(), Is.<Object>is(expected));
+	}
+
+	/**
+	 * Tests that a message which exceeds the maximum frame size is detected and a corresponding
+	 * exception is thrown.
+	 */
+	@Test(expected = IOException.class)
+	public void testMaximumFramesizeRemoteMessageTransfer() throws Exception {
+		LinkedBlockingQueue<Object> linkedBlockingQueue = new LinkedBlockingQueue<>();
+
+		TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService1, linkedBlockingQueue);
+
+		String address = testEndpoint.getAddress();
+
+		Future<TestGateway> remoteGatewayFuture = akkaRpcService2.connect(address, TestGateway.class);
+
+		TestGateway remoteGateway = Await.result(remoteGatewayFuture, timeout);
+
+		int bufferSize = maxFrameSize + 1;
+		byte[] buffer = new byte[bufferSize];
+
+		remoteGateway.foobar(buffer);
+
+		fail("Should have failed due to exceeding the maximum framesize.");
+	}
+
+	private interface TestGateway extends RpcGateway {
+		void foobar(Object object) throws IOException, InterruptedException;
+	}
+
+	private static class TestEndpoint extends RpcEndpoint<TestGateway> {
+
+		private final LinkedBlockingQueue<Object> queue;
+
+		protected TestEndpoint(RpcService rpcService, LinkedBlockingQueue<Object> queue) {
+			super(rpcService);
+			this.queue = queue;
+		}
+
+		@RpcMethod
+		public void foobar(Object object) throws InterruptedException {
+			queue.put(object);
+		}
+	}
+
+	private static class NonSerializableObject {
+		private final Object object = new Object();
+		private final int value;
+
+		NonSerializableObject(int value) {
+			this.value = value;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof NonSerializableObject) {
+				NonSerializableObject nonSerializableObject = (NonSerializableObject) obj;
+
+				return value == nonSerializableObject.value;
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			return value * 41;
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces an eager serialization for remote rpc invocation messages.
That way it is possible to check whether the message is serializable and
whether it exceeds the maximum allowed akka frame size. If either of these
constraints is violated, a proper exception is thrown instead of simply
swallowing the exception as Akka does it.