### PR TITLE
[FLINK-4373] [cluster management] Introduce SlotID, AllocationID, Res…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import org.apache.flink.util.AbstractID;
+
+/**
+ * Unique identifier for the attempt to allocate a slot, normally created by JobManager when requesting a slot,
+ * constant across re-tries. This can also be used to identify responses by the ResourceManager and to identify
+ * deployment calls towards the TaskManager that was allocated from.
+ */
+public class AllocationID extends AbstractID {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates an new random allocation ID.
+	 */
+	public AllocationID() {
+		super();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
@@ -29,10 +29,4 @@ public class AllocationID extends AbstractID {
 
 	private static final long serialVersionUID = 1L;
 
-	/**
-	 * Creates an new random allocation ID.
-	 */
-	public AllocationID() {
-		super();
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import java.io.Serializable;
+
+public class ResourceProfile implements Serializable {
+
+	private static final long serialVersionUID = -784900073893060124L;
+
+	/** How many cpu cores are needed, use double so we can specify cpu like 0.1 */
+	private final double cpuCores;
+
+	/** How many memory in mb are needed */
+	private final long memoryInMB;
+
+	public ResourceProfile(double cpuCores, long memoryInMB) {
+		this.cpuCores = cpuCores;
+		this.memoryInMB = memoryInMB;
+	}
+
+	/**
+	 * Check whether required resource profile can be matched
+	 *
+	 * @param required the required resource profile
+	 * @return true if the requirement is matched, otherwise false
+	 */
+	public boolean matchRequirement(ResourceProfile required) {
+		return Double.compare(cpuCores, required.cpuCores) >= 0 && memoryInMB >= required.memoryInMB;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -20,6 +20,11 @@ package org.apache.flink.runtime.clusterframework.types;
 
 import java.io.Serializable;
 
+/**
+ * Describe the resource profile of the slot, either when requiring or offering it. The profile can be
+ * checked whether it can match another profile's requirement, and furthermore we may calculate a matching
+ * score to decide which profile we should choose when we have lots of candidate slots.
+ */
 public class ResourceProfile implements Serializable {
 
 	private static final long serialVersionUID = -784900073893060124L;
@@ -36,12 +41,28 @@ public class ResourceProfile implements Serializable {
 	}
 
 	/**
+	 * Get the cpu cores needed
+	 * @return The cpu cores, 1.0 means a full cpu thread
+	 */
+	public double getCpuCores() {
+		return cpuCores;
+	}
+
+	/**
+	 * Get the memory needed in MB
+	 * @return The memory in MB
+	 */
+	public long getMemoryInMB() {
+		return memoryInMB;
+	}
+
+	/**
 	 * Check whether required resource profile can be matched
 	 *
 	 * @param required the required resource profile
 	 * @return true if the requirement is matched, otherwise false
 	 */
-	public boolean matchRequirement(ResourceProfile required) {
-		return Double.compare(cpuCores, required.cpuCores) >= 0 && memoryInMB >= required.memoryInMB;
+	public boolean isMatching(ResourceProfile required) {
+		return Double.compare(cpuCores, required.getCpuCores()) >= 0 && memoryInMB >= required.getMemoryInMB();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+public class SlotID implements ResourceIDRetrievable, Serializable {
+
+	private static final long serialVersionUID = -6399206032549807771L;
+
+	/** The resource id which this slot located */
+	private final ResourceID resourceId;
+
+	/** The numeric id for single slot */
+	private final int slotId;
+
+	public SlotID(ResourceID resourceId, int slotId) {
+		checkNotNull(resourceId, "ResourceID must not be null");
+		this.resourceId = resourceId;
+		this.slotId = slotId;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public ResourceID getResourceID() {
+		return resourceId;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		SlotID slotID = (SlotID) o;
+
+		if (slotId != slotID.slotId) {
+			return false;
+		}
+		return resourceId.equals(slotID.resourceId);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = resourceId.hashCode();
+		result = 31 * result + slotId;
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "SlotID{" +
+			"resourceId=" + resourceId +
+			", slotId=" + slotId +
+			'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
@@ -22,6 +22,9 @@ import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
+/**
+ * Unique identifier for a slot which located in TaskManager.
+ */
 public class SlotID implements ResourceIDRetrievable, Serializable {
 
 	private static final long serialVersionUID = -6399206032549807771L;
@@ -33,8 +36,7 @@ public class SlotID implements ResourceIDRetrievable, Serializable {
 	private final int slotId;
 
 	public SlotID(ResourceID resourceId, int slotId) {
-		checkNotNull(resourceId, "ResourceID must not be null");
-		this.resourceId = resourceId;
+		this.resourceId = checkNotNull(resourceId, "ResourceID must not be null");
 		this.slotId = slotId;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ResourceProfileTest {
+
+	@Test
+	public void testMatchRequirement() throws Exception {
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100);
+		ResourceProfile rp2 = new ResourceProfile(1.0, 200);
+		ResourceProfile rp3 = new ResourceProfile(2.0, 100);
+		ResourceProfile rp4 = new ResourceProfile(2.0, 200);
+
+		assertFalse(rp1.matchRequirement(rp2));
+		assertTrue(rp2.matchRequirement(rp1));
+
+		assertFalse(rp1.matchRequirement(rp3));
+		assertTrue(rp3.matchRequirement(rp1));
+
+		assertFalse(rp2.matchRequirement(rp3));
+		assertFalse(rp3.matchRequirement(rp2));
+
+		assertTrue(rp4.matchRequirement(rp1));
+		assertTrue(rp4.matchRequirement(rp2));
+		assertTrue(rp4.matchRequirement(rp3));
+		assertTrue(rp4.matchRequirement(rp4));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -32,18 +32,18 @@ public class ResourceProfileTest {
 		ResourceProfile rp3 = new ResourceProfile(2.0, 100);
 		ResourceProfile rp4 = new ResourceProfile(2.0, 200);
 
-		assertFalse(rp1.matchRequirement(rp2));
-		assertTrue(rp2.matchRequirement(rp1));
+		assertFalse(rp1.isMatching(rp2));
+		assertTrue(rp2.isMatching(rp1));
 
-		assertFalse(rp1.matchRequirement(rp3));
-		assertTrue(rp3.matchRequirement(rp1));
+		assertFalse(rp1.isMatching(rp3));
+		assertTrue(rp3.isMatching(rp1));
 
-		assertFalse(rp2.matchRequirement(rp3));
-		assertFalse(rp3.matchRequirement(rp2));
+		assertFalse(rp2.isMatching(rp3));
+		assertFalse(rp3.isMatching(rp2));
 
-		assertTrue(rp4.matchRequirement(rp1));
-		assertTrue(rp4.matchRequirement(rp2));
-		assertTrue(rp4.matchRequirement(rp3));
-		assertTrue(rp4.matchRequirement(rp4));
+		assertTrue(rp4.isMatching(rp1));
+		assertTrue(rp4.isMatching(rp2));
+		assertTrue(rp4.isMatching(rp3));
+		assertTrue(rp4.isMatching(rp4));
 	}
 }


### PR DESCRIPTION
For the new version of cluster management, we need some more basic data structures:

* SlotID: Identifier of one single slot located in a task executor

* AllocationID: Slot allocation identifier, created by the JobManager when requesting a slot, constant across re-tries. Used to identify responses by the ResourceManager and to identify deployment calls towards the TaskManager that was allocated from.

* ResourceProfile: The resource profile of the desired slot (currently only cpu cores and memory are supported