### PR TITLE
[FLINK-4409] [build] Exclude JSR 305 from Hadoop dependencies

### DIFF
--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -38,6 +38,15 @@ under the License.
 		<module>${shading-artifact.name}</module>
 	</modules>
 
+	<dependencies>
+		<!-- Flink already includes JSR 305. Setting this to provided excludes it from the dependencies-->
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
 	<profiles>
 		<profile>
 			<id>include-yarn-tests</id>


### PR DESCRIPTION
The JSR 305 classes (`javax.annotation`) are already in Flink's core dependencies.

I verified that after this patch, the classes are no longer in the Hadoop jar files.

