### PR TITLE
[FLINK-4402]: Wrong metrics parameter names in documentation

### DIFF
--- a/docs/apis/metrics.md
+++ b/docs/apis/metrics.md
@@ -196,10 +196,10 @@ Each of these keys expect a format string that may contain constants (e.g. "task
 - `metrics.scope.tm.job`
   - Default: &lt;host&gt;.taskmanager.&lt;tm_id&gt;.&lt;job_name&gt;
   - Applied to all metrics that were scoped to a task manager and job.
-- `metrics.scope.tm.task`
+- `metrics.scope.task`
   - Default: &lt;host&gt;.taskmanager.&lt;tm_id&gt;.&lt;job_name&gt;.&lt;task_name&gt;.&lt;subtask_index&gt;
    - Applied to all metrics that were scoped to a task.
-- `metrics.scope.tm.operator`
+- `metrics.scope.operator`
   - Default: &lt;host&gt;.taskmanager.&lt;tm_id&gt;.&lt;job_name&gt;.&lt;operator_name&gt;.&lt;subtask_index&gt;
   - Applied to all metrics that were scoped to an operator.
 
@@ -209,7 +209,7 @@ The default scope for operator metrics will result in an identifier akin to `loc
 
 If you also want to include the task name but omit the task manager information you can specify the following format:
 
-`metrics.scope.tm.operator: <host>.<job_name>.<task_name>.<operator_name>.<subtask_index>`
+`metrics.scope.operator: <host>.<job_name>.<task_name>.<operator_name>.<subtask_index>`
 
 This could create the identifier `localhost.MyJob.MySource_->_MyOperator.MyOperator.0.MyMetric`.
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - JIRA- https://issues.apache.org/jira/browse/FLINK-4402
   - Title: Wrong metrics parameter names in documentation

- [ ] Documentation
  - Changed the task and operator metrics in https://ci.apache.org/projects/flink/flink-docs-master/apis/metrics.html to align with ConfigConstants.java

- [ ] Tests & Build
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

