### PR TITLE
[FLINK-4418] [client] Improve resilience when InetAddress.getLocalHos…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
@@ -17,17 +17,30 @@
  */
 package org.apache.flink.runtime.net;
 
-import static org.junit.Assert.*;
-
-import org.junit.Test;
-
+import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the network utilities.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ConnectionUtils.class)
 public class ConnectionUtilsTest {
 
 	@Test
@@ -53,6 +66,38 @@ public class ConnectionUtilsTest {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testFindConnectingAddressWhenGetLocalHostThrows() throws Exception {
+		PowerMockito.mockStatic(InetAddress.class);
+		Mockito.when(InetAddress.getLocalHost()).thenThrow(new UnknownHostException()).thenCallRealMethod();
+
+		final InetAddress loopbackAddress = Inet4Address.getByName("127.0.0.1");
+		Thread socketServerThread;
+		try (ServerSocket socket = new ServerSocket(0, 1, loopbackAddress)) {
+			// Make sure that the thread will eventually die even if something else goes wrong
+			socket.setSoTimeout(10_000);
+			socketServerThread = new Thread(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						socket.accept();
+					} catch (IOException e) {
+						// ignore
+					}
+				}
+			});
+			socketServerThread.start();
+
+			final InetSocketAddress socketAddress = new InetSocketAddress(loopbackAddress, socket.getLocalPort());
+			final InetAddress address = ConnectionUtils.findConnectingAddress(
+				socketAddress, 2000, 400);
+
+			PowerMockito.verifyStatic();
+			// Make sure we got an address via alternative means
+			assertNotNull(address);
 		}
 	}
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

…t() throws UnknownHostException

- If InetAddress.getLocalHost() throws UnknownHostException when
attempting to connect with LOCAL_HOST strategy, the code will move on
 to try the other strategies instead of immediately failing.
- Also made minor code style improvements for trying the different
strategies.