### PR TITLE
[FLINK-4420] [table] Introduce star(*) to select all of the columns in the table

### DIFF
--- a/docs/apis/table.md
+++ b/docs/apis/table.md
@@ -504,6 +504,10 @@ This section gives a brief overview of the available operators. You can find mor
 Table in = tableEnv.fromDataSet(ds, "a, b, c");
 Table result = in.select("a, c as d");
 {% endhighlight %}
+        <p>You can use star(<code>*</code>) act as a wild card, selecting all of the columns in the table.</p>
+{% highlight java %}
+Table result = in.select("*");
+{% endhighlight %}
       </td>
     </tr>
 
@@ -725,6 +729,11 @@ Table result = in.orderBy("a.asc").limit(3, 5); // returns 5 records beginning w
 {% highlight scala %}
 val in = ds.toTable(tableEnv, 'a, 'b, 'c);
 val result = in.select('a, 'c as 'd);
+{% endhighlight %}
+        <p>You can use star(<code>*</code>) act as a wild card, selecting all of the columns in the table.</p>
+{% highlight scala %}
+val in = ds.toTable(tableEnv, 'a, 'b, 'c);
+val result = in.select('*);
 {% endhighlight %}
       </td>
     </tr>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableEnvironment.scala
@@ -336,6 +336,11 @@ abstract class TableEnvironment(val config: TableConfig) {
     }
 
     val (fieldIndexes, fieldNames) = indexedNames.unzip
+
+    if (fieldNames.contains("*")) {
+      throw new ValidationException("field name can not be '*'.")
+    }
+
     (fieldNames.toArray, fieldIndexes.toArray)
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
@@ -67,6 +67,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   lazy val MINUTE: Keyword = Keyword("minute")
   lazy val SECOND: Keyword = Keyword("second")
   lazy val MILLI: Keyword = Keyword("milli")
+  lazy val STAR: Keyword = Keyword("*")
 
   def functionIdent: ExpressionParser.Parser[String] =
     not(AS) ~ not(COUNT) ~ not(AVG) ~ not(MIN) ~ not(MAX) ~
@@ -137,7 +138,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
       stringLiteralFlink | singleQuoteStringLiteral |
       boolLiteral | nullLiteral
 
-  lazy val fieldReference: PackratParser[NamedExpression] = ident ^^ {
+  lazy val fieldReference: PackratParser[NamedExpression] = (STAR | ident) ^^ {
     sym => UnresolvedFieldReference(sym)
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/fieldExpression.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/fieldExpression.scala
@@ -22,7 +22,8 @@ import org.apache.calcite.tools.RelBuilder
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.table.UnresolvedException
-import org.apache.flink.api.table.validate.{ExprValidationResult, ValidationFailure}
+import org.apache.flink.api.table.validate.{ValidationSuccess, ExprValidationResult,
+ValidationFailure}
 
 trait NamedExpression extends Expression {
   private[flink] def name: String
@@ -89,6 +90,14 @@ case class Alias(child: Expression, name: String)
       ResolvedFieldReference(name, child.resultType)
     } else {
       UnresolvedFieldReference(name)
+    }
+  }
+
+  override private[flink] def validateInput(): ExprValidationResult = {
+    if (name == "*") {
+      ValidationFailure("Alias can not accept '*' as name")
+    } else {
+      ValidationSuccess
     }
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/RexNodeTranslator.scala
@@ -20,6 +20,9 @@ package org.apache.flink.api.table.plan
 
 import org.apache.flink.api.table.TableEnvironment
 import org.apache.flink.api.table.expressions._
+import org.apache.flink.api.table.plan.logical.LogicalNode
+
+import scala.collection.mutable.ListBuffer
 
 object RexNodeTranslator {
 
@@ -67,5 +70,19 @@ object RexNodeTranslator {
         }
         (e.makeCopy(newArgs.map(_._1).toArray), newArgs.flatMap(_._2).toList)
     }
+  }
+
+  /**
+    * Parse all input expressions to [[UnresolvedAlias]].
+    * And expand star to parent's full project list.
+    */
+  def expandProjectList(exprs: Seq[Expression], parent: LogicalNode): Seq[NamedExpression] = {
+    val projectList = new ListBuffer[NamedExpression]
+    exprs.foreach{
+      case n: UnresolvedFieldReference if n.name == "*" =>
+        projectList ++= parent.output.map(UnresolvedAlias(_))
+      case e: Expression => projectList += UnresolvedAlias(e)
+    }
+    projectList
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/operators.scala
@@ -62,14 +62,14 @@ case class Project(projectList: Seq[NamedExpression], child: LogicalNode) extend
         case n: Alias =>
           // explicit name
           if (names.contains(n.name)) {
-            throw ValidationException(s"Duplicate field name $n.name.")
+            throw ValidationException(s"Duplicate field name ${n.name}.")
           } else {
             names.add(n.name)
           }
         case r: ResolvedFieldReference =>
           // simple field forwarding
           if (names.contains(r.name)) {
-            throw ValidationException(s"Duplicate field name $r.name.")
+            throw ValidationException(s"Duplicate field name ${r.name}.")
           } else {
             names.add(r.name)
           }
@@ -109,6 +109,8 @@ case class AliasNode(aliasList: Seq[Expression], child: LogicalNode) extends Una
       failValidation("Aliasing more fields than we actually have")
     } else if (!aliasList.forall(_.isInstanceOf[UnresolvedFieldReference])) {
       failValidation("Alias only accept name expressions as arguments")
+    } else if (!aliasList.forall(_.asInstanceOf[UnresolvedFieldReference].name != "*")) {
+      failValidation("Alias can not accept '*' as name")
     } else {
       val names = aliasList.map(_.asInstanceOf[UnresolvedFieldReference].name)
       val input = child.output

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/table/SelectITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/table/SelectITCase.java
@@ -127,4 +127,27 @@ public class SelectITCase extends TableProgramsTestBase {
 			// Must fail. Field foo does not exist
 			.select("a + 1 as foo, b + 2 as foo");
 	}
+
+	@Test
+	public void testSelectStar() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		Table in = tableEnv.fromDataSet(ds, "a,b,c");
+
+		Table result = in
+			.select("*");
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "1,1,Hi\n" + "2,2,Hello\n" + "3,2,Hello world\n" +
+		                  "4,3,Hello world, how are you?\n" + "5,3,I am fine.\n" + "6,3,Luke Skywalker\n" +
+		                  "7,4,Comment#1\n" + "8,4,Comment#2\n" + "9,4,Comment#3\n" + "10,4,Comment#4\n" +
+		                  "11,5,Comment#5\n" + "12,5,Comment#6\n" + "13,5,Comment#7\n" +
+		                  "14,5,Comment#8\n" + "15,5,Comment#9\n" + "16,6,Comment#10\n" +
+		                  "17,6,Comment#11\n" + "18,6,Comment#12\n" + "19,6,Comment#13\n" +
+		                  "20,6,Comment#14\n" + "21,6,Comment#15\n";
+		compareResultAsText(results, expected);
+	}
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

When we have many columns in a table, it's easy to select all the columns if we support select *.

In Scala: 

```
val result = table.select('*);
```

In Java:

```java
Table result = table.select("*");
```

In addition, I add some constrains for field alias. Forbid `*` as a field name.

