### PR TITLE
[trivial] Fix typo in dosctring

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -208,7 +208,7 @@ public abstract class StreamExecutionEnvironment {
 	}
 
 	/**
-	 * Sets the maximum time frequency (milliseconds) for the flushing of the
+	 * Gets the maximum time frequency (milliseconds) for the flushing of the
 	 * output buffers. For clarification on the extremal values see
 	 * {@link #setBufferTimeout(long)}.
 	 *


### PR DESCRIPTION
There is a small typo in the getBufferTimeout docstring, this fixes it.

Talked with @tillrohrmann about whether it's worth it to open a PR for something like this, I guess it might be easier for a committer to gather a few of these and then commit all together.

Cheers,
Theo