### PR TITLE
[FLINK-4436] Unclosed DataOutputBuffer in Utils#setTokensFor()

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -155,16 +155,16 @@ public final class Utils {
 			LOG.info("Adding user token " + id + " with " + token);
 			credentials.addToken(id, token);
 		}
-		DataOutputBuffer dob = new DataOutputBuffer();
-		credentials.writeTokenStorageToStream(dob);
+		try (DataOutputBuffer dob = new DataOutputBuffer()) {
+			credentials.writeTokenStorageToStream(dob);
 
-		if(LOG.isDebugEnabled()) {
-			LOG.debug("Wrote tokens. Credentials buffer length: " + dob.getLength());
+			if(LOG.isDebugEnabled()) {
+				LOG.debug("Wrote tokens. Credentials buffer length: " + dob.getLength());
+			}
+
+			ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
+			amContainer.setTokens(securityTokens);
 		}
-
-		ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
-		amContainer.setTokens(securityTokens);
-		dob.close();
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -164,6 +164,7 @@ public final class Utils {
 
 		ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
 		amContainer.setTokens(securityTokens);
+		dob.close();
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -599,10 +599,9 @@ public class YarnApplicationMasterRunner {
 
 		ctx.setEnvironment(containerEnv);
 
-		try {
+		try (DataOutputBuffer dob = new DataOutputBuffer()) {
 			UserGroupInformation user = UserGroupInformation.getCurrentUser();
 			Credentials credentials = user.getCredentials();
-			DataOutputBuffer dob = new DataOutputBuffer();
 			credentials.writeTokenStorageToStream(dob);
 			ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
 			ctx.setTokens(securityTokens);


### PR DESCRIPTION
`DataOutputBuffer dob = new DataOutputBuffer(); `
   ` credentials.writeTokenStorageToStream(dob);` 
dob should be closed upon returning from the method.
Also in YarnApplicationMasterRunner#createTaskManagerContext().