### PR TITLE
[FLINK-4278]: Unclosed FSDataOutputStream in multiple files in the project

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
@@ -33,5 +33,4 @@ public abstract class FSDataOutputStream extends OutputStream {
 
 	public abstract void sync() throws IOException;
 
-	public abstract void close() throws IOException;
 }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
@@ -32,4 +32,6 @@ public abstract class FSDataOutputStream extends OutputStream {
 	public abstract void flush() throws IOException;
 
 	public abstract void sync() throws IOException;
+
+	public abstract void close() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -484,6 +485,7 @@ public class FsStateBackend extends AbstractStateBackend {
 				flush();
 				// write the bytes directly
 				outStream.write(b, off, len);
+				outStream.close();
 			}
 		}
 
@@ -500,6 +502,7 @@ public class FsStateBackend extends AbstractStateBackend {
 						try {
 							statePath = new Path(basePath, UUID.randomUUID().toString());
 							outStream = fs.create(statePath, false);
+							outStream.close();
 							break;
 						}
 						catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
-import org.apache.flink.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
@@ -24,7 +24,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.filesystem.FileSerializableStateHandle;
 import org.apache.flink.util.FileUtils;
-import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.runtime.zookeeper.StateStorageHelper;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/filesystem/FileSystemStateStorageHelper.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StateHandle;
 import org.apache.flink.runtime.state.filesystem.FileSerializableStateHandle;
 import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.runtime.zookeeper.StateStorageHelper;
 
@@ -64,6 +65,7 @@ public class FileSystemStateStorageHelper<T extends Serializable> implements Sta
 			FSDataOutputStream outStream;
 			try {
 				outStream = fs.create(filePath, false);
+				outStream.close();
 			}
 			catch (Exception e) {
 				latestException = e;
@@ -72,6 +74,7 @@ public class FileSystemStateStorageHelper<T extends Serializable> implements Sta
 
 			try(ObjectOutputStream os = new ObjectOutputStream(outStream)) {
 				os.writeObject(state);
+				os.close();
 			}
 
 			return new FileSerializableStateHandle<>(filePath);

--- a/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
+++ b/flink-streaming-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
@@ -77,6 +77,7 @@ public class StringWriter<T> extends StreamWriterBase<T> {
 		FSDataOutputStream outputStream = getStream();
 		outputStream.write(element.toString().getBytes(charset));
 		outputStream.write('\n');
+		outputStream.close();
 	}
 
 	@Override


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - JIRA: https://issues.apache.org/jira/browse/FLINK-4278
  - Added the close statements for the FSStateBackend, StringWriter and FileSystemStateStorageHelper for the unclosed FileDataOutputStream objects.
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - No documentation needed here.

- [ ] Tests & Build
  - `mvn clean verify` has been executed successfully locally or a Travis build has failed but the failure does not seem related. Can do a re-run and verify on the PR itself.
