### PR TITLE
[FLINK-4341] Let idle consumer subtasks emit max value watermarks and fail on resharding

### DIFF
--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -107,6 +107,12 @@ to `TRIM_HORIZON`, which lets the consumer start reading the Kinesis stream from
 
 Other optional configuration keys for the consumer can be found in `ConsumerConfigConstants`.
 
+**NOTE:** Currently, resharding can not be handled transparently (i.e., without failing and restarting jobs) if there are idle consumer
+subtasks, which occur when the total number of shards is lower than the configured consumer parallelism. The new shards
+due to resharding will still be picked up by the Kinesis consumer after the job automatically restores. This is a temporary
+limitation that will be resolved in future versions. Please see [FLINK-4341](https://issues.apache.org/jira/browse/FLINK-4341)
+for more detail.
+
 #### Fault Tolerance for Exactly-Once User-Defined State Update Semantics
 
 With Flink's checkpointing enabled, the Flink Kinesis Consumer will consume records from shards in Kinesis streams and

--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -108,10 +108,10 @@ to `TRIM_HORIZON`, which lets the consumer start reading the Kinesis stream from
 Other optional configuration keys for the consumer can be found in `ConsumerConfigConstants`.
 
 **NOTE:** Currently, resharding can not be handled transparently (i.e., without failing and restarting jobs) if there are idle consumer
-subtasks, which occur when the total number of shards is lower than the configured consumer parallelism. The new shards
-due to resharding will still be picked up by the Kinesis consumer after the job automatically restores. This is a temporary
-limitation that will be resolved in future versions. Please see [FLINK-4341](https://issues.apache.org/jira/browse/FLINK-4341)
-for more detail.
+subtasks, which occur when the total number of shards is lower than the configured consumer parallelism. The job must be
+configured to enable checkpointing, so that the new shards due to resharding can be correctly picked up and consumed by the
+Kinesis consumer after the job is restored. This is a temporary limitation that will be resolved in future versions.
+Please see [FLINK-4341](https://issues.apache.org/jira/browse/FLINK-4341) for more detail.
 
 #### Fault Tolerance for Exactly-Once User-Defined State Update Semantics
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -182,7 +182,6 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T>
 
 			// initialize sequence numbers with restored state
 			lastStateSnapshot = sequenceNumsToRestore;
-			sequenceNumsToRestore = null;
 		} else {
 			// start fresh with empty sequence numbers if there are no snapshots to restore from.
 			lastStateSnapshot = new HashMap<>();
@@ -198,7 +197,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T>
 		fetcher = new KinesisDataFetcher<>(
 			streams, sourceContext, getRuntimeContext(), configProps, deserializer);
 
-		boolean isRestoringFromFailure = !lastStateSnapshot.isEmpty();
+		boolean isRestoringFromFailure = (sequenceNumsToRestore != null);
 		fetcher.setIsRestoringFromFailure(isRestoringFromFailure);
 
 		// if we are restoring from a checkpoint, we iterate over the restored
@@ -210,7 +209,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T>
 
 				if (LOG.isInfoEnabled()) {
 					LOG.info("Subtask {} is seeding the fetcher with restored shard {}," +
-						"starting state set to the restored sequence number {}",
+							" starting state set to the restored sequence number {}",
 						getRuntimeContext().getIndexOfThisSubtask(), restored.getKey().toString(), restored.getValue());
 				}
 				fetcher.registerNewSubscribedShardState(
@@ -285,13 +284,13 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T>
 		}
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Snapshotting state. ...");
+			LOG.debug("Snapshotting state ...");
 		}
 
 		lastStateSnapshot = fetcher.snapshotState();
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Snapshotting state. Last processed sequence numbers: {}, checkpoint id: {}, timestamp: {}",
+			LOG.debug("Snapshotted state, last processed sequence numbers: {}, checkpoint id: {}, timestamp: {}",
 				lastStateSnapshot.toString(), checkpointId, checkpointTimestamp);
 		}
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -210,7 +210,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T>
 
 				if (LOG.isInfoEnabled()) {
 					LOG.info("Subtask {} is seeding the fetcher with restored shard {}," +
-						"starting state set to the restored sequence number {}" +
+						"starting state set to the restored sequence number {}",
 						getRuntimeContext().getIndexOfThisSubtask(), restored.getKey().toString(), restored.getValue());
 				}
 				fetcher.registerNewSubscribedShardState(

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -36,6 +36,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Properties;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -87,6 +88,9 @@ public class ShardConsumer<T> implements Runnable {
 		this.subscribedShardStateIndex = checkNotNull(subscribedShardStateIndex);
 		this.subscribedShard = checkNotNull(subscribedShard);
 		this.lastSequenceNum = checkNotNull(lastSequenceNum);
+		checkArgument(
+			!lastSequenceNum.equals(SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get()),
+			"Should not start a ShardConsumer if the shard has already been completely read.");
 
 		this.deserializer = fetcherRef.getClonedDeserializationSchema();
 

--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -201,8 +201,8 @@ public class KinesisProxy implements KinesisProxyInterface {
 		}
 
 		if (getRecordsResult == null) {
-			throw new RuntimeException("Rate Exceeded for getRecords operation - all " + getRecordsMaxAttempts + "retry" +
-				"attempts returned ProvisionedThroughputExceededException.");
+			throw new RuntimeException("Rate Exceeded for getRecords operation - all " + getRecordsMaxAttempts +
+				" retry attempts returned ProvisionedThroughputExceededException.");
 		}
 
 		return getRecordsResult;
@@ -245,8 +245,8 @@ public class KinesisProxy implements KinesisProxyInterface {
 		}
 
 		if (getShardIteratorResult == null) {
-			throw new RuntimeException("Rate Exceeded for getShardIterator operation - all " + getShardIteratorMaxAttempts + "retry" +
-				"attempts returned ProvisionedThroughputExceededException.");
+			throw new RuntimeException("Rate Exceeded for getShardIterator operation - all " + getShardIteratorMaxAttempts +
+				" retry attempts returned ProvisionedThroughputExceededException.");
 		}
 		return getShardIteratorResult.getShardIterator();
 	}


### PR DESCRIPTION
This is a short-term fix, until the min-watermark service for the JobManager described in the JIRA discussion is available.

The way this fix works is that we let idle subtasks that initially don't get assigned shards emit a `Long.MAX_VALUE` watermark. Also, to avoid messing up the watermarks on resharding, we _only deliberately fail hard_ if the new shards are assigned to _idle subtasks._ So, if all subtasks are not initially idle on startup (i.e., when total number of shards >= consumer parallelism), the Kinesis consumer can still transparently handle resharding like before without failing.

I've tested exactly-once with our manual tests (with and w/o resharding) and the fix works nicely, still retaining exactly-once guarantee despite non-transparency.

However, I can't reproduce the unbounded state & akka frame size exceeding with window operators w/o this change (perhaps the window I'm testing with is too simple?), so I'm not sure if that issue is also correctly fixed with this change; I'll need a bit of help to let us clarify this.

This change should also go into the 1.1.2 bugfix release branch.

R: @rmetzger and @aljoscha for review. Thanks in advance!