### PR TITLE
[FLINK-4245] JMXReporter exposes all defined variables

### DIFF
--- a/flink-metrics/flink-metrics-jmx/pom.xml
+++ b/flink-metrics/flink-metrics-jmx/pom.xml
@@ -49,19 +49,19 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-metrics-core</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_2.10</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
@@ -432,7 +432,7 @@ public class JMXReporter implements MetricReporter {
 		long getCount();
 	}
 
-	private class JmxMeter extends AbstractBean implements JmxMeterMBean {
+	private static class JmxMeter extends AbstractBean implements JmxMeterMBean {
 
 		private final Meter meter;
 

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.jmx;
 
+import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
@@ -25,8 +26,9 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
-
 import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 import org.apache.flink.util.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +50,7 @@ import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.rmi.server.UnicastRemoteObject;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -59,12 +62,18 @@ import java.util.Map;
  */
 public class JMXReporter implements MetricReporter {
 
-	private static final String PREFIX = "org.apache.flink.metrics:";
-	private static final String KEY_PREFIX = "key";
+	static final String JMX_DOMAIN_PREFIX = "org.apache.flink.";
 
 	public static final String ARG_PORT = "port";
 
 	private static final Logger LOG = LoggerFactory.getLogger(JMXReporter.class);
+
+	private static final CharacterFilter CHARACTER_FILTER = new CharacterFilter() {
+		@Override
+		public String filterCharacters(String input) {
+			return replaceInvalidChars(input);
+		}
+	};
 
 	// ------------------------------------------------------------------------
 
@@ -144,14 +153,19 @@ public class JMXReporter implements MetricReporter {
 
 	@Override
 	public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
-		final String name = generateJmxName(metricName, group.getScopeComponents());
+		final String domain = generateJmxDomain(metricName, group);
+		final Hashtable<String, String> table = generateJmxTable(group.getAllVariables());
 
 		AbstractBean jmxMetric;
 		ObjectName jmxName;
 		try {
-			jmxName = new ObjectName(name);
+			jmxName = new ObjectName(domain, table);
 		} catch (MalformedObjectNameException e) {
-			LOG.error("Metric name did not conform to JMX ObjectName rules: " + name, e);
+			/**
+			 * There is an implementation error on our side if this occurs. Either the domain was modified and no longer
+			 * conforms to the JMX domain rules or the table wasn't properly generated.
+			 */
+			LOG.debug("Implementation error. The domain or table does not conform to JMX rules." , e);
 			return;
 		}
 
@@ -176,12 +190,11 @@ public class JMXReporter implements MetricReporter {
 			}
 		} catch (NotCompliantMBeanException e) {
 			// implementation error on our side
-			LOG.error("Metric did not comply with JMX MBean naming rules.", e);
+			LOG.debug("Metric did not comply with JMX MBean rules.", e);
 		} catch (InstanceAlreadyExistsException e) {
-			LOG.debug("A metric with the name " + jmxName + " was already registered.", e);
-			LOG.error("A metric with the name " + jmxName + " was already registered.");
+			LOG.warn("A metric with the name " + jmxName + " was already registered.", e);
 		} catch (Throwable t) {
-			LOG.error("Failed to register metric", t);
+			LOG.warn("Failed to register metric", t);
 		}
 	}
 
@@ -209,27 +222,18 @@ public class JMXReporter implements MetricReporter {
 	//  Utilities 
 	// ------------------------------------------------------------------------
 
-	static String generateJmxName(String metricName, String[] scopeComponents) {
-		final StringBuilder nameBuilder = new StringBuilder(128);
-		nameBuilder.append(PREFIX);
-
-		for (int x = 0; x < scopeComponents.length; x++) {
-			// write keyX=
-			nameBuilder.append(KEY_PREFIX);
-			nameBuilder.append(x);
-			nameBuilder.append("=");
-
-			// write scope component
-			nameBuilder.append(replaceInvalidChars(scopeComponents[x]));
-			nameBuilder.append(",");
+	static Hashtable<String, String> generateJmxTable(Map<String, String> variables) {
+		Hashtable<String, String> ht = new Hashtable<>(variables.size());
+		for (Map.Entry<String, String> variable : variables.entrySet()) {
+			ht.put(replaceInvalidChars(variable.getKey()), replaceInvalidChars(variable.getValue()));
 		}
-
-		// write the name
-		nameBuilder.append("name=").append(replaceInvalidChars(metricName));
-
-		return nameBuilder.toString();
+		return ht;
 	}
-	
+
+	static String generateJmxDomain(String metricName, MetricGroup group) {
+		return JMX_DOMAIN_PREFIX + ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(CHARACTER_FILTER, '.') + '.' + metricName;
+	}
+
 	/**
 	 * Lightweight method to replace unsupported characters.
 	 * If the string does not contain any unsupported characters, this method creates no
@@ -251,6 +255,8 @@ public class JMXReporter implements MetricReporter {
 		for (int i = 0; i < strLen; i++) {
 			final char c = str.charAt(i);
 			switch (c) {
+				case '>':
+				case '<':
 				case '"':
 					// remove character by not moving cursor
 					if (chars == null) {

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
+import org.junit.Assert;
 import org.junit.Test;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -38,6 +39,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -83,8 +85,9 @@ public class JMXJobManagerMetricTest {
 			Await.ready(jobRunning, deadline.timeLeft());
 
 			MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-			ObjectName objectName1 = new ObjectName("org.apache.flink.metrics:key0=jobmanager,key1=TestingJob,name=lastCheckpointSize");
-			assertEquals(-1L, mBeanServer.getAttribute(objectName1, "Value"));
+			Set<ObjectName> nameSet = mBeanServer.queryNames(new ObjectName("org.apache.flink.jobmanager.job.lastCheckpointSize:job_name=TestingJob,*"), null);
+			Assert.assertEquals(1, nameSet.size());
+			assertEquals(-1L, mBeanServer.getAttribute(nameSet.iterator().next(), "Value"));
 
 			Future<Object> jobFinished = flink.getLeaderGateway(deadline.timeLeft())
 				.ask(new TestingJobManagerMessages.NotifyWhenJobRemoved(jobGraph.getJobID()), deadline.timeLeft());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -89,6 +89,10 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * For example: "host-7.taskmanager-2.window_word_count.my-mapper" */
 	private String scopeString;
 
+	/** The logical metrics scope represented by this group, as a concatenated string, lazily computed.
+	 * For example: "taskmanager.job.task" */
+	private String logicalScopeString;
+
 	/** The metrics query service scope represented by this group, lazily computed. */
 	protected QueryScopeInfo queryServiceScopeInfo;
 
@@ -117,6 +121,43 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 		}
 		return variables;
 	}
+
+	/**
+	 * Returns the logical scope of this group, for example
+	 * {@code "taskmanager.job.task"}
+	 *
+	 * @param filter character filter which is applied to the scope components
+	 * @return logical scope
+	 */
+	public String getLogicalScope(CharacterFilter filter) {
+		return getLogicalScope(filter, registry.getDelimiter());
+	}
+
+	/**
+	 * Returns the logical scope of this group, for example
+	 * {@code "taskmanager.job.task"}
+	 *
+	 * @param filter character filter which is applied to the scope components
+	 * @return logical scope
+	 */
+	public String getLogicalScope(CharacterFilter filter, char delimiter) {
+		if (logicalScopeString == null) {
+			if (parent == null) {
+				logicalScopeString = getGroupName(filter);
+			} else {
+				logicalScopeString = parent.getLogicalScope(filter, delimiter) + delimiter + getGroupName(filter);
+			}
+		}
+		return logicalScopeString;
+	}
+
+	/**
+	 * Returns the name for this group, meaning what kind of entity it represents, for example "taskmanager".
+	 * 
+	 * @param filter character filter which is applied to the name
+	 * @return logical name for this group
+	 */
+	protected abstract String getGroupName(CharacterFilter filter);
 
 	/**
 	 * Gets the scope as an array of the scope components, for example

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -46,4 +46,12 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
 	public String getMetricIdentifier(String metricName, CharacterFilter filter) {
 		return parentMetricGroup.getMetricIdentifier(metricName, filter, this.reporterIndex);
 	}
+
+	public String getLogicalScope(CharacterFilter filter) {
+		return parentMetricGroup.getLogicalScope(filter);
+	}
+
+	public String getLogicalScope(CharacterFilter filter, char delimiter) {
+		return parentMetricGroup.getLogicalScope(filter, delimiter);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericMetricGroup.java
@@ -56,4 +56,9 @@ public class GenericMetricGroup extends AbstractMetricGroup<AbstractMetricGroup<
 		}
 		return new String[] { name };
 	}
+
+	@Override
+	protected String getGroupName(CharacterFilter filter) {
+		return filter.filterCharacters(name);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -107,5 +107,10 @@ public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetric
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {
 		return jobs.values();
 	}
+
+	@Override
+	protected String getGroupName(CharacterFilter filter) {
+		return "jobmanager";
+	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobMetricGroup.java
@@ -81,4 +81,9 @@ public abstract class JobMetricGroup<C extends ComponentMetricGroup<C>> extends 
 		variables.put(ScopeFormat.SCOPE_JOB_ID, jobId.toString());
 		variables.put(ScopeFormat.SCOPE_JOB_NAME, jobName);
 	}
+
+	@Override
+	protected String getGroupName(CharacterFilter filter) {
+		return "job";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
@@ -83,4 +83,9 @@ public class OperatorMetricGroup extends ComponentMetricGroup<TaskMetricGroup> {
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {
 		return Collections.emptyList();
 	}
+
+	@Override
+	protected String getGroupName(CharacterFilter filter) {
+		return "operator";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -135,5 +135,10 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetr
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {
 		return jobs.values();
 	}
+
+	@Override
+	protected String getGroupName(CharacterFilter filter) {
+		return "taskmanager";
+	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -169,4 +169,9 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {
 		return operators.values();
 	}
+
+	@Override
+	protected String getGroupName(CharacterFilter filter) {
+		return "task";
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -39,6 +39,11 @@ public class AbstractMetricGroupTest {
 			protected QueryScopeInfo createQueryServiceMetricInfo(CharacterFilter filter) {
 				return null;
 			}
+
+			@Override
+			protected String getGroupName(CharacterFilter filter) {
+				return "";
+			}
 		};
 		assertTrue(group.getAllVariables().isEmpty());
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -177,6 +177,11 @@ public class MetricGroupTest extends TestLogger {
 		}
 
 		@Override
+		protected String getGroupName(CharacterFilter filter) {
+			return "";
+		}
+
+		@Override
 		protected void addMetric(String name, Metric metric) {}
 
 		@Override

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -1504,13 +1504,13 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 			// connect to JMX
 			MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
 			// wait until we've found all 5 offset metrics
-			Set<ObjectName> offsetMetrics = mBeanServer.queryNames(new ObjectName("*:key7=current-offsets,*"), null);
+			Set<ObjectName> offsetMetrics = mBeanServer.queryNames(new ObjectName("*current-offsets*:*"), null);
 			while (offsetMetrics.size() < 5) { // test will time out if metrics are not properly working
 				if (error.f0 != null) {
 					// fail test early
 					throw error.f0;
 				}
-				offsetMetrics = mBeanServer.queryNames(new ObjectName("*:key7=current-offsets,*"), null);
+				offsetMetrics = mBeanServer.queryNames(new ObjectName("*current-offsets*:*"), null);
 				Thread.sleep(50);
 			}
 			Assert.assertEquals(5, offsetMetrics.size());
@@ -1534,7 +1534,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 			}
 
 			// check if producer metrics are also available.
-			Set<ObjectName> producerMetrics = mBeanServer.queryNames(new ObjectName("*:key6=KafkaProducer,*"), null);
+			Set<ObjectName> producerMetrics = mBeanServer.queryNames(new ObjectName("*KafkaProducer*:*"), null);
 			Assert.assertTrue("No producer metrics found", producerMetrics.size() > 30);
 
 


### PR DESCRIPTION
This PR is a follow-up to cbbd80033204a922ccf148c5ac3f1be6de0d810d. It exposes the introduced map of variables via JMX by adding a new method `getVariables()` to the JMX metric interfaces.
