### PR TITLE
FLINK-3930 Added shared secret based authorization for Flink service …

### DIFF
--- a/docs/setup/cli.md
+++ b/docs/setup/cli.md
@@ -225,6 +225,8 @@ Action "run" compiles and runs a program.
                                                     java.net.URLClassLoader}.
      -d,--detached                                  If present, runs the job in
                                                     detached mode
+     -k,--cookie <secureCookie>                     Secure cookie to
+                                                    authenticate
      -m,--jobmanager <host:port>                    Address of the JobManager
                                                     (master) to which to
                                                     connect. Use this flag to
@@ -252,6 +254,7 @@ Action "run" compiles and runs a program.
                                                     availability mode
 
   Options for yarn-cluster mode:
+     -k,--cookie <arg>                    Secure cookie to authenticate
      -yD <arg>                            Dynamic properties
      -yd,--yarndetached                   Start detached
      -yid,--yarnapplicationId <arg>       Attach to running YARN session
@@ -297,6 +300,7 @@ Action "list" lists running and scheduled programs.
 
   Syntax: list [OPTIONS]
   "list" action options:
+     -k,--cookie <secureCookie>    Secure cookie to authenticate
      -m,--jobmanager <host:port>   Address of the JobManager (master) to which
                                    to connect. Use this flag to connect to a
                                    different JobManager than the one specified
@@ -312,6 +316,7 @@ Action "stop" stops a running program (streaming jobs only).
 
   Syntax: stop [OPTIONS] <Job ID>
   "stop" action options:
+     -k,--cookie <secureCookie>    Secure cookie to authenticate
      -m,--jobmanager <host:port>   Address of the JobManager (master) to which
                                    to connect. Use this flag to connect to a
                                    different JobManager than the one specified
@@ -325,6 +330,7 @@ Action "cancel" cancels a running program.
 
   Syntax: cancel [OPTIONS] <Job ID>
   "cancel" action options:
+     -k,--cookie <secureCookie>             Secure cookie to authenticate
      -m,--jobmanager <host:port>            Address of the JobManager (master)
                                             to which to connect. Use this flag
                                             to connect to a different JobManager
@@ -346,10 +352,12 @@ Action "savepoint" triggers savepoints for a running job or disposes existing on
   "savepoint" action options:
      -d,--dispose <arg>            Path of savepoint to dispose.
      -j,--jarfile <jarfile>        Flink program JAR file.
+     -k,--cookie <secureCookie>    Secure cookie to authenticate
      -m,--jobmanager <host:port>   Address of the JobManager (master) to which
                                    to connect. Use this flag to connect to a
                                    different JobManager than the one specified
                                    in the configuration.
   Options for yarn-cluster mode:
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
+
 ~~~

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -150,6 +150,30 @@ Below is a list of currently first-class supported connectors or components by F
 
 For more information on how Flink security internally setups Kerberos authentication, please see [here]({{site.baseurl}}/ops/security-kerberos.html). 
 
+### Secure Cookie Authentication
+
+Flink supports configuring a *secure cookie* (a shared secret) to secure Flink processes. The secure cookie is used to authorize all access to and between Flink Processes. For more details, [see here](flink_security.md))
+
+Flink supports hardening below cluster components through secure cookie implementation.
+
+- Akka Endpoints
+
+- Flink Web Module
+
+- Blob Service
+
+- Task Manager/Netty data transfer communication 
+
+Secure cookie authentication can be enabled by providing below configurations to Flink configuration file.
+
+- `security.enabled`: A boolean value (true|false) indicating security is enabled or not.
+
+- `security.cookie` : Secure cookie value to be used for authorization. For standalone deployment mode, the secure cookie value is mandatory when security is enabled but for the Yarn mode it is optional (auto-generated if not provided).
+
+Alternatively, secure cookie value can be provided through Flink/Yarn CLI using "-k" or "--cookie" parameter option.
+
+The web runtime module prompts for secure cookie using standard basic HTTP authentication mechanism, where the user id field is noop and the password field will be used to capture the secure cookie.
+
 ### Other
 
 - `taskmanager.tmp.dirs`: The directory for temporary files, or a list of directories separated by the system's directory delimiter (for example ':' (colon) on Linux/Unix). If multiple directories are specified, then the temporary files will be distributed across the directories in a round-robin fashion. The I/O manager component will spawn one reading and one writing thread per directory. A directory may be listed multiple times to have the I/O manager use multiple threads for it (for example if it is physically stored on a very fast disc or RAID) (DEFAULT: The system's tmp dir).

--- a/docs/setup/yarn_setup.md
+++ b/docs/setup/yarn_setup.md
@@ -101,13 +101,19 @@ Usage:
    Optional
      -D <arg>                        Dynamic properties
      -d,--detached                   Start detached
+     -id,--applicationId <arg>       Attach to running YARN session
+     -j,--jar <arg>                  Path to Flink jar file
      -jm,--jobManagerMemory <arg>    Memory for JobManager Container [in MB]
-     -nm,--name                      Set a custom name for the application on YARN
+     -k,--cookie <arg>               Secure cookie to authenticate
+     -n,--container <arg>            Number of YARN container to allocate (=Number of Task Managers)
+     -nm,--name <arg>                Set a custom name for the application on YARN
      -q,--query                      Display available YARN resources (memory, cores)
      -qu,--queue <arg>               Specify YARN queue.
      -s,--slots <arg>                Number of slots per TaskManager
+     -st,--streaming                 Start Flink in streaming mode
+     -t,--ship <arg>                 Ship files in the specified directory (t for transfer)
      -tm,--taskManagerMemory <arg>   Memory per TaskManager Container [in MB]
-     -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths for HA mode
+     -z,--zookeeperNamespace <arg>   Namespace to create the Zookeeper sub-paths for high availability mode
 ~~~
 
 Please note that the Client requires the `YARN_CONF_DIR` or `HADOOP_CONF_DIR` environment variable to be set to read the YARN and HDFS configuration.
@@ -133,6 +139,16 @@ Stop the YARN session by stopping the unix process (using CTRL+C) or by entering
 Flink on YARN will only start all requested containers if enough resources are available on the cluster. Most YARN schedulers account for the requested memory of the containers,
 some account also for the number of vcores. By default, the number of vcores is equal to the processing slots (`-s`) argument. The `yarn.containers.vcores` allows overwriting the
 number of vcores with a custom value.
+
+### Service Authorization using Secure Cookie
+
+If service authorization is enabled (For more details, [see here](flink_security.md)), you could pass the secure cookie value as command line argument (-k or --cookie) instead of hardcoding the value in Flink configuration file.
+ 
+The secure cookie parameter can be accepted in the context of creating a new cluster as well as accessing existing cluster.
+
+For a new cluster deployment, if the secure cookie is not provided through either configuration or command-line argument, the secure cookie will be automatically generated and applied across cluster components. The generated cookie will be persisted in the home directory of the user who started the cluster/yarn application. The persisted secure cookie will be used to communicate to the running cluster when accessed through Flink CLI.
+
+In the context of Yarn deployment mode, a secure cookie configuration is per-cluster parameter (Cookie per Yarn application) and all jobs that are running in that session will use the same cookie.
 
 #### Detached YARN Session
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -95,6 +95,9 @@ public class CliFrontendParser {
 			"directory is optional. If no directory is specified, the configured default " +
 			"directory (" + ConfigConstants.SAVEPOINT_DIRECTORY_KEY + ") is used.");
 
+	static final Option SECURE_COOKIE_OPTION = new Option("k", "cookie", true,
+			"String to authorize Akka-based RPC communication");
+
 	static {
 		HELP_OPTION.setRequired(false);
 
@@ -134,6 +137,10 @@ public class CliFrontendParser {
 		CANCEL_WITH_SAVEPOINT_OPTION.setRequired(false);
 		CANCEL_WITH_SAVEPOINT_OPTION.setArgName("targetDirectory");
 		CANCEL_WITH_SAVEPOINT_OPTION.setOptionalArg(true);
+
+		SECURE_COOKIE_OPTION.setRequired(false);
+		SECURE_COOKIE_OPTION.setArgName("secureCookie");
+
 	}
 
 	private static final Options RUN_OPTIONS = getRunOptions(buildGeneralOptions(new Options()));
@@ -188,6 +195,7 @@ public class CliFrontendParser {
 
 	private static Options getJobManagerAddressOption(Options options) {
 		options.addOption(ADDRESS_OPTION);
+		options.addOption(SECURE_COOKIE_OPTION);
 		return options;
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -23,8 +23,12 @@ import org.apache.commons.cli.Options;
 import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
 import org.apache.flink.client.program.StandaloneClusterClient;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.security.SecurityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -36,6 +40,8 @@ import static org.apache.flink.client.CliFrontend.setJobManagerAddressInConfig;
  * The default CLI which is used for interaction with standalone clusters.
  */
 public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultCLI.class);
 
 	@Override
 	public boolean isActive(CommandLine commandLine, Configuration configuration) {
@@ -59,6 +65,12 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 	@Override
 	public StandaloneClusterClient retrieveCluster(CommandLine commandLine, Configuration config) {
 
+		// get secure cookie if passed as argument
+		String secureCookieArg = commandLine.hasOption(CliFrontendParser.SECURE_COOKIE_OPTION.getOpt()) ?
+				commandLine.getOptionValue(CliFrontendParser.SECURE_COOKIE_OPTION.getOpt()) : null;
+
+		populateSecureCookieConfigurations(config, secureCookieArg);
+
 		if (commandLine.hasOption(CliFrontendParser.ADDRESS_OPTION.getOpt())) {
 			String addressWithPort = commandLine.getOptionValue(CliFrontendParser.ADDRESS_OPTION.getOpt());
 			InetSocketAddress jobManagerAddress = ClientUtils.parseHostPortAddress(addressWithPort);
@@ -81,7 +93,30 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 			Configuration config,
 			List<URL> userJarFiles) throws UnsupportedOperationException {
 
+		// get secure cookie if passed as argument
+		String secureCookieArg = commandLine.hasOption(CliFrontendParser.SECURE_COOKIE_OPTION.getOpt()) ?
+				commandLine.getOptionValue(CliFrontendParser.SECURE_COOKIE_OPTION.getOpt()) : null;
+
+		populateSecureCookieConfigurations(config, secureCookieArg);
+
 		StandaloneClusterDescriptor descriptor = new StandaloneClusterDescriptor(config);
 		return descriptor.deploy();
+	}
+
+	private void populateSecureCookieConfigurations(Configuration config, String secureCookieArg) {
+
+		boolean securityEnabled = SecurityUtils.isSecurityEnabled(config);
+
+		if(securityEnabled) {
+			LOG.debug("Security enabled");
+		} else {
+			LOG.debug("Security disabled");
+		}
+
+		if(securityEnabled && secureCookieArg != null) {
+			LOG.debug("Secure cookie is provided as CLI argument and will be used");
+			config.setString(ConfigConstants.SECURITY_COOKIE, secureCookieArg);
+		}
+
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -741,6 +741,15 @@ public final class ConfigConstants {
 	/** Flag to enable/disable hostname verification for the ssl connections */
 	public static final String SECURITY_SSL_VERIFY_HOSTNAME = "security.ssl.verify-hostname";
 
+	// ---------------------------- Secure Cookie Authentication -----------------------------------
+
+	/** Flag that specify whether service authentication is enabled or not **/
+	public static final String SECURITY_ENABLED = "security.enabled";
+
+	/** cookie to be used for authentication **/
+	public static final String SECURITY_COOKIE = "security.cookie";
+
+
 	// ----------------------------- Streaming --------------------------------
 	
 	/**
@@ -913,6 +922,7 @@ public final class ConfigConstants {
 	/** Deprecated in favour of {@link #HA_ZOOKEEPER_MAX_RETRY_ATTEMPTS}. */
 	@Deprecated
 	public static final String ZOOKEEPER_MAX_RETRY_ATTEMPTS = "recovery.zookeeper.client.max-retry-attempts";
+
 
 	// ---------------------------- Metrics -----------------------------------
 
@@ -1319,6 +1329,11 @@ public final class ConfigConstants {
 	public static String DEFAULT_SECURITY_SSL_ALGORITHMS = "TLS_RSA_WITH_AES_128_CBC_SHA";
 
 	public static boolean DEFAULT_SECURITY_SSL_VERIFY_HOSTNAME = true;
+
+	// ------------------ Defaults for Secure Cookie Authentication ----------------
+
+	/** By default, secure cookie authentication is disabled **/
+	public static final boolean DEFAULT_SECURITY_ENABLED = false;
 
 	// ----------------------------- Streaming Values --------------------------
 	

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -170,8 +170,15 @@ public final class GlobalConfiguration {
 						continue;
 					}
 
-					LOG.info("Loading configuration property: {}, {}", key, value);
 					config.setString(key, value);
+
+					//to prevent logging the secure cookie
+					if(key.equals(ConfigConstants.SECURITY_COOKIE) && value != null) {
+						value = "******";
+					}
+
+					LOG.debug("Loading configuration property: {}, {}", key, value);
+
 				}
 			}
 		} catch (IOException e) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -62,4 +62,26 @@ public class SecurityOptions {
 	public static final ConfigOption<String> ZOOKEEPER_SASL_LOGIN_CONTEXT_NAME =
 		key("zookeeper.sasl.login-context-name")
 			.defaultValue("Client");
+
+	// ------------------------------------------------------------------------
+	//  Service Level Authorization Options
+	// ------------------------------------------------------------------------
+	public static final ConfigOption<String> SECURITY_COOKIE =
+			key("security.cookie")
+			.noDefaultValue();
+
+	/**
+	 * A flag indicating if service level authorization is enabled or not
+	 */
+	public static final ConfigOption<Boolean> SECURITY_ENABLED =
+			key("security.enabled")
+					.defaultValue(false);
+
+	/**
+	 * A flag indicating if SSL is enabled or not
+	 */
+	public static final ConfigOption<Boolean> SECURITY_SSL_ENABLED =
+			key("security.ssl.enabled")
+					.defaultValue(false);
+
 }

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -182,6 +182,12 @@ jobmanager.web.port: 8081
 
 # security.kerberos.login.contexts: Client,KafkaClient
 
+# Flag to enable/disable service level authorization (disabled by default)
+#security.enabled: false
+
+#secure random cookie to be used for service level authorization (auto-generated or static if value supplied)
+#security.cookie: changeme
+
 #==============================================================================
 # ZK Security Configuration (optional configuration)
 #==============================================================================

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
@@ -49,12 +49,20 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.EndOfDataDec
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData.HttpDataType;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * Simple code which handles all HTTP requests from the user, and passes them to the Router
@@ -67,6 +75,8 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 
 	private static final Charset ENCODING = ConfigConstants.DEFAULT_CHARSET;
 
+	private static final Logger LOG = LoggerFactory.getLogger(HttpRequestHandler.class);
+
 	/** A decoder factory that always stores POST chunks on disk */
 	private static final HttpDataFactory DATA_FACTORY = new DefaultHttpDataFactory(true);
 
@@ -77,7 +87,14 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 	private HttpPostRequestDecoder currentDecoder;
 	private String currentRequestPath;
 
-	public HttpRequestHandler(File tmpDir) {
+	private final String secureCookie;
+
+	public HttpRequestHandler(Configuration config, File tmpDir) {
+		boolean securityEnabled = SecurityUtils.isSecurityEnabled(config);
+		secureCookie = config.getString(ConfigConstants.SECURITY_COOKIE, null);
+		if(securityEnabled && secureCookie == null) {
+			throw new IllegalConfigurationException(ConfigConstants.SECURITY_COOKIE + " must be configured.");
+		}
 		this.tmpDir = tmpDir;
 	}
 
@@ -98,6 +115,43 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 				if (currentDecoder != null) {
 					currentDecoder.destroy();
 					currentDecoder = null;
+				}
+
+				if(secureCookie != null) {
+
+					LOG.debug("Secure auth enabled. Going to validate auth header");
+
+					//decode the request and see if Auth header is available
+					String auth = currentRequest.headers().get("Authorization");
+					LOG.debug("authorization header: {}", auth);
+
+					if(auth == null || !auth.startsWith("Basic")) {
+						String message = (auth == null) ? "Could not find authorization header" :
+								"Only Basic authorization is supported";
+						LOG.info(message+ ". Routing the request to prompt for credentials");
+
+						ctx.writeAndFlush(buildUnauthorizedHTTPResponse());
+						return;
+
+					} else {
+						String base64Credentials = auth.substring("Basic".length()).trim();
+						String credentials = new String(
+								DatatypeConverter.parseBase64Binary(base64Credentials),
+								ENCODING);
+						final String[] values = credentials.split(":",2);
+						if(values.length != 2) {
+							String message = "Credentials supplied does not have proper values";
+							LOG.error(message);
+							ctx.writeAndFlush(buildErrorHTTPResponse());
+							return;
+						}
+						if(!values[1].equals(secureCookie)) {
+							LOG.warn("User supplied cookie does not match with the configured cookie");
+							ctx.writeAndFlush(buildUnauthorizedHTTPResponse());
+							return;
+						}
+						LOG.debug("URL request is authorized since the cookie entered matches with the configured secure value");
+					}
 				}
 
 				if (currentRequest.getMethod() == HttpMethod.GET || currentRequest.getMethod() == HttpMethod.DELETE) {
@@ -182,5 +236,29 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 				ctx.writeAndFlush(response);
 			}
 		}
+	}
+
+	private DefaultFullHttpResponse buildUnauthorizedHTTPResponse() {
+		String message = "Unable to authorize the request. " +
+				"Please provide secure cookie details to access the cluster.";
+		byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
+		DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+				HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED, Unpooled.wrappedBuffer(bytes));
+		response.headers().set(HttpHeaders.Names.WWW_AUTHENTICATE,
+				"Basic realm=\"To access web portal, please provide the secure cookie value in the password field. " +
+						"User name can be of any value.\"");
+		response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
+		response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
+		return response;
+	}
+
+	private DefaultFullHttpResponse buildErrorHTTPResponse() {
+		String message = "Credentials supplied does not have proper values" ;
+		byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
+		DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+				HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST, Unpooled.wrappedBuffer(bytes));
+		response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
+		response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
+		return response;
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -160,7 +160,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 	private MetricFetcher metricFetcher;
 
 	public WebRuntimeMonitor(
-			Configuration config,
+			final Configuration config,
 			LeaderRetrievalService leaderRetrievalService,
 			ActorSystem actorSystem) throws IOException, InterruptedException {
 
@@ -396,7 +396,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 				ch.pipeline()
 						.addLast(new HttpServerCodec())
 						.addLast(new ChunkedWriteHandler())
-						.addLast(new HttpRequestHandler(uploadDir))
+						.addLast(new HttpRequestHandler(config,uploadDir))
 						.addLast(handler.name(), handler)
 						.addLast(new PipelineErrorHandler(LOG));
 			}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobManagerConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobManagerConfigHandler.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.instance.ActorGateway;
 
@@ -47,14 +48,14 @@ public class JobManagerConfigHandler extends AbstractJsonRequestHandler {
 	public String handleJsonRequest(Map<String, String> pathParams, Map<String, String> queryParams, ActorGateway jobManager) throws Exception {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
-
 		gen.writeStartArray();
+
 		for (String key : config.keySet()) {
 			gen.writeStartObject();
 			gen.writeStringField("key", key);
 
 			// Mask key values which contain sensitive information
-			if(key.toLowerCase().contains("password")) {
+			if(key.toLowerCase().contains("password") || key.equals(ConfigConstants.SECURITY_COOKIE)) {
 				String value = config.getString(key, null);
 				if(value != null) {
 					value = "******";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.FileUtils;
+import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.NetUtils;
 
 import org.slf4j.Logger;
@@ -91,6 +92,9 @@ public class BlobServer extends Thread implements BlobService {
 	 */
 	private final Thread shutdownHook;
 
+	/** Secure cookie for service level authorization **/
+	private String secureCookie;
+
 	/**
 	 * Instantiates a new BLOB server and binds it to a free network port.
 	 *
@@ -114,6 +118,8 @@ public class BlobServer extends Thread implements BlobService {
 		String storageDirectory = config.getString(ConfigConstants.BLOB_STORAGE_DIRECTORY_KEY, null);
 		this.storageDir = BlobUtils.initStorageDirectory(storageDirectory);
 		LOG.info("Created BLOB server storage directory {}", storageDir);
+
+		secureCookie = SecurityUtils.validateAndGetSecureCookie(config);
 
 		// configure the maximum number of concurrent connections
 		final int maxConnections = config.getInteger(
@@ -442,5 +448,12 @@ public class BlobServer extends Thread implements BlobService {
 			return new ArrayList<BlobServerConnection>(activeConnections);
 		}
 	}
+
+	/* Secure cookie to authenticate */
+	@Override
+	public String getSecureCookie() { return secureCookie; }
+
+	/* Flag to indicate if service level authentication is enabled or not */
+	public boolean isSecurityEnabled() { return secureCookie != null; }
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
@@ -53,6 +53,14 @@ public class BlobServerProtocol {
 	/** Internal code to identify a reference via jobId as the key */
 	static final byte JOB_ID_SCOPE = 2;
 
+	/** Internal code to identify security header.
+	 *  The header is required because when SSL client talks to non-SSL blob server
+	 *  (see: org.apache.flink.runtime.blob.BlobClientSslTest#testSSLClientFailure) , the read operation
+	 *  reads some arbitrary data length and hence the secure cookie read operation will wait indefinitely.
+	 *  We need to pass secure cookie header first followed by cookie length and cookie data to overcome this issue.
+	 */
+	static final byte SECURITY_HEADER_CODE = 127;
+
 	// --------------------------------------------------------------------------------------------
 
 	private BlobServerProtocol() {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -56,4 +56,10 @@ public interface BlobService {
 	void shutdown();
 	
 	BlobClient createClient() throws IOException;
+
+	/**
+	 * Returns the secure cookie for service level Authorization
+	 * @return secure cookie
+	 */
+	String getSecureCookie();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.highavailability.ZookeeperHaServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.StringUtils;
 import org.slf4j.Logger;
-
+import org.slf4j.LoggerFactory;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -39,13 +39,14 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
-
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Utility class to work with blob data.
  */
 public class BlobUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(BlobUtils.class);
 
 	/**
 	 * Algorithm to be used for calculating the BLOB keys.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CookieHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CookieHandler.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CookieHandler {
+
+	public static class ClientCookieHandler extends ChannelInboundHandlerAdapter {
+
+		private final Logger LOG = LoggerFactory.getLogger(ClientCookieHandler.class);
+
+		private final String secureCookie;
+
+		final Charset DEFAULT_CHARSET = Charset.forName("utf-8");
+
+		public ClientCookieHandler(String secureCookie) {
+			this.secureCookie = secureCookie;
+		}
+
+		@Override
+		public void channelActive(ChannelHandlerContext ctx) throws Exception {
+			super.channelActive(ctx);
+			LOG.debug("In channelActive method of ClientCookieHandler");
+
+			if(this.secureCookie != null && this.secureCookie.length() != 0) {
+				LOG.debug("In channelActive method of ClientCookieHandler -> sending secure cookie");
+				final ByteBuf buffer = Unpooled.buffer(4 + this.secureCookie.getBytes(DEFAULT_CHARSET).length);
+				buffer.writeInt(secureCookie.getBytes(DEFAULT_CHARSET).length);
+				buffer.writeBytes(secureCookie.getBytes(DEFAULT_CHARSET));
+				ctx.writeAndFlush(buffer);
+			}
+		}
+	}
+
+	public static class ServerCookieDecoder extends MessageToMessageDecoder<ByteBuf> {
+
+		private final String secureCookie;
+
+		private final List<Channel> channelList = new ArrayList<>();
+
+		private final Charset DEFAULT_CHARSET = Charset.forName("utf-8");
+
+		private final Logger LOG = LoggerFactory.getLogger(ServerCookieDecoder.class);
+
+		public ServerCookieDecoder(String secureCookie) {
+			this.secureCookie = secureCookie;
+		}
+
+		/**
+		 * Decode from one message to an other. This method will be called for each written message that can be handled
+		 * by this encoder.
+		 *
+		 * @param ctx the {@link ChannelHandlerContext} which this {@link MessageToMessageDecoder} belongs to
+		 * @param msg the message to decode to an other one
+		 * @param out the {@link List} to which decoded messages should be added
+		 * @throws Exception is thrown if an error accour
+		 */
+		@Override
+		protected void decode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+
+			LOG.debug("ChannelHandlerContext name: {}, channel: {}", ctx.name(), ctx.channel());
+
+			if(secureCookie == null || secureCookie.length() == 0) {
+				LOG.debug("Not validating secure cookie since the server configuration is not enabled to use cookie");
+				return;
+			}
+
+			LOG.debug("Going to decode the secure cookie passed by the remote client");
+
+			if(channelList.contains(ctx.channel())) {
+				LOG.debug("Channel: {} already authorized", ctx.channel());
+				return;
+			}
+
+			//read cookie based on the cookie length passed
+			int cookieLength = msg.readInt();
+			if(cookieLength != secureCookie.getBytes(DEFAULT_CHARSET).length) {
+				ctx.channel().close();
+				String message = "Cookie length does not match with source cookie. Invalid secure cookie passed.";
+				throw new IllegalStateException(message);
+			}
+
+			//read only if cookie length is greater than zero
+			if(cookieLength > 0) {
+
+				final byte[] buffer = new byte[secureCookie.getBytes(DEFAULT_CHARSET).length];
+				msg.readBytes(buffer, 0, cookieLength);
+
+				if(!Arrays.equals(secureCookie.getBytes(DEFAULT_CHARSET), buffer)) {
+					LOG.error("Secure cookie from the client is not matching with the server's identity");
+					throw new IllegalStateException("Invalid secure cookie passed.");
+				}
+
+				LOG.info("Secure cookie validation passed");
+
+				channelList.add(ctx.channel());
+			}
+
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -190,6 +190,11 @@ class NettyClient {
 
 					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
 				}
+				if(config.isSecurityEnabled())
+				{
+					channel.pipeline().addLast("client-cookie",
+							new CookieHandler.ClientCookieHandler(config.getSecureCookie()));
+				}
 				channel.pipeline().addLast(protocol.getClientChannelHandlers());
 			}
 		});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.net.SSLUtils;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.security.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +71,8 @@ public class NettyConfig {
 
 	private final int numberOfSlots;
 
+	private final String secureCookie;
+
 	private final Configuration config; // optional configuration
 
 	public NettyConfig(
@@ -91,6 +95,12 @@ public class NettyConfig {
 
 		this.config = checkNotNull(config);
 
+		this.secureCookie = config.getString(ConfigConstants.SECURITY_COOKIE, "");
+
+		if(isSecurityEnabled() && this.secureCookie.equals("")) {
+			throw new IllegalConfigurationException(ConfigConstants.SECURITY_COOKIE + " must be configured.");
+		}
+
 		LOG.info(this.toString());
 	}
 
@@ -109,6 +119,8 @@ public class NettyConfig {
 	public int getNumberOfSlots() {
 		return numberOfSlots;
 	}
+
+	public String getSecureCookie() { return secureCookie; }
 
 	// ------------------------------------------------------------------------
 	// Setters
@@ -234,6 +246,10 @@ public class NettyConfig {
 		return config.getBoolean(ConfigConstants.TASK_MANAGER_DATA_SSL_ENABLED,
 				ConfigConstants.DEFAULT_TASK_MANAGER_DATA_SSL_ENABLED)
 			&& SSLUtils.getSSLEnabled(config);
+	}
+
+	public boolean isSecurityEnabled() {
+		return SecurityUtils.isSecurityEnabled(config);
 	}
 
 	public void setSSLVerifyHostname(SSLParameters sslParams) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -40,7 +40,6 @@ public class NettyConnectionManager implements ConnectionManager {
 		this.server = new NettyServer(nettyConfig);
 		this.client = new NettyClient(nettyConfig);
 		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
-
 		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -37,6 +37,8 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -73,7 +75,6 @@ abstract class NettyMessage {
 		buffer.writeInt(HEADER_LENGTH + length);
 		buffer.writeInt(MAGIC_NUMBER);
 		buffer.writeByte(id);
-
 		return buffer;
 	}
 
@@ -119,6 +120,10 @@ abstract class NettyMessage {
 
 	@ChannelHandler.Sharable
 	static class NettyMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
+
+		private static final Logger LOG = LoggerFactory.getLogger(NettyMessageDecoder.class);
+
+		public NettyMessageDecoder() {}
 
 		@Override
 		protected void decode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
@@ -223,6 +228,7 @@ abstract class NettyMessage {
 			int length = 16 + 4 + 1 + 4 + buffer.getSize();
 
 			ByteBuf result = null;
+
 			try {
 				result = allocateBuffer(allocator, ID, length);
 
@@ -300,6 +306,7 @@ abstract class NettyMessage {
 
 				// Update frame length...
 				result.setInt(0, result.readableBytes());
+
 				return result;
 			}
 			catch (Throwable t) {
@@ -505,8 +512,7 @@ abstract class NettyMessage {
 
 		private static final byte ID = 5;
 
-		public CloseRequest() {
-		}
+		public CloseRequest() {}
 
 		@Override
 		ByteBuf write(ByteBufAllocator allocator) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -144,6 +144,10 @@ class NettyServer {
 					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
 				}
 
+				if(config.isSecurityEnabled()) {
+					channel.pipeline().addLast("cookie-decoder",
+							new CookieHandler.ServerCookieDecoder(config.getSecureCookie()));
+				}
 				channel.pipeline().addLast(protocol.getServerChannelHandlers());
 			}
 		});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
@@ -150,7 +150,8 @@ public class PartitionRequestClient {
 	public void sendTaskEvent(ResultPartitionID partitionId, TaskEvent event, final RemoteInputChannel inputChannel) throws IOException {
 		checkNotClosed();
 
-		tcpChannel.writeAndFlush(new TaskEventRequest(event, partitionId, inputChannel.getInputChannelId()))
+		tcpChannel.writeAndFlush(new TaskEventRequest(event, partitionId,
+				inputChannel.getInputChannelId()))
 				.addListener(
 						new ChannelFutureListener() {
 							@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -66,6 +66,8 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 
 	private volatile ChannelHandlerContext ctx;
 
+	public PartitionRequestClientHandler() { }
+
 	// ------------------------------------------------------------------------
 	// Input channel/receiver registration
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestProtocol.java
@@ -30,16 +30,20 @@ class PartitionRequestProtocol implements NettyProtocol {
 
 	private final NettyMessageEncoder messageEncoder = new NettyMessageEncoder();
 
-	private final NettyMessage.NettyMessageDecoder messageDecoder = new NettyMessage.NettyMessageDecoder();
+	private final NettyMessage.NettyMessageDecoder messageDecoder;
 
 	private final ResultPartitionProvider partitionProvider;
 	private final TaskEventDispatcher taskEventDispatcher;
 	private final NetworkBufferPool networkbufferPool;
 
-	PartitionRequestProtocol(ResultPartitionProvider partitionProvider, TaskEventDispatcher taskEventDispatcher, NetworkBufferPool networkbufferPool) {
+	PartitionRequestProtocol(ResultPartitionProvider partitionProvider, TaskEventDispatcher taskEventDispatcher,
+							NetworkBufferPool networkbufferPool) {
 		this.partitionProvider = partitionProvider;
 		this.taskEventDispatcher = taskEventDispatcher;
 		this.networkbufferPool = networkbufferPool;
+
+		messageDecoder = new NettyMessage.NettyMessageDecoder();
+
 	}
 
 	// +-------------------------------------------------------------------+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -59,6 +59,8 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 
 	private ChannelHandlerContext ctx;
 
+	public PartitionRequestQueue() { }
+
 	@Override
 	public void channelRegistered(final ChannelHandlerContext ctx) throws Exception {
 		if (this.ctx == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -22,8 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
@@ -34,7 +32,6 @@ import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -515,49 +512,6 @@ public class JobGraph implements Serializable {
 	 */
 	public List<BlobKey> getUserJarBlobKeys() {
 		return this.userJarBlobKeys;
-	}
-
-	/**
-	 * Uploads the previously added user jar file to the job manager through the job manager's BLOB server.
-	 *
-	 * @param serverAddress
-	 *        the network address of the BLOB server
-	 * @param blobClientConfig
-	 *        the blob client configuration
-	 * @throws IOException
-	 *         thrown if an I/O error occurs during the upload
-	 */
-	public void uploadRequiredJarFiles(InetSocketAddress serverAddress,
-			Configuration blobClientConfig) throws IOException {
-		if (this.userJars.isEmpty()) {
-			return;
-		}
-
-		BlobClient bc = null;
-		try {
-			bc = new BlobClient(serverAddress, blobClientConfig);
-
-			for (final Path jar : this.userJars) {
-
-				final FileSystem fs = jar.getFileSystem();
-				FSDataInputStream is = null;
-				try {
-					is = fs.open(jar);
-					final BlobKey key = bc.put(is);
-					this.userJarBlobKeys.add(key);
-				}
-				finally {
-					if (is != null) {
-						is.close();
-					}
-				}
-			}
-		}
-		finally {
-			if (bc != null) {
-				bc.close();
-			}
-		}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -230,6 +230,36 @@ public class SecurityUtils {
 		}
 	}
 
+	/**
+	 * Utility method to validate secure cookie from Flink configuration instance
+	 * @throws IllegalConfigurationException
+	 * 			thrown if security is enabled and cookie is not provided
+	 */
+	public static String validateAndGetSecureCookie(Configuration configuration) {
+		String secureCookie = null;
+		if(isSecurityEnabled(configuration)) {
+			secureCookie = configuration.getString(SecurityOptions.SECURITY_COOKIE);
+			if(secureCookie == null) {
+				throw new IllegalConfigurationException(SecurityOptions.SECURITY_COOKIE.key() + " must be configured.");
+			}
+		}
+		return secureCookie;
+	}
+
+	public static boolean isSecurityEnabled(Configuration configuration) {
+
+		boolean securityEnabled = configuration.getBoolean(SecurityOptions.SECURITY_ENABLED);
+		boolean transportSecurityEnabled = configuration.getBoolean(SecurityOptions.SECURITY_SSL_ENABLED);
+		if(securityEnabled) {
+			if(!transportSecurityEnabled) {
+				throw new IllegalConfigurationException(SecurityOptions.SECURITY_SSL_ENABLED.key() + " must be configured.");
+			}
+			return true;
+		}
+		return false;
+	}
+
+
 	// Just a util, shouldn't be instantiated.
 	private SecurityUtils() {}
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -36,7 +36,7 @@ import org.apache.flink.metrics.groups.UnregisteredMetricsGroup
 import org.apache.flink.metrics.{Gauge, MetricGroup}
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot
 import org.apache.flink.runtime.akka.{AkkaUtils, ListeningBehaviour}
-import org.apache.flink.runtime.blob.BlobServer
+import org.apache.flink.runtime.blob.{BlobServer}
 import org.apache.flink.runtime.checkpoint._
 import org.apache.flink.runtime.checkpoint.savepoint.{SavepointLoader, SavepointStore}
 import org.apache.flink.runtime.client._
@@ -1949,6 +1949,17 @@ object JobManager {
       case t: Throwable =>
         LOG.error(t.getMessage(), t)
         t.printStackTrace()
+        System.exit(STARTUP_FAILURE_RETURN_CODE)
+        null
+    }
+
+    try {
+      //validate secure cookie configuration
+      SecurityUtils.validateAndGetSecureCookie(configuration)
+    }
+    catch {
+      case t: Throwable =>
+        LOG.error(t.getMessage(), t)
         System.exit(STARTUP_FAILURE_RETURN_CODE)
         null
     }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1542,6 +1542,17 @@ object TaskManager {
         null
     }
 
+    try {
+      //validate secure cookie configuration
+      SecurityUtils.validateAndGetSecureCookie(configuration)
+    }
+    catch {
+      case t: Throwable =>
+        LOG.error(t.getMessage(), t)
+        System.exit(STARTUP_FAILURE_RETURN_CODE)
+        null
+    }
+
     // In Standalone mode, we generate a resource identifier.
     val resourceId = ResourceID.generate()
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.junit.Rule;
@@ -88,7 +89,6 @@ public class BlobCacheRetriesTest {
 			BlobKey key;
 			try {
 				blobClient = new BlobClient(serverAddress, config);
-
 				key = blobClient.put(data);
 			}
 			finally {
@@ -180,7 +180,6 @@ public class BlobCacheRetriesTest {
 			BlobKey key;
 			try {
 				blobClient = new BlobClient(serverAddress, config);
-
 				key = blobClient.put(data);
 			}
 			finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -98,9 +98,7 @@ public class BlobCacheSuccessTest {
 			// Upload BLOBs
 			BlobClient blobClient = null;
 			try {
-
 				blobClient = new BlobClient(serverAddress, config);
-
 				blobKeys.add(blobClient.put(buf));
 				buf[0] = 1; // Make sure the BLOB key changes
 				blobKeys.add(blobClient.put(buf));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientCookieTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientCookieTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.MessageDigest;
+
+import static org.junit.Assert.fail;
+
+public class BlobClientCookieTest extends BlobClientTest {
+
+	/**
+	 * Starts the BLOB server with secure cookie enabled configuration
+	 */
+	@BeforeClass
+	public static void startServer() {
+		try {
+			config.setBoolean(ConfigConstants.SECURITY_ENABLED, true);
+			config.setString(ConfigConstants.SECURITY_COOKIE, "foo");
+
+			config.setBoolean(ConfigConstants.SECURITY_SSL_ENABLED, true);
+			config.setBoolean(ConfigConstants.BLOB_SERVICE_SSL_ENABLED, false);
+			config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE, "src/test/resources/local127.keystore");
+			config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE_PASSWORD, "password");
+			config.setString(ConfigConstants.SECURITY_SSL_KEY_PASSWORD, "password");
+
+			BLOB_SERVER = new BlobServer(config);
+
+
+			clientConfig.setString(ConfigConstants.SECURITY_COOKIE, "foo");
+			clientConfig.setBoolean(ConfigConstants.SECURITY_ENABLED, true);
+
+			clientConfig.setBoolean(ConfigConstants.SECURITY_SSL_ENABLED, true);
+			clientConfig.setBoolean(ConfigConstants.BLOB_SERVICE_SSL_ENABLED, false);
+			clientConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
+			clientConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE_PASSWORD, "password");
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test(expected = IOException.class)
+	public void testInvalidSecurityCookie() throws IOException {
+
+		BlobClient client = null;
+
+		try {
+			byte[] testBuffer = createTestBuffer();
+			MessageDigest md = BlobUtils.createMessageDigest();
+			md.update(testBuffer);
+
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", BLOB_SERVER.getPort());
+
+			Configuration clientConfig = new Configuration();
+			clientConfig.setString(ConfigConstants.SECURITY_COOKIE, "bar");
+			clientConfig.setBoolean(ConfigConstants.SECURITY_ENABLED, true);
+
+			clientConfig.setBoolean(ConfigConstants.SECURITY_SSL_ENABLED, true);
+			clientConfig.setBoolean(ConfigConstants.BLOB_SERVICE_SSL_ENABLED, false);
+			clientConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
+			clientConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE_PASSWORD, "password");
+
+			client = new BlobClient(serverAddress, clientConfig);
+
+			// Store some data
+			client.put(testBuffer);
+		}
+		finally {
+			if (client != null) {
+				try {
+					client.close();
+				} catch (Throwable t) {}
+			}
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
@@ -59,7 +58,6 @@ public class BlobLibraryCacheManagerTest {
 			server = new BlobServer(config);
 			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
 			BlobClient bc = new BlobClient(blobSocketAddress, config);
-
 			keys.add(bc.put(buf));
 			buf[0] += 1;
 			keys.add(bc.put(buf));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -99,7 +99,7 @@ public class ClientTransportErrorHandlingTest {
 		PartitionRequestClientHandler handler = getClientHandler(ch);
 
 		// Last outbound handler throws Exception after 1st write
-		ch.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+		ch.pipeline().addLast(new ChannelOutboundHandlerAdapter() {
 			int writeNum = 0;
 
 			@Override
@@ -174,6 +174,7 @@ public class ClientTransportErrorHandlingTest {
 			handler.addInputChannel(r);
 		}
 
+		String secureCookie = "";
 		// Error msg for channel[0]
 		ch.pipeline().fireChannelRead(new NettyMessage.ErrorResponse(
 				new RuntimeException("Expected test exception"),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
@@ -27,6 +28,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.NetUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 
@@ -34,6 +37,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class NettyClientServerSslTest {
+
+	private final Logger LOG = LoggerFactory.getLogger(NettyClientServerSslTest.class);
 
 	/**
 	 * Verify valid ssl configuration and connection
@@ -56,7 +61,7 @@ public class NettyClientServerSslTest {
 			NetUtils.getAvailablePort(),
 			NettyTestUtil.DEFAULT_SEGMENT_SIZE,
 			1,
-			createSslConfig());
+			createSslConfig(true));
 
 		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
 
@@ -64,7 +69,24 @@ public class NettyClientServerSslTest {
 
 		// should be able to send text data
 		ch.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
-		assertTrue(ch.writeAndFlush("test").await().isSuccess());
+		assertTrue(ch.writeAndFlush("test-1").await().isSuccess());
+
+		ch.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
+		assertTrue(ch.writeAndFlush("test-2").await().isSuccess());
+
+		//Create another client and connect to server. It should get authenticated first
+		NettyBufferPool bufferPool = new NettyBufferPool(1);
+		final NettyClient client = NettyTestUtil.initClient(nettyConfig, protocol, bufferPool);
+		Channel channel = NettyTestUtil.connect(client, serverAndClient.server());
+
+		// should be able to send text data
+		channel.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
+		assertTrue(channel.writeAndFlush("bar-1").await().isSuccess());
+
+		channel.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
+		assertTrue(channel.writeAndFlush("bar-2").await().isSuccess());
+
+		client.shutdown();
 
 		NettyTestUtil.shutdown(serverAndClient);
 	}
@@ -85,7 +107,7 @@ public class NettyClientServerSslTest {
 			public ChannelHandler[] getClientChannelHandlers() { return new ChannelHandler[0]; }
 		};
 
-		Configuration config = createSslConfig();
+		Configuration config = createSslConfig(true);
 		// Modify the keystore password to an incorrect one
 		config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE_PASSWORD, "invalidpassword");
 
@@ -123,7 +145,7 @@ public class NettyClientServerSslTest {
 			public ChannelHandler[] getClientChannelHandlers() { return new ChannelHandler[0]; }
 		};
 
-		Configuration config = createSslConfig();
+		Configuration config = createSslConfig(true);
 
 		// Use a server certificate which is not present in the truststore
 		config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE, "src/test/resources/untrusted.keystore");
@@ -146,7 +168,56 @@ public class NettyClientServerSslTest {
 		NettyTestUtil.shutdown(serverAndClient);
 	}
 
-	private Configuration createSslConfig() throws Exception {
+	/**
+	 * Verify client gets disconnected when valid secure cookie is not provided
+	 *
+	 */
+	@Test
+	public void testValidSslAndInvalidCookie() throws Exception {
+
+		NettyProtocol protocol = new NettyProtocol() {
+			@Override
+			public ChannelHandler[] getServerChannelHandlers() {
+				return new ChannelHandler[0];
+			}
+
+			@Override
+			public ChannelHandler[] getClientChannelHandlers() {
+				return new ChannelHandler[0];
+			}
+		};
+
+		NettyBufferPool bufferPool = new NettyBufferPool(1);
+
+		NettyConfig nettyConfig = new NettyConfig(
+				InetAddress.getLoopbackAddress(),
+				NetUtils.getAvailablePort(),
+				NettyTestUtil.DEFAULT_SEGMENT_SIZE,
+				1,
+				createSslConfig(true));
+
+		final NettyServer server = NettyTestUtil.initServer(nettyConfig, protocol, bufferPool);
+
+		//Create client with invalid secure cookie and it should fail
+		NettyConfig nettyConfigWithInvalidCookie = new NettyConfig(
+				InetAddress.getLoopbackAddress(),
+				NetUtils.getAvailablePort(),
+				NettyTestUtil.DEFAULT_SEGMENT_SIZE,
+				1,
+				createSslConfig(false));
+
+		final NettyClient client = NettyTestUtil.initClient(nettyConfigWithInvalidCookie, protocol, bufferPool);
+		Channel channel = NettyTestUtil.connect(client, server);
+		channel.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
+		ChannelFuture future = channel.writeAndFlush("blah").await();
+		Thread.sleep(500);
+		assertFalse(future.channel().isActive());
+
+		client.shutdown();
+		server.shutdown();
+	}
+
+	private Configuration createSslConfig(boolean enableCookie) throws Exception {
 
 		Configuration flinkConfig = new Configuration();
 		flinkConfig.setBoolean(ConfigConstants.SECURITY_SSL_ENABLED, true);
@@ -155,6 +226,12 @@ public class NettyClientServerSslTest {
 		flinkConfig.setString(ConfigConstants.SECURITY_SSL_KEY_PASSWORD, "password");
 		flinkConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
 		flinkConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE_PASSWORD, "password");
+
+		if(enableCookie) {
+			flinkConfig.setBoolean(ConfigConstants.SECURITY_ENABLED, true);
+			flinkConfig.setString(ConfigConstants.SECURITY_COOKIE, "foo");
+		}
+
 		return flinkConfig;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -174,6 +174,7 @@ public class PartitionRequestClientHandlerTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testAutoReadAfterUnsuccessfulStagedMessage() throws Exception {
+
 		PartitionRequestClientHandler handler = new PartitionRequestClientHandler();
 		EmbeddedChannel channel = new EmbeddedChannel(handler);
 
@@ -255,6 +256,7 @@ public class PartitionRequestClientHandlerTest {
 			InputChannelID receivingChannelId) throws IOException {
 
 		// Mock buffer to serialize
+		String secureCookie = "";
 		BufferResponse resp = new BufferResponse(buffer, sequenceNumber, receivingChannelId);
 
 		ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -39,6 +39,7 @@ public class PartitionRequestQueueTest {
 
 	@Test
 	public void testProducerFailedException() throws Exception {
+
 		PartitionRequestQueue queue = new PartitionRequestQueue();
 
 		ResultPartitionProvider partitionProvider = mock(ResultPartitionProvider.class);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -24,7 +24,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.test.testdata.WordCountData;
@@ -439,10 +438,10 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		LOG.info("CLI Frontend has returned, so the job is running");
 
 		// find out the application id and wait until it has finished.
+		ApplicationId tmpAppId = null;
 		try {
 			List<ApplicationReport> apps = yc.getApplications(EnumSet.of(YarnApplicationState.RUNNING));
 
-			ApplicationId tmpAppId;
 			if (apps.size() == 1) {
 				// Better method to find the right appId. But sometimes the app is shutting down very fast
 				// Only one running
@@ -521,26 +520,10 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 			LOG.warn("Error while detached yarn session was running", t);
 			Assert.fail(t.getMessage());
 		} finally {
-
-			//cleanup the yarn-properties file
-			String confDirPath = System.getenv("FLINK_CONF_DIR");
-			File configDirectory = new File(confDirPath);
-			LOG.info("testDetachedPerJobYarnClusterInternal: Using configuration directory " + configDirectory.getAbsolutePath());
-
-			// load the configuration
-			LOG.info("testDetachedPerJobYarnClusterInternal: Trying to load configuration file");
-			GlobalConfiguration.loadConfiguration(configDirectory.getAbsolutePath());
-
-			try {
-				File yarnPropertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(GlobalConfiguration.loadConfiguration());
-				if(yarnPropertiesFile.exists()) {
-					LOG.info("testDetachedPerJobYarnClusterInternal: Cleaning up temporary Yarn address reference: {}", yarnPropertiesFile.getAbsolutePath());
-					yarnPropertiesFile.delete();
-				}
-			} catch (Exception e) {
-				LOG.warn("testDetachedPerJobYarnClusterInternal: Exception while deleting the JobManager address file", e);
+			//clean up the Yarn application state INI file
+			if(tmpAppId != null) {
+				FlinkYarnSessionCli.removeAppState(tmpAppId.toString());
 			}
-
 		}
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.commons.net.util.Base64;
 import org.apache.flink.client.CliFrontend;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.configuration.ConfigConstants;
@@ -29,7 +30,9 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -73,6 +76,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -399,6 +403,14 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 			flinkConfiguration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, appReport.getHost());
 			flinkConfiguration.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, appReport.getRpcPort());
+
+			//get secure cookie
+			boolean securityEnabled = SecurityUtils.isSecurityEnabled(flinkConfiguration);
+			String secureCookie = flinkConfiguration.getString(ConfigConstants.SECURITY_COOKIE, null);
+			if(applicationID != null && securityEnabled && secureCookie == null) {
+				secureCookie = FlinkYarnSessionCli.getAppSecureCookie(applicationID);
+				flinkConfiguration.setString(ConfigConstants.SECURITY_COOKIE, secureCookie);
+			}
 
 			return createYarnClusterClient(this, yarnClient, appReport, flinkConfiguration, sessionFilesDir, false);
 		} catch (Exception e) {
@@ -834,6 +846,24 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		if(dynamicPropertiesEncoded != null) {
 			appMasterEnv.put(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES, dynamicPropertiesEncoded);
+		}
+
+		//verify if security is enabled and cookie is passed
+		boolean securityEnabled = SecurityUtils.isSecurityEnabled(flinkConfiguration);
+		String secureCookie = flinkConfiguration.getString(ConfigConstants.SECURITY_COOKIE, null);
+		if(securityEnabled) {
+			if(secureCookie == null) {
+				//create cookie if not passed
+				SecureRandom rnd = new SecureRandom();
+				final byte[] secret = new byte[256];
+				rnd.nextBytes(secret);
+				secureCookie = Base64.encodeBase64URLSafeString(secret);
+			}
+		}
+		if(secureCookie != null) {
+			LOG.info("Service Auth is enabled. Adding secure cookie to container environment");
+			appMasterEnv.put(YarnConfigKeys.ENV_SECURE_AUTH_COOKIE, secureCookie);
+			flinkConfiguration.setString(ConfigConstants.SECURITY_COOKIE, secureCookie);
 		}
 
 		// set classpath from YARN configuration

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -53,7 +53,6 @@ import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -374,18 +373,7 @@ public class YarnClusterClient extends ClusterClient {
 			LOG.warn("Error while stopping YARN cluster.", e);
 		}
 
-		try {
-			File propertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(flinkConfig);
-			if (propertiesFile.isFile()) {
-				if (propertiesFile.delete()) {
-					LOG.info("Deleted Yarn properties file at {}", propertiesFile.getAbsoluteFile().toString());
-				} else {
-					LOG.warn("Couldn't delete Yarn properties file at {}", propertiesFile.getAbsoluteFile().toString());
-				}
-			}
-		} catch (Exception e) {
-			LOG.warn("Exception while deleting the JobManager address file", e);
-		}
+		FlinkYarnSessionCli.removeAppState(appId.toString());
 
 		if (sessionFilesDir != null) {
 			LOG.info("Deleting files in " + sessionFilesDir);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -48,6 +48,8 @@ public class YarnConfigKeys {
 	public static final String ENV_KRB5_PATH = "_KRB5_PATH";
 	public static final String ENV_YARN_SITE_XML_PATH = "_YARN_SITE_XML_PATH";
 
+	public static final String ENV_SECURE_AUTH_COOKIE = "_SECURE_AUTH_COOKIE";
+
 	// ------------------------------------------------------------------------
 
 	/** Private constructor to prevent instantiation */

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
@@ -100,6 +100,13 @@ public class YarnTaskManagerRunner {
 			LOG.info("localKeytabPath: {}", localKeytabPath);
 		}
 
+		final String secureCookie = envs.get(YarnConfigKeys.ENV_SECURE_AUTH_COOKIE);
+		if(secureCookie != null) {
+			LOG.info("Found secure Cookie from the environment Map");
+			configuration.setBoolean(ConfigConstants.SECURITY_ENABLED, true);
+			configuration.setString(ConfigConstants.SECURITY_COOKIE, secureCookie);
+		}
+
 		UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
 
 		LOG.info("YARN daemon is running as: {} Yarn client user obtainer: {}",


### PR DESCRIPTION
This PR addresses FLINK-3930 requirements. It enables shared secret based secure cookie authorization for the following components
- Akka layer
- Blob Service
- Web UI

Secure cookie authentication can be enabled by providing below configurations to Flink configuration file.
- `security.enabled`: A boolean value (true|false) indicating security is enabled or not.
- `security.cookie` : Secure cookie value to be used for authentication. For standalone deployment mode, the secure cookie value is mandatory when security is enabled but for the Yarn mode it is optional (auto-generated if not provided).

Alternatively, secure cookie value can be provided through Flink/Yarn CLI using "-k" or "--cookie" parameter option.

The web runtime module prompts for secure cookie using standard basic HTTP authentication mechanism, where the user id field is a noop and the password field will be used to capture the secure cookie. 
