### PR TITLE
[FLINK-3677] Remove Guava dependency from flink-core

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -102,14 +102,6 @@ under the License.
 			<artifactId>joda-convert</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-			<scope>test</scope>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.common.io;
 
-import com.google.common.collect.Lists;
 import org.apache.flink.api.common.io.FileInputFormat.FileBaseStatistics;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
@@ -38,6 +37,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.*;
@@ -359,7 +359,7 @@ public class FileInputFormatTest {
 			format.configure(configuration);
 			format.setFilesFilter(new GlobFilePathFilter(
 				Collections.singletonList("**"),
-				Lists.newArrayList("**/another_file.bin", "**/dataFile1.txt")
+				Arrays.asList(new String[] {"**/another_file.bin", "**/dataFile1.txt"})
 			));
 			FileInputSplit[] splits = format.createInputSplits(1);
 


### PR DESCRIPTION
Removed Guava dependency from flink-core as discussed here: https://github.com/apache/flink/pull/2109

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

