### PR TITLE
[FLINK-4517] scala code refactoring

### DIFF
--- a/flink-batch-connectors/flink-hcatalog/src/main/scala/org/apache/flink/hcatalog/scala/HCatInputFormat.scala
+++ b/flink-batch-connectors/flink-hcatalog/src/main/scala/org/apache/flink/hcatalog/scala/HCatInputFormat.scala
@@ -33,10 +33,10 @@ import org.apache.hive.hcatalog.data.schema.HCatFieldSchema
  *
  */
 class HCatInputFormat[T](
-                        database: String,
-                        table: String,
-                        config: Configuration
-                          ) extends HCatInputFormatBase[T](database, table, config) {
+  database: String,
+  table: String,
+  config: Configuration
+) extends HCatInputFormatBase[T](database, table, config) {
 
   def this(database: String, table: String) {
     this(database, table, new Configuration)
@@ -57,97 +57,83 @@ class HCatInputFormat[T](
     var i: Int = 0
     while (i < this.fieldNames.length) {
 
-        val o: AnyRef = record.get(this.fieldNames(i), this.outputSchema)
+      val o: AnyRef = record.get(this.fieldNames(i), this.outputSchema)
 
-        // partition columns are returned as String
-        //   Check and convert to actual type.
-        this.outputSchema.get(i).getType match {
-          case HCatFieldSchema.Type.INT =>
-            if (o.isInstanceOf[String]) {
-              vals(i) = o.asInstanceOf[String].toInt
-            }
-            else {
-              vals(i) = o.asInstanceOf[Int]
-            }
-          case HCatFieldSchema.Type.TINYINT =>
-            if (o.isInstanceOf[String]) {
-              vals(i) = o.asInstanceOf[String].toInt.toByte
-            }
-            else {
-              vals(i) = o.asInstanceOf[Byte]
-            }
-          case HCatFieldSchema.Type.SMALLINT =>
-            if (o.isInstanceOf[String]) {
-              vals(i) = o.asInstanceOf[String].toInt.toShort
-            }
-            else {
-              vals(i) = o.asInstanceOf[Short]
-            }
-          case HCatFieldSchema.Type.BIGINT =>
-            if (o.isInstanceOf[String]) {
-              vals(i) = o.asInstanceOf[String].toLong
-            }
-            else {
-              vals(i) = o.asInstanceOf[Long]
-            }
-          case HCatFieldSchema.Type.BOOLEAN =>
-            if (o.isInstanceOf[String]) {
-              vals(i) = o.asInstanceOf[String].toBoolean
-            }
-            else {
-              vals(i) = o.asInstanceOf[Boolean]
-            }
-          case HCatFieldSchema.Type.FLOAT =>
-            if (o.isInstanceOf[String]) {
-              vals(i) = o.asInstanceOf[String].toFloat
-            }
-            else {
-              vals(i) = o.asInstanceOf[Float]
-            }
-          case HCatFieldSchema.Type.DOUBLE =>
-            if (o.isInstanceOf[String]) {
-              vals(i) = o.asInstanceOf[String].toDouble
-            }
-            else {
-              vals(i) = o.asInstanceOf[Double]
-            }
-          case HCatFieldSchema.Type.STRING =>
-            vals(i) = o
-          case HCatFieldSchema.Type.BINARY =>
-            if (o.isInstanceOf[String]) {
-              throw new RuntimeException("Cannot handle partition keys of type BINARY.")
-            }
-            else {
-              vals(i) = o.asInstanceOf[Array[Byte]]
-            }
-          case HCatFieldSchema.Type.ARRAY =>
-            if (o.isInstanceOf[String]) {
-              throw new RuntimeException("Cannot handle partition keys of type ARRAY.")
-            }
-            else {
-              vals(i) = o.asInstanceOf[List[Object]]
-            }
-          case HCatFieldSchema.Type.MAP =>
-            if (o.isInstanceOf[String]) {
-              throw new RuntimeException("Cannot handle partition keys of type MAP.")
-            }
-            else {
-              vals(i) = o.asInstanceOf[Map[Object, Object]]
-            }
-          case HCatFieldSchema.Type.STRUCT =>
-            if (o.isInstanceOf[String]) {
-              throw new RuntimeException("Cannot handle partition keys of type STRUCT.")
-            }
-            else {
-              vals(i) = o.asInstanceOf[List[Object]]
-            }
-          case _ =>
-            throw new RuntimeException("Invalid type " + this.outputSchema.get(i).getType +
-              " encountered.")
-        }
-
-        i += 1
+      // partition columns are returned as String
+      //   Check and convert to actual type.
+      this.outputSchema.get(i).getType match {
+        case HCatFieldSchema.Type.INT =>
+          o match {
+            case s: String => vals(i) = s.toInt
+            case _ => vals(i) = o.asInstanceOf[Int]
+          }
+        case HCatFieldSchema.Type.TINYINT =>
+          o match {
+            case s: String => vals(i) = s.toInt.toByte
+            case _ => vals(i) = o.asInstanceOf[Byte]
+          }
+        case HCatFieldSchema.Type.SMALLINT =>
+          o match {
+            case s: String => vals(i) = s.toInt.toShort
+            case _ => vals(i) = o.asInstanceOf[Short]
+          }
+        case HCatFieldSchema.Type.BIGINT =>
+          o match {
+            case s: String => vals(i) = s.toLong
+            case _ => vals(i) = o.asInstanceOf[Long]
+          }
+        case HCatFieldSchema.Type.BOOLEAN =>
+          o match {
+            case s: String => vals(i) = s.toBoolean
+            case _ => vals(i) = o.asInstanceOf[Boolean]
+          }
+        case HCatFieldSchema.Type.FLOAT =>
+          o match {
+            case s: String => vals(i) = s.toFloat
+            case _ => vals(i) = o.asInstanceOf[Float]
+          }
+        case HCatFieldSchema.Type.DOUBLE =>
+          o match {
+            case s: String => vals(i) = s.toDouble
+            case _ => vals(i) = o.asInstanceOf[Double]
+          }
+        case HCatFieldSchema.Type.STRING =>
+          vals(i) = o
+        case HCatFieldSchema.Type.BINARY =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type BINARY.")
+          }
+          else {
+            vals(i) = o.asInstanceOf[Array[Byte]]
+          }
+        case HCatFieldSchema.Type.ARRAY =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type ARRAY.")
+          }
+          else {
+            vals(i) = o.asInstanceOf[List[Object]]
+          }
+        case HCatFieldSchema.Type.MAP =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type MAP.")
+          }
+          else {
+            vals(i) = o.asInstanceOf[Map[Object, Object]]
+          }
+        case HCatFieldSchema.Type.STRUCT =>
+          if (o.isInstanceOf[String]) {
+            throw new RuntimeException("Cannot handle partition keys of type STRUCT.")
+          }
+          else {
+            vals(i) = o.asInstanceOf[List[Object]]
+          }
+        case _ =>
+          throw new RuntimeException("Invalid type " + this.outputSchema.get(i).getType +
+            " encountered.")
       }
+
+      i += 1
+    }
     createScalaTuple(vals)
   }
 
@@ -155,75 +141,75 @@ class HCatInputFormat[T](
 
     this.fieldNames.length match {
       case 1 =>
-        new Tuple1(vals(0)).asInstanceOf[T]
+        Tuple1(vals(0)).asInstanceOf[T]
       case 2 =>
-        new Tuple2(vals(0), vals(1)).asInstanceOf[T]
+        Tuple2(vals(0), vals(1)).asInstanceOf[T]
       case 3 =>
-        new Tuple3(vals(0), vals(1), vals(2)).asInstanceOf[T]
+        Tuple3(vals(0), vals(1), vals(2)).asInstanceOf[T]
       case 4 =>
-        new Tuple4(vals(0), vals(1), vals(2), vals(3)).asInstanceOf[T]
+        Tuple4(vals(0), vals(1), vals(2), vals(3)).asInstanceOf[T]
       case 5 =>
-        new Tuple5(vals(0), vals(1), vals(2), vals(3), vals(4)).asInstanceOf[T]
+        Tuple5(vals(0), vals(1), vals(2), vals(3), vals(4)).asInstanceOf[T]
       case 6 =>
-        new Tuple6(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5)).asInstanceOf[T]
+        Tuple6(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5)).asInstanceOf[T]
       case 7 =>
-        new Tuple7(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6)).asInstanceOf[T]
+        Tuple7(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6)).asInstanceOf[T]
       case 8 =>
-        new Tuple8(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7))
+        Tuple8(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7))
           .asInstanceOf[T]
       case 9 =>
-        new Tuple9(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple9(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8)).asInstanceOf[T]
       case 10 =>
-        new Tuple10(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple10(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9)).asInstanceOf[T]
       case 11 =>
-        new Tuple11(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple11(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10)).asInstanceOf[T]
       case 12 =>
-        new Tuple12(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple12(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11)).asInstanceOf[T]
       case 13 =>
-        new Tuple13(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple13(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12)).asInstanceOf[T]
       case 14 =>
-        new Tuple14(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple14(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13)).asInstanceOf[T]
       case 15 =>
-        new Tuple15(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple15(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14)).asInstanceOf[T]
       case 16 =>
-        new Tuple16(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple16(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14), vals(15))
           .asInstanceOf[T]
       case 17 =>
-        new Tuple17(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple17(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14), vals(15),
           vals(16)).asInstanceOf[T]
       case 18 =>
-        new Tuple18(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple18(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14), vals(15),
           vals(16), vals(17)).asInstanceOf[T]
       case 19 =>
-        new Tuple19(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple19(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14), vals(15),
           vals(16), vals(17), vals(18)).asInstanceOf[T]
       case 20 =>
-        new Tuple20(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple20(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14), vals(15),
           vals(16), vals(17), vals(18), vals(19)).asInstanceOf[T]
       case 21 =>
-        new Tuple21(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple21(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14), vals(15),
           vals(16), vals(17), vals(18), vals(19), vals(20)).asInstanceOf[T]
       case 22 =>
-        new Tuple22(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
+        Tuple22(vals(0), vals(1), vals(2), vals(3), vals(4), vals(5), vals(6), vals(7),
           vals(8), vals(9), vals(10), vals(11), vals(12), vals(13), vals(14), vals(15),
           vals(16), vals(17), vals(18), vals(19), vals(20), vals(21)).asInstanceOf[T]
       case _ =>
         throw new RuntimeException("Only up to 22 fields supported for Scala Tuples.")
 
-  }
+    }
 
   }
 }

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/package.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/package.scala
@@ -40,7 +40,7 @@ package object scala {
 
   private[flink] def cleanClosure[F <: AnyRef](f: F, checkSerializable: Boolean = true): F = {
     ClosureCleaner.clean(f, checkSerializable)
-    return f
+    f
   }
 }
 

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -346,7 +346,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * consisting of (srcVertexId, trgVertexId, srcVertexValue, trgVertexValue, edgeValue)
    */
   def getTriplets(): DataSet[Triplet[K, VV, EV]] = {
-    wrap(jgraph.getTriplets())
+    wrap(jgraph.getTriplets)
   }
 
   /**

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/Splitter.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/Splitter.scala
@@ -18,47 +18,45 @@
 
 package org.apache.flink.ml.preprocessing
 
-import org.apache.flink.api.common.typeinfo.{TypeInformation, BasicTypeInfo}
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.Utils
-import org.apache.flink.api.scala._
-import org.apache.flink.api.scala.DataSet
 import org.apache.flink.api.scala.utils._
-
-
-import org.apache.flink.ml.common.{FlinkMLTools, ParameterMap, WithParameters}
+import org.apache.flink.api.scala.{DataSet, _}
 import org.apache.flink.util.Collector
+
 import _root_.scala.reflect.ClassTag
 
 object Splitter {
 
   case class TrainTestDataSet[T: TypeInformation : ClassTag](training: DataSet[T],
-                                                             testing: DataSet[T])
+    testing: DataSet[T])
 
   case class TrainTestHoldoutDataSet[T: TypeInformation : ClassTag](training: DataSet[T],
-                                                                    testing: DataSet[T],
-                                                                    holdout: DataSet[T])
+    testing: DataSet[T],
+    holdout: DataSet[T])
+
   // --------------------------------------------------------------------------------------------
   //  randomSplit
   // --------------------------------------------------------------------------------------------
   /**
-   * Split a DataSet by the probability fraction of each element.
-   *
-   * @param input           DataSet to be split
-   * @param fraction        Probability that each element is chosen, should be [0,1] This fraction
-   *                        refers to the first element in the resulting array.
-   * @param precise         Sampling by default is random and can result in slightly lop-sided
-   *                        sample sets. When precise is true, equal sample set size are forced,
-   *                        however this is somewhat less efficient.
-   * @param seed            Random number generator seed.
-   * @return An array of two datasets
-   */
+    * Split a DataSet by the probability fraction of each element.
+    *
+    * @param input    DataSet to be split
+    * @param fraction Probability that each element is chosen, should be [0,1] This fraction
+    *                 refers to the first element in the resulting array.
+    * @param precise  Sampling by default is random and can result in slightly lop-sided
+    *                 sample sets. When precise is true, equal sample set size are forced,
+    *                 however this is somewhat less efficient.
+    * @param seed     Random number generator seed.
+    * @return An array of two datasets
+    */
 
   def randomSplit[T: TypeInformation : ClassTag](
-      input: DataSet[T],
-      fraction: Double,
-      precise: Boolean = false,
-      seed: Long = Utils.RNG.nextLong())
-    : Array[DataSet[T]] = {
+    input: DataSet[T],
+    fraction: Double,
+    precise: Boolean = false,
+    seed: Long = Utils.RNG.nextLong())
+  : Array[DataSet[T]] = {
     import org.apache.flink.api.scala._
 
     val indexedInput: DataSet[(Long, T)] = input.zipWithUniqueId
@@ -68,12 +66,11 @@ object Splitter {
     }
 
     val leftSplit: DataSet[(Long, T)] = precise match {
-      case false => indexedInput.sample(false, fraction, seed)
-      case true => {
-        val count = indexedInput.count()  // todo: count only needed for precise and kills perf.
-        val numOfSamples = math.round(fraction * count).toInt
-        indexedInput.sampleWithSize(false, numOfSamples, seed)
-      }
+      case false => indexedInput.sample(withReplacement = false, fraction, seed)
+      case true =>
+        val count = indexedInput.count() // todo: count only needed for precise and kills perf.
+      val numOfSamples = math.round(fraction * count).toInt
+        indexedInput.sampleWithSize(withReplacement = false, numOfSamples, seed)
     }
 
     val leftSplitLight = leftSplit.map(o => (o._1, false))
@@ -81,7 +78,7 @@ object Splitter {
     val rightSplit: DataSet[T] = indexedInput.leftOuterJoin[(Long, Boolean)](leftSplitLight)
       .where(0)
       .equalTo(0).apply {
-        (full: (Long,T) , left: (Long, Boolean), collector: Collector[T]) =>
+      (full: (Long, T), left: (Long, Boolean), collector: Collector[T]) =>
         if (left == null) {
           collector.collect(full._2)
         }
@@ -94,37 +91,36 @@ object Splitter {
   //  multiRandomSplit
   // --------------------------------------------------------------------------------------------
   /**
-   * Split a DataSet by the probability fraction of each element of a vector.
-   *
-   * @param input           DataSet to be split
-   * @param fracArray       An array of PROPORTIONS for splitting the DataSet. Unlike the
-   *                        randomSplit function, number greater than 1 do not lead to over
-   *                        sampling. The number of splits is dictated by the length of this array.
-   *                        The number are normalized, eg. Array(1.0, 2.0) would yield
-   *                        two data sets with a 33/66% split.
-   * @param seed            Random number generator seed.
-   * @return An array of DataSets whose length is equal to the length of fracArray
-   */
+    * Split a DataSet by the probability fraction of each element of a vector.
+    *
+    * @param input           DataSet to be split
+    * @param fracArray       An array of PROPORTIONS for splitting the DataSet. Unlike the
+    *                        randomSplit function, number greater than 1 do not lead to over
+    *                        sampling. The number of splits is dictated by the length of this array.
+    *                        The number are normalized, eg. Array(1.0, 2.0) would yield
+    *                        two data sets with a 33/66% split.
+    * @param seed            Random number generator seed.
+    * @return An array of DataSets whose length is equal to the length of fracArray
+    */
   def multiRandomSplit[T: TypeInformation : ClassTag](
-      input: DataSet[T],
-      fracArray: Array[Double],
-      seed: Long = Utils.RNG.nextLong())
-    : Array[DataSet[T]] = {
+    input: DataSet[T],
+    fracArray: Array[Double],
+    seed: Long = Utils.RNG.nextLong()
+  ): Array[DataSet[T]] = {
 
     import org.apache.commons.math3.distribution.EnumeratedIntegerDistribution
 
-    val eid = new EnumeratedIntegerDistribution((0 to fracArray.length - 1).toArray, fracArray)
+    val eid = new EnumeratedIntegerDistribution(fracArray.indices.toArray, fracArray)
 
     eid.reseedRandomGenerator(seed)
 
-    val tempDS: DataSet[(Int,T)] = input.map(o => (eid.sample, o))
+    val tempDS: DataSet[(Int, T)] = input.map(o => (eid.sample, o))
 
     val splits = fracArray.length
-    val outputArray = new Array[DataSet[T]]( splits )
+    val outputArray = new Array[DataSet[T]](splits)
 
-    for (k <- 0 to splits-1){
-      outputArray(k) = tempDS.filter(o => o._1 == k)
-                             .map(o => o._2)
+    for (k <- 0 until splits) {
+      outputArray(k) = tempDS.filter(o => o._1 == k).map(o => o._2)
     }
 
     outputArray
@@ -134,28 +130,28 @@ object Splitter {
   //  kFoldSplit
   // --------------------------------------------------------------------------------------------
   /**
-   * Split a DataSet into an array of TrainTest DataSets
-   *
-   * @param input           DataSet to be split
-   * @param kFolds          The number of TrainTest DataSets to be returns. Each 'testing' will be
-   *                        1/k of the dataset, randomly sampled, the training will be the remainder
-   *                        of the dataset.  The DataSet is split into kFolds first, so that no
-   *                        observation will occurin in multiple folds.
-   * @param seed            Random number generator seed.
-   * @return An array of TrainTestDataSets
-   */
+    * Split a DataSet into an array of TrainTest DataSets
+    *
+    * @param input  DataSet to be split
+    * @param kFolds The number of TrainTest DataSets to be returns. Each 'testing' will be
+    *               1/k of the dataset, randomly sampled, the training will be the remainder
+    *               of the dataset.  The DataSet is split into kFolds first, so that no
+    *               observation will occurin in multiple folds.
+    * @param seed   Random number generator seed.
+    * @return An array of TrainTestDataSets
+    */
   def kFoldSplit[T: TypeInformation : ClassTag](
-      input: DataSet[T],
-      kFolds: Int,
-      seed: Long = Utils.RNG.nextLong())
-    : Array[TrainTestDataSet[T]] = {
+    input: DataSet[T],
+    kFolds: Int,
+    seed: Long = Utils.RNG.nextLong())
+  : Array[TrainTestDataSet[T]] = {
 
     val fracs = Array.fill(kFolds)(1.0)
     val dataSetArray = multiRandomSplit(input, fracs, seed)
 
-    dataSetArray.map( ds => TrainTestDataSet(dataSetArray.filter(_ != ds)
-                                                         .reduce(_ union _),
-                                             ds))
+    dataSetArray.map(ds => TrainTestDataSet(dataSetArray.filter(_ != ds)
+      .reduce(_ union _),
+      ds))
 
   }
 
@@ -163,23 +159,23 @@ object Splitter {
   //  trainTestSplit
   // --------------------------------------------------------------------------------------------
   /**
-   * A wrapper for randomSplit that yields a TrainTestDataSet
-   *
-   * @param input           DataSet to be split
-   * @param fraction        Probability that each element is chosen, should be [0,1].
-   *                        This fraction refers to the training element in TrainTestSplit
-   * @param precise         Sampling by default is random and can result in slightly lop-sided
-   *                        sample sets. When precise is true, equal sample set size are forced,
-   *                        however this is somewhat less efficient.
-   * @param seed            Random number generator seed.
-   * @return A TrainTestDataSet
-   */
+    * A wrapper for randomSplit that yields a TrainTestDataSet
+    *
+    * @param input    DataSet to be split
+    * @param fraction Probability that each element is chosen, should be [0,1].
+    *                 This fraction refers to the training element in TrainTestSplit
+    * @param precise  Sampling by default is random and can result in slightly lop-sided
+    *                 sample sets. When precise is true, equal sample set size are forced,
+    *                 however this is somewhat less efficient.
+    * @param seed     Random number generator seed.
+    * @return A TrainTestDataSet
+    */
   def trainTestSplit[T: TypeInformation : ClassTag](
-      input: DataSet[T],
-      fraction: Double = 0.6,
-      precise: Boolean = false,
-      seed: Long = Utils.RNG.nextLong())
-    : TrainTestDataSet[T] = {
+    input: DataSet[T],
+    fraction: Double = 0.6,
+    precise: Boolean = false,
+    seed: Long = Utils.RNG.nextLong())
+  : TrainTestDataSet[T] = {
     val dataSetArray = randomSplit(input, fraction, precise, seed)
     TrainTestDataSet(dataSetArray(0), dataSetArray(1))
   }
@@ -188,21 +184,21 @@ object Splitter {
   //  trainTestHoldoutSplit
   // --------------------------------------------------------------------------------------------
   /**
-   * A wrapper for multiRandomSplit that yields a TrainTestHoldoutDataSet
-   *
-   * @param input           DataSet to be split
-   * @param fracTuple       A tuple of three doubles, where the first element specifies the
-   *                        size of the training set, the second element the testing set, and
-   *                        the third element is the holdout set. These are proportional and
-   *                        will be normalized internally.
-   * @param seed            Random number generator seed.
-   * @return A TrainTestDataSet
-   */
+    * A wrapper for multiRandomSplit that yields a TrainTestHoldoutDataSet
+    *
+    * @param input     DataSet to be split
+    * @param fracTuple A tuple of three doubles, where the first element specifies the
+    *                  size of the training set, the second element the testing set, and
+    *                  the third element is the holdout set. These are proportional and
+    *                  will be normalized internally.
+    * @param seed      Random number generator seed.
+    * @return A TrainTestDataSet
+    */
   def trainTestHoldoutSplit[T: TypeInformation : ClassTag](
-      input: DataSet[T],
-      fracTuple: Tuple3[Double, Double, Double] = (0.6,0.3,0.1),
-      seed: Long = Utils.RNG.nextLong())
-    : TrainTestHoldoutDataSet[T] = {
+    input: DataSet[T],
+    fracTuple: (Double, Double, Double) = (0.6, 0.3, 0.1),
+    seed: Long = Utils.RNG.nextLong()
+  ): TrainTestHoldoutDataSet[T] = {
     val fracArray = Array(fracTuple._1, fracTuple._2, fracTuple._3)
     val dataSetArray = multiRandomSplit(input, fracArray, seed)
     TrainTestHoldoutDataSet(dataSetArray(0), dataSetArray(1), dataSetArray(2))

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/regression/MultipleLinearRegression.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/regression/MultipleLinearRegression.scala
@@ -121,18 +121,15 @@ class MultipleLinearRegression extends Predictor[MultipleLinearRegression] {
 
   def squaredResidualSum(input: DataSet[LabeledVector]): DataSet[Double] = {
     weightsOption match {
-      case Some(weights) => {
+      case Some(weights) =>
         input.mapWithBcVariable(weights){
           (dataPoint, weights) => lossFunction.loss(dataPoint, weights)
         }.reduce {
           _ + _
         }
-      }
-
-      case None => {
+      case None =>
         throw new RuntimeException("The MultipleLinearRegression has not been fitted to the " +
           "data. This is necessary to learn the weight vector of the linear function.")
-      }
     }
 
   }
@@ -215,12 +212,9 @@ object MultipleLinearRegression {
         : DataSet[WeightVector] = {
         self.weightsOption match {
           case Some(weights) => weights
-
-
-          case None => {
+          case None =>
             throw new RuntimeException("The MultipleLinearRegression has not been fitted to the " +
               "data. This is necessary to learn the weight vector of the linear function.")
-          }
         }
       }
       override def predict(value: T, model: WeightVector): Double = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/StreamTableEnvironment.scala
@@ -59,7 +59,7 @@ class StreamTableEnvironment(
   def fromDataStream[T](dataStream: DataStream[T]): Table = {
 
     val name = createUniqueTableName()
-    registerDataStreamInternal(name, dataStream.javaStream, false)
+    registerDataStreamInternal(name, dataStream.javaStream, wrapper = false)
     ingest(name)
   }
 
@@ -121,9 +121,8 @@ class StreamTableEnvironment(
     * @tparam T The type of the [[DataStream]] to register.
     */
   def registerDataStream[T](name: String, dataStream: DataStream[T], fields: Expression*): Unit = {
-
     checkValidTableName(name)
-    registerDataStreamInternal(name, dataStream.javaStream, fields.toArray, true)
+    registerDataStreamInternal(name, dataStream.javaStream, fields.toArray, wrapper = true)
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableConversions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/TableConversions.scala
@@ -40,7 +40,7 @@ class TableConversions(table: Table) {
       case tEnv: ScalaBatchTableEnv =>
         tEnv.toDataSet(table)
       case _ =>
-        throw new TableException(
+        throw TableException(
           "Only tables that originate from Scala DataSets can be converted to Scala DataSets.")
     }
   }
@@ -49,10 +49,9 @@ class TableConversions(table: Table) {
   def toDataStream[T: TypeInformation]: DataStream[T] = {
 
     table.tableEnv match {
-      case tEnv: ScalaStreamTableEnv =>
-        tEnv.toDataStream(table)
+      case tEnv: ScalaStreamTableEnv => tEnv.toDataStream(table)
       case _ =>
-        throw new TableException(
+        throw TableException(
           "Only tables that originate from Scala DataStreams " +
             "can be converted to Scala DataStreams.")
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/BatchTableEnvironment.scala
@@ -73,7 +73,7 @@ abstract class BatchTableEnvironment(
     val m = internalNamePattern.findFirstIn(name)
     m match {
       case Some(_) =>
-        throw new ValidationException(s"Illegal Table name. " +
+        throw ValidationException(s"Illegal Table name. " +
           s"Please choose a name that does not contain the pattern $internalNamePattern")
       case None =>
     }
@@ -96,7 +96,7 @@ abstract class BatchTableEnvironment(
     if (isRegistered(tableName)) {
       new Table(this, CatalogNode(tableName, getRowType(tableName)))
     } else {
-      throw new ValidationException(s"Table \'$tableName\' was not found in the registry.")
+      throw ValidationException(s"Table \'$tableName\' was not found in the registry.")
     }
   }
 
@@ -154,7 +154,7 @@ abstract class BatchTableEnvironment(
         // Give the DataSet to the TableSink to emit it.
         batchSink.emitDataSet(result)
       case _ =>
-        throw new TableException("BatchTableSink required to emit batch Table")
+        throw TableException("BatchTableSink required to emit batch Table")
     }
   }
 
@@ -254,13 +254,13 @@ abstract class BatchTableEnvironment(
     }
     catch {
       case e: CannotPlanException =>
-        throw new TableException(
+        throw TableException(
           s"Cannot generate a valid execution plan for the given query: \n\n" +
             s"${RelOptUtil.toString(relNode)}\n" +
             s"This exception indicates that the query uses an unsupported SQL feature.\n" +
             s"Please check the documentation for the set of currently supported SQL features.")
       case t: TableException =>
-        throw new TableException(
+        throw TableException(
         s"Cannot generate a valid execution plan for the given query: \n\n" +
           s"${RelOptUtil.toString(relNode)}\n" +
           s"${t.msg}\n" +

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/FlinkPlannerImpl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/FlinkPlannerImpl.scala
@@ -85,10 +85,9 @@ class FlinkPlannerImpl(
     validator.setIdentifierExpansion(true)
     try {
       validatedSqlNode = validator.validate(sqlNode)
-    }
-    catch {
+    } catch {
       case e: RuntimeException =>
-        throw new ValidationException(s"SQL validation failed. ${e.getMessage}", e)
+        throw ValidationException(s"SQL validation failed. ${e.getMessage}", e)
     }
     validatedSqlNode
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableEnvironment.scala
@@ -106,7 +106,7 @@ abstract class TableEnvironment(val config: TableConfig) {
         functionCatalog.registerSqlFunction(sf.getSqlFunction(name, typeFactory))
 
       case _ =>
-        throw new TableException("Unsupported user-defined function type.")
+        throw TableException("Unsupported user-defined function type.")
     }
   }
 
@@ -121,7 +121,7 @@ abstract class TableEnvironment(val config: TableConfig) {
 
     // check that table belongs to this table environment
     if (table.tableEnv != this) {
-      throw new ValidationException(
+      throw ValidationException(
         "Only tables that belong to this TableEnvironment can be registered.")
     }
 
@@ -151,7 +151,7 @@ abstract class TableEnvironment(val config: TableConfig) {
     if (isRegistered(name)) {
       tables.add(name, table)
     } else {
-      throw new TableException(s"Table \'$name\' is not registered.")
+      throw TableException(s"Table \'$name\' is not registered.")
     }
   }
 
@@ -185,7 +185,7 @@ abstract class TableEnvironment(val config: TableConfig) {
   protected def registerTableInternal(name: String, table: AbstractTable): Unit = {
 
     if (isRegistered(name)) {
-      throw new TableException(s"Table \'$name\' already exists. " +
+      throw TableException(s"Table \'$name\' already exists. " +
         s"Please, choose a different name.")
     } else {
       tables.add(name, table)
@@ -262,7 +262,7 @@ abstract class TableEnvironment(val config: TableConfig) {
       case c: CaseClassTypeInfo[A] => c.getFieldNames
       case p: PojoTypeInfo[A] => p.getFieldNames
       case tpe =>
-        throw new TableException(s"Type $tpe lacks explicit field naming")
+        throw TableException(s"Type $tpe lacks explicit field naming")
     }
     val fieldIndexes = fieldNames.indices.toArray
     (fieldNames, fieldIndexes)
@@ -284,11 +284,11 @@ abstract class TableEnvironment(val config: TableConfig) {
     val indexedNames: Array[(Int, String)] = inputType match {
       case a: AtomicType[A] =>
         if (exprs.length != 1) {
-          throw new TableException("Table of atomic type can only have a single field.")
+          throw TableException("Table of atomic type can only have a single field.")
         }
         exprs.map {
           case UnresolvedFieldReference(name) => (0, name)
-          case _ => throw new TableException("Field reference expression expected.")
+          case _ => throw TableException("Field reference expression expected.")
         }
       case t: TupleTypeInfo[A] =>
         exprs.zipWithIndex.map {
@@ -296,10 +296,10 @@ abstract class TableEnvironment(val config: TableConfig) {
           case (Alias(UnresolvedFieldReference(origName), name), _) =>
             val idx = t.getFieldIndex(origName)
             if (idx < 0) {
-              throw new TableException(s"$origName is not a field of type $t")
+              throw TableException(s"$origName is not a field of type $t")
             }
             (idx, name)
-          case _ => throw new TableException(
+          case _ => throw TableException(
             "Field reference expression or alias on field expression expected.")
         }
       case c: CaseClassTypeInfo[A] =>
@@ -308,10 +308,10 @@ abstract class TableEnvironment(val config: TableConfig) {
           case (Alias(UnresolvedFieldReference(origName), name), _) =>
             val idx = c.getFieldIndex(origName)
             if (idx < 0) {
-              throw new TableException(s"$origName is not a field of type $c")
+              throw TableException(s"$origName is not a field of type $c")
             }
             (idx, name)
-          case _ => throw new TableException(
+          case _ => throw TableException(
             "Field reference expression or alias on field expression expected.")
         }
       case p: PojoTypeInfo[A] =>
@@ -319,19 +319,19 @@ abstract class TableEnvironment(val config: TableConfig) {
           case (UnresolvedFieldReference(name)) =>
             val idx = p.getFieldIndex(name)
             if (idx < 0) {
-              throw new TableException(s"$name is not a field of type $p")
+              throw TableException(s"$name is not a field of type $p")
             }
             (idx, name)
           case Alias(UnresolvedFieldReference(origName), name) =>
             val idx = p.getFieldIndex(origName)
             if (idx < 0) {
-              throw new TableException(s"$origName is not a field of type $p")
+              throw TableException(s"$origName is not a field of type $p")
             }
             (idx, name)
-          case _ => throw new TableException(
+          case _ => throw TableException(
             "Field reference expression or alias on field expression expected.")
         }
-      case tpe => throw new TableException(
+      case tpe => throw TableException(
         s"Source of type $tpe cannot be converted into Table.")
     }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/exceptions.scala
@@ -21,12 +21,12 @@ package org.apache.flink.api.table
 /**
   * Exception for all errors occurring during expression parsing.
   */
-case class ExpressionParserException(msg: String) extends RuntimeException(msg)
+final case class ExpressionParserException(msg: String) extends RuntimeException(msg)
 
 /**
   * Exception for all errors occurring during sql parsing.
   */
-case class SqlParserException(
+final case class SqlParserException(
     msg: String,
     cause: Throwable)
   extends RuntimeException(msg, cause) {
@@ -38,18 +38,17 @@ case class SqlParserException(
 /**
   * General Exception for all errors during table handling.
   */
-case class TableException(msg: String) extends RuntimeException(msg)
+final case class TableException(msg: String) extends RuntimeException(msg)
 
 /**
   * Exception for all errors occurring during validation phase.
   */
-case class ValidationException(
-    msg: String,
-    cause: Throwable)
-  extends RuntimeException(msg, cause) {
+final case class ValidationException(
+  msg: String,
+  cause: Throwable
+) extends RuntimeException(msg, cause) {
 
   def this(msg: String) = this(msg, null)
-
 }
 
 object ValidationException {
@@ -59,4 +58,4 @@ object ValidationException {
 /**
   * Exception for unwanted method calling on unresolved expression.
   */
-case class UnresolvedException(msg: String) extends RuntimeException(msg)
+final case class UnresolvedException(msg: String) extends RuntimeException(msg)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/fieldExpression.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/fieldExpression.scala
@@ -19,13 +19,13 @@ package org.apache.flink.api.table.expressions
 
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.tools.RelBuilder
-
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.table.UnresolvedException
 import org.apache.flink.api.table.validate.{ExprValidationResult, ValidationFailure}
 
 trait NamedExpression extends Expression {
   private[flink] def name: String
+
   private[flink] def toAttribute: Attribute
 }
 
@@ -39,19 +39,20 @@ case class UnresolvedFieldReference(name: String) extends Attribute {
 
   override def toString = "\"" + name
 
-  override private[flink] def withName(newName: String): Attribute =
-    UnresolvedFieldReference(newName)
+  override private[flink] def withName(newName: String): Attribute = UnresolvedFieldReference(newName)
 
-  override private[flink] def resultType: TypeInformation[_] =
-    throw new UnresolvedException(s"calling resultType on ${this.getClass}")
+  override private[flink] def resultType: TypeInformation[_] = {
+    throw UnresolvedException(s"calling resultType on ${this.getClass}")
+  }
 
-  override private[flink] def validateInput(): ExprValidationResult =
+  override private[flink] def validateInput(): ExprValidationResult = {
     ValidationFailure(s"Unresolved reference $name")
+  }
 }
 
 case class ResolvedFieldReference(
-    name: String,
-    resultType: TypeInformation[_]) extends Attribute {
+  name: String,
+  resultType: TypeInformation[_]) extends Attribute {
 
   override def toString = s"'$name"
 
@@ -69,7 +70,7 @@ case class ResolvedFieldReference(
 }
 
 case class Alias(child: Expression, name: String)
-    extends UnaryExpression with NamedExpression {
+  extends UnaryExpression with NamedExpression {
 
   override def toString = s"$child as '$name"
 
@@ -96,13 +97,13 @@ case class Alias(child: Expression, name: String)
 case class UnresolvedAlias(child: Expression) extends UnaryExpression with NamedExpression {
 
   override private[flink] def name: String =
-    throw new UnresolvedException("Invalid call to name on UnresolvedAlias")
+    throw UnresolvedException("Invalid call to name on UnresolvedAlias")
 
   override private[flink] def toAttribute: Attribute =
-    throw new UnresolvedException("Invalid call to toAttribute on UnresolvedAlias")
+    throw UnresolvedException("Invalid call to toAttribute on UnresolvedAlias")
 
   override private[flink] def resultType: TypeInformation[_] =
-    throw new UnresolvedException("Invalid call to resultType on UnresolvedAlias")
+    throw UnresolvedException("Invalid call to resultType on UnresolvedAlias")
 
   override private[flink] lazy val valid = false
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/ScalarFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/ScalarFunction.scala
@@ -78,7 +78,7 @@ abstract class ScalarFunction extends UserDefinedFunction {
       }
 
     if (methods.isEmpty) {
-      throw new ValidationException(s"Scalar function class '$this' does not implement at least " +
+      throw ValidationException(s"Scalar function class '$this' does not implement at least " +
         s"one method named 'eval' which is public and not abstract.")
     } else {
       methods
@@ -135,7 +135,7 @@ abstract class ScalarFunction extends UserDefinedFunction {
         TypeExtractor.getForClass(c)
       } catch {
         case ite: InvalidTypesException =>
-          throw new ValidationException(s"Parameter types of scalar function '$this' cannot be " +
+          throw ValidationException(s"Parameter types of scalar function '$this' cannot be " +
             s"automatically determined. Please provide type information manually.")
       }
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/utils/ScalarSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/utils/ScalarSqlFunction.scala
@@ -78,7 +78,7 @@ object ScalarSqlFunction {
           }
         val foundSignature = getSignature(scalarFunction, parameters)
         if (foundSignature.isEmpty) {
-          throw new ValidationException(
+          throw ValidationException(
             s"Given parameters of function '$name' do not match any signature. \n" +
               s"Actual: ${signatureToString(parameters)} \n" +
               s"Expected: ${signaturesToString(scalarFunction)}")
@@ -105,7 +105,7 @@ object ScalarSqlFunction {
         val operandTypeInfo = getOperandTypeInfo(callBinding)
 
         val foundSignature = getSignature(scalarFunction, operandTypeInfo)
-          .getOrElse(throw new ValidationException(s"Operand types of could not be inferred."))
+          .getOrElse(throw ValidationException(s"Operand types of could not be inferred."))
 
         val inferredTypes = scalarFunction
           .getParameterTypes(foundSignature)
@@ -146,7 +146,7 @@ object ScalarSqlFunction {
 
         if (foundSignature.isEmpty) {
           if (throwOnFailure) {
-            throw new ValidationException(
+            throw ValidationException(
               s"Given parameters of function '$name' do not match any signature. \n" +
                 s"Actual: ${signatureToString(operandTypeInfo)} \n" +
                 s"Expected: ${signaturesToString(scalarFunction)}")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/utils/UserDefinedFunctionUtils.scala
@@ -145,7 +145,7 @@ object UserDefinedFunctionUtils {
     // find method for signature
     val evalMethod = scalarFunction.getEvalMethods
       .find(m => signature.sameElements(m.getParameterTypes))
-      .getOrElse(throw new ValidationException("Given signature is invalid."))
+      .getOrElse(throw ValidationException("Given signature is invalid."))
 
     val userDefinedTypeInfo = scalarFunction.getResultType(signature)
     if (userDefinedTypeInfo != null) {
@@ -155,7 +155,7 @@ object UserDefinedFunctionUtils {
         TypeExtractor.getForClass(evalMethod.getReturnType)
       } catch {
         case ite: InvalidTypesException =>
-          throw new ValidationException(s"Return type of scalar function '$this' cannot be " +
+          throw ValidationException(s"Return type of scalar function '$this' cannot be " +
             s"automatically determined. Please provide type information manually.")
       }
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/LogicalNode.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/LogicalNode.scala
@@ -140,7 +140,7 @@ abstract class LogicalNode extends TreeNode[LogicalNode] {
   }
 
   protected def failValidation(msg: String): Nothing = {
-    throw new ValidationException(msg)
+    throw ValidationException(msg)
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/logical/operators.scala
@@ -464,9 +464,7 @@ case class Join(
   }
 }
 
-case class CatalogNode(
-    tableName: String,
-    rowType: RelDataType) extends LeafNode {
+case class CatalogNode(tableName: String, rowType: RelDataType) extends LeafNode {
 
   val output: Seq[Attribute] = rowType.getFieldList.asScala.map { field =>
     ResolvedFieldReference(field.getName, FlinkTypeFactory.toTypeInfo(field.getType))
@@ -482,8 +480,7 @@ case class CatalogNode(
 /**
   * Wrapper for valid logical plans generated from SQL String.
   */
-case class LogicalRelNode(
-    relNode: RelNode) extends LeafNode {
+case class LogicalRelNode(relNode: RelNode) extends LeafNode {
 
   val output: Seq[Attribute] = relNode.getRowType.getFieldList.asScala.map { field =>
     ResolvedFieldReference(field.getName, FlinkTypeFactory.toTypeInfo(field.getType))

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetJoin.scala
@@ -113,7 +113,7 @@ class DataSetJoin(
     val rightKeys = ArrayBuffer.empty[Int]
     if (keyPairs.isEmpty) {
       // if no equality keys => not supported
-      throw new TableException(
+      throw TableException(
         "Joins should have at least one equality condition.\n" +
           s"\tLeft: ${left.toString},\n" +
           s"\tRight: ${right.toString},\n" +
@@ -135,7 +135,7 @@ class DataSetJoin(
           leftKeys.add(pair.source)
           rightKeys.add(pair.target)
         } else {
-          throw new TableException(
+          throw TableException(
             "Equality join predicate on incompatible types.\n" +
               s"\tLeft: ${left.toString},\n" +
               s"\tRight: ${right.toString},\n" +
@@ -156,7 +156,7 @@ class DataSetJoin(
     }
 
     if (nullCheck && !config.getNullCheck) {
-      throw new TableException("Null check in TableConfig must be enabled for outer joins.")
+      throw TableException("Null check in TableConfig must be enabled for outer joins.")
     }
 
     val generator = new CodeGenerator(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateRule.scala
@@ -40,13 +40,13 @@ class DataSetAggregateRule
     // check if we have distinct aggregates
     val distinctAggs = agg.getAggCallList.exists(_.isDistinct)
     if (distinctAggs) {
-      throw new TableException("DISTINCT aggregates are currently not supported.")
+      throw TableException("DISTINCT aggregates are currently not supported.")
     }
 
     // check if we have grouping sets
     val groupSets = agg.getGroupSets.size() != 1 || agg.getGroupSets.get(0) != agg.getGroupSet
     if (groupSets || agg.indicator) {
-      throw new TableException("GROUPING SETS are currently not supported.")
+      throw TableException("GROUPING SETS are currently not supported.")
     }
 
     !distinctAggs && !groupSets && !agg.indicator

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/DataStreamTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/DataStreamTable.scala
@@ -23,17 +23,20 @@ import org.apache.flink.api.table.FlinkTypeFactory
 import org.apache.flink.streaming.api.datastream.DataStream
 
 class DataStreamTable[T](
-    val dataStream: DataStream[T],
-    override val fieldIndexes: Array[Int],
-    override val fieldNames: Array[String])
-  extends FlinkTable[T](dataStream.getType, fieldIndexes, fieldNames) {
+  val dataStream: DataStream[T],
+  override val fieldIndexes: Array[Int],
+  override val fieldNames: Array[String]
+) extends FlinkTable[T](dataStream.getType, fieldIndexes, fieldNames) {
 
   override def getRowType(typeFactory: RelDataTypeFactory): RelDataType = {
     val flinkTypeFactory = typeFactory.asInstanceOf[FlinkTypeFactory]
     val builder = typeFactory.builder
-    fieldNames.zip(fieldTypes)
-      .foreach( f =>
-        builder.add(f._1, flinkTypeFactory.createTypeFromTypeInfo(f._2)).nullable(true) )
+    fieldNames
+      .zip(fieldTypes)
+      .foreach { f =>
+        builder.add(f._1, flinkTypeFactory.createTypeFromTypeInfo(f._2)).nullable(true)
+      }
+
     builder.build
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/FlinkTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/FlinkTable.scala
@@ -31,13 +31,13 @@ abstract class FlinkTable[T](
   extends AbstractTable {
 
   if (fieldIndexes.length != fieldNames.length) {
-    throw new TableException(
+    throw TableException(
       "Number of field indexes and field names must be equal.")
   }
 
   // check uniqueness of field names
   if (fieldNames.length != fieldNames.toSet.size) {
-    throw new TableException(
+    throw TableException(
       "Table field names must be unique.")
   }
 
@@ -45,14 +45,14 @@ abstract class FlinkTable[T](
     typeInfo match {
       case cType: CompositeType[T] =>
         if (fieldNames.length != cType.getArity) {
-          throw new TableException(
+          throw TableException(
           s"Arity of type (" + cType.getFieldNames.deep + ") " +
             "not equal to number of field names " + fieldNames.deep + ".")
         }
         fieldIndexes.map(cType.getTypeAt(_).asInstanceOf[TypeInformation[_]])
       case aType: AtomicType[T] =>
         if (fieldIndexes.length != 1 || fieldIndexes(0) != 0) {
-          throw new TableException(
+          throw TableException(
             "Non-composite input type may have only a single field and its index must be 0.")
         }
         Array(aType)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/runtime/aggregate/AggregateUtil.scala
@@ -88,7 +88,7 @@ object AggregateUtil {
 
     if (groupingOffsetMapping.length != groupings.length ||
         aggOffsetMapping.length != namedAggregates.length) {
-      throw new TableException("Could not find output field in input data type " +
+      throw TableException("Could not find output field in input data type " +
           "or aggregate functions.")
     }
 
@@ -130,11 +130,11 @@ object AggregateUtil {
         if (aggregateCall.getAggregation.isInstanceOf[SqlCountAggFunction]) {
           aggFieldIndexes(index) = 0
         } else {
-          throw new TableException("Aggregate fields should not be empty.")
+          throw TableException("Aggregate fields should not be empty.")
         }
       } else {
         if (argList.size() > 1) {
-          throw new TableException("Currently, do not support aggregate on multi fields.")
+          throw TableException("Currently, do not support aggregate on multi fields.")
         }
         aggFieldIndexes(index) = argList.get(0)
       }
@@ -157,7 +157,7 @@ object AggregateUtil {
             case DECIMAL =>
               new DecimalSumAggregate
             case sqlType: SqlTypeName =>
-              throw new TableException("Sum aggregate does no support type:" + sqlType)
+              throw TableException("Sum aggregate does no support type:" + sqlType)
           }
         }
         case _: SqlAvgAggFunction => {
@@ -177,7 +177,7 @@ object AggregateUtil {
             case DECIMAL =>
               new DecimalAvgAggregate
             case sqlType: SqlTypeName =>
-              throw new TableException("Avg aggregate does no support type:" + sqlType)
+              throw TableException("Avg aggregate does no support type:" + sqlType)
           }
         }
         case sqlMinMaxFunction: SqlMinMaxAggFunction => {
@@ -200,7 +200,7 @@ object AggregateUtil {
               case BOOLEAN =>
                 new BooleanMinAggregate
               case sqlType: SqlTypeName =>
-                throw new TableException("Min aggregate does no support type:" + sqlType)
+                throw TableException("Min aggregate does no support type:" + sqlType)
             }
           } else {
             sqlTypeName match {
@@ -221,14 +221,14 @@ object AggregateUtil {
               case BOOLEAN =>
                 new BooleanMaxAggregate
               case sqlType: SqlTypeName =>
-                throw new TableException("Max aggregate does no support type:" + sqlType)
+                throw TableException("Max aggregate does no support type:" + sqlType)
             }
           }
         }
         case _: SqlCountAggFunction =>
           aggregates(index) = new CountAggregate
         case unSupported: SqlAggFunction =>
-          throw new TableException("unsupported Function: " + unSupported.getName)
+          throw TableException("unsupported Function: " + unSupported.getName)
       }
       setAggregateDataOffset(index)
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/table.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/table.scala
@@ -202,7 +202,7 @@ class Table(
     */
   def groupBy(fields: Expression*): GroupedTable = {
     if (tableEnv.isInstanceOf[StreamTableEnvironment]) {
-      throw new ValidationException(s"Group by on stream tables is currently not supported.")
+      throw ValidationException(s"Group by on stream tables is currently not supported.")
     }
     new GroupedTable(this, fields)
   }
@@ -394,7 +394,7 @@ class Table(
   private def join(right: Table, joinPredicate: Option[Expression], joinType: JoinType): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.tableEnv != this.tableEnv) {
-      throw new ValidationException("Only tables from the same TableEnvironment can be joined.")
+      throw ValidationException("Only tables from the same TableEnvironment can be joined.")
     }
     new Table(
       tableEnv,
@@ -418,7 +418,7 @@ class Table(
   def minus(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.tableEnv != this.tableEnv) {
-      throw new ValidationException("Only tables from the same TableEnvironment can be " +
+      throw ValidationException("Only tables from the same TableEnvironment can be " +
         "subtracted.")
     }
     new Table(tableEnv, Minus(logicalPlan, right.logicalPlan, all = false)
@@ -443,11 +443,10 @@ class Table(
   def minusAll(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.tableEnv != this.tableEnv) {
-      throw new ValidationException("Only tables from the same TableEnvironment can be " +
+      throw ValidationException("Only tables from the same TableEnvironment can be " +
         "subtracted.")
     }
-    new Table(tableEnv, Minus(logicalPlan, right.logicalPlan, all = true)
-      .validate(tableEnv))
+    new Table(tableEnv, Minus(logicalPlan, right.logicalPlan, all = true).validate(tableEnv))
   }
 
   /**
@@ -465,7 +464,7 @@ class Table(
   def union(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.tableEnv != this.tableEnv) {
-      throw new ValidationException("Only tables from the same TableEnvironment can be unioned.")
+      throw ValidationException("Only tables from the same TableEnvironment can be unioned.")
     }
     new Table(tableEnv, Union(logicalPlan, right.logicalPlan, all = false).validate(tableEnv))
   }
@@ -485,7 +484,7 @@ class Table(
   def unionAll(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.tableEnv != this.tableEnv) {
-      throw new ValidationException("Only tables from the same TableEnvironment can be unioned.")
+      throw ValidationException("Only tables from the same TableEnvironment can be unioned.")
     }
     new Table(tableEnv, Union(logicalPlan, right.logicalPlan, all = true).validate(tableEnv))
   }
@@ -507,7 +506,7 @@ class Table(
   def intersect(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.tableEnv != this.tableEnv) {
-      throw new ValidationException(
+      throw ValidationException(
         "Only tables from the same TableEnvironment can be intersected.")
     }
     new Table(tableEnv, Intersect(logicalPlan, right.logicalPlan, all = false).validate(tableEnv))
@@ -530,7 +529,7 @@ class Table(
   def intersectAll(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.tableEnv != this.tableEnv) {
-      throw new ValidationException(
+      throw ValidationException(
         "Only tables from the same TableEnvironment can be intersected.")
     }
     new Table(tableEnv, Intersect(logicalPlan, right.logicalPlan, all = true).validate(tableEnv))
@@ -547,11 +546,9 @@ class Table(
     * }}}
     */
   def orderBy(fields: Expression*): Table = {
-    val order: Seq[Ordering] = fields.map { case e =>
-      e match {
-        case o: Ordering => o
-        case _ => Asc(e)
-      }
+    val order: Seq[Ordering] = fields.map {
+      case o: Ordering => o
+      case e => Asc(e)
     }
     new Table(tableEnv, Sort(order, logicalPlan).validate(tableEnv))
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/typeutils/TypeConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/typeutils/TypeConverter.scala
@@ -70,7 +70,7 @@ object TypeConverter {
       // check if expected physical type is compatible with logical field type
       case Some(typeInfo) if typeInfo.getTypeClass != classOf[Row] =>
         if (typeInfo.getArity != logicalFieldTypes.length) {
-          throw new TableException("Arity of result does not match expected type.")
+          throw TableException("Arity of result does not match expected type.")
         }
         typeInfo match {
 
@@ -80,11 +80,11 @@ object TypeConverter {
               case (fName, fType) =>
                 val pojoIdx = pt.getFieldIndex(fName)
                 if (pojoIdx < 0) {
-                  throw new TableException(s"POJO does not define field name: $fName")
+                  throw TableException(s"POJO does not define field name: $fName")
                 }
                 val expectedTypeInfo = pt.getTypeAt(pojoIdx)
                 if (fType != expectedTypeInfo) {
-                  throw new TableException(s"Result field does not match expected type. " +
+                  throw TableException(s"Result field does not match expected type. " +
                     s"Expected: $expectedTypeInfo; Actual: $fType")
                 }
             }
@@ -95,7 +95,7 @@ object TypeConverter {
               case (fieldTypeInfo, i) =>
                 val expectedTypeInfo = ct.getTypeAt(i)
                 if (fieldTypeInfo != expectedTypeInfo) {
-                  throw new TableException(s"Result field does not match expected type. " +
+                  throw TableException(s"Result field does not match expected type. " +
                     s"Expected: $expectedTypeInfo; Actual: $fieldTypeInfo")
                 }
             }
@@ -104,12 +104,12 @@ object TypeConverter {
           case at: AtomicType[_] =>
             val fieldTypeInfo = logicalFieldTypes.head
             if (fieldTypeInfo != at) {
-              throw new TableException(s"Result field does not match expected type. " +
+              throw TableException(s"Result field does not match expected type. " +
                 s"Expected: $at; Actual: $fieldTypeInfo")
             }
 
           case _ =>
-            throw new TableException("Unsupported result type.")
+            throw TableException("Unsupported result type.")
         }
         typeInfo
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/validate/FunctionCatalog.scala
@@ -81,7 +81,7 @@ class FunctionCatalog {
           case Success(seqCtor) =>
             Try(seqCtor.newInstance(children).asInstanceOf[Expression]) match {
               case Success(expr) => expr
-              case Failure(e) => throw new ValidationException(e.getMessage)
+              case Failure(e) => throw ValidationException(e.getMessage)
             }
           case Failure(e) =>
             val childrenClass = Seq.fill(children.length)(classOf[Expression])

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1090,10 +1090,12 @@ class JobManager(
         }
 
         val restartStrategy =
-          Option(jobGraph.getSerializedExecutionConfig()
+          Option(
+            jobGraph.getSerializedExecutionConfig
             .deserializeValue(userCodeLoader)
-            .getRestartStrategy())
-            .map(RestartStrategyFactory.createRestartStrategy(_)) match {
+            .getRestartStrategy
+          )
+            .map(RestartStrategyFactory.createRestartStrategy) match {
             case Some(strategy) => strategy
             case None => restartStrategyFactory.createRestartStrategy()
           }
@@ -2416,12 +2418,12 @@ object JobManager {
         s"Invalid command line arguments: ${args.mkString(" ")}. Usage: ${parser.usage}")
     }
     
-    val configDir = config.getConfigDir()
+    val configDir = config.getConfigDir
     
     if (configDir == null) {
       throw new Exception("Missing parameter '--configDir'")
     }
-    if (config.getJobManagerMode() == null) {
+    if (config.getJobManagerMode == null) {
       throw new Exception("Missing parameter '--executionMode'")
     }
 
@@ -2432,22 +2434,21 @@ object JobManager {
       FileSystem.setDefaultScheme(configuration)
     }
     catch {
-      case e: IOException => {
+      case e: IOException =>
         throw new Exception("Error while setting the default " +
           "filesystem scheme from configuration.", e)
-      }
     }
 
     if (new File(configDir).isDirectory) {
       configuration.setString(ConfigConstants.FLINK_BASE_DIR_PATH_KEY, configDir + "/..")
     }
 
-    if (config.getWebUIPort() >= 0) {
-      configuration.setInteger(ConfigConstants.JOB_MANAGER_WEB_PORT_KEY, config.getWebUIPort())
+    if (config.getWebUIPort >= 0) {
+      configuration.setInteger(ConfigConstants.JOB_MANAGER_WEB_PORT_KEY, config.getWebUIPort)
     }
 
-    if (config.getHost() != null) {
-      configuration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, config.getHost())
+    if (config.getHost != null) {
+      configuration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, config.getHost)
     }
 
     val host = configuration.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null)

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -749,10 +749,10 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     *
     */
   def maxBy(fields: Int*) : DataSet[T] = {
-    if (!getType.isTupleType) {
+    if (!getType().isTupleType) {
       throw new InvalidProgramException("DataSet#maxBy(int...) only works on Tuple types.")
     }
-    reduce(new SelectByMaxFunction[T](getType.asInstanceOf[TupleTypeInfoBase[T]], fields.toArray))
+    reduce(new SelectByMaxFunction[T](getType().asInstanceOf[TupleTypeInfoBase[T]], fields.toArray))
   }
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -63,7 +63,7 @@ class DataStream[T](stream: JavaStream[T]) {
    */
   @deprecated
   @PublicEvolving
-  def getType(): TypeInformation[T] = stream.getType()
+  def getType(): TypeInformation[T] = stream.getType
 
   /**
    * Returns the parallelism of this operation.
@@ -87,7 +87,7 @@ class DataStream[T](stream: JavaStream[T]) {
    * Returns the ID of the DataStream.
    */
   @Internal
-  private[flink] def getId = stream.getId()
+  private[flink] def getId = stream.getId
   
   // --------------------------------------------------------------------------
   //  Scalaesk accessors 
@@ -101,24 +101,24 @@ class DataStream[T](stream: JavaStream[T]) {
   /**
    * Returns the TypeInformation for the elements of this DataStream.
    */
-  def dataType: TypeInformation[T] = stream.getType()
+  def dataType: TypeInformation[T] = stream.getType
 
   /**
    * Returns the execution config.
    */
-  def executionConfig: ExecutionConfig = stream.getExecutionConfig()
+  def executionConfig: ExecutionConfig = stream.getExecutionConfig
 
   /**
    * Returns the [[StreamExecutionEnvironment]] associated with this data stream
    */
   def executionEnvironment: StreamExecutionEnvironment =
-    new StreamExecutionEnvironment(stream.getExecutionEnvironment())
+    new StreamExecutionEnvironment(stream.getExecutionEnvironment)
   
   
   /**
    * Returns the parallelism of this operation.
    */
-  def parallelism: Int = stream.getParallelism()
+  def parallelism: Int = stream.getParallelism
 
   /**
    * Sets the parallelism of this operation. This must be at least 1.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/package.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/package.scala
@@ -39,8 +39,7 @@ package object scala {
    * Converts an [[org.apache.flink.streaming.api.datastream.DataStream]] to a
    * [[org.apache.flink.streaming.api.scala.DataStream]].
    */
-  private[flink] def asScalaStream[R](stream: JavaStream[R])
-                                             = new DataStream[R](stream)
+  private[flink] def asScalaStream[R](stream: JavaStream[R]) = new DataStream[R](stream)
 
   /**
    * Converts an [[org.apache.flink.streaming.api.datastream.KeyedStream]] to a

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/types/TypeInformationGenTest.scala
@@ -198,7 +198,7 @@ class TypeInformationGenTest {
     Assert.assertEquals(9, ti.getArity)
     Assert.assertTrue(ti.isInstanceOf[TupleTypeInfoBase[_]])
     val tti = ti.asInstanceOf[TupleTypeInfoBase[_]]
-    Assert.assertEquals(classOf[Tuple9[_,_,_,_,_,_,_,_,_]], tti.getTypeClass)
+    Assert.assertEquals(classOf[(_, _, _, _, _, _, _, _, _)], tti.getTypeClass)
     for (i <- 0 until 9) {
       Assert.assertTrue(tti.getTypeAt(i).isInstanceOf[BasicTypeInfo[_]])
     }


### PR DESCRIPTION
the refacter type:

1. case class does't need `new`
2. case block does't need `{  ...  }`
3. match-case instead of isInstanceOf 

references the related [FLINK-4517]

