### PR TITLE
[FLINK-4519] scala maxLineLength increased to 120

### DIFF
--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -18,35 +18,34 @@ specific language governing permissions and limitations
 under the License.
 -->
 <!DOCTYPE module PUBLIC
-          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-
+	"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+	"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">
-		<property name="file" value="${checkstyle.suppressions.file}" />
+		<property name="file" value="${checkstyle.suppressions.file}"/>
 	</module>
 
 	<!-- Syntax:    //CHECKSTYLE.OFF: CheckstyleModuleToDisable - Reason for deactivation. -->
 	<!--            //CHECKSTYLE.ON: CheckstyleModuleToReEnable                            -->
 	<module name="SuppressionCommentFilter">
-    		<property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+) - (.+)"/>
-    		<property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
-    		<property name="checkFormat" value="$1"/>
+		<property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+) - (.+)"/>
+		<property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+		<property name="checkFormat" value="$1"/>
 	</module>
 
-    <module name="FileLength">
-        <property name="max" value="2500"/>
-    </module>
+	<module name="FileLength">
+		<property name="max" value="2500"/>
+	</module>
 
 	<module name="TreeWalker">
 		<module name="RegexpSinglelineJava">
-			<property name="format" value="^\t* +\t*\S" />
+			<property name="format" value="^\t* +\t*\S"/>
 			<property name="message"
-				value="Line has leading space characters; indentation should be performed with tabs only." />
-			<property name="ignoreComments" value="true" />
+					  value="Line has leading space characters; indentation should be performed with tabs only."/>
+			<property name="ignoreComments" value="true"/>
 		</module>
-		<module name="AvoidStarImport" />
+		<module name="AvoidStarImport"/>
 		<module name="UnusedImports">
 			<!-- Allow imports for JavaDocs -->
 			<property name="processJavadoc" value="true"/>
@@ -58,7 +57,8 @@ under the License.
 		<module name="Regexp">
 			<property name="format" value="org\.apache\.commons\.lang3\.Validate"/>
 			<property name="illegalPattern" value="true"/>
-			<property name="message" value="Use Guava Checks instead of Commons Validate. Please refer to the coding guidelines."/>
+			<property name="message"
+					  value="Use Guava Checks instead of Commons Validate. Please refer to the coding guidelines."/>
 		</module>
 		<!-- forbid the use of google.common.base.Preconditions -->
 		<module name="Regexp">
@@ -120,40 +120,40 @@ under the License.
 		<module name="NeedBraces">
 			<property name="tokens" value="LITERAL_IF, LITERAL_ELSE"/>
 		</module>
-		<module name="ArrayTypeStyle" />
+		<module name="ArrayTypeStyle"/>
 
 		<module name="FileContentsHolder"/>
 
-	<!--	<module name="ConstantName" />
-		<module name="LocalFinalVariableName" />
-		<module name="LocalVariableName" />
-		<module name="MemberName" />
-		<module name="MethodName" />
-		<module name="PackageName" />
-		<module name="ParameterName" />
-  	<module name="StaticVariableName" />
-		<module name="TypeName" />
-		<module name="AvoidStarImport" />
-		<module name="RedundantImport" />
-		<module name="UnusedImports" />
-	  <module name="MethodLength" />
-		<module name="ParameterNumber" />
-		<module name="AvoidNestedBlocks" />
-		<module name="EmptyBlock" />
-		<module name="LeftCurly" />
-		<module name="NeedBraces" />
-		<module name="RightCurly" /> 
-		<module name="EmptyStatement" />
-		<module name="EqualsHashCode" />
-		<module name="IllegalInstantiation" />
-		<module name="MissingSwitchDefault" />
-		<module name="RedundantThrows" />
-		<module name="SimplifyBooleanExpression" />
-		<module name="SimplifyBooleanReturn" />
-		<module name="HideUtilityClassConstructor" />
-		<module name="InterfaceIsType" />
-		<module name="VisibilityModifier" />
-		<module name="ArrayTypeStyle" />
-		<module name="UpperEll" /> -->
+		<!--	<module name="ConstantName" />
+        <module name="LocalFinalVariableName" />
+        <module name="LocalVariableName" />
+        <module name="MemberName" />
+        <module name="MethodName" />
+        <module name="PackageName" />
+        <module name="ParameterName" />
+        <module name="StaticVariableName" />
+        <module name="TypeName" />
+        <module name="AvoidStarImport" />
+        <module name="RedundantImport" />
+        <module name="UnusedImports" />
+        <module name="MethodLength" />
+        <module name="ParameterNumber" />
+        <module name="AvoidNestedBlocks" />
+        <module name="EmptyBlock" />
+        <module name="LeftCurly" />
+        <module name="NeedBraces" />
+        <module name="RightCurly" />
+        <module name="EmptyStatement" />
+        <module name="EqualsHashCode" />
+        <module name="IllegalInstantiation" />
+        <module name="MissingSwitchDefault" />
+        <module name="RedundantThrows" />
+        <module name="SimplifyBooleanExpression" />
+        <module name="SimplifyBooleanReturn" />
+        <module name="HideUtilityClassConstructor" />
+        <module name="InterfaceIsType" />
+        <module name="VisibilityModifier" />
+        <module name="ArrayTypeStyle" />
+        <module name="UpperEll" /> -->
 	</module>
 </module>

--- a/tools/maven/scalastyle-config.xml
+++ b/tools/maven/scalastyle-config.xml
@@ -25,16 +25,16 @@
 <!-- // scalastyle:on -->
 
 <scalastyle>
- <name>Scalastyle standard configuration</name>
- <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
- <!-- <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="maxFileLength"><![CDATA[800]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
-  <parameters>
-      <parameter name="header"><![CDATA[/*
+	<name>Scalastyle standard configuration</name>
+	<check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
+	<!-- <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="maxFileLength"><![CDATA[800]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+		<parameters>
+			<parameter name="header"><![CDATA[/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -51,96 +51,97 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */]]></parameter>
-  </parameters>
- </check>
- <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="false"></check>
- <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLineLength"><![CDATA[100]]></parameter>
-   <parameter name="tabSize"><![CDATA[2]]></parameter>
-   <parameter name="ignoreImports">true</parameter>
-  </parameters>
- </check>
- <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
-  </parameters>
- </check>
- <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="false"></check>
- <!-- <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="maxParameters"><![CDATA[10]]></parameter>
-  </parameters>
- </check>
- <!-- <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="false"></check>
- <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"></check>
- <!-- <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check> -->
- <!-- <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="regex"><![CDATA[println]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="maxTypes"><![CDATA[30]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="maximum"><![CDATA[10]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"></check>
- <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
-  <parameters>
-   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
-   <parameter name="doubleLineAllowed"><![CDATA[true]]></parameter>
-  </parameters>
- </check>
- <!-- <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="maxLength"><![CDATA[50]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true"> -->
- <!--  <parameters> -->
- <!--   <parameter name="maxMethods"><![CDATA[30]]></parameter> -->
- <!--  </parameters> -->
- <!-- </check> -->
- <!-- <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check> -->
- <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+		</parameters>
+	</check>
+	<check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
+	<check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="false"/>
+	<check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
+	<check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+		<parameters>
+			<parameter name="maxLineLength"><![CDATA[120]]></parameter>
+			<parameter name="tabSize"><![CDATA[2]]></parameter>
+			<parameter name="ignoreImports">true</parameter>
+		</parameters>
+	</check>
+	<check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+		<parameters>
+			<parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+		</parameters>
+	</check>
+	<check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+		<parameters>
+			<parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+		</parameters>
+	</check>
+	<check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+		<parameters>
+			<parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+		</parameters>
+	</check>
+	<check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="false"/>
+	<!-- <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+		<parameters>
+			<parameter name="maxParameters"><![CDATA[10]]></parameter>
+		</parameters>
+	</check>
+	<!-- <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
+		   enabled="false"/>
+	<check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"/>
+	<!-- <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check> -->
+	<!-- <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="regex"><![CDATA[println]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="maxTypes"><![CDATA[30]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="maximum"><![CDATA[10]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+	<check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"/>
+	<check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+		<parameters>
+			<parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+			<parameter name="doubleLineAllowed"><![CDATA[true]]></parameter>
+		</parameters>
+	</check>
+	<!-- <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="maxLength"><![CDATA[50]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true"> -->
+	<!--  <parameters> -->
+	<!--   <parameter name="maxMethods"><![CDATA[30]]></parameter> -->
+	<!--  </parameters> -->
+	<!-- </check> -->
+	<!-- <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check> -->
+	<check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+	<check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
 </scalastyle>


### PR DESCRIPTION
Because Scala function's parameter is more long than Java code, We can set the maxLineLength to 120. 

The pull request references the related JIRA issue  FLINK-4519