### PR TITLE
[FLINK-3950] Implement MeterView

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.metrics;
+
+/**
+ * A MeterView provides a rate of events per second over a given time period. The events are counted by a {@link Counter}.
+ * A history of measurements is maintained from which the rate of events is calculated on demand.
+ */
+public class MeterView implements Meter, View {
+	private final Counter counter;
+	private final int timeSpanInSeconds;
+	private final long[] values;
+	private int time = 0;
+
+	private boolean updateRate = false;
+	private double currentRate = 0;
+
+	public MeterView(Counter counter, int timeSpanInSeconds) {
+		this.counter = counter;
+		this.timeSpanInSeconds = timeSpanInSeconds - (timeSpanInSeconds % UPDATE_INTERVAL_SECONDS);
+		this.values = new long[this.timeSpanInSeconds / UPDATE_INTERVAL_SECONDS + 1];
+	}
+
+	@Override
+	public void markEvent() {
+		this.counter.inc();
+	}
+
+	@Override
+	public void markEvent(long n) {
+		this.counter.inc(n);
+	}
+
+	@Override
+	public long getCount() {
+		return counter.getCount();
+	}
+
+	@Override
+	public double getRate() {
+		if (updateRate) {
+			final int time = this.time;
+			currentRate =  ((double) (values[time] - values[(time + 1) % values.length]) / timeSpanInSeconds);
+			updateRate = false;
+		}
+		return currentRate;
+	}
+
+	@Override
+	public void update() {
+		time = (time + 1) % values.length;
+		values[time] = counter.getCount();
+		updateRate = true;
+	}
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/View.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/View.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.metrics;
+
+/**
+ * An interface for metrics which should be updated in regular intervals by a background thread.
+ */
+public interface View {
+	/** The interval in which metrics are updated */
+	int UPDATE_INTERVAL_SECONDS = 5;
+
+	/**
+	 * This method will be called regularly to update the metric.
+	 */
+	void update();
+}

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.metrics;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MeterViewTest {
+	@Test
+	public void testGetCount() {
+		Counter c = new SimpleCounter();
+		c.inc(5);
+		Meter m = new MeterView(c, 60);
+
+		assertEquals(5, m.getCount());
+	}
+
+	@Test
+	public void testMarkEvent() {
+		Counter c = new SimpleCounter();
+		Meter m = new MeterView(c, 60);
+
+		assertEquals(0, m.getCount());
+		m.markEvent();
+		assertEquals(1, m.getCount());
+		m.markEvent(2);
+		assertEquals(3, m.getCount());
+	}
+
+	@Test
+	public void testGetRate() {
+		Counter c = new SimpleCounter();
+		MeterView m = new MeterView(c, 60);
+
+		// values = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+		for (int x = 0; x < 12; x++) {
+			m.markEvent(10);
+			m.update();
+		}
+		// values = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]
+		assertEquals(2.0, m.getRate(), 0.1); // 120 - 0 / 60
+
+		for (int x = 0; x < 12; x++) {
+			m.markEvent(10);
+			m.update();
+		}
+		// values = [130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 120]
+		assertEquals(2.0, m.getRate(), 0.1); // 240 - 120 / 60
+
+		for (int x = 0; x < 6; x++) {
+			m.markEvent(20);
+			m.update();
+		}
+		// values = [280, 300, 320, 340, 360, 180, 190, 200, 210, 220, 230, 240, 260]
+		assertEquals(3.0, m.getRate(), 0.1); // 360 - 180 / 60
+
+		for (int x = 0; x < 6; x++) {
+			m.markEvent(20);
+			m.update();
+		}
+		// values = [280, 300, 320, 340, 360, 380, 400, 420, 440, 460, 480, 240, 260]
+		assertEquals(4.0, m.getRate(), 0.1); // 480 - 240 / 60
+
+		for (int x = 0; x < 6; x++) {
+			m.update();
+		}
+		// values = [480, 480, 480, 480, 360, 380, 400, 420, 440, 460, 480, 480, 480]
+		assertEquals(2.0, m.getRate(), 0.1); // 480 - 360 / 60
+
+		for (int x = 0; x < 6; x++) {
+			m.update();
+		}
+		// values = [480, 480, 480, 480, 480, 480, 480, 480, 480, 480, 480, 480, 480]
+		assertEquals(0.0, m.getRate(), 0.1); // 480 - 480 / 60
+
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ViewUpdater.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ViewUpdater.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.metrics.View;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TimerTask;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.metrics.View.UPDATE_INTERVAL_SECONDS;
+
+/**
+ * The ViewUpdater is responsible for updating all metrics that implement the {@link View} interface.
+ */
+public class ViewUpdater {
+	private final Set<View> toAdd = new HashSet<>();
+	private final Set<View> toRemove = new HashSet<>();
+
+	private final Object lock = new Object();
+
+	public ViewUpdater(ScheduledExecutorService executor) {
+		executor.scheduleWithFixedDelay(new ViewUpdaterTask(lock, toAdd, toRemove), 5, UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * Notifies this ViewUpdater of a new metric that should be regularly updated.
+	 *
+	 * @param view metric that should be regularly updated
+	 */
+	public void notifyOfAddedView(View view) {
+		synchronized (lock) {
+			toAdd.add(view);
+		}
+	}
+
+	/**
+	 * Notifies this ViewUpdater of a metric that should no longer be regularly updated.
+	 *
+	 * @param view metric that should no longer be regularly updated
+	 */
+	public void notifyOfRemovedView(View view) {
+		synchronized (lock) {
+			toRemove.add(view);
+		}
+	}
+
+	/**
+	 * The TimerTask doing the actual updating.
+	 */
+	private static class ViewUpdaterTask extends TimerTask {
+		private final Object lock;
+		private final Set<View> views;
+		private final Set<View> toAdd;
+		private final Set<View> toRemove;
+
+		private ViewUpdaterTask(Object lock, Set<View> toAdd, Set<View> toRemove) {
+			this.lock = lock;
+			this.views = new HashSet<>();
+			this.toAdd = toAdd;
+			this.toRemove = toRemove;
+		}
+
+		@Override
+		public void run() {
+			for (View toUpdate : this.views) {
+				toUpdate.update();
+			}
+
+			synchronized (lock) {
+				views.addAll(toAdd);
+				toAdd.clear();
+				views.removeAll(toRemove);
+				toRemove.clear();
+			}
+		}
+	}
+}


### PR DESCRIPTION
In the JIRA discussion about FLINK-3950 @StephanEwen introduced the notion of a `MetricView`, a `Meter`that derives it's values from another Counter or Gauge. The `View` would not be updated when the backing metric is modified, but instead by a background thread shared by all `Views`.

This PR implements a `Meter` that derives it's values from a `Counter`, called `MeterView`.

The `View` class is a small interface, only containing an `update()` method.

A `TimerTask` running in the `MetricRegistry` calls this `update()` method on all `Views`, with a hard-coded update interval of 5 seconds.

The `MeterView` class implements both `View` and `Meter`. It maintains a history of N measurements in a `long[N]` which is updated whenever `View#update()` is called. The rate is only calculated on demand.

The PR contains a small example, demonstrating how a `MeterView` would be created & registered in the `AbstractStreamOperator`.

