### PR TITLE
[FLINK-4560] enforcer java version as 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@ under the License.
 		<slf4j.version>1.7.7</slf4j.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.3.7</akka.version>
+		<java.version>1.7</java.version>
 		<scala.macros.version>2.0.1</scala.macros.version>
 		<!-- Default scala versions, may be overwritten by build profiles -->
 		<scala.version>2.10.4</scala.version>
@@ -922,8 +923,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<!-- The output of Xlint is not shown by default, but we activate it for the QA bot
 					to be able to get more warnings -->
 					<compilerArgument>-Xlint:all</compilerArgument>
@@ -992,7 +993,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.3.1</version><!--$NO-MVN-MAN-VER$-->
+				<version>1.4.1</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>enforce-maven</id>
@@ -1005,6 +1006,9 @@ under the License.
 									<!-- enforce at least mvn version 3.0.3 -->
 									<version>[3.0.3,)</version>
 								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>${java.version}</version>
+								</requireJavaVersion>
 							</rules>
 						</configuration>
 					</execution>


### PR DESCRIPTION
[FLINK-4560](https://issues.apache.org/jira/browse/FLINK-4560) enforcer java version as 1.7
1. maven-enforcer-plugin add java version enforce
2. maven-enforcer-plugin version upgrade to 1.4.1
explicit require java version

Only modify the root pom file.

The pull request references the related JIRA issue ("[FLINK-4560] enforcer java version as 1.7")
