### PR TITLE
[FLINK-4570] revert Scalastyle version to 0.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1157,7 +1157,7 @@ under the License.
 				<plugin>
 					<groupId>org.scalastyle</groupId>
 					<artifactId>scalastyle-maven-plugin</artifactId>
-					<version>0.8.0</version>
+					<version>0.5.0</version>
 					<executions>
 						<execution>
 							<goals>


### PR DESCRIPTION
Due to very involved bugs in the 0.8.0 version, we revert back to the 0.5.0 version.
