### PR TITLE
[FLINK-4538][FLINK-4348] ResourceManager slot allocation protcol

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -68,6 +68,6 @@ public class ResourceProfile implements Serializable {
 	 * @return true if the requirement is matched, otherwise false
 	 */
 	public boolean isMatching(ResourceProfile required) {
-		return Double.compare(cpuCores, required.getCpuCores()) >= 0 && memoryInMB >= required.getMemoryInMB();
+		return cpuCores >= required.getCpuCores() && memoryInMB >= required.getMemoryInMB();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceSlot.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.clusterframework.types;
 
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+
 import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -26,7 +28,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A ResourceSlot represents a slot located in TaskManager from ResourceManager's view. It has a unique
  * identification and resource profile which we can compare to the resource request.
  */
-public class ResourceSlot implements ResourceIDRetrievable, Serializable {
+public class ResourceSlot implements ResourceIDRetrievable {
 
 	private static final long serialVersionUID = -5853720153136840674L;
 
@@ -36,9 +38,13 @@ public class ResourceSlot implements ResourceIDRetrievable, Serializable {
 	/** The resource profile of this slot */
 	private final ResourceProfile resourceProfile;
 
-	public ResourceSlot(SlotID slotId, ResourceProfile resourceProfile) {
+	/** Gateway to the TaskExecutor which owns the slot */
+	private final TaskExecutorGateway taskExecutorGateway;
+
+	public ResourceSlot(SlotID slotId, ResourceProfile resourceProfile, TaskExecutorGateway taskExecutorGateway) {
 		this.slotId = checkNotNull(slotId);
 		this.resourceProfile = checkNotNull(resourceProfile);
+		this.taskExecutorGateway = taskExecutorGateway;
 	}
 
 	@Override
@@ -52,6 +58,10 @@ public class ResourceSlot implements ResourceIDRetrievable, Serializable {
 
 	public ResourceProfile getResourceProfile() {
 		return resourceProfile;
+	}
+
+	public TaskExecutorGateway getTaskExecutorGateway() {
+		return taskExecutorGateway;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/RegistrationResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/RegistrationResponse.java
@@ -18,26 +18,19 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import org.apache.flink.runtime.instance.InstanceID;
-
 import java.io.Serializable;
 
 public class RegistrationResponse implements Serializable {
 	private static final long serialVersionUID = -2379003255993119993L;
 
 	private final boolean isSuccess;
-	private final InstanceID instanceID;
 
-	public RegistrationResponse(boolean isSuccess, InstanceID instanceID) {
+	public RegistrationResponse(boolean isSuccess) {
 		this.isSuccess = isSuccess;
-		this.instanceID = instanceID;
 	}
 
 	public boolean isSuccess() {
 		return isSuccess;
 	}
 
-	public InstanceID getInstanceID() {
-		return instanceID;
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -58,7 +58,7 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * @param slotRequest Slot request
 	 * @return Future slot assignment
 	 */
-	Future<SlotAssignment> requestSlot(SlotRequest slotRequest);
+	Future<SlotRequestRegistered> requestSlot(SlotRequest slotRequest);
 
 	/**
 	 * 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/SlotRequestRegistered.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/SlotRequestRegistered.java
@@ -18,26 +18,16 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 
 import java.io.Serializable;
 
-public class JobMasterRegistration implements Serializable {
-	private static final long serialVersionUID = 8411214999193765202L;
+/**
+ * Acknowledgment by the ResourceManager for a SlotRequest from the JobManager
+ */
+public class SlotRequestRegistered extends SlotRequestReply {
 
-	private final String address;
-	private final JobID jobID;
-
-	public JobMasterRegistration(String address, JobID jobID) {
-		this.address = address;
-		this.jobID = jobID;
-	}
-
-	public String getAddress() {
-		return address;
-	}
-
-	public JobID getJobID() {
-		return jobID;
+	public SlotRequestRegistered(AllocationID allocationID) {
+		super(allocationID);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/SlotRequestRejected.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/SlotRequestRejected.java
@@ -18,26 +18,17 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 
 import java.io.Serializable;
 
-public class JobMasterRegistration implements Serializable {
-	private static final long serialVersionUID = 8411214999193765202L;
+/**
+ * Rejection message by the ResourceManager for a SlotRequest from the JobManager
+ */
+public class SlotRequestRejected extends SlotRequestReply {
 
-	private final String address;
-	private final JobID jobID;
-
-	public JobMasterRegistration(String address, JobID jobID) {
-		this.address = address;
-		this.jobID = jobID;
+	public SlotRequestRejected(AllocationID allocationID) {
+		super(allocationID);
 	}
 
-	public String getAddress() {
-		return address;
-	}
-
-	public JobID getJobID() {
-		return jobID;
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/SlotRequestReply.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/SlotRequestReply.java
@@ -18,8 +18,24 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+
 import java.io.Serializable;
 
-public class SlotAssignment implements Serializable{
-	private static final long serialVersionUID = -6990813455942742322L;
+/**
+ * Acknowledgment by the ResourceManager for a SlotRequest from the JobManager
+ */
+public abstract class SlotRequestReply implements Serializable {
+
+	private static final long serialVersionUID = 42;
+
+	private final AllocationID allocationID;
+
+	public SlotRequestReply(AllocationID allocationID) {
+		this.allocationID = allocationID;
+	}
+
+	public AllocationID getAllocationID() {
+		return allocationID;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SimpleSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SimpleSlotManager.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.ResourceSlot;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.resourcemanager.SlotRequest;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * A simple SlotManager which ignores resource profiles.
+ */
+public class SimpleSlotManager extends SlotManager {
+
+	@Override
+	protected ResourceSlot chooseSlotToUse(SlotRequest request, Map<SlotID, ResourceSlot> freeSlots) {
+		final Iterator<ResourceSlot> slotIterator = freeSlots.values().iterator();
+		if (slotIterator.hasNext()) {
+			return slotIterator.next();
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	protected SlotRequest chooseRequestToFulfill(ResourceSlot offeredSlot, Map<AllocationID, SlotRequest> pendingRequests) {
+		final Iterator<SlotRequest> requestIterator = pendingRequests.values().iterator();
+		if (requestIterator.hasNext()) {
+			return requestIterator.next();
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	protected void allocateContainer(ResourceProfile resourceProfile) {
+		// TODO
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotStatus.java
@@ -50,7 +50,10 @@ public class SlotStatus implements Serializable {
 		this(slotID, profiler, null, null);
 	}
 
-	public SlotStatus(SlotID slotID, ResourceProfile profiler, AllocationID allocationID, JobID jobID) {
+	public SlotStatus(
+			SlotID slotID, ResourceProfile profiler,
+			JobID jobID,
+			AllocationID allocationID) {
 		this.slotID = checkNotNull(slotID, "slotID cannot be null");
 		this.profiler = checkNotNull(profiler, "profile cannot be null");
 		this.allocationID = allocationID;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.resourcemanager.SlotRequestReply;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcTimeout;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
 
 import java.util.UUID;
 
@@ -32,4 +37,16 @@ public interface TaskExecutorGateway extends RpcGateway {
 	// ------------------------------------------------------------------------
 
 	void notifyOfNewResourceManagerLeader(String address, UUID resourceManagerLeaderId);
+
+	/**
+	 * Send by the ResourceManager to the TaskExecutor
+	 * @param allocationID id for the request
+	 * @param resourceManagerLeaderID current leader id of the ResourceManager
+	 * @return SlotRequestReply Answer to the request
+	 */
+
+	Future<SlotRequestReply> requestSlot(
+		AllocationID allocationID,
+		UUID resourceManagerLeaderID,
+		@RpcTimeout FiniteDuration timeout);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.MainThreadExecutor;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
@@ -53,7 +54,8 @@ public class ResourceManagerHATest {
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
 		highAvailabilityServices.setResourceManagerLeaderElectionService(leaderElectionService);
 
-		final ResourceManager resourceManager = new ResourceManager(rpcService, highAvailabilityServices);
+		SlotManager slotManager = mock(SlotManager.class);
+		final ResourceManager resourceManager = new ResourceManager(rpcService, highAvailabilityServices, slotManager);
 		resourceManager.start();
 		// before grant leadership, resourceManager's leaderId is null
 		Assert.assertNull(resourceManager.getLeaderSessionID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.highavailability.NonHaServices;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.resourcemanager.JobMasterRegistration;
+import org.apache.flink.runtime.resourcemanager.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.SlotRequestReply;
+import org.apache.flink.runtime.rpc.TestingSerialRpcService;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.util.TestLogger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+public class SlotProtocolTest extends TestLogger {
+
+	private static TestingSerialRpcService testRpcService;
+
+	@BeforeClass
+	public static void beforeClass() {
+		testRpcService = new TestingSerialRpcService();
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		testRpcService.stopService();
+		testRpcService = null;
+	}
+
+	@Before
+	public void beforeTest(){
+		testRpcService.clearGateways();
+	}
+
+	/**
+	 * Tests whether
+	 * 1) SlotRequest is routed to the SlotManager
+	 * 2) SlotRequest is confirmed
+	 * 3) SlotRequest leads to a container allocation
+	 * 4) Slot becomes available and TaskExecutor gets a SlotRequest
+	 */
+	@Test
+	public void testSlotsUnavailableRequest() throws Exception {
+		final String rmAddress = "/rm1";
+		final String jmAddress = "/jm1";
+		final JobID jobID = new JobID();
+
+		testRpcService.registerGateway(jmAddress, mock(JobMasterGateway.class));
+
+
+		TestingSlotManager slotManager = Mockito.spy(new TestingSlotManager());
+		ResourceManager resourceManager =
+			new ResourceManager(testRpcService, new NonHaServices(rmAddress), slotManager);
+		resourceManager.start();
+
+		Future<RegistrationResponse> registrationFuture =
+			resourceManager.registerJobMaster(new JobMasterRegistration(jmAddress, jobID));
+		try {
+			Await.ready(registrationFuture, Duration.create(5, TimeUnit.SECONDS));
+		} catch (Exception e) {
+			Assert.fail("JobManager registration Future didn't become ready.");
+		}
+
+		final AllocationID allocationID = new AllocationID();
+		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 100);
+
+		SlotRequest slotRequest = new SlotRequest(jobID, allocationID, resourceProfile);
+		SlotRequestReply slotRequestReply =
+			resourceManager.requestSlot(slotRequest);
+
+		// 1) SlotRequest is routed to the SlotManager
+		verify(slotManager).requestSlot(slotRequest);
+
+		// 2) SlotRequest is confirmed
+		Assert.assertEquals(
+			slotRequestReply.getAllocationID(),
+			allocationID);
+
+		// 3) SlotRequest leads to a container allocation
+		verify(slotManager, timeout(5000)).allocateContainer(resourceProfile);
+
+		Assert.assertFalse(slotManager.isAllocated(allocationID));
+
+		// slot becomes available
+		final String tmAddress = "/tm1";
+		TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
+		testRpcService.registerGateway(tmAddress, taskExecutorGateway);
+
+		final ResourceID resourceID = ResourceID.generate();
+		final SlotID slotID = new SlotID(resourceID, 0);
+
+		final SlotStatus slotStatus =
+			new SlotStatus(slotID, resourceProfile);
+		final SlotReport slotReport =
+			new SlotReport(Collections.singletonList(slotStatus), resourceID);
+		// register slot at SlotManager
+		slotManager.registerTaskExecutor(resourceID, taskExecutorGateway);
+		slotManager.updateSlotStatus(slotReport);
+
+		// 4) Slot becomes available and TaskExecutor gets a SlotRequest
+		verify(taskExecutorGateway, timeout(5000)).requestSlot(eq(allocationID), any(UUID.class), any(FiniteDuration.class));
+	}
+
+	/**
+	 * Tests whether
+	 * 1) a SlotRequest is routed to the SlotManager
+	 * 2) a SlotRequest is confirmed
+	 * 3) a SlotRequest leads to an allocation of a registered slot
+	 * 4) a SlotRequest is routed to the TaskExecutor
+	 */
+	@Test
+	public void testSlotAvailableRequest() throws Exception {
+		final String rmAddress = "/rm1";
+		final String jmAddress = "/jm1";
+		final String tmAddress = "/tm1";
+		final JobID jobID = new JobID();
+
+		testRpcService.registerGateway(jmAddress, mock(JobMasterGateway.class));
+
+		TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
+		testRpcService.registerGateway(tmAddress, taskExecutorGateway);
+
+		TestingSlotManager slotManager = Mockito.spy(new TestingSlotManager());
+		ResourceManager resourceManager =
+			new ResourceManager(testRpcService, new NonHaServices(rmAddress), slotManager);
+		resourceManager.start();
+
+		Future<RegistrationResponse> registrationFuture =
+			resourceManager.registerJobMaster(new JobMasterRegistration(jmAddress, jobID));
+		try {
+			Await.ready(registrationFuture, Duration.create(5, TimeUnit.SECONDS));
+		} catch (Exception e) {
+			Assert.fail("JobManager registration Future didn't become ready.");
+		}
+
+		final ResourceID resourceID = ResourceID.generate();
+		final AllocationID allocationID = new AllocationID();
+		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 100);
+		final SlotID slotID = new SlotID(resourceID, 0);
+
+		final SlotStatus slotStatus =
+			new SlotStatus(slotID, resourceProfile);
+		final SlotReport slotReport =
+			new SlotReport(Collections.singletonList(slotStatus), resourceID);
+		// register slot at SlotManager
+		slotManager.registerTaskExecutor(resourceID, taskExecutorGateway);
+		slotManager.updateSlotStatus(slotReport);
+
+		SlotRequest slotRequest = new SlotRequest(jobID, allocationID, resourceProfile);
+		SlotRequestReply slotRequestReply =
+			resourceManager.requestSlot(slotRequest);
+
+		// 1) a SlotRequest is routed to the SlotManager
+		verify(slotManager).requestSlot(slotRequest);
+
+		// 2) a SlotRequest is confirmed
+		Assert.assertEquals(
+			slotRequestReply.getAllocationID(),
+			allocationID);
+
+		// 3) a SlotRequest leads to an allocation of a registered slot
+		Assert.assertTrue(slotManager.isAllocated(slotID));
+		Assert.assertTrue(slotManager.isAllocated(allocationID));
+
+
+		// 4) a SlotRequest is routed to the TaskExecutor
+		verify(taskExecutorGateway, timeout(5000)).requestSlot(eq(allocationID), any(UUID.class), any(FiniteDuration.class));
+	}
+
+
+	private static class TestingSlotManager extends SimpleSlotManager {
+
+		// change visibility of function to public for testing
+		@Override
+		public void allocateContainer(ResourceProfile resourceProfile) {
+			super.allocateContainer(resourceProfile);
+		}
+
+
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
@@ -112,4 +112,8 @@ public class TestingRpcService extends AkkaRpcService {
 			return Futures.failed(new Exception("No gateway registered under that name"));
 		}
 	}
+
+	public void clearGateways() {
+		registeredConnections.clear();
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingSerialRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingSerialRpcService.java
@@ -137,6 +137,10 @@ public class TestingSerialRpcService implements RpcService {
 		}
 	}
 
+	public void clearGateways() {
+		registeredConnections.clear();
+	}
+
 	private static final class TestingSerialInvocationHandler<C extends RpcGateway, T extends RpcEndpoint<C>> implements InvocationHandler, RpcGateway, MainThreadExecutor, StartStoppable {
 
 		private final T rpcEndpoint;


### PR DESCRIPTION
This implements and tests the ResourceManager part of the protocol for slot allocation.

- associates JobMasters with JobID instead of InstanceID
- adds TaskExecutorGateway to slot and notify from SlotManager
- adds SlotManager as RM constructor parameter
- adds LeaderIdRetriever to keep track of the leader id

- tests the interaction JM->RM requestSlot
- tests the interaction RM->TM requestSlot