### PR TITLE
[FLINK-4522] [docs] Gelly link broken in homepage

### DIFF
--- a/docs/redirects/gelly.md
+++ b/docs/redirects/gelly.md
@@ -2,7 +2,7 @@
 title: "Gelly"
 layout: redirect
 redirect: /dev/libs/gelly/index.html
-permalink: /apis/batch/libs/gelly/index.html
+permalink: /apis/batch/libs/gelly.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
The Gelly documentation was recently split in multiple pages in FLINK-4104 but was missing a redirect. This commit updates the Gelly redirect to point to the old page.

Another option is to have two Gelly redirects: add a redirect to the old page and keep the existing redirect to the new page which only existed for one week.

The redirect needs to be added to 1.1 and added/updated to 1.2.