### PR TITLE
[FLINK-4570] remove conflicting Unicode character

### DIFF
--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/Utils.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/Utils.scala
@@ -16,14 +16,12 @@
  * limitations under the License.
  */
 
-// disable Scalastyle for now to prevent random failures reported in FLINK-4570
-// scalastyle:off
 package org.apache.flink.mesos
 
 import java.util.concurrent.atomic.AtomicLong
 
 import akka.actor._
-import akka.testkit.{TestActorRef, TestFSMRef}
+import akka.testkit.TestFSMRef
 import org.mockito.ArgumentMatcher
 
 import scala.collection.JavaConverters._
@@ -49,9 +47,8 @@ object TestFSMUtils {
     "$" + akka.util.Helpers.base64(l)
   }
 
-  def testFSMRef[S, D, T <: Actor: ClassTag](factory: ⇒ T, supervisor: ActorRef)
+  def testFSMRef[S, D, T <: Actor: ClassTag](factory: => T, supervisor: ActorRef)
       (implicit ev: T <:< FSM[S, D], system: ActorSystem): TestFSMRef[S, D, T] = {
     new TestFSMRef(system, Props(factory), supervisor, TestFSMUtils.randomName)
   }
 }
-// scalastyle:on


### PR DESCRIPTION
This caused Scalastyle to fail, presumably depending on the locale
used. After a bit of debugging on the Scalastyle plugin I found out that
the number in the error is the byte position.

"Expected identifier, but got Token(COMMA,,,1772,,)"

head -c 1772 flink-mesos/src/test/scala/org/apache/flink/mesos/Utils.scala

pointed to the Unicode character '⇒' which causes Scalastyle to fail in
certain environments.