### PR TITLE
[FLINK-4580] [rpc] Verify that the rpc endpoint supports the rpc gateway at connect time

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/VerifyRpcGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/VerifyRpcGateway.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka.messages;
+
+import org.apache.flink.runtime.rpc.RpcGateway;
+
+import java.io.Serializable;
+
+/**
+ * Message to verify that the {@link org.apache.flink.runtime.rpc.RpcEndpoint} supports the
+ * specified {@link RpcGateway}.
+ */
+public class VerifyRpcGateway implements Serializable {
+	private static final long serialVersionUID = 2253701464989577738L;
+
+	private final Class<? extends RpcGateway> clazz;
+
+	public VerifyRpcGateway(Class<? extends RpcGateway> clazz) {
+		this.clazz = clazz;
+	}
+
+	public Class<? extends RpcGateway> getClazz() {
+		return clazz;
+	}
+}


### PR DESCRIPTION
When calling RpcService.connect it is checked that the rpc endpoint supports the specified
rpc gateway. If not, then a RpcConnectionException is thrown. The verification is implemented
as an additional message following after the Identify message. The reason for this is that
the ActorSystem won't wait for the Identify message to time out after it has determined that
the specified actor does not exist. For user-level messages this seems to be not the case and,
thus, we would have to wait for the timeout.