### PR TITLE
FLINK-3322 - Make sorters to reuse the memory pages allocated for iterative tasks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -283,6 +284,12 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	public void cancel() throws Exception {
 		requestTermination();
 		super.cancel();
+	}
+
+	@Override
+	protected void createMemoryAllocator(int inputNum) throws MemoryAllocationException {
+		sorterMemoryAllocator[inputNum] =
+			new SorterMemoryAllocator(getMemoryManager(), this, this.config.getRelativeMemoryInput(inputNum), this.config.getFilehandlesInput(inputNum), this.config.getUseLargeRecordHandler(), true);
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/SorterMemoryAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/SorterMemoryAllocator.java
@@ -168,9 +168,10 @@ public class SorterMemoryAllocator {
 
 	/**
 	 * Close all the created buffers
+	 * @param force forces the closure of the allocated memory
 	 */
-	public void close() {
-		if (!keepOpenForIterativeTasks) {
+	public void close(boolean force) {
+		if (force || !keepOpenForIterativeTasks) {
 			releaseWriteBufferMemory();
 
 			releaseSortBufferMemory();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/SorterMemoryAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/SorterMemoryAllocator.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.iterative.task;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.sort.UnilateralSortMerger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A memory allocator that is used by the sorters so that they can reuse the memory
+ * allocated in case of iterative tasks
+ */
+public class SorterMemoryAllocator {
+
+	private MemoryManager memoryManager;
+
+	// The memory segments that does the sort read
+	private List<MemorySegment> sortReadBufferPages;
+
+	// The memory segments that does the write
+	private List<MemorySegment> writeBufferPages;
+
+	// The memory segments that processes large records
+	private List<MemorySegment> largeBufferPages;
+
+	private int numWriteBuffers;
+
+	private int numLargeBufferHolders;
+
+	// The parent task creating this memoryallocator
+	private final AbstractInvokable parentTask;
+
+	// Indicates whether this allocator was created as part of iterative tasks.
+	private boolean keepOpenForIterativeTasks;
+
+	public SorterMemoryAllocator(MemoryManager memoryManager, AbstractInvokable parentTask, double relativeMemory, int maxNumFileHandles, boolean handleLargeRecords) throws MemoryAllocationException {
+		this(memoryManager, parentTask, relativeMemory, maxNumFileHandles, handleLargeRecords, false);
+	}
+
+	public SorterMemoryAllocator(MemoryManager memoryManager, AbstractInvokable parentTask, double relativeMemory, int maxNumFileHandles, boolean handleLargeRecords, boolean keepOpenForIterativeTasks)
+		throws MemoryAllocationException {
+		this.memoryManager = memoryManager;
+		this.parentTask = parentTask;
+		sortReadBufferPages = this.memoryManager.allocatePages(parentTask, this.memoryManager
+			.computeNumberOfPages(relativeMemory));
+		init(maxNumFileHandles, handleLargeRecords, keepOpenForIterativeTasks);
+	}
+
+	private void init(int maxNumFileHandles, boolean handleLargeRecords, boolean keepOpenedForIterativeTasks) {
+		numWriteBuffers = UnilateralSortMerger.calculateNumOfWriteBuffers(false, handleLargeRecords, maxNumFileHandles, sortReadBufferPages.size());
+		if (numWriteBuffers > 0) {
+			this.writeBufferPages = new ArrayList<MemorySegment>(numWriteBuffers);
+			for (int j = 0; j < numWriteBuffers; j++) {
+				this.writeBufferPages.add(this.sortReadBufferPages.remove(this.sortReadBufferPages.size() - 1));
+			}
+		}
+		numLargeBufferHolders = UnilateralSortMerger.calculateNumOfLargeRecords(false, handleLargeRecords, maxNumFileHandles, sortReadBufferPages.size());
+		if (numLargeBufferHolders > 0) {
+			this.largeBufferPages = new ArrayList<MemorySegment>(numLargeBufferHolders);
+			for (int j = 0; j < numLargeBufferHolders; j++) {
+				largeBufferPages.add(this.sortReadBufferPages.remove(this.sortReadBufferPages.size() - 1));
+			}
+		}
+		this.keepOpenForIterativeTasks = keepOpenedForIterativeTasks;
+	}
+
+	public SorterMemoryAllocator(MemoryManager memoryManager, List<MemorySegment> memorySegments, AbstractInvokable parentTask, int maxNumFileHandles, boolean handleLargeRecords, boolean keepOpenForIterativeTasks) {
+		this.memoryManager = memoryManager;
+		this.parentTask = parentTask;
+		sortReadBufferPages = memorySegments;
+		init(maxNumFileHandles, handleLargeRecords, keepOpenForIterativeTasks);
+	}
+
+	/**
+	 * Allows to put back the sort read buffers back to the original allocated sort read buffers
+	 * This ideally happens when some of the sort read buffers were removed from the original list.
+	 *
+	 * @param memory list of memory segments to be returned back
+	 */
+	private void putBackSortReadBuffers(List<MemorySegment> memory) {
+		if (getSortBufferMemory() != null) {
+			this.sortReadBufferPages.addAll(memory);
+		}
+	}
+
+	/**
+	 * Returns list of writeBuffer
+	 *
+	 * @return list of write buffer pages
+	 */
+	public List<MemorySegment> getWriteBufferMemory() {
+		return writeBufferPages;
+	}
+
+	/**
+	 * Returns list of sortBuffer
+	 *
+	 * @return list of sort read buffer pages
+	 */
+	public List<MemorySegment> getSortBufferMemory() {
+		return sortReadBufferPages;
+	}
+
+	/**
+	 * Returns list of large buffers
+	 *
+	 * @return list of large buffer pages
+	 */
+	public List<MemorySegment> getLargeBufferMemory() {
+		return largeBufferPages;
+	}
+
+	/**
+	 * Number of write buffers
+	 *
+	 * @return number of write buffers
+	 */
+	public int getNumWriteBuffers() {
+		return this.numWriteBuffers;
+	}
+
+	/**
+	 * Number of large buffers
+	 *
+	 * @return number of large buffers
+	 */
+	public int getNumLargeBufferHolder() {
+		return this.numLargeBufferHolders;
+	}
+
+	/**
+	 * The owner who created this allocator
+	 *
+	 * @return the owner created this allocator
+	 */
+	public AbstractInvokable getParentTask() {
+		return this.parentTask;
+	}
+
+	/**
+	 * If this allocator has to be retained for iterative tasks
+	 *
+	 * @return true if the allocator has to be retained for iterative tasks, else false.
+	 */
+	public boolean isKeepOpenForIterativeTasks() {
+		return this.keepOpenForIterativeTasks;
+	}
+
+	/**
+	 * Close all the created buffers
+	 */
+	public void close() {
+		if (!keepOpenForIterativeTasks) {
+			releaseWriteBufferMemory();
+
+			releaseSortBufferMemory();
+
+			releaseLargeBufferMemory();
+		}
+	}
+
+	public void releaseLargeBufferMemory() {
+		if (!keepOpenForIterativeTasks && getLargeBufferMemory() != null) {
+			this.memoryManager.release(getLargeBufferMemory());
+			getLargeBufferMemory().clear();
+		}
+	}
+
+	public void releaseSortBufferMemory() {
+		if (!keepOpenForIterativeTasks && getSortBufferMemory() != null) {
+			this.memoryManager.release(getSortBufferMemory());
+			getSortBufferMemory().clear();
+		}
+	}
+
+	public void releaseWriteBufferMemory() {
+		if (!keepOpenForIterativeTasks && getWriteBufferMemory() != null) {
+			this.memoryManager.release(getWriteBufferMemory());
+			getWriteBufferMemory().clear();
+		}
+	}
+
+	/**
+	 * Releases the given set of memory segments to the sort buffer memory.
+	 * If the allocator is for iterative tasks then the segments are put back to
+	 * the sort buffer memory, if not it is released back to the memory manager
+	 *
+	 * @param segments the list of segments to be released
+	 */
+	public void releaseToSortBufferMemory(List<MemorySegment> segments) {
+		if (!keepOpenForIterativeTasks) {
+			if (segments != null) {
+				this.memoryManager.release(segments);
+				segments.clear();
+			}
+		} else {
+			putBackSortReadBuffers(segments);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -590,7 +590,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			if (this.sorterMemoryAllocator != null) {
 				for (SorterMemoryAllocator sorterMemoryAllocator : this.sorterMemoryAllocator) {
 					if (sorterMemoryAllocator != null) {
-						sorterMemoryAllocator.close();
+						sorterMemoryAllocator.close(true);
 					}
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/UnilateralSortMerger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/UnilateralSortMerger.java
@@ -505,7 +505,8 @@ public class UnilateralSortMerger<E> implements Sorter<E> {
 			// exceptions, because their memory segments are freed
 			try {
 				if (sorterMemoryAllocator != null) {
-					this.sorterMemoryAllocator.close();
+					// do not force close here in case of iterative tasks
+					this.sorterMemoryAllocator.close(false);
 				}
 			}
 			catch (Throwable t) {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsITCase.java
@@ -104,7 +104,7 @@ public class FileChannelStreamsITCase {
 			List<MemorySegment> readMemory = memManager.allocatePages(new DummyInvokable(), NUM_MEMORY_SEGMENTS);
 			
 			final BlockChannelReader<MemorySegment> reader = ioManager.createBlockChannelReader(channel);
-			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, readMemory, outView.getBytesInLatestSegment());
+			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, null, readMemory, outView.getBytesInLatestSegment());
 			generator.reset();
 			
 			// read and re-generate all records and compare them
@@ -148,7 +148,7 @@ public class FileChannelStreamsITCase {
 			List<MemorySegment> readMemory = memManager.allocatePages(new DummyInvokable(), NUM_MEMORY_SEGMENTS);
 			
 			final BlockChannelReader<MemorySegment> reader = ioManager.createBlockChannelReader(channel);
-			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, readMemory, outView.getBytesInLatestSegment());
+			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, null, readMemory, outView.getBytesInLatestSegment());
 			generator.reset();
 			
 			// read and re-generate all records and compare them
@@ -192,7 +192,7 @@ public class FileChannelStreamsITCase {
 			List<MemorySegment> readMemory = memManager.allocatePages(new DummyInvokable(), NUM_MEMORY_SEGMENTS);
 			
 			final BlockChannelReader<MemorySegment> reader = ioManager.createBlockChannelReader(channel);
-			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, readMemory, outView.getBytesInLatestSegment());
+			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, null, readMemory, outView.getBytesInLatestSegment());
 			generator.reset();
 	
 			// read and re-generate all records and compare them
@@ -242,7 +242,7 @@ public class FileChannelStreamsITCase {
 			List<MemorySegment> readMemory = memManager.allocatePages(new DummyInvokable(), 1);
 			
 			final BlockChannelReader<MemorySegment> reader = ioManager.createBlockChannelReader(channel);
-			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, readMemory, outView.getBytesInLatestSegment());
+			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, null, readMemory, outView.getBytesInLatestSegment());
 			generator.reset();
 			
 			// read and re-generate all records and compare them
@@ -286,7 +286,7 @@ public class FileChannelStreamsITCase {
 			List<MemorySegment> readMemory = memManager.allocatePages(new DummyInvokable(), NUM_MEMORY_SEGMENTS);
 			
 			final BlockChannelReader<MemorySegment> reader = ioManager.createBlockChannelReader(channel);
-			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, readMemory, outView.getBytesInLatestSegment());
+			final FileChannelInputView inView = new FileChannelInputView(reader, memManager, null, readMemory, outView.getBytesInLatestSegment());
 			generator.reset();
 			
 			// read and re-generate all records and compare them

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelStreamsTest.java
@@ -92,7 +92,7 @@ public class FileChannelStreamsTest {
 			}
 			
 			BlockChannelReader<MemorySegment> reader = ioManager.createBlockChannelReader(channel);
-			FileChannelInputView in = new FileChannelInputView(reader, memMan, memory, 9);
+			FileChannelInputView in = new FileChannelInputView(reader, memMan, null, memory, 9);
 			
 			// read just something
 			in.readInt();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SeekableFileChannelInputViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/SeekableFileChannelInputViewTest.java
@@ -62,7 +62,7 @@ public class SeekableFileChannelInputViewTest {
 			assertTrue(memMan.verifyEmpty());
 			
 			memMan.allocatePages(new DummyInvokable(), memory, 4);
-			SeekableFileChannelInputView in = new SeekableFileChannelInputView(ioManager, channel, memMan, memory, out.getBytesInLatestSegment());
+			SeekableFileChannelInputView in = new SeekableFileChannelInputView(ioManager, channel, memMan, null, memory, out.getBytesInLatestSegment());
 			
 			// read first, complete
 			for (int i = 0; i < NUM_RECORDS; i += 4) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskExternalITCase.java
@@ -21,10 +21,10 @@ package org.apache.flink.runtime.operators;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.Validate;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.GroupCombineFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.runtime.iterative.task.SorterMemoryAllocator;
 import org.apache.flink.types.Value;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -132,11 +132,12 @@ public class ReduceTaskExternalITCase extends DriverTestBase<RichGroupReduceFunc
 		
 		CombiningUnilateralSortMerger<Record> sorter = null;
 		try {
+			SorterMemoryAllocator sorterMemoryAllocator = new SorterMemoryAllocator(getMemoryManager(), getContainingTask(), this.perSortFractionMem, 2, true /* use large record handler */);
 			sorter = new CombiningUnilateralSortMerger<>(new MockCombiningReduceStub(),
-				getMemoryManager(), getIOManager(), new UniformRecordGenerator(keyCnt, valCnt, false), 
-				getContainingTask(), RecordSerializerFactory.get(), this.comparator.duplicate(),
+				getMemoryManager(), getIOManager(), sorterMemoryAllocator, new UniformRecordGenerator(keyCnt, valCnt, false),
+				RecordSerializerFactory.get(), this.comparator.duplicate(),
 					this.perSortFractionMem,
-					2, 0.8f, true /* use large record handler */, true);
+					2, 0.8f, true);
 			addInput(sorter.getIterator());
 			
 			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<>();
@@ -178,11 +179,12 @@ public class ReduceTaskExternalITCase extends DriverTestBase<RichGroupReduceFunc
 		
 		CombiningUnilateralSortMerger<Record> sorter = null;
 		try {
+			SorterMemoryAllocator sorterMemoryAllocator = new SorterMemoryAllocator(getMemoryManager(), getContainingTask(), this.perSortFractionMem, 2, true /* use large record handler */);
 			sorter = new CombiningUnilateralSortMerger<>(new MockCombiningReduceStub(),
-				getMemoryManager(), getIOManager(), new UniformRecordGenerator(keyCnt, valCnt, false), 
-				getContainingTask(), RecordSerializerFactory.get(), this.comparator.duplicate(),
+				getMemoryManager(), getIOManager(), sorterMemoryAllocator, new UniformRecordGenerator(keyCnt, valCnt, false),
+				RecordSerializerFactory.get(), this.comparator.duplicate(),
 					this.perSortFractionMem,
-					2, 0.8f, true /* use large record handler */, false);
+					2, 0.8f, false);
 			addInput(sorter.getIterator());
 			
 			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskTest.java
@@ -144,7 +144,7 @@ public class ReduceTaskTest extends DriverTestBase<RichGroupReduceFunction<Recor
 			Assert.fail("Invoke method caused exception.");
 		} finally {
 			if(sorterMemoryAllocator != null) {
-				sorterMemoryAllocator.close();
+				sorterMemoryAllocator.close(true);
 			}
 			if (sorter != null) {
 				sorter.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/CombiningUnilateralSortMergerITCase.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.flink.api.common.functions.GroupCombineFunction;
+import org.apache.flink.runtime.iterative.task.SorterMemoryAllocator;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,10 +115,10 @@ public class CombiningUnilateralSortMergerITCase {
 		LOG.debug("initializing sortmerger");
 		
 		TestCountCombiner comb = new TestCountCombiner();
-		
+		SorterMemoryAllocator sorterMemoryAllocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, 0.25, 64, true /* use large record handler */);
 		Sorter<Tuple2<Integer, Integer>> merger = new CombiningUnilateralSortMerger<>(comb,
-				this.memoryManager, this.ioManager, reader, this.parentTask, this.serializerFactory2, this.comparator2,
-				0.25, 64, 0.7f, true /* use large record handler */, false);
+				this.memoryManager, this.ioManager, sorterMemoryAllocator, reader, this.serializerFactory2, this.comparator2,
+				0.25, 64, 0.7f, false);
 
 		final Tuple2<Integer, Integer> rec = new Tuple2<>();
 		rec.setField(1, 1);
@@ -153,10 +154,10 @@ public class CombiningUnilateralSortMergerITCase {
 		LOG.debug("initializing sortmerger");
 		
 		TestCountCombiner comb = new TestCountCombiner();
-		
+		SorterMemoryAllocator sorterMemoryAllocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, 0.01, 64, true /* use large record handler */);
 		Sorter<Tuple2<Integer, Integer>> merger = new CombiningUnilateralSortMerger<>(comb,
-				this.memoryManager, this.ioManager, reader, this.parentTask, this.serializerFactory2, this.comparator2,
-				0.01, 64, 0.005f, true /* use large record handler */, true);
+				this.memoryManager, this.ioManager, sorterMemoryAllocator, reader, this.serializerFactory2, this.comparator2,
+				0.01, 64, 0.005f, true);
 
 		final Tuple2<Integer, Integer> rec = new Tuple2<>();
 		rec.setField(1, 1);
@@ -200,10 +201,10 @@ public class CombiningUnilateralSortMergerITCase {
 		LOG.debug("initializing sortmerger");
 		
 		TestCountCombiner2 comb = new TestCountCombiner2();
-		
+		SorterMemoryAllocator sorterMemoryAllocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, 0.25, 2, true /* use large record handler */);
 		Sorter<Tuple2<Integer, String>> merger = new CombiningUnilateralSortMerger<>(comb,
-				this.memoryManager, this.ioManager, reader, this.parentTask, this.serializerFactory1, this.comparator1,
-				0.25, 2, 0.7f, true /* use large record handler */, false);
+				this.memoryManager, this.ioManager, sorterMemoryAllocator, reader, this.serializerFactory1, this.comparator1,
+				0.25, 2, 0.7f, false);
 
 		// emit data
 		LOG.debug("emitting data");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.base.IntComparator;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.iterative.task.SorterMemoryAllocator;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -111,9 +112,9 @@ public class ExternalSortITCase {
 	
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
-			
-			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
-				source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, (double)64/78, 2, true /*use large record handler*/);
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager, allocator,
+				source, this.pactRecordSerializer, this.pactRecordComparator,
 					(double)64/78, 2, 0.9f, true /*use large record handler*/, true);
 	
 			// emit data
@@ -160,9 +161,10 @@ public class ExternalSortITCase {
 	
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
-			
-			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
-					source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
+
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, (double)64/78, 2, true /*use large record handler*/);
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager, allocator,
+					source, this.pactRecordSerializer, this.pactRecordComparator,
 					(double)64/78, 10, 2, 0.9f, true /*use large record handler*/, false);
 	
 			// emit data
@@ -209,10 +211,11 @@ public class ExternalSortITCase {
 	
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
-			
-			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
-					source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
-					(double)16/78, 64, 0.7f, true /*use large record handler*/, true);
+
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, (double) 16 / 78, 64, true /*use large record handler*/);
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager, allocator,
+				source, this.pactRecordSerializer, this.pactRecordComparator,
+				(double) 16 / 78, 64, 0.7f, true /*use large record handler*/, true);
 	
 			// emit data
 			LOG.debug("Reading and sorting data...");
@@ -261,10 +264,11 @@ public class ExternalSortITCase {
 			
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
-			
-			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager,
-					source, this.parentTask, this.pactRecordSerializer, this.pactRecordComparator,
-					(double)64/78, 16, 0.7f, true /*use large record handler*/, false);
+
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, (double) 64 / 78, 16, true /*use large record handler*/);
+			Sorter<Tuple2<Integer, String>> merger = new UnilateralSortMerger<>(this.memoryManager, this.ioManager, allocator,
+				source, this.pactRecordSerializer, this.pactRecordComparator,
+				(double) 64 / 78, 16, 0.7f, true /*use large record handler*/, false);
 			
 			// emit data
 			LOG.debug("Emitting data...");
@@ -319,10 +323,10 @@ public class ExternalSortITCase {
 			
 			// merge iterator
 			LOG.debug("Initializing sortmerger...");
-			
-			Sorter<IntPair> merger = new UnilateralSortMerger<IntPair>(this.memoryManager, this.ioManager, 
-					generator, this.parentTask, serializerFactory, comparator, (double)64/78, 4, 0.7f,
-					true /*use large record handler*/, true);
+
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, (double) 64 / 78, 4, true /*use large record handler*/);
+			Sorter<IntPair> merger = new UnilateralSortMerger<IntPair>(this.memoryManager, this.ioManager, allocator,
+				generator, serializerFactory, comparator, (double) 64 / 78, 4, 0.7f, true /*use large record handler*/, true);
 	
 			// emit data
 			LOG.debug("Emitting data...");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortLargeRecordsITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/ExternalSortLargeRecordsITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.iterative.task.SorterMemoryAllocator;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
@@ -124,11 +125,12 @@ public class ExternalSortLargeRecordsITCase {
 					};
 			
 			@SuppressWarnings("unchecked")
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, 1.0, 128, true /*use large record handler*/);
 			Sorter<Tuple2<Long, SomeMaybeLongValue>> sorter = new UnilateralSortMerger<Tuple2<Long, SomeMaybeLongValue>>(
-					this.memoryManager, this.ioManager, 
-					source, this.parentTask,
+					this.memoryManager, this.ioManager, allocator,
+					source,
 					new RuntimeSerializerFactory<Tuple2<Long, SomeMaybeLongValue>>(serializer, (Class<Tuple2<Long, SomeMaybeLongValue>>) (Class<?>) Tuple2.class),
-					comparator, 1.0, 1, 128, 0.7f, true /* use large record handler */ , false);
+					comparator, 1.0, 1, 128, 0.7f , true /*use large record handler*/, false);
 			
 			// check order
 			MutableObjectIterator<Tuple2<Long, SomeMaybeLongValue>> iterator = sorter.getIterator();
@@ -194,9 +196,10 @@ public class ExternalSortLargeRecordsITCase {
 					};
 			
 			@SuppressWarnings("unchecked")
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, 1.0, 128, true /*use large record handler*/);
 			Sorter<Tuple2<Long, SomeMaybeLongValue>> sorter = new UnilateralSortMerger<Tuple2<Long, SomeMaybeLongValue>>(
-					this.memoryManager, this.ioManager, 
-					source, this.parentTask,
+					this.memoryManager, this.ioManager, allocator,
+					source,
 					new RuntimeSerializerFactory<Tuple2<Long, SomeMaybeLongValue>>(serializer, (Class<Tuple2<Long, SomeMaybeLongValue>>) (Class<?>) Tuple2.class),
 					comparator, 1.0, 1, 128, 0.7f, true /*use large record handler*/, true);
 			
@@ -279,9 +282,10 @@ public class ExternalSortLargeRecordsITCase {
 					};
 			
 			@SuppressWarnings("unchecked")
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, 1.0, 128, true /*use large record handler*/);
 			Sorter<Tuple2<Long, SmallOrMediumOrLargeValue>> sorter = new UnilateralSortMerger<Tuple2<Long, SmallOrMediumOrLargeValue>>(
-					this.memoryManager, this.ioManager, 
-					source, this.parentTask,
+					this.memoryManager, this.ioManager, allocator,
+					source,
 					new RuntimeSerializerFactory<Tuple2<Long, SmallOrMediumOrLargeValue>>(serializer, (Class<Tuple2<Long, SmallOrMediumOrLargeValue>>) (Class<?>) Tuple2.class),
 					comparator, 1.0, 1, 128, 0.7f, true /*use large record handler*/, false);
 			
@@ -350,9 +354,10 @@ public class ExternalSortLargeRecordsITCase {
 					};
 			
 			@SuppressWarnings("unchecked")
+			SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memoryManager, this.parentTask, 1.0, 128, true /*use large record handler*/);
 			Sorter<Tuple2<Long, SmallOrMediumOrLargeValue>> sorter = new UnilateralSortMerger<Tuple2<Long, SmallOrMediumOrLargeValue>>(
-					this.memoryManager, this.ioManager, 
-					source, this.parentTask,
+					this.memoryManager, this.ioManager, allocator,
+					source,
 					new RuntimeSerializerFactory<Tuple2<Long, SmallOrMediumOrLargeValue>>(serializer, (Class<Tuple2<Long, SmallOrMediumOrLargeValue>>) (Class<?>) Tuple2.class),
 					comparator, 1.0, 1, 128, 0.7f, true /*use large record handler*/, true);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerITCase.java
@@ -138,7 +138,7 @@ public class LargeRecordHandlerITCase {
 			catch (IllegalStateException e) {
 				// expected
 			}
-			sorterMemoryAllocator.close();
+			sorterMemoryAllocator.close(true);
 			assertTrue(memMan.verifyEmpty());
 		}
 		catch (Exception e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/LargeRecordHandlerTest.java
@@ -80,7 +80,7 @@ import org.junit.Test;
 			catch (IllegalStateException e) {
 				// expected
 			}
-			sorterMemoryAllocator.close();
+			sorterMemoryAllocator.close(true);
 			assertTrue(memMan.verifyEmpty());
 		}
 		catch (Exception e) {
@@ -166,7 +166,7 @@ import org.junit.Test;
 			catch (IllegalStateException e) {
 				// expected
 			}
-			sorterMemoryAllocator.close();
+			sorterMemoryAllocator.close(true);
 			assertTrue(memMan.verifyEmpty());
 		}
 		catch (Exception e) {
@@ -247,7 +247,7 @@ import org.junit.Test;
 			
 			handler.close();
 
-			sorterMemoryAllocator.close();
+			sorterMemoryAllocator.close(true);
 			
 			try {
 				handler.addRecord(new Tuple3<Long, String, Byte>(92L, "peter pepper", (byte) 1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.iterative.task.SorterMemoryAllocator;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.Driver;
@@ -141,18 +142,18 @@ public class BinaryOperatorTestBase<S extends Function, IN, OUT> extends TestLog
 	@SuppressWarnings("unchecked")
 	public void addInputSorted(MutableObjectIterator<IN> input, TypeSerializer<IN> serializer, TypeComparator<IN> comp) throws Exception {
 		this.inputSerializers.add(serializer);
+		SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memManager, this.owner, this.perSortFractionMem, 32, true /*use large record handler*/);
 		UnilateralSortMerger<IN> sorter = new UnilateralSortMerger<>(
-				this.memManager,
-				this.ioManager,
-				input,
-				this.owner,
-				new RuntimeSerializerFactory<>(serializer, (Class<IN>) serializer.createInstance().getClass()),
-				comp,
-				this.perSortFractionMem,
-				32,
-				0.8f,
-				true /*use large record handler*/,
-				false
+			this.memManager,
+			this.ioManager, allocator,
+			input,
+			new RuntimeSerializerFactory<>(serializer, (Class<IN>) serializer.createInstance().getClass()),
+			comp,
+			this.perSortFractionMem,
+			32,
+			0.8f,
+			true /*use large record handler*/,
+			false
 		);
 		this.sorters.add(sorter);
 		this.inputs.add(null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
@@ -29,6 +29,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.iterative.task.SorterMemoryAllocator;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.Driver;
@@ -144,12 +145,12 @@ public class UnaryOperatorTestBase<S extends Function, IN, OUT> extends TestLogg
 	{
 		this.input = null;
 		this.inputSerializer = serializer;
+		SorterMemoryAllocator allocator = new SorterMemoryAllocator(this.memManager, this.owner, this.perSortFractionMem, 32, true /*use large record handler*/);
 		this.sorter = new UnilateralSortMerger<IN>(
-				this.memManager, this.ioManager, input, this.owner,
+				this.memManager, this.ioManager, allocator, input,
 				this.<IN>getInputSerializer(0),
 				comp,
-				this.perSortFractionMem, 32, 0.8f,
-				true /*use large record handler*/,
+				this.perSortFractionMem, 32, 0.8f, true /*use large record handler*/,
 				false);
 	}
 	

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringSorting.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringSorting.java
@@ -123,7 +123,7 @@ public class MassiveStringSorting {
 					sorter.close();
 				}
 				if (memoryAllocator != null) {
-					memoryAllocator.close();
+					memoryAllocator.close(true);
 				}
 			}
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringValueSorting.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringValueSorting.java
@@ -123,7 +123,7 @@ public class MassiveStringValueSorting {
 					sorter.close();
 				}
 				if (allocator != null) {
-					allocator.close();
+					allocator.close(true);
 				}
 			}
 		}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
@@ -33,8 +33,10 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.runtime.operators.sort.UnilateralSortMerger
 import org.apache.flink.api.java.typeutils.runtime.RuntimeSerializerFactory
+import org.apache.flink.runtime.iterative.task.{SorterMemoryAllocator}
 import org.junit.Assert._
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable
+import org.apache.flink.runtime.operators.testutils.DummyInvokable
 
 /**
  * This test is wrote as manual test.
@@ -94,9 +96,9 @@ class MassiveCaseClassSortingITCase {
         
         val mm = new MemoryManager(1024 * 1024, 1)
         val ioMan = new IOManagerAsync()
-        
-        sorter = new UnilateralSortMerger[StringTuple](mm, ioMan, inputIterator,
-              new DummyInvokable(), 
+        val  invokable = new DummyInvokable();
+        val allocator = new SorterMemoryAllocator(mm, invokable, 1.0, 4, true /*use large record handler*/);
+        sorter = new UnilateralSortMerger[StringTuple](mm, ioMan, allocator, inputIterator,
               new RuntimeSerializerFactory[StringTuple](serializer, classOf[StringTuple]),
               comparator, 1.0, 4, 0.8f, true /*use large record handler*/, false)
             

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/manual/MassiveCaseClassSortingITCase.scala
@@ -97,7 +97,8 @@ class MassiveCaseClassSortingITCase {
         val mm = new MemoryManager(1024 * 1024, 1)
         val ioMan = new IOManagerAsync()
         val  invokable = new DummyInvokable();
-        val allocator = new SorterMemoryAllocator(mm, invokable, 1.0, 4, true /*use large record handler*/);
+        val allocator =
+          new SorterMemoryAllocator(mm, invokable, 1.0, 4, true /*use large record handler*/);
         sorter = new UnilateralSortMerger[StringTuple](mm, ioMan, allocator, inputIterator,
               new RuntimeSerializerFactory[StringTuple](serializer, classOf[StringTuple]),
               comparator, 1.0, 4, 0.8f, true /*use large record handler*/, false)


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.
- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This is part1 for FLINK-3322 where only the Sorters are made to reuse the memory pages. As @ggevay  pointed out we have to handle the iterators also where the memory pages are allocated. I have a seperate PR for that because that involves touching lot of places. But am open to feedback here. It is fine with me to combine both also but it was making the changes much bigger. 
I would like to get the feed back here on this apporach. 
Here a SorterMemoryAllocator is now passed to the UnilateralSortMergers. That will allocate the required memory pages and it will allocate the required read, write and large buffers. As per the existing logic the buffers will be released. But if the task is an iterative task we wait for the tasks to be released until a close or termination call happens for the iterative task. 
In case of pages that were grabbed in between for keysort or record sort those will be put back to the respective pages so that we have the required number of pages through out the life cycle of the iterative task.

As said this is only part 1. We need to address the iterators also. But that according to me touches more places. I have done the changes for that but it is not in a shape to be pushed as a PR but am open to feed back here. Thanks all. 
