### PR TITLE
FLINK-4615 Reusing the memory allocated for the drivers and iterators

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -45,14 +45,12 @@ import org.apache.flink.runtime.iterative.convergence.WorksetEmptyConvergenceCri
 import org.apache.flink.runtime.iterative.io.SolutionSetObjectsUpdateOutputCollector;
 import org.apache.flink.runtime.iterative.io.SolutionSetUpdateOutputCollector;
 import org.apache.flink.runtime.iterative.io.WorksetUpdateOutputCollector;
-import org.apache.flink.runtime.operators.Driver;
 import org.apache.flink.runtime.operators.ResettableDriver;
 import org.apache.flink.runtime.operators.hash.CompactingHashTable;
 import org.apache.flink.runtime.operators.util.DistributedRuntimeUDFContext;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.types.Value;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.MutableObjectIterator;
 
 import java.io.IOException;
@@ -153,6 +151,11 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	}
 
 	@Override
+	protected void postRun() throws Exception {
+		this.driver.resetForIterativeTasks();
+	}
+
+	@Override
 	protected void closeLocalStrategiesAndCaches() {
 		try {
 			super.closeLocalStrategiesAndCaches();
@@ -206,9 +209,7 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 			final ResettableDriver<?, ?> resDriver = (ResettableDriver<?, ?>) this.driver;
 			resDriver.reset();
 		} else {
-			Class<? extends Driver<S, OT>> driverClass = this.config.getDriver();
-			this.driver = InstantiationUtil.instantiate(driverClass, Driver.class);
-
+			// do not re instantiate the driver. Just reuse the same one
 			try {
 				this.driver.setup(this);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
@@ -113,7 +113,8 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 		
 		// create and return outer join iterator according to provided local strategy.
 		if (objectReuseEnabled) {
-			this.outerJoinIterator = getReusingOuterJoinIterator(
+			if (outerJoinIterator == null) {
+				this.outerJoinIterator = getReusingOuterJoinIterator(
 					ls,
 					in1,
 					in2,
@@ -125,9 +126,11 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 					memoryManager,
 					ioManager,
 					driverMemFraction
-			);
+				);
+			}
 		} else {
-			this.outerJoinIterator = getNonReusingOuterJoinIterator(
+			if (outerJoinIterator == null) {
+				this.outerJoinIterator = getNonReusingOuterJoinIterator(
 					ls,
 					in1,
 					in2,
@@ -139,7 +142,8 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 					memoryManager,
 					ioManager,
 					driverMemFraction
-			);
+				);
+			}
 		}
 		
 		this.outerJoinIterator.open();
@@ -204,4 +208,11 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 			IOManager ioManager,
 			double driverMemFraction
 	) throws Exception;
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+		if (outerJoinIterator != null) {
+			outerJoinIterator.resetForIterativeTasks();
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllGroupCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllGroupCombineDriver.java
@@ -129,5 +129,9 @@ public class AllGroupCombineDriver<IN, OUT> implements Driver<GroupCombineFuncti
 	@Override
 	public void cancel() {
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllGroupReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllGroupReduceDriver.java
@@ -162,4 +162,9 @@ public class AllGroupReduceDriver<IT, OT> implements Driver<GroupReduceFunction<
 
 	@Override
 	public void cancel() {}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllReduceDriver.java
@@ -160,4 +160,8 @@ public class AllReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -531,8 +531,12 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			}
 		}
 		finally {
-			this.driver.cleanup();
+			postRun();
 		}
+	}
+
+	protected void postRun() throws Exception {
+		this.driver.cleanup();
 	}
 
 	protected void closeLocalStrategiesAndCaches() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupDriver.java
@@ -175,4 +175,10 @@ public class CoGroupDriver<IT1, IT2, OT> implements Driver<CoGroupFunction<IT1, 
 		this.running = false;
 		cleanup();
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+		// call cleanup here
+		cleanup();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupRawDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupRawDriver.java
@@ -147,4 +147,8 @@ public class CoGroupRawDriver<IT1, IT2, OT> implements Driver<CoGroupFunction<IT
 			}
 		}
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetFirstDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetFirstDriver.java
@@ -256,4 +256,8 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetSecondDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetSecondDriver.java
@@ -256,4 +256,8 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CrossDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CrossDriver.java
@@ -432,4 +432,9 @@ public class CrossDriver<T1, T2, OT> implements Driver<CrossFunction<T1, T2, OT>
 
 		}
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+		cleanup();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/Driver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/Driver.java
@@ -87,4 +87,6 @@ public interface Driver<S extends Function, OT> {
 	 * @throws Exception Exceptions may be forwarded.
 	 */
 	void cancel() throws Exception;
+
+	void resetForIterativeTasks() throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/FlatMapDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/FlatMapDriver.java
@@ -119,4 +119,9 @@ public class FlatMapDriver<IT, OT> implements Driver<FlatMapFunction<IT, OT>, OT
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceCombineDriver.java
@@ -129,9 +129,8 @@ public class GroupReduceCombineDriver<IN, OUT> implements Driver<GroupCombineFun
 
 		MemoryManager memManager = this.taskContext.getMemoryManager();
 		final int numMemoryPages = memManager.computeNumberOfPages(this.taskContext.getTaskConfig().getRelativeMemoryDriver());
-		if(this.memory == null) {
-			this.memory = memManager.allocatePages(this.taskContext.getContainingTask(), numMemoryPages);
-		}
+		this.memory = memManager.allocatePages(this.taskContext.getContainingTask(), numMemoryPages);
+
 
 		// instantiate a fix-length in-place sorter, if possible, otherwise the out-of-place sorter
 		if (sortingComparator.supportsSerializationWithKeyNormalization() &&
@@ -271,9 +270,6 @@ public class GroupReduceCombineDriver<IN, OUT> implements Driver<GroupCombineFun
 
 	@Override
 	public void resetForIterativeTasks() throws Exception {
-		if (this.sorter != null) {
-			this.sorter.dispose();
-		}
-		// do not release the memory
+		cleanup();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceCombineDriver.java
@@ -129,7 +129,9 @@ public class GroupReduceCombineDriver<IN, OUT> implements Driver<GroupCombineFun
 
 		MemoryManager memManager = this.taskContext.getMemoryManager();
 		final int numMemoryPages = memManager.computeNumberOfPages(this.taskContext.getTaskConfig().getRelativeMemoryDriver());
-		this.memory = memManager.allocatePages(this.taskContext.getContainingTask(), numMemoryPages);
+		if(this.memory == null) {
+			this.memory = memManager.allocatePages(this.taskContext.getContainingTask(), numMemoryPages);
+		}
 
 		// instantiate a fix-length in-place sorter, if possible, otherwise the out-of-place sorter
 		if (sortingComparator.supportsSerializationWithKeyNormalization() &&
@@ -265,5 +267,13 @@ public class GroupReduceCombineDriver<IN, OUT> implements Driver<GroupCombineFun
 	 */
 	public long getOversizedRecordCount() {
 		return oversizedRecordCount;
+	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+		if (this.sorter != null) {
+			this.sorter.dispose();
+		}
+		// do not release the memory
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceDriver.java
@@ -140,4 +140,9 @@ public class GroupReduceDriver<IT, OT> implements Driver<GroupReduceFunction<IT,
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinDriver.java
@@ -131,14 +131,17 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 		if (objectReuseEnabled) {
 			switch (ls) {
 				case INNER_MERGE:
-					this.joinIterator = new ReusingMergeInnerJoinIterator<>(in1, in2, 
+					if (joinIterator == null) {
+						this.joinIterator = new ReusingMergeInnerJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator12(comparator1, comparator2),
 							memoryManager, ioManager, numPages, this.taskContext.getContainingTask());
+					}
 					break;
 				case HYBRIDHASH_BUILD_FIRST:
-					this.joinIterator = new ReusingBuildFirstHashJoinIterator<>(in1, in2,
+					if (joinIterator == null) {
+						this.joinIterator = new ReusingBuildFirstHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator21(comparator1, comparator2),
@@ -148,9 +151,11 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 							false,
 							false,
 							hashJoinUseBitMaps);
+					}
 					break;
 				case HYBRIDHASH_BUILD_SECOND:
-					this.joinIterator = new ReusingBuildSecondHashJoinIterator<>(in1, in2,
+					if (joinIterator == null) {
+						this.joinIterator = new ReusingBuildSecondHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator12(comparator1, comparator2),
@@ -160,6 +165,7 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 							false,
 							false,
 							hashJoinUseBitMaps);
+					}
 					break;
 				default:
 					throw new Exception("Unsupported driver strategy for join driver: " + ls.name());
@@ -167,15 +173,17 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 		} else {
 			switch (ls) {
 				case INNER_MERGE:
-					this.joinIterator = new NonReusingMergeInnerJoinIterator<>(in1, in2,
+					if (joinIterator == null) {
+						this.joinIterator = new NonReusingMergeInnerJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator12(comparator1, comparator2),
 							memoryManager, ioManager, numPages, this.taskContext.getContainingTask());
-
+					}
 					break;
 				case HYBRIDHASH_BUILD_FIRST:
-					this.joinIterator = new NonReusingBuildFirstHashJoinIterator<>(in1, in2,
+					if (joinIterator == null) {
+						this.joinIterator = new NonReusingBuildFirstHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator21(comparator1, comparator2),
@@ -185,9 +193,11 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 							false,
 							false,
 							hashJoinUseBitMaps);
+					}
 					break;
 				case HYBRIDHASH_BUILD_SECOND:
-					this.joinIterator = new NonReusingBuildSecondHashJoinIterator<>(in1, in2,
+					if (joinIterator == null) {
+						this.joinIterator = new NonReusingBuildSecondHashJoinIterator<>(in1, in2,
 							serializer1, comparator1,
 							serializer2, comparator2,
 							pairComparatorFactory.createComparator12(comparator1, comparator2),
@@ -197,6 +207,7 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 							false,
 							false,
 							hashJoinUseBitMaps);
+					}
 					break;
 				default:
 					throw new Exception("Unsupported driver strategy for join driver: " + ls.name());
@@ -235,6 +246,13 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
 		this.running = false;
 		if (this.joinIterator != null) {
 			this.joinIterator.abort();
+		}
+	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+		if(this.joinIterator != null) {
+			this.joinIterator.resetForIterativeTasks();
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinWithSolutionSetFirstDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinWithSolutionSetFirstDriver.java
@@ -225,4 +225,8 @@ public class JoinWithSolutionSetFirstDriver<IT1, IT2, OT> implements ResettableD
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinWithSolutionSetSecondDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinWithSolutionSetSecondDriver.java
@@ -228,4 +228,8 @@ public class JoinWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resettable
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MapDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MapDriver.java
@@ -114,4 +114,9 @@ public class MapDriver<IT, OT> implements Driver<MapFunction<IT, OT>, OT> {
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MapPartitionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/MapPartitionDriver.java
@@ -111,4 +111,9 @@ public class MapPartitionDriver<IT, OT> implements Driver<MapPartitionFunction<I
 
 	@Override
 	public void cancel() {}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpDriver.java
@@ -106,4 +106,9 @@ public class NoOpDriver<T> implements Driver<AbstractRichFunction, T> {
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceCombineDriver.java
@@ -125,9 +125,8 @@ public class ReduceCombineDriver<T> implements Driver<ReduceFunction<T>, T> {
 		MemoryManager memManager = taskContext.getMemoryManager();
 		final int numMemoryPages = memManager.computeNumberOfPages(
 			taskContext.getTaskConfig().getRelativeMemoryDriver());
-		if(memory == null) {
-			memory = memManager.allocatePages(taskContext.getContainingTask(), numMemoryPages);
-		}
+		memory = memManager.allocatePages(taskContext.getContainingTask(), numMemoryPages);
+
 
 		ExecutionConfig executionConfig = taskContext.getExecutionConfig();
 		objectReuseEnabled = executionConfig.isObjectReuseEnabled();
@@ -356,16 +355,6 @@ public class ReduceCombineDriver<T> implements Driver<ReduceFunction<T>, T> {
 
 	@Override
 	public void resetForIterativeTasks() throws Exception {
-		try {
-			if (sorter != null) {
-				sorter.dispose();
-			}
-			if (table != null) {
-				table.close();
-			}
-		} catch (Exception e) {
-			// may happen during concurrent modification
-		}
-		// do not release the segments
+		cleanup();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceCombineDriver.java
@@ -125,7 +125,9 @@ public class ReduceCombineDriver<T> implements Driver<ReduceFunction<T>, T> {
 		MemoryManager memManager = taskContext.getMemoryManager();
 		final int numMemoryPages = memManager.computeNumberOfPages(
 			taskContext.getTaskConfig().getRelativeMemoryDriver());
-		memory = memManager.allocatePages(taskContext.getContainingTask(), numMemoryPages);
+		if(memory == null) {
+			memory = memManager.allocatePages(taskContext.getContainingTask(), numMemoryPages);
+		}
 
 		ExecutionConfig executionConfig = taskContext.getExecutionConfig();
 		objectReuseEnabled = executionConfig.isObjectReuseEnabled();
@@ -350,5 +352,20 @@ public class ReduceCombineDriver<T> implements Driver<ReduceFunction<T>, T> {
 		running = false;
 
 		cleanup();
+	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+		try {
+			if (sorter != null) {
+				sorter.dispose();
+			}
+			if (table != null) {
+				table.close();
+			}
+		} catch (Exception e) {
+			// may happen during concurrent modification
+		}
+		// do not release the segments
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
@@ -198,4 +198,9 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/UnionWithTempOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/UnionWithTempOperator.java
@@ -87,4 +87,9 @@ public class UnionWithTempOperator<T> implements Driver<Function, T> {
 	public void cancel() {
 		this.running = false;
 	}
+
+	@Override
+	public void resetForIterativeTasks() throws Exception {
+		
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
@@ -177,4 +177,9 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 		this.running = false;
 		this.hashJoin.abort();
 	}
+
+	@Override
+	public void resetForIterativeTasks() {
+		this.hashJoin.close();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
@@ -174,4 +174,9 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 		this.running = false;
 		this.hashJoin.abort();
 	}
+
+	@Override
+	public void resetForIterativeTasks() {
+		this.hashJoin.close();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
@@ -22,6 +22,7 @@ package org.apache.flink.runtime.operators.hash;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -44,13 +45,21 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 
 	protected final MutableHashTable<V2, V1> hashJoin;
 
-	protected final TypeSerializer<V1> probeSideSerializer;
+	protected TypeSerializer<V1> probeSideSerializer;
+
+	protected TypeSerializer<V2> serializer2;
+
+	protected TypeComparator<V1> comparator1;
+
+	protected  TypeComparator<V2> comparator2;
+
+	protected TypePairComparator<V1, V2> typePairComparator;
 
 	private final MemoryManager memManager;
 
-	private final MutableObjectIterator<V1> firstInput;
+	private MutableObjectIterator<V1> firstInput;
 
-	private final MutableObjectIterator<V2> secondInput;
+	private MutableObjectIterator<V2> secondInput;
 
 	private final boolean buildSideOuterJoin;
 
@@ -79,6 +88,8 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 		this.firstInput = firstInput;
 		this.secondInput = secondInput;
 		this.probeSideSerializer = serializer1;
+		this.serializer2 = serializer2;
+		this.typePairComparator = pairComparator;
 
 		if(useBitmapFilters && probeSideOuterJoin) {
 			throw new IllegalArgumentException("Bitmap filter may not be activated for joining with empty build side");
@@ -176,7 +187,14 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 	}
 
 	@Override
-	public void resetForIterativeTasks() {
+	public void resetForIterativeTasks(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
 		this.hashJoin.close();
+		this.firstInput = in1;
+		this.secondInput = in2;
+		this.comparator1 = comp1;
+		this.comparator2 = comp2;
+		this.serializer2 = serializer2;
+		this.probeSideSerializer = serializer1;
+		this.typePairComparator = pairComparatorFactory.createComparator12(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
@@ -163,4 +163,11 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 		this.running = false;
 		this.hashJoin.abort();
 	}
+
+	@Override
+	public void resetForIterativeTasks() {
+		// close the join
+		this.hashJoin.close();
+		// do not relase the memory
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -48,13 +49,21 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 	
 	private final V2 tempBuildSideRecord;
 	
-	protected final TypeSerializer<V1> probeSideSerializer;
+	protected TypeSerializer<V1> probeSideSerializer;
+
+	protected TypeSerializer<V2> serializer2;
+
+	protected TypeComparator<V1> comparator1;
+
+	protected  TypeComparator<V2> comparator2;
+
+	protected TypePairComparator<V1, V2> typePairComparator;
 	
 	private final MemoryManager memManager;
 	
-	private final MutableObjectIterator<V1> firstInput;
+	private MutableObjectIterator<V1> firstInput;
 	
-	private final MutableObjectIterator<V2> secondInput;
+	private MutableObjectIterator<V2> secondInput;
 
 	private final boolean probeSideOuterJoin;
 
@@ -159,7 +168,14 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 	}
 
 	@Override
-	public void resetForIterativeTasks() {
+	public void resetForIterativeTasks(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
 		this.hashJoin.close();
+		this.firstInput = in1;
+		this.secondInput = in2;
+		this.comparator1 = comp1;
+		this.comparator2 = comp2;
+		this.serializer2 = serializer2;
+		this.probeSideSerializer = serializer1;
+		this.typePairComparator = pairComparatorFactory.createComparator12(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
@@ -157,4 +157,9 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 		this.running = false;
 		this.hashJoin.abort();
 	}
+
+	@Override
+	public void resetForIterativeTasks() {
+		this.hashJoin.close();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/AbstractBlockResettableIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/AbstractBlockResettableIterator.java
@@ -45,9 +45,9 @@ abstract class AbstractBlockResettableIterator<T> implements MemoryBlockIterator
 	
 	// ------------------------------------------------------------------------
 	
-	protected final RandomAccessInputView readView;
+	protected RandomAccessInputView readView;
 	
-	protected final SimpleCollectingOutputView collectingView;
+	protected SimpleCollectingOutputView collectingView;
 	
 	protected final TypeSerializer<T> serializer;
 	
@@ -105,6 +105,28 @@ abstract class AbstractBlockResettableIterator<T> implements MemoryBlockIterator
 		
 		this.readView.setReadPosition(0);
 		this.numRecordsReturned = 0;
+	}
+
+	public void resetForIterativeTasks() {
+		if (this.closed) {
+			throw new IllegalStateException("Iterator was closed.");
+		}
+
+		this.numRecordsInBuffer = 0;
+		this.numRecordsReturned = 0;
+
+		// add the full segments to the empty ones
+		for (int i = this.fullSegments.size() - 1; i >= 0; i--) {
+			this.emptySegments.add(this.fullSegments.remove(i));
+		}
+
+		this.collectingView = new SimpleCollectingOutputView(this.fullSegments,
+			new ListMemorySegmentSource(this.emptySegments), memoryManager.getPageSize());
+		this.readView = new RandomAccessInputView(this.fullSegments, memoryManager.getPageSize());
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Block Resettable Iterator resetted for iterative tasks.");
+		}
+		// do not close the segments
 	}
 	
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/NonReusingBlockResettableIterator.java
@@ -201,4 +201,13 @@ public class NonReusingBlockResettableIterator<T> extends AbstractBlockResettabl
 		this.readPhase = true;
 		super.close();
 	}
+
+	@Override
+	public void resetForIterativeTasks() {
+		nextElement = null;
+		leftOverElement = null;
+		readPhase = false;
+		noMoreBlocks = false;
+		super.resetForIterativeTasks();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
@@ -23,8 +23,12 @@ package org.apache.flink.runtime.operators.util;
 import java.io.IOException;
 
 import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
 
 /**
  * Interface of an iterator that performs the logic of a match task. The iterator follows the
@@ -72,5 +76,6 @@ public interface JoinTaskIterator<V1, V2, O>
 	/**
 	 * Resets the iterator specifically for the iterative tasks where the memory segments are not released
 	 */
-	void resetForIterativeTasks();
+	void resetForIterativeTasks(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2,
+								TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
@@ -68,4 +68,9 @@ public interface JoinTaskIterator<V1, V2, O>
 	 * method signals an interrupt to that procedure.
 	 */
 	void abort();
+
+	/**
+	 * Resets the iterator specifically for the iterative tasks where the memory segments are not released
+	 */
+	void resetForIterativeTasks();
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.
- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

First PR for initial review. Helps to reuse the memory for the iterators that are created by the drivers. If some one could point me to more test cases other than the ConnectedComponents example can see how things work. Suggestions/feedback are welcome. 
