### PR TITLE
[FLINK-4485] close and remove user class loader after job completion

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -328,13 +328,4 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		}
 	}
 
-	/**
-	 * Give the URLClassLoader a nicer name for debugging purposes.
-	 */
-	private static class FlinkUserCodeClassLoader extends URLClassLoader {
-
-		public FlinkUserCodeClassLoader(URL[] urls) {
-			super(urls, FlinkUserCodeClassLoader.class.getClassLoader());
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoader.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.execution.librarycache;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Gives the URLClassLoader a nicer name for debugging purposes.
+ */
+public class FlinkUserCodeClassLoader extends URLClassLoader {
+
+	public FlinkUserCodeClassLoader(URL[] urls) {
+		super(urls, FlinkUserCodeClassLoader.class.getClassLoader());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
+import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.archive.ExecutionConfigSummary;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.instance.SlotProvider;
@@ -62,7 +63,6 @@ import org.slf4j.LoggerFactory;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.FiniteDuration;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -948,11 +948,11 @@ public class ExecutionGraph {
 		jobStatusListeners.clear();
 		executionListeners.clear();
 
-		if (userClassLoader instanceof Closeable) {
+		if (userClassLoader instanceof FlinkUserCodeClassLoader) {
 			try {
 				// close the classloader to free space of user jars immediately
 				// otherwise we have to wait until garbage collection
-				((Closeable) userClassLoader).close();
+				((FlinkUserCodeClassLoader) userClassLoader).close();
 			} catch (IOException e) {
 				LOG.warn("Failed to close the user classloader for job {}", jobID, e);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
+import org.apache.flink.runtime.executiongraph.archive.ExecutionConfigSummary;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.instance.SlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -61,6 +62,7 @@ import org.slf4j.LoggerFactory;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -222,6 +224,9 @@ public class ExecutionGraph {
 	// ------ Fields that are only relevant for archived execution graphs ------------
 	private String jsonPlan;
 
+	/** Serializable summary of all job config values, e.g. for web interface */
+	private ExecutionConfigSummary executionConfigSummary;
+
 	// --------------------------------------------------------------------------------------------
 	//   Constructors
 	// --------------------------------------------------------------------------------------------
@@ -301,6 +306,16 @@ public class ExecutionGraph {
 		metricGroup.gauge(RESTARTING_TIME_METRIC_NAME, new RestartTimeGauge());
 
 		this.kvStateLocationRegistry = new KvStateLocationRegistry(jobId, getAllVertices());
+
+		// create a summary of all relevant data accessed in the web interface's JobConfigHandler
+		try {
+			ExecutionConfig executionConfig = serializedConfig.deserializeValue(userClassLoader);
+			if (executionConfig != null) {
+				this.executionConfigSummary = new ExecutionConfigSummary(executionConfig);
+			}
+		} catch (IOException | ClassNotFoundException e) {
+			LOG.error("Couldn't create ExecutionConfigSummary for job {} ", jobID, e);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -933,7 +948,26 @@ public class ExecutionGraph {
 		jobStatusListeners.clear();
 		executionListeners.clear();
 
+		if (userClassLoader instanceof Closeable) {
+			try {
+				// close the classloader to free space of user jars immediately
+				// otherwise we have to wait until garbage collection
+				((Closeable) userClassLoader).close();
+			} catch (IOException e) {
+				LOG.warn("Failed to close the user classloader for job {}", jobID, e);
+			}
+		}
+		userClassLoader = null;
+
 		isArchived = true;
+	}
+
+	/**
+	 * Returns the serializable ExecutionConfigSummary
+	 * @return ExecutionConfigSummary which may be null in case of errors
+	 */
+	public ExecutionConfigSummary getExecutionConfigSummary() {
+		return executionConfigSummary;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/archive/ExecutionConfigSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/archive/ExecutionConfigSummary.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.executiongraph.archive;
+
+import org.apache.flink.api.common.ExecutionConfig;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Serializable class which is created when archiving the job.
+ * It can be used to display job information on the web interface
+ * without having to keep the classloader around after job completion.
+ */
+public class ExecutionConfigSummary implements Serializable {
+
+	private final String executionMode;
+	private final String restartStrategyDescription;
+	private final int parallelism;
+	private final boolean objectReuseEnabled;
+	private final Map<String, String> globalJobParameters;
+
+	public ExecutionConfigSummary(ExecutionConfig ec) {
+		executionMode = ec.getExecutionMode().name();
+		if (ec.getRestartStrategy() != null) {
+			restartStrategyDescription = ec.getRestartStrategy().getDescription();
+		} else {
+			restartStrategyDescription = "default";
+		}
+		parallelism = ec.getParallelism();
+		objectReuseEnabled = ec.isObjectReuseEnabled();
+		if (ec.getGlobalJobParameters() != null
+				&& ec.getGlobalJobParameters().toMap() != null) {
+			globalJobParameters = ec.getGlobalJobParameters().toMap();
+		} else {
+			globalJobParameters = Collections.emptyMap();
+		}
+	}
+
+	public String getExecutionMode() {
+		return executionMode;
+	}
+
+	public String getRestartStrategyDescription() {
+		return restartStrategyDescription;
+	}
+
+	public int getParallelism() {
+		return parallelism;
+	}
+
+	public boolean getObjectReuseEnabled() {
+		return objectReuseEnabled;
+	}
+
+	public Map<String, String> getGlobalJobParameters() {
+		return globalJobParameters;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoader;
 import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
@@ -63,7 +64,6 @@ import org.apache.flink.util.SerializedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
@@ -702,8 +702,8 @@ public class Task implements Runnable {
 				removeCachedFiles(distributedCacheEntries, fileCache);
 
 				// release any referenced jar files to cleanup blob entries
-				if (userCodeClassLoader instanceof Closeable) {
-					((Closeable) userCodeClassLoader).close();
+				if (userCodeClassLoader instanceof FlinkUserCodeClassLoader) {
+					((FlinkUserCodeClassLoader) userCodeClassLoader).close();
 				}
 				userCodeClassLoader = null;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/web/WebFrontendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/web/WebFrontendITCase.java
@@ -250,7 +250,7 @@ public class WebFrontendITCase extends TestLogger {
 			assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("json"));
 			assertEquals("{\"jid\":\""+jid+"\",\"name\":\"Stoppable streaming test job\"," +
 					"\"execution-config\":{\"execution-mode\":\"PIPELINED\",\"restart-strategy\":\"default\"," +
-					"\"job-parallelism\":-1,\"object-reuse-mode\":false}}", response.getContent());
+					"\"job-parallelism\":-1,\"object-reuse-mode\":false,\"user-config\":{}}}", response.getContent());
 		}
 	}
 


### PR DESCRIPTION
Keeping the user class loader around after job completion may lead to
excessive temp space usage because all user jars are kept until the
class loader is garbage collected. Tests showed that garbage collection
can be delayed for a long time after the class loader is not referenced
anymore. Note that for the class loader to not be referenced anymore,
its job has to be removed from the archive.

The fastest way to minimize temp space usage is to close and remove the
URLClassloader after job completion. This requires us to keep a
serializable copy of all data which needs the user class loader after
job completion, e.g. to display data on the web interface.