### PR TITLE
[FLINK-4628] provide user class loader during input split assignment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -165,10 +165,17 @@ public class ExecutionJobVertex {
 			InputSplitSource<InputSplit> splitSource = (InputSplitSource<InputSplit>) jobVertex.getInputSplitSource();
 			
 			if (splitSource != null) {
-				inputSplits = splitSource.createInputSplits(numTaskVertices);
-				
-				if (inputSplits != null) {
-					splitAssigner = splitSource.getInputSplitAssigner(inputSplits);
+				Thread currentThread = Thread.currentThread();
+				ClassLoader oldContextClassLoader = currentThread.getContextClassLoader();
+				currentThread.setContextClassLoader(graph.getUserClassLoader());
+				try {
+					inputSplits = splitSource.createInputSplits(numTaskVertices);
+
+					if (inputSplits != null) {
+						splitAssigner = splitSource.getInputSplitAssigner(inputSplits);
+					}
+				} finally {
+					currentThread.setContextClassLoader(oldContextClassLoader);
 				}
 			}
 			else {


### PR DESCRIPTION
In analogy to the configure() method, this also sets a context class loader during input split assignment.