### PR TITLE
FLINK-3322 Allow drivers and iterators to reuse the memory segments

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -125,16 +125,6 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	}
 
 	@Override
-	protected void postRun() throws Exception {
-		if (this.driver instanceof ResettableDriver) {
-			final ResettableDriver<?, ?> resDriver = (ResettableDriver<?, ?>) this.driver;
-			resDriver.reset();
-		} else {
-			super.postRun();
-		}
-	}
-
-	@Override
 	public void run() throws Exception {
 		if (inFirstIteration()) {
 			if (this.driver instanceof ResettableDriver) {
@@ -212,7 +202,10 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	}
 
 	private void reinstantiateDriver() throws Exception {
-		if (!(this.driver instanceof ResettableDriver)) {
+		if (this.driver instanceof ResettableDriver) {
+			final ResettableDriver<?, ?> resDriver = (ResettableDriver<?, ?>) this.driver;
+			resDriver.reset();
+		} else {
 			Class<? extends Driver<S, OT>> driverClass = this.config.getDriver();
 			this.driver = InstantiationUtil.instantiate(driverClass, Driver.class);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -125,6 +125,16 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	}
 
 	@Override
+	protected void postRun() throws Exception {
+		if (this.driver instanceof ResettableDriver) {
+			final ResettableDriver<?, ?> resDriver = (ResettableDriver<?, ?>) this.driver;
+			resDriver.reset();
+		} else {
+			super.postRun();
+		}
+	}
+
+	@Override
 	public void run() throws Exception {
 		if (inFirstIteration()) {
 			if (this.driver instanceof ResettableDriver) {
@@ -202,19 +212,15 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	}
 
 	private void reinstantiateDriver() throws Exception {
-		if (this.driver instanceof ResettableDriver) {
-			final ResettableDriver<?, ?> resDriver = (ResettableDriver<?, ?>) this.driver;
-			resDriver.reset();
-		} else {
+		if (!(this.driver instanceof ResettableDriver)) {
 			Class<? extends Driver<S, OT>> driverClass = this.config.getDriver();
 			this.driver = InstantiationUtil.instantiate(driverClass, Driver.class);
 
 			try {
 				this.driver.setup(this);
-			}
-			catch (Throwable t) {
+			} catch (Throwable t) {
 				throw new Exception("The pact driver setup for '" + this.getEnvironment().getTaskInfo().getTaskName() +
-						"' , caused an error: " + t.getMessage(), t);
+					"' , caused an error: " + t.getMessage(), t);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -531,8 +531,12 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			}
 		}
 		finally {
-			this.driver.cleanup();
+			postRun();
 		}
+	}
+
+	protected void postRun() throws Exception {
+		this.driver.cleanup();
 	}
 
 	protected void closeLocalStrategiesAndCaches() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -529,14 +529,9 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 				// throw only if task was not cancelled. in the case of canceling, exceptions are expected 
 				BatchTask.logAndThrowException(ex, this);
 			}
+		} finally {
+			this.driver.cleanup();
 		}
-		finally {
-			postRun();
-		}
-	}
-
-	protected void postRun() throws Exception {
-		this.driver.cleanup();
 	}
 
 	protected void closeLocalStrategiesAndCaches() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
@@ -22,7 +22,6 @@ package org.apache.flink.runtime.operators.hash;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
-import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -192,14 +191,9 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 	}
 
 	@Override
-	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
+	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2) {
 		this.hashJoin.close();
 		this.firstInput = in1;
 		this.secondInput = in2;
-		this.comparator1 = comp1;
-		this.comparator2 = comp2;
-		this.serializer1 = serializer1;
-		this.probeSideSerializer = serializer2;
-		this.pairComparator = pairComparatorFactory.createComparator21(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
@@ -22,6 +22,7 @@ package org.apache.flink.runtime.operators.hash;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -45,13 +46,21 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 
 	protected final MutableHashTable<V1, V2> hashJoin;
 
-	protected final TypeSerializer<V2> probeSideSerializer;
+	protected TypeSerializer<V2> probeSideSerializer;
+
+	protected TypeSerializer<V1> serializer1;
+
+	protected TypeComparator<V1> comparator1;
+
+	protected TypeComparator<V2> comparator2;
+
+	protected TypePairComparator<V2, V1> pairComparator;
 
 	private final MemoryManager memManager;
 
-	private final MutableObjectIterator<V1> firstInput;
+	private MutableObjectIterator<V1> firstInput;
 
-	private final MutableObjectIterator<V2> secondInput;
+	private MutableObjectIterator<V2> secondInput;
 
 	private final boolean probeSideOuterJoin;
 
@@ -80,6 +89,10 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 		this.firstInput = firstInput;
 		this.secondInput = secondInput;
 		this.probeSideSerializer = serializer2;
+		this.serializer1 = serializer1;
+		this.comparator1 = comparator1;
+		this.comparator2 = comparator2;
+		this.pairComparator = pairComparator;
 
 		if(useBitmapFilters && probeSideOuterJoin) {
 			throw new IllegalArgumentException("Bitmap filter may not be activated for joining with empty build side");
@@ -176,5 +189,17 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 	public void abort() {
 		this.running = false;
 		this.hashJoin.abort();
+	}
+
+	@Override
+	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
+		this.hashJoin.close();
+		this.firstInput = in1;
+		this.secondInput = in2;
+		this.comparator1 = comp1;
+		this.comparator2 = comp2;
+		this.serializer1 = serializer1;
+		this.probeSideSerializer = serializer2;
+		this.pairComparator = pairComparatorFactory.createComparator21(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
@@ -22,7 +22,6 @@ package org.apache.flink.runtime.operators.hash;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
-import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -189,14 +188,9 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 	}
 
 	@Override
-	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
+	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2) {
 		this.hashJoin.close();
 		this.firstInput = in1;
 		this.secondInput = in2;
-		this.comparator1 = comp1;
-		this.comparator2 = comp2;
-		this.serializer2 = serializer2;
-		this.probeSideSerializer = serializer1;
-		this.typePairComparator = pairComparatorFactory.createComparator12(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
-import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -178,14 +177,9 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 	}
 
 	@Override
-	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
+	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2) {
 		this.hashJoin.close();
 		this.firstInput = in1;
 		this.secondInput = in2;
-		this.comparator1 = comp1;
-		this.comparator2 = comp2;
-		this.serializer1 = serializer1;
-		this.probeSideSerializer = serializer2;
-		this.typePairComparator = pairComparatorFactory.createComparator21(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -48,13 +49,21 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 
 	private final V1 tempBuildSideRecord;
 
-	protected final TypeSerializer<V2> probeSideSerializer;
+	protected TypeSerializer<V2> probeSideSerializer;
+
+	protected TypeSerializer<V1> serializer1;
+
+	protected TypeComparator<V1> comparator1;
+
+	protected TypeComparator<V2> comparator2;
+
+	protected TypePairComparator<V2, V1> typePairComparator;
 	
 	private final MemoryManager memManager;
 	
-	private final MutableObjectIterator<V1> firstInput;
+	private MutableObjectIterator<V1> firstInput;
 	
-	private final MutableObjectIterator<V2> secondInput;
+	private MutableObjectIterator<V2> secondInput;
 
 	private final boolean probeSideOuterJoin;
 
@@ -84,6 +93,10 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 		this.firstInput = firstInput;
 		this.secondInput = secondInput;
 		this.probeSideSerializer = serializer2;
+		this.serializer1 = serializer1;
+		this.comparator1 = comparator1;
+		this.comparator2 = comparator2;
+		this.typePairComparator = pairComparator;
 
 		if(useBitmapFilters && probeSideOuterJoin) {
 			throw new IllegalArgumentException("Bitmap filter may not be activated for joining with empty build side");
@@ -162,5 +175,17 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 	public void abort() {
 		this.running = false;
 		this.hashJoin.abort();
+	}
+
+	@Override
+	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
+		this.hashJoin.close();
+		this.firstInput = in1;
+		this.secondInput = in2;
+		this.comparator1 = comp1;
+		this.comparator2 = comp2;
+		this.serializer1 = serializer1;
+		this.probeSideSerializer = serializer2;
+		this.typePairComparator = pairComparatorFactory.createComparator21(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -47,14 +48,22 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 	private final V2 nextBuildSideObject;
 	
 	private final V2 tempBuildSideRecord;
-	
-	protected final TypeSerializer<V1> probeSideSerializer;
+
+	protected TypeSerializer<V1> probeSideSerializer;
+
+	protected TypeSerializer<V2> serializer2;
+
+	protected TypeComparator<V1> comparator1;
+
+	protected TypeComparator<V2> comparator2;
+
+	protected TypePairComparator<V1, V2> typePairComparator;
 	
 	private final MemoryManager memManager;
 	
-	private final MutableObjectIterator<V1> firstInput;
+	private MutableObjectIterator<V1> firstInput;
 	
-	private final MutableObjectIterator<V2> secondInput;
+	private MutableObjectIterator<V2> secondInput;
 
 	private final boolean probeSideOuterJoin;
 
@@ -84,6 +93,10 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 		this.firstInput = firstInput;
 		this.secondInput = secondInput;
 		this.probeSideSerializer = serializer1;
+		this.serializer2 = serializer2;
+		this.comparator1 = comparator1;
+		this.comparator2 = comparator2;
+		this.typePairComparator = pairComparator;
 
 		if(useBitmapFilters && probeSideOuterJoin) {
 			throw new IllegalArgumentException("Bitmap filter may not be activated for joining with empty build side");
@@ -156,5 +169,17 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 	public void abort() {
 		this.running = false;
 		this.hashJoin.abort();
+	}
+
+	@Override
+	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
+		this.hashJoin.close();
+		this.firstInput = in1;
+		this.secondInput = in2;
+		this.comparator1 = comp1;
+		this.comparator2 = comp2;
+		this.serializer2 = serializer2;
+		this.probeSideSerializer = serializer1;
+		this.typePairComparator = pairComparatorFactory.createComparator12(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
-import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -172,14 +171,9 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 	}
 
 	@Override
-	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory) {
+	public void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2) {
 		this.hashJoin.close();
 		this.firstInput = in1;
 		this.secondInput = in2;
-		this.comparator1 = comp1;
-		this.comparator2 = comp2;
-		this.serializer2 = serializer2;
-		this.probeSideSerializer = serializer1;
-		this.typePairComparator = pairComparatorFactory.createComparator12(comp1, comp2);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/AbstractMergeIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/AbstractMergeIterator.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators.sort;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -354,4 +355,11 @@ public abstract class AbstractMergeIterator<T1, T2, O> implements JoinTaskIterat
 	 */
 	protected abstract <T> T createCopy(TypeSerializer<T> serializer, T value, T reuse);
 
+	@Override
+	public void reset(MutableObjectIterator<T1> in1, MutableObjectIterator<T2> in2, TypeSerializer<T1> serializer1, TypeSerializer<T2> serializer2, TypeComparator<T1> comp1, TypeComparator<T2> comp2, TypePairComparatorFactory<T1, T2> pairComparatorFactory) {
+		this.blockIt.resetForIterativeTasks();
+		this.iterator1 = createKeyGroupedIterator(in1, serializer1, comp1.duplicate());
+		this.iterator2 = createKeyGroupedIterator(in2, serializer2, comp2.duplicate());
+		this.pairComparator = pairComparatorFactory.createComparator12(comp1, comp2);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
@@ -23,9 +23,6 @@ package org.apache.flink.runtime.operators.util;
 import java.io.IOException;
 
 import org.apache.flink.api.common.functions.FlatJoinFunction;
-import org.apache.flink.api.common.typeutils.TypeComparator;
-import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.MutableObjectIterator;
@@ -76,5 +73,5 @@ public interface JoinTaskIterator<V1, V2, O>
 	/**
 	 * Allows to reset the iterator
 	 */
-	void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory);
+	void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/JoinTaskIterator.java
@@ -23,8 +23,12 @@ package org.apache.flink.runtime.operators.util;
 import java.io.IOException;
 
 import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparatorFactory;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
 
 /**
  * Interface of an iterator that performs the logic of a match task. The iterator follows the
@@ -68,4 +72,9 @@ public interface JoinTaskIterator<V1, V2, O>
 	 * method signals an interrupt to that procedure.
 	 */
 	void abort();
+
+	/**
+	 * Allows to reset the iterator
+	 */
+	void reset(MutableObjectIterator<V1> in1, MutableObjectIterator<V2> in2, TypeSerializer<V1> serializer1, TypeSerializer<V2> serializer2, TypeComparator<V1> comp1, TypeComparator<V2> comp2, TypePairComparatorFactory<V1, V2> pairComparatorFactory);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskExternalITCase.java
@@ -95,7 +95,7 @@ public abstract class AbstractOuterJoinTaskExternalITCase extends BinaryOperator
 		
 		addInputSorted(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), serializer, this.comparator1.duplicate());
 		addInputSorted(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), serializer, this.comparator2.duplicate());
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 		
 		Assert.assertEquals("Wrong result set size.", expCnt, this.output.getNumberOfRecords());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/AbstractOuterJoinTaskTest.java
@@ -167,7 +167,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		
 		addInputSorted(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), this.serializer, this.comparator1.duplicate());
 		addInputSorted(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), this.serializer, this.comparator2.duplicate());
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 		
 		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
 		
@@ -196,7 +196,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		
 		addInputSorted(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), this.serializer, this.comparator1.duplicate());
 		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, true), this.serializer);
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 		
 		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
 		
@@ -225,7 +225,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		
 		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, true), this.serializer);
 		addInputSorted(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), this.serializer, this.comparator2.duplicate());
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 		
 		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
 		
@@ -254,8 +254,8 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		
 		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, true), this.serializer);
 		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, true), this.serializer);
-		
-		testDriver(testTask, MockJoinStub.class);
+
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 		
 		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
 		
@@ -284,8 +284,8 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 		
 		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, true), this.serializer);
 		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, true), this.serializer);
-		
-		testDriver(testTask, MockFailingJoinStub.class);
+
+		testResettableDriver(testTask, MockFailingJoinStub.class, 1);
 	}
 	
 	@Test
@@ -309,7 +309,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockJoinStub.class);
+					testResettableDriver(testTask, MockJoinStub.class, 1);
 				} catch (Throwable t) {
 					error.set(t);
 				}
@@ -353,7 +353,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockJoinStub.class);
+					testResettableDriver(testTask, MockJoinStub.class, 1);
 				} catch (Throwable t) {
 					error.set(t);
 				}
@@ -397,7 +397,7 @@ public abstract class AbstractOuterJoinTaskTest extends BinaryOperatorTestBase<F
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockJoinStub.class);
+					testResettableDriver(testTask, MockJoinStub.class, 1);
 				} catch (Throwable t) {
 					error.set(t);
 				}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CachedMatchTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CachedMatchTaskTest.java
@@ -302,7 +302,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testResettableDriver(testTask, MockFailingMatchStub.class, 1);
+					testDriver(testTask, MockFailingMatchStub.class);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();
@@ -346,7 +346,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testResettableDriver(testTask, MockMatchStub.class, 1);
+					testDriver(testTask, MockMatchStub.class);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();
@@ -390,7 +390,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testResettableDriver(testTask, MockMatchStub.class, 1);
+					testDriver(testTask, MockMatchStub.class);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();
@@ -435,7 +435,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testResettableDriver(testTask, MockMatchStub.class, 3);
+					testResettableDriver(testTask, MockMatchStub.class, 1);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CachedMatchTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CachedMatchTaskTest.java
@@ -302,7 +302,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockFailingMatchStub.class);
+					testResettableDriver(testTask, MockFailingMatchStub.class, 1);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();
@@ -346,7 +346,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockMatchStub.class);
+					testResettableDriver(testTask, MockMatchStub.class, 1);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();
@@ -390,7 +390,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockMatchStub.class);
+					testResettableDriver(testTask, MockMatchStub.class, 1);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();
@@ -435,7 +435,7 @@ public class CachedMatchTaskTest extends DriverTestBase<FlatJoinFunction<Record,
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockMatchStub.class);
+					testResettableDriver(testTask, MockMatchStub.class, 3);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskExternalITCase.java
@@ -73,7 +73,7 @@ public class CombineTaskExternalITCase extends DriverTestBase<RichGroupReduceFun
 		final GroupReduceCombineDriver<Record, Record> testTask = new GroupReduceCombineDriver<>();
 		
 		try {
-			testDriver(testTask, MockCombiningReduceStub.class);
+			testResettableDriver(testTask, MockCombiningReduceStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Invoke method caused exception.");
@@ -127,7 +127,7 @@ public class CombineTaskExternalITCase extends DriverTestBase<RichGroupReduceFun
 		final GroupReduceCombineDriver<Record, Record> testTask = new GroupReduceCombineDriver<>();
 
 		try {
-			testDriver(testTask, MockCombiningReduceStub.class);
+			testResettableDriver(testTask, MockCombiningReduceStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Invoke method caused exception.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskTest.java
@@ -92,7 +92,7 @@ public class CombineTaskTest
 			final GroupReduceCombineDriver<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> testTask =
 					new GroupReduceCombineDriver<>();
 			
-			testDriver(testTask, MockCombiningReduceStub.class);
+			testResettableDriver(testTask, MockCombiningReduceStub.class, 3);
 			
 			int expSum = 0;
 			for (int i = 1;i < valCnt; i++) {
@@ -132,7 +132,7 @@ public class CombineTaskTest
 					new GroupReduceCombineDriver<>();
 			
 			try {
-				testDriver(testTask, MockFailingCombiningReduceStub.class);
+				testResettableDriver(testTask, MockFailingCombiningReduceStub.class, 3);
 				fail("Exception not forwarded.");
 			}
 			catch (ExpectedTestException etex) {
@@ -167,7 +167,7 @@ public class CombineTaskTest
 				@Override
 				public void run() {
 					try {
-						testDriver(testTask, MockFailingCombiningReduceStub.class);
+						testResettableDriver(testTask, MockFailingCombiningReduceStub.class, 1);
 					}
 					catch (Exception e) {
 						// exceptions may happen during canceling

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombinerOversizedRecordsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombinerOversizedRecordsTest.java
@@ -133,7 +133,7 @@ public class CombinerOversizedRecordsTest
 			GroupReduceCombineDriver<Tuple3<Integer, Integer, String>, Tuple3<Integer, Double, String>> testTask = 
 					new GroupReduceCombineDriver<Tuple3<Integer, Integer, String>, Tuple3<Integer, Double, String>>();
 			
-			testDriver(testTask, TestCombiner.class);
+			testResettableDriver(testTask, TestCombiner.class, 3);
 
 			assertEquals(3, testTask.getOversizedRecordCount());
 			assertTrue(keyCnt + 3 == outList.size() || 2*keyCnt + 3 == outList.size());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/JoinTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/JoinTaskExternalITCase.java
@@ -83,7 +83,7 @@ public class JoinTaskExternalITCase extends DriverTestBase<FlatJoinFunction<Reco
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
 			addInputSorted(new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -114,7 +114,7 @@ public class JoinTaskExternalITCase extends DriverTestBase<FlatJoinFunction<Reco
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Test caused an exception.");
@@ -145,7 +145,7 @@ public class JoinTaskExternalITCase extends DriverTestBase<FlatJoinFunction<Reco
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Test caused an exception.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/JoinTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/JoinTaskTest.java
@@ -96,7 +96,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
 			addInputSorted(new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -130,7 +130,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
 			addInputSorted(new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -166,7 +166,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
 			addInputSorted(new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -202,7 +202,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
 			addInputSorted(new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -238,7 +238,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
 			addInputSorted(new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -274,7 +274,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
 			addInput(new UniformRecordGenerator(keyCnt2, valCnt2, true));
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -310,7 +310,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		try {
 			addInput(new UniformRecordGenerator(keyCnt1, valCnt1, true));
 			addInputSorted(new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -346,7 +346,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		addInput(new UniformRecordGenerator(keyCnt2, valCnt2, true));
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test caused an exception.");
@@ -382,7 +382,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		addInput(new UniformRecordGenerator(keyCnt2, valCnt2, true));
 		
 		try {
-			testDriver(testTask, MockFailingMatchStub.class);
+			testResettableDriver(testTask, MockFailingMatchStub.class, 3);
 			Assert.fail("Driver did not forward Exception.");
 		} catch (ExpectedTestException e) {
 			// good!
@@ -422,7 +422,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 				@Override
 				public void run() {
 					try {
-						testDriver(testTask, MockMatchStub.class);
+						testResettableDriver(testTask, MockMatchStub.class, 1);
 					}
 					catch (Throwable t) {
 						error.set(t);
@@ -482,7 +482,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 				@Override
 				public void run() {
 					try {
-						testDriver(testTask, MockMatchStub.class);
+						testResettableDriver(testTask, MockMatchStub.class, 1);
 					}
 					catch (Throwable t) {
 						error.set(t);
@@ -537,7 +537,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 				@Override
 				public void run() {
 					try {
-						testDriver(testTask, MockDelayingMatchStub.class);
+						testResettableDriver(testTask, MockDelayingMatchStub.class, 3);
 					}
 					catch (Throwable t) {
 						error.set(t);
@@ -587,7 +587,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Test caused an exception.");
@@ -618,7 +618,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Test caused an exception.");
@@ -649,7 +649,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Test caused an exception.");
@@ -680,7 +680,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Test caused an exception.");
@@ -711,7 +711,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockMatchStub.class);
+			testResettableDriver(testTask, MockMatchStub.class, 3);
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Test caused an exception.");
@@ -742,7 +742,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockFailingMatchStub.class);
+			testResettableDriver(testTask, MockFailingMatchStub.class, 3);
 			Assert.fail("Function exception was not forwarded.");
 		} catch (ExpectedTestException etex) {
 			// good!
@@ -772,7 +772,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 		JoinDriver<Record, Record, Record> testTask = new JoinDriver<>();
 		
 		try {
-			testDriver(testTask, MockFailingMatchStub.class);
+			testResettableDriver(testTask, MockFailingMatchStub.class, 3);
 			Assert.fail("Function exception was not forwarded.");
 		} catch (ExpectedTestException etex) {
 			// good!
@@ -809,7 +809,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 				@Override
 				public void run() {
 					try {
-						testDriver(testTask, MockMatchStub.class);
+						testResettableDriver(testTask, MockMatchStub.class, 1);
 						success.set(true);
 					} catch (Exception ie) {
 						ie.printStackTrace();
@@ -863,7 +863,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 				@Override
 				public void run() {
 					try {
-						testDriver(testTask, MockMatchStub.class);
+						testResettableDriver(testTask, MockMatchStub.class, 1);
 						success.set(true);
 					} catch (Exception ie) {
 						ie.printStackTrace();
@@ -912,7 +912,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockMatchStub.class);
+					testResettableDriver(testTask, MockMatchStub.class, 1);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();
@@ -956,7 +956,7 @@ public class JoinTaskTest extends DriverTestBase<FlatJoinFunction<Record, Record
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockMatchStub.class);
+					testResettableDriver(testTask, MockMatchStub.class, 3);
 					success.set(true);
 				} catch (Exception ie) {
 					ie.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskExternalITCase.java
@@ -72,7 +72,7 @@ public class LeftOuterJoinTaskExternalITCase extends AbstractOuterJoinTaskExtern
 
 		addInputSorted(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), serializer, this.comparator1.duplicate());
 		addInputSorted(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), serializer, this.comparator2.duplicate());
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 
 		Assert.assertEquals("Wrong result set size.", expCnt, this.output.getNumberOfRecords());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/LeftOuterJoinTaskTest.java
@@ -141,7 +141,7 @@ public class LeftOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 
 		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), this.serializer);
 		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), this.serializer);
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 
 		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
 
@@ -170,7 +170,7 @@ public class LeftOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, true), this.serializer);
 		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, true), this.serializer);
 
-		testDriver(testTask, MockFailingJoinStub.class);
+		testResettableDriver(testTask, MockFailingJoinStub.class, 3);
 	}
 
 	@Test
@@ -193,7 +193,7 @@ public class LeftOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockJoinStub.class);
+					testResettableDriver(testTask, MockJoinStub.class, 1);
 				} catch (Throwable t) {
 					error.set(t);
 				}
@@ -234,7 +234,7 @@ public class LeftOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockJoinStub.class);
+					testResettableDriver(testTask, MockJoinStub.class, 1);
 				} catch (Throwable t) {
 					error.set(t);
 				}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/RightOuterJoinTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/RightOuterJoinTaskExternalITCase.java
@@ -72,7 +72,7 @@ public class RightOuterJoinTaskExternalITCase extends AbstractOuterJoinTaskExter
 
 		addInputSorted(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), serializer, this.comparator1.duplicate());
 		addInputSorted(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), serializer, this.comparator2.duplicate());
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 
 		Assert.assertEquals("Wrong result set size.", expCnt, this.output.getNumberOfRecords());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/RightOuterJoinTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/RightOuterJoinTaskTest.java
@@ -143,7 +143,7 @@ public class RightOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 
 		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, false), this.serializer);
 		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, false), this.serializer);
-		testDriver(testTask, MockJoinStub.class);
+		testResettableDriver(testTask, MockJoinStub.class, 3);
 
 		final int expCnt = calculateExpectedCount(keyCnt1, valCnt1, keyCnt2, valCnt2);
 
@@ -173,7 +173,7 @@ public class RightOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 		addInput(new UniformIntTupleGenerator(keyCnt1, valCnt1, true), this.serializer);
 		addInput(new UniformIntTupleGenerator(keyCnt2, valCnt2, true), this.serializer);
 
-		testDriver(testTask, MockFailingJoinStub.class);
+		testResettableDriver(testTask, MockFailingJoinStub.class, 3);
 	}
 
 	@Test
@@ -196,7 +196,7 @@ public class RightOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockJoinStub.class);
+					testResettableDriver(testTask, MockJoinStub.class, 1);
 				} catch (Throwable t) {
 					error.set(t);
 				}
@@ -237,7 +237,7 @@ public class RightOuterJoinTaskTest extends AbstractOuterJoinTaskTest {
 			@Override
 			public void run() {
 				try {
-					testDriver(testTask, MockJoinStub.class);
+					testResettableDriver(testTask, MockJoinStub.class, 1);
 				} catch (Throwable t) {
 					error.set(t);
 				}


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.
- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Updated PR based on @ggevay 's feedback. Now the drivers are all made of type ResettableDrivers and we use the existing APIs to reuse the driver and the iterators. The JoinTaskITerator has now a new method called reset() that allows to reset the iterator's state.
If we go with the approach then it makes sense to remove the ResettableDriver and add all the API in it to the Driver interface itself. That is for a later PR. 
@ggevay - Pls review and give your valuable feedback.
I tried mvn clean verify and got the tests to pass in flink-runtime and flink-gelly-examples. One failed 'org.apache.flink.runtime.io.disk.ChannelViewsTest.testWriteAndReadLongRecords' and when I ran locally it passed again. 
