### PR TITLE
[FLINK-4555] add test case to test Yarn cluster shutdown

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
@@ -33,16 +33,17 @@ import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.clusterframework.messages.CheckAndAllocateContainers;
 import org.apache.flink.runtime.clusterframework.messages.FatalErrorOccurred;
 import org.apache.flink.runtime.clusterframework.messages.InfoMessage;
-import org.apache.flink.runtime.clusterframework.messages.RegisterInfoMessageListenerSuccessful;
-import org.apache.flink.runtime.clusterframework.messages.NotifyResourceStarted;
-import org.apache.flink.runtime.clusterframework.messages.RegisterResourceManagerSuccessful;
 import org.apache.flink.runtime.clusterframework.messages.NewLeaderAvailable;
+import org.apache.flink.runtime.clusterframework.messages.NotifyResourceStarted;
 import org.apache.flink.runtime.clusterframework.messages.RegisterInfoMessageListener;
+import org.apache.flink.runtime.clusterframework.messages.RegisterInfoMessageListenerSuccessful;
 import org.apache.flink.runtime.clusterframework.messages.RegisterResourceManager;
+import org.apache.flink.runtime.clusterframework.messages.RegisterResourceManagerSuccessful;
 import org.apache.flink.runtime.clusterframework.messages.RemoveResource;
 import org.apache.flink.runtime.clusterframework.messages.ResourceRemoved;
 import org.apache.flink.runtime.clusterframework.messages.SetWorkerPoolSize;
 import org.apache.flink.runtime.clusterframework.messages.StopCluster;
+import org.apache.flink.runtime.clusterframework.messages.StopClusterSuccessful;
 import org.apache.flink.runtime.clusterframework.messages.TriggerRegistrationAtJobManager;
 import org.apache.flink.runtime.clusterframework.messages.UnRegisterInfoMessageListener;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -253,6 +254,7 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceIDRetrieva
 			else if (message instanceof StopCluster) {
 				StopCluster msg = (StopCluster) message;
 				shutdownCluster(msg.finalStatus(), msg.message());
+				sender().tell(decorateMessage(StopClusterSuccessful.getInstance()), ActorRef.noSender());
 			}
 
 			// --- miscellaneous messages

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1024,8 +1024,15 @@ class JobManager(
       // send resource manager the ok
       currentResourceManager match {
         case Some(rm) =>
-          // inform rm
-          rm ! decorateMessage(msg)
+          try {
+            // inform rm and wait for it to confirm
+            val waitTime = FiniteDuration(5, TimeUnit.SECONDS)
+            val answer = (rm ? decorateMessage(msg))(waitTime)
+            Await.ready(answer, waitTime)
+          } catch {
+            case e: TimeoutException =>
+            case e: InterruptedException =>
+          }
         case None =>
           // ResourceManager not available
           // we choose not to wait here beacuse it might block the shutdown forever

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -519,29 +519,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		}
 	}
 
-	/**
-	 * Tests that the Flink cluster shuts down cleanly even if Yarn doesn't kill all containers.
-	 * This can happen, e.g. if the kill command is not available or Yarn doesn't know
-	 * how to call it correctly.
-	 */
-	@Test(timeout = 60000)
-	public void testCleanShutdown() {
-		Runner runner = startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
-				"-n", "1",
-				"-jm", "768",
-				"-tm", "1024"},
-			"Number of connected TaskManagers changed to 1. Slots available: 1",
-			RunTypes.YARN_SESSION);
-
-		Assert.assertEquals(2, getRunningContainers());
-
-		runner.sendStop();
-
-		while (getRunningContainers() != 0) {
-			sleep();
-		}
-	}
-
 	@After
 	public void checkForProhibitedLogContents() {
 		ensureNoProhibitedStringInLogFiles(PROHIBITED_STRINGS, WHITELISTED_STRINGS);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -519,6 +519,29 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		}
 	}
 
+	/**
+	 * Tests that the Flink cluster shuts down cleanly even if Yarn doesn't kill all containers.
+	 * This can happen, e.g. if the kill command is not available or Yarn doesn't know
+	 * how to call it correctly.
+	 */
+	@Test(timeout = 60000)
+	public void testCleanShutdown() {
+		Runner runner = startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
+				"-n", "1",
+				"-jm", "768",
+				"-tm", "1024"},
+			"Number of connected TaskManagers changed to 1. Slots available: 1",
+			RunTypes.YARN_SESSION);
+
+		Assert.assertEquals(2, getRunningContainers());
+
+		runner.sendStop();
+
+		while (getRunningContainers() != 0) {
+			sleep();
+		}
+	}
+
 	@After
 	public void checkForProhibitedLogContents() {
 		ensureNoProhibitedStringInLogFiles(PROHIBITED_STRINGS, WHITELISTED_STRINGS);


### PR DESCRIPTION
In the first commit, it ensures that the cluster shutdown is working as expected.

In a second commit, it gives the ResourceManager more time to unregister the application. This is not important as Yarn also monitors processes but should ensure that everything shuts down cleanly.