### PR TITLE
[FLINK-4639] [table] Make Calcite features more pluggable

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/BatchTableEnvironment.scala
@@ -23,10 +23,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.apache.calcite.plan.RelOptPlanner.CannotPlanException
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.sql2rel.RelDecorrelator
-import org.apache.calcite.tools.Programs
-
+import org.apache.calcite.tools.{Programs, RuleSet}
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.{ExecutionEnvironment, DataSet}
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
 import org.apache.flink.api.java.io.DiscardingOutputFormat
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.table.explain.PlanJsonParser
@@ -34,7 +33,7 @@ import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.api.table.plan.logical.{CatalogNode, LogicalRelNode}
 import org.apache.flink.api.table.plan.nodes.dataset.{DataSetConvention, DataSetRel}
 import org.apache.flink.api.table.plan.rules.FlinkRuleSets
-import org.apache.flink.api.table.plan.schema.{TableSourceTable, DataSetTable}
+import org.apache.flink.api.table.plan.schema.{DataSetTable, TableSourceTable}
 import org.apache.flink.api.table.sinks.{BatchTableSink, TableSink}
 import org.apache.flink.api.table.sources.BatchTableSource
 
@@ -228,6 +227,11 @@ abstract class BatchTableEnvironment(
   }
 
   /**
+    * Returns the built-in rules that are defined by the environment.
+    */
+  protected def getBuiltInRuleSet: RuleSet = FlinkRuleSets.DATASET_OPT_RULES
+
+  /**
     * Translates a [[Table]] into a [[DataSet]].
     *
     * The transformation involves optimizing the relational expression tree as defined by
@@ -246,7 +250,7 @@ abstract class BatchTableEnvironment(
     val decorPlan = RelDecorrelator.decorrelateQuery(relNode)
 
     // optimize the logical Flink plan
-    val optProgram = Programs.ofRules(FlinkRuleSets.DATASET_OPT_RULES)
+    val optProgram = Programs.ofRules(getRuleSet)
     val flinkOutputProps = relNode.getTraitSet.replace(DataSetConvention.INSTANCE).simplify()
 
     val dataSetPlan = try {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/CalciteConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/CalciteConfig.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table
+
+import org.apache.calcite.sql.SqlOperatorTable
+import org.apache.calcite.sql.parser.SqlParser
+import org.apache.calcite.tools.RuleSet
+import org.apache.flink.util.Preconditions
+
+/**
+  * Builder for creating a Calcite configuration.
+  */
+class CalciteConfigBuilder {
+  private var replaceRuleSet: Option[RuleSet] = None
+  private var chainRuleSet: Option[RuleSet] = None
+
+  private var replaceSqlOperatorTable: Option[SqlOperatorTable] = None
+  private var chainSqlOperatorTable: Option[SqlOperatorTable] = None
+
+  private var replaceSqlParserConfig: Option[SqlParser.Config] = None
+
+  /**
+    * Replaces the built-in rule set with the given rule set.
+    */
+  def replaceRuleSet(ruleSet: RuleSet): CalciteConfigBuilder = {
+    Preconditions.checkNotNull(ruleSet)
+    replaceRuleSet = Some(ruleSet)
+    chainRuleSet = None
+    this
+  }
+
+  /**
+    * Appends the given rule set to the built-in rule set.
+    */
+  def addRuleSet(ruleSet: RuleSet): CalciteConfigBuilder = {
+    Preconditions.checkNotNull(ruleSet)
+    replaceRuleSet = None
+    chainRuleSet = Some(ruleSet)
+    this
+  }
+
+  /**
+    * Replaces the built-in SQL operator table with the given table.
+    */
+  def replaceSqlOperatorTable(sqlOperatorTable: SqlOperatorTable): CalciteConfigBuilder = {
+    Preconditions.checkNotNull(sqlOperatorTable)
+    replaceSqlOperatorTable = Some(sqlOperatorTable)
+    chainSqlOperatorTable = None
+    this
+  }
+
+  /**
+    * Appends the given table to the built-in SQL operator table.
+    */
+  def addSqlOperatorTable(sqlOperatorTable: SqlOperatorTable): CalciteConfigBuilder = {
+    Preconditions.checkNotNull(sqlOperatorTable)
+    replaceSqlOperatorTable = None
+    chainSqlOperatorTable = Some(sqlOperatorTable)
+    this
+  }
+
+  /**
+    * Replaces the built-in SQL parser configuration with the given configuration.
+    */
+  def replaceSqlParserConfig(sqlParserConfig: SqlParser.Config): CalciteConfigBuilder = {
+    Preconditions.checkNotNull(sqlParserConfig)
+    replaceSqlParserConfig = Some(sqlParserConfig)
+    this
+  }
+
+  private class CalciteConfigImpl(
+      val getRuleSet: Option[RuleSet],
+      val replacesRuleSet: Boolean,
+      val getSqlOperatorTable: Option[SqlOperatorTable],
+      val replacesSqlOperatorTable: Boolean,
+      val getSqlParserConfig: Option[SqlParser.Config])
+    extends CalciteConfig
+
+  /**
+    * Builds a new [[CalciteConfig]].
+    */
+  def build(): CalciteConfig = new CalciteConfigImpl(
+    replaceRuleSet.orElse(chainRuleSet),
+    replaceRuleSet.isDefined,
+    replaceSqlOperatorTable.orElse(chainSqlOperatorTable),
+    replaceSqlOperatorTable.isDefined,
+    replaceSqlParserConfig)
+}
+
+/**
+  * Calcite configuration for defining a custom Calcite configuration for Table and SQL API.
+  */
+trait CalciteConfig {
+  /**
+    * Returns whether this configuration replaces the built-in rule set.
+    */
+  def replacesRuleSet: Boolean
+
+  /**
+    * Returns a custom rule set.
+    */
+  def getRuleSet: Option[RuleSet]
+
+  /**
+    * Returns whether this configuration replaces the built-in SQL operator table.
+    */
+  def replacesSqlOperatorTable: Boolean
+
+  /**
+    * Returns a custom SQL operator table.
+    */
+  def getSqlOperatorTable: Option[SqlOperatorTable]
+
+  /**
+    * Returns a custom SQL parser configuration.
+    */
+  def getSqlParserConfig: Option[SqlParser.Config]
+}
+
+object CalciteConfig {
+
+  val DEFAULT = createBuilder().build()
+
+  /**
+    * Creates a new builder for constructing a [[CalciteConfig]].
+    */
+  def createBuilder(): CalciteConfigBuilder = {
+    new CalciteConfigBuilder
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/FlinkRelBuilder.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/FlinkRelBuilder.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.api.table
 
 import org.apache.calcite.jdbc.CalciteSchema
-import org.apache.calcite.plan.{Context, RelOptCluster, RelOptSchema}
+import org.apache.calcite.plan.{Context, RelOptCluster, RelOptPlanner, RelOptSchema}
 import org.apache.calcite.prepare.CalciteCatalogReader
 import org.apache.calcite.rex.RexBuilder
 import org.apache.calcite.schema.SchemaPlus
@@ -38,7 +38,7 @@ class FlinkRelBuilder(
     cluster,
     relOptSchema) {
 
-  def getPlanner = cluster.getPlanner
+  def getPlanner: RelOptPlanner = cluster.getPlanner
 
   def getCluster = cluster
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/StreamTableEnvironment.scala
@@ -23,16 +23,14 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.apache.calcite.plan.RelOptPlanner.CannotPlanException
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.sql2rel.RelDecorrelator
-import org.apache.calcite.tools.Programs
-
+import org.apache.calcite.tools.{Programs, RuleSet}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.table.expressions.Expression
 import org.apache.flink.api.table.plan.logical.{CatalogNode, LogicalRelNode}
 import org.apache.flink.api.table.plan.nodes.datastream.{DataStreamConvention, DataStreamRel}
 import org.apache.flink.api.table.plan.rules.FlinkRuleSets
 import org.apache.flink.api.table.sinks.{StreamTableSink, TableSink}
-import org.apache.flink.api.table.plan.schema.
-  {StreamableTableSourceTable, TransStreamTable, DataStreamTable}
+import org.apache.flink.api.table.plan.schema.{DataStreamTable, StreamableTableSourceTable, TransStreamTable}
 import org.apache.flink.api.table.sources.StreamTableSource
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
@@ -228,6 +226,11 @@ abstract class StreamTableEnvironment(
   }
 
   /**
+    * Returns the built-in rules that are defined by the environment.
+    */
+  protected def getBuiltInRuleSet: RuleSet = FlinkRuleSets.DATASTREAM_OPT_RULES
+
+  /**
     * Translates a [[Table]] into a [[DataStream]].
     *
     * The transformation involves optimizing the relational expression tree as defined by
@@ -246,7 +249,7 @@ abstract class StreamTableEnvironment(
     val decorPlan = RelDecorrelator.decorrelateQuery(relNode)
 
     // optimize the logical Flink plan
-    val optProgram = Programs.ofRules(FlinkRuleSets.DATASTREAM_OPT_RULES)
+    val optProgram = Programs.ofRules(getRuleSet)
     val flinkOutputProps = relNode.getTraitSet.replace(DataStreamConvention.INSTANCE).simplify()
 
     val dataStreamPlan = try {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableConfig.scala
@@ -22,7 +22,7 @@ import java.util.TimeZone
 /**
  * A config to define the runtime behavior of the Table API.
  */
-class TableConfig extends Serializable {
+class TableConfig {
 
   /**
    * Defines the timezone for date/time/timestamp conversions.
@@ -39,6 +39,11 @@ class TableConfig extends Serializable {
     * should be used within operators where possible.
     */
   private var efficientTypeUsage = false
+
+  /**
+    * Defines the configuration of Calcite for Table API and SQL queries.
+    */
+  private var calciteConfig = CalciteConfig.DEFAULT
 
   /**
    * Sets the timezone for date/time/timestamp conversions.
@@ -83,6 +88,18 @@ class TableConfig extends Serializable {
     this.efficientTypeUsage = efficientTypeUsage
   }
 
+  /**
+    * Returns the current configuration of Calcite for Table API and SQL queries.
+    */
+  def getCalciteConfig: CalciteConfig = calciteConfig
+
+  /**
+    * Sets the configuration of Calcite for Table API and SQL queries.
+    * Changing the configuration has no effect after the first query has been defined.
+    */
+  def setCalciteConfig(calciteConfig: CalciteConfig): Unit = {
+    this.calciteConfig = calciteConfig
+  }
 }
 
 object TableConfig {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/TableEnvironment.scala
@@ -27,7 +27,8 @@ import org.apache.calcite.schema.SchemaPlus
 import org.apache.calcite.schema.impl.AbstractTable
 import org.apache.calcite.sql.SqlOperatorTable
 import org.apache.calcite.sql.parser.SqlParser
-import org.apache.calcite.tools.{FrameworkConfig, Frameworks}
+import org.apache.calcite.sql.util.ChainedSqlOperatorTable
+import org.apache.calcite.tools.{FrameworkConfig, Frameworks, RuleSet, RuleSets}
 import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
 import org.apache.flink.api.java.table.{BatchTableEnvironment => JavaBatchTableEnv, StreamTableEnvironment => JavaStreamTableEnv}
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfo}
@@ -44,6 +45,8 @@ import org.apache.flink.api.table.validate.FunctionCatalog
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaStreamExecEnv}
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecEnv}
 
+import scala.collection.JavaConverters._
+
 /**
   * The abstract base class for batch and stream TableEnvironments.
   *
@@ -51,46 +54,98 @@ import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => Scala
   */
 abstract class TableEnvironment(val config: TableConfig) {
 
-  // configure sql parser
-  // we use Java lex because back ticks are easier than double quotes in programming
-  // and cases are preserved
-  private val parserConfig = SqlParser
-    .configBuilder()
-    .setLex(Lex.JAVA)
-    .build()
-
   // the catalog to hold all registered and translated tables
   private val tables: SchemaPlus = Frameworks.createRootSchema(true)
 
   // Table API/SQL function catalog
   private val functionCatalog: FunctionCatalog = FunctionCatalog.withBuildIns
 
-  // SQL operator and function catalog
-  private val sqlOperatorTable: SqlOperatorTable = functionCatalog.getSqlOperatorTable
-
   // the configuration to create a Calcite planner
-  private val frameworkConfig: FrameworkConfig = Frameworks
+  private lazy val frameworkConfig: FrameworkConfig = Frameworks
     .newConfigBuilder
     .defaultSchema(tables)
-    .parserConfig(parserConfig)
+    .parserConfig(getSqlParserConfig)
     .costFactory(new DataSetCostFactory)
     .typeSystem(new FlinkTypeSystem)
-    .operatorTable(sqlOperatorTable)
+    .operatorTable(getSqlOperatorTable)
     .build
 
   // the builder for Calcite RelNodes, Calcite's representation of a relational expression tree.
-  protected val relBuilder: FlinkRelBuilder = FlinkRelBuilder.create(frameworkConfig)
+  protected lazy val relBuilder: FlinkRelBuilder = FlinkRelBuilder.create(frameworkConfig)
 
   // the planner instance used to optimize queries of this TableEnvironment
-  private val planner: RelOptPlanner = relBuilder.getPlanner
+  private lazy val planner: RelOptPlanner = relBuilder.getPlanner
 
-  private val typeFactory: FlinkTypeFactory = relBuilder.getTypeFactory
+  private lazy val typeFactory: FlinkTypeFactory = relBuilder.getTypeFactory
 
   // a counter for unique attribute names
   private val attrNameCntr: AtomicInteger = new AtomicInteger(0)
 
   /** Returns the table config to define the runtime behavior of the Table API. */
   def getConfig = config
+
+  /**
+    * Returns the operator table for this environment including a custom Calcite configuration.
+    */
+  protected def getSqlOperatorTable: SqlOperatorTable = {
+    val calciteConfig = config.getCalciteConfig
+    calciteConfig.getSqlOperatorTable match {
+
+      case None =>
+        functionCatalog.getSqlOperatorTable
+
+      case Some(table) =>
+        if (calciteConfig.replacesSqlOperatorTable) {
+          table
+        } else {
+          ChainedSqlOperatorTable.of(functionCatalog.getSqlOperatorTable, table)
+        }
+    }
+  }
+
+  /**
+    * Returns the rule set for this environment including a custom Calcite configuration.
+    */
+  protected def getRuleSet: RuleSet = {
+    val calciteConfig = config.getCalciteConfig
+    calciteConfig.getRuleSet match {
+
+      case None =>
+        getBuiltInRuleSet
+
+      case Some(ruleSet) =>
+        if (calciteConfig.replacesRuleSet) {
+          ruleSet
+        } else {
+          RuleSets.ofList((getBuiltInRuleSet.asScala ++ ruleSet.asScala).asJava)
+        }
+    }
+  }
+
+  /**
+    * Returns the SQL parser config for this environment including a custom Calcite configuration.
+    */
+  protected def getSqlParserConfig: SqlParser.Config = {
+    val calciteConfig = config.getCalciteConfig
+    calciteConfig.getSqlParserConfig match {
+
+      case None =>
+        // we use Java lex because back ticks are easier than double quotes in programming
+        // and cases are preserved
+        SqlParser
+          .configBuilder()
+          .setLex(Lex.JAVA)
+          .build()
+
+      case Some(sqlParserConfig) =>
+        sqlParserConfig
+    }
+  }
+
+  /**
+    * Returns the built-in rules that are defined by the environment.
+    */
+  protected def getBuiltInRuleSet: RuleSet
 
   /**
     * Registers a [[UserDefinedFunction]] under a unique name. Replaces already existing

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/TableEnvironmentITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/TableEnvironmentITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.batch;
 
+import org.apache.calcite.tools.RuleSets;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.table.BatchTableEnvironment;
@@ -144,5 +145,18 @@ public class TableEnvironmentITCase extends TableProgramsTestBase {
 		Table t = tableEnv1.fromDataSet(CollectionDataSets.get3TupleDataSet(env));
 		// Must fail. Table is bound to different TableEnvironment.
 		tableEnv2.registerTable("MyTable", t);
+	}
+
+	@Test(expected = TableException.class)
+	public void testCustomCalciteConfig() {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		CalciteConfig cc = new CalciteConfigBuilder().replaceRuleSet(RuleSets.ofList()).build();
+		tableEnv.getConfig().setCalciteConfig(cc);
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+		Table t = tableEnv.fromDataSet(ds);
+		tableEnv.toDataSet(t, Row.class);
 	}
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/TableEnvironmentTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/TableEnvironmentTest.scala
@@ -18,10 +18,11 @@
 
 package org.apache.flink.api.table
 
+import org.apache.calcite.tools.RuleSet
 import org.apache.flink.api.scala._
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.typeutils.{TypeExtractor, TupleTypeInfo}
+import org.apache.flink.api.java.typeutils.{TupleTypeInfo, TypeExtractor}
 import org.apache.flink.api.table.expressions.{Alias, UnresolvedFieldReference}
 import org.apache.flink.api.table.sinks.TableSink
 import org.junit.Test
@@ -278,6 +279,8 @@ class MockTableEnvironment extends TableEnvironment(new TableConfig) {
   override private[flink] def writeToSink[T](table: Table, sink: TableSink[T]): Unit = ???
 
   override protected def checkValidTableName(name: String): Unit = ???
+
+  override protected def getBuiltInRuleSet: RuleSet = ???
 
   override def sql(query: String): Table = ???
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR adds some means to modify Calcites behavior within the Table/SQL API. It introduces a `CalciteConfig` which is available through `tEnv.getConfig().getCalciteConfig()`. It allows to append/replace a rule set, append/replace SQL operators and replace the SQL parser so far. 