### PR TITLE
[FLINK-4624] Allow for null values in Graph Summarization

### DIFF
--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/SummarizationData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/SummarizationData.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.graph.examples.data;
 
-import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Vertex;
-import org.apache.flink.types.NullValue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,34 +30,6 @@ import java.util.List;
  * Provides the default data set used for Summarization tests.
  */
 public class SummarizationData {
-
-	/**
-	 * Used to parse vertex and edge values of the input graph
-	 * @param <VV>
-	 */
-	abstract static class ValueReader<VV> {
-		abstract VV readValue(String value);
-	}
-
-	/**
-	 * Reads String values
-	 */
-	public static class StringValueReader extends ValueReader<String> {
-		@Override
-		String readValue(String value) {
-			return value;
-		}
-	}
-
-	/**
-	 * Reads Long values
-	 */
-	public static class LongValueReader extends ValueReader<Long> {
-		@Override
-		Long readValue(String value) {
-			return Long.parseLong(value);
-		}
-	}
 
 	private SummarizationData() {}
 
@@ -146,11 +116,11 @@ public class SummarizationData {
 	 * @param env execution environment
 	 * @return vertex data set with string values
 	 */
-	public static <VV> DataSet<Vertex<Long, VV>> getVertices(ExecutionEnvironment env, ValueReader<VV> valueReader) {
-		List<Vertex<Long, VV>> vertices = new ArrayList<>(INPUT_VERTICES.length);
+	public static DataSet<Vertex<Long, String>> getVertices(ExecutionEnvironment env) {
+		List<Vertex<Long, String>> vertices = new ArrayList<>(INPUT_VERTICES.length);
 		for (String vertex : INPUT_VERTICES) {
 			String[] tokens = vertex.split(";");
-			vertices.add(new Vertex<>(Long.parseLong(tokens[0]), valueReader.readValue(tokens[1])));
+			vertices.add(new Vertex<>(Long.parseLong(tokens[0]), tokens[1]));
 		}
 
 		return env.fromCollection(vertices);
@@ -162,29 +132,13 @@ public class SummarizationData {
 	 * @param env execution environment
 	 * @return edge data set with string values
 	 */
-	public static <EV> DataSet<Edge<Long, EV>> getEdges(ExecutionEnvironment env, ValueReader<EV> valueReader) {
-		List<Edge<Long, EV>> edges = new ArrayList<>(INPUT_EDGES.length);
+	public static DataSet<Edge<Long, String>> getEdges(ExecutionEnvironment env) {
+		List<Edge<Long, String>> edges = new ArrayList<>(INPUT_EDGES.length);
 		for (String edge : INPUT_EDGES) {
 			String[] tokens = edge.split(";");
-			edges.add(new Edge<>(Long.parseLong(tokens[0]), Long.parseLong(tokens[1]), valueReader.readValue(tokens[2])));
+			edges.add(new Edge<>(Long.parseLong(tokens[0]), Long.parseLong(tokens[1]), tokens[2]));
 		}
 
 		return env.fromCollection(edges);
-	}
-
-	/**
-	 * Creates a set of edges with {@link NullValue} as edge value.
-	 *
-	 * @param env execution environment
-	 * @return edge data set with null values
-	 */
-	@SuppressWarnings("serial")
-	public static DataSet<Edge<Long, NullValue>> getEdgesWithAbsentValues(ExecutionEnvironment env) {
-		return getEdges(env, new StringValueReader()).map(new MapFunction<Edge<Long, String>, Edge<Long, NullValue>>() {
-			@Override
-			public Edge<Long, NullValue> map(Edge<Long, String> value) throws Exception {
-				return new Edge<>(value.getSource(), value.getTarget(), NullValue.getInstance());
-			}
-		});
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.graph.library;
 
-import com.google.common.collect.Lists;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.apache.flink.graph.Edge;
@@ -35,6 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -63,8 +63,8 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 				SummarizationData.getEdges(env),
 				env);
 
-		List<Vertex<Long, Summarization.VertexValue<String>>> summarizedVertices = Lists.newArrayList();
-		List<Edge<Long, EdgeValue<String>>> summarizedEdges = Lists.newArrayList();
+		List<Vertex<Long, Summarization.VertexValue<String>>> summarizedVertices = new ArrayList<>();
+		List<Edge<Long, EdgeValue<String>>> summarizedEdges = new ArrayList<>();
 
 		Graph<Long, Summarization.VertexValue<String>, EdgeValue<String>> output =
 				input.run(new Summarization<Long, String, String>());
@@ -87,8 +87,8 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 				env)
 			.run(new TranslateEdgeValues<Long, String, String, NullValue>(new ToNullValue<String>()));
 
-		List<Vertex<Long, Summarization.VertexValue<String>>> summarizedVertices = Lists.newArrayList();
-		List<Edge<Long, EdgeValue<NullValue>>> summarizedEdges = Lists.newArrayList();
+		List<Vertex<Long, Summarization.VertexValue<String>>> summarizedVertices = new ArrayList<>();
+		List<Edge<Long, EdgeValue<NullValue>>> summarizedEdges = new ArrayList<>();
 
 		Graph<Long, Summarization.VertexValue<String>, EdgeValue<NullValue>> output =
 				input.run(new Summarization<Long, String, NullValue>());
@@ -113,8 +113,8 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 			.run(new TranslateVertexValues<Long, String, Long, String>(new StringToLong()))
 			.run(new TranslateEdgeValues<Long, Long, String, Long>(new StringToLong()));
 
-		List<Vertex<Long, Summarization.VertexValue<Long>>> summarizedVertices = Lists.newArrayList();
-		List<Edge<Long, EdgeValue<Long>>> summarizedEdges = Lists.newArrayList();
+		List<Vertex<Long, Summarization.VertexValue<Long>>> summarizedVertices = new ArrayList<>();
+		List<Edge<Long, EdgeValue<Long>>> summarizedEdges = new ArrayList<>();
 
 		Graph<Long, Summarization.VertexValue<Long>, EdgeValue<Long>> output =
 			input.run(new Summarization<Long, Long, Long>());
@@ -184,7 +184,7 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 	}
 
 	private List<Long> getListFromIdRange(String idRange) {
-		List<Long> result = Lists.newArrayList();
+		List<Long> result = new ArrayList<>();
 		for (String id : ID_SEPARATOR.split(idRange)) {
 			result.add(Long.parseLong(id));
 		}

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.translate.TranslateEdgeValues;
 import org.apache.flink.graph.asm.translate.TranslateFunction;
 import org.apache.flink.graph.asm.translate.TranslateVertexValues;
+import org.apache.flink.graph.asm.translate.translators.ToNullValue;
 import org.apache.flink.graph.examples.data.SummarizationData;
 import org.apache.flink.graph.library.Summarization.EdgeValue;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
@@ -204,15 +205,6 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 		@Override
 		public Long translate(String value, Long reuse) throws Exception {
 			return Long.parseLong(value);
-		}
-	}
-
-	private static class ToNullValue<T> implements TranslateFunction<T, NullValue> {
-
-		private static final NullValue nullValue = NullValue.getInstance();
-		@Override
-		public NullValue translate(T value, NullValue reuse) throws Exception {
-			return nullValue;
 		}
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
@@ -220,6 +220,8 @@ public class Summarization<K, VV, EV>
 	@SuppressWarnings("serial")
 	public static final class VertexGroupItem<K, VGV> extends Tuple4<K, K, Either<VGV, NullValue>, Long> {
 
+		private final Either.Right<VGV, NullValue> nullValue = new Either.Right<>(NullValue.getInstance());
+
 		public VertexGroupItem() {
 			reset();
 		}
@@ -246,7 +248,7 @@ public class Summarization<K, VV, EV>
 
 		public void setVertexGroupValue(VGV vertexGroupValue) {
 			if (vertexGroupValue == null) {
-				f2 = new Either.Right<>(NullValue.getInstance());
+				f2 = nullValue;
 			} else {
 				f2 = new Either.Left<>(vertexGroupValue);
 			}
@@ -266,7 +268,7 @@ public class Summarization<K, VV, EV>
 		public void reset() {
 			f0 = null;
 			f1 = null;
-			f2 = new Either.Right<>(NullValue.getInstance());
+			f2 = nullValue;
 			f3 = 0L;
 		}
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
@@ -31,7 +31,6 @@ import org.apache.flink.api.java.operators.GroupReduceOperator;
 import org.apache.flink.api.java.operators.UnsortedGrouping;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
-import org.apache.flink.api.java.typeutils.EitherTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.Edge;
@@ -101,10 +100,6 @@ public class Summarization<K, VV, EV>
 		// create type infos for correct return type definitions
 		TypeInformation<K> keyType = ((TupleTypeInfo<?>) input.getVertices().getType()).getTypeAt(0);
 		TypeInformation<VV> valueType = ((TupleTypeInfo<?>) input.getVertices().getType()).getTypeAt(1);
-		EitherTypeInfo<VV, NullValue> eitherType = new EitherTypeInfo<>(valueType, TypeInformation.of(NullValue.class));
-		@SuppressWarnings("unchecked")
-		TypeInformation<VertexGroupItem<K, VV>> tupleTypeInfo = (TypeInformation<VertexGroupItem<K, VV>>) new TupleTypeInfo(
-			VertexGroupItem.class, keyType, keyType, eitherType, BasicTypeInfo.LONG_TYPE_INFO);
 		@SuppressWarnings("unchecked")
 		TupleTypeInfo<Vertex<K, VertexValue<VV>>> vertexType = (TupleTypeInfo<Vertex<K, VertexValue<VV>>>) new TupleTypeInfo(
 			Vertex.class, keyType, new TupleTypeInfo(VertexValue.class, valueType, BasicTypeInfo.LONG_TYPE_INFO));
@@ -118,8 +113,7 @@ public class Summarization<K, VV, EV>
 				.groupBy(1);
 		// reduce vertex group and create vertex group items
 		GroupReduceOperator<Vertex<K, VV>, VertexGroupItem<K, VV>> vertexGroupItems = vertexUnsortedGrouping
-				.reduceGroup(new VertexGroupReducer<K, VV>())
-				.returns(tupleTypeInfo);
+				.reduceGroup(new VertexGroupReducer<K, VV>());
 		// create super vertices
 		DataSet<Vertex<K, VertexValue<VV>>> summarizedVertices = vertexGroupItems
 				.filter(new VertexGroupItemToSummarizedVertexFilter<K, VV>())

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
@@ -22,16 +22,24 @@ import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.RichGroupReduceFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.operators.GroupReduceOperator;
 import org.apache.flink.api.java.operators.UnsortedGrouping;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.api.java.typeutils.EitherTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.Either;
+import org.apache.flink.types.NullValue;
 import org.apache.flink.util.Collector;
 
 /**
@@ -90,8 +98,19 @@ public class Summarization<K, VV, EV>
 
 	@Override
 	public Graph<K, VertexValue<VV>, EdgeValue<EV>> run(Graph<K, VV, EV> input) throws Exception {
+		// create type infos for correct return type definitions
+		TypeInformation<K> keyType = ((TupleTypeInfo<?>) input.getVertices().getType()).getTypeAt(0);
+		TypeInformation<VV> valueType = ((TupleTypeInfo<?>) input.getVertices().getType()).getTypeAt(1);
+		EitherTypeInfo<VV, NullValue> eitherType = new EitherTypeInfo<>(valueType, TypeInformation.of(NullValue.class));
+		@SuppressWarnings("unchecked")
+		TypeInformation<VertexGroupItem<K, VV>> tupleTypeInfo = (TypeInformation<VertexGroupItem<K, VV>>) new TupleTypeInfo(
+			VertexGroupItem.class, keyType, keyType, eitherType, BasicTypeInfo.LONG_TYPE_INFO);
+		@SuppressWarnings("unchecked")
+		TupleTypeInfo<Vertex<K, VertexValue<VV>>> vertexType = (TupleTypeInfo<Vertex<K, VertexValue<VV>>>) new TupleTypeInfo(
+			Vertex.class, keyType, new TupleTypeInfo(VertexValue.class, valueType, BasicTypeInfo.LONG_TYPE_INFO));
+
 		// -------------------------
-		// build summarized vertices
+		// build super vertices
 		// -------------------------
 
 		// group vertices by value
@@ -99,20 +118,22 @@ public class Summarization<K, VV, EV>
 				.groupBy(1);
 		// reduce vertex group and create vertex group items
 		GroupReduceOperator<Vertex<K, VV>, VertexGroupItem<K, VV>> vertexGroupItems = vertexUnsortedGrouping
-				.reduceGroup(new VertexGroupReducer<K, VV>());
-		// create summarized vertices
+				.reduceGroup(new VertexGroupReducer<K, VV>())
+				.returns(tupleTypeInfo);
+		// create super vertices
 		DataSet<Vertex<K, VertexValue<VV>>> summarizedVertices = vertexGroupItems
 				.filter(new VertexGroupItemToSummarizedVertexFilter<K, VV>())
-				.map(new VertexGroupItemToSummarizedVertexMapper<K, VV>());
+				.map(new VertexGroupItemToSummarizedVertexMapper<K, VV>())
+				.returns(vertexType);
+
+		// -------------------------
+		// build super edges
+		// -------------------------
+
 		// create mapping between vertices and their representative
 		DataSet<VertexWithRepresentative<K>> vertexToRepresentativeMap = vertexGroupItems
-				.filter(new VertexGroupItemToRepresentativeFilter<K, VV>())
-				.map(new VertexGroupItemToVertexWithRepresentativeMapper<K, VV>());
-
-		// -------------------------
-		// build summarized edges
-		// -------------------------
-
+			.filter(new VertexGroupItemToRepresentativeFilter<K, VV>())
+			.map(new VertexGroupItemToVertexWithRepresentativeMapper<K, VV>());
 		// join edges with vertex representatives and update source and target identifiers
 		DataSet<Edge<K, EV>> edgesForGrouping = input.getEdges()
 				.join(vertexToRepresentativeMap)
@@ -123,7 +144,7 @@ public class Summarization<K, VV, EV>
 				.where(1) 	// target vertex id
 				.equalTo(0) // vertex id
 				.with(new TargetVertexJoinFunction<K, EV>());
-		// create summarized edges
+		// create super edges
 		DataSet<Edge<K, EdgeValue<EV>>> summarizedEdges = edgesForGrouping
 				.groupBy(0, 1, 2) // group by source id (0), target id (1) and edge value (2)
 				.reduceGroup(new EdgeGroupReducer<K, EV>());
@@ -203,10 +224,10 @@ public class Summarization<K, VV, EV>
 	 * @param <VGV> vertex group value type
 	 */
 	@SuppressWarnings("serial")
-	public static final class VertexGroupItem<K, VGV> extends Tuple4<K, K, VGV, Long> {
+	public static final class VertexGroupItem<K, VGV> extends Tuple4<K, K, Either<VGV, NullValue>, Long> {
 
 		public VertexGroupItem() {
-			setVertexGroupCount(0L);
+			reset();
 		}
 
 		public K getVertexId() {
@@ -226,11 +247,15 @@ public class Summarization<K, VV, EV>
 		}
 
 		public VGV getVertexGroupValue() {
-			return f2;
+			return f2.isLeft() ? f2.left() : null;
 		}
 
 		public void setVertexGroupValue(VGV vertexGroupValue) {
-			f2 = vertexGroupValue;
+			if (vertexGroupValue == null) {
+				f2 = new Either.Right<>(NullValue.getInstance());
+			} else {
+				f2 = new Either.Left<>(vertexGroupValue);
+			}
 		}
 
 		public Long getVertexGroupCount() {
@@ -247,7 +272,7 @@ public class Summarization<K, VV, EV>
 		public void reset() {
 			f0 = null;
 			f1 = null;
-			f2 = null;
+			f2 = new Either.Right<>(NullValue.getInstance());
 			f3 = 0L;
 		}
 	}
@@ -290,11 +315,13 @@ public class Summarization<K, VV, EV>
 	 */
 	@SuppressWarnings("serial")
 	private static final class VertexGroupReducer<K, VV>
-			implements GroupReduceFunction<Vertex<K, VV>, VertexGroupItem<K, VV>> {
+			extends RichGroupReduceFunction<Vertex<K, VV>, VertexGroupItem<K, VV>> {
 
-		private final VertexGroupItem<K, VV> reuseVertexGroupItem;
+		private transient VertexGroupItem<K, VV> reuseVertexGroupItem;
 
-		private VertexGroupReducer() {
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
 			this.reuseVertexGroupItem = new VertexGroupItem<>();
 		}
 
@@ -329,12 +356,10 @@ public class Summarization<K, VV, EV>
 		 * group.
 		 *
 		 * @param vertexGroupRepresentativeId group representative vertex identifier
-		 * @param vertexGroupValue  					group property value
-		 * @param vertexGroupCount          	total group count
+		 * @param vertexGroupValue  		  group property value
+		 * @param vertexGroupCount            total group count
 		 */
-		private void createGroupRepresentativeTuple(K vertexGroupRepresentativeId,
-																								VV vertexGroupValue,
-																								Long vertexGroupCount) {
+		private void createGroupRepresentativeTuple(K vertexGroupRepresentativeId, VV vertexGroupValue, Long vertexGroupCount) {
 			reuseVertexGroupItem.setVertexId(vertexGroupRepresentativeId);
 			reuseVertexGroupItem.setVertexGroupValue(vertexGroupValue);
 			reuseVertexGroupItem.setVertexGroupCount(vertexGroupCount);
@@ -511,9 +536,9 @@ public class Summarization<K, VV, EV>
 	@FunctionAnnotation.ForwardedFieldsSecond("f1") 	// vertex group id -> edge target id
 	private static final class TargetVertexJoinFunction<K, EV>
 			implements JoinFunction<Edge<K, EV>, VertexWithRepresentative<K>, Edge<K, EV>> {
+
 		@Override
-		public Edge<K, EV> join(Edge<K, EV> edge,
-														VertexWithRepresentative<K> vertexRepresentative) throws Exception {
+		public Edge<K, EV> join(Edge<K, EV> edge, VertexWithRepresentative<K> vertexRepresentative) throws Exception {
 			edge.setTarget(vertexRepresentative.getGroupRepresentativeId());
 			return edge;
 		}


### PR DESCRIPTION
* Bug was caused by serializers that cannot handle null values (e.g. Long)
* VertexGroupItem now uses Either<NullValue, VV> instead of VV
* Generalized test cases
* Added tests for vertex/edge values of type Long