### PR TITLE
[FLINK-4663] Flink JDBCOutputFormat logs wrong WARN message - Fixed

### DIFF
--- a/flink-batch-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-batch-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -108,7 +108,7 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 	@Override
 	public void writeRecord(Row row) throws IOException {
 
-		if (typesArray != null && typesArray.length > 0 && typesArray.length == row.productArity()) {
+		if (typesArray != null && typesArray.length > 0 && typesArray.length != row.productArity()) {
 			LOG.warn("Column SQL types array doesn't match arity of passed Row! Check the passed array...");
 		} 
 		try {


### PR DESCRIPTION
Fixed wrong WARN message logged by JDBCOutputFormat while adding row (writing record to prepared statement) as
"Column SQL types array doesn't match arity of passed Row! Check the passed array..."
even if there is no mismatch is SQL types array & arity of passed Row. [FLINK-4663]

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-4663]")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - No need to change documentation for same.

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

