### PR TITLE
[FLINK-4613] [ml] Extend ALS to handle implicit feedback datasets

### DIFF
--- a/docs/dev/libs/ml/als.md
+++ b/docs/dev/libs/ml/als.md
@@ -57,7 +57,7 @@ viewed which video, so the users only provide their preference implicitly.
 In these cases the feedback should not be treated as a
 rating, but rather an evidence that the user prefers that item.
 Thus, for implicit feedback datasets there is a slightly different
-minimalization problem to solve (see [Hu et al.](http://dx.doi.org/10.1109/ICDM.2008.22) for details).
+optimization problem to solve (see [Hu et al.](http://dx.doi.org/10.1109/ICDM.2008.22) for details).
 The implementation is based on the
 [Apache Spark implementation](https://github.com/apache/spark/blob/branch-2.0/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala)
 of implicit ALS.
@@ -118,7 +118,8 @@ The alternating least squares implementation can be controlled by the following 
         <td>
           <p>
             Implicit property of the observations, meaning that they do not represent an explicit
-            preference of the user, just the implicit information how many times the user consumed the
+            rating from the user, just the implicit information how many times the user consumed the
+            item.
             (Default value: <strong>false</strong>)
           </p>
         </td>
@@ -129,7 +130,7 @@ The alternating least squares implementation can be controlled by the following 
           <p>
             Weight of the positive implicit observations. Should be non-negative.
             Only relevant when ImplicitPrefs is set to true.
-            (Default value: <strong>1</strong>)
+            (Default value: <strong>40</strong>)
           </p>
         </td>
       </tr>

--- a/docs/dev/libs/ml/als.md
+++ b/docs/dev/libs/ml/als.md
@@ -49,6 +49,21 @@ By applying this step alternately to the matrices $U$ and $V$, we can iterativel
 
 The matrix $R$ is given in its sparse representation as a tuple of $(i, j, r)$ where $i$ denotes the row index, $j$ the column index and $r$ is the matrix value at position $(i,j)$.
 
+An alternative model can be used for _implicit feedback_ datasets.
+These datasets only contain implicit feedback from the user
+in contrast to datasets with explicit feedback like movie ratings.
+For example users watch videos on a website and the website monitors which user
+viewed which video, so the users only provide their preference implicitly.
+In these cases the feedback should not be treated as a
+rating, but rather an evidence that the user prefers that item.
+Thus, for implicit feedback datasets there is a slightly different
+minimalization problem to solve (see [Hu et al.](http://dx.doi.org/10.1109/ICDM.2008.22) for details).
+The implementation is based on the
+[Apache Spark implementation](https://github.com/apache/spark/blob/branch-2.0/mllib/src/main/scala/org/apache/spark/ml/recommendation/ALS.scala)
+of implicit ALS.
+Flink supports both explicit and implicit ALS,
+and the choice between the two can be set in the parameters.
+
 ## Operations
 
 `ALS` is a `Predictor`.
@@ -94,6 +109,26 @@ The alternating least squares implementation can be controlled by the following 
         <td>
           <p>
             Regularization factor. Tune this value in order to avoid overfitting or poor performance due to strong generalization.
+            (Default value: <strong>1</strong>)
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td><strong>ImplicitPrefs</strong></td>
+        <td>
+          <p>
+            Implicit property of the observations, meaning that they do not represent an explicit
+            preference of the user, just the implicit information how many times the user consumed the
+            (Default value: <strong>false</strong>)
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Alpha</strong></td>
+        <td>
+          <p>
+            Weight of the positive implicit observations. Should be non-negative.
+            Only relevant when ImplicitPrefs is set to true.
             (Default value: <strong>1</strong>)
           </p>
         </td>

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -100,14 +100,14 @@ import scala.util.Random
   *
   *  - [[org.apache.flink.ml.recommendation.ALS.ImplicitPrefs]]:
   *  Implicit property of the observations, meaning that they do not represent an explicit
-  *  preference of the user, just the implicit information how many times the user consumed the
+  *  rating from the user, just the implicit information how many times the user consumed the
   *  item (Default value: '''false''')
   *
   *  - [[org.apache.flink.ml.recommendation.ALS.Alpha]]:
   *  Weight of the positive implicit observations. Should be non-negative.
   *  Only relevant when [[org.apache.flink.ml.recommendation.ALS.ImplicitPrefs]]
   *  is set to '''true'''.
-  *  (Default value: '''1''')
+  *  (Default value: '''40''')
   *
   *  - [[org.apache.flink.ml.recommendation.ALS.Blocks]]:
   *  The number of blocks into which the user and item matrix a grouped. The fewer
@@ -313,7 +313,7 @@ object ALS {
   }
 
   case object Alpha extends Parameter[Double] {
-    val defaultValue: Option[Double] = Some(1.0)
+    val defaultValue: Option[Double] = Some(40.0)
   }
 
   case object Blocks extends Parameter[Int] {

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.ml.recommendation
 
-import java.lang.Iterable
 import java.{util, lang}
 
 import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint
@@ -30,7 +29,7 @@ import org.apache.flink.ml.pipeline.{FitOperation, PredictDataSetOperation, Pred
 import org.apache.flink.types.Value
 import org.apache.flink.util.Collector
 import org.apache.flink.api.common.functions.{CoGroupFunction, GroupReduceFunction,
-  MapPartitionFunction, RichCoGroupFunction, Partitioner => FlinkPartitioner}
+  RichCoGroupFunction, Partitioner => FlinkPartitioner}
 
 import com.github.fommil.netlib.BLAS.{ getInstance => blas }
 import com.github.fommil.netlib.LAPACK.{ getInstance => lapack }

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -140,9 +140,7 @@ class ALS extends Predictor[ALS] {
   // Stores the matrix factorization after the fitting phase
   var factorsOption: Option[(DataSet[Factors], DataSet[Factors])] = None
 
-  /** Sets the number of latent factors/row dimension of the latent model.
-    * We recommend working with highest number of factors feasible within
-    * computational limitations.
+  /** Sets the number of latent factors/row dimension of the latent model
     *
     * @param numFactors
     * @return
@@ -299,7 +297,7 @@ object ALS {
   // ========================================= Parameters ==========================================
 
   case object NumFactors extends Parameter[Int] {
-    val defaultValue: Option[Int] = Some(50)
+    val defaultValue: Option[Int] = Some(10)
   }
 
   case object Lambda extends Parameter[Double] {

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -141,7 +141,9 @@ class ALS extends Predictor[ALS] {
   // Stores the matrix factorization after the fitting phase
   var factorsOption: Option[(DataSet[Factors], DataSet[Factors])] = None
 
-  /** Sets the number of latent factors/row dimension of the latent model
+  /** Sets the number of latent factors/row dimension of the latent model.
+    * We recommend working with highest number of factors feasible within
+    * computational limitations.
     *
     * @param numFactors
     * @return
@@ -171,7 +173,8 @@ class ALS extends Predictor[ALS] {
     this
   }
 
-  /** Sets the input observations to be implicit, thus using the iALS algorithm for learning.
+  /** When set to true, we assume implicit observations, thus we will use the iALS algorithm
+    * for learning.
     *
     * @param implicitPrefs
     * @return
@@ -297,7 +300,7 @@ object ALS {
   // ========================================= Parameters ==========================================
 
   case object NumFactors extends Parameter[Int] {
-    val defaultValue: Option[Int] = Some(10)
+    val defaultValue: Option[Int] = Some(50)
   }
 
   case object Lambda extends Parameter[Double] {

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -324,7 +324,7 @@ object ALS {
   }
 
   case object Seed extends Parameter[Long] {
-    val defaultValue: Option[Long] = Some(0L)
+    val defaultValue: Option[Long] = None
   }
 
   case object TemporaryPath extends Parameter[String] {
@@ -487,7 +487,7 @@ object ALS {
       val userBlocks = resultParameters.get(Blocks).getOrElse(input.count.toInt)
       val itemBlocks = userBlocks
       val persistencePath = resultParameters.get(TemporaryPath)
-      val seed = resultParameters(Seed)
+      val seed = resultParameters.get(Seed)
       val factors = resultParameters(NumFactors)
       val iterations = resultParameters(Iterations)
       val lambda = resultParameters(Lambda)
@@ -537,7 +537,7 @@ object ALS {
 
           (blockID, infos.elementIDs.map{
             id =>
-              val random = new Random(id ^ seed)
+              val random = seed.map(s => new Random(id ^ s)).getOrElse(Random)
               randomFactors(factors, random)
           })
       }.withForwardedFields("0")
@@ -1137,15 +1137,6 @@ object ALS {
 
       pos += 1
       row += 1
-    }
-  }
-
-  def generateRandomMatrix(users: DataSet[Int], factors: Int, seed: Long): DataSet[Factors] = {
-    users map {
-      id =>{
-        val random = new Random(id ^ seed)
-        Factors(id, randomFactors(factors, random))
-      }
     }
   }
 

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.recommendation
 
+import java.lang.Iterable
 import java.{util, lang}
 
 import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint
@@ -29,7 +30,7 @@ import org.apache.flink.ml.pipeline.{FitOperation, PredictDataSetOperation, Pred
 import org.apache.flink.types.Value
 import org.apache.flink.util.Collector
 import org.apache.flink.api.common.functions.{CoGroupFunction, GroupReduceFunction,
-  RichCoGroupFunction, Partitioner => FlinkPartitioner}
+  MapPartitionFunction, RichCoGroupFunction, Partitioner => FlinkPartitioner}
 
 import com.github.fommil.netlib.BLAS.{ getInstance => blas }
 import com.github.fommil.netlib.LAPACK.{ getInstance => lapack }
@@ -104,6 +105,8 @@ import scala.util.Random
   *
   *  - [[org.apache.flink.ml.recommendation.ALS.Alpha]]:
   *  Weight of the positive implicit observations. Should be non-negative.
+  *  Only relevant when [[org.apache.flink.ml.recommendation.ALS.ImplicitPrefs]]
+  *  is set to '''true'''.
   *  (Default value: '''1''')
   *
   *  - [[org.apache.flink.ml.recommendation.ALS.Blocks]]:
@@ -765,10 +768,57 @@ object ALS {
     updatedFactorMatrix.withForwardedFieldsFirst("0").withForwardedFieldsSecond("0")
   }
 
-  def computeXtX(x: DataSet[(Int, Array[Array[Double]])], factors: Int):
+  /**
+    * Computes the XtX matrix for the implicit version before updating the factors.
+    * This matrix is intended to be broadcast, but as we cannot use a sink inside a Flink
+    * iteration, so we represent it as a [[DataSet]] with a single element containing the matrix.
+    *
+    * The algorithm computes `X_i^T * X_i` for every block `X_i` of `X`,
+    * then sums all these computed matrices to get `X^T * X`.
+    */
+  private[recommendation] def computeXtX(x: DataSet[(Int, Array[Array[Double]])], factors: Int):
   DataSet[Array[Double]] = {
-    // todo compute XtX
-    null
+    val triangleSize = factors * (factors - 1) / 2 + factors
+
+    type MtxBlock = (Int, Array[Array[Double]])
+    // construct XtX for all blocks
+    val xtx = x
+      .mapPartition(new MapPartitionFunction[MtxBlock, Array[Double]]() {
+        var xtxForBlock: Array[Double] = null
+
+        override def mapPartition(blocks: Iterable[(Int, Array[Array[Double]])],
+                                  out: Collector[Array[Double]]): Unit = {
+
+          if (xtxForBlock == null) {
+            // creating the matrix if not yet created
+            xtxForBlock = Array.fill(triangleSize)(0.0)
+          } else {
+            // erasing the matrix
+            var i = 0
+            while (i < xtxForBlock.length) {
+              xtxForBlock(i) = 0
+              i = i + 1
+            }
+          }
+
+          val it = blocks.iterator()
+          while (it.hasNext) {
+            val xBlock = it.next()._2
+            xBlock.foreach(row => {
+              blas.dspr("U", row.length, 1, row, 1, xtxForBlock)
+            })
+          }
+
+          out.collect(xtxForBlock)
+        }
+      })
+      .reduce((bxtx1: Array[Double], bxtx2: Array[Double]) => {
+        // aggregating the XtXs computed for blocks
+        blas.daxpy(bxtx1.length, 1, bxtx1, 1, bxtx2, 1)
+        bxtx2
+      })
+
+    xtx
   }
 
   /** Creates the meta information needed to route the item and user vectors to the respective user

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ALSITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ALSITSuite.scala
@@ -44,6 +44,7 @@ class ALSITSuite
       .setLambda(lambda)
       .setBlocks(4)
       .setNumFactors(numFactors)
+      .setSeed(seed)
 
     val inputDS = env.fromCollection(data)
 

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ImplicitALSTest.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ImplicitALSTest.scala
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.recommendation
+
+import org.apache.flink.ml.util.FlinkTestBase
+import org.scalatest._
+
+import scala.language.postfixOps
+import org.apache.flink.api.scala._
+import org.apache.flink.core.testutils.CommonTestUtils
+
+class ImplicitALSTest
+  extends FlatSpec
+    with Matchers
+    with FlinkTestBase {
+
+  override val parallelism = 2
+
+  behavior of "The modification of the alternating least squares (ALS) implementation" +
+    "for implicit feedback datasets."
+
+  it should "properly compute Y^T * Y, and factorize matrix" in {
+    import ExampleMatrix._
+
+    val rand = scala.util.Random
+    val numBlocks = 3
+    // randomly split matrix to blocks
+    val blocksY = Y
+      // add a random block id to every row
+      .map { row =>
+        (rand.nextInt(numBlocks), row)
+      }
+      // get the block via grouping
+      .groupBy(_._1).values
+      // add a block id (-1) to each block
+      .map(b => (-1, b.map(_._2)))
+      .toSeq
+
+    // use Flink to compute YtY
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val distribBlocksY = env.fromCollection(blocksY)
+
+    val YtY = ALS
+      .computeXtX(distribBlocksY, factors)
+      .collect().head
+
+    // check YtY size
+    YtY.length should be (factors * (factors - 1) / 2 + factors)
+
+    // check result is as expected
+    expectedUpperTriangleYtY
+      .zip(YtY)
+      .foreach { case (expected, result) =>
+        result should be (expected +- 0.1)
+      }
+
+    // temporary directory to avoid too few memory segments
+    val tempDir = CommonTestUtils.getTempDir + "/"
+
+    // factorize matrix with implicit ALS
+    val als = ALS()
+      .setIterations(iterations)
+      .setLambda(lambda)
+      .setBlocks(blocks)
+      .setNumFactors(factors)
+      .setImplicit(true)
+      .setAlpha(alpha)
+      .setSeed(seed)
+      .setTemporaryPath(tempDir)
+
+    val inputDS = env.fromCollection(implicitRatings)
+
+    als.fit(inputDS)
+
+    // check predictions on some user-item pairs
+    val testData = env.fromCollection(expectedResult.map{
+      case (userID, itemID, rating) => (userID, itemID)
+    })
+
+    val predictions = als.predict(testData).collect()
+
+    predictions.length should equal(expectedResult.length)
+
+    val resultMap = expectedResult map {
+      case (uID, iID, value) => (uID, iID) -> value
+    } toMap
+
+    predictions foreach {
+      case (uID, iID, value) => {
+        resultMap.isDefinedAt((uID, iID)) should be(true)
+
+        value should be(resultMap((uID, iID)) +- 1e-5)
+      }
+    }
+
+  }
+
+}
+
+object ExampleMatrix {
+
+  val seed = 500
+  val factors = 3
+  val blocks = 2
+  val alpha = 40.0
+  val lambda = 0.1
+  val iterations = 10
+
+  val implicitRatings = Seq(
+    (0, 3, 1.0),
+    (0, 6, 2.0),
+    (0, 9, 1.0),
+    (1, 0, 1.0),
+    (1, 2, 3.0),
+    (1, 6, 1.0),
+    (1, 7, 5.0),
+    (1, 8, 1.0),
+    (2, 1, 1.0),
+    (2, 4, 3.0),
+    (3, 1, 2.0),
+    (3, 3, 4.0),
+    (3, 5, 5.0),
+    (4, 5, 1.0),
+    (4, 8, 2.0),
+    (4, 10, 2.0),
+    (5, 2, 1.0)
+  )
+
+  val expectedResult = Seq(
+    (1, 1, -0.22642740122582822),
+    (3, 2, -0.40638720202261835),
+    (4, 3, 0.28037645952568335),
+    (2, 3, 0.9176106683061931)
+  )
+
+  val Y = Array(
+    Array(1.0, 3.0, 1.0),
+    Array(-3.0, 4.0, 1.0),
+    Array(1.0, 2.0, -1.0),
+    Array(4.0, 1.0, 4.0),
+    Array(3.0, -2.0, 3.0),
+    Array(-1.0, 1.0, 2.0)
+  )
+
+  /**
+    * Upper triangle representation by columns.
+    */
+  val expectedUpperTriangleYtY = Array(
+    37.0,
+    -10.0, 35.0,
+    20.0, 5.0, 32.0
+  )
+
+}

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ImplicitALSTest.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ImplicitALSTest.scala
@@ -34,13 +34,13 @@ class ImplicitALSTest
   behavior of "The modification of the alternating least squares (ALS) implementation" +
     "for implicit feedback datasets."
 
-  it should "properly compute Y^T * Y" in {
+  it should "properly compute X^T * X" in {
     import Recommendation._
 
     val rand = scala.util.Random
     val numBlocks = 3
     // randomly split matrix to blocks
-    val blocksY = Y
+    val blocksX = X
       // add a random block id to every row
       .map { row =>
         (rand.nextInt(numBlocks), row)
@@ -51,21 +51,21 @@ class ImplicitALSTest
       .map(b => (-1, b.map(_._2)))
       .toSeq
 
-    // use Flink to compute YtY
+    // use Flink to compute XtX
     val env = ExecutionEnvironment.getExecutionEnvironment
 
-    val distribBlocksY = env.fromCollection(blocksY)
+    val distribBlocksX = env.fromCollection(blocksX)
 
-    val YtY = ALS
-      .computeXtX(distribBlocksY, implicitFactors)
+    val XtX = ALS
+      .computeXtX(distribBlocksX, implicitFactors)
       .collect().head
 
-    // check YtY size
-    YtY.length should be (implicitFactors * (implicitFactors - 1) / 2 + implicitFactors)
+    // check XtX size
+    XtX.length should be (implicitFactors * (implicitFactors - 1) / 2 + implicitFactors)
 
     // check result is as expected
-    expectedUpperTriangleYtY
-      .zip(YtY)
+    expectedUpperTriangleXtX
+      .zip(XtX)
       .foreach { case (expected, result) =>
         result should be (expected +- 0.1)
       }

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/Recommendation.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/Recommendation.scala
@@ -87,4 +87,60 @@ object Recommendation {
   }
 
   val expectedEmpiricalRisk = 505374.1877
+
+
+  // data for implicit ALS
+
+  val implicitSeed = 500
+  val implicitFactors = 3
+  val implicitBlocks = 2
+  val implicitAlpha = 40.0
+  val implicitLambda = 0.1
+  val implicitIterations = 10
+
+  val implicitRatings = Seq(
+    (0, 3, 1.0),
+    (0, 6, 2.0),
+    (0, 9, 1.0),
+    (1, 0, 1.0),
+    (1, 2, 3.0),
+    (1, 6, 1.0),
+    (1, 7, 5.0),
+    (1, 8, 1.0),
+    (2, 1, 1.0),
+    (2, 4, 3.0),
+    (3, 1, 2.0),
+    (3, 3, 4.0),
+    (3, 5, 5.0),
+    (4, 5, 1.0),
+    (4, 8, 2.0),
+    (4, 10, 2.0),
+    (5, 2, 1.0)
+  )
+
+  val implicitExpectedResult = Seq(
+    (1, 1, -0.22642740122582822),
+    (3, 2, -0.40638720202261835),
+    (4, 3, 0.28037645952568335),
+    (2, 3, 0.9176106683061931)
+  )
+
+  val Y = Array(
+    Array(1.0, 3.0, 1.0),
+    Array(-3.0, 4.0, 1.0),
+    Array(1.0, 2.0, -1.0),
+    Array(4.0, 1.0, 4.0),
+    Array(3.0, -2.0, 3.0),
+    Array(-1.0, 1.0, 2.0)
+  )
+
+  /**
+    * Upper triangle representation by columns.
+    */
+  val expectedUpperTriangleYtY = Array(
+    37.0,
+    -10.0, 35.0,
+    20.0, 5.0, 32.0
+  )
+
 }

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/Recommendation.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/Recommendation.scala
@@ -22,6 +22,7 @@ object Recommendation {
   val iterations = 9
   val lambda = 1.0
   val numFactors = 5
+  val seed = 0L
 
   val data: Seq[(Int, Int, Double)] = {
     Seq(

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/Recommendation.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/Recommendation.scala
@@ -126,7 +126,7 @@ object Recommendation {
     (2, 3, 0.9176106683061931)
   )
 
-  val Y = Array(
+  val X = Array(
     Array(1.0, 3.0, 1.0),
     Array(-3.0, 4.0, 1.0),
     Array(1.0, 2.0, -1.0),
@@ -138,7 +138,7 @@ object Recommendation {
   /**
     * Upper triangle representation by columns.
     */
-  val expectedUpperTriangleYtY = Array(
+  val expectedUpperTriangleXtX = Array(
     37.0,
     -10.0, 35.0,
     20.0, 5.0, 32.0


### PR DESCRIPTION
This extension of the ALS algorithm changes some parts of the code if `implicitPrefs` flag is set to true. Mainly the local parts parts are changed: the `Xt * X` computation takes into consideration the confidence, thus computing `Xt * (C - I) * X` instead (see the paper by Hu et al. for details). The `Xt * X` matrix is precomputed and broadcasted, and that is the only thing that affects distributed execution.

Note, that we use a temporary directory in the test, because there would not be enough memory segments to perform a hash join for prediction. I assume that memory segments are not freed up after the training if no temporary directory is set, but I did not investigate the issue as using a tempdir is a simple workaround.
