### PR TITLE
[FLINK-4670] [cluster management] Add watch mechanism on current RPC framework

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -73,7 +73,7 @@ public abstract class RpcEndpoint<C extends RpcGateway> {
 	private final Executor mainThreadExecutor;
 
 	/** A reference to the endpoint's main thread, if the current method is called by the main thread */
-	final AtomicReference<Thread> currentMainThread = new AtomicReference<>(null); 
+	final AtomicReference<Thread> currentMainThread = new AtomicReference<>(null);
 
 	/**
 	 * Initializes the RPC endpoint.
@@ -152,6 +152,43 @@ public abstract class RpcEndpoint<C extends RpcGateway> {
 	 */
 	public String getAddress() {
 		return self.getAddress();
+	}
+
+	/**
+	 * Add a rpc gateway to watch on
+	 *
+	 * @param rpcGateway the rpc gateway to watch on
+	 */
+	public void watch(RpcGateway rpcGateway) {
+		if(self instanceof WatchOperationHandler) {
+			((WatchOperationHandler) self).watch(rpcGateway);
+		} else {
+			throw new UnsupportedOperationException("Watch operation is not supported yet!");
+		}
+	}
+
+	/**
+	 * Stop watch a rpc gateway
+	 *
+	 * @param rpcGateway the rpc gateway to unwatch on
+	 */
+	public void unWatch(RpcGateway rpcGateway) {
+		if(self instanceof WatchOperationHandler) {
+			((WatchOperationHandler) self).unWatch(rpcGateway);
+		} else {
+			throw new UnsupportedOperationException("UnWatch operation is not supported yet!");
+		}
+	}
+
+	/**
+	 * Notify a rpc gateway unreachable event. The notification could come under two cases:
+	 * 1. watch a unreachable gateway at first
+	 * 2. after the service on watched gateway dead
+	 *
+	 * @param rpcGateway the dead rpc gateway
+	 */
+	public void notifyUnreachableRpcGateway(RpcGateway rpcGateway) {
+		log.warn("Rpc gateway on address {} is unreachable", rpcGateway.getAddress());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/WatchOperationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/WatchOperationHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+public interface WatchOperationHandler {
+
+	/**
+	 * Add a rpc gateway to watch on
+	 *
+	 * @param rpcGateway the rpc gateway to watch on
+	 */
+	void watch(RpcGateway rpcGateway);
+
+	/**
+	 * Stop watch a rpc gateway
+	 *
+	 * @param rpcGateway the rpc gateway to unwatch on
+	 */
+	void unWatch(RpcGateway rpcGateway);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/WatchOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/messages/WatchOperation.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka.messages;
+
+import org.apache.flink.runtime.rpc.RpcGateway;
+
+import java.io.Serializable;
+
+/**
+ * Base class for watch operation
+ */
+public abstract class WatchOperation implements Serializable {
+
+	private static final long serialVersionUID = 2018682807453586774L;
+
+	/** the rpcGateway to take watch operation on */
+	private final transient RpcGateway rpcGateway;
+
+	/** timeout for look service on rpcGateway address in millisecond */
+	private final long timeoutInMillis;
+
+	/**
+	 * Constructs a base watch operation
+	 *
+	 * @param rpcGateway      the rpcGateway to take watch operation on
+	 * @param timeoutInMillis timeout for look service on rpcGateway address in millisecond
+	 */
+	public WatchOperation(RpcGateway rpcGateway, long timeoutInMillis) {
+		this.rpcGateway = rpcGateway;
+		this.timeoutInMillis = timeoutInMillis;
+	}
+
+	/**
+	 * Gets the rpcGateway to take watch operation on
+	 *
+	 * @return the rpcGateway to take watch operation on
+	 */
+	public RpcGateway getRpcGateway() {
+		return rpcGateway;
+	}
+
+	/**
+	 * Gets timeout for connect rpcGateway address at first time in millisecond
+	 *
+	 * @return timeout for look service on rpcGateway address in millisecond
+	 */
+	public long getTimeoutInMillis() {
+		return timeoutInMillis;
+	}
+
+	public static final class AddWatch extends WatchOperation {
+
+		private static final long serialVersionUID = 1287429984556496379L;
+
+		public AddWatch(RpcGateway rpcGateway, long timeoutInMillis) {
+			super(rpcGateway, timeoutInMillis);
+		}
+
+	}
+
+	public static final class RemoveWatch extends WatchOperation {
+
+		private static final long serialVersionUID = -3120037314548359084L;
+
+		public RemoveWatch(RpcGateway rpcGateway, long timeoutInMillis) {
+			super(rpcGateway, timeoutInMillis);
+		}
+
+	}
+}
+


### PR DESCRIPTION
This pr aims at adding watch mechanism on current RPC framework, so RPC gateway could be watched to make sure the rpc server is running just like previous DeathWatch in akka.
There are following main differences:
1. Add watch and unwatch method to RpcEndpoint class
2. Implement WatchOperationHandler in AkkaInvocationHandler, so it could handle watch and unwatch operation
