### PR TITLE
[FLINK-4218] [checkpoints] Do not rely on FileSystem to determine state sizes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -108,7 +108,7 @@ public class CompletedCheckpoint implements StateObject {
 	}
 
 	@Override
-	public long getStateSize() throws Exception {
+	public long getStateSize() throws IOException {
 		long result = 0L;
 
 		for (TaskState taskState : taskStates.values()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
@@ -152,7 +152,7 @@ public class TaskState implements StateObject {
 
 
 	@Override
-	public long getStateSize() throws Exception {
+	public long getStateSize() throws IOException {
 		long result = 0L;
 
 		for (int i = 0; i < parallelism; i++) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV1Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV1Serializer.java
@@ -197,6 +197,7 @@ class SavepointV1Serializer implements SavepointSerializer<SavepointV1> {
 		} else if (stateHandle instanceof FileStateHandle) {
 			dos.writeByte(FILE_STREAM_STATE_HANDLE);
 			FileStateHandle fileStateHandle = (FileStateHandle) stateHandle;
+			dos.writeLong(stateHandle.getStateSize());
 			dos.writeUTF(fileStateHandle.getFilePath().toString());
 
 		} else if (stateHandle instanceof ByteStreamStateHandle) {
@@ -218,12 +219,13 @@ class SavepointV1Serializer implements SavepointSerializer<SavepointV1> {
 		if (NULL_HANDLE == type) {
 			return null;
 		} else if (FILE_STREAM_STATE_HANDLE == type) {
+			long size = dis.readLong();
 			String pathString = dis.readUTF();
-			return new FileStateHandle(new Path(pathString));
+			return new FileStateHandle(new Path(pathString), size);
 		} else if (BYTE_STREAM_STATE_HANDLE == type) {
 			int numBytes = dis.readInt();
 			byte[] data = new byte[numBytes];
-			dis.read(data);
+			dis.readFully(data);
 			return new ByteStreamStateHandle(data);
 		} else {
 			throw new IOException("Unknown implementation of StreamStateHandle, code: " + type);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChainedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChainedStateHandle.java
@@ -85,7 +85,7 @@ public class ChainedStateHandle<T extends StateObject> implements StateObject {
 	}
 
 	@Override
-	public long getStateSize() throws Exception {
+	public long getStateSize() throws IOException {
 		long sumStateSize = 0;
 
 		if (operatorStateHandles != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -118,7 +118,7 @@ public class KeyGroupsStateHandle implements StateObject {
 	}
 
 	@Override
-	public long getStateSize() throws Exception {
+	public long getStateSize() throws IOException {
 		return stateHandle.getStateSize();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -20,8 +20,6 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.state.RetrievableStateHandle;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
@@ -41,6 +39,7 @@ public class RetrievableStreamStateHandle<T extends Serializable> implements
 		StreamStateHandle, RetrievableStateHandle<T>, Closeable {
 
 	private static final long serialVersionUID = 314567453677355L;
+
 	/** wrapped inner stream state handle from which we deserialize on retrieval */
 	private final StreamStateHandle wrappedStreamStateHandle;
 
@@ -48,9 +47,9 @@ public class RetrievableStreamStateHandle<T extends Serializable> implements
 		this.wrappedStreamStateHandle = Preconditions.checkNotNull(streamStateHandle);
 	}
 
-	public RetrievableStreamStateHandle(Path filePath) {
+	public RetrievableStreamStateHandle(Path filePath, long stateSize) {
 		Preconditions.checkNotNull(filePath);
-		this.wrappedStreamStateHandle = new FileStateHandle(filePath);
+		this.wrappedStreamStateHandle = new FileStateHandle(filePath, stateSize);
 	}
 
 	@Override
@@ -71,7 +70,7 @@ public class RetrievableStreamStateHandle<T extends Serializable> implements
 	}
 
 	@Override
-	public long getStateSize() throws Exception {
+	public long getStateSize() throws IOException {
 		return wrappedStreamStateHandle.getStateSize();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
+import java.io.IOException;
+
 /**
  * Base of all types that represent checkpointed state. Specializations are for
  * example {@link StateHandle StateHandles} (directly resolve to state).
@@ -47,7 +49,7 @@ public interface StateObject extends java.io.Closeable, java.io.Serializable {
 	 * <p>If the the size is not known, return {@code 0}.
 	 *
 	 * @return Size of the state in bytes.
-	 * @throws Exception If the operation fails during size retrieval.
+	 * @throws IOException If the operation fails during size retrieval.
 	 */
-	long getStateSize() throws Exception;
+	long getStateSize() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -26,7 +26,9 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 
 import java.io.IOException;
 
-import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 
 /**
  * {@link StreamStateHandle} for state that was written to a file stream. The written data is
@@ -36,14 +38,13 @@ public class FileStateHandle extends AbstractCloseableHandle implements StreamSt
 
 	private static final long serialVersionUID = 350284443258002355L;
 
-	/**
-	 * The path to the file in the filesystem, fully describing the file system
-	 */
+	/** The path to the file in the filesystem, fully describing the file system */
 	private final Path filePath;
 
-	/**
-	 * Cached file system handle
-	 */
+	/** The size of the state in the file */
+	private final long stateSize;
+
+	/** Cached file system handle */
 	private transient FileSystem fs;
 
 	/**
@@ -51,8 +52,10 @@ public class FileStateHandle extends AbstractCloseableHandle implements StreamSt
 	 *
 	 * @param filePath The path to the file that stores the state.
 	 */
-	public FileStateHandle(Path filePath) {
-		this.filePath = requireNonNull(filePath);
+	public FileStateHandle(Path filePath, long stateSize) {
+		checkArgument(stateSize >= -1);
+		this.filePath = checkNotNull(filePath);
+		this.stateSize = stateSize;
 	}
 
 	/**
@@ -86,8 +89,7 @@ public class FileStateHandle extends AbstractCloseableHandle implements StreamSt
 		// fail (and be ignored) when some files still exist
 		try {
 			getFileSystem().delete(filePath.getParent(), false);
-		} catch (IOException ignored) {
-		}
+		} catch (IOException ignored) {}
 	}
 
 	/**
@@ -98,7 +100,7 @@ public class FileStateHandle extends AbstractCloseableHandle implements StreamSt
 	 */
 	@Override
 	public long getStateSize() throws IOException {
-		return getFileSystem().getFileStatus(filePath).getLen();
+		return stateSize;
 	}
 
 	/**
@@ -114,6 +116,7 @@ public class FileStateHandle extends AbstractCloseableHandle implements StreamSt
 		return fs;
 	}
 
+	// ------------------------------------------------------------------------
 
 	@Override
 	public boolean equals(Object o) {
@@ -132,5 +135,10 @@ public class FileStateHandle extends AbstractCloseableHandle implements StreamSt
 	@Override
 	public int hashCode() {
 		return filePath.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return String.format("File State: %s [%d bytes]", filePath, stateSize);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -301,9 +301,16 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 					}
 					else {
 						flush();
+
+						long size = -1;
+						// make a best effort attempt to figure out the size
+						try {
+							size = outStream.getPos();
+						} catch (Exception ignored) {}
+						
 						outStream.close();
 						closed = true;
-						return new FileStateHandle(statePath);
+						return new FileStateHandle(statePath, size);
 					}
 				}
 				else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -183,7 +183,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		}
 
 		@Override
-		public long getStateSize() throws Exception {
+		public long getStateSize() throws IOException {
 			return 0;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTrackerTest.java
@@ -334,7 +334,7 @@ public class SimpleCheckpointStatsTrackerTest {
 					StreamStateHandle proxy = new StateHandleProxy(new Path(), proxySize);
 
 					SubtaskState subtaskState = new SubtaskState(
-						new ChainedStateHandle<>(Arrays.asList(proxy)),
+						new ChainedStateHandle<>(Collections.singletonList(proxy)),
 						duration);
 
 					taskState.putState(subtaskIndex, subtaskState);
@@ -371,21 +371,11 @@ public class SimpleCheckpointStatsTrackerTest {
 
 		private static final long serialVersionUID = 35356735683568L;
 
-		public StateHandleProxy(Path filePath, long proxySize) {
-			super(filePath);
-			this.proxySize = proxySize;
-		}
-
-		private long proxySize;
-
-		@Override
-		public void discardState() throws Exception {
-
+		public StateHandleProxy(Path filePath, long size) {
+			super(filePath, size);
 		}
 
 		@Override
-		public long getStateSize() {
-			return proxySize;
-		}
+		public void discardState() {}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/AbstractCloseableHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/AbstractCloseableHandleTest.java
@@ -87,12 +87,10 @@ public class AbstractCloseableHandleTest {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public void discardState() throws Exception {
-
-		}
+		public void discardState() {}
 
 		@Override
-		public long getStateSize() throws Exception {
+		public long getStateSize() {
 			return 0;
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -198,6 +198,7 @@ public class InterruptSensitiveRestoreTest {
 			// an interrupt on a waiting object leads to an infinite loop
 			try {
 				synchronized (this) {
+					//noinspection WaitNotInLoop
 					wait();
 				}
 			}
@@ -216,7 +217,7 @@ public class InterruptSensitiveRestoreTest {
 		public void discardState() throws Exception {}
 
 		@Override
-		public long getStateSize() throws Exception {
+		public long getStateSize() throws IOException {
 			return 0;
 		}
 	}


### PR DESCRIPTION
This prevents failures on eventually consistent S3, where the operations for keys (=entries in the parent directory/bucket) are not guaranteed to be immediately consistent (visible) after a blob was written.

Not relying on any operation on keys (= requesting `FileStatus`) should mitigate the problem.

This also changes the exception signature from `getStateSize()` from `Exception` to `IOException`, which fits more natural with the exception signatures of some other I/O methods.

Related issue: We may still want to have retries on `FileStatus` operations on S3, for other parts of the system (like FileOutputFormats)