### PR TITLE
[FLINK-4673] [core] TypeInfoFactory for Either type

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
@@ -18,13 +18,16 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.EitherSerializer;
 import org.apache.flink.types.Either;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A {@link TypeInformation} for the {@link Either} type of the Java API.
@@ -76,6 +79,15 @@ public class EitherTypeInfo<L, R> extends TypeInformation<Either<L, R>> {
 	@PublicEvolving
 	public Class<Either<L, R>> getTypeClass() {
 		return (Class<Either<L, R>>) (Class<?>) Either.class;
+	}
+
+	@Override
+	@PublicEvolving
+	public Map<String, TypeInformation<?>> getGenericParameters() {
+		Map<String, TypeInformation<?>> m = new HashMap<>();
+		m.put("L", this.leftType);
+		m.put("R", this.rightType);
+		return m;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
@@ -29,6 +29,8 @@ import org.apache.flink.types.Either;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A {@link TypeInformation} for the {@link Either} type of the Java API.
  *
@@ -46,8 +48,8 @@ public class EitherTypeInfo<L, R> extends TypeInformation<Either<L, R>> {
 
 	@PublicEvolving
 	public EitherTypeInfo(TypeInformation<L> leftType, TypeInformation<R> rightType) {
-		this.leftType = leftType;
-		this.rightType = rightType;
+		this.leftType = checkNotNull(leftType);
+		this.rightType = checkNotNull(rightType);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfoFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfoFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.types.Either;
@@ -29,6 +30,19 @@ public class EitherTypeInfoFactory<L, R> extends TypeInfoFactory<Either<L, R>> {
 
 	@Override
 	public TypeInformation<Either<L, R>> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
-		return new EitherTypeInfo(genericParameters.get("L"), genericParameters.get("R"));
+		TypeInformation<?> leftType = genericParameters.get("L");
+		TypeInformation<?> rightType = genericParameters.get("R");
+
+		if (leftType == null) {
+			throw new InvalidTypesException("Type extraction is not possible on Either" +
+				" type as it does not contain information about the 'left' type.");
+		}
+
+		if (rightType == null) {
+			throw new InvalidTypesException("Type extraction is not possible on Either" +
+				" type as it does not contain information about the 'right' type.");
+		}
+
+		return new EitherTypeInfo(leftType, rightType);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfoFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfoFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils;
+
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.types.Either;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class EitherTypeInfoFactory<L, R> extends TypeInfoFactory<Either<L, R>> {
+
+	@Override
+	public TypeInformation<Either<L, R>> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
+		return new EitherTypeInfo(genericParameters.get("L"), genericParameters.get("R"));
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/types/Either.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Either.java
@@ -19,6 +19,8 @@
 package org.apache.flink.types;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.java.typeutils.EitherTypeInfoFactory;
 
 /**
  * This type represents a value of one two possible types, Left or Right (a
@@ -30,6 +32,7 @@ import org.apache.flink.annotation.Public;
  *            the type of Right
  */
 @Public
+@TypeInfo(EitherTypeInfoFactory.class)
 public abstract class Either<L, R> {
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
@@ -18,6 +18,16 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import java.util.Map;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -43,25 +53,16 @@ import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple9;
+import org.apache.flink.types.Either;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.types.DoubleValue;
-import org.apache.flink.types.Either;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 import org.apache.flink.util.Collector;
+
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @SuppressWarnings("serial")
 public class TypeExtractorTest {
@@ -1854,6 +1855,12 @@ public class TypeExtractorTest {
 		Either<String, Tuple1<Integer>> either = new Either2();
 		ti = TypeExtractor.getForObject(either);
 		Assert.assertEquals(expected, ti);
+	}
+
+	@Test(expected=InvalidTypesException.class)
+	public void testEitherFromObjectException() {
+		Either<String, Tuple1<Integer>> either = Either.Left("test");
+		TypeExtractor.getForObject(either);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
@@ -18,16 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import java.util.Map;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -53,16 +43,25 @@ import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple9;
-import org.apache.flink.types.Either;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.types.DoubleValue;
+import org.apache.flink.types.Either;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 import org.apache.flink.util.Collector;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings("serial")
 public class TypeExtractorTest {
@@ -1855,12 +1854,6 @@ public class TypeExtractorTest {
 		Either<String, Tuple1<Integer>> either = new Either2();
 		ti = TypeExtractor.getForObject(either);
 		Assert.assertEquals(expected, ti);
-	}
-
-	@Test(expected=InvalidTypesException.class)
-	public void testEitherFromObjectException() {
-		Either<String, Tuple1<Integer>> either = Either.Left("test");
-		TypeExtractor.getForObject(either);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
Removes from TypeExtractor the explicit parsing for Either and adds an EitherTypeInfoFactory.

A test was removed that was expected to fail but now looks to succeed.
