### PR TITLE
[FLINK-4677] fail if user jar contains no executions

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -320,6 +320,10 @@ public abstract class ClusterClient {
 			try {
 				// invoke main method
 				prog.invokeInteractiveModeForExecution();
+				if (lastJobExecutionResult == null && factory.getLastEnvCreated() == null) {
+					throw new ProgramInvocationException("The program didn't contain Flink jobs. " +
+						"Perhaps you forgot to call execute() on the execution environment.");
+				}
 				if (isDetached()) {
 					// in detached mode, we execute the whole user code to extract the Flink job, afterwards we run it here
 					return ((DetachedEnvironment) factory.getLastEnvCreated()).finalizeExecute();
@@ -334,7 +338,7 @@ public abstract class ClusterClient {
 			}
 		}
 		else {
-			throw new RuntimeException("PackagedProgram does not have a valid invocation mode.");
+			throw new ProgramInvocationException("PackagedProgram does not have a valid invocation mode.");
 		}
 	}
 


### PR DESCRIPTION
If the user has an empty main method with no Flink executions, this will print a nicer error message.