### PR TITLE
[FLINK-4671] [table] Table API can not be built

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -82,26 +82,9 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-minikdc</artifactId>
 			<version>${minikdc.version}</version>
+			<scope>compile</scope>
 		</dependency>
 
 	</dependencies>
-
-	<build>
-		<plugins>
-
-			<!--
-            https://issues.apache.org/jira/browse/DIRSHARED-134
-            Required to pull the Mini-KDC transitive dependency
-            -->
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.0.1</version>
-				<inherited>true</inherited>
-				<extensions>true</extensions>
-			</plugin>
-
-		</plugins>
-	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1081,6 +1081,15 @@ under the License.
 				</executions>
 			</plugin>
 
+			<!-- Pull bundled transitive dependencies (e.g. Mini-KDC see DIRSHARED-134) -->
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>3.0.1</version>
+				<inherited>true</inherited>
+				<extensions>true</extensions>
+			</plugin>
+
 		</plugins>
 
 		<!-- Plugin configurations for plugins activated in sub-projects --> 


### PR DESCRIPTION
This PR solves problems introduced by FLINK-3929 / 25a622f. Now the plugin is configured globally. All projects that depend on `flink-test-utils` should build again.

@mxm what do you think?

