### PR TITLE
[FLINK-3656] [table] Reduce number of ITCases

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/utils/TableProgramsTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/utils/TableProgramsTestBase.scala
@@ -62,13 +62,7 @@ object TableProgramsTestBase {
   }
 
   @Parameterized.Parameters(name = "Execution mode = {0}, Table config = {1}")
-  def tableConfigs(): util.Collection[Array[java.lang.Object]] = {
-    Seq(
-      // TODO more tests in cluster mode?
-      Array[AnyRef](TestExecutionMode.CLUSTER, TableConfigMode.DEFAULT),
-      Array[AnyRef](TestExecutionMode.COLLECTION, TableConfigMode.DEFAULT),
-      Array[AnyRef](TestExecutionMode.COLLECTION, TableConfigMode.NULL),
-      Array[AnyRef](TestExecutionMode.COLLECTION, TableConfigMode.EFFICIENT)
-    )
+  def parameters(): util.Collection[Array[java.lang.Object]] = {
+    Seq[Array[AnyRef]](Array(TestExecutionMode.COLLECTION, TableConfigMode.DEFAULT))
   }
 }


### PR DESCRIPTION
This is the first step of reducing the number of ITCases of the Table API. This PR modifies the TableProgramsTestBase to test only the default configuration in collection execution environment. Other configurations will be enabled individually per test.

It reduces the number of tests. From 955 to 403 tests.