### PR TITLE
[FLINK-4636] Add boundary check for priorityqueue for cep operator

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractCEPPatternOperator.java
@@ -126,11 +126,12 @@ abstract public class AbstractCEPPatternOperator<IN, OUT> extends AbstractCEPBas
 
 		int numberPriorityQueueEntries = ois.readInt();
 
-		priorityQueue = new PriorityQueue<StreamRecord<IN>>(numberPriorityQueueEntries, new StreamRecordComparator<IN>());
-
-		for (int i = 0; i <numberPriorityQueueEntries; i++) {
-			StreamElement streamElement = streamRecordSerializer.deserialize(new DataInputViewStreamWrapper(ois));
-			priorityQueue.offer(streamElement.<IN>asRecord());
+		if(numberPriorityQueueEntries > 0) {
+			priorityQueue = new PriorityQueue<StreamRecord<IN>>(numberPriorityQueueEntries, new StreamRecordComparator<IN>());
+			for (int i = 0; i <numberPriorityQueueEntries; i++) {
+				StreamElement streamElement = streamRecordSerializer.deserialize(new DataInputViewStreamWrapper(ois));
+				priorityQueue.offer(streamElement.<IN>asRecord());
+			}
 		}
 	}
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.
- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

When numberPriorityQueueEntries=0, creation of priority queue object
fails as its constructor throws exception when size is passed as 0.
We check for this condition and skip creating object as it doesn't serve
any purpose in that case.
