### PR TITLE
[FLINK-4348] Simplify logic of SlotManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceSlot.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework.types;
 
-import org.apache.flink.runtime.resourcemanager.registration.SimpleTaskExecutorRegistration;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorRegistration;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -35,12 +35,12 @@ public class ResourceSlot implements ResourceIDRetrievable {
 	private final ResourceProfile resourceProfile;
 
 	/** Gateway to the TaskExecutor which owns the slot */
-	private final SimpleTaskExecutorRegistration taskExecutorRegistration;
+	private final TaskExecutorRegistration taskExecutorRegistration;
 
-	public ResourceSlot(SlotID slotId, ResourceProfile resourceProfile, SimpleTaskExecutorRegistration taskExecutorRegistration) {
+	public ResourceSlot(SlotID slotId, ResourceProfile resourceProfile, TaskExecutorRegistration taskExecutorRegistration) {
 		this.slotId = checkNotNull(slotId);
 		this.resourceProfile = checkNotNull(resourceProfile);
-		this.taskExecutorRegistration = taskExecutorRegistration;
+		this.taskExecutorRegistration = checkNotNull(taskExecutorRegistration);
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public class ResourceSlot implements ResourceIDRetrievable {
 		return resourceProfile;
 	}
 
-	public SimpleTaskExecutorRegistration getTaskExecutorRegistration() {
+	public TaskExecutorRegistration getTaskExecutorRegistration() {
 		return taskExecutorRegistration;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceSlot.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework.types;
 
-import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.resourcemanager.registration.SimpleTaskExecutorRegistration;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -35,12 +35,12 @@ public class ResourceSlot implements ResourceIDRetrievable {
 	private final ResourceProfile resourceProfile;
 
 	/** Gateway to the TaskExecutor which owns the slot */
-	private final TaskExecutorGateway taskExecutorGateway;
+	private final SimpleTaskExecutorRegistration taskExecutorRegistration;
 
-	public ResourceSlot(SlotID slotId, ResourceProfile resourceProfile, TaskExecutorGateway taskExecutorGateway) {
+	public ResourceSlot(SlotID slotId, ResourceProfile resourceProfile, SimpleTaskExecutorRegistration taskExecutorRegistration) {
 		this.slotId = checkNotNull(slotId);
 		this.resourceProfile = checkNotNull(resourceProfile);
-		this.taskExecutorGateway = taskExecutorGateway;
+		this.taskExecutorRegistration = taskExecutorRegistration;
 	}
 
 	@Override
@@ -56,8 +56,8 @@ public class ResourceSlot implements ResourceIDRetrievable {
 		return resourceProfile;
 	}
 
-	public TaskExecutorGateway getTaskExecutorGateway() {
-		return taskExecutorGateway;
+	public SimpleTaskExecutorRegistration getTaskExecutorRegistration() {
+		return taskExecutorRegistration;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -270,7 +270,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 					WorkerRegistration oldRegistration = taskExecutors.remove(resourceID);
 					if (oldRegistration != null) {
 						// TODO :: suggest old taskExecutor to stop itself
-						slotManager.notifyTaskManagerFailure(resourceID);
+						log.info("Replacing old instance of worker for ResourceID {}", resourceID);
 					}
 					WorkerType newWorker = workerStarted(resourceID);
 					WorkerRegistration<WorkerType> registration =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -81,29 +81,37 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		extends RpcEndpoint<ResourceManagerGateway>
 		implements LeaderContender {
 
-	/** The exit code with which the process is stopped in case of a fatal error */
+	/** The exit code with which the process is stopped in case of a fatal error. */
 	protected static final int EXIT_CODE_FATAL_ERROR = -13;
 
+	/** All currently registered JobMasterGateways scoped by JobID. */
 	private final Map<JobID, JobMasterGateway> jobMasterGateways;
 
+	/** LeaderListeners for all registered JobMasters. */
 	private final Map<JobID, JobMasterLeaderListener> jobMasterLeaderRetrievalListeners;
 
+	/** All currently registered TaskExecutors with there framework specific worker information. */
 	private final Map<ResourceID, WorkerRegistration<WorkerType>> taskExecutors;
 
+	/** High availability services for leader retrieval and election. */
 	private final HighAvailabilityServices highAvailabilityServices;
 
-	/** The factory to construct the SlotManager */
+	/** The factory to construct the SlotManager. */
 	private final SlotManagerFactory slotManagerFactory;
 
 	/** The SlotManager created by the slotManagerFactory when the ResourceManager is started. */
 	private SlotManager slotManager;
 
+	/** The service to elect a ResourceManager leader. */
 	private LeaderElectionService leaderElectionService;
 
+	/** ResourceManager's leader session id which is updated on leader election. */
 	private UUID leaderSessionID;
 
+	/** All registered listeners for status updates of the ResourceManager. */
 	private Map<String, InfoMessageListenerRpcGateway> infoMessageListeners;
 
+	/** Default timeout for messages */
 	private final Time timeout = Time.seconds(5);
 
 	public ResourceManager(
@@ -116,6 +124,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		this.jobMasterGateways = new HashMap<>();
 		this.jobMasterLeaderRetrievalListeners = new HashMap<>();
 		this.taskExecutors = new HashMap<>();
+		this.leaderSessionID = new UUID(0, 0);
 		infoMessageListeners = new HashMap<>();
 	}
 
@@ -381,7 +390,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 				jobMasterGateways.clear();
 				taskExecutors.clear();
 				slotManager.clearState();
-				leaderSessionID = null;
+				leaderSessionID = new UUID(0, 0);
 			}
 		});
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -92,8 +92,11 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 
 	private final HighAvailabilityServices highAvailabilityServices;
 
+	/** The factory to construct the SlotManager */
 	private final SlotManagerFactory slotManagerFactory;
-	protected SlotManager slotManager;
+
+	/** The SlotManager created by the slotManagerFactory when the ResourceManager is started. */
+	private SlotManager slotManager;
 
 	private LeaderElectionService leaderElectionService;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -22,12 +22,16 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.messages.jobmanager.RMSlotRequestReply;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.SlotAvailableReply;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.UUID;
 
@@ -72,6 +76,7 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * @param resourceManagerLeaderId  The fencing token for the ResourceManager leader
 	 * @param taskExecutorAddress     The address of the TaskExecutor that registers
 	 * @param resourceID              The resource ID of the TaskExecutor that registers
+	 * @param slotReport              The slot report containing free and allocated task slots
 	 * @param timeout                 The timeout for the response.
 	 *
 	 * @return The future to the response by the ResourceManager.
@@ -80,6 +85,18 @@ public interface ResourceManagerGateway extends RpcGateway {
 		UUID resourceManagerLeaderId,
 		String taskExecutorAddress,
 		ResourceID resourceID,
+		SlotReport slotReport,
+		@RpcTimeout Time timeout);
+
+	/**
+	 * Sent by the TaskExecutor to notify the ResourceManager that a slot has become available.
+	 * @return
+	 */
+	Future<SlotAvailableReply> notifySlotAvailable(
+		UUID resourceManagerLeaderId,
+		ResourceID resourceID,
+		InstanceID instanceID,
+		SlotID slotID,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -61,8 +61,10 @@ public interface ResourceManagerGateway extends RpcGateway {
 	/**
 	 * Requests a slot from the resource manager.
 	 *
-	 * @param slotRequest Slot request
-	 * @return Future slot assignment
+	 * @param jobMasterLeaderID leader id of the JobMaster
+	 * @param resourceManagerLeaderID leader if of the ResourceMaster
+	 * @param slotRequest The slot to request
+	 * @return The confirmation that the slot gets allocated
 	 */
 	Future<RMSlotRequestReply> requestSlot(
 		UUID jobMasterLeaderID,
@@ -90,7 +92,12 @@ public interface ResourceManagerGateway extends RpcGateway {
 
 	/**
 	 * Sent by the TaskExecutor to notify the ResourceManager that a slot has become available.
-	 * @return
+	 *
+	 * @param resourceManagerLeaderId The ResourceManager leader id
+	 * @param resourceID The ResourceID of the TaskExecutor
+	 * @param instanceID The InstanceID of the TaskExecutor
+	 * @param slotID The SlotID of the freed slot
+	 * @return The confirmation by the ResourceManager
 	 */
 	Future<SlotAvailableReply> notifySlotAvailable(
 		UUID resourceManagerLeaderId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.resourcemanager.messages.jobmanager.RMSlotRequestReply;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.jobmaster.JobMaster;
@@ -59,7 +60,7 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * @param slotRequest Slot request
 	 * @return Future slot assignment
 	 */
-	Future<SlotRequestReply> requestSlot(
+	Future<RMSlotRequestReply> requestSlot(
 		UUID jobMasterLeaderID,
 		UUID resourceManagerLeaderID,
 		SlotRequest slotRequest,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServices.java
@@ -39,6 +39,6 @@ public interface ResourceManagerServices {
 	/**
 	 * Gets the executor which executes in the main thread of the ResourceManager
 	 */
-	Executor getExecutor();
+	Executor getMainThreadExecutor();
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -22,7 +22,7 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerFactory;
 import org.apache.flink.runtime.rpc.RpcService;
 
 /**
@@ -34,9 +34,9 @@ import org.apache.flink.runtime.rpc.RpcService;
 public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 
 	public StandaloneResourceManager(RpcService rpcService,
-		HighAvailabilityServices highAvailabilityServices,
-		SlotManager slotManager) {
-		super(rpcService, highAvailabilityServices, slotManager);
+			HighAvailabilityServices highAvailabilityServices,
+			SlotManagerFactory slotManagerFactory) {
+		super(rpcService, highAvailabilityServices, slotManagerFactory);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/jobmanager/RMSlotRequestRegistered.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/jobmanager/RMSlotRequestRegistered.java
@@ -16,19 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.resourcemanager;
+package org.apache.flink.runtime.resourcemanager.messages.jobmanager;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 
 /**
- * Rejection message by the ResourceManager for a SlotRequest from the JobManager
+ * Acknowledgment by the ResourceManager for a SlotRequest from the JobManager
  */
-public class SlotRequestRejected extends SlotRequestReply {
+public class RMSlotRequestRegistered extends RMSlotRequestReply {
 
-	private static final long serialVersionUID = 9049346740895325144L;
+	private static final long serialVersionUID = 4760320859275256855L;
 
-	public SlotRequestRejected(AllocationID allocationID) {
+	public RMSlotRequestRegistered(AllocationID allocationID) {
 		super(allocationID);
 	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/jobmanager/RMSlotRequestRejected.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/jobmanager/RMSlotRequestRejected.java
@@ -16,18 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.resourcemanager;
+package org.apache.flink.runtime.resourcemanager.messages.jobmanager;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 
 /**
- * Acknowledgment by the ResourceManager for a SlotRequest from the JobManager
+ * Rejection message by the ResourceManager for a SlotRequest from the JobManager
  */
-public class SlotRequestRegistered extends SlotRequestReply {
+public class RMSlotRequestRejected extends RMSlotRequestReply {
 
-	private static final long serialVersionUID = 4760320859275256855L;
+	private static final long serialVersionUID = 9049346740895325144L;
 
-	public SlotRequestRegistered(AllocationID allocationID) {
+	public RMSlotRequestRejected(AllocationID allocationID) {
 		super(allocationID);
 	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/jobmanager/RMSlotRequestReply.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/jobmanager/RMSlotRequestReply.java
@@ -16,30 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.resourcemanager.registration;
+package org.apache.flink.runtime.resourcemanager.messages.jobmanager;
 
-import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 
 import java.io.Serializable;
 
 /**
- * This class is responsible for grouping the TaskExecutorGateway and the InstanceID
- * of a registered task executor. It also contains the worker information.
+ * Acknowledgment by the ResourceManager for a SlotRequest from the JobManager
  */
-public class TaskExecutorRegistration<WorkerType extends Serializable>
-		extends SimpleTaskExecutorRegistration
-		implements Serializable {
+public abstract class RMSlotRequestReply implements Serializable {
 
-	private static final long serialVersionUID = -2062957799469434614L;
+	private static final long serialVersionUID = 42;
 
-	private WorkerType worker;
+	private final AllocationID allocationID;
 
-	public TaskExecutorRegistration(TaskExecutorGateway taskExecutorGateway, WorkerType worker) {
-		super(taskExecutorGateway);
-		this.worker = worker;
+	public RMSlotRequestReply(AllocationID allocationID) {
+		this.allocationID = allocationID;
 	}
 
-	public WorkerType getWorker() {
-		return worker;
+	public AllocationID getAllocationID() {
+		return allocationID;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/SlotAvailableReply.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/SlotAvailableReply.java
@@ -15,21 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.runtime.resourcemanager.messages.taskexecutor;
 
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+
+import java.io.Serializable;
+import java.util.UUID;
 
 /**
- * Rejection by the TaskExecutor for a SlotRequest from the ResourceManager
+ * Sent by the ResourceManager to the TaskExecutor confirm receipt of
+ * {@code org.apache.flink.runtime.resourcemanager.ResourceManagerGateway.notifySlotAvailable}.
  */
-public class TMSlotRequestRejected extends TMSlotRequestReply {
+public class SlotAvailableReply implements Serializable {
 
-	private static final long serialVersionUID = 9049346740895325144L;
+	private final UUID resourceManagerLeaderID;
 
-	public TMSlotRequestRejected(InstanceID instanceID, ResourceID resourceID, AllocationID allocationID) {
-		super(instanceID, resourceID, allocationID);
+	private final SlotID slotID;
+
+	public SlotAvailableReply(UUID resourceManagerLeaderID, SlotID slotID) {
+		this.resourceManagerLeaderID = resourceManagerLeaderID;
+		this.slotID = slotID;
+	}
+
+	public UUID getResourceManagerLeaderID() {
+		return resourceManagerLeaderID;
+	}
+
+	public SlotID getSlotID() {
+		return slotID;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/TMSlotRequestRegistered.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/TMSlotRequestRegistered.java
@@ -16,30 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.resourcemanager.registration;
+package org.apache.flink.runtime.resourcemanager.messages.taskexecutor;
 
-import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
-
-import java.io.Serializable;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.instance.InstanceID;
 
 /**
- * This class is responsible for grouping the TaskExecutorGateway and the InstanceID
- * of a registered task executor. It also contains the worker information.
+ * Acknowledgment by the TaskExecutor for a SlotRequest from the ResourceManager
  */
-public class TaskExecutorRegistration<WorkerType extends Serializable>
-		extends SimpleTaskExecutorRegistration
-		implements Serializable {
+public class TMSlotRequestRegistered extends TMSlotRequestReply {
 
-	private static final long serialVersionUID = -2062957799469434614L;
+	private static final long serialVersionUID = 4760320859275256855L;
 
-	private WorkerType worker;
-
-	public TaskExecutorRegistration(TaskExecutorGateway taskExecutorGateway, WorkerType worker) {
-		super(taskExecutorGateway);
-		this.worker = worker;
-	}
-
-	public WorkerType getWorker() {
-		return worker;
+	public TMSlotRequestRegistered(InstanceID instanceID, ResourceID resourceID, AllocationID allocationID) {
+		super(instanceID, resourceID, allocationID);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/TMSlotRequestRejected.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/TMSlotRequestRejected.java
@@ -16,30 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.resourcemanager.registration;
+package org.apache.flink.runtime.resourcemanager.messages.taskexecutor;
 
-import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
-
-import java.io.Serializable;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.instance.InstanceID;
 
 /**
- * This class is responsible for grouping the TaskExecutorGateway and the InstanceID
- * of a registered task executor. It also contains the worker information.
+ * Rejection by the TaskExecutor for a SlotRequest from the ResourceManager
  */
-public class TaskExecutorRegistration<WorkerType extends Serializable>
-		extends SimpleTaskExecutorRegistration
-		implements Serializable {
+public class TMSlotRequestRejected extends TMSlotRequestReply {
 
-	private static final long serialVersionUID = -2062957799469434614L;
+	private static final long serialVersionUID = 9049346740895325144L;
 
-	private WorkerType worker;
-
-	public TaskExecutorRegistration(TaskExecutorGateway taskExecutorGateway, WorkerType worker) {
-		super(taskExecutorGateway);
-		this.worker = worker;
-	}
-
-	public WorkerType getWorker() {
-		return worker;
+	protected TMSlotRequestRejected(InstanceID instanceID, ResourceID resourceID, AllocationID allocationID) {
+		super(instanceID, resourceID, allocationID);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/TMSlotRequestReply.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/messages/taskexecutor/TMSlotRequestReply.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.messages.taskexecutor;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.instance.InstanceID;
+
+import java.io.Serializable;
+
+/**
+ * Acknowledgment by the TaskExecutor for a SlotRequest from the ResourceManager
+ */
+public abstract class TMSlotRequestReply implements Serializable {
+
+	private static final long serialVersionUID = 42;
+
+	private final InstanceID instanceID;
+
+	private final ResourceID resourceID;
+
+	private final AllocationID allocationID;
+
+	protected TMSlotRequestReply(InstanceID instanceID, ResourceID resourceID, AllocationID allocationID) {
+		this.instanceID = instanceID;
+		this.resourceID = resourceID;
+		this.allocationID = allocationID;
+	}
+
+	public InstanceID getInstanceID() {
+		return instanceID;
+	}
+
+	public ResourceID getResourceID() {
+		return resourceID;
+	}
+
+	public AllocationID getAllocationID() {
+		return allocationID;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/SimpleTaskExecutorRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/SimpleTaskExecutorRegistration.java
@@ -16,26 +16,36 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.resourcemanager;
+package org.apache.flink.runtime.resourcemanager.registration;
 
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 
 import java.io.Serializable;
 
 /**
- * Acknowledgment by the ResourceManager for a SlotRequest from the JobManager
+ * This class is responsible for grouping the TaskExecutorGateway and the InstanceID
+ * of a registered task executor.
  */
-public abstract class SlotRequestReply implements Serializable {
+public class SimpleTaskExecutorRegistration implements Serializable {
 
-	private static final long serialVersionUID = 42;
+	private static final long serialVersionUID = -2062957799469434614L;
 
-	private final AllocationID allocationID;
+	private TaskExecutorGateway taskExecutorGateway;
 
-	public SlotRequestReply(AllocationID allocationID) {
-		this.allocationID = allocationID;
+	private InstanceID instanceID;
+
+	public SimpleTaskExecutorRegistration(TaskExecutorGateway taskExecutorGateway) {
+		this.taskExecutorGateway = taskExecutorGateway;
+		this.instanceID = new InstanceID();
 	}
 
-	public AllocationID getAllocationID() {
-		return allocationID;
+	public InstanceID getInstanceID() {
+		return instanceID;
 	}
+
+	public TaskExecutorGateway getTaskExecutorGateway() {
+		return taskExecutorGateway;
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/TaskExecutorRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/TaskExecutorRegistration.java
@@ -18,28 +18,34 @@
 
 package org.apache.flink.runtime.resourcemanager.registration;
 
+import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 
 import java.io.Serializable;
 
 /**
  * This class is responsible for grouping the TaskExecutorGateway and the InstanceID
- * of a registered task executor. It also contains the worker information.
+ * of a registered task executor.
  */
-public class TaskExecutorRegistration<WorkerType extends Serializable>
-		extends SimpleTaskExecutorRegistration
-		implements Serializable {
+public class TaskExecutorRegistration implements Serializable {
 
 	private static final long serialVersionUID = -2062957799469434614L;
 
-	private WorkerType worker;
+	private final InstanceID instanceID;
 
-	public TaskExecutorRegistration(TaskExecutorGateway taskExecutorGateway, WorkerType worker) {
-		super(taskExecutorGateway);
-		this.worker = worker;
+	private TaskExecutorGateway taskExecutorGateway;
+
+	public TaskExecutorRegistration(TaskExecutorGateway taskExecutorGateway) {
+		this.instanceID = new InstanceID();
+		this.taskExecutorGateway = taskExecutorGateway;
 	}
 
-	public WorkerType getWorker() {
-		return worker;
+	public InstanceID getInstanceID() {
+		return instanceID;
 	}
+
+	public TaskExecutorGateway getTaskExecutorGateway() {
+		return taskExecutorGateway;
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
@@ -23,8 +23,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import java.io.Serializable;
 
 /**
- * This class is responsible for grouping the TaskExecutorGateway and the InstanceID
- * of a registered task executor. It also contains the worker information.
+ * This class extends the {@link TaskExecutorRegistration}, adding the worker information.
  */
 public class WorkerRegistration<WorkerType extends Serializable> extends TaskExecutorRegistration {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
@@ -18,34 +18,26 @@
 
 package org.apache.flink.runtime.resourcemanager.registration;
 
-import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 
 import java.io.Serializable;
 
 /**
  * This class is responsible for grouping the TaskExecutorGateway and the InstanceID
- * of a registered task executor.
+ * of a registered task executor. It also contains the worker information.
  */
-public class SimpleTaskExecutorRegistration implements Serializable {
+public class WorkerRegistration<WorkerType extends Serializable> extends TaskExecutorRegistration {
 
 	private static final long serialVersionUID = -2062957799469434614L;
 
-	private TaskExecutorGateway taskExecutorGateway;
+	private WorkerType worker;
 
-	private InstanceID instanceID;
-
-	public SimpleTaskExecutorRegistration(TaskExecutorGateway taskExecutorGateway) {
-		this.taskExecutorGateway = taskExecutorGateway;
-		this.instanceID = new InstanceID();
+	public WorkerRegistration(TaskExecutorGateway taskExecutorGateway, WorkerType worker) {
+		super(taskExecutorGateway);
+		this.worker = worker;
 	}
 
-	public InstanceID getInstanceID() {
-		return instanceID;
+	public WorkerType getWorker() {
+		return worker;
 	}
-
-	public TaskExecutorGateway getTaskExecutorGateway() {
-		return taskExecutorGateway;
-	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerFactory.java
@@ -15,21 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-package org.apache.flink.runtime.resourcemanager.messages.taskexecutor;
-
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerServices;
 
 /**
- * Rejection by the TaskExecutor for a SlotRequest from the ResourceManager
+ * Factory to create a SlotManager and provide it with dependencies.
  */
-public class TMSlotRequestRejected extends TMSlotRequestReply {
+public interface SlotManagerFactory {
 
-	private static final long serialVersionUID = 9049346740895325144L;
-
-	public TMSlotRequestRejected(InstanceID instanceID, ResourceID resourceID, AllocationID allocationID) {
-		super(instanceID, resourceID, allocationID);
-	}
+	/**
+	 * Creates a SlotManager and provides it with ResourceManager services.
+	 */
+	SlotManager create(ResourceManagerServices rmServices);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
@@ -18,9 +18,8 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -37,20 +36,20 @@ public class SlotReport implements Serializable {
 	/** The slots status of the TaskManager */
 	private final List<SlotStatus> slotsStatus;
 
-	/** The resource id which identifies the TaskManager */
-	private final ResourceID resourceID;
+	public SlotReport() {
+		this(Collections.<SlotStatus>emptyList());
+	}
 
-	public SlotReport(final List<SlotStatus> slotsStatus, final ResourceID resourceID) {
+	public SlotReport(SlotStatus slotStatus) {
+		this(Collections.singletonList(slotStatus));
+	}
+
+	public SlotReport(final List<SlotStatus> slotsStatus) {
 		this.slotsStatus = checkNotNull(slotsStatus);
-		this.resourceID = checkNotNull(resourceID);
 	}
 
 	public List<SlotStatus> getSlotsStatus() {
 		return slotsStatus;
-	}
-
-	public ResourceID getResourceID() {
-		return resourceID;
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -20,9 +20,11 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestRegistered;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestRejected;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -39,6 +41,8 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -79,6 +83,9 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	/** The fatal error handler to use in case of a fatal error */
 	private final FatalErrorHandler fatalErrorHandler;
 
+	/** Slots which have become available but haven't been confirmed by the RM */
+	private final Set<SlotID> unconfirmedFreeSlots;
+
 	// --------- resource manager --------
 
 	private TaskExecutorToResourceManagerConnection resourceManagerConnection;
@@ -110,6 +117,8 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 		this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
 
 		this.numberOfSlots =  taskManagerConfiguration.getNumberSlots();
+
+		this.unconfirmedFreeSlots = new HashSet<>();
 	}
 
 	// ------------------------------------------------------------------------
@@ -153,6 +162,8 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 			}
 		}
 
+		unconfirmedFreeSlots.clear();
+
 		// establish a connection to the new leader
 		if (newLeaderAddress != null) {
 			log.info("Attempting to register at ResourceManager {}", newLeaderAddress);
@@ -170,14 +181,26 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	/**
 	 * Requests a slot from the TaskManager
 	 *
+	 * @param slotID Slot id for the request
 	 * @param allocationID id for the request
 	 * @param resourceManagerLeaderID current leader id of the ResourceManager
 	 * @return answer to the slot request
 	 */
 	@RpcMethod
-	public TMSlotRequestReply requestSlot(AllocationID allocationID, UUID resourceManagerLeaderID) {
-		// TODO
+	public TMSlotRequestReply requestSlot(SlotID slotID, AllocationID allocationID, UUID resourceManagerLeaderID) {
+		if (!resourceManagerConnection.getTargetLeaderId().equals(resourceManagerLeaderID)) {
+
+			return new TMSlotRequestRejected(
+				resourceManagerConnection.getRegistrationId(), getResourceID(), allocationID);
+		}
+		if (unconfirmedFreeSlots.contains(slotID)) {
+			// check if request has not been blacklisted because the notification of a free slot
+			// has not been confirmed by the ResourceManager
+			return new TMSlotRequestRejected(
+				resourceManagerConnection.getRegistrationId(), getResourceID(), allocationID);
+		}
 		return new TMSlotRequestRegistered(new InstanceID(), ResourceID.generate(), allocationID);
+
 	}
 
 	// ------------------------------------------------------------------------
@@ -227,6 +250,11 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	@VisibleForTesting
 	TaskExecutorToResourceManagerConnection getResourceManagerConnection() {
 		return resourceManagerConnection;
+	}
+
+	@VisibleForTesting
+	public void addUnconfirmedFreeSlotNotification(SlotID slotID) {
+		unconfirmedFreeSlots.add(slotID);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -20,9 +20,10 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.resourcemanager.SlotRequestRegistered;
-import org.apache.flink.runtime.resourcemanager.SlotRequestReply;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestRegistered;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -174,8 +175,9 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	 * @return answer to the slot request
 	 */
 	@RpcMethod
-	public SlotRequestReply requestSlot(AllocationID allocationID, UUID resourceManagerLeaderID) {
-		return new SlotRequestRegistered(allocationID);
+	public TMSlotRequestReply requestSlot(AllocationID allocationID, UUID resourceManagerLeaderID) {
+		// TODO
+		return new TMSlotRequestRegistered(new InstanceID(), ResourceID.generate(), allocationID);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -189,7 +189,6 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	@RpcMethod
 	public TMSlotRequestReply requestSlot(SlotID slotID, AllocationID allocationID, UUID resourceManagerLeaderID) {
 		if (!resourceManagerConnection.getTargetLeaderId().equals(resourceManagerLeaderID)) {
-
 			return new TMSlotRequestRejected(
 				resourceManagerConnection.getRegistrationId(), getResourceID(), allocationID);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
 import org.apache.flink.runtime.rpc.RpcGateway;
@@ -41,11 +42,13 @@ public interface TaskExecutorGateway extends RpcGateway {
 	/**
 	 * Requests a slot from the TaskManager
 	 *
+	 * @param slotID slot id for the request
 	 * @param allocationID id for the request
 	 * @param resourceManagerLeaderID current leader id of the ResourceManager
 	 * @return answer to the slot request
 	 */
 	Future<TMSlotRequestReply> requestSlot(
+		SlotID slotID,
 		AllocationID allocationID,
 		UUID resourceManagerLeaderID,
 		@RpcTimeout Time timeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.Future;
-import org.apache.flink.runtime.resourcemanager.SlotRequestReply;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
@@ -45,7 +45,7 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @param resourceManagerLeaderID current leader id of the ResourceManager
 	 * @return answer to the slot request
 	 */
-	Future<SlotRequestReply> requestSlot(
+	Future<TMSlotRequestReply> requestSlot(
 		AllocationID allocationID,
 		UUID resourceManagerLeaderID,
 		@RpcTimeout Time timeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -113,7 +113,7 @@ public class TaskExecutorToResourceManagerConnection
 				ResourceManagerGateway resourceManager, UUID leaderId, long timeoutMillis) throws Exception {
 
 			Time timeout = Time.milliseconds(timeoutMillis);
-			return resourceManager.registerTaskExecutor(leaderId, taskExecutorAddress, resourceID, timeout);
+			return resourceManager.registerTaskExecutor(leaderId, taskExecutorAddress, resourceID, new SlotReport(), timeout);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -60,14 +60,14 @@ public class ResourceManagerHATest {
 			new TestingResourceManager(rpcService, highAvailabilityServices);
 		resourceManager.start();
 		// before grant leadership, resourceManager's leaderId is null
-		Assert.assertNull(resourceManager.getLeaderSessionID());
+		Assert.assertEquals(new UUID(0,0), resourceManager.getLeaderSessionID());
 		final UUID leaderId = UUID.randomUUID();
 		leaderElectionService.isLeader(leaderId);
 		// after grant leadership, resourceManager's leaderId has value
 		Assert.assertEquals(leaderId, resourceManager.getLeaderSessionID());
 		// then revoke leadership, resourceManager's leaderId is null again
 		leaderElectionService.notLeader();
-		Assert.assertNull(resourceManager.getLeaderSessionID());
+		Assert.assertEquals(new UUID(0,0), resourceManager.getLeaderSessionID());
 	}
 
 	private static abstract class TestingResourceManagerGatewayProxy implements MainThreadExecutable, StartStoppable, RpcGateway {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerFactory;
 import org.apache.flink.runtime.rpc.MainThreadExecutable;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
@@ -43,7 +44,8 @@ public class ResourceManagerHATest {
 
 	@Test
 	public void testGrantAndRevokeLeadership() throws Exception {
-		// mock a RpcService which will return a special RpcGateway when call its startServer method, the returned RpcGateway directly execute runAsync call
+		// mock a RpcService which will return a special RpcGateway when call its startServer method,
+		// the returned RpcGateway directly executes runAsync calls
 		TestingResourceManagerGatewayProxy gateway = mock(TestingResourceManagerGatewayProxy.class);
 		doCallRealMethod().when(gateway).runAsync(any(Runnable.class));
 
@@ -54,8 +56,8 @@ public class ResourceManagerHATest {
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
 		highAvailabilityServices.setResourceManagerLeaderElectionService(leaderElectionService);
 
-		SlotManager slotManager = mock(SlotManager.class);
-		final ResourceManager resourceManager = new StandaloneResourceManager(rpcService, highAvailabilityServices, slotManager);
+		final ResourceManager resourceManager =
+			new TestingResourceManager(rpcService, highAvailabilityServices);
 		resourceManager.start();
 		// before grant leadership, resourceManager's leaderId is null
 		Assert.assertNull(resourceManager.getLeaderSessionID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -25,10 +25,8 @@ import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
-import org.apache.flink.runtime.resourcemanager.slotmanager.SimpleSlotManager;
 import org.apache.flink.runtime.rpc.TestingSerialRpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
-import org.apache.flink.runtime.rpc.exceptions.LeaderSessionIDException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -160,7 +158,7 @@ public class ResourceManagerJobMasterTest {
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
 		highAvailabilityServices.setResourceManagerLeaderElectionService(resourceManagerLeaderElectionService);
 		highAvailabilityServices.setJobMasterLeaderRetriever(jobID, jobMasterLeaderRetrievalService);
-		ResourceManager resourceManager = new StandaloneResourceManager(rpcService, highAvailabilityServices, new SimpleSlotManager());
+		ResourceManager resourceManager = new TestingResourceManager(rpcService, highAvailabilityServices);
 		resourceManager.start();
 		return resourceManager;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerFactory;
+import org.apache.flink.runtime.rpc.RpcService;
+
+public class TestingResourceManager extends StandaloneResourceManager {
+
+	public TestingResourceManager(RpcService rpcService) {
+		this(rpcService, new TestingHighAvailabilityServices());
+	}
+
+	public TestingResourceManager(
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices) {
+		this(rpcService, highAvailabilityServices, new TestingSlotManagerFactory());
+	}
+
+	public TestingResourceManager(
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			SlotManagerFactory slotManagerFactory) {
+		super(rpcService, highAvailabilityServices, slotManagerFactory);
+	}
+
+	private static class TestingSlotManagerFactory implements SlotManagerFactory {
+
+		@Override
+		public SlotManager create(ResourceManagerServices rmServices) {
+			return new TestingSlotManager(rmServices);
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingSlotManager.java
@@ -15,20 +15,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.runtime.resourcemanager.slotmanager;
+package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.ResourceSlot;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
-import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.mockito.Mockito;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
-/**
- * A simple SlotManager which ignores resource profiles.
- */
-public class SimpleSlotManager extends SlotManager {
+public class TestingSlotManager extends SlotManager {
+
+	public TestingSlotManager() {
+		this(new TestingResourceManagerServices());
+	}
+
+	public TestingSlotManager(ResourceManagerServices rmServices) {
+		super(rmServices);
+	}
 
 	@Override
 	protected ResourceSlot chooseSlotToUse(SlotRequest request, Map<SlotID, ResourceSlot> freeSlots) {
@@ -50,4 +58,21 @@ public class SimpleSlotManager extends SlotManager {
 		}
 	}
 
+	private static class TestingResourceManagerServices implements ResourceManagerServices {
+
+		@Override
+		public void allocateResource(ResourceProfile resourceProfile) {
+
+		}
+
+		@Override
+		public Executor getAsyncExecutor() {
+			return Mockito.mock(Executor.class);
+		}
+
+		@Override
+		public Executor getMainThreadExecutor() {
+			return Mockito.mock(Executor.class);
+		}
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -29,13 +29,15 @@ import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerServices;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
-import org.apache.flink.runtime.resourcemanager.registration.SimpleTaskExecutorRegistration;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorRegistration;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +48,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 
 public class SlotManagerTest {
 
@@ -60,14 +61,14 @@ public class SlotManagerTest {
 	private static final ResourceProfile DEFAULT_TESTING_BIG_PROFILE =
 		new ResourceProfile(DEFAULT_TESTING_CPU_CORES * 2, DEFAULT_TESTING_MEMORY * 2);
 
-	private static SimpleTaskExecutorRegistration taskExecutorRegistration;
+	private static TaskExecutorRegistration taskExecutorRegistration;
 
 	@BeforeClass
 	public static void setUp() {
-		taskExecutorRegistration = Mockito.mock(SimpleTaskExecutorRegistration.class);
+		taskExecutorRegistration = Mockito.mock(TaskExecutorRegistration.class);
 		TaskExecutorGateway gateway = Mockito.mock(TaskExecutorGateway.class);
 		Mockito.when(taskExecutorRegistration.getTaskExecutorGateway()).thenReturn(gateway);
-		Mockito.when(gateway.requestSlot(any(AllocationID.class), any(UUID.class), any(Time.class)))
+		Mockito.when(gateway.requestSlot(any(SlotID.class), any(AllocationID.class), any(UUID.class), any(Time.class)))
 			.thenReturn(new FlinkCompletableFuture<TMSlotRequestReply>());
 	}
 
@@ -183,9 +184,9 @@ public class SlotManagerTest {
 		assertEquals(1, slotManager.getPendingRequestCount());
 
 		SlotID slotId = SlotID.generate();
-		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration);
 		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE);
-		slotManager.updateSlotStatus(slotStatus);
+		SlotReport slotReport = new SlotReport(Collections.singletonList(slotStatus));
+		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration, slotReport);
 
 		assertEquals(1, slotManager.getAllocatedSlotCount());
 		assertEquals(0, slotManager.getFreeSlotCount());
@@ -201,9 +202,9 @@ public class SlotManagerTest {
 		TestingSlotManager slotManager = new TestingSlotManager();
 
 		SlotID slotId = SlotID.generate();
-		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration);
 		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE);
-		slotManager.updateSlotStatus(slotStatus);
+		SlotReport slotReport = new SlotReport(Collections.singletonList(slotStatus));
+		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration, slotReport);
 
 		assertEquals(0, slotManager.getAllocatedSlotCount());
 		assertEquals(1, slotManager.getFreeSlotCount());
@@ -219,9 +220,9 @@ public class SlotManagerTest {
 		assertEquals(1, slotManager.getPendingRequestCount());
 
 		SlotID slotId = SlotID.generate();
-		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration);
 		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE);
-		slotManager.updateSlotStatus(slotStatus);
+		SlotReport slotReport = new SlotReport(Collections.singletonList(slotStatus));
+		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration, slotReport);
 
 		assertEquals(0, slotManager.getAllocatedSlotCount());
 		assertEquals(1, slotManager.getFreeSlotCount());
@@ -237,9 +238,9 @@ public class SlotManagerTest {
 		TestingSlotManager slotManager = new TestingSlotManager();
 
 		SlotID slotId = SlotID.generate();
-		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration);
 		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE, new JobID(), new AllocationID());
-		slotManager.updateSlotStatus(slotStatus);
+		SlotReport slotReport = new SlotReport(Collections.singletonList(slotStatus));
+		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration, slotReport);
 
 		assertEquals(1, slotManager.getAllocatedSlotCount());
 		assertEquals(0, slotManager.getFreeSlotCount());
@@ -247,48 +248,44 @@ public class SlotManagerTest {
 	}
 
 	/**
-	 * Tests that we had a slot in-use, and it's confirmed by SlotReport
+	 * Tests that we had a slot in-use and is freed again subsequently.
 	 */
 	@Test
 	public void testExistingInUseSlotUpdateStatus() {
 		TestingSlotManager slotManager = new TestingSlotManager();
-		SlotRequest request = new SlotRequest(new JobID(), new AllocationID(), DEFAULT_TESTING_PROFILE);
-		slotManager.requestSlot(request);
 
-		// make this slot in use
 		SlotID slotId = SlotID.generate();
-		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration);
-		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE);
-		slotManager.updateSlotStatus(slotStatus);
+		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE, new JobID(), new AllocationID());
+		SlotReport slotReport = new SlotReport(Collections.singletonList(slotStatus));
+		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration, slotReport);
 
 		assertEquals(1, slotManager.getAllocatedSlotCount());
 		assertEquals(0, slotManager.getFreeSlotCount());
 		assertTrue(slotManager.isAllocated(slotId));
 
-		// slot status is confirmed
-		SlotStatus slotStatus2 = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE,
-			request.getJobId(), request.getAllocationId());
-		slotManager.updateSlotStatus(slotStatus2);
+		// slot is freed again
+		slotManager.notifySlotAvailable(slotId.getResourceID(), slotId);
 
-		assertEquals(1, slotManager.getAllocatedSlotCount());
-		assertEquals(0, slotManager.getFreeSlotCount());
-		assertTrue(slotManager.isAllocated(slotId));
+		assertEquals(0, slotManager.getAllocatedSlotCount());
+		assertEquals(1, slotManager.getFreeSlotCount());
+		assertFalse(slotManager.isAllocated(slotId));
 	}
 
 	/**
-	 * Tests that we had a slot in-use, but it's empty according to the SlotReport
+	 * Tests multiple slot requests with one slots.
 	 */
 	@Test
-	public void testExistingInUseSlotAdjustedToEmpty() {
+	public void testMultipleSlotRequestsWithOneSlot() {
 		TestingSlotManager slotManager = new TestingSlotManager();
-		SlotRequest request1 = new SlotRequest(new JobID(), new AllocationID(), DEFAULT_TESTING_PROFILE);
+		final AllocationID allocationID = new AllocationID();
+
+		SlotRequest request1 = new SlotRequest(new JobID(), allocationID, DEFAULT_TESTING_PROFILE);
 		slotManager.requestSlot(request1);
 
-		// make this slot in use
-		SlotID slotId = SlotID.generate();
-		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration);
-		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE);
-		slotManager.updateSlotStatus(slotStatus);
+		final ResourceID resourceID = ResourceID.generate();
+		final SlotStatus slotStatus = new SlotStatus(new SlotID(resourceID, 0), DEFAULT_TESTING_PROFILE);
+		final SlotReport slotReport = new SlotReport(slotStatus);
+		slotManager.registerTaskExecutor(resourceID, taskExecutorRegistration, slotReport);
 
 		// another request pending
 		SlotRequest request2 = new SlotRequest(new JobID(), new AllocationID(), DEFAULT_TESTING_PROFILE);
@@ -297,96 +294,24 @@ public class SlotManagerTest {
 		assertEquals(1, slotManager.getAllocatedSlotCount());
 		assertEquals(0, slotManager.getFreeSlotCount());
 		assertEquals(1, slotManager.getPendingRequestCount());
-		assertTrue(slotManager.isAllocated(slotId));
+		assertTrue(slotManager.isAllocated(allocationID));
 		assertTrue(slotManager.isAllocated(request1.getAllocationId()));
 
 		// but slot is reported empty in a report in the meantime which shouldn't affect the state
-		slotManager.updateSlotStatus(slotStatus);
-
-		assertEquals(1, slotManager.getAllocatedSlotCount());
-		assertEquals(0, slotManager.getFreeSlotCount());
-		assertEquals(1, slotManager.getPendingRequestCount());
-		assertTrue(slotManager.isAllocated(slotId));
-		assertTrue(slotManager.isAllocated(request1.getAllocationId()));
-	}
-
-	/**
-	 * Tests that we had a slot in use, and it's also reported in use by TaskManager, but the allocation
-	 * information didn't match.
-	 */
-	@Test
-	public void testExistingInUseSlotWithDifferentAllocationInfo() {
-		TestingSlotManager slotManager = new TestingSlotManager();
-		SlotRequest request = new SlotRequest(new JobID(), new AllocationID(), DEFAULT_TESTING_PROFILE);
-		slotManager.requestSlot(request);
-
-		// make this slot in use
-		SlotID slotId = SlotID.generate();
-		slotManager.registerTaskExecutor(slotId.getResourceID(), taskExecutorRegistration);
-		SlotStatus slotStatus = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE);
-		slotManager.updateSlotStatus(slotStatus);
+		slotManager.notifySlotAvailable(resourceID, slotStatus.getSlotID());
 
 		assertEquals(1, slotManager.getAllocatedSlotCount());
 		assertEquals(0, slotManager.getFreeSlotCount());
 		assertEquals(0, slotManager.getPendingRequestCount());
-		assertTrue(slotManager.isAllocated(slotId));
-		assertTrue(slotManager.isAllocated(request.getAllocationId()));
+		assertTrue(slotManager.isAllocated(slotStatus.getSlotID()));
+		assertTrue(slotManager.isAllocated(request2.getAllocationId()));
 
-		SlotStatus slotStatus2 = new SlotStatus(slotId, DEFAULT_TESTING_PROFILE, new JobID(), new AllocationID());
-		// update slot status with different allocation info
-		slotManager.updateSlotStatus(slotStatus2);
-
-		// original request is missing and won't be allocated
-		assertEquals(1, slotManager.getAllocatedSlotCount());
-		assertEquals(0, slotManager.getFreeSlotCount());
-		assertEquals(0, slotManager.getPendingRequestCount());
-		assertTrue(slotManager.isAllocated(slotId));
-		assertTrue(slotManager.isAllocated(request.getAllocationId()));
-		assertFalse(slotManager.isAllocated(slotStatus2.getAllocationID()));
-	}
-
-	/**
-	 * Tests that we had a free slot, and it's confirmed by SlotReport
-	 */
-	@Test
-	public void testExistingEmptySlotUpdateStatus() {
-		TestingSlotManager slotManager = new TestingSlotManager();
-		ResourceSlot slot = new ResourceSlot(SlotID.generate(), DEFAULT_TESTING_PROFILE, taskExecutorRegistration);
-		slotManager.addFreeSlot(slot);
-
-		SlotStatus slotStatus = new SlotStatus(slot.getSlotId(), DEFAULT_TESTING_PROFILE);
-		slotManager.updateSlotStatus(slotStatus);
+		// but slot is reported empty in a report in the meantime which shouldn't affect the state
+		slotManager.notifySlotAvailable(resourceID, slotStatus.getSlotID());
 
 		assertEquals(0, slotManager.getAllocatedSlotCount());
 		assertEquals(1, slotManager.getFreeSlotCount());
 		assertEquals(0, slotManager.getPendingRequestCount());
-	}
-
-	/**
-	 * Tests that we had a free slot registered but its then reported as allocated by the task manager
-	 */
-	@Test
-	public void testExistingEmptySlotAdjustedToInUse() {
-		TestingSlotManager slotManager = new TestingSlotManager();
-		final SlotID slotID = SlotID.generate();
-		slotManager.registerTaskExecutor(slotID.getResourceID(), taskExecutorRegistration);
-
-		ResourceSlot slot = new ResourceSlot(slotID, DEFAULT_TESTING_PROFILE, taskExecutorRegistration);
-		slotManager.addFreeSlot(slot);
-
-		assertEquals(0, slotManager.getAllocatedSlotCount());
-		assertEquals(1, slotManager.getFreeSlotCount());
-		assertEquals(0, slotManager.getPendingRequestCount());
-		assertFalse(slotManager.isAllocated(slot.getSlotId()));
-
-		SlotStatus slotStatus = new SlotStatus(slot.getSlotId(), DEFAULT_TESTING_PROFILE,
-			new JobID(), new AllocationID());
-		slotManager.updateSlotStatus(slotStatus);
-
-		assertEquals(0, slotManager.getAllocatedSlotCount());
-		assertEquals(1, slotManager.getFreeSlotCount());
-		assertEquals(0, slotManager.getPendingRequestCount());
-		assertFalse(slotManager.isAllocated(slot.getSlotId()));
 	}
 
 	/**
@@ -416,15 +341,15 @@ public class SlotManagerTest {
 
 	/**
 	 * Tests that we did some allocation but failed / rejected by TaskManager, and slot is occupied by another request
+	 * This can only occur after reconnect of the TaskExecutor.
 	 */
 	@Test
 	public void testSlotAllocationFailedAtTaskManagerOccupiedByOther() {
 		TestingSlotManager slotManager = new TestingSlotManager();
 		final SlotID slotID = SlotID.generate();
-		slotManager.registerTaskExecutor(slotID.getResourceID(), taskExecutorRegistration);
-
-		ResourceSlot slot = new ResourceSlot(slotID, DEFAULT_TESTING_PROFILE, taskExecutorRegistration);
-		slotManager.addFreeSlot(slot);
+		SlotStatus slot = new SlotStatus(slotID, DEFAULT_TESTING_PROFILE);
+		SlotReport slotReport = new SlotReport(slot);
+		slotManager.registerTaskExecutor(slotID.getResourceID(), taskExecutorRegistration, slotReport);
 
 		SlotRequest request = new SlotRequest(new JobID(), new AllocationID(), DEFAULT_TESTING_PROFILE);
 		slotManager.requestSlot(request);
@@ -433,32 +358,31 @@ public class SlotManagerTest {
 		assertEquals(0, slotManager.getFreeSlotCount());
 		assertEquals(0, slotManager.getPendingRequestCount());
 
-		// slot is set empty by heartbeat
-		SlotStatus slotStatus = new SlotStatus(slot.getSlotId(), slot.getResourceProfile());
-		slotManager.updateSlotStatus(slotStatus);
+		// slot is set empty by a reconnect of the TaskExecutor
+		slotManager.registerTaskExecutor(slotID.getResourceID(), taskExecutorRegistration, slotReport);
 
-		assertEquals(1, slotManager.getAllocatedSlotCount());
-		assertEquals(0, slotManager.getFreeSlotCount());
+		assertEquals(0, slotManager.getAllocatedSlotCount());
+		assertEquals(1, slotManager.getFreeSlotCount());
 		assertEquals(0, slotManager.getPendingRequestCount());
 
-		// another request took this slot
+		// another request takes the slot
 		SlotRequest request2 = new SlotRequest(new JobID(), new AllocationID(), DEFAULT_TESTING_PROFILE);
 		slotManager.requestSlot(request2);
 
 		assertEquals(1, slotManager.getAllocatedSlotCount());
 		assertEquals(0, slotManager.getFreeSlotCount());
-		assertEquals(1, slotManager.getPendingRequestCount());
-		assertTrue(slotManager.isAllocated(request.getAllocationId()));
-		assertFalse(slotManager.isAllocated(request2.getAllocationId()));
+		assertEquals(0, slotManager.getPendingRequestCount());
+		assertFalse(slotManager.isAllocated(request.getAllocationId()));
+		assertTrue(slotManager.isAllocated(request2.getAllocationId()));
 
 		// original request should be retried
-		slotManager.handleSlotRequestFailedAtTaskManager(request, slot.getSlotId());
+		slotManager.handleSlotRequestFailedAtTaskManager(request, slotID);
 
 		assertEquals(1, slotManager.getAllocatedSlotCount());
 		assertEquals(0, slotManager.getFreeSlotCount());
-		assertEquals(1, slotManager.getPendingRequestCount());
-		assertTrue(slotManager.isAllocated(request.getAllocationId()));
-		assertFalse(slotManager.isAllocated(request2.getAllocationId()));
+		assertEquals(0, slotManager.getPendingRequestCount());
+		assertFalse(slotManager.isAllocated(request.getAllocationId()));
+		assertTrue(slotManager.isAllocated(request2.getAllocationId()));
 	}
 
 	@Test
@@ -522,13 +446,13 @@ public class SlotManagerTest {
 	//  testing classes
 	// ------------------------------------------------------------------------
 
-	private static class TestingSlotManager extends SlotManager implements ResourceManagerServices {
+	private static class TestingSlotManager extends SlotManager {
 
-		private final List<ResourceProfile> allocatedContainers;
+		private static TestingRmServices testingRmServices = new TestingRmServices();
 
 		TestingSlotManager() {
-			this.allocatedContainers = new LinkedList<>();
-			setupResourceManagerServices(this);
+			super(testingRmServices);
+			testingRmServices.allocatedContainers.clear();
 		}
 
 		/**
@@ -567,24 +491,34 @@ public class SlotManagerTest {
 			return null;
 		}
 
-		@Override
-		public void allocateResource(ResourceProfile resourceProfile) {
-			allocatedContainers.add(resourceProfile);
-		}
-
-		@Override
-		public Executor getAsyncExecutor() {
-			return Mockito.mock(Executor.class);
-		}
-
-		@Override
-		public Executor getExecutor() {
-			return Mockito.mock(Executor.class);
-		}
-
 		List<ResourceProfile> getAllocatedContainers() {
-			return allocatedContainers;
+			return testingRmServices.allocatedContainers;
 		}
 
+
+		private static class TestingRmServices implements ResourceManagerServices {
+
+			private List<ResourceProfile> allocatedContainers;
+
+			public TestingRmServices() {
+				this.allocatedContainers = new LinkedList<>();
+			}
+
+			@Override
+			public void allocateResource(ResourceProfile resourceProfile) {
+				allocatedContainers.add(resourceProfile);
+			}
+
+			@Override
+			public Executor getAsyncExecutor() {
+				return Mockito.mock(Executor.class);
+			}
+
+			@Override
+			public Executor getMainThreadExecutor() {
+				return Mockito.mock(Executor.class);
+			}
+
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -95,7 +95,7 @@ public class SlotProtocolTest extends TestLogger {
 			configureHA(testingHaServices, jobID, rmAddress, rmLeaderID, jmAddress, jmLeaderID);
 
 		SlotManager slotManager = Mockito.spy(new SimpleSlotManager());
-		ResourceManager resourceManager =
+		StandaloneResourceManager resourceManager =
 			Mockito.spy(new StandaloneResourceManager(testRpcService, testingHaServices, slotManager));
 		resourceManager.start();
 		rmLeaderElectionService.isLeader(rmLeaderID);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -19,7 +19,9 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.highavailability.NonHaServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -28,11 +30,15 @@ import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestRegistered;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestRejected;
+import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.TestingSerialRpcService;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import org.powermock.api.mockito.PowerMockito;
@@ -76,7 +82,7 @@ public class TaskExecutorTest extends TestLogger {
 			String taskManagerAddress = taskManager.getAddress();
 
 			verify(rmGateway).registerTaskExecutor(
-					any(UUID.class), eq(taskManagerAddress), eq(resourceID), any(Time.class));
+					any(UUID.class), eq(taskManagerAddress), eq(resourceID), any(SlotReport.class), any(Time.class));
 		}
 		finally {
 			rpc.stopService();
@@ -132,7 +138,7 @@ public class TaskExecutorTest extends TestLogger {
 			testLeaderService.notifyListener(address1, leaderId1);
 
 			verify(rmGateway1).registerTaskExecutor(
-					eq(leaderId1), eq(taskManagerAddress), eq(resourceID), any(Time.class));
+					eq(leaderId1), eq(taskManagerAddress), eq(resourceID), any(SlotReport.class), any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 
 			// cancel the leader 
@@ -142,11 +148,95 @@ public class TaskExecutorTest extends TestLogger {
 			testLeaderService.notifyListener(address2, leaderId2);
 
 			verify(rmGateway2).registerTaskExecutor(
-					eq(leaderId2), eq(taskManagerAddress), eq(resourceID), any(Time.class));
+					eq(leaderId2), eq(taskManagerAddress), eq(resourceID), any(SlotReport.class), any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 		}
 		finally {
 			rpc.stopService();
 		}
+	}
+
+	/**
+	 * Tests that all allocation requests for slots are ignored if the slot has been reported as
+	 * free by the TaskExecutor but this report hasn't been confirmed by the ResourceManager.
+	 *
+	 * This is essential for the correctness of the state of the ResourceManager.
+	 */
+	@Test
+	public void testRejectAllocationRequestsForOutOfSyncSlots() {
+		final ResourceID resourceID = ResourceID.generate();
+
+		final String address1 = "/resource/manager/address/one";
+		final UUID leaderId = UUID.randomUUID();
+
+		final TestingSerialRpcService rpc = new TestingSerialRpcService();
+		try {
+			// register the mock resource manager gateways
+			ResourceManagerGateway rmGateway1 = mock(ResourceManagerGateway.class);
+			rpc.registerGateway(address1, rmGateway1);
+
+			TestingLeaderRetrievalService testLeaderService = new TestingLeaderRetrievalService();
+
+			TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
+			haServices.setResourceManagerLeaderRetriever(testLeaderService);
+
+			TaskManagerConfiguration taskManagerServicesConfiguration = mock(TaskManagerConfiguration.class);
+			PowerMockito.when(taskManagerServicesConfiguration.getNumberSlots()).thenReturn(1);
+
+			TaskManagerLocation taskManagerLocation = mock(TaskManagerLocation.class);
+			when(taskManagerLocation.getResourceID()).thenReturn(resourceID);
+
+			TaskExecutor taskManager = new TaskExecutor(
+				taskManagerServicesConfiguration,
+				taskManagerLocation,
+				rpc,
+				mock(MemoryManager.class),
+				mock(IOManager.class),
+				mock(NetworkEnvironment.class),
+				haServices,
+				mock(MetricRegistry.class),
+				mock(FatalErrorHandler.class));
+
+			taskManager.start();
+			String taskManagerAddress = taskManager.getAddress();
+
+			// no connection initially, since there is no leader
+			assertNull(taskManager.getResourceManagerConnection());
+
+			// define a leader and see that a registration happens
+			testLeaderService.notifyListener(address1, leaderId);
+
+			verify(rmGateway1).registerTaskExecutor(
+				eq(leaderId), eq(taskManagerAddress), eq(resourceID), any(SlotReport.class), any(Time.class));
+			assertNotNull(taskManager.getResourceManagerConnection());
+
+			// test that allocating a slot works
+			final SlotID slotID = new SlotID(resourceID, 0);
+			TMSlotRequestReply tmSlotRequestReply = taskManager.requestSlot(slotID, new AllocationID(), leaderId);
+			assertTrue(tmSlotRequestReply instanceof TMSlotRequestRegistered);
+
+			// test that we can't allocate slots which are blacklisted due to pending confirmation of the RM
+			final SlotID unconfirmedFreeSlotID = new SlotID(resourceID, 1);
+			taskManager.addUnconfirmedFreeSlotNotification(unconfirmedFreeSlotID);
+			TMSlotRequestReply tmSlotRequestReply2 =
+				taskManager.requestSlot(unconfirmedFreeSlotID, new AllocationID(), leaderId);
+			assertTrue(tmSlotRequestReply2 instanceof TMSlotRequestRejected);
+
+			// re-register
+			verify(rmGateway1).registerTaskExecutor(
+				eq(leaderId), eq(taskManagerAddress), eq(resourceID), any(SlotReport.class), any(Time.class));
+			testLeaderService.notifyListener(address1, leaderId);
+
+			// now we should be successful because the slots status has been synced
+			// test that we can't allocate slots which are blacklisted due to pending confirmation of the RM
+			TMSlotRequestReply tmSlotRequestReply3 =
+				taskManager.requestSlot(unconfirmedFreeSlotID, new AllocationID(), leaderId);
+			assertTrue(tmSlotRequestReply3 instanceof TMSlotRequestRegistered);
+
+		}
+		finally {
+			rpc.stopService();
+		}
+
 	}
 }


### PR DESCRIPTION
This pull request is split up into two commits:

1. It removes some code from the `SlotManager` to make it simpler. 
  - It makes use of `handleSlotRequestFailedAtTaskManager` and simplifies it because we can assume that a Slot is only registered once if we talk to the same instance of a TaskExecutor. Further, we can omit to check the free slots because we previously removed the slot from the free slots.
  - `updateSlotStatus` only deals with new Task slots. All other updates are performed by the `ResourceManager`. In case the ResourceManager creashes, it will re-register all slot statuses.

2. It fences `TaskExecutor` messages using an `InstanceID` which is required to make 1 work correctly. New messages have been introduced to achieve that.