### PR TITLE
'Id' is the key of the stream and not the id of the event.

### DIFF
--- a/docs/fig/parallel_streams_watermarks.svg
+++ b/docs/fig/parallel_streams_watermarks.svg
@@ -472,7 +472,7 @@ under the License.
          y="153.13097"
          id="text3161"
          xml:space="preserve"
-         style="font-size:10.05127621px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">id|timestamp</text>
+         style="font-size:10.05127621px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">key|timestamp</text>
       <text
          x="425.19507"
          y="153.13097"


### PR DESCRIPTION
FLINK-4718 Confusing label in Parallel Streams Diagram

Minor text change to clarify a mildly confusing label in a diagram.