### PR TITLE
[FLINK-4723] [kafka-connector] Unify committed offsets to Kafka to be the next record to process

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010FetcherTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010FetcherTest.java
@@ -143,7 +143,7 @@ public class Kafka010FetcherTest {
             @Override
             public void run() {
                 try {
-                    fetcher.commitSpecificOffsetsToKafka(testCommitData);
+                    fetcher.commitInternalOffsetsToKafka(testCommitData);
                 } catch (Throwable t) {
                     commitError.set(t);
                 }
@@ -255,7 +255,7 @@ public class Kafka010FetcherTest {
 
         // ----- trigger the first offset commit -----
 
-        fetcher.commitSpecificOffsetsToKafka(testCommitData1);
+        fetcher.commitInternalOffsetsToKafka(testCommitData1);
         Map<TopicPartition, OffsetAndMetadata> result1 = commitStore.take();
 
         for (Entry<TopicPartition, OffsetAndMetadata> entry : result1.entrySet()) {
@@ -272,7 +272,7 @@ public class Kafka010FetcherTest {
 
         // ----- trigger the second offset commit -----
 
-        fetcher.commitSpecificOffsetsToKafka(testCommitData2);
+        fetcher.commitInternalOffsetsToKafka(testCommitData2);
         Map<TopicPartition, OffsetAndMetadata> result2 = commitStore.take();
 
         for (Entry<TopicPartition, OffsetAndMetadata> entry : result2.entrySet()) {

--- a/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
@@ -131,6 +131,24 @@ public class Kafka010ITCase extends KafkaConsumerTestBase {
 		runEndOfStreamTest();
 	}
 
+	// --- offset committing ---
+
+	@Test(timeout = 60000)
+	public void testCommitOffsetsToKafka() throws Exception {
+		runCommitOffsetsToKafka();
+	}
+
+	@Test(timeout = 60000)
+	public void testStartFromKafkaCommitOffsets() throws Exception {
+		runStartFromKafkaCommitOffsets();
+	}
+
+	// TODO: This test will not pass until FLINK-4727 is resolved
+//	@Test(timeout = 60000)
+//	public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+//		runAutoOffsetRetrievalAndCommitToKafka();
+//	}
+
 	/**
 	 * Kafka 0.10 specific test, ensuring Timestamps are properly written to and read from Kafka
 	 */

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
@@ -140,7 +140,7 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 					}
 				}
 
-				Map<KafkaTopicPartition, Long> zkOffsets = zookeeperOffsetHandler.getOffsets(partitionsWithNoOffset);
+				Map<KafkaTopicPartition, Long> zkOffsets = zookeeperOffsetHandler.getCommittedOffsets(partitionsWithNoOffset);
 				for (KafkaTopicPartitionState<TopicAndPartition> partition : subscribedPartitions()) {
 					Long zkOffset = zkOffsets.get(partition.getKafkaTopicPartition());
 					if (zkOffset != null) {
@@ -326,10 +326,11 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void commitSpecificOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception {
+	public void commitInternalOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception {
 		ZookeeperOffsetHandler zkHandler = this.zookeeperOffsetHandler;
 		if (zkHandler != null) {
-			zkHandler.writeOffsets(offsets);
+			// the ZK handler takes care of incrementing the offsets by 1 before committing
+			zkHandler.prepareAndCommitOffsets(offsets);
 		}
 
 		// Set committed offsets in topic partition state

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
@@ -142,9 +142,11 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 
 				Map<KafkaTopicPartition, Long> zkOffsets = zookeeperOffsetHandler.getOffsets(partitionsWithNoOffset);
 				for (KafkaTopicPartitionState<TopicAndPartition> partition : subscribedPartitions()) {
-					Long offset = zkOffsets.get(partition.getKafkaTopicPartition());
-					if (offset != null) {
-						partition.setOffset(offset);
+					Long zkOffset = zkOffsets.get(partition.getKafkaTopicPartition());
+					if (zkOffset != null) {
+						// the offset in ZK represents the "next record to process", so we need to subtract it by 1
+						// to correctly represent our internally checkpointed offsets
+						partition.setOffset(zkOffset - 1);
 					}
 				}
 			}

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
@@ -64,12 +64,10 @@ public class PeriodicOffsetCommitter extends Thread {
 				// create copy a deep copy of the current offsets
 				HashMap<KafkaTopicPartition, Long> offsetsToCommit = new HashMap<>(partitionStates.length);
 				for (KafkaTopicPartitionState<?> partitionState : partitionStates) {
-					// the offset to commit is incremented by 1 because offsets
-					// in ZK need to represent "the next record to process"
-					offsetsToCommit.put(partitionState.getKafkaTopicPartition(), partitionState.getOffset() + 1);
+					offsetsToCommit.put(partitionState.getKafkaTopicPartition(), partitionState.getOffset());
 				}
 				
-				offsetHandler.writeOffsets(offsetsToCommit);
+				offsetHandler.prepareAndCommitOffsets(offsetsToCommit);
 			}
 		}
 		catch (Throwable t) {

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
@@ -62,12 +62,14 @@ public class PeriodicOffsetCommitter extends Thread {
 				Thread.sleep(commitInterval);
 
 				// create copy a deep copy of the current offsets
-				HashMap<KafkaTopicPartition, Long> currentOffsets = new HashMap<>(partitionStates.length);
+				HashMap<KafkaTopicPartition, Long> offsetsToCommit = new HashMap<>(partitionStates.length);
 				for (KafkaTopicPartitionState<?> partitionState : partitionStates) {
-					currentOffsets.put(partitionState.getKafkaTopicPartition(), partitionState.getOffset());
+					// the offset to commit is incremented by 1 because offsets
+					// in ZK need to represent "the next record to process"
+					offsetsToCommit.put(partitionState.getKafkaTopicPartition(), partitionState.getOffset() + 1);
 				}
 				
-				offsetHandler.writeOffsets(currentOffsets);
+				offsetHandler.writeOffsets(offsetsToCommit);
 			}
 		}
 		catch (Throwable t) {

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
@@ -300,7 +300,7 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> implem
 	}
 
 	@Override
-	public void commitSpecificOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception {
+	public void commitInternalOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception {
 		KafkaTopicPartitionState<TopicPartition>[] partitions = subscribedPartitions();
 		Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>(partitions.length);
 

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09FetcherTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09FetcherTest.java
@@ -143,7 +143,7 @@ public class Kafka09FetcherTest {
 			@Override
 			public void run() {
 				try {
-					fetcher.commitSpecificOffsetsToKafka(testCommitData);
+					fetcher.commitInternalOffsetsToKafka(testCommitData);
 				} catch (Throwable t) {
 					commitError.set(t);
 				}
@@ -259,14 +259,14 @@ public class Kafka09FetcherTest {
 
 		// ----- trigger the first offset commit -----
 
-		fetcher.commitSpecificOffsetsToKafka(testCommitData1);
+		fetcher.commitInternalOffsetsToKafka(testCommitData1);
 		Map<TopicPartition, OffsetAndMetadata> result1 = commitStore.take();
 
 		for (Entry<TopicPartition, OffsetAndMetadata> entry : result1.entrySet()) {
 			TopicPartition partition = entry.getKey();
 			if (partition.topic().equals("test")) {
 				assertEquals(42, partition.partition());
-				assertEquals(11L, entry.getValue().offset());
+				assertEquals(12L, entry.getValue().offset());
 			}
 			else if (partition.topic().equals("another")) {
 				assertEquals(99, partition.partition());
@@ -276,14 +276,14 @@ public class Kafka09FetcherTest {
 
 		// ----- trigger the second offset commit -----
 
-		fetcher.commitSpecificOffsetsToKafka(testCommitData2);
+		fetcher.commitInternalOffsetsToKafka(testCommitData2);
 		Map<TopicPartition, OffsetAndMetadata> result2 = commitStore.take();
 
 		for (Entry<TopicPartition, OffsetAndMetadata> entry : result2.entrySet()) {
 			TopicPartition partition = entry.getKey();
 			if (partition.topic().equals("test")) {
 				assertEquals(42, partition.partition());
-				assertEquals(19L, entry.getValue().offset());
+				assertEquals(20L, entry.getValue().offset());
 			}
 			else if (partition.topic().equals("another")) {
 				assertEquals(99, partition.partition());

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09FetcherTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09FetcherTest.java
@@ -266,11 +266,11 @@ public class Kafka09FetcherTest {
 			TopicPartition partition = entry.getKey();
 			if (partition.topic().equals("test")) {
 				assertEquals(42, partition.partition());
-				assertEquals(12L, entry.getValue().offset());
+				assertEquals(11L, entry.getValue().offset());
 			}
 			else if (partition.topic().equals("another")) {
 				assertEquals(99, partition.partition());
-				assertEquals(18L, entry.getValue().offset());
+				assertEquals(17L, entry.getValue().offset());
 			}
 		}
 
@@ -283,11 +283,11 @@ public class Kafka09FetcherTest {
 			TopicPartition partition = entry.getKey();
 			if (partition.topic().equals("test")) {
 				assertEquals(42, partition.partition());
-				assertEquals(20L, entry.getValue().offset());
+				assertEquals(19L, entry.getValue().offset());
 			}
 			else if (partition.topic().equals("another")) {
 				assertEquals(99, partition.partition());
-				assertEquals(28L, entry.getValue().offset());
+				assertEquals(27L, entry.getValue().offset());
 			}
 		}
 		

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -109,4 +109,22 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 	public void testMetrics() throws Throwable {
 		runMetricsTest();
 	}
+
+	// --- offset committing ---
+
+	@Test(timeout = 60000)
+	public void testCommitOffsetsToKafka() throws Exception {
+		runCommitOffsetsToKafka();
+	}
+
+	@Test(timeout = 60000)
+	public void testStartFromKafkaCommitOffsets() throws Exception {
+		runStartFromKafkaCommitOffsets();
+	}
+
+	// TODO: This test will not pass until FLINK-4727 is resolved
+//	@Test(timeout = 60000)
+//	public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+//		runAutoOffsetRetrievalAndCommitToKafka();
+//	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -159,7 +159,9 @@ public abstract class AbstractFetcher<T, KPH> {
 
 	/**
 	 * Commits the given partition offsets to the Kafka brokers (or to ZooKeeper for
-	 * older Kafka versions).
+	 * older Kafka versions). The given offsets will be larger by 1 compared to the
+	 * internally checkpointed offsets since committed offsets to Kafka represent the
+	 * next record to be processed.
 	 * 
 	 * @param offsets The offsets to commit to Kafka.
 	 * @throws Exception This method forwards exceptions.

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -159,14 +159,15 @@ public abstract class AbstractFetcher<T, KPH> {
 
 	/**
 	 * Commits the given partition offsets to the Kafka brokers (or to ZooKeeper for
-	 * older Kafka versions). The given offsets will be larger by 1 compared to the
-	 * internally checkpointed offsets since committed offsets to Kafka represent the
-	 * next record to be processed.
+	 * older Kafka versions). The given offsets are the internal checkpointed offsets, representing
+	 * the last processed record of each partition. Version-specific implementations of this method
+	 * need to hold the contract that the given offsets must be incremented by 1 before
+	 * committing them, so that committed offsets to Kafka represent "the next record to process".
 	 * 
-	 * @param offsets The offsets to commit to Kafka.
+	 * @param offsets The offsets to commit to Kafka (implementations must increment offsets by 1 before committing).
 	 * @throws Exception This method forwards exceptions.
 	 */
-	public abstract void commitSpecificOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception;
+	public abstract void commitInternalOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception;
 	
 	// ------------------------------------------------------------------------
 	//  snapshot and restore the state

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -169,30 +169,20 @@ public class FlinkKafkaConsumerBaseTest {
 	public void testSnapshotState() throws Exception {
 
 		// --------------------------------------------------------------------
-		//   prepare fake states and corresponding expected offsets to commit;
-		//   the offsets to commit should be 1 more than the snapshot state
+		//   prepare fake states
 		// --------------------------------------------------------------------
 
 		final HashMap<KafkaTopicPartition, Long> state1 = new HashMap<>();
-		final HashMap<KafkaTopicPartition, Long> expectedOffsetsToCommit1 = new HashMap<>();
 		state1.put(new KafkaTopicPartition("abc", 13), 16768L);
 		state1.put(new KafkaTopicPartition("def", 7), 987654321L);
-		expectedOffsetsToCommit1.put(new KafkaTopicPartition("abc", 13), 16769L);
-		expectedOffsetsToCommit1.put(new KafkaTopicPartition("def", 7), 987654322L);
 
 		final HashMap<KafkaTopicPartition, Long> state2 = new HashMap<>();
-		final HashMap<KafkaTopicPartition, Long> expectedOffsetsToCommit2 = new HashMap<>();
 		state2.put(new KafkaTopicPartition("abc", 13), 16770L);
 		state2.put(new KafkaTopicPartition("def", 7), 987654329L);
-		expectedOffsetsToCommit2.put(new KafkaTopicPartition("abc", 13), 16771L);
-		expectedOffsetsToCommit2.put(new KafkaTopicPartition("def", 7), 987654330L);
 
 		final HashMap<KafkaTopicPartition, Long> state3 = new HashMap<>();
-		final HashMap<KafkaTopicPartition, Long> expectedOffsetsToCommit3 = new HashMap<>();
 		state3.put(new KafkaTopicPartition("abc", 13), 16780L);
 		state3.put(new KafkaTopicPartition("def", 7), 987654377L);
-		expectedOffsetsToCommit3.put(new KafkaTopicPartition("abc", 13), 16781L);
-		expectedOffsetsToCommit3.put(new KafkaTopicPartition("def", 7), 987654378L);
 
 		// --------------------------------------------------------------------
 		
@@ -228,7 +218,7 @@ public class FlinkKafkaConsumerBaseTest {
 
 		assertEquals(state1, snapshot1);
 		assertEquals(1, pendingOffsetsToCommit.size());
-		assertEquals(expectedOffsetsToCommit1, pendingOffsetsToCommit.get(138L));
+		assertEquals(state1, pendingOffsetsToCommit.get(138L));
 
 		// checkpoint 2
 		consumer.prepareSnapshot(140L, 140L);
@@ -242,7 +232,7 @@ public class FlinkKafkaConsumerBaseTest {
 
 		assertEquals(state2, snapshot2);
 		assertEquals(2, pendingOffsetsToCommit.size());
-		assertEquals(expectedOffsetsToCommit2, pendingOffsetsToCommit.get(140L));
+		assertEquals(state2, pendingOffsetsToCommit.get(140L));
 		
 		// ack checkpoint 1
 		consumer.notifyCheckpointComplete(138L);
@@ -261,7 +251,7 @@ public class FlinkKafkaConsumerBaseTest {
 
 		assertEquals(state3, snapshot3);
 		assertEquals(2, pendingOffsetsToCommit.size());
-		assertEquals(expectedOffsetsToCommit3, pendingOffsetsToCommit.get(141L));
+		assertEquals(state3, pendingOffsetsToCommit.get(141L));
 		
 		// ack checkpoint 3, subsumes number 2
 		consumer.notifyCheckpointComplete(141L);

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -97,7 +97,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.Date;
@@ -200,6 +199,226 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 				assertTrue(re.getMessage().contains("Unable to retrieve any partitions for the requested topics [doesntexist]"));
 			}
 		}
+	}
+
+	/**
+	 * Ensures that the committed offsets to Kafka are the offsets of "the next record to process"
+	 */
+	public void runCommitOffsetsToKafka() throws Exception {
+		// 3 partitions with 50 records each (0-49, so the expected commit offset of each partition should be 50)
+		final int parallelism = 3;
+		final int recordsInEachPartition = 50;
+
+		final String topicName = writeSequence("testCommitOffsetsToKafkaTopic", recordsInEachPartition, parallelism, 1);
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
+		env.getConfig().disableSysoutLogging();
+		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+		env.setParallelism(parallelism);
+		env.enableCheckpointing(200);
+
+		DataStream<String> stream = env.addSource(kafkaServer.getConsumer(topicName, new SimpleStringSchema(), standardProps));
+		stream.addSink(new DiscardingSink<String>());
+
+		final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+		final Thread runner = new Thread("runner") {
+			@Override
+			public void run() {
+				try {
+					env.execute();
+				}
+				catch (Throwable t) {
+					if (!(t.getCause() instanceof JobCancellationException)) {
+						errorRef.set(t);
+					}
+				}
+			}
+		};
+		runner.start();
+
+		final Long l50 = 50L; // the final committed offset in Kafka should be 50
+		final long deadline = 30000 + System.currentTimeMillis();
+
+		KafkaTestEnvironment.KafkaOffsetHandler kafkaOffsetHandler = kafkaServer.createOffsetHandler(standardProps);
+
+		do {
+			Long o1 = kafkaOffsetHandler.getCommittedOffset(topicName, 0);
+			Long o2 = kafkaOffsetHandler.getCommittedOffset(topicName, 1);
+			Long o3 = kafkaOffsetHandler.getCommittedOffset(topicName, 2);
+
+			if (l50.equals(o1) && l50.equals(o2) && l50.equals(o3)) {
+				break;
+			}
+
+			Thread.sleep(100);
+		}
+		while (System.currentTimeMillis() < deadline);
+
+		// cancel the job
+		JobManagerCommunicationUtils.cancelCurrentJob(flink.getLeaderGateway(timeout));
+
+		final Throwable t = errorRef.get();
+		if (t != null) {
+			throw new RuntimeException("Job failed with an exception", t);
+		}
+
+		// final check to see if offsets are correctly in Kafka
+		Long o1 = kafkaOffsetHandler.getCommittedOffset(topicName, 0);
+		Long o2 = kafkaOffsetHandler.getCommittedOffset(topicName, 1);
+		Long o3 = kafkaOffsetHandler.getCommittedOffset(topicName, 2);
+		Assert.assertEquals(Long.valueOf(50L), o1);
+		Assert.assertEquals(Long.valueOf(50L), o2);
+		Assert.assertEquals(Long.valueOf(50L), o3);
+
+		kafkaOffsetHandler.close();
+		deleteTestTopic(topicName);
+	}
+
+	/**
+	 * This test first writes a total of 200 records to a test topic, reads the first 100 so that some offsets are
+	 * committed to Kafka, and then startup the consumer again to read the remaining records starting from the committed offsets.
+	 * The test ensures that whatever offsets were committed to Kafka, the consumer correctly picks them up
+	 * and starts at the correct position.
+	 */
+	public void runStartFromKafkaCommitOffsets() throws Exception {
+		final int parallelism = 3;
+		final int recordsInEachPartition = 200;
+
+		final String topicName = writeSequence("testStartFromKafkaCommitOffsetsTopic", recordsInEachPartition, parallelism, 1);
+
+		final StreamExecutionEnvironment env1 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
+		env1.getConfig().disableSysoutLogging();
+		env1.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+		env1.setParallelism(parallelism);
+		env1.enableCheckpointing(20); // fast checkpoints to make sure we commit some offsets
+
+		env1
+			.addSource(kafkaServer.getConsumer(topicName, new SimpleStringSchema(), standardProps))
+			.map(new ThrottledMapper<String>(20))
+			.map(new MapFunction<String, Object>() {
+				int count = 0;
+				@Override
+				public Object map(String value) throws Exception {
+					count++;
+					if (count == 100) {
+						throw new SuccessException();
+					}
+					return null;
+				}
+			})
+			.addSink(new DiscardingSink<>());
+
+		tryExecute(env1, "Read some records to commit offsets to Kafka");
+
+		KafkaTestEnvironment.KafkaOffsetHandler kafkaOffsetHandler = kafkaServer.createOffsetHandler(standardProps);
+
+		Long o1 = kafkaOffsetHandler.getCommittedOffset(topicName, 0);
+		Long o2 = kafkaOffsetHandler.getCommittedOffset(topicName, 1);
+		Long o3 = kafkaOffsetHandler.getCommittedOffset(topicName, 2);
+
+		LOG.info("Got final committed offsets from Kafka o1={}, o2={}, o3={}", o1, o2, o3);
+
+		final StreamExecutionEnvironment env2 = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
+		env2.getConfig().disableSysoutLogging();
+		env2.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+		env2.setParallelism(parallelism);
+
+		// whatever offsets were committed for each partition, the consumer should pick
+		// them up and start from the correct position so that the remaining records are all read
+		HashMap<Integer, Tuple2<Integer, Integer>> partitionsToValuesCountAndStartOffset = new HashMap<>();
+		partitionsToValuesCountAndStartOffset.put(0, new Tuple2<>((int) (recordsInEachPartition - o1), o1.intValue()));
+		partitionsToValuesCountAndStartOffset.put(1, new Tuple2<>((int) (recordsInEachPartition - o2), o2.intValue()));
+		partitionsToValuesCountAndStartOffset.put(2, new Tuple2<>((int) (recordsInEachPartition - o3), o3.intValue()));
+
+		readSequence(env2, standardProps, topicName, partitionsToValuesCountAndStartOffset);
+
+		kafkaOffsetHandler.close();
+		deleteTestTopic(topicName);
+	}
+
+	/**
+	 * This test ensures that when the consumers retrieve some start offset from kafka (earliest, latest), that this offset
+	 * is committed to Kafka, even if some partitions are not read.
+	 *
+	 * Test:
+	 * - Create 3 partitions
+	 * - write 50 messages into each.
+	 * - Start three consumers with auto.offset.reset='latest' and wait until they committed into Kafka.
+	 * - Check if the offsets in Kafka are set to 50 for the three partitions
+	 *
+	 * See FLINK-3440 as well
+	 */
+	public void runAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+		// 3 partitions with 50 records each (0-49, so the expected commit offset of each partition should be 50)
+		final int parallelism = 3;
+		final int recordsInEachPartition = 50;
+
+		final String topicName = writeSequence("testAutoOffsetRetrievalAndCommitToKafkaTopic", recordsInEachPartition, parallelism, 1);
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);
+		env.getConfig().disableSysoutLogging();
+		env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+		env.setParallelism(parallelism);
+		env.enableCheckpointing(200);
+
+		Properties readProps = new Properties();
+		readProps.putAll(standardProps);
+		readProps.setProperty("auto.offset.reset", "latest"); // set to reset to latest, so that partitions are initially not read
+
+		DataStream<String> stream = env.addSource(kafkaServer.getConsumer(topicName, new SimpleStringSchema(), readProps));
+		stream.addSink(new DiscardingSink<String>());
+
+		final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+		final Thread runner = new Thread("runner") {
+			@Override
+			public void run() {
+				try {
+					env.execute();
+				}
+				catch (Throwable t) {
+					if (!(t.getCause() instanceof JobCancellationException)) {
+						errorRef.set(t);
+					}
+				}
+			}
+		};
+		runner.start();
+
+		KafkaTestEnvironment.KafkaOffsetHandler kafkaOffsetHandler = kafkaServer.createOffsetHandler(standardProps);
+
+		final Long l50 = 50L; // the final committed offset in Kafka should be 50
+		final long deadline = 30000 + System.currentTimeMillis();
+		do {
+			Long o1 = kafkaOffsetHandler.getCommittedOffset(topicName, 0);
+			Long o2 = kafkaOffsetHandler.getCommittedOffset(topicName, 1);
+			Long o3 = kafkaOffsetHandler.getCommittedOffset(topicName, 2);
+
+			if (l50.equals(o1) && l50.equals(o2) && l50.equals(o3)) {
+				break;
+			}
+
+			Thread.sleep(100);
+		}
+		while (System.currentTimeMillis() < deadline);
+
+		// cancel the job
+		JobManagerCommunicationUtils.cancelCurrentJob(flink.getLeaderGateway(timeout));
+
+		final Throwable t = errorRef.get();
+		if (t != null) {
+			throw new RuntimeException("Job failed with an exception", t);
+		}
+
+		// final check to see if offsets are correctly in Kafka
+		Long o1 = kafkaOffsetHandler.getCommittedOffset(topicName, 0);
+		Long o2 = kafkaOffsetHandler.getCommittedOffset(topicName, 1);
+		Long o3 = kafkaOffsetHandler.getCommittedOffset(topicName, 2);
+		Assert.assertEquals(Long.valueOf(50L), o1);
+		Assert.assertEquals(Long.valueOf(50L), o2);
+		Assert.assertEquals(Long.valueOf(50L), o3);
+
+		kafkaOffsetHandler.close();
+		deleteTestTopic(topicName);
 	}
 	
 	/**
@@ -1346,48 +1565,80 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 	//  Reading writing test data sets
 	// ------------------------------------------------------------------------
 
+	/**
+	 * Runs a job using the provided environment to read a sequence of records from a single Kafka topic.
+	 * The method allows to individually specify the expected starting offset and total read value count of each partition.
+	 * The job will be considered successful only if all partition read results match the start offset and value count criteria.
+	 */
 	protected void readSequence(StreamExecutionEnvironment env, Properties cc,
-								final int sourceParallelism,
 								final String topicName,
-								final int valuesCount, final int startFrom) throws Exception {
+								final Map<Integer, Tuple2<Integer, Integer>> partitionsToValuesCountAndStartOffset) throws Exception {
+		final int sourceParallelism = partitionsToValuesCountAndStartOffset.keySet().size();
 
-		final int finalCount = valuesCount * sourceParallelism;
+		int finalCountTmp = 0;
+		for (Map.Entry<Integer, Tuple2<Integer, Integer>> valuesCountAndStartOffset : partitionsToValuesCountAndStartOffset.entrySet()) {
+			finalCountTmp += valuesCountAndStartOffset.getValue().f0;
+		}
+		final int finalCount = finalCountTmp;
 
 		final TypeInformation<Tuple2<Integer, Integer>> intIntTupleType = TypeInfoParser.parse("Tuple2<Integer, Integer>");
 
 		final TypeInformationSerializationSchema<Tuple2<Integer, Integer>> deser =
-				new TypeInformationSerializationSchema<>(intIntTupleType, env.getConfig());
+			new TypeInformationSerializationSchema<>(intIntTupleType, env.getConfig());
 
 		// create the consumer
 		cc.putAll(secureProps);
 		FlinkKafkaConsumerBase<Tuple2<Integer, Integer>> consumer = kafkaServer.getConsumer(topicName, deser, cc);
 
 		DataStream<Tuple2<Integer, Integer>> source = env
-				.addSource(consumer).setParallelism(sourceParallelism)
-				.map(new ThrottledMapper<Tuple2<Integer, Integer>>(20)).setParallelism(sourceParallelism);
+			.addSource(consumer).setParallelism(sourceParallelism)
+			.map(new ThrottledMapper<Tuple2<Integer, Integer>>(20)).setParallelism(sourceParallelism);
 
 		// verify data
 		source.flatMap(new RichFlatMapFunction<Tuple2<Integer, Integer>, Integer>() {
 
-			private int[] values = new int[valuesCount];
+			private HashMap<Integer, BitSet> partitionsToValueCheck;
 			private int count = 0;
 
 			@Override
+			public void open(Configuration parameters) throws Exception {
+				partitionsToValueCheck = new HashMap<>();
+				for (Integer partition : partitionsToValuesCountAndStartOffset.keySet()) {
+					partitionsToValueCheck.put(partition, new BitSet());
+				}
+			}
+
+			@Override
 			public void flatMap(Tuple2<Integer, Integer> value, Collector<Integer> out) throws Exception {
-				values[value.f1 - startFrom]++;
+				int partition = value.f0;
+				int val = value.f1;
+
+				BitSet bitSet = partitionsToValueCheck.get(partition);
+				if (bitSet == null) {
+					throw new RuntimeException("Got a record from an unknown partition");
+				} else {
+					bitSet.set(val - partitionsToValuesCountAndStartOffset.get(partition).f1);
+				}
+
 				count++;
+
 				LOG.info("Received message {}, total {} messages", value, count);
 
 				// verify if we've seen everything
 				if (count == finalCount) {
-					for (int i = 0; i < values.length; i++) {
-						int v = values[i];
-						if (v != sourceParallelism) {
-							printTopic(topicName, valuesCount, deser);
-							throw new RuntimeException("Expected v to be " + sourceParallelism + 
-									", but was " + v + " on element " + i + " array=" + Arrays.toString(values));
+					for (Map.Entry<Integer, BitSet> partitionsToValueCheck : this.partitionsToValueCheck.entrySet()) {
+						BitSet check = partitionsToValueCheck.getValue();
+						int expectedValueCount = partitionsToValuesCountAndStartOffset.get(partitionsToValueCheck.getKey()).f0;
+
+						if (check.cardinality() != expectedValueCount) {
+							throw new RuntimeException("Expected cardinality to be " + expectedValueCount +
+								", but was " + check.cardinality());
+						} else if (check.nextClearBit(0) != expectedValueCount) {
+							throw new RuntimeException("Expected next clear bit to be " + expectedValueCount +
+								", but was " + check.cardinality());
 						}
 					}
+
 					// test has passed
 					throw new SuccessException();
 				}
@@ -1398,6 +1649,21 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		tryExecute(env, "Read data from Kafka");
 
 		LOG.info("Successfully read sequence for verification");
+	}
+
+	/**
+	 * Variant of {@link KafkaConsumerTestBase#readSequence(StreamExecutionEnvironment, Properties, String, Map)} to
+	 * expect reading from the same start offset and the same value count for all partitions of a single Kafka topic.
+	 */
+	protected void readSequence(StreamExecutionEnvironment env, Properties cc,
+								final int sourceParallelism,
+								final String topicName,
+								final int valuesCount, final int startFrom) throws Exception {
+		HashMap<Integer, Tuple2<Integer, Integer>> partitionsToValuesCountAndStartOffset = new HashMap<>();
+		for (int i = 0; i < sourceParallelism; i++) {
+			partitionsToValuesCountAndStartOffset.put(i, new Tuple2<>(valuesCount, startFrom));
+		}
+		readSequence(env, cc, topicName, partitionsToValuesCountAndStartOffset);
 	}
 
 	protected String writeSequence(
@@ -1430,7 +1696,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 			LOG.info("Writing attempt #1");
 			
 			// -------- Write the Sequence --------
-			
+
 			createTestTopic(topicName, parallelism, replicationFactor);
 
 			StreamExecutionEnvironment writeEnv = StreamExecutionEnvironment.createRemoteEnvironment("localhost", flinkPort);

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -29,6 +29,8 @@ import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.Properties;
 
 /**
@@ -83,6 +85,14 @@ public abstract class KafkaTestEnvironment {
 														KeyedSerializationSchema<T> serSchema, Properties props,
 														KafkaPartitioner<T> partitioner);
 
+	// -- offset handlers
+
+	public interface KafkaOffsetHandler {
+		Long getCommittedOffset(String topicName, int partition);
+		void close();
+	}
+
+	public abstract KafkaOffsetHandler createOffsetHandler(Properties props);
 
 	// -- leader failure simulation
 

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTimestampsTest.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTimestampsTest.java
@@ -225,7 +225,7 @@ public class AbstractFetcherTimestampsTest {
 		}
 
 		@Override
-		public void commitSpecificOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception {
+		public void commitInternalOffsetsToKafka(Map<KafkaTopicPartition, Long> offsets) throws Exception {
 			throw new UnsupportedOperationException();
 		}
 	}


### PR DESCRIPTION
The description within the JIRA ticket ([FLINK-4723](https://issues.apache.org/jira/browse/FLINK-4723)) explains the reasoning for this change.

With this change, offsets committed to Kafka of both 0.8 and 0.9 are larger by 1 compared to the internally checkpointed offsets. This is changed at the `FlinkKafkaConsumerBase` level, so that offsets given through the abstract `commitSpecificOffsetsToKafka()` method to the version-specific implementations are already incremented and represent the next record to process. This way, the version-specific implementations simply commit the given offsets without the need to manipulate them.

To test the behaviour on both connector versions, this PR also includes major refactoring of the IT tests by adding offset committing related IT tests to `FlinkKafkaConsumerTestBase`, and let both the 0.8 and 0.9 consumers run offset committing / initial offset startup tests (previously only the 0.8 consumer had these tests).

R: @rmetzger what do you think of this?