### PR TITLE
[FLINK-4709] Fix resource leak in InputStreamFSInputWrapper

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
@@ -42,6 +42,11 @@ public class InputStreamFSInputWrapper extends FSDataInputStream {
 	}
 
 	@Override
+	public void close() throws IOException {
+		this.inStream.close();
+	}
+
+	@Override
 	public void seek(long desired) throws IOException {
 		if (desired < this.pos) {
 			throw new IllegalArgumentException("Wrapped InputStream: cannot search backwards.");

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/InputStreamFSInputWrapperTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/InputStreamFSInputWrapperTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.io;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class InputStreamFSInputWrapperTest {
+
+	@Test
+	public void testClose() throws Exception {
+		InputStream mockedInputStream = mock(InputStream.class);
+		InputStreamFSInputWrapper wrapper = new InputStreamFSInputWrapper(mockedInputStream);
+		wrapper.close();
+		verify(mockedInputStream).close();
+	}
+
+}


### PR DESCRIPTION
InputStreamFSInputWrapper is a wrapper around an arbitrary Java InputStream. As such, it needs to reimplement the close() function and forward it to the wrapped stream, otherwise there is a potential resource leak. This PR forwards the close() call to the underlying stream.