### PR TITLE
[FLINK-4727] [kafka-connector] Set missing initial offset states with starting KafkaConsumer position

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
@@ -143,11 +143,10 @@ public class Kafka010ITCase extends KafkaConsumerTestBase {
 		runStartFromKafkaCommitOffsets();
 	}
 
-	// TODO: This test will not pass until FLINK-4727 is resolved
-//	@Test(timeout = 60000)
-//	public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
-//		runAutoOffsetRetrievalAndCommitToKafka();
-//	}
+	@Test(timeout = 60000)
+	public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+		runAutoOffsetRetrievalAndCommitToKafka();
+	}
 
 	/**
 	 * Kafka 0.10 specific test, ensuring Timestamps are properly written to and read from Kafka

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
@@ -205,7 +205,22 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> implem
 			// seek the consumer to the initial offsets
 			for (KafkaTopicPartitionState<TopicPartition> partition : subscribedPartitions()) {
 				if (partition.isOffsetDefined()) {
+					LOG.info("Partition {} has restored initial offsets {} from checkpoint / savepoint; seeking the consumer " +
+						"to position {}", partition.getKafkaPartitionHandle(), partition.getOffset(), partition.getOffset() + 1);
+
 					consumer.seek(partition.getKafkaPartitionHandle(), partition.getOffset() + 1);
+				} else {
+					// for partitions that do not have offsets restored from a checkpoint/savepoint,
+					// we need to define our internal offset state for them using the initial offsets retrieved from Kafka
+					// by the KafkaConsumer, so that they are correctly checkpointed and committed on the next checkpoint
+
+					long fetchedOffset = consumer.position(partition.getKafkaPartitionHandle());
+
+					LOG.info("Partition {} has no initial offset; the consumer has position {}, so the initial offset " +
+						"will be set to {}", partition.getKafkaPartitionHandle(), fetchedOffset, fetchedOffset - 1);
+
+					// the fetched offset represents the next record to process, so we need to subtract it by 1
+					partition.setOffset(fetchedOffset - 1);
 				}
 			}
 

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -122,9 +122,8 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 		runStartFromKafkaCommitOffsets();
 	}
 
-	// TODO: This test will not pass until FLINK-4727 is resolved
-//	@Test(timeout = 60000)
-//	public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
-//		runAutoOffsetRetrievalAndCommitToKafka();
-//	}
+	@Test(timeout = 60000)
+	public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+		runAutoOffsetRetrievalAndCommitToKafka();
+	}
 }


### PR DESCRIPTION
This was fixed for the 0.8 consumer before. This PR adds the behaviour to the 0.9 consumer.

In #2580, there's a new IT test that assures this behaviour for 0.8 and 0.9, but is commented out for 0.9 in #2580 because that test won't pass until the changes in this PR is also included.

I wanted to keep the review / discussion of the two issues apart, hence separate PRs. I suggest to merge #2580 first, and then rebase this afterwards and de-comment the test.