### PR TITLE
[FLINK-4732] remove maven junction plugin

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -268,35 +268,6 @@ under the License.
 				</configuration>
 			</plugin>
 
-			<!-- create a symbolic link to the build target in the root directory -->
-			<plugin>
-				<groupId>com.pyx4j</groupId>
-				<artifactId>maven-junction-plugin</artifactId>
-				<version>1.0.3</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>link</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>unlink</id>
-						<phase>pre-clean</phase>
-						<goals>
-							<goal>unlink</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<links>
-						<link>
-							<dst>${project.basedir}/../build-target</dst>
-							<src>${project.basedir}/target/flink-${project.version}-bin/flink-${project.version}</src>
-						</link>
-					</links>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
On Windows, the plugin may download code from the author's web
site. The downloaded file is not signed in the same way as Maven
artifacts from Maven central which have to be signed with the
developer's key. This could be a potential target for attackers.