### PR TITLE
FLINK-3932 State Backend Security

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -332,6 +332,8 @@ Previously this key was named `recovery.mode` and the default value was `standal
 
 - `high-availability.job.delay`: (Default `akka.ask.timeout`) Defines the delay before persisted jobs are recovered in case of a master recovery situation. Previously this key was named `recovery.job.delay`.
 
+- `high-availability.zookeeper.client.acl`: (Default `open`) Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be set to "creator" if the ZooKeeper server configuration has the "authProvider" property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos). The ACL options are based on https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_BuiltinACLSchemes
+
 ### ZooKeeper-Security
 
 - `zookeeper.sasl.disable`: (Default: `true`) Defines if SASL based authentication needs to be enabled or disabled. The configuration value can be set to "true" if ZooKeeper cluster is running in secure mode (Kerberos)

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -759,6 +759,9 @@ public final class ConfigConstants {
 	public static final String HA_ZOOKEEPER_MAX_RETRY_ATTEMPTS = "high-availability.zookeeper.client.max-retry-attempts";
 
 	@PublicEvolving
+	public static final String HA_ZOOKEEPER_CLIENT_ACL = "high-availability.zookeeper.client.acl";
+
+	@PublicEvolving
 	public static final String ZOOKEEPER_SASL_DISABLE = "zookeeper.sasl.disable";
 
 	@PublicEvolving
@@ -1241,6 +1244,10 @@ public final class ConfigConstants {
 
 	/** Defaults for ZK client security **/
 	public static final boolean DEFAULT_ZOOKEEPER_SASL_DISABLE = true;
+
+	/** ACL options supported "creator" or "open" */
+	public static final String DEFAULT_HA_ZOOKEEPER_CLIENT_ACL = "open";
+
 
 	// ------------------------- Queryable state ------------------------------
 

--- a/flink-dist/src/main/flink-bin/conf/log4j-yarn-session.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-yarn-session.properties
@@ -25,3 +25,7 @@ log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p 
 
 # suppress the irrelevant (wrong) warnings from the netty channel handler
 log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, stdout
+log4j.logger.org.apache.zookeeper=OFF, stdout
+log4j.logger.org.apache.flink.shaded.org.apache.curator.framework=OFF, stdout
+log4j.logger.org.apache.flink.runtime.util.ZooKeeperUtils=OFF, stdout
+log4j.logger.org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalService=OFF, stdout

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -144,6 +144,12 @@ jobmanager.web.port: 8081
 # high-availability.zookeeper.quorum: localhost:2181
 # high-availability.zookeeper.storageDir: hdfs:///flink/ha/
 
+# ACL options are based on https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_BuiltinACLSchemes
+# It can be either "creator" (ZOO_CREATE_ALL_ACL) or "open" (ZOO_OPEN_ACL_UNSAFE)
+# The default value is "open" and it can be changed to "creator" if ZK security is enabled
+#
+# high-availability.zookeeper.client.acl: open
+
 #==============================================================================
 # Flink Cluster Security Configuration (optional configuration)
 #==============================================================================

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.util;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.imps.DefaultACLProvider;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
@@ -37,11 +39,14 @@ import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalService;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.filesystem.FileSystemStateStorageHelper;
 import org.apache.flink.util.ConfigurationUtil;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -105,6 +110,29 @@ public class ZooKeeperUtils {
 				ConfigConstants.DEFAULT_ZOOKEEPER_NAMESPACE_KEY,
 				ConfigConstants.ZOOKEEPER_NAMESPACE_KEY);
 
+		boolean disableSaslClient = configuration.getBoolean(ConfigConstants.ZOOKEEPER_SASL_DISABLE,
+				ConfigConstants.DEFAULT_ZOOKEEPER_SASL_DISABLE);
+
+		ACLProvider aclProvider;
+
+		ZkClientACLMode aclMode = ZkClientACLMode.fromConfig(configuration);
+
+		if(disableSaslClient && aclMode == ZkClientACLMode.CREATOR) {
+			String errorMessage = "Cannot set ACL role to " + aclMode +"  since SASL authentication is " +
+					"disabled through the " + ConfigConstants.ZOOKEEPER_SASL_DISABLE + " property";
+			LOG.warn(errorMessage);
+			throw new IllegalConfigurationException(errorMessage);
+		}
+
+		if(aclMode == ZkClientACLMode.CREATOR) {
+			LOG.info("Enforcing creator for ZK connections");
+			aclProvider = new SecureAclProvider();
+		} else {
+			LOG.info("Enforcing default ACL for ZK connections");
+			aclProvider = new DefaultACLProvider();
+		}
+
+
 		String rootWithNamespace = generateZookeeperPath(root, namespace);
 
 		LOG.info("Using '{}' as Zookeeper namespace.", rootWithNamespace);
@@ -117,6 +145,7 @@ public class ZooKeeperUtils {
 				// Curator prepends a '/' manually and throws an Exception if the
 				// namespace starts with a '/'.
 				.namespace(rootWithNamespace.startsWith("/") ? rootWithNamespace.substring(1) : rootWithNamespace)
+				.aclProvider(aclProvider)
 				.build();
 
 		cf.start();
@@ -341,6 +370,47 @@ public class ZooKeeperUtils {
 		}
 
 		return root + namespace;
+	}
+
+
+	public static class SecureAclProvider implements ACLProvider
+	{
+		@Override
+		public List<ACL> getDefaultAcl()
+		{
+			return ZooDefs.Ids.CREATOR_ALL_ACL;
+		}
+
+		@Override
+		public List<ACL> getAclForPath(String path)
+		{
+			return ZooDefs.Ids.CREATOR_ALL_ACL;
+		}
+	}
+
+	public enum ZkClientACLMode {
+		CREATOR,
+		OPEN;
+
+		/**
+		 * Return the configured {@link ZkClientACLMode}.
+		 *
+		 * @param config The config to parse
+		 * @return Configured ACL mode or {@link ConfigConstants#DEFAULT_HA_ZOOKEEPER_CLIENT_ACL} if not
+		 * configured.
+		 */
+		public static ZkClientACLMode fromConfig(Configuration config) {
+			String aclMode = config.getString(ConfigConstants.HA_ZOOKEEPER_CLIENT_ACL, null);
+			if (aclMode == null || aclMode.equalsIgnoreCase(ZkClientACLMode.OPEN.name())) {
+				return ZkClientACLMode.OPEN;
+			} else if (aclMode.equalsIgnoreCase(ZkClientACLMode.CREATOR.name())) {
+				return ZkClientACLMode.CREATOR;
+			} else {
+				String message = "Unsupported ACL option: [" + aclMode + "] provided";
+				LOG.error(message);
+				throw new IllegalConfigurationException(message);
+			}
+		}
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -572,6 +572,15 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 		} else if (cmd.hasOption(APPLICATION_ID.getOpt())) {
 
 			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor();
+
+			//configure ZK namespace depending on the value passed
+			String zkNamespace = cmd.hasOption(ZOOKEEPER_NAMESPACE.getOpt()) ?
+									cmd.getOptionValue(ZOOKEEPER_NAMESPACE.getOpt())
+									:yarnDescriptor.getFlinkConfiguration()
+									.getString(HA_ZOOKEEPER_NAMESPACE_KEY, cmd.getOptionValue(APPLICATION_ID.getOpt()));
+			LOG.info("Going to use the ZK namespace: {}", zkNamespace);
+			yarnDescriptor.getFlinkConfiguration().setString(HA_ZOOKEEPER_NAMESPACE_KEY, zkNamespace);
+
 			try {
 				yarnCluster = yarnDescriptor.retrieve(cmd.getOptionValue(APPLICATION_ID.getOpt()));
 			} catch (Exception e) {


### PR DESCRIPTION
This PR addresses ZK authorization (ACLs) requirement of FLINK-3932 and its dependency FLINK-4667 (Yarn session CLI not using correct ZK namespace in secure environment).

No code change has been done for "checkpoint/savepoint data protection" since the default implementation limits the access to user/groups. However, the root directory for both checkpoint and savepoint should be configured to a sub-directory under the "user home" directory with permissions 700 (mainly for local file system since the default umask grants both the user and the group RW access). For HDFS, since the user home directory is not accessible by any other user (except superuser), we don't need to set any additional permissions for the state backend directories.
