### PR TITLE
[FLINK-4740] [tests] Upgrade testing libraries

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedAllReduceDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedAllReduceDriverTest.java
@@ -121,7 +121,7 @@ public class ChainedAllReduceDriverTest extends TaskTestBase {
 		}
 	}
 
-	private static class MockReduceStub implements ReduceFunction<Record> {
+	public static class MockReduceStub implements ReduceFunction<Record> {
 		private static final long serialVersionUID = 1047525105526690165L;
 
 		@Override

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,9 @@ under the License.
 		<curator.version>2.8.0</curator.version>
 		<jackson.version>2.7.4</jackson.version>
 		<metrics.version>3.1.0</metrics.version>
-		<junit.version>4.11</junit.version>
+		<junit.version>4.12</junit.version>
+		<mockito.version>1.10.19</mockito.version>
+		<powermock.version>1.6.5</powermock.version>
 		<!--
 			Keeping the MiniKDC version fixed instead of taking hadoop version dependency
 			to support testing Kafka, ZK etc., modules that does not have Hadoop dependency
@@ -166,7 +168,7 @@ under the License.
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
-			<version>1.9.5</version>
+			<version>${mockito.version}</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -174,7 +176,7 @@ under the License.
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>1.5.5</version>
+			<version>${powermock.version}</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -182,7 +184,7 @@ under the License.
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
-			<version>1.5.5</version>
+			<version>${powermock.version}</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
Upgrades
  JUnit from 4.11 to 4.12
  Mockito from 1.9.5 to 1.10.19
  PowerMock from 1.5.5 to 1.6.5