### PR TITLE
[FLINK-4744] Introduce usercode class loader to deserialize partitionable operator state

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -311,18 +311,6 @@ public final class InstantiationUtil {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	public static <T> T deserializeObject(byte[] bytes) throws IOException, ClassNotFoundException {
-		ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-		return deserializeObject(byteArrayInputStream);
-	}
-
-	@SuppressWarnings("unchecked")
-	public static <T> T deserializeObject(InputStream in) throws IOException, ClassNotFoundException {
-		ObjectInputStream objectInputStream = new ObjectInputStream(in);
-		return (T) objectInputStream.readObject();
-	}
-
 	public static byte[] serializeObject(Object o) throws IOException {
 		try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
 				ObjectOutputStream oos = new ObjectOutputStream(baos)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -83,7 +83,7 @@ public abstract class AbstractStateBackend implements java.io.Serializable {
 			Environment env,
 			String operatorIdentifier
 	) throws Exception {
-		return new DefaultOperatorStateBackend();
+		return new DefaultOperatorStateBackend(env.getUserClassLoader());
 	}
 
 	/**
@@ -95,6 +95,6 @@ public abstract class AbstractStateBackend implements java.io.Serializable {
 			String operatorIdentifier,
 			Collection<OperatorStateHandle> restoreSnapshots
 	) throws Exception {
-		return new DefaultOperatorStateBackend(restoreSnapshots);
+		return new DefaultOperatorStateBackend(env.getUserClassLoader(), restoreSnapshots);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.JavaSerializer;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.memory.DataInputView;
@@ -30,6 +31,7 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -46,6 +48,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	private final Map<String, PartitionableListState<?>> registeredStates;
 	private final Collection<OperatorStateHandle> restoreSnapshots;
 	private final ClosableRegistry closeStreamOnCancelRegistry;
+	private final JavaSerializer<Serializable> javaSerializer;
 
 	/**
 	 * Restores a OperatorStateStore (lazily) using the provided snapshots.
@@ -53,7 +56,11 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	 * @param restoreSnapshots snapshots that are available to restore partitionable states on request.
 	 */
 	public DefaultOperatorStateBackend(
+			ClassLoader userClassLoader,
 			Collection<OperatorStateHandle> restoreSnapshots) {
+
+		Preconditions.checkNotNull(userClassLoader);
+		this.javaSerializer = new JavaSerializer<>(userClassLoader);
 		this.restoreSnapshots = restoreSnapshots;
 		this.registeredStates = new HashMap<>();
 		this.closeStreamOnCancelRegistry = new ClosableRegistry();
@@ -62,8 +69,13 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	/**
 	 * Creates an empty OperatorStateStore.
 	 */
-	public DefaultOperatorStateBackend() {
-		this(null);
+	public DefaultOperatorStateBackend(ClassLoader userClassLoader) {
+		this(userClassLoader, null);
+	}
+
+	@Override
+	public ListState<Serializable> getDefaultPartitionableState(String stateName) throws Exception {
+		return getPartitionableState(new ListStateDescriptor<>(stateName, javaSerializer));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateStore.java
@@ -20,13 +20,26 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.java.typeutils.runtime.JavaSerializer;
 
+import java.io.Serializable;
 import java.util.Set;
 
 /**
  * Interface for a backend that manages partitionable operator state.
  */
 public interface OperatorStateStore {
+
+	String DEFAULT_OPERATOR_STATE_NAME = "";
+
+	/**
+	 * Creates a satte descriptor of the given name that uses {@link JavaSerializer}.
+	 *
+	 * @param stateName The name of state to create
+	 * @return A state descriptor that uses {@link JavaSerializer}
+	 * @throws Exception
+	 */
+	ListState<Serializable> getDefaultPartitionableState(String stateName) throws Exception;
 
 	/**
 	 * Creates (or restores) the partitionable state in this backend. Each state is registered under a unique name.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -55,7 +55,7 @@ public class RetrievableStreamStateHandle<T extends Serializable> implements
 	@Override
 	public T retrieveState() throws Exception {
 		try (FSDataInputStream in = openInputStream()) {
-			return InstantiationUtil.deserializeObject(in);
+			return InstantiationUtil.deserializeObject(in, Thread.currentThread().getContextClassLoader());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -219,7 +219,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 		checkNotNull(pathInZooKeeper, "Path in ZooKeeper");
 
 		byte[] data = client.getData().forPath(pathInZooKeeper);
-		return InstantiationUtil.deserializeObject(data);
+		return InstantiationUtil.deserializeObject(data, Thread.currentThread().getContextClassLoader());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -2478,14 +2478,19 @@ public class CheckpointCoordinatorTest {
 			for (int groupId : expectedHeadOpKeyGroupStateHandle.keyGroups()) {
 				long offset = expectedHeadOpKeyGroupStateHandle.getOffsetForKeyGroup(groupId);
 				inputStream.seek(offset);
-				int expectedKeyGroupState = InstantiationUtil.deserializeObject(inputStream);
+				int expectedKeyGroupState =
+						InstantiationUtil.deserializeObject(inputStream, Thread.currentThread().getContextClassLoader());
 				for (KeyGroupsStateHandle oneActualKeyGroupStateHandle : actualPartitionedKeyGroupState) {
 					if (oneActualKeyGroupStateHandle.containsKeyGroup(groupId)) {
 						long actualOffset = oneActualKeyGroupStateHandle.getOffsetForKeyGroup(groupId);
-						try (FSDataInputStream actualInputStream =
-								     oneActualKeyGroupStateHandle.getStateHandle().openInputStream()) {
+						try (FSDataInputStream actualInputStream = oneActualKeyGroupStateHandle.
+								getStateHandle().openInputStream()) {
+
 							actualInputStream.seek(actualOffset);
-							int actualGroupState = InstantiationUtil.deserializeObject(actualInputStream);
+
+							int actualGroupState = InstantiationUtil.
+									deserializeObject(actualInputStream, Thread.currentThread().getContextClassLoader());
+
 							assertEquals(expectedKeyGroupState, actualGroupState);
 						}
 					}
@@ -2506,7 +2511,8 @@ public class CheckpointCoordinatorTest {
 					for (Map.Entry<String, long[]> entry : operatorStateHandle.getStateNameToPartitionOffsets().entrySet()) {
 						for (long offset : entry.getValue()) {
 							in.seek(offset);
-							Integer state = InstantiationUtil.deserializeObject(in);
+							Integer state = InstantiationUtil.
+									deserializeObject(in, Thread.currentThread().getContextClassLoader());
 							expectedResult.add(i + " : " + entry.getKey() + " : " + state);
 						}
 					}
@@ -2525,7 +2531,8 @@ public class CheckpointCoordinatorTest {
 							for (Map.Entry<String, long[]> entry : operatorStateHandle.getStateNameToPartitionOffsets().entrySet()) {
 								for (long offset : entry.getValue()) {
 									in.seek(offset);
-									Integer state = InstantiationUtil.deserializeObject(in);
+									Integer state = InstantiationUtil.
+											deserializeObject(in, Thread.currentThread().getContextClassLoader());
 									actualResult.add(i + " : " + entry.getKey() + " : " + state);
 								}
 							}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -452,7 +452,7 @@ public class JobManagerHARecoveryTest {
 			int subtaskIndex = getIndexInSubtaskGroup();
 			if (subtaskIndex < recoveredStates.length) {
 				try (FSDataInputStream in = chainedState.get(0).openInputStream()) {
-					recoveredStates[subtaskIndex] = InstantiationUtil.deserializeObject(in);
+					recoveredStates[subtaskIndex] = InstantiationUtil.deserializeObject(in, getUserCodeClassLoader());
 				}
 			}
 		}
@@ -464,7 +464,10 @@ public class JobManagerHARecoveryTest {
 						InstantiationUtil.serializeObject(checkpointId));
 
 				RetrievableStreamStateHandle<Long> state = new RetrievableStreamStateHandle<Long>(byteStreamStateHandle);
-				ChainedStateHandle<StreamStateHandle> chainedStateHandle = new ChainedStateHandle<StreamStateHandle>(Collections.singletonList(state));
+
+				ChainedStateHandle<StreamStateHandle> chainedStateHandle =
+						new ChainedStateHandle<StreamStateHandle>(Collections.singletonList(state));
+
 				CheckpointStateHandles checkpointStateHandles =
 						new CheckpointStateHandles(chainedStateHandle, null, Collections.<KeyGroupsStateHandle>emptyList());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.java.typeutils.runtime.JavaSerializer;
+import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.junit.Test;
 
@@ -31,13 +32,21 @@ import java.util.Iterator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class OperatorStateBackendTest {
 
 	AbstractStateBackend abstractStateBackend = new MemoryStateBackend(1024);
 
+	static Environment createMockEnvironment() {
+		Environment env = mock(Environment.class);
+		when(env.getUserClassLoader()).thenReturn(Thread.currentThread().getContextClassLoader());
+		return env;
+	}
+
 	private OperatorStateBackend createNewOperatorStateBackend() throws Exception {
-		return abstractStateBackend.createOperatorStateBackend(null, "test-operator");
+		return abstractStateBackend.createOperatorStateBackend(createMockEnvironment(), "test-operator");
 	}
 
 	@Test
@@ -123,8 +132,8 @@ public class OperatorStateBackendTest {
 
 			operatorStateBackend.dispose();
 
-			operatorStateBackend = abstractStateBackend.
-					restoreOperatorStateBackend(null, "testOperator", Collections.singletonList(stateHandle));
+			operatorStateBackend = abstractStateBackend.restoreOperatorStateBackend(
+					createMockEnvironment(), "testOperator", Collections.singletonList(stateHandle));
 
 			assertEquals(0, operatorStateBackend.getRegisteredStateNames().size());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
@@ -19,8 +19,6 @@
 package org.apache.flink.streaming.api.checkpoint;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.java.typeutils.runtime.JavaSerializer;
 
 import java.io.Serializable;
 import java.util.List;
@@ -35,9 +33,6 @@ import java.util.List;
  */
 @PublicEvolving
 public interface ListCheckpointed<T extends Serializable> {
-
-	ListStateDescriptor<Serializable> DEFAULT_LIST_DESCRIPTOR =
-			new ListStateDescriptor<>("", new JavaSerializer<>());
 
 	/**
 	 * Gets the current state of the function of operator. The state must reflect the result of all

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.OperatorStateStore;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
@@ -70,7 +71,6 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 	/** Flag to prevent duplicate function.close() calls in close() and dispose() */
 	private transient boolean functionsClosed = false;
 	
-	
 	public AbstractUdfStreamOperator(F userFunction) {
 		this.userFunction = requireNonNull(userFunction);
 	}
@@ -107,8 +107,8 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 			@SuppressWarnings("unchecked")
 			ListCheckpointed<Serializable> listCheckpointedFun = (ListCheckpointed<Serializable>) userFunction;
 
-			ListState<Serializable> listState =
-					getOperatorStateBackend().getPartitionableState(ListCheckpointed.DEFAULT_LIST_DESCRIPTOR);
+			ListState<Serializable> listState = getOperatorStateBackend().
+					getDefaultPartitionableState(OperatorStateStore.DEFAULT_OPERATOR_STATE_NAME);
 
 			List<Serializable> list = new ArrayList<>();
 
@@ -201,8 +201,8 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 			List<Serializable> partitionableState =
 					((ListCheckpointed<Serializable>) userFunction).snapshotState(checkpointId, timestamp);
 
-			ListState<Serializable> listState =
-					getOperatorStateBackend().getPartitionableState(ListCheckpointed.DEFAULT_LIST_DESCRIPTOR);
+			ListState<Serializable> listState = getOperatorStateBackend().
+					getDefaultPartitionableState(OperatorStateStore.DEFAULT_OPERATOR_STATE_NAME);
 
 			listState.clear();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -39,12 +39,12 @@ import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.streaming.api.operators.StreamCheckpointedOperator;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamCheckpointedOperator;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -632,8 +632,10 @@ public class OneInputStreamTaskTest extends TestLogger {
 
 			assertNotNull(in);
 
-			Serializable functionState= InstantiationUtil.deserializeObject(in);
-			Integer operatorState= InstantiationUtil.deserializeObject(in);
+			ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
+			Serializable functionState= InstantiationUtil.deserializeObject(in, cl);
+			Integer operatorState= InstantiationUtil.deserializeObject(in, cl);
 
 			assertEquals(random.nextInt(), functionState);
 			assertEquals(random.nextInt(), (int) operatorState);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -30,10 +30,10 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -45,7 +45,6 @@ import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
-
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -62,7 +61,9 @@ import java.util.HashMap;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.flink.test.util.TestUtils.tryExecute;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This verifies that checkpointing works correctly with event time windows. This is more


### PR DESCRIPTION
With this PR, deserialization of partitionable operator state respects user class loader. This fixes a regression in the Kafka consumer.