### PR TITLE
[FLINK-4751] [futures] Add thenCombineAsync function to Flink's futures

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Future.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Future.java
@@ -138,12 +138,13 @@ public interface Future<T> {
 	 * @param <R> type of the returned future's value
 	 * @return future representing the flattened return value of the apply function
 	 */
-	<R> Future<R> thenComposeAsync(ApplyFunction<? super T, Future<? extends R>> composeFunction, Executor executor);
+	<R> Future<R> thenComposeAsync(ApplyFunction<? super T, ? extends Future<R>> composeFunction, Executor executor);
 
 	/**
 	 * Applies the given handle function to the result of the future. The result can either be the
 	 * future's value or the exception with which the future has been completed. The two cases are
-	 * mutually exclusive. The result of the handle function is the returned future's value.
+	 * mutually exclusive. This means that either the left or right argument of the handle function
+	 * are non null. The result of the handle function is the returned future's value.
 	 * <p>
 	 * The handle function is executed asynchronously by the given executor.
 	 *
@@ -153,4 +154,19 @@ public interface Future<T> {
 	 * @return future representing the handle function's return value
 	 */
 	<R> Future<R> handleAsync(BiFunction<? super T, Throwable, ? extends R> biFunction, Executor executor);
+
+	/**
+	 * Applies the given function to the result of this and the other future after both futures
+	 * have completed. The result of the bi-function is the result of the returned future.
+	 * <p>
+	 * The bi-function is executed asynchronously by the given executor.
+	 *
+	 * @param other future whose result is the right input to the bi-function
+	 * @param biFunction applied to the result of this and that future
+	 * @param executor used to execute the bi-function asynchronously
+	 * @param <U> type of that future's return value
+	 * @param <R> type of the bi-function's return value
+	 * @return future representing the bi-function's return value
+	 */
+	<U, R> Future<R> thenCombineAsync(Future<U> other, BiFunction<? super T, ? super U, ? extends R> biFunction, Executor executor);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/impl/FlinkFuture.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/impl/FlinkFuture.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.BiFunction;
 import org.apache.flink.util.Preconditions;
 import scala.Option;
+import scala.Tuple2;
 import scala.concurrent.Await;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.Duration;
@@ -81,6 +82,8 @@ public class FlinkFuture<T> implements Future<T> {
 			return Await.result(scalaFuture, Duration.Inf());
 		} catch (InterruptedException e) {
 			throw e;
+		} catch (FlinkFuture.ThrowableWrapperException e) {
+			throw new ExecutionException(e.getCause());
 		} catch (Exception e) {
 			throw new ExecutionException(e);
 		}
@@ -171,7 +174,7 @@ public class FlinkFuture<T> implements Future<T> {
 	}
 
 	@Override
-	public <R> Future<R> thenComposeAsync(final ApplyFunction<? super T, Future<? extends R>> applyFunction, final Executor executor) {
+	public <R> Future<R> thenComposeAsync(final ApplyFunction<? super T, ? extends Future<R>> applyFunction, final Executor executor) {
 		Preconditions.checkNotNull(scalaFuture);
 		Preconditions.checkNotNull(applyFunction);
 		Preconditions.checkNotNull(executor);
@@ -190,7 +193,16 @@ public class FlinkFuture<T> implements Future<T> {
 					return Futures.future(new Callable<R>() {
 						@Override
 						public R call() throws Exception {
-							return future.get();
+							try {
+								return future.get();
+							} catch (ExecutionException e) {
+								// unwrap the execution exception if it's not a throwable
+								if (e.getCause() instanceof Exception) {
+									throw (Exception) e.getCause();
+								} else {
+									throw new FlinkFuture.ThrowableWrapperException(e.getCause());
+								}
+							}
 						}
 					}, createExecutionContext(executor));
 				}
@@ -232,6 +244,40 @@ public class FlinkFuture<T> implements Future<T> {
 		return new FlinkFuture<>(recoveredFuture);
 	}
 
+	@Override
+	public <U, R> Future<R> thenCombineAsync(final Future<U> other, final BiFunction<? super T, ? super U, ? extends R> biFunction, final Executor executor) {
+		final scala.concurrent.Future<U> thatScalaFuture;
+
+		if (other instanceof FlinkFuture) {
+			thatScalaFuture = ((FlinkFuture<U>) other).scalaFuture;
+		} else {
+			thatScalaFuture = Futures.future(new Callable<U>() {
+				@Override
+				public U call() throws Exception {
+					try {
+						return other.get();
+					} catch (ExecutionException e) {
+						// unwrap the execution exception if it's not a throwable
+						if (e.getCause() instanceof Exception) {
+							throw (Exception) e.getCause();
+						} else {
+							throw new FlinkFuture.ThrowableWrapperException(e.getCause());
+						}
+					}
+				}
+			}, createExecutionContext(executor));
+		}
+
+		scala.concurrent.Future<R>  result = scalaFuture.zip(thatScalaFuture).map(new Mapper<Tuple2<T, U>, R>() {
+			@Override
+			public R apply(Tuple2<T, U> tuple2) {
+				return biFunction.apply(tuple2._1, tuple2._2);
+			}
+		}, createExecutionContext(executor));
+
+		return new FlinkFuture<>(result);
+	}
+
 	//-----------------------------------------------------------------------------------
 	// Static factory methods
 	//-----------------------------------------------------------------------------------
@@ -267,6 +313,19 @@ public class FlinkFuture<T> implements Future<T> {
 
 		WrapperException(Throwable cause) {
 			super(cause);
+		}
+	}
+
+	/**
+	 * Wrapper for {@link Throwable} which is used to emit the proper exception when calling
+	 * {@link Future#get}.
+	 */
+	private static class ThrowableWrapperException extends Exception {
+
+		private static final long serialVersionUID = 3855668690181179801L;
+
+		ThrowableWrapperException(Throwable throwable) {
+			super(Preconditions.checkNotNull(throwable));
 		}
 	}
 }


### PR DESCRIPTION
The `thenCombineAsync` method allows to combine two futures and apply a `BiFunction` on
the results of both futures. The `BiFunction` is only applied after both futures have
completed.

```
Future<Left> left = ...
Future<Right> right = ...

Future<Result> resultFuture = left.thenCombineAsync(
    right, 
    new BiFunction<Left, Right, Result>() {....}, 
    executor);
```