### PR TITLE
[FLINK-4736] [core] Don't duplicate fields in Ordering

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/Ordering.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/Ordering.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.api.common.operators;
 
-import java.util.ArrayList;
-
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.operators.util.FieldList;
 import org.apache.flink.api.common.operators.util.FieldSet;
+
+import java.util.ArrayList;
 
 /**
  * This class represents an ordering on a set of fields. It specifies the fields and order direction
@@ -55,6 +55,8 @@ public class Ordering implements Cloneable {
 	
 	/**
 	 * Extends this ordering by appending an additional order requirement.
+	 * If the index has been previously appended then the unmodified Ordering
+	 * is returned.
 	 * 
 	 * @param index Field index of the appended order requirement.
 	 * @param type Type of the appended order requirement.
@@ -63,7 +65,7 @@ public class Ordering implements Cloneable {
 	 * @return This ordering with an additional appended order requirement.
 	 */
 	public Ordering appendOrdering(Integer index, Class<? extends Comparable<?>> type, Order order) {
-		if (index.intValue() < 0) {
+		if (index < 0) {
 			throw new IllegalArgumentException("The key index must not be negative.");
 		}
 		if (order == null) {
@@ -72,10 +74,13 @@ public class Ordering implements Cloneable {
 		if (order == Order.NONE) {
 			throw new IllegalArgumentException("An ordering must not be created with a NONE order.");
 		}
-		
-		this.indexes = this.indexes.addField(index);
-		this.types.add(type);
-		this.orders.add(order);
+
+		if (!this.indexes.contains(index)) {
+			this.indexes = this.indexes.addField(index);
+			this.types.add(type);
+			this.orders.add(order);
+		}
+
 		return this;
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/OrderingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/OrderingTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class OrderingTest {
+
+	@Test
+	public void testNewOrdering() {
+		Ordering ordering = new Ordering();
+
+		// add a field
+		ordering.appendOrdering(3, Integer.class, Order.ASCENDING);
+		assertEquals(1, ordering.getNumberOfFields());
+
+		// add a second field
+		ordering.appendOrdering(1, Long.class, Order.DESCENDING);
+		assertEquals(2, ordering.getNumberOfFields());
+
+		// duplicate field index does not change Ordering
+		ordering.appendOrdering(1, String.class, Order.ASCENDING);
+		assertEquals(2, ordering.getNumberOfFields());
+
+		// verify field positions, types, and orderings
+		assertArrayEquals(new int[]{3, 1}, ordering.getFieldPositions());
+		assertArrayEquals(new Class[]{Integer.class, Long.class}, ordering.getTypes());
+		assertArrayEquals(new boolean[]{true, false}, ordering.getFieldSortDirections());
+	}
+}


### PR DESCRIPTION
Duplicate fields should not be appended to an ordering. In an ordering each subsequent field is only used as a comparison when all prior fields test equal; therefore, a repeated field cannot contribute to the ordering.