### PR TITLE
[hotfix] Re-register restored processing time timers.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -230,6 +230,11 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		if (windowAssigner instanceof MergingWindowAssigner) {
 			mergingWindowsByKey = new HashMap<>();
 		}
+
+		// re-register the restored timers (if any)
+		if (processingTimeTimersQueue.size() > 0) {
+			nextTimer = getTimerService().registerTimer(processingTimeTimersQueue.peek().timestamp, this);
+		}
 	}
 
 	@Override
@@ -880,10 +885,6 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			Timer<K, W> timer = new Timer<>(timestamp, key, window);
 			processingTimeTimersQueue.add(timer);
 			processingTimeTimers.add(timer);
-		}
-
-		if (numProcessingTimeTimers > 0) {
-			nextTimer = getTimerService().registerTimer(processingTimeTimersQueue.peek().timestamp, this);
 		}
 	}
 


### PR DESCRIPTION
Re-registers the processing time timers at the
open() of the WindowOperator instead of the restoreTimers().