### PR TITLE
[FLINK-4753] [kafka] PeriodicOffsetCommitter should synchronize on checkpoint lock

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -128,17 +128,6 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 		this.deserializer = checkNotNull(deserializer, "valueDeserializer");
 	}
 
-	/**
-	 * This method must be called from the subclasses, to set the list of all subscribed partitions
-	 * that this consumer will fetch from (across all subtasks).
-	 * 
-	 * @param allSubscribedPartitions The list of all partitions that all subtasks together should fetch from.
-	 */
-	protected void setSubscribedPartitions(List<KafkaTopicPartition> allSubscribedPartitions) {
-		checkNotNull(allSubscribedPartitions);
-		this.subscribedPartitions = Collections.unmodifiableList(allSubscribedPartitions);
-	}
-
 	// ------------------------------------------------------------------------
 	//  Configuration
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
The `PeriodicOffsetCommitter` in Kafka 0.8 currently doesn't synchronize on the checkpoint lock when creating a copy of the partition offsets in the current state.

This change proposes to pass the checkpoint lock into `PeriodicOffsetCommitter`, and let `PeriodicOffsetCommitter` use `Kafka08Fetcher#snapshotCurrentState()` to make copies of the current state.

This PR also includes removal of some leftover unused code after some recent refactoring of the Kafka connectors in commit 53ed6ada.