### PR TITLE
[FLINK-3888] Allow custom convergence criterion in delta iterations

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/aggregators/AggregatorRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/aggregators/AggregatorRegistry.java
@@ -49,18 +49,14 @@ public class AggregatorRegistry {
 		}
 		this.registry.put(name, aggregator);
 	}
-	
-	public Aggregator<?> unregisterAggregator(String name) {
-		return this.registry.remove(name);
-	}
-	
+
 	public Collection<AggregatorWithName<?>> getAllRegisteredAggregators() {
 		ArrayList<AggregatorWithName<?>> list = new ArrayList<AggregatorWithName<?>>(this.registry.size());
 		
 		for (Map.Entry<String, Aggregator<?>> entry : this.registry.entrySet()) {
 			@SuppressWarnings("unchecked")
 			Aggregator<Value> valAgg = (Aggregator<Value>) entry.getValue();
-			list.add(new AggregatorWithName<Value>(entry.getKey(), valAgg));
+			list.add(new AggregatorWithName<>(entry.getKey(), valAgg));
 		}
 		return list;
 	}
@@ -72,7 +68,7 @@ public class AggregatorRegistry {
 			throw new IllegalArgumentException("Name, aggregator, or convergence criterion must not be null");
 		}
 		
-		Aggregator<?> genAgg = (Aggregator<?>) aggregator;
+		Aggregator<?> genAgg = aggregator;
 		
 		Aggregator<?> previous = this.registry.get(name);
 		if (previous != null && previous != genAgg) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/CollectionExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/CollectionExecutor.java
@@ -412,6 +412,9 @@ public class CollectionExecutor {
 			aggregators.put(a.getName(), a.getAggregator());
 		}
 
+		String convCriterionAggName = iteration.getAggregators().getConvergenceCriterionAggregatorName();
+		ConvergenceCriterion<Value> convCriterion = (ConvergenceCriterion<Value>) iteration.getAggregators().getConvergenceCriterion();
+
 		final int maxIterations = iteration.getMaximumNumberOfIterations();
 
 		for (int superstep = 1; superstep <= maxIterations; superstep++) {
@@ -440,6 +443,14 @@ public class CollectionExecutor {
 
 			if (currentWorkset.isEmpty()) {
 				break;
+			}
+
+			// evaluate the aggregator convergence criterion
+			if (convCriterion != null && convCriterionAggName != null) {
+				Value v = aggregators.get(convCriterionAggName).getAggregate();
+				if (convCriterion.isConverged(superstep, v)) {
+					break;
+				}
 			}
 
 			// clear the dynamic results

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIteration.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIteration.java
@@ -64,13 +64,13 @@ public class DeltaIteration<ST, WT> {
 	private int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
 	
 	private boolean solutionSetUnManaged;
-	
-	
+
+
 	public DeltaIteration(ExecutionEnvironment context, TypeInformation<ST> type, DataSet<ST> solutionSet, DataSet<WT> workset, Keys<ST> keys, int maxIterations) {
 		initialSolutionSet = solutionSet;
 		initialWorkset = workset;
-		solutionSetPlaceholder = new SolutionSetPlaceHolder<ST>(context, solutionSet.getType(), this);
-		worksetPlaceholder = new WorksetPlaceHolder<WT>(context, workset.getType());
+		solutionSetPlaceholder = new SolutionSetPlaceHolder<>(context, solutionSet.getType(), this);
+		worksetPlaceholder = new WorksetPlaceHolder<>(context, workset.getType());
 		this.keys = keys;
 		this.maxIterations = maxIterations;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIteration.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIteration.java
@@ -26,10 +26,12 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.aggregators.Aggregator;
 import org.apache.flink.api.common.aggregators.AggregatorRegistry;
+import org.apache.flink.api.common.aggregators.ConvergenceCriterion;
 import org.apache.flink.api.common.operators.Keys;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.types.Value;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -208,6 +210,28 @@ public class DeltaIteration<ST, WT> {
 	@PublicEvolving
 	public DeltaIteration<ST, WT> registerAggregator(String name, Aggregator<?> aggregator) {
 		this.aggregators.registerAggregator(name, aggregator);
+		return this;
+	}
+
+	/**
+	 * Registers an {@link Aggregator} for the iteration together with a {@link ConvergenceCriterion}. For a general description
+	 * of aggregators, see {@link #registerAggregator(String, Aggregator)} and {@link Aggregator}.
+	 * At the end of each iteration, the convergence criterion takes the aggregator's global aggregate value and decides whether
+	 * the iteration should terminate. A typical use case is to have an aggregator that sums up the total error of change
+	 * in an iteration step and have to have a convergence criterion that signals termination as soon as the aggregate value
+	 * is below a certain threshold.
+	 *
+	 * @param name The name under which the aggregator is registered.
+	 * @param aggregator The aggregator class.
+	 * @param convergenceCheck The convergence criterion.
+	 *
+	 * @return The DeltaIteration itself, to allow chaining function calls.
+	 */
+	@PublicEvolving
+	public <X extends Value> DeltaIteration<ST, WT> registerAggregationConvergenceCriterion(
+			String name, Aggregator<X> aggregator, ConvergenceCriterion<X> convergenceCheck)
+	{
+		this.aggregators.registerAggregationConvergenceCriterion(name, aggregator, convergenceCheck);
 		return this;
 	}
 	

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -1513,14 +1513,21 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		
 		String convAggName = aggs.getConvergenceCriterionAggregatorName();
 		ConvergenceCriterion<?> convCriterion = aggs.getConvergenceCriterion();
-		
+
 		if (convCriterion != null || convAggName != null) {
-			throw new CompilerException("Error: Cannot use custom convergence criterion with workset iteration. Workset iterations have implicit convergence criterion where workset is empty.");
+			if (convCriterion == null) {
+				throw new CompilerException("Error: Convergence criterion aggregator set, but criterion is null.");
+			}
+			if (convAggName == null) {
+				throw new CompilerException("Error: Aggregator convergence criterion set, but aggregator is null.");
+			}
+
+			syncConfig.setConvergenceCriterion(convAggName, convCriterion);
 		}
 		
 		headConfig.addIterationAggregator(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new LongSumAggregator());
 		syncConfig.addIterationAggregator(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new LongSumAggregator());
-		syncConfig.setConvergenceCriterion(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new WorksetEmptyConvergenceCriterion());
+		syncConfig.setDefaultConvergenceCriterion(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new WorksetEmptyConvergenceCriterion());
 	}
 	
 	private String getDescriptionForUserCode(UserCodeWrapper<?> wrapper) {

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -1527,7 +1527,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		
 		headConfig.addIterationAggregator(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new LongSumAggregator());
 		syncConfig.addIterationAggregator(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new LongSumAggregator());
-		syncConfig.setDefaultConvergenceCriterion(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new WorksetEmptyConvergenceCriterion());
+		syncConfig.setImplicitConvergenceCriterion(WorksetEmptyConvergenceCriterion.AGGREGATOR_NAME, new WorksetEmptyConvergenceCriterion());
 	}
 	
 	private String getDescriptionForUserCode(UserCodeWrapper<?> wrapper) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
@@ -57,13 +57,13 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 
 	private ConvergenceCriterion<Value> convergenceCriterion;
 
-	private ConvergenceCriterion<Value> defaultConvergenceCriterion;
+	private ConvergenceCriterion<Value> implicitConvergenceCriterion;
 	
 	private Map<String, Aggregator<?>> aggregators;
 
 	private String convergenceAggregatorName;
 
-	private String defaultConvergenceAggregatorName;
+	private String implicitConvergenceAggregatorName;
 
 	private int currentIteration = 1;
 	
@@ -95,10 +95,10 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 		}
 
 		// store the default aggregator convergence criterion
-		if (taskConfig.usesDefaultConvergenceCriterion()) {
-			defaultConvergenceCriterion = taskConfig.getDefaultConvergenceCriterion(getUserCodeClassLoader());
-			defaultConvergenceAggregatorName = taskConfig.getDefaultConvergenceCriterionAggregatorName();
-			Preconditions.checkNotNull(defaultConvergenceAggregatorName);
+		if (taskConfig.usesImplicitConvergenceCriterion()) {
+			implicitConvergenceCriterion = taskConfig.getImplicitConvergenceCriterion(getUserCodeClassLoader());
+			implicitConvergenceAggregatorName = taskConfig.getImplicitConvergenceCriterionAggregatorName();
+			Preconditions.checkNotNull(implicitConvergenceAggregatorName);
 		}
 		
 		maxNumberOfIterations = taskConfig.getNumberOfIterations();
@@ -177,16 +177,16 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 			}
 		}
 
-		if (defaultConvergenceAggregatorName != null) {
+		if (implicitConvergenceAggregatorName != null) {
 			@SuppressWarnings("unchecked")
-			Aggregator<Value> aggregator = (Aggregator<Value>) aggregators.get(defaultConvergenceAggregatorName);
+			Aggregator<Value> aggregator = (Aggregator<Value>) aggregators.get(implicitConvergenceAggregatorName);
 			if (aggregator == null) {
 				throw new RuntimeException("Error: Aggregator for default convergence criterion was null.");
 			}
 
 			Value aggregate = aggregator.getAggregate();
 
-			if (defaultConvergenceCriterion.isConverged(currentIteration, aggregate)) {
+			if (implicitConvergenceCriterion.isConverged(currentIteration, aggregate)) {
 				if (log.isInfoEnabled()) {
 					log.info(formatLogString("empty workset convergence reached after [" + currentIteration
 							+ "] iterations, terminating..."));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
@@ -75,14 +75,14 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 	
 	@Override
 	public void invoke() throws Exception {
-		this.headEventReader = new MutableRecordReader<IntValue>(
+		this.headEventReader = new MutableRecordReader<>(
 				getEnvironment().getInputGate(0),
 				getEnvironment().getTaskManagerInfo().getTmpDirectories());
 
 		TaskConfig taskConfig = new TaskConfig(getTaskConfiguration());
 		
 		// store all aggregators
-		this.aggregators = new HashMap<String, Aggregator<?>>();
+		this.aggregators = new HashMap<>();
 		for (AggregatorWithName<?> aggWithName : taskConfig.getIterationAggregators(getUserCodeClassLoader())) {
 			aggregators.put(aggWithName.getName(), aggWithName.getAggregator());
 		}
@@ -113,7 +113,6 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 		
 		while (!terminationRequested()) {
 
-//			notifyMonitor(IterationMonitoring.Event.SYNC_STARTING, currentIteration);
 			if (log.isInfoEnabled()) {
 				log.info(formatLogString("starting iteration [" + currentIteration + "]"));
 			}
@@ -133,7 +132,6 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 
 				requestTermination();
 				sendToAllWorkers(new TerminationEvent());
-//				notifyMonitor(IterationMonitoring.Event.SYNC_FINISHED, currentIteration);
 			} else {
 				if (log.isInfoEnabled()) {
 					log.info(formatLogString("signaling that all workers are done in iteration [" + currentIteration
@@ -147,18 +145,10 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 				for (Aggregator<?> agg : aggregators.values()) {
 					agg.reset();
 				}
-				
-//				notifyMonitor(IterationMonitoring.Event.SYNC_FINISHED, currentIteration);
 				currentIteration++;
 			}
 		}
 	}
-
-//	protected void notifyMonitor(IterationMonitoring.Event event, int currentIteration) {
-//		if (log.isInfoEnabled()) {
-//			log.info(IterationMonitoring.logLine(getEnvironment().getJobID(), event, currentIteration, 1));
-//		}
-//	}
 
 	private boolean checkForConvergence() {
 		if (maxNumberOfIterations == currentIteration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
@@ -199,9 +199,9 @@ public class TaskConfig implements Serializable {
 	
 	private static final String ITERATION_CONVERGENCE_CRITERION_AGG_NAME = "iterative.terminationCriterion.agg.name";
 
-	private static final String ITERATION_DEFAULT_CONVERGENCE_CRITERION = "iterative.default.terminationCriterion";
+	private static final String ITERATION_IMPLICIT_CONVERGENCE_CRITERION = "iterative.implicit.terminationCriterion";
 
-	private static final String ITERATION_DEFAULT_CONVERGENCE_CRITERION_AGG_NAME = "iterative.default.terminationCriterion.agg.name";
+	private static final String ITERATION_IMPLICIT_CONVERGENCE_CRITERION_AGG_NAME = "iterative.implicit.terminationCriterion.agg.name";
 	
 	private static final String ITERATION_NUM_AGGREGATORS = "iterative.num-aggs";
 	
@@ -1003,13 +1003,13 @@ public class TaskConfig implements Serializable {
 	 * @param aggregatorName
 	 * @param convCriterion
 	 */
-	public void setDefaultConvergenceCriterion(String aggregatorName, ConvergenceCriterion<?> convCriterion) {
+	public void setImplicitConvergenceCriterion(String aggregatorName, ConvergenceCriterion<?> convCriterion) {
 		try {
-			InstantiationUtil.writeObjectToConfig(convCriterion, this.config, ITERATION_DEFAULT_CONVERGENCE_CRITERION);
+			InstantiationUtil.writeObjectToConfig(convCriterion, this.config, ITERATION_IMPLICIT_CONVERGENCE_CRITERION);
 		} catch (IOException e) {
-			throw new RuntimeException("Error while writing the default convergence criterion object to the task configuration.");
+			throw new RuntimeException("Error while writing the implicit convergence criterion object to the task configuration.");
 		}
-		this.config.setString(ITERATION_DEFAULT_CONVERGENCE_CRITERION_AGG_NAME, aggregatorName);
+		this.config.setString(ITERATION_IMPLICIT_CONVERGENCE_CRITERION_AGG_NAME, aggregatorName);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -1039,11 +1039,11 @@ public class TaskConfig implements Serializable {
 	}
 
 	@SuppressWarnings("unchecked")
-	public <T extends Value> ConvergenceCriterion<T> getDefaultConvergenceCriterion(ClassLoader cl) {
+	public <T extends Value> ConvergenceCriterion<T> getImplicitConvergenceCriterion(ClassLoader cl) {
 		ConvergenceCriterion<T> convCriterionObj;
 		try {
 			convCriterionObj = InstantiationUtil.readObjectFromConfig(
-					this.config, ITERATION_DEFAULT_CONVERGENCE_CRITERION, cl);
+					this.config, ITERATION_IMPLICIT_CONVERGENCE_CRITERION, cl);
 		} catch (IOException e) {
 			throw new RuntimeException("Error while reading the default convergence criterion object from the task configuration.");
 		} catch (ClassNotFoundException e) {
@@ -1056,12 +1056,12 @@ public class TaskConfig implements Serializable {
 		return convCriterionObj;
 	}
 
-	public boolean usesDefaultConvergenceCriterion() {
-		return config.getBytes(ITERATION_DEFAULT_CONVERGENCE_CRITERION, null) != null;
+	public boolean usesImplicitConvergenceCriterion() {
+		return config.getBytes(ITERATION_IMPLICIT_CONVERGENCE_CRITERION, null) != null;
 	}
 
-	public String getDefaultConvergenceCriterionAggregatorName() {
-		return this.config.getString(ITERATION_DEFAULT_CONVERGENCE_CRITERION_AGG_NAME, null);
+	public String getImplicitConvergenceCriterionAggregatorName() {
+		return this.config.getString(ITERATION_IMPLICIT_CONVERGENCE_CRITERION_AGG_NAME, null);
 	}
 	
 	public void setIsSolutionSetUpdate() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
@@ -1014,14 +1014,14 @@ public class TaskConfig implements Serializable {
 
 	@SuppressWarnings("unchecked")
 	public <T extends Value> ConvergenceCriterion<T> getConvergenceCriterion(ClassLoader cl) {
-		ConvergenceCriterion<T> convCriterionObj = null;
+		ConvergenceCriterion<T> convCriterionObj;
 		try {
-			convCriterionObj = (ConvergenceCriterion<T>) InstantiationUtil.readObjectFromConfig(
+			convCriterionObj = InstantiationUtil.readObjectFromConfig(
 			this.config, ITERATION_CONVERGENCE_CRITERION, cl);
 		} catch (IOException e) {
-			throw new RuntimeException("Error while reading the covergence criterion object from the task configuration.");
+			throw new RuntimeException("Error while reading the convergence criterion object from the task configuration.");
 		} catch (ClassNotFoundException e) {
-			throw new RuntimeException("Error while reading the covergence criterion object from the task configuration. " +
+			throw new RuntimeException("Error while reading the convergence criterion object from the task configuration. " +
 					"ConvergenceCriterion class not found.");
 		}
 		if (convCriterionObj == null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorConvergenceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorConvergenceITCase.java
@@ -57,36 +57,36 @@ public class AggregatorConvergenceITCase extends MultipleProgramsTestBase {
 	public void testConnectedComponentsWithParametrizableConvergence() {
 		try {
 			List<Tuple2<Long, Long>> verticesInput = Arrays.asList(
-					new Tuple2<Long, Long>(1l,1l),
-					new Tuple2<Long, Long>(2l,2l),
-					new Tuple2<Long, Long>(3l,3l),
-					new Tuple2<Long, Long>(4l,4l),
-					new Tuple2<Long, Long>(5l,5l),
-					new Tuple2<Long, Long>(6l,6l),
-					new Tuple2<Long, Long>(7l,7l),
-					new Tuple2<Long, Long>(8l,8l),
-					new Tuple2<Long, Long>(9l,9l)
+					new Tuple2<>(1l,1l),
+					new Tuple2<>(2l,2l),
+					new Tuple2<>(3l,3l),
+					new Tuple2<>(4l,4l),
+					new Tuple2<>(5l,5l),
+					new Tuple2<>(6l,6l),
+					new Tuple2<>(7l,7l),
+					new Tuple2<>(8l,8l),
+					new Tuple2<>(9l,9l)
 			);
 			
 			List<Tuple2<Long, Long>> edgesInput = Arrays.asList(
-					new Tuple2<Long, Long>(1l,2l),
-					new Tuple2<Long, Long>(1l,3l),
-					new Tuple2<Long, Long>(2l,3l),
-					new Tuple2<Long, Long>(2l,4l),
-					new Tuple2<Long, Long>(2l,1l),
-					new Tuple2<Long, Long>(3l,1l),
-					new Tuple2<Long, Long>(3l,2l),
-					new Tuple2<Long, Long>(4l,2l),
-					new Tuple2<Long, Long>(4l,6l),
-					new Tuple2<Long, Long>(5l,6l),
-					new Tuple2<Long, Long>(6l,4l),
-					new Tuple2<Long, Long>(6l,5l),
-					new Tuple2<Long, Long>(7l,8l),
-					new Tuple2<Long, Long>(7l,9l),
-					new Tuple2<Long, Long>(8l,7l),
-					new Tuple2<Long, Long>(8l,9l),
-					new Tuple2<Long, Long>(9l,7l),
-					new Tuple2<Long, Long>(9l,8l)
+					new Tuple2<>(1l,2l),
+					new Tuple2<>(1l,3l),
+					new Tuple2<>(2l,3l),
+					new Tuple2<>(2l,4l),
+					new Tuple2<>(2l,1l),
+					new Tuple2<>(3l,1l),
+					new Tuple2<>(3l, 2l),
+					new Tuple2<>(4l, 2l),
+					new Tuple2<>(4l,6l),
+					new Tuple2<>(5l,6l),
+					new Tuple2<>(6l,4l),
+					new Tuple2<>(6l,5l),
+					new Tuple2<>(7l,8l),
+					new Tuple2<>(7l,9l),
+					new Tuple2<>(8l,7l),
+					new Tuple2<>(8l,9l),
+					new Tuple2<>(9l,7l),
+					new Tuple2<>(9l,8l)
 			);
 
 			// name of the aggregator that checks for convergence
@@ -119,15 +119,15 @@ public class AggregatorConvergenceITCase extends MultipleProgramsTestBase {
 			Collections.sort(result, new JavaProgramTestBase.TupleComparator<Tuple2<Long, Long>>());
 
 			List<Tuple2<Long, Long>> expectedResult = Arrays.asList(
-					new Tuple2<Long, Long>(1L,1L),
-					new Tuple2<Long, Long>(2L,1L),
-					new Tuple2<Long, Long>(3L,1L),
-					new Tuple2<Long, Long>(4L,1L),
-					new Tuple2<Long, Long>(5L,2L),
-					new Tuple2<Long, Long>(6L,1L),
-					new Tuple2<Long, Long>(7L,7L),
-					new Tuple2<Long, Long>(8L,7L),
-					new Tuple2<Long, Long>(9L,7L)
+					new Tuple2<>(1L,1L),
+					new Tuple2<>(2L,1L),
+					new Tuple2<>(3L,1L),
+					new Tuple2<>(4L,1L),
+					new Tuple2<>(5L,2L),
+					new Tuple2<>(6L,1L),
+					new Tuple2<>(7L,7L),
+					new Tuple2<>(8L,7L),
+					new Tuple2<>(9L,7L)
 			);
 			
 			assertEquals(expectedResult, result);
@@ -142,15 +142,15 @@ public class AggregatorConvergenceITCase extends MultipleProgramsTestBase {
 	public void testParameterizableAggregator() {
 		try {
 			List<Tuple2<Long, Long>> verticesInput = Arrays.asList(
-				new Tuple2<Long, Long>(1l,1l),
-				new Tuple2<Long, Long>(2l,2l),
-				new Tuple2<Long, Long>(3l,3l),
-				new Tuple2<Long, Long>(4l,4l),
-				new Tuple2<Long, Long>(5l,5l),
-				new Tuple2<Long, Long>(6l,6l),
-				new Tuple2<Long, Long>(7l,7l),
-				new Tuple2<Long, Long>(8l,8l),
-				new Tuple2<Long, Long>(9l,9l)
+				new Tuple2<>(1l,1l),
+				new Tuple2<>(2l,2l),
+				new Tuple2<>(3l,3l),
+				new Tuple2<>(4l,4l),
+				new Tuple2<>(5l,5l),
+				new Tuple2<>(6l,6l),
+				new Tuple2<>(7l,7l),
+				new Tuple2<>(8l,8l),
+				new Tuple2<>(9l,9l)
 			);
 			
 			List<Tuple2<Long, Long>> edgesInput = Arrays.asList(

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorConvergenceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorConvergenceITCase.java
@@ -100,8 +100,7 @@ public class AggregatorConvergenceITCase extends MultipleProgramsTestBase {
 	);
 
 	@Test
-	public void testConnectedComponentsWithParametrizableConvergence() {
-		try {
+	public void testConnectedComponentsWithParametrizableConvergence() throws Exception {
 
 			// name of the aggregator that checks for convergence
 			final String UPDATED_ELEMENTS = "updated.elements.aggr";
@@ -132,16 +131,10 @@ public class AggregatorConvergenceITCase extends MultipleProgramsTestBase {
 			Collections.sort(result, new JavaProgramTestBase.TupleComparator<Tuple2<Long, Long>>());
 			
 			assertEquals(expectedResult, result);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
 	}
 
 	@Test
-	public void testDeltaConnectedComponentsWithParametrizableConvergence() {
-		try {
+	public void testDeltaConnectedComponentsWithParametrizableConvergence() throws Exception {
 
 			// name of the aggregator that checks for convergence
 			final String UPDATED_ELEMENTS = "updated.elements.aggr";
@@ -173,16 +166,10 @@ public class AggregatorConvergenceITCase extends MultipleProgramsTestBase {
 			Collections.sort(result, new JavaProgramTestBase.TupleComparator<Tuple2<Long, Long>>());
 
 			assertEquals(expectedResult, result);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
 	}
 	
 	@Test
-	public void testParameterizableAggregator() {
-		try {
+	public void testParameterizableAggregator() throws Exception {
 
 			final int MAX_ITERATIONS = 5;
 			final String AGGREGATOR_NAME = "elements.in.component.aggregator";
@@ -236,11 +223,6 @@ public class AggregatorConvergenceITCase extends MultipleProgramsTestBase {
 			assertEquals(4, aggr_values[1]);
 			assertEquals(5, aggr_values[2]);
 			assertEquals(6, aggr_values[3]);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
@@ -272,6 +272,44 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 				+ "5\n" + "5\n" + "5\n" + "5\n" + "5\n";
 	}
 
+	@Test
+	public void testConvergenceCriterionWithParameterForIterateDelta() throws Exception {
+		/*
+		 * Test convergence criterion with parameter for iterate delta
+		 */
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(parallelism);
+
+		DataSet<Tuple2<Integer, Integer>> initialSolutionSet = CollectionDataSets.getIntegerDataSet(env).map(new TupleMakerMap());
+
+		DeltaIteration<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> iteration = initialSolutionSet.iterateDelta(
+				initialSolutionSet, MAX_ITERATIONS, 0);
+
+		// register aggregator
+		LongSumAggregator aggr = new LongSumAggregator();
+		iteration.registerAggregator(NEGATIVE_ELEMENTS_AGGR, aggr);
+
+		// register convergence criterion
+		iteration.registerAggregationConvergenceCriterion(NEGATIVE_ELEMENTS_AGGR, aggr,
+				new NegativeElementsConvergenceCriterionWithParam(3));
+
+		DataSet<Tuple2<Integer, Integer>> updatedDs = iteration.getWorkset().map(new AggregateAndSubtractOneDelta());
+
+		DataSet<Tuple2<Integer, Integer>> newElements = updatedDs.join(iteration.getSolutionSet())
+				.where(0).equalTo(0).projectFirst(0, 1);
+
+		DataSet<Tuple2<Integer, Integer>> iterationRes = iteration.closeWith(newElements, newElements);
+		DataSet<Integer> result = iterationRes.map(new ProjectSecondMapper());
+		result.writeAsText(resultPath);
+
+		env.execute();
+
+		expected = "-3\n" + "-2\n" + "-2\n" + "-1\n" + "-1\n"
+				+ "-1\n" + "0\n" + "0\n" + "0\n" + "0\n"
+				+ "1\n" + "1\n" + "1\n" + "1\n" + "1\n";
+	}
+
 	@SuppressWarnings("serial")
 	public static final class NegativeElementsConvergenceCriterion implements ConvergenceCriterion<LongValue> {
 
@@ -335,7 +373,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		@Override
 		public Integer map(Integer value) {
 			Integer newValue = value - 1;
-			// count numbers less then the aggregator parameter
+			// count numbers less than the aggregator parameter
 			if ( newValue < aggr.getValue() ) {
 				aggr.aggregate(1l);
 			}
@@ -436,48 +474,32 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 	}
 
 	@SuppressWarnings("serial")
-	public static final class AggregateMapDeltaWithParam extends RichMapFunction<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> {
+	public static final class AggregateAndSubtractOneDelta extends RichMapFunction<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>> {
 
-		private LongSumAggregatorWithParameter aggr;
+		private LongSumAggregator aggr;
 		private LongValue previousAggr;
 		private int superstep;
 
 		@Override
 		public void open(Configuration conf) {
-
 			aggr = getIterationRuntimeContext().getIterationAggregator(NEGATIVE_ELEMENTS_AGGR);
 			superstep = getIterationRuntimeContext().getSuperstepNumber();
 
 			if (superstep > 1) {
 				previousAggr = getIterationRuntimeContext().getPreviousIterationAggregate(NEGATIVE_ELEMENTS_AGGR);
-
 				// check previous aggregator value
-				switch(superstep) {
-					case 2: {
-						Assert.assertEquals(6, previousAggr.getValue());
-					}
-					case 3: {
-						Assert.assertEquals(5, previousAggr.getValue());
-					}
-					case 4: {
-						Assert.assertEquals(3, previousAggr.getValue());
-					}
-					case 5: {
-						Assert.assertEquals(0, previousAggr.getValue());
-					}
-					default:
-				}
-				Assert.assertEquals(superstep-1, previousAggr.getValue());
+				Assert.assertEquals(superstep - 1, previousAggr.getValue());
 			}
 
 		}
 
 		@Override
 		public Tuple2<Integer, Integer> map(Tuple2<Integer, Integer> value) {
-			// count the elements that are equal to the superstep number
-			if (value.f1 < aggr.getValue()) {
+			// count the ones
+			if (value.f1 == 1) {
 				aggr.aggregate(1l);
 			}
+			value.f1--;
 			return value;
 		}
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
@@ -313,9 +313,9 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 
 		@Override
 		public Integer map(Integer value) {
-			Integer newValue = Integer.valueOf(value.intValue() - 1);
+			Integer newValue = value - 1;
 			// count negative numbers
-			if (newValue.intValue() < 0) {
+			if (newValue < 0) {
 				aggr.aggregate(1l);
 			}
 			return newValue;
@@ -334,9 +334,9 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 
 		@Override
 		public Integer map(Integer value) {
-			Integer newValue = Integer.valueOf(value.intValue() - 1);
+			Integer newValue = value - 1;
 			// count numbers less then the aggregator parameter
-			if ( newValue.intValue() < aggr.getValue() ) {
+			if ( newValue < aggr.getValue() ) {
 				aggr.aggregate(1l);
 			}
 			return newValue;
@@ -369,8 +369,8 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 
 		@Override
 		public Tuple2<Integer, Integer> map(Integer value) {
-			Integer nodeId = Integer.valueOf(rnd.nextInt(100000));
-			return new Tuple2<Integer, Integer>(nodeId, value);
+			Integer nodeId = rnd.nextInt(100000);
+			return new Tuple2<>(nodeId, value);
 		}
 
 	}
@@ -398,7 +398,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		@Override
 		public Tuple2<Integer, Integer> map(Tuple2<Integer, Integer> value) {
 			// count the elements that are equal to the superstep number
-			if (value.f1.intValue() == superstep) {
+			if (value.f1 == superstep) {
 				aggr.aggregate(1l);
 			}
 			return value;
@@ -475,7 +475,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		@Override
 		public Tuple2<Integer, Integer> map(Tuple2<Integer, Integer> value) {
 			// count the elements that are equal to the superstep number
-			if (value.f1.intValue() < aggr.getValue()) {
+			if (value.f1 < aggr.getValue()) {
 				aggr.aggregate(1l);
 			}
 			return value;


### PR DESCRIPTION
As discussed in the Jira issue, this PR contains the following changes:
1. use `TaskConfig.setConvergenceCriterion()` to set the custom, user-defined convergence criterion (like in the case of bulk iteration)
2. add a new method `TaskConfig.setDefaultConvergeCriterion()` to handle the default empty workset convergence
​3. check both criteria in `IterationSynchronizationSinkTask.checkForConvergence()​`
4. expose the custom convergence criterion in `DeltaIteration`
It also contains some minor cleanup and corresponding changes in the `CollectionExecutor`.
The iteration docs already state that custom convergence is possible, so no update needed there ;)