### PR TITLE
[FLINK-4772] [FLINK-4775] Metric Store enhancements

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/AbstractMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/AbstractMetricsHandler.java
@@ -61,7 +61,7 @@ public abstract class AbstractMetricsHandler implements RequestHandler {
 	 * @param metrics MetricStore containing all metrics
 	 * @return Map containing metrics, or null if no metric exists
 	 */
-	protected abstract Map<String, Object> getMapFor(Map<String, String> pathParams, MetricStore metrics);
+	protected abstract Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics);
 
 	private String getMetricsValues(Map<String, String> pathParams, String requestedMetricsList) throws IOException {
 		if (requestedMetricsList.isEmpty()) {
@@ -73,7 +73,7 @@ public abstract class AbstractMetricsHandler implements RequestHandler {
 		}
 		MetricStore metricStore = fetcher.getMetricStore();
 		synchronized (metricStore) {
-			Map<String, Object> metrics = getMapFor(pathParams, metricStore);
+			Map<String, String> metrics = getMapFor(pathParams, metricStore);
 			if (metrics == null) {
 				return "";
 			}
@@ -102,7 +102,7 @@ public abstract class AbstractMetricsHandler implements RequestHandler {
 	private String getAvailableMetricsList(Map<String, String> pathParams) throws IOException {
 		MetricStore metricStore = fetcher.getMetricStore();
 		synchronized (metricStore) {
-			Map<String, Object> metrics = getMapFor(pathParams, metricStore);
+			Map<String, String> metrics = getMapFor(pathParams, metricStore);
 			if (metrics == null) {
 				return "";
 			}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandler.java
@@ -37,7 +37,7 @@ public class JobManagerMetricsHandler extends AbstractMetricsHandler {
 
 	@Override
 	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
-		MetricStore.JobManagerMetricStore jobManager = metrics.jobManager;
+		MetricStore.JobManagerMetricStore jobManager = metrics.getJobManagerMetricStore();
 		if (jobManager == null) {
 			return null;
 		} else {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandler.java
@@ -36,7 +36,7 @@ public class JobManagerMetricsHandler extends AbstractMetricsHandler {
 	}
 
 	@Override
-	protected Map<String, Object> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
+	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
 		MetricStore.JobManagerMetricStore jobManager = metrics.jobManager;
 		if (jobManager == null) {
 			return null;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandler.java
@@ -38,7 +38,7 @@ public class JobMetricsHandler extends AbstractMetricsHandler {
 	}
 
 	@Override
-	protected Map<String, Object> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
+	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
 		MetricStore.JobMetricStore job = metrics.jobs.get(pathParams.get(PARAMETER_JOB_ID));
 		if (job == null) {
 			return null;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandler.java
@@ -39,11 +39,9 @@ public class JobMetricsHandler extends AbstractMetricsHandler {
 
 	@Override
 	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
-		MetricStore.JobMetricStore job = metrics.jobs.get(pathParams.get(PARAMETER_JOB_ID));
-		if (job == null) {
-			return null;
-		} else {
-			return job.metrics;
-		}
+		MetricStore.JobMetricStore job = metrics.getJobMetricStore(pathParams.get(PARAMETER_JOB_ID));
+		return job != null
+			? job.metrics
+			: null;
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobVertexMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobVertexMetricsHandler.java
@@ -39,16 +39,11 @@ public class JobVertexMetricsHandler extends AbstractMetricsHandler {
 
 	@Override
 	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
-		MetricStore.JobMetricStore job = metrics.jobs.get(pathParams.get(JobMetricsHandler.PARAMETER_JOB_ID));
-		if (job == null) {
-			return null;
-		} else {
-			MetricStore.TaskMetricStore task = job.tasks.get(pathParams.get(PARAMETER_VERTEX_ID));
-			if (task == null) {
-				return null;
-			} else {
-				return task.metrics;
-			}
-		}
+		MetricStore.TaskMetricStore task = metrics.getTaskMetricStore(
+			pathParams.get(JobMetricsHandler.PARAMETER_JOB_ID),
+			pathParams.get(PARAMETER_VERTEX_ID));
+		return task != null
+			? task.metrics
+			: null;
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobVertexMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/JobVertexMetricsHandler.java
@@ -38,7 +38,7 @@ public class JobVertexMetricsHandler extends AbstractMetricsHandler {
 	}
 
 	@Override
-	protected Map<String, Object> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
+	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
 		MetricStore.JobMetricStore job = metrics.jobs.get(pathParams.get(JobMetricsHandler.PARAMETER_JOB_ID));
 		if (job == null) {
 			return null;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
@@ -129,11 +129,11 @@ public class MetricStore {
 		}
 	}
 
-	private void addMetric(Map<String, Object> target, String name, MetricDump metric) {
+	private void addMetric(Map<String, String> target, String name, MetricDump metric) {
 		switch (metric.getCategory()) {
 			case METRIC_CATEGORY_COUNTER:
 				MetricDump.CounterDump counter = (MetricDump.CounterDump) metric;
-				target.put(name, counter.count);
+				target.put(name, String.valueOf(counter.count));
 				break;
 			case METRIC_CATEGORY_GAUGE:
 				MetricDump.GaugeDump gauge = (MetricDump.GaugeDump) metric;
@@ -141,21 +141,21 @@ public class MetricStore {
 				break;
 			case METRIC_CATEGORY_HISTOGRAM:
 				MetricDump.HistogramDump histogram = (MetricDump.HistogramDump) metric;
-				target.put(name + "_min", histogram.min);
-				target.put(name + "_max", histogram.max);
-				target.put(name + "_mean", histogram.mean);
-				target.put(name + "_median", histogram.median);
-				target.put(name + "_stddev", histogram.stddev);
-				target.put(name + "_p75", histogram.p75);
-				target.put(name + "_p90", histogram.p90);
-				target.put(name + "_p95", histogram.p95);
-				target.put(name + "_p98", histogram.p98);
-				target.put(name + "_p99", histogram.p99);
-				target.put(name + "_p999", histogram.p999);
+				target.put(name + "_min", String.valueOf(histogram.min));
+				target.put(name + "_max", String.valueOf(histogram.max));
+				target.put(name + "_mean", String.valueOf(histogram.mean));
+				target.put(name + "_median", String.valueOf(histogram.median));
+				target.put(name + "_stddev", String.valueOf(histogram.stddev));
+				target.put(name + "_p75", String.valueOf(histogram.p75));
+				target.put(name + "_p90", String.valueOf(histogram.p90));
+				target.put(name + "_p95", String.valueOf(histogram.p95));
+				target.put(name + "_p98", String.valueOf(histogram.p98));
+				target.put(name + "_p99", String.valueOf(histogram.p99));
+				target.put(name + "_p999", String.valueOf(histogram.p999));
 				break;
 			case METRIC_CATEGORY_METER:
 				MetricDump.MeterDump meter = (MetricDump.MeterDump) metric;
-				target.put(name, meter.rate);
+				target.put(name, String.valueOf(meter.rate));
 				break;
 		}
 	}
@@ -164,21 +164,21 @@ public class MetricStore {
 	 * Sub-structure containing metrics of the JobManager.
 	 */
 	static class JobManagerMetricStore {
-		public final Map<String, Object> metrics = new HashMap<>();
+		public final Map<String, String> metrics = new HashMap<>();
 	}
 
 	/**
 	 * Sub-structure containing metrics of a single TaskManager.
 	 */
 	static class TaskManagerMetricStore {
-		public final Map<String, Object> metrics = new HashMap<>();
+		public final Map<String, String> metrics = new HashMap<>();
 	}
 
 	/**
 	 * Sub-structure containing metrics of a single Job.
 	 */
 	static class JobMetricStore {
-		public final Map<String, Object> metrics = new HashMap<>();
+		public final Map<String, String> metrics = new HashMap<>();
 		public final Map<String, TaskMetricStore> tasks = new HashMap<>();
 	}
 
@@ -186,6 +186,6 @@ public class MetricStore {
 	 * Sub-structure containing metrics of a single Task.
 	 */
 	static class TaskMetricStore {
-		public final Map<String, Object> metrics = new HashMap<>();
+		public final Map<String, String> metrics = new HashMap<>();
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/TaskManagerMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/TaskManagerMetricsHandler.java
@@ -39,7 +39,7 @@ public class TaskManagerMetricsHandler extends AbstractMetricsHandler {
 
 	@Override
 	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
-		MetricStore.TaskManagerMetricStore taskManager = metrics.taskManagers.get(pathParams.get(PARAMETER_TM_ID));
+		MetricStore.TaskManagerMetricStore taskManager = metrics.getTaskManagerMetricStore(pathParams.get(PARAMETER_TM_ID));
 		if (taskManager == null) {
 			return null;
 		} else {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/TaskManagerMetricsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/TaskManagerMetricsHandler.java
@@ -38,7 +38,7 @@ public class TaskManagerMetricsHandler extends AbstractMetricsHandler {
 	}
 
 	@Override
-	protected Map<String, Object> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
+	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
 		MetricStore.TaskManagerMetricStore taskManager = metrics.taskManagers.get(pathParams.get(PARAMETER_TM_ID));
 		if (taskManager == null) {
 			return null;

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandlerTest.java
@@ -40,7 +40,7 @@ public class JobManagerMetricsHandlerTest extends TestLogger {
 
 		Map<String, String> pathParams = new HashMap<>();
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
 		assertEquals(0L, metrics.get("abc.metric1"));
 	}
@@ -54,7 +54,7 @@ public class JobManagerMetricsHandlerTest extends TestLogger {
 
 		Map<String, String> pathParams = new HashMap<>();
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
 		assertNotNull(metrics);
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobManagerMetricsHandlerTest.java
@@ -42,7 +42,7 @@ public class JobManagerMetricsHandlerTest extends TestLogger {
 
 		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
-		assertEquals(0L, metrics.get("abc.metric1"));
+		assertEquals("0", metrics.get("abc.metric1"));
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandlerTest.java
@@ -44,7 +44,7 @@ public class JobMetricsHandlerTest extends TestLogger {
 
 		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
-		assertEquals(2L, metrics.get("abc.metric3"));
+		assertEquals("2", metrics.get("abc.metric3"));
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobMetricsHandlerTest.java
@@ -42,7 +42,7 @@ public class JobMetricsHandlerTest extends TestLogger {
 		Map<String, String> pathParams = new HashMap<>();
 		pathParams.put(PARAMETER_JOB_ID, "jobid");
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
 		assertEquals(2L, metrics.get("abc.metric3"));
 	}
@@ -56,7 +56,7 @@ public class JobMetricsHandlerTest extends TestLogger {
 
 		Map<String, String> pathParams = new HashMap<>();
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
 		assertNull(metrics);
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobVertexMetricsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/JobVertexMetricsHandlerTest.java
@@ -44,11 +44,11 @@ public class JobVertexMetricsHandlerTest extends TestLogger {
 		pathParams.put(PARAMETER_JOB_ID, "jobid");
 		pathParams.put(PARAMETER_VERTEX_ID, "taskid");
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
-		assertEquals(3L, metrics.get("8.abc.metric4"));
+		assertEquals("3", metrics.get("8.abc.metric4"));
 
-		assertEquals(4L, metrics.get("8.opname.abc.metric5"));
+		assertEquals("4", metrics.get("8.opname.abc.metric5"));
 	}
 
 	@Test
@@ -60,7 +60,7 @@ public class JobVertexMetricsHandlerTest extends TestLogger {
 
 		Map<String, String> pathParams = new HashMap<>();
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
 		assertNull(metrics);
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcherTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcherTest.java
@@ -153,10 +153,10 @@ public class MetricFetcherTest extends TestLogger {
 			assertEquals("0.99", store.jobManager.metrics.get("abc.hist_p99"));
 			assertEquals("0.999", store.jobManager.metrics.get("abc.hist_p999"));
 
-			assertEquals("x", store.taskManagers.get(tmID.toString()).metrics.get("abc.gauge"));
-			assertEquals("5.0", store.jobs.get(jobID.toString()).metrics.get("abc.jc"));
-			assertEquals("2", store.jobs.get(jobID.toString()).tasks.get("taskid").metrics.get("2.abc.tc"));
-			assertEquals("1", store.jobs.get(jobID.toString()).tasks.get("taskid").metrics.get("2.opname.abc.oc"));
+			assertEquals("x", store.getTaskManagerMetricStore(tmID.toString()).metrics.get("abc.gauge"));
+			assertEquals("5.0", store.getJobMetricStore(jobID.toString()).metrics.get("abc.jc"));
+			assertEquals("2", store.getTaskMetricStore(jobID.toString(), "taskid").metrics.get("2.abc.tc"));
+			assertEquals("1", store.getTaskMetricStore(jobID.toString(), "taskid").metrics.get("2.opname.abc.oc"));
 		}
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcherTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcherTest.java
@@ -141,22 +141,22 @@ public class MetricFetcherTest extends TestLogger {
 		fetcher.update();
 		MetricStore store = fetcher.getMetricStore();
 		synchronized (store) {
-			assertEquals(7L, store.jobManager.metrics.get("abc.hist_min"));
-			assertEquals(6L, store.jobManager.metrics.get("abc.hist_max"));
-			assertEquals(4.0, store.jobManager.metrics.get("abc.hist_mean"));
-			assertEquals(0.5, store.jobManager.metrics.get("abc.hist_median"));
-			assertEquals(5.0, store.jobManager.metrics.get("abc.hist_stddev"));
-			assertEquals(0.75, store.jobManager.metrics.get("abc.hist_p75"));
-			assertEquals(0.9, store.jobManager.metrics.get("abc.hist_p90"));
-			assertEquals(0.95, store.jobManager.metrics.get("abc.hist_p95"));
-			assertEquals(0.98, store.jobManager.metrics.get("abc.hist_p98"));
-			assertEquals(0.99, store.jobManager.metrics.get("abc.hist_p99"));
-			assertEquals(0.999, store.jobManager.metrics.get("abc.hist_p999"));
+			assertEquals("7", store.jobManager.metrics.get("abc.hist_min"));
+			assertEquals("6", store.jobManager.metrics.get("abc.hist_max"));
+			assertEquals("4.0", store.jobManager.metrics.get("abc.hist_mean"));
+			assertEquals("0.5", store.jobManager.metrics.get("abc.hist_median"));
+			assertEquals("5.0", store.jobManager.metrics.get("abc.hist_stddev"));
+			assertEquals("0.75", store.jobManager.metrics.get("abc.hist_p75"));
+			assertEquals("0.9", store.jobManager.metrics.get("abc.hist_p90"));
+			assertEquals("0.95", store.jobManager.metrics.get("abc.hist_p95"));
+			assertEquals("0.98", store.jobManager.metrics.get("abc.hist_p98"));
+			assertEquals("0.99", store.jobManager.metrics.get("abc.hist_p99"));
+			assertEquals("0.999", store.jobManager.metrics.get("abc.hist_p999"));
 
 			assertEquals("x", store.taskManagers.get(tmID.toString()).metrics.get("abc.gauge"));
-			assertEquals(5.0, store.jobs.get(jobID.toString()).metrics.get("abc.jc"));
-			assertEquals(2L, store.jobs.get(jobID.toString()).tasks.get("taskid").metrics.get("2.abc.tc"));
-			assertEquals(1L, store.jobs.get(jobID.toString()).tasks.get("taskid").metrics.get("2.opname.abc.oc"));
+			assertEquals("5.0", store.jobs.get(jobID.toString()).metrics.get("abc.jc"));
+			assertEquals("2", store.jobs.get(jobID.toString()).tasks.get("taskid").metrics.get("2.abc.tc"));
+			assertEquals("1", store.jobs.get(jobID.toString()).tasks.get("taskid").metrics.get("2.opname.abc.oc"));
 		}
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricStoreTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricStoreTest.java
@@ -31,11 +31,11 @@ public class MetricStoreTest extends TestLogger {
 	public void testAdd() throws IOException {
 		MetricStore store = setupStore(new MetricStore());
 
-		assertEquals(0L, store.jobManager.metrics.get("abc.metric1"));
-		assertEquals(1L, store.taskManagers.get("tmid").metrics.get("abc.metric2"));
-		assertEquals(2L, store.jobs.get("jobid").metrics.get("abc.metric3"));
-		assertEquals(3L, store.jobs.get("jobid").tasks.get("taskid").metrics.get("8.abc.metric4"));
-		assertEquals(4L, store.jobs.get("jobid").tasks.get("taskid").metrics.get("8.opname.abc.metric5"));
+		assertEquals("0", store.jobManager.metrics.get("abc.metric1"));
+		assertEquals("1", store.taskManagers.get("tmid").metrics.get("abc.metric2"));
+		assertEquals("2", store.jobs.get("jobid").metrics.get("abc.metric3"));
+		assertEquals("3", store.jobs.get("jobid").tasks.get("taskid").metrics.get("8.abc.metric4"));
+		assertEquals("4", store.jobs.get("jobid").tasks.get("taskid").metrics.get("8.opname.abc.metric5"));
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricStoreTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricStoreTest.java
@@ -31,11 +31,11 @@ public class MetricStoreTest extends TestLogger {
 	public void testAdd() throws IOException {
 		MetricStore store = setupStore(new MetricStore());
 
-		assertEquals("0", store.jobManager.metrics.get("abc.metric1"));
-		assertEquals("1", store.taskManagers.get("tmid").metrics.get("abc.metric2"));
-		assertEquals("2", store.jobs.get("jobid").metrics.get("abc.metric3"));
-		assertEquals("3", store.jobs.get("jobid").tasks.get("taskid").metrics.get("8.abc.metric4"));
-		assertEquals("4", store.jobs.get("jobid").tasks.get("taskid").metrics.get("8.opname.abc.metric5"));
+		assertEquals("0", store.getJobManagerMetricStore().getMetric("abc.metric1", "-1"));
+		assertEquals("1", store.getTaskManagerMetricStore("tmid").getMetric("abc.metric2", "-1"));
+		assertEquals("2", store.getJobMetricStore("jobid").getMetric("abc.metric3", "-1"));
+		assertEquals("3", store.getTaskMetricStore("jobid", "taskid").getMetric("8.abc.metric4", "-1"));
+		assertEquals("4", store.getTaskMetricStore("jobid", "taskid").getMetric("8.opname.abc.metric5", "-1"));
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/TaskManagerMetricsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/TaskManagerMetricsHandlerTest.java
@@ -42,9 +42,9 @@ public class TaskManagerMetricsHandlerTest extends TestLogger {
 		Map<String, String> pathParams = new HashMap<>();
 		pathParams.put(PARAMETER_TM_ID, "tmid");
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
-		assertEquals(1L, metrics.get("abc.metric2"));
+		assertEquals("1", metrics.get("abc.metric2"));
 	}
 
 	@Test
@@ -56,7 +56,7 @@ public class TaskManagerMetricsHandlerTest extends TestLogger {
 
 		Map<String, String> pathParams = new HashMap<>();
 
-		Map<String, Object> metrics = handler.getMapFor(pathParams, store);
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
 
 		assertNull(metrics);
 	}


### PR DESCRIPTION
This PR changes a few things about the MetricStore class to make it easier to work with.

* metrics are now stored as strings (Map<String, Object> => Map<String, String>) since the differentiation only leads to cumbersome casts.
* sub-structures are no longer accessed directly but through helper methods. This allows traversing several layers with a single call.
* finally, a simple getMetric(name, defaultValue) was added to easier handle metrics that weren't updated yet (and potentially never will) and thus would return null